### PR TITLE
docs(rocprofiler-compute): document vLLM profiling procedure

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -24,6 +24,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   modes on partition-capable accelerators, noting that analysis derives logical
   XCD, L2 channel, and HBM channel counts from them.
 
+* Added a guide for profiling vLLM workloads and its caveats.
+
 ### Changed
 
 * Renamed the PC sampling analysis output: `pc_sampling.csv` is now `pc_sampling_summary.csv`, and the `compute_pc_sampling_view` view is now `compute_pc_sampling_summary_view`.

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -1185,6 +1185,34 @@ The output is identical to enabling each framework's trace flag individually.
 Captured kernels are attributed in the ``Backend`` column and analyzed with the
 corresponding per-framework operator options (see :doc:`../analyze/cli`).
 
+.. _profile-vllm-workloads:
+
+Profile vLLM workloads
+======================
+
+vLLM normally runs GPU kernels in a worker process separate from the
+vLLM entry process. ROCm Compute Profiler does not profile the kernels in that
+worker process, so a profiling run can finish without GPU kernel dispatch or
+performance counter data.
+
+To profile vLLM workloads, set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before
+launching ROCm Compute Profiler. The vLLM workload then inherits the setting
+and runs the model in the profiled process. For example:
+
+.. code-block:: shell-session
+
+   $ VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+       rocprof-compute profile \
+       --iteration-multiplexing \
+       --no-roof \
+       --name vllm-offline -- \
+       python offline_inference.py
+
+.. warning::
+
+   Disabling vLLM V1 multiprocessing changes the workload's execution flow and
+   may affect performance characteristics.
+
 .. _iteration-multiplexing:
 
 Iteration multiplexing

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -1190,14 +1190,17 @@ corresponding per-framework operator options (see :doc:`../analyze/cli`).
 Profile vLLM workloads
 ======================
 
-vLLM normally runs GPU kernels in a worker process separate from the
-vLLM entry process. ROCm Compute Profiler does not profile the kernels in that
-worker process, so a profiling run can finish without GPU kernel dispatch or
+vLLM V1 runs GPU kernels in a worker process separate from the vLLM entry
+process. ROCm Compute Profiler profiles that worker process and records its
+kernel dispatches, but vLLM terminates the worker with a signal on shutdown,
+and counter data is only written when a process exits normally. The profiling
+run therefore reports success while leaving no GPU kernel dispatch or
 performance counter data.
 
-To profile vLLM workloads, set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before
-launching ROCm Compute Profiler. The vLLM workload then inherits the setting
-and runs the model in the profiled process. For example:
+To profile vLLM V1 workloads on a single GPU, set
+``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before launching ROCm Compute Profiler.
+The vLLM workload then inherits the setting and runs the model in the profiled
+process, which exits normally and writes its counter data. For example:
 
 .. code-block:: shell-session
 
@@ -1208,10 +1211,18 @@ and runs the model in the profiled process. For example:
        --name vllm-offline -- \
        python offline_inference.py
 
-.. warning::
+.. important::
 
-   Disabling vLLM V1 multiprocessing changes the workload's execution flow and
-   may affect performance characteristics.
+   This workaround applies to single-GPU runs. When the model is split across
+   several GPUs, vLLM starts a separate worker process for each GPU, and a
+   profiling run still completes without performance counter data.
+
+.. note::
+
+   Disabling vLLM V1 multiprocessing does not change the model or the kernels
+   it runs, so the collected counter data remains representative. It does
+   affect end-to-end throughput, because work that normally overlaps across two
+   processes is serialized into one.
 
 .. _iteration-multiplexing:
 

--- a/projects/rocprofiler-compute/docs/reference/faq.rst
+++ b/projects/rocprofiler-compute/docs/reference/faq.rst
@@ -112,11 +112,14 @@ occur during normal execution.
 Why does profiling a vLLM workload produce empty performance counter data?
 ==========================================================================
 
-vLLM V1 normally runs GPU kernels in a worker process separate from the vLLM
-entry process. ROCm Compute Profiler does not profile kernels in that worker,
-so a profiling run can finish without GPU kernel dispatch or performance
+vLLM V1 runs GPU kernels in a worker process separate from the vLLM entry
+process. ROCm Compute Profiler profiles that worker and records its kernel
+dispatches, but vLLM terminates the worker with a signal on shutdown, and
+counter data is only written when a process exits normally. The profiling run
+therefore reports success while leaving no GPU kernel dispatch or performance
 counter data.
 
-Set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before launching ROCm Compute
-Profiler. For an example command and the performance caveat, see
-:ref:`profile-vllm-workloads`.
+For a single-GPU run, set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before launching
+ROCm Compute Profiler. When the model is split across several GPUs, this
+setting does not recover the counter data. For an example command and the
+throughput caveat, see :ref:`profile-vllm-workloads`.

--- a/projects/rocprofiler-compute/docs/reference/faq.rst
+++ b/projects/rocprofiler-compute/docs/reference/faq.rst
@@ -112,14 +112,6 @@ occur during normal execution.
 Why does profiling a vLLM workload produce empty performance counter data?
 ==========================================================================
 
-vLLM V1 runs GPU kernels in a worker process separate from the vLLM entry
-process. ROCm Compute Profiler profiles that worker and records its kernel
-dispatches, but vLLM terminates the worker with a signal on shutdown, and
-counter data is only written when a process exits normally. The profiling run
-therefore reports success while leaving no GPU kernel dispatch or performance
-counter data.
-
-For a single-GPU run, set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before launching
-ROCm Compute Profiler. When the model is split across several GPUs, this
-setting does not recover the counter data. For an example command and the
-throughput caveat, see :ref:`profile-vllm-workloads`.
+vLLM V1 runs GPU kernels in a worker process that it terminates with a signal
+on shutdown, and counter data is only written when a process exits normally.
+See :ref:`profile-vllm-workloads` for the workaround and where it applies.

--- a/projects/rocprofiler-compute/docs/reference/faq.rst
+++ b/projects/rocprofiler-compute/docs/reference/faq.rst
@@ -1,7 +1,7 @@
 .. meta::
     :description: ROCm Compute Profiler FAQ and troubleshooting
     :keywords: ROCm Compute Profiler, FAQ, troubleshooting, ROCm, profiler, tool, Instinct,
-               accelerator, AMD, SSH, error, version, workaround, help
+               accelerator, AMD, SSH, error, version, workaround, help, vLLM
 
 ***
 FAQ
@@ -108,3 +108,15 @@ launched on separate HIP streams on the same GPU will run one after
 another during profiling. Kernel duration and throughput metrics reflect
 this serialized execution rather than the concurrent behavior that may
 occur during normal execution.
+
+Why does profiling a vLLM workload produce empty performance counter data?
+==========================================================================
+
+vLLM V1 normally runs GPU kernels in a worker process separate from the vLLM
+entry process. ROCm Compute Profiler does not profile kernels in that worker,
+so a profiling run can finish without GPU kernel dispatch or performance
+counter data.
+
+Set ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` before launching ROCm Compute
+Profiler. For an example command and the performance caveat, see
+:ref:`profile-vllm-workloads`.


### PR DESCRIPTION
## Motivation

vLLM V1 can execute GPU kernels outside the profiled entry process, leaving ROCm Compute Profiler results without dispatch or counter data. Document the verified single-process workaround and its performance caveat.

## Technical Details

- Add vLLM profiling guidance and example
- Document V1 multiprocessing environment workaround
- Add FAQ entry for empty counter data

## JIRA ID

JIRA ID: AIPROFCOMP-182

## Test Plan

- [x] Run workload: python -m sphinx -q -b html docs docs/_build/html

## Test Result

- [x] workload: python -m sphinx -q -b html docs docs/_build/html passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.