### PR TITLE
fix(hip-tests): build shared HW queue ordering test on AMD only

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -37,7 +37,9 @@ stream:
     <<: *level_2
     tags: [lifecycle]
   Unit_hipMultiStream_SharedHwQueuePacketOrdering:
+    # Uses wall_clock64(), so the test is only compiled on AMD.
     <<: *level_2
+    disabled: [nvidia_linux, nvidia_windows]
     tags: [synchronization]
   Unit_hipMultiStream_multimeDevice:
     <<: *level_2

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -27,6 +27,9 @@ __global__ void nKernel(float* y) {
   y[tid] = y[tid] + 1.0f;
 }
 
+// wall_clock64() is an AMD device builtin, so this test is AMD-only.
+#if HT_AMD
+
 __global__ void verifyStreamPacketOrder(uint32_t* sequence_value, uint32_t expected_value,
                                         uint32_t* ordering_errors, uint64_t delay_cycles) {
   if (blockIdx.x != 0 || threadIdx.x != 0) {
@@ -131,6 +134,8 @@ HIP_TEST_CASE(Unit_hipMultiStream_SharedHwQueuePacketOrdering) {
   HIP_CHECK(hipFree(ordering_errors));
   HIP_CHECK(hipFree(sequence_values));
 }
+
+#endif  // HT_AMD
 
 HIP_TEST_CASE(Unit_hipMultiStream_sameDevice) {
   constexpr int num_streams{8};


### PR DESCRIPTION
Unit_hipMultiStream_SharedHwQueuePacketOrdering calls wall_clock64(), which is an AMD device builtin, so compiling hipMultiStream.cc with nvcc failed with "identifier wall_clock64 is undefined".

Guard the kernel and the test case with HT_AMD so the NVIDIA build preprocesses them away, and disable the test for nvidia_linux/nvidia_windows in the stream config. HT_LINUX is not required here because the test uses no Linux-only APIs.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
JIRA ID: AIRUNTIME 0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
