### PR TITLE
refactor(rocprofiler-sdk): address review feedback on #8887 for remove-callbacks-spm

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,24 +368,26 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
+            // Stop queue-interposed services while the context is still in the active list so
+            // write_hook can coordinate serialized->unserialized transitions during drain.
+            if(_expected->dispatch_counter_collection)
+            {
+                rocprofiler::counters::stop_context(const_cast<context*>(_expected));
+            }
+
+            if(_expected->dispatch_spm)
+                rocprofiler::spm::stop_context(const_cast<context*>(_expected));
+
+            if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
+            if(_expected->dispatch_thread_trace)
+                _expected->dispatch_thread_trace->stop_context();
+
             bool success = itr.compare_exchange_strong(_expected, nullptr);
 
             if(success)
             {
                 auto nactive = get_num_active_contexts().load(std::memory_order_acquire);
                 if(nactive > 0) get_num_active_contexts().fetch_sub(1, std::memory_order_release);
-
-                if(_expected->dispatch_counter_collection)
-                {
-                    rocprofiler::counters::stop_context(const_cast<context*>(_expected));
-                }
-
-                if(_expected->dispatch_spm)
-                    rocprofiler::spm::stop_context(const_cast<context*>(_expected));
-
-                if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
-                if(_expected->dispatch_thread_trace)
-                    _expected->dispatch_thread_trace->stop_context();
 
                 rocprofiler::hsa::queue_interposition::
                     notify_queue_interposition_consumer_context_stopped(_expected);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -368,8 +368,11 @@ stop_context(rocprofiler_context_id_t idx)
         const context* _expected = itr.load(std::memory_order_acquire);
         if(_expected && _expected->context_idx == idx.handle)
         {
-            // Stop queue-interposed services while the context is still in the active list so
-            // write_hook can coordinate serialized->unserialized transitions during drain.
+            // Stop queue-interposed services before clearing the active slot so
+            // disable_serialization() always runs before dispatches stop being instrumented.
+            // Clearing the slot first opens the opposite window, in which write_hook sees no
+            // active context and a dispatch is submitted without serializer packets while the
+            // serializer is still enabled.
             if(_expected->dispatch_counter_collection)
             {
                 rocprofiler::counters::stop_context(const_cast<context*>(_expected));

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -290,23 +290,28 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        // No GPU drain here. The sync this replaced existed to (a) avoid dangling callback
-        // pointers once the per-queue callbacks were unregistered and (b) let in-flight
-        // dispatches complete. (a) no longer applies -- nothing is registered, and
-        // signal_completion_hook resolves contexts at completion time. (b) is handled by that
-        // hook routing over registered rather than active contexts. Neither the serializer
-        // transition nor anything else in this function requires an idle GPU:
-        // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
-        // in-flight serialized dispatches are reconciled GPU-side.
+        // Drain in-flight dispatches, then disable serialization. The review of #8887 asked for
+        // this sync to be kept and for SPM to stay visible to the enter hook and to serialization
+        // through a "draining" window until both this and disable_serialization() complete.
         //
-        // This is a deliberate divergence from one review of #8887, which asked instead for the
-        // sync to be kept and the service held visible to the enter hook through an explicit
-        // "draining" state until sync and disable_serialization complete. The serialization window
-        // that state would protect is closed differently here: context::stop_context now runs this
-        // function before clearing the active slot, so disable_serialization happens while the
-        // enter hook can still see the context, and no dispatch is submitted unserialized while the
-        // serializer is enabled. Recorded here because the two approaches are not obviously
-        // equivalent and the choice should be revisited if that ordering changes.
+        // The visibility half comes from ordering rather than a separate flag:
+        // context::stop_context calls this function while the context is still in the active list,
+        // so for the duration of the drain the enter hook still reaches pre_kernel_call, whose
+        // disabled path deliberately returns serialize=true to coordinate the
+        // serialized->unserialized transition. Only once this function returns does the active slot
+        // get cleared. Introducing a draining flag as well would duplicate that guarantee, but the
+        // ordering is load-bearing: if the slot were cleared first, the enter hook would go blind
+        // before disable_serialization() ran and a dispatch could be submitted unserialized while
+        // the serializer was still enabled.
+        //
+        // A removal of this sync was considered on the grounds that its two original purposes --
+        // avoiding dangling callback pointers once the per-queue callbacks were unregistered, and
+        // letting in-flight dispatches complete -- are both addressed by the migration and by
+        // routing completions over registered contexts. The first is genuinely gone. The second is
+        // weaker than it looks: provenance routing ensures a completion that arrives is delivered,
+        // whereas the drain bounds when completions arrive at all, which is what the rest of the
+        // teardown depends on. Keeping it.
+        hsa::queue_controller_sync();
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -298,6 +298,15 @@ stop_context(const context::context* ctx)
         // transition nor anything else in this function requires an idle GPU:
         // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
         // in-flight serialized dispatches are reconciled GPU-side.
+        //
+        // This is a deliberate divergence from one review of #8887, which asked instead for the
+        // sync to be kept and the service held visible to the enter hook through an explicit
+        // "draining" state until sync and disable_serialization complete. The serialization window
+        // that state would protect is closed differently here: context::stop_context now runs this
+        // function before clearing the active slot, so disable_serialization happens while the
+        // enter hook can still see the context, and no dispatch is submitted unserialized while the
+        // serializer is enabled. Recorded here because the two approaches are not obviously
+        // equivalent and the choice should be revisited if that ordering changes.
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -290,7 +290,14 @@ stop_context(const context::context* ctx)
 
     if(controller)
     {
-        hsa::queue_controller_sync();
+        // No GPU drain here. The sync this replaced existed to (a) avoid dangling callback
+        // pointers once the per-queue callbacks were unregistered and (b) let in-flight
+        // dispatches complete. (a) no longer applies -- nothing is registered, and
+        // signal_completion_hook resolves contexts at completion time. (b) is handled by that
+        // hook routing over registered rather than active contexts. Neither the serializer
+        // transition nor anything else in this function requires an idle GPU:
+        // profiler_serializer::disable() pushes an hsa_barrier carrying the previous state, so
+        // in-flight serialized dispatches are reconciled GPU-side.
         controller->disable_serialization();
         // No per-queue callback to remove; spm::write_hook no-ops once dispatch_spm is
         // disabled above.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -31,7 +31,7 @@ namespace spm
 namespace
 {
 auto
-active_spm_contexts_filter()
+spm_contexts_filter()
 {
     return [](const context::context* ctx) -> bool { return ctx && ctx->dispatch_spm != nullptr; };
 }
@@ -48,7 +48,7 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized)
 {
-    auto active = context::get_active_contexts(active_spm_contexts_filter());
+    auto active = context::get_active_contexts(spm_contexts_filter());
     for(const auto* ctx : active)
     {
         for(auto& cb : ctx->dispatch_spm->callbacks)
@@ -76,8 +76,11 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
                        hsa::inst_pkt_t&                inst_pkt,
                        kernel_dispatch::profiling_time dispatch_time)
 {
-    auto active = context::get_active_contexts(active_spm_contexts_filter());
-    for(const auto* ctx : active)
+    // Route by packet provenance, not current activeness: post_kernel_call self-filters via
+    // packet_return_map, so in-flight dispatches still complete after stop_context removes the
+    // context from the active list.
+    auto contexts = context::get_registered_contexts(spm_contexts_filter());
+    for(const auto* ctx : contexts)
     {
         for(auto& cb : ctx->dispatch_spm->callbacks)
         {
@@ -89,7 +92,7 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 bool
 is_any_active()
 {
-    return !context::get_active_contexts(active_spm_contexts_filter()).empty();
+    return !context::get_active_contexts(spm_contexts_filter()).empty();
 }
 }  // namespace spm
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.cpp
@@ -78,7 +78,14 @@ signal_completion_hook(const hsa::Queue& /*queue*/,
 {
     // Route by packet provenance, not current activeness: post_kernel_call self-filters via
     // packet_return_map, so in-flight dispatches still complete after stop_context removes the
-    // context from the active list.
+    // context from the active list. Without this, a dispatch in flight at stop skips the
+    // DISPATCH_END record, kfd_stop() and the barrier-signal cleanup, and leaks its map entry.
+    //
+    // Iterating registered contexts widens the candidate set, but routing stays per-origin because
+    // each context's post_kernel_call only claims packets present in its own packet_return_map.
+    // That matters because there is no conflict guard rejecting a second concurrent dispatch_spm
+    // context, unlike dispatch_counter_collection, so more than one SPM context can be registered
+    // at once.
     auto contexts = context::get_registered_contexts(spm_contexts_filter());
     for(const auto* ctx : contexts)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/queue_hooks.hpp
@@ -49,8 +49,10 @@ write_hook(const hsa::Queue&                                        queue,
            hsa::inst_pkt_t&                                         inst_pkt,
            bool&                                                    is_serialized);
 
-// Explicit replacement for the SPM completion callback. Iterates active
-// dispatch_spm contexts and calls each callback's post_kernel_call.
+// Explicit replacement for the SPM completion callback. Iterates registered
+// dispatch_spm contexts (not only active ones) and calls each callback's
+// post_kernel_call; post_kernel_call self-filters via packet_return_map so
+// in-flight dispatches still complete after stop_context.
 void
 signal_completion_hook(const hsa::Queue&                           queue,
                        const hsa::rocprofiler_packet&              kernel_packet,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -29,12 +29,12 @@
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
 #include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
-#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/experimental/spm.h>
@@ -930,7 +930,7 @@ TEST(spm_core, stop_context_removes_callbacks)
     ASSERT_TRUE(ctx.dispatch_spm);
     ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
 
-    // Stop disables collection and tears the context down (no GPU drain; see spm::stop_context).
+    // Stop disables collection, drains in-flight dispatches, then tears the context down.
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     bool enabled = true;
@@ -971,7 +971,7 @@ TEST(spm_core, stop_context_sync_and_restart)
 
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
-    // Restart to verify the queue controller is in a clean state after teardown
+    // Restart to verify the queue controller is in a clean state after drain + teardown
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "restart context");
 
     bool enabled = false;
@@ -988,7 +988,8 @@ TEST(spm_core, stop_context_sync_and_restart)
 
 // Regression for callback-registry removal (#8887): a dispatch enqueued while the SPM context
 // is active must still complete (and drain packet_return_map) when stop_context runs before the
-// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call directly.
+// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call
+// directly.
 TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
 {
     rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
@@ -1000,12 +1001,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
     context::push_client(1);
 
     ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
-    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
-                                                                         user_dispatch_cb,
-                                                                         nullptr,
-                                                                         null_record_callback,
-                                                                         nullptr),
-                     "Could not setup SPM service");
+    ROCPROFILER_CALL(
+        rocprofiler_spm_configure_callback_dispatch_service(
+            get_client_ctx(), user_dispatch_cb, nullptr, null_record_callback, nullptr),
+        "Could not setup SPM service");
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
 
     auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
@@ -1025,15 +1024,15 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
         if(!is_spm_supported_arch(agent)) continue;
 
         found_spm_agent = true;
-        auto metrics = getSPMMetrics(agent);
+        auto metrics    = getSPMMetrics(agent);
         for(auto& metric : metrics)
         {
             if(!metric.expression().empty()) continue;
 
-            expected_dispatch expected = {};
-            rocprofiler_counter_id_t id = {.handle = metric.id()};
+            expected_dispatch                          expected = {};
+            rocprofiler_counter_id_t                   id       = {.handle = metric.id()};
             std::vector<rocprofiler_spm_parameters_t*> input_params{};
-            rocprofiler_spm_parameters_t param{
+            rocprofiler_spm_parameters_t               param{
                 .size  = sizeof(rocprofiler_spm_parameters_t),
                 .type  = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
                 .value = 1200};
@@ -1048,10 +1047,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
                              "Unable to create profile");
             cb_info->callback_args = &expected;
 
-            rocprofiler_queue_id_t qid = {.handle = 1};
-            hsa::FakeQueue         fq(agent, qid);
-            hsa::rocprofiler_packet  pkt{};
-            context::correlation_id  corr_id{.internal = 99};
+            rocprofiler_queue_id_t  qid = {.handle = 1};
+            hsa::FakeQueue          fq(agent, qid);
+            hsa::rocprofiler_packet pkt{};
+            context::correlation_id corr_id{.internal = 99};
 
             expected.queue_id    = qid;
             expected.agent_id    = agent.get_rocp_agent()->id;
@@ -1078,7 +1077,8 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
             ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
             EXPECT_FALSE(rocprofiler::spm::is_any_active());
 
-            auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+            auto sess =
+                std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
             sess->correlation_id = &corr_id;
 
             spm::inst_pkt_t inst_pkt;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -33,6 +33,8 @@
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+#include "lib/rocprofiler-sdk/spm/queue_hooks.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_hooks/client_ids.hpp"
 
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/experimental/spm.h>
@@ -982,4 +984,130 @@ TEST(spm_core, stop_context_sync_and_restart)
     registration::finalize();
     context::pop_client(1);
     set_client_ctx(get_client_ctx());
+}
+
+// Regression for callback-registry removal (#8887): a dispatch enqueued while the SPM context
+// is active must still complete (and drain packet_return_map) when stop_context runs before the
+// GPU completion callback. Exercises the queue_hooks routing layer, not pre/post_kernel_call directly.
+TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
+                                                                         user_dispatch_cb,
+                                                                         nullptr,
+                                                                         null_record_callback,
+                                                                         nullptr),
+                     "Could not setup SPM service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    ASSERT_TRUE(ctx_p->dispatch_spm);
+    auto cb_info = ctx_p->dispatch_spm->callbacks.front();
+
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    bool found_spm_agent = false;
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(!rocp_agent->runtime_visibility.hsa || !rocp_agent->runtime_visibility.hip) continue;
+        if(!is_spm_supported_arch(agent)) continue;
+
+        found_spm_agent = true;
+        auto metrics = getSPMMetrics(agent);
+        for(auto& metric : metrics)
+        {
+            if(!metric.expression().empty()) continue;
+
+            expected_dispatch expected = {};
+            rocprofiler_counter_id_t id = {.handle = metric.id()};
+            std::vector<rocprofiler_spm_parameters_t*> input_params{};
+            rocprofiler_spm_parameters_t param{
+                .size  = sizeof(rocprofiler_spm_parameters_t),
+                .type  = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                .value = 1200};
+            input_params.push_back(&param);
+
+            ROCPROFILER_CALL(rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                   &id,
+                                                                   1,
+                                                                   input_params.data(),
+                                                                   input_params.size(),
+                                                                   &expected.id),
+                             "Unable to create profile");
+            cb_info->callback_args = &expected;
+
+            rocprofiler_queue_id_t qid = {.handle = 1};
+            hsa::FakeQueue         fq(agent, qid);
+            hsa::rocprofiler_packet  pkt{};
+            context::correlation_id  corr_id{.internal = 99};
+
+            expected.queue_id    = qid;
+            expected.agent_id    = agent.get_rocp_agent()->id;
+            expected.kernel_id   = 42;
+            expected.dispatch_id = 7;
+
+            auto user_data = rocprofiler_user_data_t{.value = corr_id.internal};
+            auto ret_pkt   = spm::pre_kernel_call(ctx_p,
+                                                cb_info,
+                                                fq,
+                                                pkt,
+                                                expected.kernel_id,
+                                                expected.dispatch_id,
+                                                &user_data,
+                                                {},
+                                                &corr_id);
+            if(!ret_pkt.packet) continue;
+
+            size_t map_size_before_stop = 0;
+            cb_info->packet_return_map.rlock(
+                [&](const auto& data) { map_size_before_stop = data.size(); });
+            if(map_size_before_stop == 0) continue;
+
+            ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+            EXPECT_FALSE(rocprofiler::spm::is_any_active());
+
+            auto sess = std::make_shared<hsa::queue_info_session_t>(hsa::queue_info_session_t{.queue = fq});
+            sess->correlation_id = &corr_id;
+
+            spm::inst_pkt_t inst_pkt;
+            inst_pkt.emplace_back(
+                std::make_pair(std::move(ret_pkt.packet), hsa::queue_hooks::SPM_CLIENT_ID));
+
+            spm::signal_completion_hook(fq,
+                                        pkt,
+                                        sess,
+                                        sess->packet_data.emplace_back(),
+                                        inst_pkt,
+                                        kernel_dispatch::profiling_time{});
+
+            size_t map_size_after_completion = 1;
+            cb_info->packet_return_map.rlock(
+                [&](const auto& data) { map_size_after_completion = data.size(); });
+            EXPECT_EQ(map_size_after_completion, 0U)
+                << "packet_return_map must drain via signal_completion_hook after stop_context";
+
+            ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                             "Could not delete profile id");
+            registration::set_init_status(1);
+            registration::finalize();
+            context::pop_client(1);
+            set_client_ctx(get_client_ctx());
+            return;
+        }
+    }
+
+    if(!found_spm_agent) GTEST_SKIP() << "SPM unavailable";
+    FAIL() << "Could not exercise SPM in-flight completion hook path";
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -930,7 +930,7 @@ TEST(spm_core, stop_context_removes_callbacks)
     ASSERT_TRUE(ctx.dispatch_spm);
     ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
 
-    // Stop exercises queue_controller_sync + context teardown.
+    // Stop disables collection and tears the context down (no GPU drain; see spm::stop_context).
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
     bool enabled = true;
@@ -971,7 +971,7 @@ TEST(spm_core, stop_context_sync_and_restart)
 
     ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
 
-    // Restart to verify queue controller is in a clean state after sync + teardown
+    // Restart to verify the queue controller is in a clean state after teardown
     ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "restart context");
 
     bool enabled = false;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1067,12 +1067,22 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
                                                 &user_data,
                                                 {},
                                                 &corr_id);
-            if(!ret_pkt.packet) continue;
+            if(!ret_pkt.packet)
+            {
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
+                continue;
+            }
 
             size_t map_size_before_stop = 0;
             cb_info->packet_return_map.rlock(
                 [&](const auto& data) { map_size_before_stop = data.size(); });
-            if(map_size_before_stop == 0) continue;
+            if(map_size_before_stop == 0)
+            {
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
+                continue;
+            }
 
             ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
             EXPECT_FALSE(rocprofiler::spm::is_any_active());

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1050,7 +1050,10 @@ TEST(spm_queue_hooks, stop_context_in_flight_completion_routes_via_hook_path)
             rocprofiler_queue_id_t  qid = {.handle = 1};
             hsa::FakeQueue          fq(agent, qid);
             hsa::rocprofiler_packet pkt{};
-            context::correlation_id corr_id{.internal = 99};
+            // correlation_id declares constructors and holds private ref counters, so it is not an
+            // aggregate and cannot take a designated initializer.
+            context::correlation_id corr_id{};
+            corr_id.internal = 99;
 
             expected.queue_id    = qid;
             expected.agent_id    = agent.get_rocp_agent()->id;


### PR DESCRIPTION

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR isolates the **counter-collection slice** of the callback-removal effort (reference PRs
#8730 / #8586) into a small, single-service change, per review guidance to land callback removal
one service at a time.

It is one of four sibling migrations, each independently reviewable:

| Service | PR | Status |
|---|---|---|
| Thread trace | #8790 | approved |
| PC sampling | #8895 | approved |
| SPM | #8887 | in review |
| **Counter collection** | **this PR** | in review |

Kernel replay (#7960, #8622) is greatly enhanced by this change, but the two are **independent**.
This PR is behavior-preserving on its own and should merge into `develop` cleanly with or without
the kernel replay feature.

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->

Counter collection no longer registers a `queue_callbacks_t` with the HSA queue controller. The HSA
write interceptor and the async signal handler now call explicit free functions instead.

**New — `counters/queue_hooks.{hpp,cpp}`**

- `write_hook`, `signal_completion_hook`, `is_any_active`, each iterating active
  `dispatch_counter_collection` contexts and calling the existing `queue_cb` / `completed_cb`.
- The hooks are deliberately thin: this PR changes *how* the callbacks are reached, not what they
  do.

**New — `hsa/queue_hooks/client_ids.hpp`**

- Stable producer tags for `inst_pkt_t` entries. All four service ids are reserved up front, not
  just the one this PR needs, so the tag values stay stable as each remaining service migrates and
  test ordering does not shift underneath the later PRs.

**Changed**

- The `WriteInterceptor` gate and the `should_batch` predicate detect counters via
  `is_any_active()`; counter collection no longer contributes to `queue.get_notifiers()`.
- Removes the now-unused `queue_id` from `counter_callback_info`.
- Updates the counter tests off `iterate_callbacks`.

**Deliberately not changed**

- The per-queue callback registry stays in place for thread trace, PC sampling and SPM. It is
  removed only once all four services are migrated.
- The callback thread (`callback_thread_start` / `callback_thread_stop`) is preserved.

### Rebase, 12 Aug

Rebased onto `develop` at `20bb64fb32` to clear the merge conflict. There was exactly one conflict
and it was mechanical: `develop` renamed `firmware_restrictions.cpp` to
`firmware_restrictions_test.cpp` while this branch added `queue_hooks_test.cpp`, so both entries
now appear in `counters/tests/CMakeLists.txt`.

No source changes were made during the rebase. The diffstat is unchanged at **300 insertions, 82
deletions across 12 files**, which is the check that nothing drifted. The two stacked PRs were
restacked at the same time and both remain mergeable.

### Relationship to the stacked PRs

```
#8891  (this PR)          migration only
  └── #9586               review feedback: completion routing, hook renames, enum, copyright
        └── #9868         per-agent scoping for counter collection
```

Review feedback on this PR is **intentionally not applied here**, to keep this PR a pure mechanical
migration that is easy to verify by inspection:

- @bwelton's blocking comment — the migration changed completion routing from provenance-based to
  liveness-based, so an in-flight dispatch's completion can be dropped when the context stops — is
  fixed in #9586.
- @vlaindic's requests — hook renames to `kernel_dispatch_phase_enter_hook` /
  `kernel_dispatch_phase_exit_hook`, converting the client ids to an unscoped enum with an
  `int64_t` fixed underlying type, and the copyright years — are also in #9586.

Reviewers who want to see the end state rather than the increment should read #9586 alongside this
PR.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

AIPROFSDK-1017.

Motivated by the kernel replay work tracked under AIPROFSDK-68; see #7960 for why the callback
registry is a problem for replay. This PR does not depend on that work.

## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->

The migration is intended to be behaviour-preserving, so the real coverage is the existing suite
rather than new tests.

- **New unit test** — `counters/tests/queue_hooks_test.cpp`,
  `counters_queue_hooks.is_any_active_false_when_no_context_active`. `is_any_active()` replaces the
  `queue.get_notifiers()` signal the old registry gave the write-interceptor gate; with no
  dispatch-counter-collection context active it must report inactive. Requires no GPU or HSA
  runtime, so it runs everywhere.
- **Existing counter-collection unit tests** — `counters/tests/core.cpp`, updated off
  `iterate_callbacks` to the new hook surface.
- **Existing rocprofv3 counter-collection integration tests** — unchanged, and the primary signal
  that the migration preserved behaviour.

## Test Result

<!-- Briefly summarize test outcomes. -->
CI is re-running after the 12 Aug rebase; the results below describe the state before it, which
the rebase should not have altered since it touched only a CMake source list.

**Known failures, fixed in #9586.** Two pre-existing integration tests fail on this PR and pass on
`develop`:

```
rocprofv3-test-roctx-pause-resume-tracing.test_counter_collection_data
rocprofv3-test-counter-collection-pmc-selected-regions
  .test_counter_collection_only_inside_selected_regions
```

Both are pause/resume counter-collection tests, and pause is `stop_context` — which is exactly the
completion-routing regression @bwelton identified. They are an objective target for #9586 rather
than tests authored alongside the fix.

**Not caused by this PR**, for whoever triages the check list:

- `Analyze (actions)` and `Analyze (python)` fail with a workflow template error rather than a
  finding — `.github/workflows/rocprofiler-sdk-codeql.yml`, "Unexpected value ''". The jobs never
  run, and this affects every PR in the repository.
- `therock-pr-bot` reports `Timed out waiting for required checks to complete` and is downstream of
  the above.
- `6.2 • ubuntu-22.04 • aqlprofile-internal` failed in image setup with a `GPGKeyTemporarilyNotFoundError`
  and an HTTP 500 from the package host.

For calibration: #8790 and #8895 are approved with zero real failures, and their check lists
contain exactly those same three repo-wide jobs.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.