### PR TITLE
fix(rocdecode): validate dynamic surface indices

### DIFF
--- a/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
+++ b/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
@@ -149,6 +149,8 @@ int FFMpegVideoDecoder::HandleVideoSequence(RocdecVideoFormatHost *format_host) 
         // rocdecCreateDecoder() has been called before, and now there's possible config change
         return ReconfigureDecoder(p_video_format);
     }
+    num_decode_surfaces_ = num_decode_surfaces;
+    sei_message_display_q_.resize(num_decode_surfaces_);
     // e_codec has been set in the constructor (for parser). Here it's set again for potential correction
     codec_id_ = p_video_format->codec;
     video_chroma_format_ = p_video_format->chroma_format;
@@ -254,8 +256,13 @@ int FFMpegVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
                                      p_video_format->display_area.top == disp_rect_.top &&
                                      p_video_format->display_area.left == disp_rect_.left &&
                                      p_video_format->display_area.right == disp_rect_.right);
+    bool is_dec_surface_num_changed = p_video_format->min_num_decode_surfaces != num_decode_surfaces_;
 
     if (!is_decode_res_changed && !is_display_rect_changed && !b_force_recofig_flush_) {
+        if (is_dec_surface_num_changed) {
+            num_decode_surfaces_ = p_video_format->min_num_decode_surfaces;
+            sei_message_display_q_.resize(num_decode_surfaces_);
+        }
         return 1;
     }
 
@@ -280,6 +287,8 @@ int FFMpegVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
         }
     }
     output_frame_cnt_ = 0;     // reset frame_count
+    num_decode_surfaces_ = p_video_format->min_num_decode_surfaces;
+    sei_message_display_q_.resize(num_decode_surfaces_);
     if (is_decode_res_changed) {
         coded_width_ = p_video_format->coded_width;
         coded_height_ = p_video_format->coded_height;
@@ -349,37 +358,15 @@ int FFMpegVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
  * @return int 0:fail 1: success
  */
 int FFMpegVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
-    if (b_extract_sei_message_) {
-        if (sei_message_display_q_[pDispInfo->picture_index].sei_data) {
-            // Write SEI Message
-            uint8_t *sei_buffer = static_cast<uint8_t *>(sei_message_display_q_[pDispInfo->picture_index].sei_data);
-            uint32_t sei_num_messages = sei_message_display_q_[pDispInfo->picture_index].sei_message_count;
-            RocdecSeiMessage *sei_message = sei_message_display_q_[pDispInfo->picture_index].sei_message;
-            if (fp_sei_) {
-                for (uint32_t i = 0; i < sei_num_messages; i++) {
-                    if (codec_id_ == rocDecVideoCodec_AVC || codec_id_ == rocDecVideoCodec_HEVC) {
-                        switch (sei_message[i].sei_message_type) {
-                            case SEI_TYPE_TIME_CODE: {
-                                //todo:: check if we need to write timecode
-                            }
-                            break;
-                            case SEI_TYPE_USER_DATA_UNREGISTERED: {
-                                fwrite(sei_buffer, sei_message[i].sei_message_size, 1, fp_sei_);
-                            }
-                            break;
-                        }
-                    }
-                    if (codec_id_ == rocDecVideoCodec_AV1) {
-                        fwrite(sei_buffer, sei_message[i].sei_message_size, 1, fp_sei_);
-                    }    
-                    sei_buffer += sei_message[i].sei_message_size;
-                }
-            }
-            free(sei_message_display_q_[pDispInfo->picture_index].sei_data);
-            sei_message_display_q_[pDispInfo->picture_index].sei_data = NULL; // to avoid double free
-            free(sei_message_display_q_[pDispInfo->picture_index].sei_message);
-            sei_message_display_q_[pDispInfo->picture_index].sei_message = NULL; // to avoid double free
-        }
+    if (!pDispInfo || pDispInfo->picture_index < 0 ||
+        static_cast<uint32_t>(pDispInfo->picture_index) >= num_decode_surfaces_) {
+        RocVideoDecCriticalLog("Invalid display picture index");
+        return 0;
+    }
+
+    if (b_extract_sei_message_ &&
+        !HandleSeiMessageDisplay(pDispInfo->picture_index)) {
+        return 0;
     }
 
     RocdecParserDispInfo *p_disp_info = static_cast<RocdecParserDispInfo *>(pDispInfo);

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
@@ -22,6 +22,8 @@ THE SOFTWARE.
 
 #include "roc_video_dec.h"
 
+#include <limits>
+
 RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_type, rocDecVideoCodec codec, bool force_zero_latency,
               const Rect *p_crop_rect, bool extract_user_sei_Message, uint32_t disp_delay, int max_width, int max_height, uint32_t clk_rate, bool skip_init) :
               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency), 
@@ -30,8 +32,6 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
     if (p_crop_rect) crop_rect_ = *p_crop_rect;
     if (b_extract_sei_message_) {
         fp_sei_ = fopen("rocdec_sei_message.txt", "wb");
-        curr_sei_message_ptr_ = new RocdecSeiMessageInfo;
-        memset(&sei_message_display_q_, 0, sizeof(sei_message_display_q_));
     }
     // derived class can skip the following initialization by setting skip_init flag
     if (!skip_init) {
@@ -56,11 +56,6 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
 
 RocVideoDecoder::~RocVideoDecoder() {
     auto start_time = StartTimer();
-    if (curr_sei_message_ptr_) {
-        delete curr_sei_message_ptr_;
-        curr_sei_message_ptr_ = nullptr;
-    }
-
     if (fp_sei_) {
         fclose(fp_sei_);
         fp_sei_ = nullptr;
@@ -114,6 +109,36 @@ RocVideoDecoder::~RocVideoDecoder() {
     }
     double elapsed_time = StopTimer(start_time);
     AddDecoderSessionOverHead(std::this_thread::get_id(), elapsed_time);
+}
+
+bool RocVideoDecoder::HandleSeiMessageDisplay(int picture_index) {
+    if (picture_index < 0 ||
+        static_cast<size_t>(picture_index) >= sei_message_display_q_.size()) {
+        RocVideoDecCriticalLog("Invalid SEI display picture index: " + ROCVIDEODEC_TOSTR(picture_index));
+        return false;
+    }
+
+    SeiMessageEntry &entry = sei_message_display_q_[picture_index];
+    size_t offset = 0;
+    for (const RocdecSeiMessage &message : entry.messages) {
+        if (message.sei_message_size > entry.data.size() - offset) {
+            RocVideoDecCriticalLog("Invalid SEI message size for picture index: " + ROCVIDEODEC_TOSTR(picture_index));
+            entry = {};
+            return false;
+        }
+
+        const bool write_message =
+            codec_id_ == rocDecVideoCodec_AV1 ||
+            ((codec_id_ == rocDecVideoCodec_AVC ||
+              codec_id_ == rocDecVideoCodec_HEVC) &&
+             message.sei_message_type == SEI_TYPE_USER_DATA_UNREGISTERED);
+        if (fp_sei_ && write_message && message.sei_message_size) {
+            fwrite(entry.data.data() + offset, message.sei_message_size, 1, fp_sei_);
+        }
+        offset += message.sei_message_size;
+    }
+    entry = {};
+    return true;
 }
 
 static const char * GetVideoCodecString(rocDecVideoCodec e_codec) {
@@ -336,6 +361,7 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     disp_width_ = p_video_format->display_area.right - p_video_format->display_area.left;
     disp_height_ = p_video_format->display_area.bottom - p_video_format->display_area.top;
     num_decode_surfaces_ = p_video_format->min_num_decode_surfaces;
+    sei_message_display_q_.resize(num_decode_surfaces_);
 
     // AV1 has max width/height of sequence in sequence header
     if (codec_id_ == rocDecVideoCodec_AV1 && p_video_format->seqhdr_data_length > 0) {
@@ -559,6 +585,7 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
     }
 
     num_decode_surfaces_ = p_video_format->min_num_decode_surfaces;
+    sei_message_display_q_.resize(num_decode_surfaces_);
 
     if (p_video_format->reconfig_options == ROCDEC_RECONFIG_NEW_SURFACES) {
         if (out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL || out_mem_type_ == OUT_SURFACE_MEM_NOT_MAPPED) {
@@ -674,10 +701,18 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
  * @return int 1: success 0: fail
  */
 int RocVideoDecoder::HandlePictureDecode(RocdecPicParams *pPicParams) {
+    if (!pPicParams) {
+        RocVideoDecCriticalLog("Invalid picture parameters");
+        return 0;
+    }
     if (!roc_decoder_) {
         ROCDEC_THROW("RocDecoder not initialized: failed with ErrCode: " +  ROCVIDEODEC_TOSTR(ROCDEC_NOT_INITIALIZED), ROCDEC_NOT_INITIALIZED);
     }
-    pic_num_in_dec_order_[pPicParams->curr_pic_idx] = decode_poc_++;
+    if (pPicParams->curr_pic_idx < 0 ||
+        static_cast<uint32_t>(pPicParams->curr_pic_idx) >= num_decode_surfaces_) {
+        RocVideoDecCriticalLog("Invalid decode picture index: " + ROCVIDEODEC_TOSTR(pPicParams->curr_pic_idx));
+        return 0;
+    }
     ROCDEC_API_CALL(rocDecDecodeFrame(roc_decoder_, pPicParams));
     last_decode_surf_idx_ = pPicParams->curr_pic_idx;
     decoded_pic_cnt_++;
@@ -699,41 +734,19 @@ int RocVideoDecoder::HandlePictureDecode(RocdecPicParams *pPicParams) {
  * @return int 0:fail 1: success
  */
 int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
+    if (!pDispInfo || pDispInfo->picture_index < 0 ||
+        static_cast<uint32_t>(pDispInfo->picture_index) >= num_decode_surfaces_) {
+        RocVideoDecCriticalLog("Invalid display picture index");
+        return 0;
+    }
+
     RocdecProcParams video_proc_params = {};
     video_proc_params.progressive_frame = pDispInfo->progressive_frame;
     video_proc_params.top_field_first = pDispInfo->top_field_first;
 
-    if (b_extract_sei_message_) {
-        if (sei_message_display_q_[pDispInfo->picture_index].sei_data) {
-            // Write SEI Message
-            uint8_t *sei_buffer = (uint8_t *)(sei_message_display_q_[pDispInfo->picture_index].sei_data);
-            uint32_t sei_num_messages = sei_message_display_q_[pDispInfo->picture_index].sei_message_count;
-            RocdecSeiMessage *sei_message = sei_message_display_q_[pDispInfo->picture_index].sei_message;
-            if (fp_sei_) {
-                for (uint32_t i = 0; i < sei_num_messages; i++) {
-                    if (codec_id_ == rocDecVideoCodec_AVC || codec_id_ == rocDecVideoCodec_HEVC) {
-                        switch (sei_message[i].sei_message_type) {
-                            case SEI_TYPE_TIME_CODE: {
-                                //todo:: check if we need to write timecode
-                            }
-                            break;
-                            case SEI_TYPE_USER_DATA_UNREGISTERED: {
-                                fwrite(sei_buffer, sei_message[i].sei_message_size, 1, fp_sei_);
-                            }
-                            break;
-                        }
-                    }
-                    if (codec_id_ == rocDecVideoCodec_AV1) {
-                        fwrite(sei_buffer, sei_message[i].sei_message_size, 1, fp_sei_);
-                    }    
-                    sei_buffer += sei_message[i].sei_message_size;
-                }
-            }
-            free(sei_message_display_q_[pDispInfo->picture_index].sei_data);
-            sei_message_display_q_[pDispInfo->picture_index].sei_data = NULL; // to avoid double free
-            free(sei_message_display_q_[pDispInfo->picture_index].sei_message);
-            sei_message_display_q_[pDispInfo->picture_index].sei_message = NULL; // to avoid double free
-        }
+    if (b_extract_sei_message_ &&
+        !HandleSeiMessageDisplay(pDispInfo->picture_index)) {
+        return 0;
     }
     if (out_mem_type_ != OUT_SURFACE_MEM_NOT_MAPPED) {
         void * src_dev_ptr[3] = { 0 };
@@ -824,36 +837,57 @@ int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
 }
 
 int RocVideoDecoder::GetSEIMessage(RocdecSeiMessageInfo *pSEIMessageInfo) {
-    uint32_t sei_num_mesages = pSEIMessageInfo->sei_message_count;
-    if (sei_num_mesages) {
-      RocdecSeiMessage *p_sei_msg_info = pSEIMessageInfo->sei_message;
-      size_t total_SEI_buff_size = 0;
-      if ((pSEIMessageInfo->picIdx < 0) || (pSEIMessageInfo->picIdx >= MAX_FRAME_NUM)) {
-          RocVideoDecCriticalLog("Invalid picture index for SEI message: " + ROCVIDEODEC_TOSTR(pSEIMessageInfo->picIdx));
-          return 0;
-      }
-      for (uint32_t i = 0; i < sei_num_mesages; i++) {
-          total_SEI_buff_size += p_sei_msg_info[i].sei_message_size;
-      }
-      if (!curr_sei_message_ptr_) {
-          RocVideoDecCriticalLog("Out of Memory, Allocation failed for m_pCurrSEIMessage");
-          return 0;
-      }
-      curr_sei_message_ptr_->sei_data = malloc(total_SEI_buff_size);
-      if (!curr_sei_message_ptr_->sei_data) {
-          RocVideoDecCriticalLog("Out of Memory, Allocation failed for SEI Buffer");
-          return 0;
-      }
-      memcpy(curr_sei_message_ptr_->sei_data, pSEIMessageInfo->sei_data, total_SEI_buff_size);
-      curr_sei_message_ptr_->sei_message = (RocdecSeiMessage *)malloc(sizeof(RocdecSeiMessage) * sei_num_mesages);
-      if (!curr_sei_message_ptr_->sei_message) {
-          free(curr_sei_message_ptr_->sei_data);
-          curr_sei_message_ptr_->sei_data = NULL;
-          return 0;
-      }
-      memcpy(curr_sei_message_ptr_->sei_message, pSEIMessageInfo->sei_message, sizeof(RocdecSeiMessage) * sei_num_mesages);
-      curr_sei_message_ptr_->sei_message_count = pSEIMessageInfo->sei_message_count;
-      sei_message_display_q_[pSEIMessageInfo->picIdx] = *curr_sei_message_ptr_;
+    if (!pSEIMessageInfo) {
+        RocVideoDecCriticalLog("Invalid SEI message info");
+        return 0;
+    }
+    if (pSEIMessageInfo->picIdx >= num_decode_surfaces_ ||
+        pSEIMessageInfo->picIdx >= sei_message_display_q_.size()) {
+        RocVideoDecCriticalLog("Invalid picture index for SEI message: " + ROCVIDEODEC_TOSTR(pSEIMessageInfo->picIdx));
+        return 0;
+    }
+
+    const uint32_t sei_num_messages = pSEIMessageInfo->sei_message_count;
+    SeiMessageEntry &entry = sei_message_display_q_[pSEIMessageInfo->picIdx];
+    if (!sei_num_messages) {
+        entry = {};
+        return 1;
+    }
+
+    if (!pSEIMessageInfo->sei_message) {
+        RocVideoDecCriticalLog("Invalid SEI message metadata");
+        return 0;
+    }
+
+    size_t total_sei_buffer_size = 0;
+    for (uint32_t i = 0; i < sei_num_messages; i++) {
+        const size_t message_size =
+            pSEIMessageInfo->sei_message[i].sei_message_size;
+        if (message_size >
+            std::numeric_limits<size_t>::max() - total_sei_buffer_size) {
+            RocVideoDecCriticalLog("SEI message data size overflow");
+            return 0;
+        }
+        total_sei_buffer_size += message_size;
+    }
+    if (total_sei_buffer_size && !pSEIMessageInfo->sei_data) {
+        RocVideoDecCriticalLog("Invalid SEI message data");
+        return 0;
+    }
+
+    try {
+        entry.messages.assign(pSEIMessageInfo->sei_message,
+                              pSEIMessageInfo->sei_message + sei_num_messages);
+        entry.data.clear();
+        if (total_sei_buffer_size) {
+            const uint8_t *sei_data =
+                static_cast<const uint8_t *>(pSEIMessageInfo->sei_data);
+            entry.data.assign(sei_data, sei_data + total_sei_buffer_size);
+        }
+    } catch (const std::exception &) {
+        entry = {};
+        RocVideoDecCriticalLog("Allocation failed for SEI message");
+        return 0;
     }
     return 1;
 }

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -74,8 +74,6 @@ THE SOFTWARE.
  * \brief AMD The rocDecode video decoder for AMD’s GPUs.
  */
 
-#define MAX_FRAME_NUM       16
-
 typedef int (ROCDECAPI *PFNRECONFIGUEFLUSHCALLBACK)(void *, uint32_t, void *);
 
 typedef enum SeiAvcHevcPayloadType_enum {
@@ -467,6 +465,16 @@ class RocVideoDecoder {
          *   @brief  This function gets called when all unregistered user SEI messages are parsed for a frame
          */
         int GetSEIMessage(RocdecSeiMessageInfo *p_sei_message_info);
+
+        struct SeiMessageEntry {
+            std::vector<uint8_t> data;
+            std::vector<RocdecSeiMessage> messages;
+        };
+
+        /**
+         *   @brief Write and release a queued SEI message for a displayed picture.
+         */
+        bool HandleSeiMessageDisplay(int picture_index);
         
         /**
          * @brief function to release all internal frames and clear the vp_frames_q_ (used with reconfigure): Only used with "OUT_SURFACE_MEM_DEV_INTERNAL"
@@ -510,12 +518,10 @@ class RocVideoDecoder {
         hipStream_t hip_stream_ = nullptr;
         rocDecVideoChromaFormat video_chroma_format_ = rocDecVideoChromaFormat_420;
         rocDecVideoSurfaceFormat video_surface_format_ = rocDecVideoSurfaceFormat_NV12;
-        RocdecSeiMessageInfo *curr_sei_message_ptr_ = nullptr;
-        RocdecSeiMessageInfo sei_message_display_q_[MAX_FRAME_NUM];
+        std::vector<SeiMessageEntry> sei_message_display_q_;
         RocdecVideoFormat *curr_video_format_ptr_ = nullptr;
         int output_frame_cnt_ = 0, output_frame_cnt_ret_ = 0;
         int decoded_pic_cnt_ = 0;
-        int decode_poc_ = 0, pic_num_in_dec_order_[MAX_FRAME_NUM];
         int num_alloced_frames_ = 0;
         int last_decode_surf_idx_ = 0;
         std::ostringstream input_video_info_str_;


### PR DESCRIPTION
Size SEI storage to the parser's surface pool so valid high indices cannot cause out-of-bounds accesses.

## Motivation

JIRA ID: SWSPLAT-24274
https://amd.atlassian.net/browse/SWSPLAT-24274
JIRA ID: SWSPLAT-24272
https://amd.atlassian.net/browse/SWSPLAT-24272

This PR addresses two related rocDecode security findings:

SWSPLAT-24272: out-of-bounds write in HandlePictureDecode()
SWSPLAT-24274: out-of-bounds read and invalid free() in HandlePictureDisplay()
Both findings originate from fixed 16-entry arrays indexed with parser-provided picture indices.

The parser's decode surface pool is not limited to 16 entries. It is calculated from the codec DPB requirement and display delay, and can legitimately contain:

up to 18 surfaces for AVC/HEVC
up to 22 surfaces for AV1 with film grain
Therefore, valid indices such as 16–21 could access memory outside the utility arrays.

The goal is to prevent the out-of-bounds accesses without imposing a fixed limit that would reject valid streams.

## Technical Details

### Decode path
HandlePictureDecode() previously wrote to pic_num_in_dec_order_[curr_pic_idx] without validating curr_pic_idx.

The fixed decode-order array was only written and never otherwise used, so it was removed.

The callback now validates that:

- the picture parameters are not null
- curr_pic_idx is non-negative
- curr_pic_idx is smaller than the parser-reported decode surface count
- Invalid indices are rejected before calling rocDecDecodeFrame().

### SEI display path
The fixed sei_message_display_q_[16] array was replaced with storage sized according to min_num_decode_surfaces.

SEI payloads and message metadata now use std::vector, which provides automatic ownership and cleanup. This removes the previous manual malloc() and free() handling that could free invalid pointers after an out-of-bounds read.

SEI indices are validated against both the current surface count and the actual queue size before access.

The queue is resized during:

- initial sequence handling
- decoder reconfiguration
- FFmpeg decoder sequence changes

Existing entries are preserved when the queue grows, while removed entries are automatically released when it shrinks.

### Shared SEI handling
The duplicated SEI display and cleanup logic from the GPU and FFmpeg decoder paths was consolidated into a shared bounds-checked implementation.

This keeps both decoder paths consistent and prevents the same invalid-free pattern from remaining in the FFmpeg implementation.


## Test Plan

Build the modified rocDecode and FFmpeg utility sources.
Run targeted tests for invalid and valid high surface indices, SEI ownership, and queue resizing.
Run the regression test with ASan, UBSan, and LeakSanitizer.

## Test Result

Compilation checks passed.
Targeted and sanitizer tests passed without memory errors or leaks.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
