### PR TITLE
ci(rocprofiler-sdk): raise timeout for install-test steps to 30 minutes

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -288,7 +288,7 @@ jobs:
 
       - name: Test Install Build
         if: ${{ contains(matrix.system.gpu, env.CORE_EXT_RUNNER) }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run: |
@@ -319,7 +319,7 @@ jobs:
 
       - name: Test Installed Packages
         if: ${{ contains(matrix.system.gpu, env.CORE_EXT_RUNNER) }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run: |


### PR DESCRIPTION
The "Test Install Build" and "Test Installed Packages" steps in the Ubuntu/DEB job have been running close to their 20 minute budget, so runs intermittently fail with:

    The action 'Test Installed Packages' has timed out after 20 minutes.

Raise both to 30 minutes to restore headroom.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
 JIRA ID:  1234
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
