### PR TITLE
feat(hip): add hipExtMemcpyBatch graph node type

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
@@ -48,7 +48,7 @@
 #define HIP_API_TABLE_STEP_VERSION 0
 #define HIP_COMPILER_API_TABLE_STEP_VERSION 0
 #define HIP_TOOLS_API_TABLE_STEP_VERSION 1
-#define HIP_RUNTIME_API_TABLE_STEP_VERSION 31
+#define HIP_RUNTIME_API_TABLE_STEP_VERSION 32
 
 // HIP API interface
 // HIP compiler dispatch functions
@@ -1180,6 +1180,17 @@ typedef hipError_t (*t_hipExecutionCtxWaitEvent)(hipExecutionCtx_t ctx, hipEvent
 
 typedef hipError_t (*t_hipMemGetDefaultMemPool)(hipMemPool_t* memPool, hipMemLocation* location,
                                                 hipMemAllocationType type);
+
+typedef hipError_t (*t_hipGraphAddExtMemcpyBatchNode)(
+    hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies,
+    size_t numDependencies, const hipExtMemcpyBatchNodeParams* nodeParams);
+typedef hipError_t (*t_hipGraphExtMemcpyBatchNodeGetParams)(
+    hipGraphNode_t node, hipExtMemcpyBatchNodeParams* pNodeParams);
+typedef hipError_t (*t_hipGraphExtMemcpyBatchNodeSetParams)(
+    hipGraphNode_t node, const hipExtMemcpyBatchNodeParams* pNodeParams);
+typedef hipError_t (*t_hipGraphExecExtMemcpyBatchNodeSetParams)(
+    hipGraphExec_t hGraphExec, hipGraphNode_t node,
+    const hipExtMemcpyBatchNodeParams* pNodeParams);
 // HIP Compiler dispatch table
 struct HipCompilerDispatchTable {
   // HIP_COMPILER_API_TABLE_STEP_VERSION == 0
@@ -1827,8 +1838,14 @@ struct HipDispatchTable {
   // HIP_RUNTIME_API_TABLE_STEP_VERSION == 31
   t_hipMemGetDefaultMemPool hipMemGetDefaultMemPool_fn;
 
-  // DO NOT EDIT ABOVE!
   // HIP_RUNTIME_API_TABLE_STEP_VERSION == 32
+  t_hipGraphAddExtMemcpyBatchNode hipGraphAddExtMemcpyBatchNode_fn;
+  t_hipGraphExtMemcpyBatchNodeGetParams hipGraphExtMemcpyBatchNodeGetParams_fn;
+  t_hipGraphExtMemcpyBatchNodeSetParams hipGraphExtMemcpyBatchNodeSetParams_fn;
+  t_hipGraphExecExtMemcpyBatchNodeSetParams hipGraphExecExtMemcpyBatchNodeSetParams_fn;
+
+  // DO NOT EDIT ABOVE!
+  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 33
 
   // ******************************************************************************************* //
   //

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -507,7 +507,11 @@ enum hip_api_id_t {
   HIP_API_ID_hipMemDiscardAndPrefetchBatchAsync = 482,
   HIP_API_ID_hipDrvMemDiscardAndPrefetchBatchAsync = 483,
   HIP_API_ID_hipMemGetDefaultMemPool = 484,
-  HIP_API_ID_LAST = 484,
+  HIP_API_ID_hipGraphAddExtMemcpyBatchNode = 485,
+  HIP_API_ID_hipGraphExtMemcpyBatchNodeGetParams = 486,
+  HIP_API_ID_hipGraphExtMemcpyBatchNodeSetParams = 487,
+  HIP_API_ID_hipGraphExecExtMemcpyBatchNodeSetParams = 488,
+  HIP_API_ID_LAST = 488,
 
   HIP_API_ID_hipChooseDevice = HIP_API_ID_CONCAT(HIP_API_ID_,hipChooseDevice),
   HIP_API_ID_hipGetDeviceProperties = HIP_API_ID_CONCAT(HIP_API_ID_,hipGetDeviceProperties),
@@ -687,6 +691,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphAddEmptyNode: return "hipGraphAddEmptyNode";
     case HIP_API_ID_hipGraphAddEventRecordNode: return "hipGraphAddEventRecordNode";
     case HIP_API_ID_hipGraphAddEventWaitNode: return "hipGraphAddEventWaitNode";
+    case HIP_API_ID_hipGraphAddExtMemcpyBatchNode: return "hipGraphAddExtMemcpyBatchNode";
     case HIP_API_ID_hipGraphAddExternalSemaphoresSignalNode: return "hipGraphAddExternalSemaphoresSignalNode";
     case HIP_API_ID_hipGraphAddExternalSemaphoresWaitNode: return "hipGraphAddExternalSemaphoresWaitNode";
     case HIP_API_ID_hipGraphAddHostNode: return "hipGraphAddHostNode";
@@ -716,6 +721,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphExecDestroy: return "hipGraphExecDestroy";
     case HIP_API_ID_hipGraphExecEventRecordNodeSetEvent: return "hipGraphExecEventRecordNodeSetEvent";
     case HIP_API_ID_hipGraphExecEventWaitNodeSetEvent: return "hipGraphExecEventWaitNodeSetEvent";
+    case HIP_API_ID_hipGraphExecExtMemcpyBatchNodeSetParams: return "hipGraphExecExtMemcpyBatchNodeSetParams";
     case HIP_API_ID_hipGraphExecExternalSemaphoresSignalNodeSetParams: return "hipGraphExecExternalSemaphoresSignalNodeSetParams";
     case HIP_API_ID_hipGraphExecExternalSemaphoresWaitNodeSetParams: return "hipGraphExecExternalSemaphoresWaitNodeSetParams";
     case HIP_API_ID_hipGraphExecGetFlags: return "hipGraphExecGetFlags";
@@ -728,6 +734,8 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphExecMemsetNodeSetParams: return "hipGraphExecMemsetNodeSetParams";
     case HIP_API_ID_hipGraphExecNodeSetParams: return "hipGraphExecNodeSetParams";
     case HIP_API_ID_hipGraphExecUpdate: return "hipGraphExecUpdate";
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeGetParams: return "hipGraphExtMemcpyBatchNodeGetParams";
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeSetParams: return "hipGraphExtMemcpyBatchNodeSetParams";
     case HIP_API_ID_hipGraphExternalSemaphoresSignalNodeGetParams: return "hipGraphExternalSemaphoresSignalNodeGetParams";
     case HIP_API_ID_hipGraphExternalSemaphoresSignalNodeSetParams: return "hipGraphExternalSemaphoresSignalNodeSetParams";
     case HIP_API_ID_hipGraphExternalSemaphoresWaitNodeGetParams: return "hipGraphExternalSemaphoresWaitNodeGetParams";
@@ -1165,6 +1173,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphAddEmptyNode", name) == 0) return HIP_API_ID_hipGraphAddEmptyNode;
   if (strcmp("hipGraphAddEventRecordNode", name) == 0) return HIP_API_ID_hipGraphAddEventRecordNode;
   if (strcmp("hipGraphAddEventWaitNode", name) == 0) return HIP_API_ID_hipGraphAddEventWaitNode;
+  if (strcmp("hipGraphAddExtMemcpyBatchNode", name) == 0) return HIP_API_ID_hipGraphAddExtMemcpyBatchNode;
   if (strcmp("hipGraphAddExternalSemaphoresSignalNode", name) == 0) return HIP_API_ID_hipGraphAddExternalSemaphoresSignalNode;
   if (strcmp("hipGraphAddExternalSemaphoresWaitNode", name) == 0) return HIP_API_ID_hipGraphAddExternalSemaphoresWaitNode;
   if (strcmp("hipGraphAddHostNode", name) == 0) return HIP_API_ID_hipGraphAddHostNode;
@@ -1194,6 +1203,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphExecDestroy", name) == 0) return HIP_API_ID_hipGraphExecDestroy;
   if (strcmp("hipGraphExecEventRecordNodeSetEvent", name) == 0) return HIP_API_ID_hipGraphExecEventRecordNodeSetEvent;
   if (strcmp("hipGraphExecEventWaitNodeSetEvent", name) == 0) return HIP_API_ID_hipGraphExecEventWaitNodeSetEvent;
+  if (strcmp("hipGraphExecExtMemcpyBatchNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExecExtMemcpyBatchNodeSetParams;
   if (strcmp("hipGraphExecExternalSemaphoresSignalNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExecExternalSemaphoresSignalNodeSetParams;
   if (strcmp("hipGraphExecExternalSemaphoresWaitNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExecExternalSemaphoresWaitNodeSetParams;
   if (strcmp("hipGraphExecGetFlags", name) == 0) return HIP_API_ID_hipGraphExecGetFlags;
@@ -1206,6 +1216,8 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphExecMemsetNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExecMemsetNodeSetParams;
   if (strcmp("hipGraphExecNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExecNodeSetParams;
   if (strcmp("hipGraphExecUpdate", name) == 0) return HIP_API_ID_hipGraphExecUpdate;
+  if (strcmp("hipGraphExtMemcpyBatchNodeGetParams", name) == 0) return HIP_API_ID_hipGraphExtMemcpyBatchNodeGetParams;
+  if (strcmp("hipGraphExtMemcpyBatchNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExtMemcpyBatchNodeSetParams;
   if (strcmp("hipGraphExternalSemaphoresSignalNodeGetParams", name) == 0) return HIP_API_ID_hipGraphExternalSemaphoresSignalNodeGetParams;
   if (strcmp("hipGraphExternalSemaphoresSignalNodeSetParams", name) == 0) return HIP_API_ID_hipGraphExternalSemaphoresSignalNodeSetParams;
   if (strcmp("hipGraphExternalSemaphoresWaitNodeGetParams", name) == 0) return HIP_API_ID_hipGraphExternalSemaphoresWaitNodeGetParams;
@@ -2267,6 +2279,16 @@ typedef struct hip_api_data_s {
       const hipGraphNode_t* pDependencies;
       hipGraphNode_t pDependencies__val;
       size_t numDependencies;
+      const hipExtMemcpyBatchNodeParams* nodeParams;
+      hipExtMemcpyBatchNodeParams nodeParams__val;
+    } hipGraphAddExtMemcpyBatchNode;
+    struct {
+      hipGraphNode_t* pGraphNode;
+      hipGraphNode_t pGraphNode__val;
+      hipGraph_t graph;
+      const hipGraphNode_t* pDependencies;
+      hipGraphNode_t pDependencies__val;
+      size_t numDependencies;
       const hipExternalSemaphoreSignalNodeParams* nodeParams;
       hipExternalSemaphoreSignalNodeParams nodeParams__val;
     } hipGraphAddExternalSemaphoresSignalNode;
@@ -2468,6 +2490,12 @@ typedef struct hip_api_data_s {
     } hipGraphExecEventWaitNodeSetEvent;
     struct {
       hipGraphExec_t hGraphExec;
+      hipGraphNode_t node;
+      const hipExtMemcpyBatchNodeParams* pNodeParams;
+      hipExtMemcpyBatchNodeParams pNodeParams__val;
+    } hipGraphExecExtMemcpyBatchNodeSetParams;
+    struct {
+      hipGraphExec_t hGraphExec;
       hipGraphNode_t hNode;
       const hipExternalSemaphoreSignalNodeParams* nodeParams;
       hipExternalSemaphoreSignalNodeParams nodeParams__val;
@@ -2547,6 +2575,16 @@ typedef struct hip_api_data_s {
       hipGraphExecUpdateResult* updateResult_out;
       hipGraphExecUpdateResult updateResult_out__val;
     } hipGraphExecUpdate;
+    struct {
+      hipGraphNode_t node;
+      hipExtMemcpyBatchNodeParams* pNodeParams;
+      hipExtMemcpyBatchNodeParams pNodeParams__val;
+    } hipGraphExtMemcpyBatchNodeGetParams;
+    struct {
+      hipGraphNode_t node;
+      const hipExtMemcpyBatchNodeParams* pNodeParams;
+      hipExtMemcpyBatchNodeParams pNodeParams__val;
+    } hipGraphExtMemcpyBatchNodeSetParams;
     struct {
       hipGraphNode_t hNode;
       hipExternalSemaphoreSignalNodeParams* params_out;
@@ -5173,6 +5211,14 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphAddEventWaitNode.numDependencies = (size_t)numDependencies; \
   cb_data.args.hipGraphAddEventWaitNode.event = (hipEvent_t)event; \
 };
+// hipGraphAddExtMemcpyBatchNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('const hipExtMemcpyBatchNodeParams*', 'nodeParams')]
+#define INIT_hipGraphAddExtMemcpyBatchNode_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphAddExtMemcpyBatchNode.pGraphNode = (hipGraphNode_t*)pGraphNode; \
+  cb_data.args.hipGraphAddExtMemcpyBatchNode.graph = (hipGraph_t)graph; \
+  cb_data.args.hipGraphAddExtMemcpyBatchNode.pDependencies = (const hipGraphNode_t*)pDependencies; \
+  cb_data.args.hipGraphAddExtMemcpyBatchNode.numDependencies = (size_t)numDependencies; \
+  cb_data.args.hipGraphAddExtMemcpyBatchNode.nodeParams = (const hipExtMemcpyBatchNodeParams*)nodeParams; \
+};
 // hipGraphAddExternalSemaphoresSignalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('const hipExternalSemaphoreSignalNodeParams*', 'nodeParams')]
 #define INIT_hipGraphAddExternalSemaphoresSignalNode_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphAddExternalSemaphoresSignalNode.pGraphNode = (hipGraphNode_t*)pGraphNode; \
@@ -5367,6 +5413,12 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphExecEventWaitNodeSetEvent.hNode = (hipGraphNode_t)hNode; \
   cb_data.args.hipGraphExecEventWaitNodeSetEvent.event = (hipEvent_t)event; \
 };
+// hipGraphExecExtMemcpyBatchNodeSetParams[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'node'), ('const hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+#define INIT_hipGraphExecExtMemcpyBatchNodeSetParams_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphExecExtMemcpyBatchNodeSetParams.hGraphExec = (hipGraphExec_t)hGraphExec; \
+  cb_data.args.hipGraphExecExtMemcpyBatchNodeSetParams.node = (hipGraphNode_t)node; \
+  cb_data.args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams = (const hipExtMemcpyBatchNodeParams*)pNodeParams; \
+};
 // hipGraphExecExternalSemaphoresSignalNodeSetParams[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'hNode'), ('const hipExternalSemaphoreSignalNodeParams*', 'nodeParams')]
 #define INIT_hipGraphExecExternalSemaphoresSignalNodeSetParams_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphExecExternalSemaphoresSignalNodeSetParams.hGraphExec = (hipGraphExec_t)hGraphExec; \
@@ -5449,6 +5501,16 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphExecUpdate.hGraph = (hipGraph_t)hGraph; \
   cb_data.args.hipGraphExecUpdate.hErrorNode_out = (hipGraphNode_t*)hErrorNode_out; \
   cb_data.args.hipGraphExecUpdate.updateResult_out = (hipGraphExecUpdateResult*)updateResult_out; \
+};
+// hipGraphExtMemcpyBatchNodeGetParams[('hipGraphNode_t', 'node'), ('hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+#define INIT_hipGraphExtMemcpyBatchNodeGetParams_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphExtMemcpyBatchNodeGetParams.node = (hipGraphNode_t)node; \
+  cb_data.args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams = (hipExtMemcpyBatchNodeParams*)pNodeParams; \
+};
+// hipGraphExtMemcpyBatchNodeSetParams[('hipGraphNode_t', 'node'), ('const hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+#define INIT_hipGraphExtMemcpyBatchNodeSetParams_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphExtMemcpyBatchNodeSetParams.node = (hipGraphNode_t)node; \
+  cb_data.args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams = (const hipExtMemcpyBatchNodeParams*)pNodeParams; \
 };
 // hipGraphExternalSemaphoresSignalNodeGetParams[('hipGraphNode_t', 'hNode'), ('hipExternalSemaphoreSignalNodeParams*', 'params_out')]
 #define INIT_hipGraphExternalSemaphoresSignalNodeGetParams_CB_ARGS_DATA(cb_data) { \
@@ -7927,6 +7989,12 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
       if (data->args.hipGraphAddEventWaitNode.pGraphNode) data->args.hipGraphAddEventWaitNode.pGraphNode__val = *(data->args.hipGraphAddEventWaitNode.pGraphNode);
       if (data->args.hipGraphAddEventWaitNode.pDependencies) data->args.hipGraphAddEventWaitNode.pDependencies__val = *(data->args.hipGraphAddEventWaitNode.pDependencies);
       break;
+// hipGraphAddExtMemcpyBatchNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('const hipExtMemcpyBatchNodeParams*', 'nodeParams')]
+    case HIP_API_ID_hipGraphAddExtMemcpyBatchNode:
+      if (data->args.hipGraphAddExtMemcpyBatchNode.pGraphNode) data->args.hipGraphAddExtMemcpyBatchNode.pGraphNode__val = *(data->args.hipGraphAddExtMemcpyBatchNode.pGraphNode);
+      if (data->args.hipGraphAddExtMemcpyBatchNode.pDependencies) data->args.hipGraphAddExtMemcpyBatchNode.pDependencies__val = *(data->args.hipGraphAddExtMemcpyBatchNode.pDependencies);
+      if (data->args.hipGraphAddExtMemcpyBatchNode.nodeParams) data->args.hipGraphAddExtMemcpyBatchNode.nodeParams__val = *(data->args.hipGraphAddExtMemcpyBatchNode.nodeParams);
+      break;
 // hipGraphAddExternalSemaphoresSignalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('const hipExternalSemaphoreSignalNodeParams*', 'nodeParams')]
     case HIP_API_ID_hipGraphAddExternalSemaphoresSignalNode:
       if (data->args.hipGraphAddExternalSemaphoresSignalNode.pGraphNode) data->args.hipGraphAddExternalSemaphoresSignalNode.pGraphNode__val = *(data->args.hipGraphAddExternalSemaphoresSignalNode.pGraphNode);
@@ -8055,6 +8123,10 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
 // hipGraphExecEventWaitNodeSetEvent[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'hNode'), ('hipEvent_t', 'event')]
     case HIP_API_ID_hipGraphExecEventWaitNodeSetEvent:
       break;
+// hipGraphExecExtMemcpyBatchNodeSetParams[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'node'), ('const hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+    case HIP_API_ID_hipGraphExecExtMemcpyBatchNodeSetParams:
+      if (data->args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams) data->args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams__val = *(data->args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams);
+      break;
 // hipGraphExecExternalSemaphoresSignalNodeSetParams[('hipGraphExec_t', 'hGraphExec'), ('hipGraphNode_t', 'hNode'), ('const hipExternalSemaphoreSignalNodeParams*', 'nodeParams')]
     case HIP_API_ID_hipGraphExecExternalSemaphoresSignalNodeSetParams:
       if (data->args.hipGraphExecExternalSemaphoresSignalNodeSetParams.nodeParams) data->args.hipGraphExecExternalSemaphoresSignalNodeSetParams.nodeParams__val = *(data->args.hipGraphExecExternalSemaphoresSignalNodeSetParams.nodeParams);
@@ -8100,6 +8172,14 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
     case HIP_API_ID_hipGraphExecUpdate:
       if (data->args.hipGraphExecUpdate.hErrorNode_out) data->args.hipGraphExecUpdate.hErrorNode_out__val = *(data->args.hipGraphExecUpdate.hErrorNode_out);
       if (data->args.hipGraphExecUpdate.updateResult_out) data->args.hipGraphExecUpdate.updateResult_out__val = *(data->args.hipGraphExecUpdate.updateResult_out);
+      break;
+// hipGraphExtMemcpyBatchNodeGetParams[('hipGraphNode_t', 'node'), ('hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeGetParams:
+      if (data->args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams) data->args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams__val = *(data->args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams);
+      break;
+// hipGraphExtMemcpyBatchNodeSetParams[('hipGraphNode_t', 'node'), ('const hipExtMemcpyBatchNodeParams*', 'pNodeParams')]
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeSetParams:
+      if (data->args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams) data->args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams__val = *(data->args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams);
       break;
 // hipGraphExternalSemaphoresSignalNodeGetParams[('hipGraphNode_t', 'hNode'), ('hipExternalSemaphoreSignalNodeParams*', 'params_out')]
     case HIP_API_ID_hipGraphExternalSemaphoresSignalNodeGetParams:
@@ -10313,6 +10393,18 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << ", event="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddEventWaitNode.event);
       oss << ")";
     break;
+    case HIP_API_ID_hipGraphAddExtMemcpyBatchNode:
+      oss << "hipGraphAddExtMemcpyBatchNode(";
+      if (data->args.hipGraphAddExtMemcpyBatchNode.pGraphNode == NULL) oss << "pGraphNode=NULL";
+      else { oss << "pGraphNode="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddExtMemcpyBatchNode.pGraphNode__val); }
+      oss << ", graph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddExtMemcpyBatchNode.graph);
+      if (data->args.hipGraphAddExtMemcpyBatchNode.pDependencies == NULL) oss << ", pDependencies=NULL";
+      else { oss << ", pDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddExtMemcpyBatchNode.pDependencies__val); }
+      oss << ", numDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddExtMemcpyBatchNode.numDependencies);
+      if (data->args.hipGraphAddExtMemcpyBatchNode.nodeParams == NULL) oss << ", nodeParams=NULL";
+      else { oss << ", nodeParams="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddExtMemcpyBatchNode.nodeParams__val); }
+      oss << ")";
+    break;
     case HIP_API_ID_hipGraphAddExternalSemaphoresSignalNode:
       oss << "hipGraphAddExternalSemaphoresSignalNode(";
       if (data->args.hipGraphAddExternalSemaphoresSignalNode.pGraphNode == NULL) oss << "pGraphNode=NULL";
@@ -10577,6 +10669,14 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << ", event="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecEventWaitNodeSetEvent.event);
       oss << ")";
     break;
+    case HIP_API_ID_hipGraphExecExtMemcpyBatchNodeSetParams:
+      oss << "hipGraphExecExtMemcpyBatchNodeSetParams(";
+      oss << "hGraphExec="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecExtMemcpyBatchNodeSetParams.hGraphExec);
+      oss << ", node="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecExtMemcpyBatchNodeSetParams.node);
+      if (data->args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams == NULL) oss << ", pNodeParams=NULL";
+      else { oss << ", pNodeParams="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecExtMemcpyBatchNodeSetParams.pNodeParams__val); }
+      oss << ")";
+    break;
     case HIP_API_ID_hipGraphExecExternalSemaphoresSignalNodeSetParams:
       oss << "hipGraphExecExternalSemaphoresSignalNodeSetParams(";
       oss << "hGraphExec="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecExternalSemaphoresSignalNodeSetParams.hGraphExec);
@@ -10680,6 +10780,20 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       else { oss << ", hErrorNode_out="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecUpdate.hErrorNode_out__val); }
       if (data->args.hipGraphExecUpdate.updateResult_out == NULL) oss << ", updateResult_out=NULL";
       else { oss << ", updateResult_out="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExecUpdate.updateResult_out__val); }
+      oss << ")";
+    break;
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeGetParams:
+      oss << "hipGraphExtMemcpyBatchNodeGetParams(";
+      oss << "node="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExtMemcpyBatchNodeGetParams.node);
+      if (data->args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams == NULL) oss << ", pNodeParams=NULL";
+      else { oss << ", pNodeParams="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExtMemcpyBatchNodeGetParams.pNodeParams__val); }
+      oss << ")";
+    break;
+    case HIP_API_ID_hipGraphExtMemcpyBatchNodeSetParams:
+      oss << "hipGraphExtMemcpyBatchNodeSetParams(";
+      oss << "node="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExtMemcpyBatchNodeSetParams.node);
+      if (data->args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams == NULL) oss << ", pNodeParams=NULL";
+      else { oss << ", pNodeParams="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphExtMemcpyBatchNodeSetParams.pNodeParams__val); }
       oss << ")";
     break;
     case HIP_API_ID_hipGraphExternalSemaphoresSignalNodeGetParams:

--- a/projects/clr/hipamd/src/amdhip.def.in
+++ b/projects/clr/hipamd/src/amdhip.def.in
@@ -560,4 +560,8 @@ hipExecutionCtxRecordEvent
 hipExecutionCtxSynchronize
 hipExecutionCtxWaitEvent
 hipMemGetDefaultMemPool
+hipGraphAddExtMemcpyBatchNode
+hipGraphExtMemcpyBatchNodeGetParams
+hipGraphExtMemcpyBatchNodeSetParams
+hipGraphExecExtMemcpyBatchNodeSetParams
 @HSA_EXPORTS@

--- a/projects/clr/hipamd/src/hip_api_trace.cpp
+++ b/projects/clr/hipamd/src/hip_api_trace.cpp
@@ -937,6 +937,16 @@ hipError_t hipExecutionCtxSynchronize(hipExecutionCtx_t ctx);
 hipError_t hipExecutionCtxWaitEvent(hipExecutionCtx_t ctx, hipEvent_t event);
 hipError_t hipMemGetDefaultMemPool(hipMemPool_t* memPool, hipMemLocation* location,
                                    hipMemAllocationType type);
+hipError_t hipGraphAddExtMemcpyBatchNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
+                                         const hipGraphNode_t* pDependencies,
+                                         size_t numDependencies,
+                                         const hipExtMemcpyBatchNodeParams* nodeParams);
+hipError_t hipGraphExtMemcpyBatchNodeGetParams(hipGraphNode_t node,
+                                               hipExtMemcpyBatchNodeParams* pNodeParams);
+hipError_t hipGraphExtMemcpyBatchNodeSetParams(hipGraphNode_t node,
+                                               const hipExtMemcpyBatchNodeParams* pNodeParams);
+hipError_t hipGraphExecExtMemcpyBatchNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t node,
+                                                   const hipExtMemcpyBatchNodeParams* pNodeParams);
 }  // namespace hip
 
 namespace hip {
@@ -1521,6 +1531,13 @@ void UpdateDispatchTable(HipDispatchTable* ptrDispatchTable) {
   ptrDispatchTable->hipExecutionCtxSynchronize_fn = hip::hipExecutionCtxSynchronize;
   ptrDispatchTable->hipExecutionCtxWaitEvent_fn = hip::hipExecutionCtxWaitEvent;
   ptrDispatchTable->hipMemGetDefaultMemPool_fn = hip::hipMemGetDefaultMemPool;
+  ptrDispatchTable->hipGraphAddExtMemcpyBatchNode_fn = hip::hipGraphAddExtMemcpyBatchNode;
+  ptrDispatchTable->hipGraphExtMemcpyBatchNodeGetParams_fn =
+      hip::hipGraphExtMemcpyBatchNodeGetParams;
+  ptrDispatchTable->hipGraphExtMemcpyBatchNodeSetParams_fn =
+      hip::hipGraphExtMemcpyBatchNodeSetParams;
+  ptrDispatchTable->hipGraphExecExtMemcpyBatchNodeSetParams_fn =
+      hip::hipGraphExecExtMemcpyBatchNodeSetParams;
 }
 
 #if HIP_ROCPROFILER_REGISTER > 0
@@ -2256,15 +2273,20 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipMemDiscardAndPrefetchBatchAsync_fn, 539);
 HIP_ENFORCE_ABI(HipDispatchTable, hipDrvMemDiscardAndPrefetchBatchAsync_fn, 540);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 31
 HIP_ENFORCE_ABI(HipDispatchTable, hipMemGetDefaultMemPool_fn, 541);
+// HIP_RUNTIME_API_TABLE_STEP_VERSION == 32
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphAddExtMemcpyBatchNode_fn, 542);
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphExtMemcpyBatchNodeGetParams_fn, 543);
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphExtMemcpyBatchNodeSetParams_fn, 544);
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphExecExtMemcpyBatchNodeSetParams_fn, 545);
 // if HIP_ENFORCE_ABI entries are added for each new function pointer in the table, the number below
 // will be +1 of the number in the last HIP_ENFORCE_ABI line. E.g.:
 //
 //  HIP_ENFORCE_ABI(<table>, <functor>, 8)
 //
 //  HIP_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 542)
+HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 546)
 
-static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 31,
+static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 32,
               "If you get this error, add new HIP_ENFORCE_ABI(...) code for the new function "
               "pointers and then update this check so it is true");
 #endif

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3792,6 +3792,156 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
   HIP_RETURN(reinterpret_cast<hip::hipGraphBatchMemOpNode*>(clonedNode)->SetParams(nodeParams));
 }
 
+// Mirrors the argument validation hipMemcpyBatchAsync performs before reaching the backend, so a
+// batch rejected on a stream is rejected identically when recorded as a node.
+static hipError_t ValidateExtMemcpyBatchNodeParams(const hipExtMemcpyBatchNodeParams* params) {
+  if (params == nullptr || params->dsts == nullptr || params->srcs == nullptr ||
+      params->sizes == nullptr || params->count == 0) {
+    return hipErrorInvalidValue;
+  }
+
+  if (params->numAttrs > 0) {
+    if (params->attrs == nullptr || params->attrsIdxs == nullptr ||
+        params->numAttrs > params->count || params->attrsIdxs[0] != 0) {
+      return hipErrorInvalidValue;
+    }
+    for (size_t attr_idx = 1; attr_idx < params->numAttrs; ++attr_idx) {
+      if (params->attrsIdxs[attr_idx] <= params->attrsIdxs[attr_idx - 1] ||
+          params->attrsIdxs[attr_idx] >= params->count) {
+        return hipErrorInvalidValue;
+      }
+    }
+    const unsigned int kIndirectFlagMask =
+        hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;
+    for (size_t attr_idx = 0; attr_idx < params->numAttrs; ++attr_idx) {
+      const hipMemcpyAttributes& attr = params->attrs[attr_idx];
+      if (attr.srcAccessOrder < hipMemcpySrcAccessOrderStream ||
+          attr.srcAccessOrder > hipMemcpySrcAccessOrderAny) {
+        return hipErrorInvalidValue;
+      }
+      if ((attr.flags & hipMemcpyFlagExtOpSwap) && (attr.flags & kIndirectFlagMask)) {
+        return hipErrorInvalidValue;
+      }
+    }
+  }
+
+  for (size_t copy_idx = 0; copy_idx < params->count; ++copy_idx) {
+    if (params->dsts[copy_idx] == nullptr || params->srcs[copy_idx] == nullptr ||
+        params->sizes[copy_idx] == 0) {
+      return hipErrorInvalidValue;
+    }
+  }
+  return hipSuccess;
+}
+
+hipError_t hipGraphAddExtMemcpyBatchNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
+                                         const hipGraphNode_t* pDependencies,
+                                         size_t numDependencies,
+                                         const hipExtMemcpyBatchNodeParams* nodeParams) {
+  HIP_INIT_API(hipGraphAddExtMemcpyBatchNode, pGraphNode, graph, pDependencies, numDependencies,
+               nodeParams);
+  if (pGraphNode == nullptr || graph == nullptr ||
+      (numDependencies > 0 && pDependencies == nullptr)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hipError_t status = ValidateExtMemcpyBatchNodeParams(nodeParams);
+  if (status != hipSuccess) {
+    HIP_RETURN(status);
+  }
+
+  hip::GraphNode* node = new hip::GraphExtMemcpyBatchNode(nodeParams);
+  status = ihipGraphAddNode(node, reinterpret_cast<hip::Graph*>(graph),
+                            reinterpret_cast<hip::GraphNode* const*>(pDependencies),
+                            numDependencies);
+  *pGraphNode = reinterpret_cast<hipGraphNode_t>(node);
+  HIP_RETURN(status);
+}
+
+hipError_t hipGraphExtMemcpyBatchNodeGetParams(hipGraphNode_t node,
+                                               hipExtMemcpyBatchNodeParams* pNodeParams) {
+  HIP_INIT_API(hipGraphExtMemcpyBatchNodeGetParams, node, pNodeParams);
+  hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(node);
+  if (!hip::GraphNode::isNodeValid(n) || pNodeParams == nullptr ||
+      n->GetType() != hipGraphNodeTypeExtMemcpyBatch) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  reinterpret_cast<hip::GraphExtMemcpyBatchNode*>(n)->GetParams(pNodeParams);
+  HIP_RETURN(hipSuccess);
+}
+
+hipError_t hipGraphExtMemcpyBatchNodeSetParams(hipGraphNode_t node,
+                                               const hipExtMemcpyBatchNodeParams* pNodeParams) {
+  HIP_INIT_API(hipGraphExtMemcpyBatchNodeSetParams, node, pNodeParams);
+  hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(node);
+  if (!hip::GraphNode::isNodeValid(n) || n->GetType() != hipGraphNodeTypeExtMemcpyBatch) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hipError_t status = ValidateExtMemcpyBatchNodeParams(pNodeParams);
+  if (status != hipSuccess) {
+    HIP_RETURN(status);
+  }
+  HIP_RETURN(reinterpret_cast<hip::GraphExtMemcpyBatchNode*>(n)->SetParams(pNodeParams));
+}
+
+hipError_t hipGraphExecExtMemcpyBatchNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t node,
+                                                   const hipExtMemcpyBatchNodeParams* pNodeParams) {
+  HIP_INIT_API(hipGraphExecExtMemcpyBatchNodeSetParams, hGraphExec, node, pNodeParams);
+  hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(node);
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
+  if (!hip::GraphExecBase::isGraphExecValid(graphExec) || !hip::GraphNode::isNodeValid(n) ||
+      n->GetType() != hipGraphNodeTypeExtMemcpyBatch) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hipError_t status = ValidateExtMemcpyBatchNodeParams(pNodeParams);
+  if (status != hipSuccess) {
+    HIP_RETURN(status);
+  }
+
+  hip::GraphNode* clonedNode = graphExec->GetClonedNode(n);
+  if (clonedNode == nullptr) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  // Topology is fixed once instantiated, and the batch size is part of the work the node was
+  // scheduled with, so only the contents of the batch may be updated.
+  auto* batchNode = reinterpret_cast<hip::GraphExtMemcpyBatchNode*>(clonedNode);
+  if (batchNode->GetCount() != pNodeParams->count) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  HIP_RETURN(batchNode->SetParams(pNodeParams));
+}
+
+hipError_t capturehipMemcpyBatchAsync(hipStream_t& stream, void**& dsts, void**& srcs,
+                                      size_t*& sizes, size_t& count, hipMemcpyAttributes*& attrs,
+                                      size_t*& attrsIdxs, size_t& numAttrs, size_t*& failIdx) {
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] Current capture node MemcpyBatch on stream : %p", stream);
+  if (failIdx != nullptr) *failIdx = SIZE_MAX;
+
+  hipExtMemcpyBatchNodeParams nodeParams{};
+  nodeParams.dsts = dsts;
+  nodeParams.srcs = srcs;
+  nodeParams.sizes = sizes;
+  nodeParams.count = count;
+  nodeParams.attrs = attrs;
+  nodeParams.attrsIdxs = attrsIdxs;
+  nodeParams.numAttrs = numAttrs;
+
+  hipError_t status = ValidateExtMemcpyBatchNodeParams(&nodeParams);
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
+  hip::GraphNode* node = new hip::GraphExtMemcpyBatchNode(&nodeParams);
+  status = ihipGraphAddNode(node, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
+                            s->GetLastCapturedNodes().size());
+  if (status != hipSuccess) {
+    return status;
+  }
+  s->SetLastCapturedNode(node);
+  return hipSuccess;
+}
+
 hipError_t capturehipStreamBatchMemOp(hipStream_t& stream, unsigned int& count,
                                       hipStreamBatchMemOpParams*& paramArray,
                                       unsigned int& flags) {

--- a/projects/clr/hipamd/src/hip_graph_capture.hpp
+++ b/projects/clr/hipamd/src/hip_graph_capture.hpp
@@ -106,6 +106,10 @@ hipError_t capturehipStreamBatchMemOp(hipStream_t& stream, unsigned int& count,
                                       hipStreamBatchMemOpParams*& paramArray,
                                       unsigned int& flags);
 
+hipError_t capturehipMemcpyBatchAsync(hipStream_t& stream, void**& dsts, void**& srcs,
+                                      size_t*& sizes, size_t& count, hipMemcpyAttributes*& attrs,
+                                      size_t*& attrsIdxs, size_t& numAttrs, size_t*& failIdx);
+
 hipError_t capturehipStreamWaitValue32(hipStream_t& stream, void*& ptr, uint32_t& value,
                                        unsigned int& flags, uint32_t& mask);
 

--- a/projects/clr/hipamd/src/hip_graph_helper.hpp
+++ b/projects/clr/hipamd/src/hip_graph_helper.hpp
@@ -28,6 +28,11 @@ hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, amd
                              size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
                              size_t dstOffset, size_t srcOffset, bool isAsync = true);
 
+hipError_t ihipMemcpyBatchCreateCommands(void** dsts, void** srcs, size_t* sizes, size_t count,
+                                         hipMemcpyAttributes* attrs, size_t* attrsIdxs,
+                                         size_t numAttrs, hip::Stream& stream,
+                                         std::vector<amd::Command*>& commands);
+
 void ihipHtoHMemcpy(void* dst, const void* src, size_t sizeBytes, hip::Stream& stream);
 
 bool IsHtoHMemcpy(void* dst, const void* src);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -28,6 +28,8 @@ const char* GetGraphNodeTypeString(uint32_t op) {
     CASE_STRING(hipGraphNodeTypeMemFree, MemFreeNode)
     CASE_STRING(hipGraphNodeTypeMemcpyFromSymbol, MemcpyFromSymbolNode)
     CASE_STRING(hipGraphNodeTypeMemcpyToSymbol, MemcpyToSymbolNode)
+    CASE_STRING(hipGraphNodeTypeBatchMemOp, BatchMemOpNode)
+    CASE_STRING(hipGraphNodeTypeExtMemcpyBatch, ExtMemcpyBatchNode)
     default:
       case_string = "Unknown node type";
   };

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -3673,4 +3673,108 @@ class hipGraphBatchMemOpNode : public GraphNode {
   }
 };
 
+// A batch of 1D copies executed as a single node. The batch is submitted as one or more
+// amd::Batch*MemoryCommand, so the copies within it are unordered with respect to each other.
+class GraphExtMemcpyBatchNode : public GraphNode {
+  std::vector<void*> dsts_;
+  std::vector<void*> srcs_;
+  std::vector<size_t> sizes_;
+  std::vector<hipMemcpyAttributes> attrs_;
+  std::vector<size_t> attrsIdxs_;
+
+  void copyParams(const hipExtMemcpyBatchNodeParams* params) {
+    // Deep-copy every array: the caller's storage may be freed before the graph is launched.
+    dsts_.assign(params->dsts, params->dsts + params->count);
+    srcs_.assign(params->srcs, params->srcs + params->count);
+    sizes_.assign(params->sizes, params->sizes + params->count);
+    if (params->numAttrs > 0) {
+      attrs_.assign(params->attrs, params->attrs + params->numAttrs);
+      attrsIdxs_.assign(params->attrsIdxs, params->attrsIdxs + params->numAttrs);
+    } else {
+      attrs_.clear();
+      attrsIdxs_.clear();
+    }
+  }
+
+ protected:
+  // Copy constructor is needed for cloning the node, but it should not be used for any other
+  // purpose. To prevent accidental misuse, the copy-assignment operator is deleted.
+  GraphExtMemcpyBatchNode(const GraphExtMemcpyBatchNode& rhs)
+      : GraphNode(rhs),
+        dsts_(rhs.dsts_),
+        srcs_(rhs.srcs_),
+        sizes_(rhs.sizes_),
+        attrs_(rhs.attrs_),
+        attrsIdxs_(rhs.attrsIdxs_) {}
+
+ public:
+  GraphExtMemcpyBatchNode(const hipExtMemcpyBatchNodeParams* params)
+      : GraphNode(hipGraphNodeTypeExtMemcpyBatch, "solid", "rectangle", "EXT_MEMCPY_BATCH_NODE") {
+    copyParams(params);
+  }
+
+  // Delete copy-assignment operator to prevent accidental copies causing unexpected behaviors.
+  GraphExtMemcpyBatchNode& operator=(const GraphExtMemcpyBatchNode&) = delete;
+
+  GraphNode* clone() const override { return new GraphExtMemcpyBatchNode(*this); }
+
+  size_t GetCount() const { return sizes_.size(); }
+
+  hipError_t CreateCommand(hip::Stream* stream) override {
+    hipError_t status = GraphNode::CreateCommand(stream);
+    if (status != hipSuccess) {
+      return status;
+    }
+    if (!isEnabled_) {
+      return hipSuccess;
+    }
+    return ihipMemcpyBatchCreateCommands(
+        dsts_.data(), srcs_.data(), sizes_.data(), sizes_.size(),
+        attrs_.empty() ? nullptr : attrs_.data(),
+        attrsIdxs_.empty() ? nullptr : attrsIdxs_.data(), attrs_.size(), *stream, commands_);
+  }
+
+  // The returned arrays alias the node's own storage, matching the documented contract that they
+  // are owned by the node and valid until it is destroyed or its parameters change.
+  void GetParams(hipExtMemcpyBatchNodeParams* params) {
+    params->dsts = dsts_.data();
+    params->srcs = srcs_.data();
+    params->sizes = sizes_.data();
+    params->count = sizes_.size();
+    params->attrs = attrs_.empty() ? nullptr : attrs_.data();
+    params->attrsIdxs = attrsIdxs_.empty() ? nullptr : attrsIdxs_.data();
+    params->numAttrs = attrs_.size();
+  }
+
+  hipError_t SetParams(const hipExtMemcpyBatchNodeParams* params) {
+    copyParams(params);
+    return hipSuccess;
+  }
+
+  // Used by hipGraphExecUpdate to copy the updated graph node's parameters onto the executable
+  // node. The batch size is part of the work the executable node was built for, so a batch that
+  // grew or shrank is reported as a parameter change rather than silently applied.
+  hipError_t SetParams(GraphNode* node) override {
+    const GraphExtMemcpyBatchNode* batchNode = static_cast<GraphExtMemcpyBatchNode const*>(node);
+    if (batchNode->sizes_.size() != sizes_.size()) {
+      return hipErrorInvalidValue;
+    }
+    dsts_ = batchNode->dsts_;
+    srcs_ = batchNode->srcs_;
+    sizes_ = batchNode->sizes_;
+    attrs_ = batchNode->attrs_;
+    attrsIdxs_ = batchNode->attrsIdxs_;
+    return hipSuccess;
+  }
+
+  virtual std::string GetLabel(hipGraphDebugDotFlags flag) override {
+    size_t total_bytes = 0;
+    for (size_t size : sizes_) {
+      total_bytes += size;
+    }
+    return std::to_string(GetID()) + "\n" + label_ + "\n" + std::to_string(sizes_.size()) +
+        " copies, " + std::to_string(total_bytes) + " bytes";
+  }
+};
+
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -703,6 +703,10 @@ local:
 hip_7.15 {
 global:
     hipMemGetDefaultMemPool;
+    hipGraphAddExtMemcpyBatchNode;
+    hipGraphExtMemcpyBatchNodeGetParams;
+    hipGraphExtMemcpyBatchNodeSetParams;
+    hipGraphExecExtMemcpyBatchNodeSetParams;
 local:
     *;
 } hip_7.14;

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2956,6 +2956,29 @@ static amd::CopyMetadata buildCopyMetadataFromAttrs(hipMemcpyAttributes* attrs, 
   return metadata;
 }
 
+// Builds the batch command covering one device's operation list. `operations` is consumed.
+template <typename Command, typename Operation>
+static amd::Command* CreateBatchCommand(std::vector<Operation>& operations,
+                                        cl_command_type command_type, hip::Stream& queue_stream,
+                                        const amd::Command::EventWaitList& wait_list) {
+  if constexpr (std::is_same_v<Operation, amd::BatchWriteMemoryOp>) {
+    std::vector<std::vector<char>> host_snapshots;
+    if (!AMD_DIRECT_DISPATCH) {
+      for (Operation& op : operations) {
+        if (op.metadata.srcAccessOrder_ == amd::CopyMetadata::kSrcAccessOrderDuringApiCall) {
+          host_snapshots.emplace_back(op.size);
+          std::memcpy(host_snapshots.back().data(), op.src_host, op.size);
+          op.src_host = host_snapshots.back().data();
+        }
+      }
+    }
+    return new amd::BatchWriteMemoryCommand(queue_stream, command_type, wait_list,
+                                            std::move(operations), std::move(host_snapshots));
+  } else {
+    return new Command(queue_stream, command_type, wait_list, std::move(operations));
+  }
+}
+
 template <typename Command, typename Operation>
 static hipError_t EnqueueBatchCommands(std::vector<std::vector<Operation>>& operations_by_device,
                                        cl_command_type command_type, hip::Stream& stream,
@@ -2975,23 +2998,8 @@ static hipError_t EnqueueBatchCommands(std::vector<std::vector<Operation>>& oper
       wait_list.push_back(stream_wait_cmd);
     }
 
-    Command* batch_cmd = nullptr;
-    if constexpr (std::is_same_v<Operation, amd::BatchWriteMemoryOp>) {
-      std::vector<std::vector<char>> host_snapshots;
-      if (!AMD_DIRECT_DISPATCH) {
-        for (Operation& op : operations) {
-          if (op.metadata.srcAccessOrder_ == amd::CopyMetadata::kSrcAccessOrderDuringApiCall) {
-            host_snapshots.emplace_back(op.size);
-            std::memcpy(host_snapshots.back().data(), op.src_host, op.size);
-            op.src_host = host_snapshots.back().data();
-          }
-        }
-      }
-      batch_cmd = new amd::BatchWriteMemoryCommand(
-          *queue_stream, command_type, wait_list, std::move(operations), std::move(host_snapshots));
-    } else {
-      batch_cmd = new Command(*queue_stream, command_type, wait_list, std::move(operations));
-    }
+    amd::Command* batch_cmd =
+        CreateBatchCommand<Command>(operations, command_type, *queue_stream, wait_list);
     if (batch_cmd == nullptr) {
       return hipErrorOutOfMemory;
     }
@@ -3018,9 +3026,25 @@ static inline unsigned int getBatchCopyFlags(hipMemcpyAttributes* attrs, size_t*
 }
 
 // ================================================================================================
-hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count,
-                           hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
-                           hip::Stream& stream, bool isAsync) {
+// Per-device operation lists produced by classifying a batch of 1D copies.
+struct BatchCopyClassification {
+  std::vector<std::vector<amd::BatchCopyOp>> copy_ops_by_device;
+  std::vector<std::vector<amd::BatchWriteMemoryOp>> write_ops_by_device;
+  std::vector<std::vector<amd::BatchReadMemoryOp>> read_ops_by_device;
+  std::vector<size_t> host_to_host_indices;
+
+  BatchCopyClassification()
+      : copy_ops_by_device(g_devices.size()),
+        write_ops_by_device(g_devices.size()),
+        read_ops_by_device(g_devices.size()) {}
+};
+
+// Validates a batch of 1D copies and sorts every entry into the operation list of the device
+// whose queue will run it. Shared by the immediate submission path and the graph node path.
+static hipError_t ClassifyMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count,
+                                      hipMemcpyAttributes* attrs, size_t* attrsIdxs,
+                                      size_t numAttrs, hip::Stream& stream, bool isAsync,
+                                      BatchCopyClassification& classification) {
   // Pre-compute memory objects once per copy to avoid repeated expensive
   // getMemoryObject calls later in validation, classification, and submission.
   std::vector<amd::Memory*> srcMemories(count, nullptr);
@@ -3098,11 +3122,9 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
   }
 
-  // Classify copies by type and group them by the queue device that will execute each batch.
-  std::vector<std::vector<amd::BatchCopyOp>> copy_ops_by_device(g_devices.size());
-  std::vector<std::vector<amd::BatchWriteMemoryOp>> write_ops_by_device(g_devices.size());
-  std::vector<std::vector<amd::BatchReadMemoryOp>> read_ops_by_device(g_devices.size());
-  std::vector<size_t> hostToHostIndices;
+  auto& copy_ops_by_device = classification.copy_ops_by_device;
+  auto& write_ops_by_device = classification.write_ops_by_device;
+  auto& read_ops_by_device = classification.read_ops_by_device;
 
   // The ExtOp flags (hipMemcpyFlagExtOpSwap / hipMemcpyFlagExtOpIndirect*) are
   // only honored by the SDMA batch path (BatchCopyMemoryCommand ->
@@ -3168,7 +3190,7 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
         break;
       }
       case hipHostToHost:
-        hostToHostIndices.push_back(i);
+        classification.host_to_host_indices.push_back(i);
         break;
       case hipWriteBuffer: {
         const int device_id = dstMemories[i]->getUserData().deviceId;
@@ -3185,12 +3207,28 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
   }
 
-  hipError_t status = hipSuccess;
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count,
+                           hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
+                           hip::Stream& stream, bool isAsync) {
+  BatchCopyClassification classification;
+  hipError_t status = ClassifyMemcpyBatch(dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs,
+                                          stream, isAsync, classification);
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  auto& copy_ops_by_device = classification.copy_ops_by_device;
+  auto& write_ops_by_device = classification.write_ops_by_device;
+  auto& read_ops_by_device = classification.read_ops_by_device;
 
   // Handle Host-to-Host copies synchronously
-  if (!hostToHostIndices.empty()) {
+  if (!classification.host_to_host_indices.empty()) {
     stream.finish();  // Wait for prior work before CPU copy
-    for (size_t idx : hostToHostIndices) {
+    for (size_t idx : classification.host_to_host_indices) {
       memcpy(dsts[idx], srcs[idx], sizes[idx]);
     }
   }
@@ -3242,11 +3280,75 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
 }
 
 // ================================================================================================
+hipError_t ihipMemcpyBatchCreateCommands(void** dsts, void** srcs, size_t* sizes, size_t count,
+                                         hipMemcpyAttributes* attrs, size_t* attrsIdxs,
+                                         size_t numAttrs, hip::Stream& stream,
+                                         std::vector<amd::Command*>& commands) {
+  BatchCopyClassification classification;
+  hipError_t status = ClassifyMemcpyBatch(dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs,
+                                          stream, /*isAsync=*/true, classification);
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  // A graph node is a set of commands on one stream. The two shapes the immediate path handles
+  // outside that model - a CPU memcpy after draining the stream, and submissions to another
+  // device's null stream joined by a marker - have no equivalent here.
+  if (!classification.host_to_host_indices.empty()) {
+    return hipErrorNotSupported;
+  }
+  const size_t stream_device = static_cast<size_t>(stream.DeviceId());
+  for (size_t device_id = 0; device_id < classification.copy_ops_by_device.size(); ++device_id) {
+    if (device_id != stream_device &&
+        (!classification.copy_ops_by_device[device_id].empty() ||
+         !classification.write_ops_by_device[device_id].empty() ||
+         !classification.read_ops_by_device[device_id].empty())) {
+      return hipErrorNotSupported;
+    }
+  }
+
+  const amd::Command::EventWaitList wait_list;
+  std::vector<amd::Command*> batch_commands;
+  auto& copy_ops = classification.copy_ops_by_device[stream_device];
+  auto& write_ops = classification.write_ops_by_device[stream_device];
+  auto& read_ops = classification.read_ops_by_device[stream_device];
+
+  if (!copy_ops.empty()) {
+    batch_commands.push_back(CreateBatchCommand<amd::BatchCopyMemoryCommand>(
+        copy_ops, ROCCLR_COMMAND_BATCH_COPY_BUFFER, stream, wait_list));
+  }
+  if (!write_ops.empty()) {
+    batch_commands.push_back(CreateBatchCommand<amd::BatchWriteMemoryCommand>(
+        write_ops, ROCCLR_COMMAND_BATCH_WRITE_BUFFER, stream, wait_list));
+  }
+  if (!read_ops.empty()) {
+    batch_commands.push_back(CreateBatchCommand<amd::BatchReadMemoryCommand>(
+        read_ops, ROCCLR_COMMAND_BATCH_READ_BUFFER, stream, wait_list));
+  }
+
+  for (amd::Command* command : batch_commands) {
+    if (command == nullptr) {
+      for (amd::Command* created : batch_commands) {
+        if (created != nullptr) {
+          created->release();
+        }
+      }
+      return hipErrorOutOfMemory;
+    }
+  }
+
+  commands.insert(commands.end(), batch_commands.begin(), batch_commands.end());
+  return hipSuccess;
+}
+
+// ================================================================================================
 hipError_t hipMemcpyBatchAsync(void** dsts, void** srcs, size_t* sizes, size_t count,
                                hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
                                size_t* failIdx, hipStream_t stream) {
   HIP_INIT_API(hipMemcpyBatchAsync, dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs, failIdx,
                stream);
+  STREAM_CAPTURE(hipMemcpyBatchAsync, stream, dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs,
+                 failIdx);
   // validate stream
   if (!hip::isValid(stream)) {
     HIP_RETURN(hipErrorInvalidResourceHandle);

--- a/projects/clr/hipamd/src/hip_table_interface.cpp
+++ b/projects/clr/hipamd/src/hip_table_interface.cpp
@@ -3353,3 +3353,31 @@ hipError_t hipMemGetDefaultMemPool(hipMemPool_t* memPool, hipMemLocation* locati
   return hip::GetHipDispatchTable()->hipMemGetDefaultMemPool_fn(memPool, location, type);
   CATCH;
 }
+hipError_t hipGraphAddExtMemcpyBatchNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
+                                         const hipGraphNode_t* pDependencies,
+                                         size_t numDependencies,
+                                         const hipExtMemcpyBatchNodeParams* nodeParams) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphAddExtMemcpyBatchNode_fn(
+      pGraphNode, graph, pDependencies, numDependencies, nodeParams);
+  CATCH;
+}
+hipError_t hipGraphExtMemcpyBatchNodeGetParams(hipGraphNode_t node,
+                                               hipExtMemcpyBatchNodeParams* pNodeParams) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphExtMemcpyBatchNodeGetParams_fn(node, pNodeParams);
+  CATCH;
+}
+hipError_t hipGraphExtMemcpyBatchNodeSetParams(hipGraphNode_t node,
+                                               const hipExtMemcpyBatchNodeParams* pNodeParams) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphExtMemcpyBatchNodeSetParams_fn(node, pNodeParams);
+  CATCH;
+}
+hipError_t hipGraphExecExtMemcpyBatchNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t node,
+                                                   const hipExtMemcpyBatchNodeParams* pNodeParams) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphExecExtMemcpyBatchNodeSetParams_fn(hGraphExec, node,
+                                                                               pNodeParams);
+  CATCH;
+}

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -834,6 +834,34 @@ graph:
   Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts:
     <<: *level_2
     tags: [node]
+  Unit_hipGraphAddExtMemcpyBatchNode_Positive_Basic:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [node]
+  Unit_hipGraphAddExtMemcpyBatchNode_Negative_Parameters:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [node]
+  Unit_hipGraphExtMemcpyBatchNode_Positive_GetSetParams:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [node]
+  Unit_hipGraphExecExtMemcpyBatchNodeSetParams_Positive_Basic:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [exec]
+  Unit_hipGraphExtMemcpyBatchNode_Positive_ExecUpdate:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [exec]
+  Unit_hipGraphExtMemcpyBatchNode_Positive_KernelDependencies:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [capture]
+  Unit_hipGraphExtMemcpyBatchNode_Positive_BroadcastPeerToPeer:
+    <<: *level_2
+    disabled: [nvidia]
+    tags: [multigpu]
   Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative:
     <<: *level_2
     tags: [exec]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -83,6 +83,8 @@ if(HIP_PLATFORM MATCHES "amd")
     hipStreamGetCaptureInfo_v2.cc
     hipStreamUpdateCaptureDependencies.cc
     hipGraphAddNodeBeginCapture.cc
+    # hipGraphAddExtMemcpyBatchNode and hipMemcpyBatchAsync are not mapped to Nvidia
+    hipGraphAddExtMemcpyBatchNode.cc
   )
   set(TEST_SRC ${TEST_SRC} ${AMD_SRC})
 endif()

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddExtMemcpyBatchNode.cc
@@ -1,0 +1,735 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_defgroups.hh>
+
+#include <numeric>
+#include <vector>
+
+/**
+ * @addtogroup hipGraphAddExtMemcpyBatchNode hipGraphAddExtMemcpyBatchNode
+ * @{
+ * @ingroup GraphTest
+ * `hipError_t hipGraphAddExtMemcpyBatchNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
+ * const hipGraphNode_t* pDependencies, size_t numDependencies,
+ * const hipExtMemcpyBatchNodeParams* nodeParams);`
+ * - Adds a batch of 1D memory copies to a graph as a single node.
+ *
+ * Also covers the accompanying parameter APIs:
+ * - hipGraphExtMemcpyBatchNodeGetParams
+ * - hipGraphExtMemcpyBatchNodeSetParams
+ * - hipGraphExecExtMemcpyBatchNodeSetParams
+ * - recording of hipMemcpyBatchAsync during stream capture
+ */
+
+static __global__ void EmptyKernel() { return; }
+
+namespace {
+
+constexpr size_t kNumCopies = 4;
+constexpr size_t kElems = 1024;
+constexpr size_t kBytes = kElems * sizeof(int);
+
+// A batch of device destinations fed from distinct host sources, held together so a test can
+// build node parameters and check the results without repeating the bookkeeping.
+class BatchBuffers {
+ public:
+  explicit BatchBuffers(int seed) : seed_(seed), host_(kNumCopies) {
+    for (size_t copy_idx = 0; copy_idx < kNumCopies; ++copy_idx) {
+      host_[copy_idx].resize(kElems);
+      std::iota(host_[copy_idx].begin(), host_[copy_idx].end(), seed + copy_idx * kElems);
+
+      void* device = nullptr;
+      HIP_CHECK(hipMalloc(&device, kBytes));
+      HIP_CHECK(hipMemset(device, 0, kBytes));
+      dsts_.push_back(device);
+      srcs_.push_back(host_[copy_idx].data());
+      sizes_.push_back(kBytes);
+    }
+  }
+
+  ~BatchBuffers() {
+    for (void* device : dsts_) {
+      static_cast<void>(hipFree(device));
+    }
+  }
+
+  BatchBuffers(const BatchBuffers&) = delete;
+  BatchBuffers& operator=(const BatchBuffers&) = delete;
+
+  hipExtMemcpyBatchNodeParams Params() {
+    hipExtMemcpyBatchNodeParams params{};
+    params.dsts = dsts_.data();
+    params.srcs = srcs_.data();
+    params.sizes = sizes_.data();
+    params.count = kNumCopies;
+    return params;
+  }
+
+  void ClearDevice() {
+    for (void* device : dsts_) {
+      HIP_CHECK(hipMemset(device, 0, kBytes));
+    }
+  }
+
+  void VerifyCopied() const {
+    std::vector<int> readback(kElems);
+    for (size_t copy_idx = 0; copy_idx < kNumCopies; ++copy_idx) {
+      HIP_CHECK(hipMemcpy(readback.data(), dsts_[copy_idx], kBytes, hipMemcpyDeviceToHost));
+      INFO("copy index " << copy_idx << " of batch seeded with " << seed_);
+      REQUIRE(readback == host_[copy_idx]);
+    }
+  }
+
+  void VerifyUntouched() const {
+    std::vector<int> readback(kElems);
+    for (size_t copy_idx = 0; copy_idx < kNumCopies; ++copy_idx) {
+      HIP_CHECK(hipMemcpy(readback.data(), dsts_[copy_idx], kBytes, hipMemcpyDeviceToHost));
+      INFO("copy index " << copy_idx << " of batch seeded with " << seed_);
+      REQUIRE(readback == std::vector<int>(kElems, 0));
+    }
+  }
+
+  void** dsts() { return dsts_.data(); }
+  void** srcs() { return srcs_.data(); }
+  size_t* sizes() { return sizes_.data(); }
+
+ private:
+  int seed_;
+  std::vector<std::vector<int>> host_;
+  std::vector<void*> dsts_;
+  std::vector<void*> srcs_;
+  std::vector<size_t> sizes_;
+};
+
+size_t GetNodeCount(hipGraph_t graph) {
+  size_t num_nodes = 0;
+  HIP_CHECK(hipGraphGetNodes(graph, nullptr, &num_nodes));
+  return num_nodes;
+}
+
+hipGraphNode_t GetOnlyNode(hipGraph_t graph) {
+  size_t num_nodes = 1;
+  hipGraphNode_t node = nullptr;
+  HIP_CHECK(hipGraphGetNodes(graph, &node, &num_nodes));
+  return node;
+}
+
+hipGraphNode_t FindBatchNode(hipGraph_t graph) {
+  size_t num_nodes = GetNodeCount(graph);
+  std::vector<hipGraphNode_t> nodes(num_nodes);
+  HIP_CHECK(hipGraphGetNodes(graph, nodes.data(), &num_nodes));
+  for (hipGraphNode_t candidate : nodes) {
+    hipGraphNodeType node_type;
+    HIP_CHECK(hipGraphNodeGetType(candidate, &node_type));
+    if (node_type == hipGraphNodeTypeExtMemcpyBatch) return candidate;
+  }
+  return nullptr;
+}
+
+hipKernelNodeParams EmptyKernelNodeParams() {
+  hipKernelNodeParams params{};
+  params.func = reinterpret_cast<void*>(EmptyKernel);
+  params.gridDim = dim3(1, 1, 1);
+  params.blockDim = dim3(1, 1, 1);
+  params.sharedMemBytes = 0;
+  params.kernelParams = nullptr;
+  params.extra = nullptr;
+  return params;
+}
+
+// The two supported ways of getting a batch into a graph. Both must produce an equivalent node,
+// so tests that care about node behaviour rather than construction run against each.
+enum class BuildMethod { kExplicitNode, kStreamCapture };
+
+const char* ToString(BuildMethod method) {
+  return method == BuildMethod::kExplicitNode ? "hipGraphAddExtMemcpyBatchNode"
+                                              : "hipStreamBeginCapture/hipStreamEndCapture";
+}
+
+// Builds a single-node graph holding the given batch, either by adding the node directly or by
+// capturing an equivalent hipMemcpyBatchAsync. Returns the graph and its lone node.
+void BuildBatchGraph(BuildMethod method, const hipExtMemcpyBatchNodeParams& params,
+                     hipGraph_t* graph, hipGraphNode_t* node) {
+  if (method == BuildMethod::kExplicitNode) {
+    HIP_CHECK(hipGraphCreate(graph, 0));
+    HIP_CHECK(hipGraphAddExtMemcpyBatchNode(node, *graph, nullptr, 0, &params));
+  } else {
+    hipStream_t stream = nullptr;
+    HIP_CHECK(hipStreamCreate(&stream));
+    HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    size_t fail_idx = 0;
+    HIP_CHECK(hipMemcpyBatchAsync(params.dsts, params.srcs, params.sizes, params.count,
+                                  params.attrs, params.attrsIdxs, params.numAttrs, &fail_idx,
+                                  stream));
+    HIP_CHECK(hipStreamEndCapture(stream, graph));
+    HIP_CHECK(hipStreamDestroy(stream));
+    *node = GetOnlyNode(*graph);
+  }
+
+  REQUIRE(GetNodeCount(*graph) == 1);
+  hipGraphNodeType node_type;
+  HIP_CHECK(hipGraphNodeGetType(*node, &node_type));
+  REQUIRE(node_type == hipGraphNodeTypeExtMemcpyBatch);
+}
+
+}  // anonymous namespace
+
+/**
+ * Test Description
+ * ------------------------
+ * - Adds a batch of copies as a single node, verifies the node type, and checks that launching
+ *   the instantiated graph performs every copy in the batch.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphAddExtMemcpyBatchNode_Positive_Basic) {
+  // The whole batch must collapse into one node rather than one node per copy, whichever way the
+  // graph is built.
+  const auto method = GENERATE(BuildMethod::kExplicitNode, BuildMethod::kStreamCapture);
+  INFO("graph built with " << ToString(method));
+
+  BatchBuffers buffers(/*seed=*/1);
+  hipExtMemcpyBatchNodeParams params = buffers.Params();
+
+  hipGraph_t graph = nullptr;
+  hipGraphNode_t node = nullptr;
+  BuildBatchGraph(method, params, &graph, &node);
+
+  // Capture must defer the work rather than perform it.
+  buffers.VerifyUntouched();
+
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  buffers.VerifyCopied();
+
+  // The node owns a copy of the parameter arrays, so a relaunch must repeat the same work.
+  buffers.ClearDevice();
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  buffers.VerifyCopied();
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies the negative cases of hipGraphAddExtMemcpyBatchNode.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphAddExtMemcpyBatchNode_Negative_Parameters) {
+  BatchBuffers buffers(/*seed=*/2);
+  hipExtMemcpyBatchNodeParams params = buffers.Params();
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  hipGraphNode_t node = nullptr;
+
+  SECTION("Node as null pointer") {
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(nullptr, graph, nullptr, 0, &params),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Graph as null pointer") {
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, nullptr, nullptr, 0, &params),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Node params as null pointer") {
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, nullptr),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Dependencies as null pointer with non-zero count") {
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 1, &params),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Copy count is zero") {
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.count = 0;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Destination array as null pointer") {
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.dsts = nullptr;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Source array as null pointer") {
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.srcs = nullptr;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Size array as null pointer") {
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.sizes = nullptr;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("A single destination entry is null") {
+    std::vector<void*> dsts(buffers.dsts(), buffers.dsts() + kNumCopies);
+    dsts[kNumCopies - 1] = nullptr;
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.dsts = dsts.data();
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("A single copy size is zero") {
+    std::vector<size_t> sizes(buffers.sizes(), buffers.sizes() + kNumCopies);
+    sizes[1] = 0;
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.sizes = sizes.data();
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Attributes array as null pointer with non-zero count") {
+    size_t attrs_idx = 0;
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.attrs = nullptr;
+    invalid.attrsIdxs = &attrs_idx;
+    invalid.numAttrs = 1;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("First attribute index does not start at zero") {
+    hipMemcpyAttributes attrs{};
+    attrs.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+    size_t attrs_idx = 1;
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.attrs = &attrs;
+    invalid.attrsIdxs = &attrs_idx;
+    invalid.numAttrs = 1;
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("More attributes than copies") {
+    std::vector<hipMemcpyAttributes> attrs(kNumCopies + 1);
+    std::vector<size_t> attrs_idxs(kNumCopies + 1);
+    std::iota(attrs_idxs.begin(), attrs_idxs.end(), 0);
+    for (auto& attr : attrs) attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+    hipExtMemcpyBatchNodeParams invalid = params;
+    invalid.attrs = attrs.data();
+    invalid.attrsIdxs = attrs_idxs.data();
+    invalid.numAttrs = attrs.size();
+    HIP_CHECK_ERROR(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &invalid),
+                    hipErrorInvalidValue);
+  }
+
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that hipGraphExtMemcpyBatchNodeGetParams returns the batch the node was created
+ *   with, and that hipGraphExtMemcpyBatchNodeSetParams retargets the node before instantiation.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphExtMemcpyBatchNode_Positive_GetSetParams) {
+  BatchBuffers original(/*seed=*/3);
+  BatchBuffers replacement(/*seed=*/4);
+  hipExtMemcpyBatchNodeParams params = original.Params();
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  hipGraphNode_t node = nullptr;
+  HIP_CHECK(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &params));
+
+  hipExtMemcpyBatchNodeParams readback{};
+  HIP_CHECK(hipGraphExtMemcpyBatchNodeGetParams(node, &readback));
+  REQUIRE(readback.count == kNumCopies);
+  for (size_t copy_idx = 0; copy_idx < kNumCopies; ++copy_idx) {
+    INFO("copy index " << copy_idx);
+    REQUIRE(readback.dsts[copy_idx] == original.dsts()[copy_idx]);
+    REQUIRE(readback.srcs[copy_idx] == original.srcs()[copy_idx]);
+    REQUIRE(readback.sizes[copy_idx] == original.sizes()[copy_idx]);
+  }
+
+  hipExtMemcpyBatchNodeParams updated = replacement.Params();
+  HIP_CHECK(hipGraphExtMemcpyBatchNodeSetParams(node, &updated));
+  HIP_CHECK(hipGraphExtMemcpyBatchNodeGetParams(node, &readback));
+  REQUIRE(readback.dsts[0] == replacement.dsts()[0]);
+
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  replacement.VerifyCopied();
+  original.VerifyUntouched();
+
+  SECTION("Get params on a null node") {
+    HIP_CHECK_ERROR(hipGraphExtMemcpyBatchNodeGetParams(nullptr, &readback), hipErrorInvalidValue);
+  }
+
+  SECTION("Get params into a null pointer") {
+    HIP_CHECK_ERROR(hipGraphExtMemcpyBatchNodeGetParams(node, nullptr), hipErrorInvalidValue);
+  }
+
+  SECTION("Set params from a null pointer") {
+    HIP_CHECK_ERROR(hipGraphExtMemcpyBatchNodeSetParams(node, nullptr), hipErrorInvalidValue);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that hipGraphExecExtMemcpyBatchNodeSetParams retargets an instantiated graph, and
+ *   that changing the number of copies is rejected because the batch size is fixed at
+ *   instantiation.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphExecExtMemcpyBatchNodeSetParams_Positive_Basic) {
+  BatchBuffers original(/*seed=*/5);
+  BatchBuffers replacement(/*seed=*/6);
+  hipExtMemcpyBatchNodeParams params = original.Params();
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  hipGraphNode_t node = nullptr;
+  HIP_CHECK(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &params));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  hipExtMemcpyBatchNodeParams updated = replacement.Params();
+  HIP_CHECK(hipGraphExecExtMemcpyBatchNodeSetParams(graph_exec, node, &updated));
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  replacement.VerifyCopied();
+  original.VerifyUntouched();
+
+  SECTION("Changing the copy count is rejected") {
+    hipExtMemcpyBatchNodeParams resized = replacement.Params();
+    resized.count = kNumCopies - 1;
+    HIP_CHECK_ERROR(hipGraphExecExtMemcpyBatchNodeSetParams(graph_exec, node, &resized),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Null exec graph is rejected") {
+    HIP_CHECK_ERROR(hipGraphExecExtMemcpyBatchNodeSetParams(nullptr, node, &updated),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Null node is rejected") {
+    HIP_CHECK_ERROR(hipGraphExecExtMemcpyBatchNodeSetParams(graph_exec, nullptr, &updated),
+                    hipErrorInvalidValue);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that hipGraphExecUpdate propagates a retargeted batch node into an already
+ *   instantiated graph, and reports a parameter change when the batch size differs.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphExtMemcpyBatchNode_Positive_ExecUpdate) {
+  BatchBuffers original(/*seed=*/7);
+  BatchBuffers replacement(/*seed=*/8);
+  hipExtMemcpyBatchNodeParams params = original.Params();
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  hipGraphNode_t node = nullptr;
+  HIP_CHECK(hipGraphAddExtMemcpyBatchNode(&node, graph, nullptr, 0, &params));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  // Retargeting the graph node alone must not disturb the already instantiated exec.
+  hipExtMemcpyBatchNodeParams updated = replacement.Params();
+  HIP_CHECK(hipGraphExtMemcpyBatchNodeSetParams(node, &updated));
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  original.VerifyCopied();
+  replacement.VerifyUntouched();
+
+  original.ClearDevice();
+  hipGraphNode_t error_node = nullptr;
+  hipGraphExecUpdateResult update_result = hipGraphExecUpdateSuccess;
+  HIP_CHECK(hipGraphExecUpdate(graph_exec, graph, &error_node, &update_result));
+  REQUIRE(update_result == hipGraphExecUpdateSuccess);
+
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  replacement.VerifyCopied();
+  original.VerifyUntouched();
+
+  SECTION("A resized batch is reported as a parameter change") {
+    hipExtMemcpyBatchNodeParams resized = replacement.Params();
+    resized.count = kNumCopies - 1;
+    HIP_CHECK(hipGraphExtMemcpyBatchNodeSetParams(node, &resized));
+    HIP_CHECK_ERROR(hipGraphExecUpdate(graph_exec, graph, &error_node, &update_result),
+                    hipErrorGraphExecUpdateFailure);
+    REQUIRE(update_result == hipGraphExecUpdateErrorParametersChanged);
+    REQUIRE(error_node == node);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Places an empty kernel before and after the batch so the node has to link into a dependency
+ *   chain rather than stand alone, and checks the chain is identical whether it is built with
+ *   hipGraphAddExtMemcpyBatchNode or recorded with hipStreamBeginCapture/hipStreamEndCapture.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ */
+HIP_TEST_CASE(Unit_hipGraphExtMemcpyBatchNode_Positive_KernelDependencies) {
+  const auto method = GENERATE(BuildMethod::kExplicitNode, BuildMethod::kStreamCapture);
+  INFO("graph built with " << ToString(method));
+
+  BatchBuffers buffers(/*seed=*/9);
+  BatchBuffers replacement(/*seed=*/10);
+  hipExtMemcpyBatchNodeParams params = buffers.Params();
+
+  hipStream_t stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&stream));
+  hipGraph_t graph = nullptr;
+
+  if (method == BuildMethod::kStreamCapture) {
+    HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    EmptyKernel<<<1, 1, 0, stream>>>();
+    size_t fail_idx = 0;
+    HIP_CHECK(hipMemcpyBatchAsync(buffers.dsts(), buffers.srcs(), buffers.sizes(), kNumCopies,
+                                  nullptr, nullptr, 0, &fail_idx, stream));
+    EmptyKernel<<<1, 1, 0, stream>>>();
+    HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  } else {
+    HIP_CHECK(hipGraphCreate(&graph, 0));
+    hipKernelNodeParams kernel_params = EmptyKernelNodeParams();
+    hipGraphNode_t before = nullptr;
+    hipGraphNode_t batch = nullptr;
+    hipGraphNode_t after = nullptr;
+    HIP_CHECK(hipGraphAddKernelNode(&before, graph, nullptr, 0, &kernel_params));
+    HIP_CHECK(hipGraphAddExtMemcpyBatchNode(&batch, graph, &before, 1, &params));
+    HIP_CHECK(hipGraphAddKernelNode(&after, graph, &batch, 1, &kernel_params));
+  }
+
+  // Empty kernel, batch, empty kernel: the batch is still a single node no matter how many
+  // copies it carries.
+  REQUIRE(GetNodeCount(graph) == 3);
+  hipGraphNode_t batch_node = FindBatchNode(graph);
+  REQUIRE(batch_node != nullptr);
+
+  size_t num_dependencies = 0;
+  HIP_CHECK(hipGraphNodeGetDependencies(batch_node, nullptr, &num_dependencies));
+  REQUIRE(num_dependencies == 1);
+  size_t num_dependents = 0;
+  HIP_CHECK(hipGraphNodeGetDependentNodes(batch_node, nullptr, &num_dependents));
+  REQUIRE(num_dependents == 1);
+
+  // Building the graph must defer the work rather than perform it.
+  buffers.VerifyUntouched();
+
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+  buffers.VerifyCopied();
+
+  // A node sitting between two kernels must still be updatable.
+  hipExtMemcpyBatchNodeParams updated = replacement.Params();
+  HIP_CHECK(hipGraphExecExtMemcpyBatchNodeSetParams(graph_exec, batch_node, &updated));
+  HIP_CHECK(hipGraphLaunch(graph_exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+  replacement.VerifyCopied();
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Broadcasts one source buffer to a destination on every reachable peer GPU plus one local
+ *   device-to-device destination, all within a single batch node, and confirms the source can
+ *   then be swapped through hipGraphExecUpdate.
+ * Test source
+ * ------------------------
+ *    - unit/graph/hipGraphAddExtMemcpyBatchNode.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.2
+ *    - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphExtMemcpyBatchNode_Positive_BroadcastPeerToPeer) {
+  const auto method = GENERATE(BuildMethod::kExplicitNode, BuildMethod::kStreamCapture);
+  INFO("graph built with " << ToString(method));
+
+  int num_gpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&num_gpus));
+  if (num_gpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  HIP_CHECK(hipSetDevice(0));
+  std::vector<int> pattern(kElems);
+  std::iota(pattern.begin(), pattern.end(), 0x1000);
+  std::vector<int> second_pattern(kElems);
+  std::iota(second_pattern.begin(), second_pattern.end(), 0x2000);
+
+  int* src = nullptr;
+  int* second_src = nullptr;
+  int* local_dst = nullptr;
+  HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&src), kBytes));
+  HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&second_src), kBytes));
+  HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&local_dst), kBytes));
+  HIP_CHECK(hipMemcpy(src, pattern.data(), kBytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(second_src, second_pattern.data(), kBytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemset(local_dst, 0, kBytes));
+
+  // One destination per peer that device 0 can reach directly.
+  std::vector<int> peer_devices;
+  std::vector<int*> peer_dsts;
+  for (int peer = 1; peer < num_gpus; ++peer) {
+    int can_access = 0;
+    HIP_CHECK(hipDeviceCanAccessPeer(&can_access, 0, peer));
+    if (!can_access) continue;
+
+    HIP_CHECK(hipSetDevice(peer));
+    int* peer_dst = nullptr;
+    HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&peer_dst), kBytes));
+    HIP_CHECK(hipMemset(peer_dst, 0, kBytes));
+    peer_devices.push_back(peer);
+    peer_dsts.push_back(peer_dst);
+  }
+  HIP_CHECK(hipSetDevice(0));
+  if (peer_devices.empty()) {
+    HIP_CHECK(hipFree(src));
+    HIP_CHECK(hipFree(second_src));
+    HIP_CHECK(hipFree(local_dst));
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
+  }
+  for (int peer : peer_devices) {
+    hipError_t status = hipDeviceEnablePeerAccess(peer, 0);
+    if (status != hipErrorPeerAccessAlreadyEnabled) {
+      HIP_CHECK(status);
+    }
+  }
+
+  // Same source for every entry: one local device-to-device copy plus one peer copy each.
+  std::vector<void*> dsts{local_dst};
+  std::vector<size_t> sizes(1 + peer_dsts.size(), kBytes);
+  for (int* peer_dst : peer_dsts) {
+    dsts.push_back(peer_dst);
+  }
+  std::vector<void*> srcs(dsts.size(), src);
+  std::vector<void*> second_srcs(dsts.size(), second_src);
+
+  hipExtMemcpyBatchNodeParams params{};
+  params.dsts = dsts.data();
+  params.srcs = srcs.data();
+  params.sizes = sizes.data();
+  params.count = dsts.size();
+
+  // A broadcast of any width stays a single node, however the graph was built.
+  hipGraph_t graph = nullptr;
+  hipGraphNode_t node = nullptr;
+  BuildBatchGraph(method, params, &graph, &node);
+
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+
+  auto verify_destination = [](int device, int* ptr, const std::vector<int>& expected) {
+    HIP_CHECK(hipSetDevice(device));
+    std::vector<int> readback(kElems);
+    HIP_CHECK(hipMemcpy(readback.data(), ptr, kBytes, hipMemcpyDeviceToHost));
+    HIP_CHECK(hipSetDevice(0));
+    INFO("destination on device " << device);
+    REQUIRE(readback == expected);
+  };
+
+  verify_destination(0, local_dst, pattern);
+  for (size_t peer_idx = 0; peer_idx < peer_dsts.size(); ++peer_idx) {
+    verify_destination(peer_devices[peer_idx], peer_dsts[peer_idx], pattern);
+  }
+
+  // Retarget the broadcast at a different source and push it through hipGraphExecUpdate.
+  hipExtMemcpyBatchNodeParams updated = params;
+  updated.srcs = second_srcs.data();
+  HIP_CHECK(hipGraphExtMemcpyBatchNodeSetParams(node, &updated));
+  hipGraphNode_t error_node = nullptr;
+  hipGraphExecUpdateResult update_result = hipGraphExecUpdateSuccess;
+  HIP_CHECK(hipGraphExecUpdate(graph_exec, graph, &error_node, &update_result));
+  REQUIRE(update_result == hipGraphExecUpdateSuccess);
+
+  HIP_CHECK(hipGraphLaunch(graph_exec, 0));
+  HIP_CHECK(hipStreamSynchronize(0));
+  verify_destination(0, local_dst, second_pattern);
+  for (size_t peer_idx = 0; peer_idx < peer_dsts.size(); ++peer_idx) {
+    verify_destination(peer_devices[peer_idx], peer_dsts[peer_idx], second_pattern);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(src));
+  HIP_CHECK(hipFree(second_src));
+  HIP_CHECK(hipFree(local_dst));
+  for (size_t peer_idx = 0; peer_idx < peer_dsts.size(); ++peer_idx) {
+    HIP_CHECK(hipSetDevice(peer_devices[peer_idx]));
+    HIP_CHECK(hipFree(peer_dsts[peer_idx]));
+  }
+  HIP_CHECK(hipSetDevice(0));
+}
+
+/**
+* End doxygen group GraphTest.
+* @}
+*/

--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -1152,6 +1152,25 @@ typedef struct hipBatchMemOpNodeParams {
   unsigned int flags;
 } hipBatchMemOpNodeParams;
 
+/**
+ * Parameters for a batch-of-1D-copies graph node.
+ *
+ * Mirrors the arguments of #hipMemcpyBatchAsync. The node deep-copies every array,
+ * so the caller's storage need not outlive the call.
+ *
+ * Used by hipGraphAddExtMemcpyBatchNode, hipGraphExtMemcpyBatchNodeGetParams,
+ * hipGraphExtMemcpyBatchNodeSetParams and hipGraphExecExtMemcpyBatchNodeSetParams.
+ */
+typedef struct hipExtMemcpyBatchNodeParams {
+  void** dsts;                  ///< Array of \p count destination pointers.
+  void** srcs;                  ///< Array of \p count source pointers.
+  size_t* sizes;                ///< Array of \p count copy sizes in bytes. None may be zero.
+  size_t count;                 ///< Number of copies in the batch.
+  hipMemcpyAttributes* attrs;   ///< Array of \p numAttrs attributes, or NULL.
+  size_t* attrsIdxs;            ///< Array of \p numAttrs copy indices each attribute starts at.
+  size_t numAttrs;              ///< Number of entries in \p attrs and \p attrsIdxs.
+} hipExtMemcpyBatchNodeParams;
+
 // Stream per thread
 /** Implicit stream per application thread.*/
 #define hipStreamPerThread ((hipStream_t)2)
@@ -1573,6 +1592,7 @@ typedef enum hipGraphNodeType {
   hipGraphNodeTypeMemcpyFromSymbol = 12,   ///< MemcpyFromSymbol node
   hipGraphNodeTypeMemcpyToSymbol = 13,     ///< MemcpyToSymbol node
   hipGraphNodeTypeBatchMemOp = 14,         ///< BatchMemOp node
+  hipGraphNodeTypeExtMemcpyBatch = 15,     ///< Batch of 1D memcpy node
   hipGraphNodeTypeCount
 } hipGraphNodeType;
 
@@ -9201,6 +9221,88 @@ hipError_t hipGraphMemcpyNodeSetParams1D(hipGraphNode_t node, void* dst, const v
 hipError_t hipGraphExecMemcpyNodeSetParams1D(hipGraphExec_t hGraphExec, hipGraphNode_t node,
                                              void* dst, const void* src, size_t count,
                                              hipMemcpyKind kind);
+
+/**
+ * @brief Creates a node that performs a batch of 1D copies and adds it to a graph.[BETA]
+ *
+ * @param [out] pGraphNode      - Pointer to the graph node that is created.
+ * @param [in] graph            - Instance of the graph to add the created node to.
+ * @param [in] pDependencies    - const pointer to the dependencies of the node.
+ * @param [in] numDependencies  - Number of dependencies.
+ * @param [in] nodeParams       - Parameters describing the batch. See
+ *                                #hipExtMemcpyBatchNodeParams.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotSupported
+ *
+ * The batch is submitted as a single node, so the copies are unordered with respect to each
+ * other. Every copy must resolve to the same device, and host-to-host copies are rejected with
+ * #hipErrorNotSupported, because neither can be expressed as work on a single graph node.
+ *
+ * @warning This API is marked as beta, meaning, while this is feature complete,
+ * it is still open to changes and may have outstanding issues.
+ *
+ * @see hipMemcpyBatchAsync, hipGraphExtMemcpyBatchNodeGetParams,
+ * hipGraphExtMemcpyBatchNodeSetParams
+ */
+hipError_t hipGraphAddExtMemcpyBatchNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
+                                         const hipGraphNode_t* pDependencies,
+                                         size_t numDependencies,
+                                         const hipExtMemcpyBatchNodeParams* nodeParams);
+
+/**
+ * @brief Returns a batch memcpy node's parameters.[BETA]
+ *
+ * @param [in] node            - Node to get the parameters for.
+ * @param [out] pNodeParams    - Pointer to return the parameters.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue
+ *
+ * The arrays returned in \p pNodeParams are owned by the node. They remain valid until the node
+ * is destroyed or its parameters are modified, and must not be modified directly.
+ *
+ * @warning This API is marked as beta, meaning, while this is feature complete,
+ * it is still open to changes and may have outstanding issues.
+ *
+ * @see hipGraphAddExtMemcpyBatchNode, hipGraphExtMemcpyBatchNodeSetParams
+ */
+hipError_t hipGraphExtMemcpyBatchNodeGetParams(hipGraphNode_t node,
+                                               hipExtMemcpyBatchNodeParams* pNodeParams);
+
+/**
+ * @brief Sets a batch memcpy node's parameters.[BETA]
+ *
+ * @param [in] node          - Node to set the parameters for.
+ * @param [in] pNodeParams   - Parameters to copy.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue
+ *
+ * @warning This API is marked as beta, meaning, while this is feature complete,
+ * it is still open to changes and may have outstanding issues.
+ *
+ * @see hipGraphAddExtMemcpyBatchNode, hipGraphExtMemcpyBatchNodeGetParams
+ */
+hipError_t hipGraphExtMemcpyBatchNodeSetParams(hipGraphNode_t node,
+                                               const hipExtMemcpyBatchNodeParams* pNodeParams);
+
+/**
+ * @brief Sets the parameters for a batch memcpy node in the given graphExec.[BETA]
+ *
+ * @param [in] hGraphExec  - The executable graph in which to set the specified node.
+ * @param [in] node        - Batch memcpy node from the graph the graphExec was instantiated from.
+ * @param [in] pNodeParams - Updated parameters to set.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue
+ *
+ * The number of copies in \p pNodeParams must match the count the node was instantiated with;
+ * only the pointers, sizes and attributes may change.
+ *
+ * @warning This API is marked as beta, meaning, while this is feature complete,
+ * it is still open to changes and may have outstanding issues.
+ *
+ * @see hipGraphAddExtMemcpyBatchNode, hipGraphExtMemcpyBatchNodeSetParams
+ */
+hipError_t hipGraphExecExtMemcpyBatchNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t node,
+                                                   const hipExtMemcpyBatchNodeParams* pNodeParams);
 
 /**
  * @brief Creates a memcpy node to copy from a symbol on the device and adds it to a graph.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/abi.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/abi.cpp
@@ -689,6 +689,13 @@ ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipDrvMemDiscardAndPrefetchBatchAsync_f
 ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipMemGetDefaultMemPool_fn, 541);
 #endif
 
+#if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 32
+ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipGraphAddExtMemcpyBatchNode_fn, 542);
+ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipGraphExtMemcpyBatchNodeGetParams_fn, 543);
+ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipGraphExtMemcpyBatchNodeSetParams_fn, 544);
+ROCP_SDK_ENFORCE_ABI(::HipDispatchTable, hipGraphExecExtMemcpyBatchNodeSetParams_fn, 545);
+#endif
+
 #if HIP_RUNTIME_API_TABLE_STEP_VERSION == 0
 ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 442)
 #elif HIP_RUNTIME_API_TABLE_STEP_VERSION == 1
@@ -753,6 +760,8 @@ ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 537)
 ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 541)
 #elif HIP_RUNTIME_API_TABLE_STEP_VERSION == 31
 ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 542)
+#elif HIP_RUNTIME_API_TABLE_STEP_VERSION == 32
+ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 546)
 #else
 INTERNAL_CI_ROCP_SDK_ENFORCE_ABI_VERSIONING(::HipDispatchTable, 0)
 #endif

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
@@ -382,6 +382,9 @@ struct formatter<hipGraphNodeParams> : rocprofiler::hip::details::base_formatter
 #if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 8
             case hipGraphNodeTypeBatchMemOp:
 #endif
+#if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 32
+            case hipGraphNodeTypeExtMemcpyBatch:
+#endif
             case hipGraphNodeTypeCount:
             {
                 break;


### PR DESCRIPTION
hipMemcpyBatchAsync does not natively support graph capture. Add functionality for hipExtMemcpyBatchAsync node for HIP Graphs.

The node is reachable two ways: explicitly via hipGraphAddExtMemcpyBatchNode, or by capturing hipExtMemcpyBatchAsync, which goes through STREAM_CAPTURE.

Parameter updates work through hipGraphExtMemcpyBatchNodeSetParams, hipGraphExecExtMemcpyBatchNodeSetParams and hipGraphExecUpdate.

Tests: catch/unit/graph/hipGraphAddExtMemcpyBatchNode.cc covers both construction paths, parameter get/set, exec update, a batch sandwiched between two kernel nodes, and a peer-to-peer broadcast.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
