### PR TITLE
fix(amdsmi): three follow-up fixes for the unified ABI series

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -141,6 +141,7 @@ GPU: 0
   - New APIs: `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode()`, `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`.
   - New enum: `amdsmi_accelerator_partition_mem_alloc_mode_t` (`AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL`).
   - Supersedes the equivalent `compute_partition` memory allocation mode APIs, which are now deprecated.
+  - The `amd-smi` CLI keeps its existing `compute_partition_mem_alloc_mode` JSON output key for continuity; only the C API names change.
 
 - **Added physical accelerator ID and tray info via UALoE**.
   - `amdsmi_asic_info_t` gained a `physical_acc_id` field, populated by `amdsmi_get_gpu_asic_info()`.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -85,6 +85,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `rev_id` was also assigned from the device-info structure before the `AMDGPU_INFO_DEV_INFO` query populated it. Every such path already returned an error, so this was not observable through a checked return, but the value no longer contradicts the status.
   - `amdsmi_asic_info_t` is now reset through one shared initializer used by every backend, so a field a backend cannot supply keeps its not-supported value rather than a plausible zero.
 
+- **Fixed the widened `amdsmi_gpu_metrics_t` accumulators reporting `4294967295` instead of `N/A`**.  
+  - The five accumulator counters were widened from 32-bit to 64-bit, but the amdgpu metrics table still reports them at 32 bits. Copying the table's "unset" sentinel into the wider field zero-extended it from `0xFFFFFFFF` to `0x00000000FFFFFFFF`, so it no longer matched the 64-bit sentinel every consumer checks against. `amdsmi_get_gpu_metrics_info()` and `amd-smi metric` reported an unsupported `gfx_activity_acc` / `mem_activity_acc` as a literal `4294967295` rather than `N/A`. The sentinel is now widened along with the value.
+
 ### Upcoming Changes
 
 - **UUIDs will be replaced by CUIDs in an upcoming version**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -70,6 +70,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Fixed
 
+- **Fixed the widened `amdsmi_gpu_metrics_t` accumulators reporting `4294967295` instead of `N/A`**.
+  - The five accumulator counters were widened from 32-bit to 64-bit, but the amdgpu metrics table still reports them at 32 bits. Copying the table's "unset" sentinel into the wider field zero-extended it from `0xFFFFFFFF` to `0x00000000FFFFFFFF`, so it no longer matched the 64-bit sentinel every consumer checks against. `amdsmi_get_gpu_metrics_info()` and `amd-smi metric` reported an unsupported `gfx_activity_acc` / `mem_activity_acc` as a literal `4294967295` rather than `N/A`. The sentinel is now widened along with the value.
+
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.
   - The common no-entries case printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. The command now always emits exactly one valid JSON document: `[]` when there are no entries, or a single aggregated array across all GPUs when there are. `--follow` mode stays silent until entries appear. The human-readable primary-partition warning is also suppressed in JSON mode so it no longer corrupts the output.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -12,6 +12,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - New APIs: `amdsmi_get_gpu_accelerator_partition_mem_alloc_mode()`, `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`.
   - New enum: `amdsmi_accelerator_partition_mem_alloc_mode_t` (`AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_ACCELERATOR_PARTITION_MEM_ALLOC_ALL`).
   - Supersedes the equivalent `compute_partition` memory allocation mode APIs, which are now deprecated.
+  - The `amd-smi` CLI keeps its existing `compute_partition_mem_alloc_mode` JSON output key for continuity; only the C API names change.
 
 ### Changed
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1898,7 +1898,7 @@ class SetValueCommands:
                     "Invalid accelerator partition memory allocation mode "
                     f"{args.compute_partition_mem_alloc_mode}"
                 )
-                self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
@@ -1906,16 +1906,16 @@ class SetValueCommands:
                 out = f"[{e.get_error_info(detailed=False)}] Unable to set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                     out = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
-                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     raise PermissionError("Command requires elevation") from e
                 else:
-                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
-            self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+            self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1918,7 +1918,7 @@ class SetValueCommands:
                     "Invalid accelerator partition memory allocation mode "
                     f"{args.compute_partition_mem_alloc_mode}"
                 )
-                self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
@@ -1926,16 +1926,16 @@ class SetValueCommands:
                 out = f"[{e.get_error_info(detailed=False)}] Unable to set accelerator partition memory allocation mode to {args.compute_partition_mem_alloc_mode}"
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                     out = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
-                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     raise PermissionError("Command requires elevation") from e
                 else:
-                    self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+                    self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
-            self.logger.store_output(args.gpu, "accelerator_partition_mem_alloc_mode", out)
+            self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1685,6 +1686,34 @@ class GpuMetricsBaseDynamic_t final : public GpuMetricsBase_t {
   AMDGpuDynamicMetrics_t m_dyn;
   details::AMDGpuDynamicMetricsHeader_v1_t m_header{};
 };
+
+/**
+ * @brief Copy a metric into a wider field while preserving the "unset" sentinel.
+ *
+ * Every field in the public metrics struct is initialized to the maximum value
+ * of its own type and keeps that value until the kernel reports a reading, so
+ * "all ones" means "not reported". The amdgpu table follows the same convention
+ * at its own width. When a public field is wider than the table field it
+ * mirrors -- as with the accumulators widened to 64-bit while the table still
+ * reports 32-bit -- a plain cast zero-extends the sentinel, turning 0xFFFFFFFF
+ * into 0x00000000FFFFFFFF, which no longer compares equal to the destination's
+ * maximum. Callers then surface the sentinel as a real reading: an activity
+ * accumulator of 4294967295 instead of "N/A".
+ *
+ * Widen the sentinel along with the value so the marker survives. Same-width
+ * and narrowing conversions are unaffected.
+ */
+template <typename D, typename S>
+constexpr D widen_keep_sentinel(const S value) {
+  static_assert(std::is_unsigned_v<D> && std::is_unsigned_v<S>,
+                "Error: sentinel widening is only defined for unsigned types...");
+  if constexpr (sizeof(S) < sizeof(D)) {
+    if (value == std::numeric_limits<S>::max()) {
+      return std::numeric_limits<D>::max();
+    }
+  }
+  return static_cast<D>(value);
+}
 
 template <typename T>
 rsmi_status_t rsmi_dev_gpu_metrics_info_query(uint32_t dv_ind,

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1704,6 +1705,34 @@ class GpuMetricsBaseDynamic_t final : public GpuMetricsBase_t {
   AMDGpuDynamicMetrics_t m_dyn;
   details::AMDGpuDynamicMetricsHeader_v1_t m_header{};
 };
+
+/**
+ * @brief Copy a metric into a wider field while preserving the "unset" sentinel.
+ *
+ * Every field in the public metrics struct is initialized to the maximum value
+ * of its own type and keeps that value until the kernel reports a reading, so
+ * "all ones" means "not reported". The amdgpu table follows the same convention
+ * at its own width. When a public field is wider than the table field it
+ * mirrors -- as with the accumulators widened to 64-bit while the table still
+ * reports 32-bit -- a plain cast zero-extends the sentinel, turning 0xFFFFFFFF
+ * into 0x00000000FFFFFFFF, which no longer compares equal to the destination's
+ * maximum. Callers then surface the sentinel as a real reading: an activity
+ * accumulator of 4294967295 instead of "N/A".
+ *
+ * Widen the sentinel along with the value so the marker survives. Same-width
+ * and narrowing conversions are unaffected.
+ */
+template <typename D, typename S>
+constexpr D widen_keep_sentinel(const S value) {
+  static_assert(std::is_unsigned_v<D> && std::is_unsigned_v<S>,
+                "Error: sentinel widening is only defined for unsigned types...");
+  if constexpr (sizeof(S) < sizeof(D)) {
+    if (value == std::numeric_limits<S>::max()) {
+      return std::numeric_limits<D>::max();
+    }
+  }
+  return static_cast<D>(value);
+}
 
 template <typename T>
 rsmi_status_t rsmi_dev_gpu_metrics_info_query(uint32_t dv_ind,

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -2434,7 +2434,9 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
     std::visit(
         [&](const auto& x) {
           using S = std::decay_t<decltype(x)>;
-          if constexpr (std::is_integral_v<S>) {
+          if constexpr (std::is_unsigned_v<S> && std::is_unsigned_v<D>) {
+            dst = widen_keep_sentinel<D>(x);
+          } else if constexpr (std::is_integral_v<S>) {
             dst = static_cast<D>(x);
           }
         },
@@ -2945,8 +2947,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
       metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
       // Utilization Accumulated
-      metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-      metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+      metrics_public_init.gfx_activity_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+              m_gpu_metrics_tbl.m_gfx_activity_acc);
+      metrics_public_init.mem_activity_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+              m_gpu_metrics_tbl.m_mem_activity_acc);
 
       // PCIE accumulated bandwidth
       metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -2966,10 +2972,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
           m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
       // PCIE NAK sent accumulated count
-      metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+      metrics_public_init.pcie_nak_sent_count_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+              m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
       // PCIE NAK received accumulated count
-      metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+      metrics_public_init.pcie_nak_rcvd_count_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+              m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
       // Accumulated throttler residencies
       // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3041,7 +3051,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
       metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
       metrics_public_init.pcie_lc_perf_other_end_recovery =
-          m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+              m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
       // xcp stats
       auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
@@ -3215,8 +3226,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3235,10 +3250,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // Accumulated throttler residencies
     // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3310,7 +3329,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
     metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
     metrics_public_init.pcie_lc_perf_other_end_recovery =
-        m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+            m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
     auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
     for (auto pub_it = std::begin(metrics_public_init.xcp_stats);
@@ -3401,8 +3421,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3421,10 +3445,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // Accumulated throttler residencies
     // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3486,7 +3514,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
     metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
     metrics_public_init.pcie_lc_perf_other_end_recovery =
-        m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+            m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
     auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
     for (auto pub_it = std::begin(metrics_public_init.xcp_stats);
@@ -3591,8 +3620,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v15_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3611,10 +3644,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v15_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // XGMI accumulated data transfer size
     // xgmi_read_data
@@ -3757,8 +3794,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v14_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -4110,8 +4151,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v13_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =
@@ -4388,8 +4433,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v12_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =
@@ -4641,8 +4690,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v11_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -2452,7 +2452,9 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
     std::visit(
         [&](const auto& x) {
           using S = std::decay_t<decltype(x)>;
-          if constexpr (std::is_integral_v<S>) {
+          if constexpr (std::is_unsigned_v<S> && std::is_unsigned_v<D>) {
+            dst = widen_keep_sentinel<D>(x);
+          } else if constexpr (std::is_integral_v<S>) {
             dst = static_cast<D>(x);
           }
         },
@@ -2963,8 +2965,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
       metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
       // Utilization Accumulated
-      metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-      metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+      metrics_public_init.gfx_activity_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+              m_gpu_metrics_tbl.m_gfx_activity_acc);
+      metrics_public_init.mem_activity_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+              m_gpu_metrics_tbl.m_mem_activity_acc);
 
       // PCIE accumulated bandwidth
       metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -2984,10 +2990,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
           m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
       // PCIE NAK sent accumulated count
-      metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+      metrics_public_init.pcie_nak_sent_count_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+              m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
       // PCIE NAK received accumulated count
-      metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+      metrics_public_init.pcie_nak_rcvd_count_acc =
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+              m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
       // Accumulated throttler residencies
       // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3059,7 +3069,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
       metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
       metrics_public_init.pcie_lc_perf_other_end_recovery =
-          m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+          widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+              m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
       // xcp stats
       auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
@@ -3233,8 +3244,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3253,10 +3268,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // Accumulated throttler residencies
     // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3328,7 +3347,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_m
     metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
     metrics_public_init.pcie_lc_perf_other_end_recovery =
-        m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+            m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
     auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
     for (auto pub_it = std::begin(metrics_public_init.xcp_stats);
@@ -3419,8 +3439,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3439,10 +3463,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // Accumulated throttler residencies
     // bumped up public to uint64_t due to planned size increase for newer ASICs
@@ -3504,7 +3532,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v16_t::copy_internal_to_external_m
     metrics_public_init.num_partition = m_gpu_metrics_tbl.m_num_partition;
 
     metrics_public_init.pcie_lc_perf_other_end_recovery =
-        m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery;
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_lc_perf_other_end_recovery)>(
+            m_gpu_metrics_tbl.m_pcie_lc_perf_other_end_recovery);
 
     auto priv_it = std::begin(m_gpu_metrics_tbl.m_xcp_stats);
     for (auto pub_it = std::begin(metrics_public_init.xcp_stats);
@@ -3609,8 +3638,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v15_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -3629,10 +3662,14 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v15_t::copy_internal_to_external_m
         m_gpu_metrics_tbl.m_pcie_replay_rover_count_acc;
 
     // PCIE NAK sent accumulated count
-    metrics_public_init.pcie_nak_sent_count_acc = m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc;
+    metrics_public_init.pcie_nak_sent_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_sent_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_sent_count_acc);
 
     // PCIE NAK received accumulated count
-    metrics_public_init.pcie_nak_rcvd_count_acc = m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc;
+    metrics_public_init.pcie_nak_rcvd_count_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.pcie_nak_rcvd_count_acc)>(
+            m_gpu_metrics_tbl.m_pcie_nak_rcvd_count_acc);
 
     // XGMI accumulated data transfer size
     // xgmi_read_data
@@ -3775,8 +3812,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v14_t::copy_internal_to_external_m
     metrics_public_init.xgmi_link_speed = m_gpu_metrics_tbl.m_xgmi_link_speed;
 
     // Utilization Accumulated
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // PCIE accumulated bandwidth
     metrics_public_init.pcie_bandwidth_acc = m_gpu_metrics_tbl.m_pcie_bandwidth_acc;
@@ -4128,8 +4169,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v13_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =
@@ -4406,8 +4451,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v12_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =
@@ -4659,8 +4708,12 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v11_t::copy_internal_to_external_m
     metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
     metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
 
-    metrics_public_init.gfx_activity_acc = m_gpu_metrics_tbl.m_gfx_activity_acc;
-    metrics_public_init.mem_activity_acc = m_gpu_metrics_tbl.m_mem_activity_acc;
+    metrics_public_init.gfx_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.gfx_activity_acc)>(
+            m_gpu_metrics_tbl.m_gfx_activity_acc);
+    metrics_public_init.mem_activity_acc =
+        widen_keep_sentinel<decltype(metrics_public_init.mem_activity_acc)>(
+            m_gpu_metrics_tbl.m_mem_activity_acc);
 
     // temperature_hbm
     const auto temp_hbm_num_elems =

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/metrics_sentinel_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/metrics_sentinel_test.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "rocm_smi/rocm_smi_gpu_metrics.h"
+
+namespace {
+
+using amd::smi::widen_keep_sentinel;
+
+constexpr auto kU32Max = std::numeric_limits<uint32_t>::max();
+constexpr auto kU64Max = std::numeric_limits<uint64_t>::max();
+
+// The regression: an "unset" 32-bit field copied into a 64-bit public field
+// used to zero-extend to 0x00000000FFFFFFFF, which callers report as a real
+// reading of 4294967295 instead of "N/A".
+TEST(GpuUnit, MetricsSentinelWidensTheUnsetSentinel) {
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(kU32Max), kU64Max);
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(std::numeric_limits<uint16_t>::max()), kU64Max);
+  EXPECT_EQ(widen_keep_sentinel<uint32_t>(std::numeric_limits<uint8_t>::max()), kU32Max);
+}
+
+TEST(GpuUnit, MetricsSentinelPreservesOrdinaryValuesWhenWidening) {
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(uint32_t{0}), 0u);
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(uint32_t{42}), 42u);
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(kU32Max - 1), uint64_t{kU32Max} - 1);
+}
+
+// Only a genuine width increase remaps the sentinel; a same-width copy must
+// still pass an all-ones reading through untouched.
+TEST(GpuUnit, MetricsSentinelSameWidthCopyIsUnchanged) {
+  EXPECT_EQ(widen_keep_sentinel<uint64_t>(kU64Max), kU64Max);
+  EXPECT_EQ(widen_keep_sentinel<uint32_t>(kU32Max), kU32Max);
+  EXPECT_EQ(widen_keep_sentinel<uint32_t>(uint32_t{7}), 7u);
+}
+
+TEST(GpuUnit, MetricsSentinelNarrowingIsAPlainCast) {
+  EXPECT_EQ(widen_keep_sentinel<uint32_t>(kU64Max), kU32Max);
+  EXPECT_EQ(widen_keep_sentinel<uint8_t>(uint32_t{0x1FF}), uint8_t{0xFF});
+}
+
+// Usable in constant expressions, so a mis-widened sentinel is a compile error
+// rather than a runtime surprise.
+TEST(GpuUnit, MetricsSentinelIsConstexpr) {
+  static_assert(widen_keep_sentinel<uint64_t>(kU32Max) == kU64Max);
+  static_assert(widen_keep_sentinel<uint64_t>(uint32_t{1}) == 1u);
+  SUCCEED();
+}
+
+}  // namespace

--- a/projects/amdsmi/tests/python/cli/base.py
+++ b/projects/amdsmi/tests/python/cli/base.py
@@ -68,6 +68,12 @@ class TestCliBase(unittest.TestCase):
     # this flag guards the first-and-only initialization.
     _initialized = False
 
+    # TODO: Remove this condition when CLI supports User automated input
+    # Commands that need User permission to run.  A plain class attribute, not
+    # something setUpClass assigns: setUpClass returns early once
+    # ``_initialized`` is set, so only the first CLI class to run would get it.
+    cmds_need_permission = {"set": ["--fan", "--memory-partition", "--compute-partition"]}
+
     @classmethod
     def setUpClass(cls):
         if TestCliBase._initialized:
@@ -87,10 +93,6 @@ class TestCliBase(unittest.TestCase):
         TestCliBase.gpus = baseline["gpus"]
         TestCliBase.sub_args = baseline["sub_args"]
         TestCliBase._initialized = True
-
-        # TODO: Remove this condition when CLI supports User automated input
-        # Commands that need User permission to run
-        cls.cmds_need_permission = {"set": ["--fan", "--memory-partition", "--compute-partition"]}
 
     @classmethod
     def _build_baseline(cls):

--- a/projects/amdsmi/tests/python/cli/test_set.py
+++ b/projects/amdsmi/tests/python/cli/test_set.py
@@ -4,6 +4,8 @@
 
 """CLI leaf test: set command."""
 
+import os
+
 import common.common as common
 from common.common import amdsmi
 
@@ -24,6 +26,15 @@ class TestSet(TestCliBase):
         self.common.print_func_name("")
         msg = f"{self.tab}### amd-smi set"
         self.common.print(msg)
+
+        # Nearly every `set` subcommand writes to a root-only sysfs node, and
+        # the CLI reports the refusal as a command failure. Only the handful in
+        # cmds_need_permission are filtered out downstream (they additionally
+        # need interactive input), so without this guard an unprivileged run
+        # fails on --perf-level, --profile, --perf-determinism, --clk-level and
+        # the rest rather than skipping.
+        if not self.PrintCmdsOnly and os.geteuid() != 0:
+            self.skipTest(f"{self.tab}Needs root")
 
         # Get current settings
         power_profile = {}

--- a/projects/amdsmi/tests/python/cli/test_set.py
+++ b/projects/amdsmi/tests/python/cli/test_set.py
@@ -20,6 +20,8 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """CLI leaf test: set command."""
 
+import os
+
 import common.common as common
 from common.common import amdsmi
 
@@ -40,6 +42,15 @@ class TestSet(TestCliBase):
         self.common.print_func_name("")
         msg = f"{self.tab}### amd-smi set"
         self.common.print(msg)
+
+        # Nearly every `set` subcommand writes to a root-only sysfs node, and
+        # the CLI reports the refusal as a command failure. Only the handful in
+        # cmds_need_permission are filtered out downstream (they additionally
+        # need interactive input), so without this guard an unprivileged run
+        # fails on --perf-level, --profile, --perf-determinism, --clk-level and
+        # the rest rather than skipping.
+        if not self.PrintCmdsOnly and os.geteuid() != 0:
+            self.skipTest(f"{self.tab}Needs root")
 
         # Get current settings
         power_profile = {}


### PR DESCRIPTION
## Motivation

Three follow-up fixes for defects introduced by the unified-ABI series (#8210, #7844). All three are live on `develop` today; one is a user-visible data-correctness regression, one breaks the CLI test suite, one leaves the CLI output schema self-inconsistent.

These surfaced while reviewing #9864, which backports that series to `release/therock-10.0`. The backport is faithful, so it carries all three along. Fixing them here first means 10.0 can take clean backports instead of diverging.

Each commit is self-contained and independently verified.

## Technical Details

### 1. `gpu_metrics` accumulators lose the "unset" sentinel

#8210 widened five `amdsmi_gpu_metrics_t` accumulators from 32-bit to 64-bit. The amdgpu metrics table they mirror still reports 32 bits, and the internal `m_*_acc` members correctly stayed `uint32_t`, so copying a table value into the public struct now zero-extends it. The table's "unset" sentinel `0xFFFFFFFF` becomes `0x00000000FFFFFFFF`, which no longer equals the 64-bit maximum that every consumer treats as "not reported":

- `_validate_if_max_uint(..., MaxUIntegerTypes.UINT64_T)` in `amdsmi_interface.py`
- the `numeric_limits<decltype(...)>::max()` comparisons in `rsmi_utilization_count_get()`

On a GPU that does not report these counters, `amdsmi_get_gpu_metrics_info()` returns a literal `4294967295` where it used to return `N/A`. Consumers cannot tell that apart from a real reading, and 4294967295 is not a plausible activity-percentage accumulator.

Adds `widen_keep_sentinel<D>(value)`, which maps an all-ones source to an all-ones destination when the destination is wider and is a plain cast otherwise. Applied at the 27 static-table copy sites for the five widened fields, and in the dynamic path's `assign_by_type`, whose variant carries the source at its real width and hits the same defect. Same-width and narrowing conversions are unaffected, so no other field changes behavior.

### 2. `tests/python/cli/test_set.py` fails instead of skipping

#7844 dropped the blanket `skipTest` from `test_set.py` and replaced it with a `cmds_need_permission` filter in `base.py`. Two defects came with it:

**`cmds_need_permission` is unreachable for `TestSet`.** It is assigned in `setUpClass` *after* `TestCliBase._initialized = True`, and onto `cls` rather than `TestCliBase`. `setUpClass` returns early for every class after the first, so only the first CLI class to run ever receives it. The filter dereferences it solely under `if items[1] == "set"`, so `TestSet` is the one class that trips:

```
tests/python/cli/base.py:724: AttributeError:
  'TestSet' object has no attribute 'cmds_need_permission'
```

It is a hardcoded literal with no dependency on the lazily built baseline, so it becomes a plain class attribute.

**The filter is far narrower than the skip it replaced.** It removes only `--fan`, `--memory-partition` and `--compute-partition`. Nearly every other `set` subcommand also writes a root-only sysfs node and the CLI reports the refusal as a command failure, so an unprivileged run also fails on `--perf-level` (9 variants), `--profile` (7), `--perf-determinism`, `--clk-level`, `--process-isolation` and `--compute-partition-mem-alloc-mode`. The test now skips when not root, which preserves #7844's intent that the `set` commands do run under the privileged CI job.

### 3. `amd-smi set --json` and `amd-smi static --partition --json` disagree on a key

#7844 renamed the output key emitted by `set` from `compute_partition_mem_alloc_mode` to `accelerator_partition_mem_alloc_mode`, but nothing else moved with it — the flag is still `--compute-partition-mem-alloc-mode`, and `static.py` still emits `compute_partition_mem_alloc_mode` for the same value. The `set` key also changed with no CHANGELOG entry.

This points `set` back at the existing key so the CLI is self-consistent. The call underneath still goes to the new `amdsmi_set_gpu_accelerator_partition_mem_alloc_mode()`, which is the substance of #7844; only the emitted key is held stable.

Renaming the CLI surface to `accelerator_*` is defensible, but it is a breaking output-schema change that has to move the flag, both subcommands and the docs together with a CHANGELOG entry — its own commit, not a side effect of an ABI sync. Happy to do that instead if reviewers prefer.

## Issue Tracking

JIRA ID: AILITOOLS-270, ROCM-1553

## Test Plan

Built and run on a 2× Radeon Pro W6800 (gfx1030) host, unprivileged, comparing the branch against its own merge-base so the only variable is this diff:

- `cmake -DBUILD_TESTS=ON` + `make`, library + CLI + `amdsmitst`
- `amdsmitst --gtest_filter='GpuUnit.*:SystemUnit.*'`
- full Python suite: `pytest tests/python/cli tests/python/unit`
- `amdsmi_get_gpu_metrics_info()` read back on real hardware
- new `GpuUnit.MetricsSentinel*` unit tests covering sentinel widening, ordinary-value widening, same-width copies, narrowing, and `constexpr` usability
- `check_test_conventions.py` and the amdsmi `pre-commit` config

## Test Result

**Metrics sentinel, same tree built with and without the change:**

```
develop            gfx_activity_acc = 4294967295   mem_activity_acc = 4294967295
+ this branch      gfx_activity_acc = N/A          mem_activity_acc = N/A
```

`pcie_nak_sent_count_acc`, `pcie_nak_rcvd_count_acc` and `pcie_lc_perf_other_end_recovery` also report `N/A`.

**Python suite, unprivileged:**

```
develop            1 failed, 66 passed, 27 skipped   (test_set.py AttributeError)
+ this branch                 66 passed, 28 skipped
```

**C++:** `GpuUnit.*` + `SystemUnit.*` 28/28 pass, including the 5 new `MetricsSentinel` tests. Build clean, 0 errors. `check_test_conventions.py`: OK. `pre-commit` (codespell, clang-format, ruff, test conventions): all pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
