### PR TITLE
docs(hip): Update unified memory management page

### DIFF
--- a/projects/hip/docs/how-to/hip_runtime_api/memory_management/unified_memory.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/memory_management/unified_memory.rst
@@ -125,7 +125,7 @@ allocators (e.g., ``new``, ``malloc()``) can be used.
       - ✅ :sup:`1`
     * - CDNA2
       - ✅
-      - ✅ :sup:`1`
+      - ✅ :sup:`1` :sup:`2`
     * - CDNA1
       - ✅
       - ❌
@@ -142,6 +142,9 @@ allocators (e.g., ``new``, ``malloc()``) can be used.
 
 :sup:`1` Works only with ``HSA_XNACK=1`` and kernels with HMM support. First GPU
 access causes recoverable page-fault.
+
+:sup:`2` XNACK is not supported on CDNA2 (MI200 series) in SR-IOV configurations.
+System allocator support is therefore unavailable in that environment.
 
 .. _memory allocation approaches in unified memory:
 


### PR DESCRIPTION
## Motivation

Updates the HIP documentation page for unified memory management based on a request to update the page with a caveat that XNACK is not supported on MI200 under SRIOV config.

## Technical Details

Updated projects/hip/docs/how-to/hip_runtime_api/memory_management/unified_memory.rst.

## Issue Tracking

JIRA ID : AIROCDOC-4243

## Test Plan

Verified via local RTD build.

## Test Result

Content looks ready for review.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
