### PR TITLE
[rocprofiler-sdk] Fix to prefer versioned trace-decoder SONAME (.so.<major>.<minor>), fall back to unversioned

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -142,6 +142,32 @@ rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::host)
 
 find_package(rocprof-trace-decoder 0.2.1 CONFIG)
 
+# The decoder is a runtime dlopen dependency and ships no version.h, so forward its
+# SONAME version from the CMake package to consumers that dlopen it (thread_trace/dl.cpp).
+if(rocprof-trace-decoder_FOUND AND DEFINED rocprof-trace-decoder_VERSION_MAJOR)
+    # Some packages publish only MAJOR.MINOR.
+    set(_rocprof_trace_decoder_patch 0)
+    if(DEFINED rocprof-trace-decoder_VERSION_PATCH)
+        set(_rocprof_trace_decoder_patch ${rocprof-trace-decoder_VERSION_PATCH})
+    endif()
+    target_compile_definitions(
+        rocprofiler-sdk-rocprof-trace-decoder
+        INTERFACE
+            ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR=${rocprof-trace-decoder_VERSION_MAJOR}
+            ROCPROFILER_ATT_DECODER_SOVERSION_MINOR=${rocprof-trace-decoder_VERSION_MINOR}
+            ROCPROFILER_ATT_DECODER_SOVERSION_PATCH=${_rocprof_trace_decoder_patch})
+    unset(_rocprof_trace_decoder_patch)
+else()
+    message(
+        WARNING
+        "rocprof-trace-decoder package/version not found: "
+        "ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR/MINOR/PATCH will not be defined. The "
+        "ATT decoder loader will only try the unversioned "
+        "'librocprof-trace-decoder.so' and will fail to "
+        "load the versioned decoder on runtime-only ROCm installs. Ensure the "
+        "rocprof-trace-decoder CMake config is on CMAKE_PREFIX_PATH.")
+endif()
+
 # ----------------------------------------------------------------------------------------#
 #
 # HSA runtime

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -142,8 +142,8 @@ rocprofiler_config_nolink_target(rocprofiler-sdk-hip-nolink hip::host)
 
 find_package(rocprof-trace-decoder 0.2.1 CONFIG)
 
-# The decoder is a runtime dlopen dependency and ships no version.h, so forward its
-# SONAME version from the CMake package to consumers that dlopen it (thread_trace/dl.cpp).
+# The decoder is a runtime dlopen dependency and ships no version.h, so forward its SONAME
+# version from the CMake package to consumers that dlopen it (thread_trace/dl.cpp).
 if(rocprof-trace-decoder_FOUND AND DEFINED rocprof-trace-decoder_VERSION_MAJOR)
     # Some packages publish only MAJOR.MINOR.
     set(_rocprof_trace_decoder_patch 0)
@@ -160,12 +160,12 @@ if(rocprof-trace-decoder_FOUND AND DEFINED rocprof-trace-decoder_VERSION_MAJOR)
 else()
     message(
         WARNING
-        "rocprof-trace-decoder package/version not found: "
-        "ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR/MINOR/PATCH will not be defined. The "
-        "ATT decoder loader will only try the unversioned "
-        "'librocprof-trace-decoder.so' and will fail to "
-        "load the versioned decoder on runtime-only ROCm installs. Ensure the "
-        "rocprof-trace-decoder CMake config is on CMAKE_PREFIX_PATH.")
+            "rocprof-trace-decoder package/version not found: "
+            "ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR/MINOR/PATCH will not be defined. The "
+            "ATT decoder loader will only try the unversioned "
+            "'librocprof-trace-decoder.so' and will fail to "
+            "load the versioned decoder on runtime-only ROCm installs. Ensure the "
+            "rocprof-trace-decoder CMake config is on CMAKE_PREFIX_PATH.")
 endif()
 
 # ----------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
@@ -88,6 +88,9 @@ rocprofiler_add_interface_library(rocprofiler-sdk-aqlprofile-external
 rocprofiler_add_interface_library(rocprofiler-sdk-hsakmt
                                   "HSAKMT library for AMD KFD support" INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-drm "drm (amdgpu) library" INTERNAL)
+rocprofiler_add_interface_library(
+    rocprofiler-sdk-rocprof-trace-decoder
+    "Provides ATT trace decoder SONAME version compile definitions" INTERNAL)
 
 #
 # "nolink" interface targets emulate another interface target but do not link to the

--- a/projects/rocprofiler-sdk/source/lib/att-tool/att_lib_wrapper.cpp
+++ b/projects/rocprofiler-sdk/source/lib/att-tool/att_lib_wrapper.cpp
@@ -127,7 +127,8 @@ get_shader_id(const std::string& name)
 ATTDecoder::ATTDecoder(const std::string& path)
 {
     auto status = rocprofiler_thread_trace_decoder_create(&decoder, path.c_str());
-    ROCP_FATAL_IF(status != ROCPROFILER_STATUS_SUCCESS) << "Error loading decoder: " << status;
+    ROCP_FATAL_IF(status != ROCPROFILER_STATUS_SUCCESS)
+        << "Error loading decoder (status " << status << ") from library path '" << path << "'";
 };
 
 ATTDecoder::~ATTDecoder() { rocprofiler_thread_trace_decoder_destroy(decoder); }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
@@ -78,6 +78,33 @@ target_compile_definitions(
     PRIVATE rocprofiler_EXPORTS=1
             $<$<BOOL:${ROCPROFILER_BUILD_AQLPROFILE}>:ROCPROFILER_BUILD_AQLPROFILE=1>)
 
+find_package(rocprof-trace-decoder QUIET)
+# NOTE: guard on DEFINED, not truthiness. The decoder's major version is 0, and CMake's
+# if(<var>) treats a value of "0" as a false constant, so a plain
+# "if(... AND rocprof-trace-decoder_VERSION_MAJOR)" would skip this block entirely.
+if(rocprof-trace-decoder_FOUND AND DEFINED rocprof-trace-decoder_VERSION_MAJOR)
+    target_compile_definitions(
+        rocprofiler-sdk-object-library
+        PRIVATE
+            "ROCPROFILER_ATT_DECODER_SOVERSION=\"${rocprof-trace-decoder_VERSION_MAJOR}.${rocprof-trace-decoder_VERSION_MINOR}\""
+    )
+else()
+    # The decoder is a runtime dlopen dependency, so we intentionally
+    # keep discovery soft (QUIET, not REQUIRED) to avoid forcing a hard build-time
+    # dependency on decoder-less builds. But without the version we cannot form the
+    # versioned SONAME, so the loader would only try the unversioned
+    # 'librocprof-trace-decoder.so' and regress on runtime-only installs.
+    # Fail loudly here so a misconfigured build is caught instead of silently shipping
+    # the bug.
+    message(
+        WARNING
+        "rocprof-trace-decoder package/version not found: "
+        "ROCPROFILER_ATT_DECODER_SOVERSION will not be defined. The ATT decoder loader "
+        "will only try the unversioned 'librocprof-trace-decoder.so' and will fail to "
+        "load the versioned decoder on runtime-only ROCm installs. Ensure "
+        "the rocprof-trace-decoder CMake config is on CMAKE_PREFIX_PATH.")
+endif()
+
 set_target_properties(rocprofiler-sdk-object-library PROPERTIES POSITION_INDEPENDENT_CODE
                                                                 ON)
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
@@ -71,39 +71,13 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
             rocprofiler-sdk::rocprofiler-sdk-aqlprofile
             rocprofiler-sdk::rocprofiler-sdk-drm
-            rocprofiler-sdk::rocprofiler-sdk-dw)
+            rocprofiler-sdk::rocprofiler-sdk-dw
+            rocprofiler-sdk::rocprofiler-sdk-rocprof-trace-decoder)
 
 target_compile_definitions(
     rocprofiler-sdk-object-library
     PRIVATE rocprofiler_EXPORTS=1
             $<$<BOOL:${ROCPROFILER_BUILD_AQLPROFILE}>:ROCPROFILER_BUILD_AQLPROFILE=1>)
-
-find_package(rocprof-trace-decoder QUIET)
-# NOTE: guard on DEFINED, not truthiness. The decoder's major version is 0, and CMake's
-# if(<var>) treats a value of "0" as a false constant, so a plain
-# "if(... AND rocprof-trace-decoder_VERSION_MAJOR)" would skip this block entirely.
-if(rocprof-trace-decoder_FOUND AND DEFINED rocprof-trace-decoder_VERSION_MAJOR)
-    target_compile_definitions(
-        rocprofiler-sdk-object-library
-        PRIVATE
-            "ROCPROFILER_ATT_DECODER_SOVERSION=\"${rocprof-trace-decoder_VERSION_MAJOR}.${rocprof-trace-decoder_VERSION_MINOR}\""
-    )
-else()
-    # The decoder is a runtime dlopen dependency, so we intentionally
-    # keep discovery soft (QUIET, not REQUIRED) to avoid forcing a hard build-time
-    # dependency on decoder-less builds. But without the version we cannot form the
-    # versioned SONAME, so the loader would only try the unversioned
-    # 'librocprof-trace-decoder.so' and regress on runtime-only installs.
-    # Fail loudly here so a misconfigured build is caught instead of silently shipping
-    # the bug.
-    message(
-        WARNING
-        "rocprof-trace-decoder package/version not found: "
-        "ROCPROFILER_ATT_DECODER_SOVERSION will not be defined. The ATT decoder loader "
-        "will only try the unversioned 'librocprof-trace-decoder.so' and will fail to "
-        "load the versioned decoder on runtime-only ROCm installs. Ensure "
-        "the rocprof-trace-decoder CMake config is on CMAKE_PREFIX_PATH.")
-endif()
 
 set_target_properties(rocprofiler-sdk-object-library PROPERTIES POSITION_INDEPENDENT_CODE
                                                                 ON)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
@@ -61,8 +61,8 @@ DL::DL(const char* libpath)
     std::vector<std::string> lib_names;
     // Major defines ABI compatibility, so probe most-compatible first and narrow. The
     // unversioned name is last: it is a devel-only symlink to an unknown version.
-#if defined(ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR) &&                                              \
-    defined(ROCPROFILER_ATT_DECODER_SOVERSION_MINOR) &&                                              \
+#if defined(ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR) &&                                            \
+    defined(ROCPROFILER_ATT_DECODER_SOVERSION_MINOR) &&                                            \
     defined(ROCPROFILER_ATT_DECODER_SOVERSION_PATCH)
     const auto base  = std::string{kDecoderBaseName};
     const auto major = base + "." + std::to_string(ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR);
@@ -91,8 +91,8 @@ DL::DL(const char* libpath)
 
     if(!handle)
     {
-        ROCP_ERROR << "Error loading trace decoder from directory '" << libpath << "':"
-                   << attempted;
+        ROCP_ERROR << "Error loading trace decoder from directory '" << libpath
+                   << "':" << attempted;
         return;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
@@ -28,6 +28,8 @@
 #include <dlfcn.h>
 #include <cassert>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 namespace rocprofiler
 {
@@ -44,16 +46,45 @@ decoder_supports_event_records(void* handle)
     return dlsym(handle, "rocprof_trace_decoder_get_version") != nullptr ||
            dlsym(handle, "rocprof_trace_decoder_create_handle") != nullptr;
 }
+
+constexpr auto kDecoderBaseName = "librocprof-trace-decoder.so";
 }  // namespace
 
 DL::DL(const char* libpath)
 {
     if(libpath == nullptr) return;
 
-    auto path = common::filesystem::path(libpath) / "librocprof-trace-decoder.so";
+    namespace fs = common::filesystem;
 
-    handle = dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
-    if(!handle) return;
+    const auto dir = fs::path(libpath);
+
+    std::vector<std::string> lib_names;
+#if defined(ROCPROFILER_ATT_DECODER_SOVERSION)
+    lib_names.emplace_back(std::string{kDecoderBaseName} + "." + ROCPROFILER_ATT_DECODER_SOVERSION);
+#endif
+    lib_names.emplace_back(kDecoderBaseName);
+
+    std::string attempted;
+    std::string loaded_path;
+    for(const auto& lib_name : lib_names)
+    {
+        const auto candidate = (dir / lib_name).string();
+        handle               = dlopen(candidate.c_str(), RTLD_LAZY | RTLD_LOCAL);
+        if(handle)
+        {
+            loaded_path = candidate;
+            break;
+        }
+        const char* err = dlerror();
+        attempted += "\n  tried '" + candidate + "': " + (err ? err : "not loadable");
+    }
+
+    if(!handle)
+    {
+        ROCP_ERROR << "Error loading trace decoder from directory '" << libpath << "':"
+                   << attempted;
+        return;
+    }
 
     att_parse_data_fn =
         reinterpret_cast<ParseFn*>(dlsym(handle, "rocprof_trace_decoder_parse_data"));
@@ -63,7 +94,7 @@ DL::DL(const char* libpath)
 
     // Occupancy data is unaffected by an old decoder, so warn rather than fail.
     if(!decoder_supports_event_records(handle))
-        ROCP_WARNING << path.string()
+        ROCP_WARNING << loaded_path
                      << ": decoder is older than 0.2 and cannot emit ATT event or dispatch "
                         "records. Event and dispatch timelines will be empty. Check for a "
                         "standalone rocprof-trace-decoder package shadowing the one shipped "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
@@ -59,8 +59,18 @@ DL::DL(const char* libpath)
     const auto dir = fs::path(libpath);
 
     std::vector<std::string> lib_names;
-#if defined(ROCPROFILER_ATT_DECODER_SOVERSION)
-    lib_names.emplace_back(std::string{kDecoderBaseName} + "." + ROCPROFILER_ATT_DECODER_SOVERSION);
+    // Major defines ABI compatibility, so probe most-compatible first and narrow. The
+    // unversioned name is last: it is a devel-only symlink to an unknown version.
+#if defined(ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR) &&                                              \
+    defined(ROCPROFILER_ATT_DECODER_SOVERSION_MINOR) &&                                              \
+    defined(ROCPROFILER_ATT_DECODER_SOVERSION_PATCH)
+    const auto base  = std::string{kDecoderBaseName};
+    const auto major = base + "." + std::to_string(ROCPROFILER_ATT_DECODER_SOVERSION_MAJOR);
+    const auto minor = major + "." + std::to_string(ROCPROFILER_ATT_DECODER_SOVERSION_MINOR);
+    const auto patch = minor + "." + std::to_string(ROCPROFILER_ATT_DECODER_SOVERSION_PATCH);
+    lib_names.emplace_back(major);
+    lib_names.emplace_back(minor);
+    lib_names.emplace_back(patch);
 #endif
     lib_names.emplace_back(kDecoderBaseName);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/dl.cpp
@@ -28,19 +28,48 @@
 #include <dlfcn.h>
 #include <cassert>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 namespace rocprofiler
 {
 namespace thread_trace
 {
+namespace
+{
+constexpr auto kDecoderBaseName = "librocprof-trace-decoder.so";
+}  // namespace
+
 DL::DL(const char* libpath)
 {
     if(libpath == nullptr) return;
 
-    auto path = common::filesystem::path(libpath) / "librocprof-trace-decoder.so";
+    namespace fs = common::filesystem;
 
-    handle = dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
-    if(!handle) return;
+    const auto dir = fs::path(libpath);
+
+    std::vector<std::string> lib_names;
+#if defined(ROCPROFILER_ATT_DECODER_SOVERSION)
+    lib_names.emplace_back(std::string{kDecoderBaseName} + "." + ROCPROFILER_ATT_DECODER_SOVERSION);
+#endif
+    lib_names.emplace_back(kDecoderBaseName);
+
+    std::string attempted;
+    for(const auto& lib_name : lib_names)
+    {
+        const auto candidate = (dir / lib_name).string();
+        handle               = dlopen(candidate.c_str(), RTLD_LAZY | RTLD_LOCAL);
+        if(handle) break;
+        const char* err = dlerror();
+        attempted += "\n  tried '" + candidate + "': " + (err ? err : "not loadable");
+    }
+
+    if(!handle)
+    {
+        ROCP_ERROR << "Error loading trace decoder from directory '" << libpath << "':"
+                   << attempted;
+        return;
+    }
 
     att_parse_data_fn =
         reinterpret_cast<ParseFn*>(dlsym(handle, "rocprof_trace_decoder_parse_data"));


### PR DESCRIPTION
## Summary
On installs that ship the ATT trace decoder by versioned SONAME only (e.g. TheRock/rocm-sdk runtime wheels have `librocprof-trace-decoder.so.0.2` in `_rocm_sdk_core/lib` but no unversioned `.so` symlink; the unversioned symlink only exists in the `_rocm_sdk_devel` wheel):
- `DL::DL()` hardcoded `dlopen("librocprof-trace-decoder.so")`, so on a runtime-only install the decoder fails to load and
  `rocprofiler_thread_trace_decoder_create()` returns `ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE` (37).
- `rocprofv3 --att` then aborts at decode time with `att_lib_wrapper.cpp: Error loading decoder`, after the trace has already been
  captured.

This is the ATT-decoder counterpart of the aqlprofile SONAME issue fixed for rocr-runtime in ROCm/rocm-systems#9629 (JIRA AIESW-39022) — same root cause (wheels ship versioned SONAME only, no unversioned dev symlink), different library.

## Fix:
Try the version-suffixed name first — `librocprof-trace-decoder.so.<major>.<minor>` — and fall back to the unversioned `librocprof-trace-decoder.so` only if the versioned file is absent. The SOVERSION is derived at build time from the `rocprof-trace-decoder` CMake package (`major.minor`) and injected as `ROCPROFILER_ATT_DECODER_SOVERSION`, so it tracks upstream instead of being hardcoded. Discovery stays soft (`find_package(... QUIET)`) because the decoder is a runtime `dlopen` dependency, but a `message(WARNING ...)` is emitted when it cannot be resolved so a misconfigured build is caught rather than silently regressing. Generic packaging fix, not GPU-arch specific.

## Issue Tracking
JIRA ID : AIPROFSDK-1005

## Risk:
The versioned candidate is only tried ahead of the existing unversioned load; devel installs that ship the `.so` dev symlink resolve exactly as before. If the decoder version cannot be resolved at build time, behavior falls back to the previous unversioned-only path (with a build warning).

## Test Results:
Verified end-to-end on a real gfx1151 GPU with `rocprofv3 --att` against a runtime-only decoder directory that contains only
`librocprof-trace-decoder.so.0.2` (no unversioned symlink):
- Before: `Error loading decoder (status 37 / NOT_AVAILABLE)`.
- After: the loader maps `librocprof-trace-decoder.so.0.2`, decode completes, and the ATT artifacts are produced.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
