### PR TITLE
test(rccl): fixed signal initial value setup

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1466,11 +1466,14 @@ ib_recv:
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
 
-  rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p);
+  rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p) && !remMeta.isRMA;
   rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
-  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",
-       remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
+  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d isRMA=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",
+       remMeta.isP2p, remMeta.isRMA, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
+  if (remMeta.isRMA) {
+    rComm->base.nqps = 1;
+  }
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);
 
   // IB setup

--- a/projects/rccl/test/transport/RmaMPI/RmaMPITestBase.hpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMPITestBase.hpp
@@ -253,7 +253,7 @@ protected:
         ncclRmaConfig_t cfg = {};
         cfg.nContexts    = GetNumContexts();
         cfg.trafficClass = -1;
-        cfg.rankStride   = 0;
+        cfg.rankStride   = 1;
 
         r = rma_->createContext(collComm_, &cfg, &rmaCtx_);
         if(r != ncclSuccess)

--- a/projects/rccl/test/transport/RmaMPI/RmaMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMPITests.cpp
@@ -234,6 +234,8 @@ TEST_P(RmaMPITest, IPutSignalAtOffset)
     {
         FillSentinel(recvBuf, kBufSize,    kSentinel);
         FillSentinel(sigBuf,  kSigBufSize, kSentinel);
+        FillSentinel(static_cast<uint8_t*>(sigBuf) + kSigOff,
+                     sizeof(uint64_t), /*value=*/0x00);
     }
 
     void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;


### PR DESCRIPTION
## Motivation

- As signal value is incremented, it should be initialized with 0x0 value, not 0xCC as the rest of a buffer.
- rankStride should be >=1
- Aligned connect-accept logic for GIN conmmunicators

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID: N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
