### PR TITLE
fix(rocshmem): restore functional tests on gfx1100

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -588,9 +588,13 @@ TestRMAPut() {
   ExecTest  "putnbi"           2       32           128       512
   unset LOCALBUFTYPE
 
-  export LOCALBUFTYPE=managed
-  ExecTest  "putnbi"           2       32           128       512
-  unset LOCALBUFTYPE
+  if [[ "$GPU_ARCH" != "gfx1100" ]]; then
+    export LOCALBUFTYPE=managed
+    ExecTest  "putnbi"           2       32           128       512
+    unset LOCALBUFTYPE
+  else
+    echo "Skip:   putnbi_localbuftype=managed (gfx1100: hipMallocManaged not supported)"
+  fi
 }
 
 TestRMAGet() {
@@ -666,9 +670,13 @@ TestRMAGet() {
     ExecTest  "getnbi"           2       32           128       512
     unset LOCALBUFTYPE
 
-    export LOCALBUFTYPE=managed
-    ExecTest  "getnbi"           2       32           128       512
-    unset LOCALBUFTYPE
+    if [[ "$GPU_ARCH" != "gfx1100" ]]; then
+      export LOCALBUFTYPE=managed
+      ExecTest  "getnbi"           2       32           128       512
+      unset LOCALBUFTYPE
+    else
+      echo "Skip:   getnbi_localbuftype=managed (gfx1100: hipMallocManaged not supported)"
+    fi
   fi
 }
 

--- a/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
@@ -145,7 +145,8 @@ void AMOBitwiseTester<T>::verifyDestValues() {
       const int K = (args.addr_mode == AddrMode::PerBlock)
                      ? static_cast<int>(args.wg_size)
                      : static_cast<int>(args.num_wgs * args.wg_size);
-      const T expected = (K & 1) ? MASK : static_cast<T>(0);
+      const int total_K = args.numprocs * K;
+      const T expected = (total_K & 1) ? MASK : static_cast<T>(0);
       check_equal_all(expected);
       break;
     }

--- a/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
@@ -145,8 +145,7 @@ void AMOBitwiseTester<T>::verifyDestValues() {
       const int K = (args.addr_mode == AddrMode::PerBlock)
                      ? static_cast<int>(args.wg_size)
                      : static_cast<int>(args.num_wgs * args.wg_size);
-      const int total_K = args.numprocs * K;
-      const T expected = (total_K & 1) ? MASK : static_cast<T>(0);
+      const T expected = (K & 1) ? MASK : static_cast<T>(0);
       check_equal_all(expected);
       break;
     }

--- a/projects/rocshmem/tests/functional_tests/fence_ordering_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fence_ordering_tester.cpp
@@ -356,7 +356,7 @@ FenceOrderingTester::~FenceOrderingTester() {
   rocshmem_free(s_buf);
   rocshmem_free(r_buf);
   rocshmem_free(signal);
-  CHECK_HIP(hipFree(error_count));
+  CHECK_HIP(hipFreeHost(error_count));
 }
 
 void FenceOrderingTester::resetBuffers(size_t size) {

--- a/projects/rocshmem/tests/functional_tests/fence_ordering_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fence_ordering_tester.cpp
@@ -349,7 +349,7 @@ FenceOrderingTester::FenceOrderingTester(TesterArguments args)
   r_buf = (char *)rocshmem_malloc(r_buf_size);
   // Per-wave data flags + ack flags: 2 * total_waves entries
   signal = (uint64_t *)rocshmem_malloc(2 * total_waves * sizeof(uint64_t));
-  CHECK_HIP(hipMallocManaged(&error_count, sizeof(int), hipMemAttachGlobal));
+  CHECK_HIP(hipHostMalloc(&error_count, sizeof(int)));
 }
 
 FenceOrderingTester::~FenceOrderingTester() {

--- a/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
@@ -119,7 +119,7 @@ SignalingOperationsTester::SignalingOperationsTester(TesterArguments args)
   s_buf = (char *)alloc_test_buffer(max_msg_size * args.wg_size, args.local_buf_type);
   r_buf = (char *)alloc_test_buffer(max_msg_size * args.wg_size);
   sig_addr = (uint64_t *)alloc_test_buffer(sizeof(uint64_t));
-  CHECK_HIP(hipMallocManaged(&fetched_value, sizeof(uint64_t), hipMemAttachHost));
+  CHECK_HIP(hipHostMalloc(&fetched_value, sizeof(uint64_t)));
 }
 
 SignalingOperationsTester::SignalingOperationsTester(TesterArguments args,

--- a/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
@@ -132,7 +132,7 @@ SignalingOperationsTester::~SignalingOperationsTester() {
   free_test_buffer(s_buf, args.local_buf_type);
   free_test_buffer(r_buf);
   free_test_buffer(sig_addr);
-  CHECK_HIP(hipFree(fetched_value));
+  CHECK_HIP(hipFreeHost(fetched_value));
 }
 
 void SignalingOperationsTester::resetBuffers([[maybe_unused]] size_t size) {

--- a/projects/rocshmem/tests/functional_tests/test_driver.cpp
+++ b/projects/rocshmem/tests/functional_tests/test_driver.cpp
@@ -171,13 +171,13 @@ int main(int argc, char *argv[]) {
   bool using_slr = false;
 
   int num_devices = 0;
-  CHECK_HIP(hipGetDeviceCount(&num_devices));
 
   if (slr_np != nullptr) {
-    // Using SLR runtime
+    // Using SLR runtime — fork before any HIP calls; HIP contexts are not fork-safe
     using_slr = true;
     int rank, nranks;
     init_slr(&rank, &nranks);
+    CHECK_HIP(hipGetDeviceCount(&num_devices));
     if (rank >= num_devices) {
       std::cerr << "Error: rank " << rank << " exceeds the number of available GPUs ("
                 << num_devices << "). Aborting.\n";
@@ -186,6 +186,7 @@ int main(int argc, char *argv[]) {
     CHECK_HIP(hipSetDevice(rank));
   } else if (ompi_local_rank != nullptr) {
     // Using MPI runtime
+    CHECK_HIP(hipGetDeviceCount(&num_devices));
     int device_id = atoi(ompi_local_rank);
     if (device_id >= num_devices) {
       std::cerr << "Error: OMPI_COMM_WORLD_LOCAL_RANK=" << device_id


### PR DESCRIPTION
## Motivation

The gfx1100 architectures are not tested as part of our CI, and some incompatibilities with the new functions and tests have creeped in over time. However, gfx1100 is the starting point for some upcoming work on gfx11xx.

This PR restores most tests to pass again.

## Technical Details

- key technical detail is to not use hipMallocManaged on gfx1100

## Issue Tracking

JIRA ID: AIROCSHMEM-478

## Test Plan

Tests have been executed manually, since gfx1100 is not tested in the rocSHMEM CI.

## Test Result

All tests except for one (amo_xor_n2_w1_z1) are passing again with the IPC backend.
[gfx1100-functional-tests.txt](https://github.com/user-attachments/files/31000535/gfx1100-functional-tests.txt)
