### PR TITLE
feat(rocjpeg): add batched async decode API and sample

### DIFF
--- a/projects/rocjpeg/CHANGELOG.md
+++ b/projects/rocjpeg/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
+## (unreleased) rocJPEG 1.8.0
+
+### Added
+
+* Added rocJpegDecodeBatchedAsync and rocJpegDecodeBatchedSync APIs to support asynchronous batched JPEG decoding.
+
 ## rocJPEG 1.7.0
 
 ### Added

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -267,6 +267,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND AND Threads_FOUND)
   install(FILES samples/jpegDecodePerf/CMakeLists.txt samples/jpegDecodePerf/jpegdecodeperf.cpp samples/jpegDecodePerf/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodePerf)
   install(FILES samples/jpegDecodeBatched/CMakeLists.txt samples/jpegDecodeBatched/jpegdecodebatched.cpp samples/jpegDecodeBatched/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodeBatched)
   install(FILES samples/jpegDecodeAsync/CMakeLists.txt samples/jpegDecodeAsync/jpegdecodeasync.cpp samples/jpegDecodeAsync/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodeAsync)
+  install(FILES samples/jpegDecodeBatchedAsync/CMakeLists.txt samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp samples/jpegDecodeBatchedAsync/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/jpegDecodeBatchedAsync)
   install(FILES samples/rocjpeg_samples_utils.h DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples)
   install(DIRECTORY data/images DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
   # install license information - {ROCM_PATH}/share/doc/rocjpeg

--- a/projects/rocjpeg/CMakeLists.txt
+++ b/projects/rocjpeg/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 # rocjpeg Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "1.7.0")
+set(VERSION "1.8.0")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)

--- a/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
+++ b/projects/rocjpeg/api/amd_detail/rocjpeg_api_trace.h
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 // Increment the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION when new runtime API functions are added.
 // If the corresponding ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION increases reset the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION to zero.
-#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 1
+#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 2
 
 // rocJPEG API interface
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegStreamCreate)(RocJpegStreamHandle *jpeg_stream_handle);
@@ -59,6 +59,8 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeSync)(RocJpegHandle handle, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatchedAsync)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatchedSync)(RocJpegHandle handle, RocJpegImage *destinations, int batch_size);
 
 // rocJPEG API dispatch table
 struct RocJpegDispatchTable {
@@ -81,6 +83,11 @@ struct RocJpegDispatchTable {
 
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2
+    PfnRocJpegDecodeBatchedAsync pfn_rocjpeg_decode_batched_async;
+    PfnRocJpegDecodeBatchedSync pfn_rocjpeg_decode_batched_sync;
+
+    // PLEASE DO NOT EDIT ABOVE!
+    // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 3
 
     // ******************************************************************************************* //
     //                                            READ BELOW

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -346,6 +346,13 @@ extern const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
  * @ingroup group_amd_rocjpeg
  * @brief Submits a JPEG decode operation without waiting for the output.
  *
+ * This function is one half of the rocJpegDecodeAsync/rocJpegDecodeSync pair. It submits the
+ * decode to hardware and returns immediately. The caller must subsequently call rocJpegDecodeSync()
+ * on the same handle to wait for completion and retrieve the decoded output.
+ * These two calls must not be issued concurrently on the same handle. The intended usage is a
+ * producer/consumer model where one thread calls rocJpegDecodeAsync() and a separate thread
+ * calls rocJpegDecodeSync().
+ *
  * @param handle The rocJPEG handle.
  * @param jpeg_stream_handle The rocJPEG stream handle.
  * @param decode_params The decoding parameters.
@@ -357,10 +364,13 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
 /**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
  * @ingroup group_amd_rocjpeg
- * @brief Synchronizes a pending asynchronous JPEG decode.
+ * @brief Synchronizes a pending asynchronous JPEG decode and retrieves the decoded output.
  *
- * This function must be used in conjunction with rocJpegDecodeAsync to ensure the decoding
- * is complete before accessing the decoded output.
+ * This function is one half of the rocJpegDecodeAsync/rocJpegDecodeSync pair. It must be called
+ * after rocJpegDecodeAsync() on the same handle to wait for the decode to complete and copy the
+ * result to the destination buffer. These two calls must not be issued concurrently on the same
+ * handle. The intended usage is a producer/consumer model where one thread calls
+ * rocJpegDecodeAsync() and a separate thread calls rocJpegDecodeSync().
  *
  * @param handle The rocJPEG handle.
  * @param destination A pointer to RocJpegImage where the decoded image will be stored.
@@ -373,9 +383,13 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *d
  * @ingroup group_amd_rocjpeg
  * @brief Submits a batch of JPEG decode operations without waiting for the output.
  *
- * This function submits all images in the batch to the hardware decoder and returns immediately
- * without waiting for the decodes to complete or copying the results to destination buffers.
- * Use rocJpegDecodeBatchedSync() to wait for completion and retrieve the decoded output.
+ * This function is one half of the rocJpegDecodeBatchedAsync/rocJpegDecodeBatchedSync pair. It
+ * submits all images in the batch to the hardware decoder and returns immediately without waiting
+ * for the decodes to complete or copying the results to the destination buffers. The caller must
+ * subsequently call rocJpegDecodeBatchedSync() on the same handle to wait for completion and
+ * retrieve the decoded output. These two calls must not be issued concurrently on the same handle.
+ * The intended usage is a producer/consumer model where one thread calls
+ * rocJpegDecodeBatchedAsync() and a separate thread calls rocJpegDecodeBatchedSync().
  *
  * @param handle The rocJPEG handle.
  * @param jpeg_stream_handles An array of rocJPEG stream handles representing the input JPEG streams.
@@ -389,10 +403,14 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpeg
 /**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size);
  * @ingroup group_amd_rocjpeg
- * @brief Synchronizes a pending asynchronous batched JPEG decode.
+ * @brief Synchronizes a pending asynchronous batched JPEG decode and retrieves the decoded output.
  *
- * This function must be used in conjunction with rocJpegDecodeBatchedAsync to wait for all
- * submitted decodes in the batch to complete and copy the results to the destination buffers.
+ * This function is one half of the rocJpegDecodeBatchedAsync/rocJpegDecodeBatchedSync pair. It
+ * must be called after rocJpegDecodeBatchedAsync() on the same handle to wait for all submitted
+ * decodes in the batch to complete and copy the results to the destination buffers. These two
+ * calls must not be issued concurrently on the same handle. The intended usage is a
+ * producer/consumer model where one thread calls rocJpegDecodeBatchedAsync() and a separate
+ * thread calls rocJpegDecodeBatchedSync().
  *
  * @param handle The rocJPEG handle.
  * @param destinations An array of RocJpegImage pointers identifying the pending batch, as passed to rocJpegDecodeBatchedAsync.

--- a/projects/rocjpeg/api/rocjpeg/rocjpeg.h
+++ b/projects/rocjpeg/api/rocjpeg/rocjpeg.h
@@ -368,6 +368,39 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
  */
 RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
 
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+ * @ingroup group_amd_rocjpeg
+ * @brief Submits a batch of JPEG decode operations without waiting for the output.
+ *
+ * This function submits all images in the batch to the hardware decoder and returns immediately
+ * without waiting for the decodes to complete or copying the results to destination buffers.
+ * Use rocJpegDecodeBatchedSync() to wait for completion and retrieve the decoded output.
+ *
+ * @param handle The rocJPEG handle.
+ * @param jpeg_stream_handles An array of rocJPEG stream handles representing the input JPEG streams.
+ * @param batch_size The number of JPEG streams in the batch.
+ * @param decode_params An array of RocJpegDecodeParams structs representing the decode parameters for each image.
+ * @param destinations An array of RocJpegImage structs representing the output decoded images.
+ * @return A RocJpegStatus indicating the success or failure of the submit operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size);
+ * @ingroup group_amd_rocjpeg
+ * @brief Synchronizes a pending asynchronous batched JPEG decode.
+ *
+ * This function must be used in conjunction with rocJpegDecodeBatchedAsync to wait for all
+ * submitted decodes in the batch to complete and copy the results to the destination buffers.
+ *
+ * @param handle The rocJPEG handle.
+ * @param destinations An array of RocJpegImage pointers identifying the pending batch, as passed to rocJpegDecodeBatchedAsync.
+ * @param batch_size The number of images in the batch.
+ * @return A RocJpegStatus indicating the success or failure of the sync operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size);
+
 #if defined(__cplusplus)
   }
 #endif

--- a/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeAsync/jpegdecodeasync.cpp
@@ -101,7 +101,13 @@ int main(int argc, char **argv) {
     // Sync thread: continuously drains pending_queue by calling rocJpegDecodeSync,
     // optionally saves the result, then returns the slot to available_queue.
     std::thread sync_thread([&]() {
-        CHECK_HIP(hipSetDevice(device_id));
+        if (hipSetDevice(device_id) != hipSuccess) {
+            std::lock_guard<std::mutex> lock(mtx);
+            async_status = ROCJPEG_STATUS_RUNTIME_ERROR;
+            sync_error   = true;
+            cv_available.notify_all();
+            return;
+        }
         while (true) {
             PipelineSlot* slot;
             {

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/CMakeLists.txt
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/CMakeLists.txt
@@ -1,0 +1,78 @@
+################################################################################
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+cmake_minimum_required (VERSION 3.10)
+
+# ROCM Path
+if(DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Default ROCm installation path")
+elseif(ROCM_PATH)
+  message("-- INFO:ROCM_PATH Set -- ${ROCM_PATH}")
+else()
+  set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
+endif()
+# Set AMD Clang as default compiler
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+set(CMAKE_CXX_EXTENSIONS ON)
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  set(CMAKE_C_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang)
+  set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang++)
+endif()
+
+project(jpegdecodebatchedasync)
+
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
+find_package(HIP QUIET)
+find_package(rocjpeg QUIET)
+find_package(rocprofiler-register QUIET)
+
+if(HIP_FOUND AND rocjpeg_FOUND AND rocprofiler-register_FOUND)
+    # HIP
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
+    # rocJPEG
+    include_directories (${rocjpeg_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocjpeg::rocjpeg)
+    # std filesystem
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
+    # rocprofiler-register
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
+
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} jpegdecodebatchedasync.cpp)
+    add_executable(${PROJECT_NAME} ${SOURCES})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
+    target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})
+else()
+    message("-- ERROR!: ${PROJECT_NAME} excluded! unmet dependencies")
+    if (NOT HIP_FOUND)
+        message(FATAL_ERROR "-- ERROR!: HIP Not Found!")
+    endif()
+    if (NOT rocjpeg_FOUND)
+        message(FATAL_ERROR "-- ERROR!: rocJPEG Not Found!")
+    endif()
+    if (NOT rocprofiler-register_FOUND)
+        message(FATAL_ERROR "-- ERROR!: rocprofiler-register Not Found!")
+    endif()
+endif()

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/README.md
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/README.md
@@ -1,0 +1,28 @@
+# JPEG decode batched async sample
+
+The jpeg decode batched async sample illustrates asynchronous batch decoding of JPEG images using the rocJPEG library to get the decoded images in one of the supported output formats (i.e., native, yuv, y, rgb, rgb_planar). It uses a threaded pipeline with `rocJpegDecodeBatchedAsync` and `rocJpegDecodeBatchedSync` APIs for improved throughput by overlapping batch submission with result retrieval. This sample can be configured with a device ID, a batch size, and can optionally dump the output to a file.
+
+## Prerequisites:
+
+* Install [rocJPEG](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/install/rocjpeg-build-and-install.html)
+
+## Build
+
+```shell
+mkdir jpeg_decode_batched_async_sample && cd jpeg_decode_batched_async_sample
+cmake ../
+make -j
+```
+
+## Run
+
+```shell
+./jpegdecodebatchedasync -i        <[input path] - input path to a single JPEG image or a directory containing JPEG images - [required]>
+                         -be       <[backend] - select rocJPEG backend (0 for hardware-accelerated JPEG decoding using VCN,
+                                                                        1 for hybrid JPEG decoding using CPU and GPU HIP kernels (currently not supported)) [optional - default: 0]>
+                         -fmt      <[output format] - select rocJPEG output format for decoding, one of the [native, yuv_planar, y, rgb, rgb_planar] [optional - default: native]>
+                         -o        <[output path] - path to an output file or a path to a directory - write decoded images to a file or directory based on selected output format [optional]>
+                         -d        <[device id] - specify the GPU device id for the desired device (use 0 for the first device, 1 for the second device, and so on) [optional - default: 0]>
+                         -b        <[batch size] - number of images to decode per batch [optional - default: 2]>
+                         -crop     <[crop rectangle] - crop rectangle for output in a comma-separated format: left,top,right,bottom - [optional]>
+```

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
@@ -1,0 +1,363 @@
+/*
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "../rocjpeg_samples_utils.h"
+
+int main(int argc, char **argv) {
+    int device_id = 0;
+    bool save_images = false;
+    uint8_t num_components;
+    uint32_t channel_sizes[ROCJPEG_MAX_COMPONENT] = {};
+    uint32_t num_channels = 0;
+    int total_images = 0;
+    int batch_size = 2;
+    std::string chroma_sub_sampling = "";
+    std::string input_path, output_file_path;
+    std::vector<std::string> file_paths = {};
+    bool is_dir = false;
+    bool is_file = false;
+    RocJpegBackend rocjpeg_backend = ROCJPEG_BACKEND_HARDWARE;
+    RocJpegHandle rocjpeg_handle = nullptr;
+    RocJpegDecodeParams decode_params = {};
+    RocJpegUtils rocjpeg_utils;
+    uint64_t num_bad_jpegs = 0;
+    uint64_t num_jpegs_with_411_subsampling = 0;
+    uint64_t num_jpegs_with_unknown_subsampling = 0;
+    uint64_t num_jpegs_with_unsupported_resolution = 0;
+
+    RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, &batch_size, argc, argv);
+
+    bool is_roi_valid = false;
+    uint32_t roi_width  = decode_params.crop_rectangle.right  - decode_params.crop_rectangle.left;
+    uint32_t roi_height = decode_params.crop_rectangle.bottom - decode_params.crop_rectangle.top;
+
+    if (!RocJpegUtils::GetFilePaths(input_path, file_paths, is_dir, is_file)) {
+        std::cerr << "ERROR: Failed to get input file paths!" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (!RocJpegUtils::InitHipDevice(device_id)) {
+        std::cerr << "ERROR: Failed to initialize HIP!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    CHECK_ROCJPEG(rocJpegCreate(rocjpeg_backend, device_id, &rocjpeg_handle));
+
+    batch_size = std::min(batch_size, static_cast<int>(file_paths.size()));
+
+    // Create a pool of stream handles equal to the batch size.
+    std::vector<RocJpegStreamHandle> rocjpeg_stream_handles(batch_size);
+    for (int i = 0; i < batch_size; i++) {
+        CHECK_ROCJPEG(rocJpegStreamCreate(&rocjpeg_stream_handles[i]));
+    }
+
+    // Each pipeline slot holds a full batch of GPU buffers.
+    // The main thread only blocks when all slots are in-flight (available_queue empty).
+    struct BatchPipelineSlot {
+        std::vector<RocJpegImage> images;
+        std::vector<std::vector<uint32_t>> channel_sizes_per_image;
+        std::vector<uint32_t> num_channels_per_image;
+        std::vector<std::vector<uint32_t>> widths;
+        std::vector<std::vector<uint32_t>> heights;
+        std::vector<RocJpegChromaSubsampling> subsamplings;
+        std::vector<std::string> file_names;
+        std::vector<RocJpegDecodeParams> decode_params_batch;
+        int current_batch_size = 0;
+    };
+
+    const int buf_num = 5;
+    std::vector<BatchPipelineSlot> pipeline_slots(buf_num);
+    for (int p = 0; p < buf_num; p++) {
+        pipeline_slots[p].images.resize(batch_size);
+        pipeline_slots[p].channel_sizes_per_image.resize(batch_size, std::vector<uint32_t>(ROCJPEG_MAX_COMPONENT, 0));
+        pipeline_slots[p].num_channels_per_image.resize(batch_size, 0);
+        pipeline_slots[p].widths.resize(batch_size, std::vector<uint32_t>(ROCJPEG_MAX_COMPONENT, 0));
+        pipeline_slots[p].heights.resize(batch_size, std::vector<uint32_t>(ROCJPEG_MAX_COMPONENT, 0));
+        pipeline_slots[p].subsamplings.resize(batch_size);
+        pipeline_slots[p].file_names.resize(batch_size);
+        pipeline_slots[p].decode_params_batch.resize(batch_size, decode_params);
+    }
+
+    std::queue<BatchPipelineSlot*> pending_queue;   // submitted, awaiting rocJpegDecodeBatchedSync
+    std::queue<BatchPipelineSlot*> available_queue; // idle, ready for next submit
+    std::mutex mtx;
+    std::condition_variable cv_pending, cv_available;
+    RocJpegStatus async_status = ROCJPEG_STATUS_SUCCESS;
+    bool sync_done  = false;
+    bool sync_error = false;
+    int  in_flight  = 0;
+
+    for (int p = 0; p < buf_num; p++)
+        available_queue.push(&pipeline_slots[p]);
+
+    // Sync thread: continuously drains pending_queue by calling rocJpegDecodeBatchedSync,
+    // optionally saves the results, then returns the slot to available_queue.
+    std::thread sync_thread([&]() {
+        CHECK_HIP(hipSetDevice(device_id));
+        while (true) {
+            BatchPipelineSlot* slot;
+            {
+                std::unique_lock<std::mutex> lock(mtx);
+                cv_pending.wait(lock, [&]{ return !pending_queue.empty() || sync_done || sync_error; });
+                if (sync_error) return;
+                if (pending_queue.empty()) return; // sync_done with nothing left
+                slot = pending_queue.front();
+                pending_queue.pop();
+            }
+
+            RocJpegStatus s = rocJpegDecodeBatchedSync(rocjpeg_handle, slot->images.data(), slot->current_batch_size);
+
+            if (s == ROCJPEG_STATUS_SUCCESS && save_images) {
+                for (int b = 0; b < slot->current_batch_size; b++) {
+                    std::string image_save_path = output_file_path;
+                    uint32_t img_roi_width  = slot->decode_params_batch[b].crop_rectangle.right  - slot->decode_params_batch[b].crop_rectangle.left;
+                    uint32_t img_roi_height = slot->decode_params_batch[b].crop_rectangle.bottom - slot->decode_params_batch[b].crop_rectangle.top;
+                    bool img_roi_valid = (img_roi_width > 0 && img_roi_height > 0 &&
+                                         img_roi_width  <= slot->widths[b][0] &&
+                                         img_roi_height <= slot->heights[b][0]);
+                    uint32_t width  = img_roi_valid ? img_roi_width  : slot->widths[b][0];
+                    uint32_t height = img_roi_valid ? img_roi_height : slot->heights[b][0];
+                    if (is_dir) {
+                        rocjpeg_utils.GetOutputFileExt(slot->decode_params_batch[b].output_format, slot->file_names[b], width, height, slot->subsamplings[b], image_save_path);
+                    }
+                    rocjpeg_utils.SaveImage(image_save_path, &slot->images[b], width, height, slot->subsamplings[b], slot->decode_params_batch[b].output_format);
+                }
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                in_flight--;
+                if (s != ROCJPEG_STATUS_SUCCESS) {
+                    async_status = s;
+                    sync_error   = true;
+                    cv_available.notify_all();
+                    return;
+                }
+                available_queue.push(slot);
+            }
+            cv_available.notify_one();
+        }
+    });
+
+    auto shutdown = [&]() {
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            sync_done = true;
+        }
+        cv_pending.notify_one();
+        if (sync_thread.joinable()) sync_thread.join();
+    };
+
+    std::vector<std::vector<char>> batch_file_data(batch_size);
+    std::vector<uint32_t> temp_widths(ROCJPEG_MAX_COMPONENT, 0);
+    std::vector<uint32_t> temp_heights(ROCJPEG_MAX_COMPONENT, 0);
+    RocJpegChromaSubsampling temp_subsampling;
+    std::vector<RocJpegStreamHandle> stream_handles_for_batch(batch_size);
+
+    std::cout << "Decoding started, please wait! ... " << std::endl;
+    auto total_start_time = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < static_cast<int>(file_paths.size()); i += batch_size) {
+        int batch_end = std::min(i + batch_size, static_cast<int>(file_paths.size()));
+
+        // Check for async failure before processing the next batch.
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (sync_error) {
+                std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+                sync_done = true;
+                cv_pending.notify_one();
+                if (sync_thread.joinable()) sync_thread.join();
+                return EXIT_FAILURE;
+            }
+        }
+
+        // Wait for an available slot.
+        BatchPipelineSlot* slot;
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            cv_available.wait(lock, [&]{ return !available_queue.empty() || sync_error; });
+            if (sync_error) {
+                std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+                sync_done = true;
+                cv_pending.notify_one();
+                lock.unlock();
+                if (sync_thread.joinable()) sync_thread.join();
+                return EXIT_FAILURE;
+            }
+            slot = available_queue.front();
+            available_queue.pop();
+        }
+
+        int current_batch_size = 0;
+        for (int j = i; j < batch_end; j++) {
+            int index = j - i;
+            std::string base_file_name = file_paths[j].substr(file_paths[j].find_last_of("/\\") + 1);
+
+            std::ifstream input(file_paths[j].c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+            if (!input.is_open()) {
+                std::cerr << "ERROR: Cannot open image: " << file_paths[j] << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+            std::streamsize file_size = input.tellg();
+            input.seekg(0, std::ios::beg);
+            if (batch_file_data[index].size() < (size_t)file_size)
+                batch_file_data[index].resize(file_size);
+            if (!input.read(batch_file_data[index].data(), file_size)) {
+                std::cerr << "ERROR: Cannot read from file: " << file_paths[j] << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            RocJpegStatus rocjpeg_status = rocJpegStreamParse(reinterpret_cast<uint8_t*>(batch_file_data[index].data()), file_size, rocjpeg_stream_handles[index]);
+            if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+                if (is_dir) { num_bad_jpegs++; continue; }
+                std::cerr << "ERROR: Failed to parse the input jpeg stream with " << rocJpegGetErrorName(rocjpeg_status) << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            CHECK_ROCJPEG(rocJpegGetImageInfo(rocjpeg_handle, rocjpeg_stream_handles[index], &num_components, &temp_subsampling, temp_widths.data(), temp_heights.data()));
+
+            if (temp_widths[0] < 64 || temp_heights[0] < 64) {
+                if (is_dir) { num_jpegs_with_unsupported_resolution++; continue; }
+                std::cerr << "The image resolution is not supported by VCN Hardware" << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+            if (temp_subsampling == ROCJPEG_CSS_411 || temp_subsampling == ROCJPEG_CSS_UNKNOWN) {
+                if (is_dir) {
+                    if (temp_subsampling == ROCJPEG_CSS_411)     num_jpegs_with_411_subsampling++;
+                    if (temp_subsampling == ROCJPEG_CSS_UNKNOWN) num_jpegs_with_unknown_subsampling++;
+                    continue;
+                }
+                std::cerr << "The chroma sub-sampling is not supported by VCN Hardware" << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            uint32_t local_num_channels = 0;
+            if (rocjpeg_utils.GetChannelPitchAndSizes(slot->decode_params_batch[current_batch_size], temp_subsampling, temp_widths.data(), temp_heights.data(), local_num_channels, slot->images[current_batch_size], channel_sizes)) {
+                std::cerr << "ERROR: Failed to get the channel pitch and sizes" << std::endl;
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            // Grow slot GPU buffers if this image's channels exceed current allocation.
+            for (uint32_t c = 0; c < local_num_channels; c++) {
+                if (channel_sizes[c] > slot->channel_sizes_per_image[current_batch_size][c]) {
+                    if (slot->images[current_batch_size].channel[c] != nullptr) {
+                        CHECK_HIP(hipFree(slot->images[current_batch_size].channel[c]));
+                        slot->images[current_batch_size].channel[c] = nullptr;
+                    }
+                    CHECK_HIP(hipMalloc(&slot->images[current_batch_size].channel[c], channel_sizes[c]));
+                    slot->channel_sizes_per_image[current_batch_size][c] = channel_sizes[c];
+                }
+            }
+            slot->num_channels_per_image[current_batch_size] = local_num_channels;
+            slot->widths[current_batch_size]      = temp_widths;
+            slot->heights[current_batch_size]     = temp_heights;
+            slot->subsamplings[current_batch_size] = temp_subsampling;
+            slot->file_names[current_batch_size]   = base_file_name;
+            stream_handles_for_batch[current_batch_size] = rocjpeg_stream_handles[index];
+            current_batch_size++;
+        }
+
+        slot->current_batch_size = current_batch_size;
+
+        if (current_batch_size > 0) {
+            RocJpegStatus rocjpeg_status = rocJpegDecodeBatchedAsync(rocjpeg_handle, stream_handles_for_batch.data(), current_batch_size, slot->decode_params_batch.data(), slot->images.data());
+            if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+                std::cerr << "ERROR: rocJpegDecodeBatchedAsync returned " << rocJpegGetErrorName(rocjpeg_status) << std::endl;
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    async_status = rocjpeg_status;
+                    sync_error   = true;
+                }
+                cv_pending.notify_one();
+                shutdown();
+                return EXIT_FAILURE;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                in_flight++;
+                pending_queue.push(slot);
+            }
+            cv_pending.notify_one();
+
+            total_images += current_batch_size;
+        } else {
+            // No valid images in this batch window; return slot immediately.
+            std::lock_guard<std::mutex> lock(mtx);
+            available_queue.push(slot);
+        }
+    }
+
+    // Drain: wait for all in-flight batches to complete before reporting stats.
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv_available.wait(lock, [&]{ return in_flight == 0 || sync_error; });
+    }
+    auto total_end_time = std::chrono::high_resolution_clock::now();
+
+    shutdown();
+
+    if (sync_error) {
+        std::cerr << "ERROR: Async decode failed with " << rocJpegGetErrorName(async_status) << std::endl;
+    } else if (total_images > 0) {
+        double total_time_ms     = std::chrono::duration<double, std::milli>(total_end_time - total_start_time).count();
+        double time_per_image_ms = total_time_ms / total_images;
+        std::cout << "Total decoded images: "                        << total_images << std::endl;
+        std::cout << "Average processing time per image (ms): "      << time_per_image_ms << std::endl;
+        std::cout << "Average images per sec (Images/Sec): "         << 1000.0 / time_per_image_ms << std::endl;
+    }
+
+    if (num_bad_jpegs || num_jpegs_with_411_subsampling || num_jpegs_with_unknown_subsampling || num_jpegs_with_unsupported_resolution) {
+        std::cout << "Total skipped images: "
+                  << num_bad_jpegs + num_jpegs_with_411_subsampling + num_jpegs_with_unknown_subsampling + num_jpegs_with_unsupported_resolution;
+        if (num_bad_jpegs)                        std::cout << " ,total images that cannot be parsed: "               << num_bad_jpegs;
+        if (num_jpegs_with_411_subsampling)        std::cout << " ,total images with YUV 4:1:1 chroma subsampling: "  << num_jpegs_with_411_subsampling;
+        if (num_jpegs_with_unknown_subsampling)    std::cout << " ,total images with unknown chroma subsampling: "    << num_jpegs_with_unknown_subsampling;
+        if (num_jpegs_with_unsupported_resolution) std::cout << " ,total images with unsupported resolution: "        << num_jpegs_with_unsupported_resolution;
+        std::cout << std::endl;
+    }
+
+    // Cleanup pipeline slot GPU buffers.
+    for (int p = 0; p < buf_num; p++) {
+        for (int b = 0; b < batch_size; b++) {
+            for (int c = 0; c < ROCJPEG_MAX_COMPONENT; c++) {
+                if (pipeline_slots[p].images[b].channel[c] != nullptr) {
+                    CHECK_HIP(hipFree(pipeline_slots[p].images[b].channel[c]));
+                    pipeline_slots[p].images[b].channel[c] = nullptr;
+                }
+            }
+        }
+    }
+
+    CHECK_ROCJPEG(rocJpegDestroy(rocjpeg_handle));
+    for (auto& it : rocjpeg_stream_handles) {
+        CHECK_ROCJPEG(rocJpegStreamDestroy(it));
+    }
+    std::cout << "Decoding completed!" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
@@ -174,6 +174,7 @@ int main(int argc, char **argv) {
 
     std::cout << "Decoding started, please wait! ... " << std::endl;
     auto total_start_time = std::chrono::high_resolution_clock::now();
+    bool timing_started = false;
 
     for (int i = 0; i < static_cast<int>(file_paths.size()); i += batch_size) {
         int batch_end = std::min(i + batch_size, static_cast<int>(file_paths.size()));
@@ -285,6 +286,10 @@ int main(int argc, char **argv) {
         slot->current_batch_size = current_batch_size;
 
         if (current_batch_size > 0) {
+            if (!timing_started) {
+                total_start_time = std::chrono::high_resolution_clock::now();
+                timing_started = true;
+            }
             RocJpegStatus rocjpeg_status = rocJpegDecodeBatchedAsync(rocjpeg_handle, stream_handles_for_batch.data(), current_batch_size, slot->decode_params_batch.data(), slot->images.data());
             if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
                 std::cerr << "ERROR: rocJpegDecodeBatchedAsync returned " << rocJpegGetErrorName(rocjpeg_status) << std::endl;

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
@@ -46,10 +46,6 @@ int main(int argc, char **argv) {
 
     RocJpegUtils::ParseCommandLine(input_path, output_file_path, save_images, device_id, rocjpeg_backend, decode_params, nullptr, &batch_size, argc, argv);
 
-    bool is_roi_valid = false;
-    uint32_t roi_width  = decode_params.crop_rectangle.right  - decode_params.crop_rectangle.left;
-    uint32_t roi_height = decode_params.crop_rectangle.bottom - decode_params.crop_rectangle.top;
-
     if (!RocJpegUtils::GetFilePaths(input_path, file_paths, is_dir, is_file)) {
         std::cerr << "ERROR: Failed to get input file paths!" << std::endl;
         return EXIT_FAILURE;

--- a/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp
@@ -107,7 +107,13 @@ int main(int argc, char **argv) {
     // Sync thread: continuously drains pending_queue by calling rocJpegDecodeBatchedSync,
     // optionally saves the results, then returns the slot to available_queue.
     std::thread sync_thread([&]() {
-        CHECK_HIP(hipSetDevice(device_id));
+        if (hipSetDevice(device_id) != hipSuccess) {
+            std::lock_guard<std::mutex> lock(mtx);
+            async_status = ROCJPEG_STATUS_RUNTIME_ERROR;
+            sync_error   = true;
+            cv_available.notify_all();
+            return;
+        }
         while (true) {
             BatchPipelineSlot* slot;
             {

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -59,3 +59,9 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamH
 RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_sync(handle, destination);
 }
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched_async(handle, jpeg_stream_handles, batch_size, decode_params, destinations);
+}
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched_sync(handle, destinations, batch_size);
+}

--- a/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/projects/rocjpeg/src/amd_detail/rocjpeg_api_trace.cpp
@@ -45,6 +45,8 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStrea
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size);
 }
 
 namespace rocjpeg {
@@ -62,6 +64,8 @@ void UpdateDispatchTable(RocJpegDispatchTable* ptr_dispatch_table) {
     ptr_dispatch_table->pfn_rocjpeg_get_error_name = rocjpeg::rocJpegGetErrorName;
     ptr_dispatch_table->pfn_rocjpeg_decode_async = rocjpeg::rocJpegDecodeAsync;
     ptr_dispatch_table->pfn_rocjpeg_decode_sync = rocjpeg::rocJpegDecodeSync;
+    ptr_dispatch_table->pfn_rocjpeg_decode_batched_async = rocjpeg::rocJpegDecodeBatchedAsync;
+    ptr_dispatch_table->pfn_rocjpeg_decode_batched_sync = rocjpeg::rocJpegDecodeBatchedSync;
 }
 
 #if ROCJPEG_ROCPROFILER_REGISTER > 0
@@ -147,14 +151,17 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
 // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_sync, 10)
+// ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched_async, 11)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched_sync, 12)
 
 // If ROCJPEG_ENFORCE_ABI entries are added for each new function pointer in the table,
 // the number below will be one greater than the number in the last ROCJPEG_ENFORCE_ABI line. For example:
-//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 10)
-//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 11) <- 10 + 1 = 11
-ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 11)
+//  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 12)
+//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 13) <- 12 + 1 = 13
+ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 13)
 
-static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1,
+static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2,
               "If you encounter this error, add the new ROCJPEG_ENFORCE_ABI(...) code for the updated function pointers, "
               "and then modify this check to ensure it evaluates to true.");
 #endif

--- a/projects/rocjpeg/src/rocjpeg_api.cpp
+++ b/projects/rocjpeg/src/rocjpeg_api.cpp
@@ -349,4 +349,47 @@ RocJpegStatus ROCJPEGAPI rocJpegDecodeSync(RocJpegHandle handle, RocJpegImage *d
 
     return rocjpeg_status;
 }
+
+/**
+ * @brief Submits a batch of JPEG decode operations without waiting for output completion.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedAsync(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(jpeg_stream_handles) + ", " +
+                             ROCJPEG_TOSTR(batch_size) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destinations));
+    if (handle == nullptr || jpeg_stream_handles == nullptr || decode_params == nullptr || destinations == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeBatchedAsync(jpeg_stream_handles, batch_size, decode_params, destinations);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Synchronizes all pending asynchronous batched JPEG decodes and writes the decoded output.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedSync(RocJpegHandle handle, RocJpegImage *destinations, int batch_size) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(handle) + ", " + RocJpegFmtPtr(destinations) + ", " + ROCJPEG_TOSTR(batch_size));
+    if (handle == nullptr || destinations == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeBatchedSync(destinations, batch_size);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ErrorLog(g_rocjpeg_logger, e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
 } //namespace rocjpeg

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -307,6 +307,90 @@ RocJpegStatus RocJpegDecoder::FinalizeDecode(VASurfaceID current_surface_id, con
 }
 
 /**
+ * @brief Syncs a flat array of decoded surfaces, copies/converts their output into destinations,
+ * issues a single hipStreamSynchronize per sub-batch, then releases all surfaces.
+ * @param surface_ids Array of VASurfaceIDs for the decoded surfaces, one per image.
+ * @param jpeg_stream_params Array of JPEG stream parameters, one per image.
+ * @param decode_params Array of decode parameters, one per image.
+ * @param destinations Array of output images, one per image.
+ * @param batch_size Number of images in the batch.
+ * @return The status of the finalize operation.
+ */
+RocJpegStatus RocJpegDecoder::FinalizeDecodeBatched(const VASurfaceID *surface_ids, const JpegStreamParameters *jpeg_stream_params,
+                                                     const RocJpegDecodeParams *decode_params, RocJpegImage *destinations, int batch_size) {
+    VcnJpegSpec current_vcn_jpeg_spec = jpeg_vaapi_decoder_.GetCurrentVcnJpegSpec();
+    for (int i = 0; i < batch_size; i += current_vcn_jpeg_spec.num_jpeg_cores) {
+        int sub_batch_end = std::min(i + static_cast<int>(current_vcn_jpeg_spec.num_jpeg_cores), batch_size);
+        int current_sub_batch_size = sub_batch_end - i;
+
+        for (int k = 0; k < current_sub_batch_size; k++) {
+            int idx = i + k;
+            HipInteropDeviceMem hip_interop_dev_mem = {};
+            CHECK_ROCJPEG(jpeg_vaapi_decoder_.SyncSurface(surface_ids[idx]));
+            CHECK_ROCJPEG(jpeg_vaapi_decoder_.GetHipInteropMem(surface_ids[idx], hip_interop_dev_mem));
+
+            uint16_t chroma_height = 0;
+            uint16_t picture_width = 0;
+            uint16_t picture_height = 0;
+            bool is_roi_valid = false;
+            uint32_t roi_width  = decode_params[idx].crop_rectangle.right  - decode_params[idx].crop_rectangle.left;
+            uint32_t roi_height = decode_params[idx].crop_rectangle.bottom - decode_params[idx].crop_rectangle.top;
+
+            if (roi_width > 0 && roi_height > 0 &&
+                roi_width  <= jpeg_stream_params[idx].picture_parameter_buffer.picture_width &&
+                roi_height <= jpeg_stream_params[idx].picture_parameter_buffer.picture_height) {
+                is_roi_valid = true;
+            }
+
+            picture_width  = is_roi_valid ? roi_width  : jpeg_stream_params[idx].picture_parameter_buffer.picture_width;
+            picture_height = is_roi_valid ? roi_height : jpeg_stream_params[idx].picture_parameter_buffer.picture_height;
+
+            if (is_roi_valid && current_vcn_jpeg_spec.can_roi_decode) {
+                is_roi_valid = false;
+            }
+
+            switch (decode_params[idx].output_format) {
+                case ROCJPEG_OUTPUT_NATIVE:
+                    CHECK_ROCJPEG(GetChromaHeight(hip_interop_dev_mem.surface_format, picture_height, chroma_height));
+                    CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, picture_height, 0, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    if (hip_interop_dev_mem.surface_format == VA_FOURCC_NV12) {
+                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 1, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    } else if (hip_interop_dev_mem.surface_format == VA_FOURCC_444P ||
+                               hip_interop_dev_mem.surface_format == VA_FOURCC_422V) {
+                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 1, &destinations[idx], &decode_params[idx], is_roi_valid));
+                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 2, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    }
+                    break;
+                case ROCJPEG_OUTPUT_YUV_PLANAR:
+                    CHECK_ROCJPEG(GetChromaHeight(hip_interop_dev_mem.surface_format, picture_height, chroma_height));
+                    CHECK_ROCJPEG(GetPlanarYUVOutputFormat(hip_interop_dev_mem, picture_width,
+                                                           picture_height, chroma_height, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    break;
+                case ROCJPEG_OUTPUT_Y:
+                    CHECK_ROCJPEG(GetYOutputFormat(hip_interop_dev_mem, picture_width,
+                                                   picture_height, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    break;
+                case ROCJPEG_OUTPUT_RGB:
+                    CHECK_ROCJPEG(ColorConvertToRGB(hip_interop_dev_mem, picture_width,
+                                                    picture_height, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    break;
+                case ROCJPEG_OUTPUT_RGB_PLANAR:
+                    CHECK_ROCJPEG(ColorConvertToRGBPlanar(hip_interop_dev_mem, picture_width,
+                                                          picture_height, &destinations[idx], &decode_params[idx], is_roi_valid));
+                    break;
+                default:
+                    break;
+            }
+        }
+        CHECK_HIP(hipStreamSynchronize(hip_stream_));
+        for (int k = 0; k < current_sub_batch_size; k++) {
+            jpeg_vaapi_decoder_.SetSurfaceAsIdle(surface_ids[i + k]);
+        }
+    }
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
  * Decodes a batch of JPEG streams using the specified decode parameters and stores the decoded images in the provided destinations.
  *
  * @param jpeg_streams An array of RocJpegStreamHandle objects representing the JPEG streams to be decoded.
@@ -346,79 +430,9 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
         }
 
         CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecodeBatched(jpeg_streams_params.data() + i, current_batch_size, &decode_params[i], current_surface_ids.data() + i));
-
-        for (int k = 0; k < current_batch_size; k++) {
-            HipInteropDeviceMem hip_interop_dev_mem = {};
-            VASurfaceID current_surface_id = *(current_surface_ids.data() + k + i);
-            const JpegStreamParameters *jpeg_stream_params = jpeg_streams_params.data() + k + i;
-            CHECK_ROCJPEG(jpeg_vaapi_decoder_.SyncSurface(current_surface_id));
-            CHECK_ROCJPEG(jpeg_vaapi_decoder_.GetHipInteropMem(current_surface_id, hip_interop_dev_mem));
-
-            uint16_t chroma_height = 0;
-            uint16_t picture_width = 0;
-            uint16_t picture_height = 0;
-            bool is_roi_valid = false;
-            uint32_t roi_width;
-            uint32_t roi_height;
-            roi_width = decode_params[k + i].crop_rectangle.right - decode_params[k + i].crop_rectangle.left;
-            roi_height = decode_params[k + i].crop_rectangle.bottom - decode_params[k + i].crop_rectangle.top;
-    
-            if (roi_width > 0 && roi_height > 0 && roi_width <= jpeg_stream_params->picture_parameter_buffer.picture_width && roi_height <= jpeg_stream_params->picture_parameter_buffer.picture_height) {
-                is_roi_valid = true;
-            }
-
-            picture_width = is_roi_valid ? roi_width : jpeg_stream_params->picture_parameter_buffer.picture_width;
-            picture_height = is_roi_valid ? roi_height : jpeg_stream_params->picture_parameter_buffer.picture_height;
-
-            if (is_roi_valid && current_vcn_jpeg_spec.can_roi_decode) {
-                // Set is_roi_valid to false because in this case, the hardware handles the ROI decode and we don't need to calculate the roi_offset
-                // later in the following functions (e.g., CopyChannel, GetPlanarYUVOutputFormat, etc) to copy the crop rectangle
-                is_roi_valid = false;
-            }
-
-            switch (decode_params[k + i].output_format) {
-                case ROCJPEG_OUTPUT_NATIVE:
-                    // Copy the native decoded output buffers from interop memory directly to the destination buffers
-                    CHECK_ROCJPEG(GetChromaHeight(hip_interop_dev_mem.surface_format, picture_height, chroma_height));
-                    // Copy Luma (first channel) for any surface format
-                    CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, picture_height, 0, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    if (hip_interop_dev_mem.surface_format == VA_FOURCC_NV12) {
-                        // Copy the second channel (UV interleaved) for NV12
-                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 1, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    } else if (hip_interop_dev_mem.surface_format == VA_FOURCC_444P ||
-                            hip_interop_dev_mem.surface_format == VA_FOURCC_422V) {
-                        // Copy the second and third channels for YUV444 and YUV440 (i.e., YUV422V)
-                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 1, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                        CHECK_ROCJPEG(CopyChannel(hip_interop_dev_mem, picture_width, chroma_height, 2, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    }
-                    break;
-                case ROCJPEG_OUTPUT_YUV_PLANAR:
-                    CHECK_ROCJPEG(GetChromaHeight(hip_interop_dev_mem.surface_format, picture_height, chroma_height));
-                    CHECK_ROCJPEG(GetPlanarYUVOutputFormat(hip_interop_dev_mem, picture_width,
-                                                        picture_height, chroma_height, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    break;
-                case ROCJPEG_OUTPUT_Y:
-                    CHECK_ROCJPEG(GetYOutputFormat(hip_interop_dev_mem, picture_width,
-                                                picture_height, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    break;
-                case ROCJPEG_OUTPUT_RGB:
-                    CHECK_ROCJPEG(ColorConvertToRGB(hip_interop_dev_mem, picture_width,
-                                                            picture_height, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    break;
-                case ROCJPEG_OUTPUT_RGB_PLANAR:
-                    CHECK_ROCJPEG(ColorConvertToRGBPlanar(hip_interop_dev_mem, picture_width,
-                                                            picture_height, &destinations[k + i], &decode_params[k + i], is_roi_valid));
-                    break;
-                default:
-                    break;
-            }
-        }
-        CHECK_HIP(hipStreamSynchronize(hip_stream_));
-        for (int k = 0; k < current_batch_size; k++) {
-            VASurfaceID current_surface_id = *(current_surface_ids.data() + k + i);
-            CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
-        }
     }
+
+    CHECK_ROCJPEG(FinalizeDecodeBatched(current_surface_ids.data(), jpeg_streams_params.data(), decode_params, destinations, batch_size));
 
     FunctionExitLog(g_rocjpeg_logger);
     return ROCJPEG_STATUS_SUCCESS;
@@ -428,17 +442,20 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
  */
 RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
     FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(jpeg_streams) + ", " + ROCJPEG_TOSTR(batch_size) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destinations));
-    std::lock_guard<std::mutex> lock(mutex_);
     if (jpeg_streams == nullptr || decode_params == nullptr || destinations == nullptr) {
         CriticalLog(g_rocjpeg_logger, "Null pointer");
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
-    for (int i = 0; i < batch_size; i++) {
-        if (pending_decodes_.count(&destinations[i]) > 0) {
-            ErrorLog(g_rocjpeg_logger, "An async decode is already pending for destination at index " + ROCJPEG_TOSTR(i));
-            FunctionExitLog(g_rocjpeg_logger);
-            return ROCJPEG_STATUS_INVALID_PARAMETER;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (int i = 0; i < batch_size; i++) {
+            if (pending_decodes_.count(&destinations[i]) > 0) {
+                ErrorLog(g_rocjpeg_logger, "An async decode is already pending for destination at index " + ROCJPEG_TOSTR(i));
+                FunctionExitLog(g_rocjpeg_logger);
+                return ROCJPEG_STATUS_INVALID_PARAMETER;
+            }
         }
     }
 
@@ -452,6 +469,8 @@ RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_strea
     VcnJpegSpec current_vcn_jpeg_spec = jpeg_vaapi_decoder_.GetCurrentVcnJpegSpec();
     std::vector<VASurfaceID> surface_ids(batch_size);
 
+    // SubmitDecodeBatched does not touch pending_decodes_ — hold no lock during GPU submission
+    // so DecodeBatchedSync can concurrently drain its own states on the sync thread.
     for (int i = 0; i < batch_size; i += current_vcn_jpeg_spec.num_jpeg_cores) {
         int batch_end = std::min(i + static_cast<int>(current_vcn_jpeg_spec.num_jpeg_cores), batch_size);
         int current_batch_size = batch_end - i;
@@ -463,12 +482,15 @@ RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_strea
         }
     }
 
-    for (int i = 0; i < batch_size; i++) {
-        AsyncDecodeState state;
-        state.jpeg_stream_params = jpeg_streams_params[i];
-        state.decode_params = decode_params[i];
-        state.surface_id = surface_ids[i];
-        pending_decodes_.emplace(&destinations[i], std::move(state));
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (int i = 0; i < batch_size; i++) {
+            AsyncDecodeState state;
+            state.jpeg_stream_params = jpeg_streams_params[i];
+            state.decode_params = decode_params[i];
+            state.surface_id = surface_ids[i];
+            pending_decodes_.emplace(&destinations[i], std::move(state));
+        }
     }
 
     FunctionExitLog(g_rocjpeg_logger);
@@ -501,19 +523,17 @@ RocJpegStatus RocJpegDecoder::DecodeBatchedSync(RocJpegImage *destinations, int 
         }
     }
 
-    // Finalize each image without holding the mutex
+    // Flatten states into contiguous arrays for FinalizeDecodeBatched.
+    std::vector<VASurfaceID> surface_ids(batch_size);
+    std::vector<JpegStreamParameters> jpeg_stream_params(batch_size);
+    std::vector<RocJpegDecodeParams> decode_params(batch_size);
     for (int i = 0; i < batch_size; i++) {
-        RocJpegStatus rocjpeg_status = FinalizeDecode(states[i].surface_id, &states[i].jpeg_stream_params, &states[i].decode_params, &destinations[i]);
-        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
-            jpeg_vaapi_decoder_.SetSurfaceAsIdle(states[i].surface_id);
-            // Release remaining surface IDs
-            for (int j = i + 1; j < batch_size; j++) {
-                jpeg_vaapi_decoder_.SetSurfaceAsIdle(states[j].surface_id);
-            }
-            FunctionExitLog(g_rocjpeg_logger);
-            return rocjpeg_status;
-        }
+        surface_ids[i]       = states[i].surface_id;
+        jpeg_stream_params[i] = states[i].jpeg_stream_params;
+        decode_params[i]     = states[i].decode_params;
     }
+
+    CHECK_ROCJPEG(FinalizeDecodeBatched(surface_ids.data(), jpeg_stream_params.data(), decode_params.data(), destinations, batch_size));
 
     FunctionExitLog(g_rocjpeg_logger);
     return ROCJPEG_STATUS_SUCCESS;

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -434,7 +434,17 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
             jpeg_streams_params[j] = std::move(*jpeg_stream_params);
         }
 
-        CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecodeBatched(jpeg_streams_params.data() + i, current_batch_size, &decode_params[i], current_surface_ids.data() + i));
+        RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecodeBatched(jpeg_streams_params.data() + i, current_batch_size, &decode_params[i], current_surface_ids.data() + i);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            // Sync and release surfaces from all previously successful sub-batches to avoid leaking
+            // VA surfaces that are already in-flight on the hardware.
+            for (int j = 0; j < i; j++) {
+                jpeg_vaapi_decoder_.SyncSurface(current_surface_ids[j]);
+                jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_ids[j]);
+            }
+            FunctionExitLog(g_rocjpeg_logger);
+            return rocjpeg_status;
+        }
     }
 
     CHECK_ROCJPEG(FinalizeDecodeBatched(current_surface_ids.data(), jpeg_streams_params.data(), decode_params, destinations, batch_size));
@@ -487,6 +497,12 @@ RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_strea
 
         RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecodeBatched(jpeg_streams_params.data() + i, current_batch_size, &decode_params[i], surface_ids.data() + i);
         if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            // Sync and release surfaces from all previously successful sub-batches to avoid leaking
+            // VA surfaces that are already in-flight on the hardware.
+            for (int j = 0; j < i; j++) {
+                jpeg_vaapi_decoder_.SyncSurface(surface_ids[j]);
+                jpeg_vaapi_decoder_.SetSurfaceAsIdle(surface_ids[j]);
+            }
             FunctionExitLog(g_rocjpeg_logger);
             return rocjpeg_status;
         }

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -424,6 +424,102 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
     return ROCJPEG_STATUS_SUCCESS;
 }
 /**
+ * @brief Submits a batch of JPEG decode operations and stores pending state for all images.
+ */
+RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(jpeg_streams) + ", " + ROCJPEG_TOSTR(batch_size) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destinations));
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (jpeg_streams == nullptr || decode_params == nullptr || destinations == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    for (int i = 0; i < batch_size; i++) {
+        if (pending_decodes_.count(&destinations[i]) > 0) {
+            ErrorLog(g_rocjpeg_logger, "An async decode is already pending for destination at index " + ROCJPEG_TOSTR(i));
+            FunctionExitLog(g_rocjpeg_logger);
+            return ROCJPEG_STATUS_INVALID_PARAMETER;
+        }
+    }
+
+    std::vector<JpegStreamParameters> jpeg_streams_params(batch_size);
+    for (int i = 0; i < batch_size; i++) {
+        auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_streams[i]);
+        const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
+        jpeg_streams_params[i] = *jpeg_stream_params;
+    }
+
+    VcnJpegSpec current_vcn_jpeg_spec = jpeg_vaapi_decoder_.GetCurrentVcnJpegSpec();
+    std::vector<VASurfaceID> surface_ids(batch_size);
+
+    for (int i = 0; i < batch_size; i += current_vcn_jpeg_spec.num_jpeg_cores) {
+        int batch_end = std::min(i + static_cast<int>(current_vcn_jpeg_spec.num_jpeg_cores), batch_size);
+        int current_batch_size = batch_end - i;
+
+        RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecodeBatched(jpeg_streams_params.data() + i, current_batch_size, &decode_params[i], surface_ids.data() + i);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            FunctionExitLog(g_rocjpeg_logger);
+            return rocjpeg_status;
+        }
+    }
+
+    for (int i = 0; i < batch_size; i++) {
+        AsyncDecodeState state;
+        state.jpeg_stream_params = jpeg_streams_params[i];
+        state.decode_params = decode_params[i];
+        state.surface_id = surface_ids[i];
+        pending_decodes_.emplace(&destinations[i], std::move(state));
+    }
+
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Synchronizes all pending asynchronous decodes for a batch and copies/converts the output.
+ */
+RocJpegStatus RocJpegDecoder::DecodeBatchedSync(RocJpegImage *destinations, int batch_size) {
+    FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(destinations) + ", " + ROCJPEG_TOSTR(batch_size));
+    if (destinations == nullptr) {
+        CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    std::vector<AsyncDecodeState> states(batch_size);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (int i = 0; i < batch_size; i++) {
+            auto it = pending_decodes_.find(&destinations[i]);
+            if (it == pending_decodes_.end()) {
+                ErrorLog(g_rocjpeg_logger, "No asynchronous decode is pending for destination at index " + ROCJPEG_TOSTR(i));
+                FunctionExitLog(g_rocjpeg_logger);
+                return ROCJPEG_STATUS_INVALID_PARAMETER;
+            }
+            states[i] = std::move(it->second);
+            pending_decodes_.erase(it);
+        }
+    }
+
+    // Finalize each image without holding the mutex
+    for (int i = 0; i < batch_size; i++) {
+        RocJpegStatus rocjpeg_status = FinalizeDecode(states[i].surface_id, &states[i].jpeg_stream_params, &states[i].decode_params, &destinations[i]);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            jpeg_vaapi_decoder_.SetSurfaceAsIdle(states[i].surface_id);
+            // Release remaining surface IDs
+            for (int j = i + 1; j < batch_size; j++) {
+                jpeg_vaapi_decoder_.SetSurfaceAsIdle(states[j].surface_id);
+            }
+            FunctionExitLog(g_rocjpeg_logger);
+            return rocjpeg_status;
+        }
+    }
+
+    FunctionExitLog(g_rocjpeg_logger);
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
  * @brief Retrieves the image information from the JPEG stream.
  *
  * This function retrieves the number of components, chroma subsampling, widths, and heights

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -407,6 +407,11 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
+    if (batch_size <= 0) {
+        ErrorLog(g_rocjpeg_logger, "Invalid batch_size: " + ROCJPEG_TOSTR(batch_size));
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
     if (!pending_decodes_.empty()) {
         ErrorLog(g_rocjpeg_logger, "Asynchronous decodes are pending for this handle!");
         FunctionExitLog(g_rocjpeg_logger);
@@ -444,6 +449,11 @@ RocJpegStatus RocJpegDecoder::DecodeBatchedAsync(RocJpegStreamHandle *jpeg_strea
     FunctionEntryLogWithArgs(g_rocjpeg_logger, RocJpegFmtPtr(jpeg_streams) + ", " + ROCJPEG_TOSTR(batch_size) + ", " + RocJpegFmtPtr(decode_params) + ", " + RocJpegFmtPtr(destinations));
     if (jpeg_streams == nullptr || decode_params == nullptr || destinations == nullptr) {
         CriticalLog(g_rocjpeg_logger, "Null pointer");
+        FunctionExitLog(g_rocjpeg_logger);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (batch_size <= 0) {
+        ErrorLog(g_rocjpeg_logger, "Invalid batch_size: " + ROCJPEG_TOSTR(batch_size));
         FunctionExitLog(g_rocjpeg_logger);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -151,6 +151,7 @@ private:
     * @brief Waits for a submitted surface and copies/converts the decoded output.
     */
    RocJpegStatus FinalizeDecode(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+   RocJpegStatus FinalizeDecodeBatched(const VASurfaceID *surface_ids, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations, int batch_size);
 
    /**
     * @brief Retrieves the height of the chroma channel.

--- a/projects/rocjpeg/src/rocjpeg_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_decoder.h
@@ -115,6 +115,24 @@ public:
     */
    RocJpegStatus DecodeSync(RocJpegImage *destination);
 
+   /**
+    * @brief Submits a batch of JPEG decode operations and stores pending state for all images.
+    * @param jpeg_streams Array of handles to JPEG streams.
+    * @param batch_size Number of images in the batch.
+    * @param decode_params Array of decoding parameters, one per image.
+    * @param destinations Array of output images, one per image.
+    * @return The status of the submit operation.
+    */
+   RocJpegStatus DecodeBatchedAsync(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
+
+   /**
+    * @brief Synchronizes all pending asynchronous decodes for a batch and copies/converts the output.
+    * @param destinations Array of destination images identifying the pending batch.
+    * @param batch_size Number of images in the batch.
+    * @return The status of the sync operation.
+    */
+   RocJpegStatus DecodeBatchedSync(RocJpegImage *destinations, int batch_size);
+
 private:
    struct AsyncDecodeState {
       VASurfaceID surface_id;

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
@@ -53,6 +53,7 @@ RocJpegVaapiMemoryPool::RocJpegVaapiMemoryPool() {
  * Finally, it resets the HIP interop structure for each entry in the memory pool.
  */
 void RocJpegVaapiMemoryPool::ReleaseResources() {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     VAStatus va_status;
     hipError_t hip_status;
     for (auto& pair : mem_pool_) {
@@ -159,6 +160,7 @@ bool RocJpegVaapiMemoryPool::DeleteIdleEntry() {
  * @return The status of the operation. Returns ROCJPEG_STATUS_SUCCESS if the operation is successful.
  */
 RocJpegStatus RocJpegVaapiMemoryPool::AddPoolEntry(uint32_t surface_format, const RocJpegVaapiMemPoolEntry& pool_entry) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     size_t total_mem_pool_size = GetTotalMemPoolSize();
     auto& entries = mem_pool_[surface_format];
     if (total_mem_pool_size < max_pool_size_) {
@@ -184,6 +186,7 @@ RocJpegStatus RocJpegVaapiMemoryPool::AddPoolEntry(uint32_t surface_format, cons
  * @return The matching `RocJpegVaapiMemPoolEntry` if found, or a default-initialized entry if not found.
  */
 RocJpegVaapiMemPoolEntry RocJpegVaapiMemoryPool::GetEntry(uint32_t surface_format, uint32_t image_width, uint32_t image_height, uint32_t num_surfaces) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     for (auto& entry : mem_pool_[surface_format]) {
         if (entry.image_width >= image_width && entry.image_height >= image_height && entry.va_surface_ids.size() == num_surfaces && entry.entry_status == kIdle) {
             entry.entry_status = kBusy;
@@ -194,6 +197,7 @@ RocJpegVaapiMemPoolEntry RocJpegVaapiMemoryPool::GetEntry(uint32_t surface_forma
 }
 
 bool RocJpegVaapiMemoryPool::FindSurfaceId(VASurfaceID surface_id) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     for (auto& pair : mem_pool_) {
         for (auto& entry : pair.second) {
             if (std::find(entry.va_surface_ids.begin(), entry.va_surface_ids.end(), surface_id) != entry.va_surface_ids.end()) {
@@ -221,6 +225,7 @@ bool RocJpegVaapiMemoryPool::FindSurfaceId(VASurfaceID surface_id) {
  *         ROCJPEG_STATUS_INVALID_PARAMETER if the requested surface_id is not found in the memory pool.
  */
 RocJpegStatus RocJpegVaapiMemoryPool::GetHipInteropMem(VASurfaceID surface_id, HipInteropDeviceMem& hip_interop) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     for (auto& pair : mem_pool_) {
         auto& entries = pair.second;
         auto it = std::find_if(entries.begin(), entries.end(),
@@ -319,6 +324,7 @@ RocJpegStatus RocJpegVaapiMemoryPool::GetHipInteropMem(VASurfaceID surface_id, H
 }
 
 bool RocJpegVaapiMemoryPool::SetSurfaceAsIdle(VASurfaceID surface_id) {
+    std::lock_guard<std::mutex> lock(pool_mutex_);
     for (auto& pair : mem_pool_) {
         for (auto& entry : pair.second) {
             if (std::find(entry.va_surface_ids.begin(), entry.va_surface_ids.end(), surface_id) != entry.va_surface_ids.end()) {

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include <sys/stat.h>
 #include <unordered_map>
 #include <memory>
+#include <mutex>
 #include <functional>
 #include <libdrm/amdgpu.h>
 #include <libdrm/amdgpu_drm.h>
@@ -192,6 +193,7 @@ class RocJpegVaapiMemoryPool {
         VADisplay va_display_; // The VADisplay associated with the memory pool.
         uint32_t max_pool_size_; // The maximum pool size of the memory pool (mem_pool_) per entry.
         std::unordered_map<uint32_t, std::vector<RocJpegVaapiMemPoolEntry>> mem_pool_; // The memory pool.
+        std::mutex pool_mutex_; // Protects mem_pool_ for concurrent async/sync access.
         /**
          * @brief Retrieves the total size of the memory pool.
          *


### PR DESCRIPTION
## Motivation

The existing `rocJpegDecodeBatched` API serializes batch submission and
result retrieval, leaving VCN idle during the HIP interop/copy phase.
This commit adds a batched asynchronous counterpart allowing applications to overlap batch submission
with result retrieval from a previous batch. JIRA ID: AICV-275

## Technical Details

- `rocJpegDecodeBatchedAsync(handle, jpeg_stream_handles, batch_size,
  decode_params, destinations)` — submits an entire batch of JPEG images
  to the VCN hardware decoder and returns immediately without waiting for
  completion or copying any output.

- `rocJpegDecodeBatchedSync(handle, destinations, batch_size)` — waits
  for all images in a previously submitted batch to finish decoding and
  copies/converts the results into the caller-supplied destination
  buffers.

Both APIs follow the same contract as their single-image counterparts:
Mixing synchronous `rocJpegDecodeBatched` with pending async batch decodes
on the same handle is rejected with `ROCJPEG_STATUS_EXECUTION_FAILED`.
Submitting the same destination pointer twice without an intervening sync
is rejected with `ROCJPEG_STATUS_INVALID_PARAMETER`.

## Implementation Details

### rocjpeg_decoder.cpp / rocjpeg_decoder.h
- `DecodeBatchedAsync`: acquires the mutex, validates that no destination
  is already in `pending_decodes_`, extracts stream params for all images,
  calls `SubmitDecodeBatched` in sub-batches of `num_jpeg_cores` (matching
  the existing `DecodeBatched` logic), then records each image's
  `AsyncDecodeState` (surface_id + copied stream/decode params) in the
  existing `pending_decodes_` map keyed by `RocJpegImage*`. Returns
  immediately after all submissions complete.
- `DecodeBatchedSync`: acquires the mutex briefly to move all batch states
  out of `pending_decodes_`, then calls `FinalizeDecode` for each image
  without holding the mutex. On any per-image failure, the remaining
  surface IDs are recycled via `SetSurfaceAsIdle` before returning.

### rocjpeg_api.cpp
- Added `rocJpegDecodeBatchedAsync` and `rocJpegDecodeBatchedSync` public
  C API wrappers with the same null-pointer checking and exception-handling
  pattern used by all other API functions.

### rocjpeg_api_trace.h
- Added `PfnRocJpegDecodeBatchedAsync` and `PfnRocJpegDecodeBatchedSync`
  typedef declarations.
- Added `pfn_rocjpeg_decode_batched_async` and
  `pfn_rocjpeg_decode_batched_sync` entries to `RocJpegDispatchTable`
  under a new `STEP_VERSION == 2` section.
- Bumped `ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION` from 1 to 2.

### rocjpeg_api_trace.cpp
- Added forward declarations in the `rocjpeg` namespace.
- Wired new function pointers in `UpdateDispatchTable`.
- Added `ROCJPEG_ENFORCE_ABI` entries for positions 11 and 12.
- Updated `ROCJPEG_ENFORCE_ABI_VERSIONING` to 13.
- Updated the `static_assert` to match `STEP_VERSION == 2`.

### rocjpeg_api_dispatch_interface.cpp
- Added call-through stubs for both new functions.

## New Sample: jpegDecodeBatchedAsync

`samples/jpegDecodeBatchedAsync/jpegdecodebatchedasync.cpp` demonstrates
a threaded producer/consumer pipeline:

- **5 batch pipeline slots**, each pre-allocated with GPU buffers for a
  full batch.
- **Main thread (producer)**: reads and parses a batch of JPEG files,
  grows slot GPU buffers on demand, calls `rocJpegDecodeBatchedAsync`,
  and pushes the slot to `pending_queue`. Blocks only when all 5 slots
  are in-flight (natural backpressure).
- **Sync thread (consumer)**: pops slots from `pending_queue`, calls
  `rocJpegDecodeBatchedSync`, optionally saves decoded images, then
  returns the slot to `available_queue`.
- Error propagation: either thread sets `sync_error = true` to unblock
  the other; the main thread drains all in-flight batches before
  reporting statistics.


## Issue Tracking

JIRA ID: AICV-275

## Test Plan

rocjpeg ctest.

## Test Result

rocjpeg ctest should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
