### PR TITLE
DO NOT MERGE: end-to-end smoke test for the RCCL perf gate (#10073)

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -5,6 +5,12 @@
  * See LICENSE.txt for more license information
  *************************************************************************/
 
+// THROWAWAY -- do not merge. Exercises the RCCL perf-regression gate end to
+// end (ROCm/rocm-systems#10073). A comment-only edit clears the workflow's
+// paths filter and forces a real two-sided build, while leaving reference
+// and candidate functionally identical, so the expected verdict is known in
+// advance: no regression. Close this PR and delete the branch afterwards.
+
 #include "argcheck.h" // Need some checks here since we access comm
 #include "collectives.h"
 #include "enqueue.h"

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -10,6 +10,9 @@
 // paths filter and forces a real two-sided build, while leaving reference
 // and candidate functionally identical, so the expected verdict is known in
 // advance: no regression. Close this PR and delete the branch afterwards.
+// Round 2: re-run to validate the report job now that it posts from
+// ubuntu-latest off an uploaded artifact instead of re-rendering on the
+// self-hosted runner. Same known answer: no regression.
 
 #include "argcheck.h" // Need some checks here since we access comm
 #include "collectives.h"


### PR DESCRIPTION
> [!CAUTION]
> **Throwaway. Do not merge, do not review.** This PR exists only to make the RCCL
> perf-regression gate in #10073 execute. Close it and delete
> `aimvt-196-e2e-gate-smoke` once the gate has posted its verdict.

## Why this PR has to exist

The gate cannot run on #10073 itself. `on.pull_request.branches` matches a PR's
**base** branch, and #10073's base is `develop` while the filter is temporarily
pointed at `aimvt-196-rccl-regression-robustness`. Nothing about #10073 satisfies that,
so it collects `skipping` for every RCCL check and the new workflow never fires.

`workflow_dispatch` is not a way around it either: Actions only offers manual dispatch
for workflows present on the default branch, and this one is not on `develop` yet.

So the test needs a PR whose **base is** the branch under review. `pull_request` events
resolve the workflow from the merge commit, which means a PR into
`aimvt-196-rccl-regression-robustness` runs the workflow file *as written in #10073* —
the version under review is the version that executes.

## What the change is

One comment block in `projects/rccl/src/collectives.cc`. It does two things and nothing
else:

- clears the `paths` filter (`projects/rccl/**`, and not one of the `*.md` / `docs/**` /
  `LICENSE*` / `CODEOWNERS` exclusions)
- forces a genuine two-sided build. The build cache is rev-keyed, so reference
  (merge-base) and candidate (this head) have different SHAs and compile separately
  rather than the candidate being served from cache.

Because the edit is a comment, the two `librccl.so` are functionally identical. That
makes this a known-answer test rather than a fishing trip.

## What a correct run looks like

| stage | expected |
|---|---|
| `build` | two builds, both succeed, lib dirs templated into the run config |
| `detect` | Slurm job on `mia1-p01-g[22,26,28,32]`, ~35 min once it starts |
| verdict | **✅ STABLE** — 10 groups scored, 10 trustworthy, 460 keys, 0 regressions |
| `report` | sticky PR comment on this PR, rendered from *this* run's artifacts |

Anything else is the finding. In particular:

- a verdict posted from a stale report would mean the per-run artifact path fix
  (`workspace.sh --print-artifacts`) did not take
- `⚠️ NO VERDICT` with an exit 2 means the detector ran but could not vouch for what it
  measured — that is the gate working, not the gate broken
- `❌ Not measured.` means an earlier job died and the `always()` report job caught it,
  which is also the intended behaviour

Cluster-side numbers this is being checked against, both A=A control runs on the real
4-node reservation with alltoall_perf enabled: Slurm **16368** (34:56) and **16382**
(34:52), each 460 keys, 0 false positives, 10/10 groups trustworthy.

## Companion PRs

- **ROCm/rocm-systems#10073** — the workflow under test
- **ROCm/cvs#310** — the Slurm-side scripts it calls
