### PR TITLE
fix(rocshmem): [gda] use team-relative PE ranks in alltoallv

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -1058,12 +1058,12 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
     uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[constmem.my_pe];
-    size_t nelems = source_nelems[dest_pe] * sizeof(T);
+    size_t nelems = source_nelems[j] * sizeof(T);
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
 
     if (nelems != 0) {
       T* src = (T*)((char*)source + (source_displs[j] * sizeof(T)));
-      T* dst = (T*)((char*)&tmp_buf[constmem.my_pe * tmp_buf_off] + base_heap_offset);
+      T* dst = (T*)((char*)&tmp_buf[my_pe_in_team * tmp_buf_off] + base_heap_offset);
       qps[dest_pe].put_nbi_single(dst, src, nelems, false);
     }
 
@@ -1074,12 +1074,12 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
+    long *sync_flags = &pSync[alltoall_pSync_offset + j];
     while (uncached_load(sync_flags) != 1) { }
 
     qps[dest_pe].quiet_single();
 
-    pSync[alltoall_pSync_offset + dest_pe] = ROCSHMEM_SYNC_VALUE;
+    pSync[alltoall_pSync_offset + j] = ROCSHMEM_SYNC_VALUE;
   }
 
   // Copy out of staging buffer
@@ -1112,11 +1112,11 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
   int my_pe_in_team = team_obj->my_pe;
   uint64_t a2a_sn   = team_obj->alltoall_sequence_number;
   uint64_t alltoall_pSync_offset = (a2a_sn % 2) * pe_size;
-  uint64_t *tmp_buf = (uint64_t*)team_obj->pWrk;
+  uint64_t *tmp_buf = reinterpret_cast<uint64_t*>(team_obj->pWrk);
 
-  const uint64_t displs_mask = 0x0000'FFFF'FFFF'FFFF;
-  const uint64_t seq_mask = 0xFFFF;
-  const uint64_t seq_shift = 48;
+  static constexpr uint64_t displs_mask = 0x0000'FFFF'FFFF'FFFF;
+  static constexpr uint64_t seq_mask = 0xFFFF;
+  static constexpr uint64_t seq_shift = 48;
 
   int tid = get_flat_block_id();
   int step_size = min(get_flat_block_size(), WF_SIZE);
@@ -1133,18 +1133,18 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
 
     /* Pack Ctrl Message * 16 bits seq | 48bit displ */
     seq_bits = (seq_mask & (a2a_sn + 1)) << seq_shift;
-    displ_bits = (displs_mask & source_displs[dest_pe]);
+    displ_bits = (displs_mask & source_displs[j]);
     uint64_t ctrl_msg = seq_bits | displ_bits;
 
     /* Prepare Ctrl Message */
     src = (uint64_t*)&ctrl_msg;
-    dst = (uint64_t*)((char*)&tmp_buf[constmem.my_pe] + base_heap_offset);
+    dst = (uint64_t*)((char*)&tmp_buf[my_pe_in_team] + base_heap_offset);
 
     qps[dest_pe].put_nbi_single(dst, src, sizeof(uint64_t), true);
 
     /* Wait for Ctrl Message */
     uint64_t ctrl_value;
-    uint64_t *vol_ctrl = &tmp_buf[dest_pe];
+    uint64_t *vol_ctrl = &tmp_buf[j];
 
     do {
       ctrl_value = uncached_load(vol_ctrl);
@@ -1153,7 +1153,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
     } while (seq_bits != ((a2a_sn + 1) & seq_mask));
 
     /* Get data */
-    size_t nelems = dest_nelems[dest_pe] * sizeof(T);
+    size_t nelems = dest_nelems[j] * sizeof(T);
     src = (uint64_t*)((char*)source + (displ_bits * sizeof(T)));
     dst = (uint64_t*)((char*)dest + (dest_displs[j] * sizeof(T)));
 
@@ -1163,12 +1163,12 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
     qps[dest_pe].atomic_add_single(amo_dst, 1);
 
-    long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
+    long *sync_flags = &pSync[alltoall_pSync_offset + j];
     while (uncached_load(sync_flags) != 1) { }
 
     qps[dest_pe].quiet_single();
 
-    pSync[alltoall_pSync_offset + dest_pe] = ROCSHMEM_SYNC_VALUE;
+    pSync[alltoall_pSync_offset + j] = ROCSHMEM_SYNC_VALUE;
   }
 
   if (is_thread_zero_in_block()) {


### PR DESCRIPTION
## Motivation

Fix likely bug when using GDA alltoallv with teams other than `ROCSHMEM_TEAM_WORLD`.

## Technical Details

`alltoallv_copy` and `alltoallv_get` intermix team-relative and world-relative PE ranks for buffer offsets. When the team is not a copy of the world team, this may result in writing to or polling on incorrect locations in memory, resulting in deadlock or otherwise invalid behavior.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
