### PR TITLE
[CLR] Add indirect blit kernel

### DIFF
--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for HIP is available at [rocm.docs.amd.com](https://rocm.docs
 * New HIP APIs
     - Device Management: support for querying a device identifier.
       * `hipDeviceGetLuid` returns the locally unique identifier (LUID) and device node mask for a device
+* Batched Memcpy: Add `GPU_FORCE_BLIT_INDIRECT_SIZE` to allow tuning of when SDMA instead of Blit is used for indirect batched copies.
 
 ## HIP 10.0.0 for ROCm 10.0.0
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3122,10 +3122,7 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     if (copyFlags & kExtOpFlagMask) {
       switch (type) {
         case hipCopyBuffer:
-        case hipCopyBufferSDMA:
-        case hipCopyBufferP2P: {
-          // Narrow to H<->D for swap and single-sided indirect. Dual-sided
-          // indirect skips the type-equality check (both operands are holders).
+        case hipCopyBufferSDMA: {
           amd::Memory* sMem = srcMemories[i];
           amd::Memory* dMem = dstMemories[i];
           if (sMem == nullptr || dMem == nullptr ||
@@ -3134,6 +3131,11 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
           }
           break;
         }
+        case hipCopyBufferP2P:
+          if (srcMemories[i] == nullptr || dstMemories[i] == nullptr) {
+            return hipErrorNotSupported;
+          }
+          break;
         case hipHostToHost:
         case hipWriteBuffer:
         case hipReadBuffer:

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3125,8 +3125,16 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
         case hipCopyBufferSDMA: {
           amd::Memory* sMem = srcMemories[i];
           amd::Memory* dMem = dstMemories[i];
-          if (sMem == nullptr || dMem == nullptr ||
-              (!isDualSidedIndirect && getMemoryType(sMem) == getMemoryType(dMem))) {
+          if (sMem == nullptr || dMem == nullptr) {
+            return hipErrorNotSupported;
+          }
+          const hipMemoryType sType = getMemoryType(sMem);
+          const hipMemoryType dType = getMemoryType(dMem);
+          if (isDualSidedIndirect) {
+            if (sType == hipMemoryTypeHost && dType == hipMemoryTypeHost) {
+              return hipErrorNotSupported;
+            }
+          } else if (sType == dType) {
             return hipErrorNotSupported;
           }
           break;

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3089,10 +3089,12 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
   }
 
   if (attrs != nullptr && !stream.device().settings().sdma_indirect_supported_) {
-    const unsigned int kIndirectMask =
+    const unsigned int kBothIndirect =
         hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;
     for (size_t i = 0; i < numAttrs; ++i) {
-      if (attrs[i].flags & kIndirectMask) {
+      // Single-sided indirect (Src XOR Dst) can fall back to the shader path;
+      // dual-sided indirect still requires HW SDMA indirect support.
+      if ((attrs[i].flags & kBothIndirect) == kBothIndirect) {
         return hipErrorNotSupported;
       }
     }

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3088,18 +3088,6 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
   }
 
-  if (attrs != nullptr && !stream.device().settings().sdma_indirect_supported_) {
-    const unsigned int kBothIndirect =
-        hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;
-    for (size_t i = 0; i < numAttrs; ++i) {
-      // Single-sided indirect (Src XOR Dst) can fall back to the shader path;
-      // dual-sided indirect still requires HW SDMA indirect support.
-      if ((attrs[i].flags & kBothIndirect) == kBothIndirect) {
-        return hipErrorNotSupported;
-      }
-    }
-  }
-
   // Classify copies by type and group them by the queue device that will execute each batch.
   std::vector<std::vector<amd::BatchCopyOp>> copy_ops_by_device(g_devices.size());
   std::vector<std::vector<amd::BatchWriteMemoryOp>> write_ops_by_device(g_devices.size());
@@ -3128,20 +3116,24 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
 
     const unsigned int copyFlags = getBatchCopyFlags(attrs, attrsIdxs, numAttrs, i, attrIdx);
+    const bool isDualSidedIndirect =
+        (copyFlags & (hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst)) ==
+        (hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
     if (copyFlags & kExtOpFlagMask) {
       switch (type) {
         case hipCopyBuffer:
-        case hipCopyBufferSDMA: {
-          // Narrow to H<->D for both swap and indirect.
+        case hipCopyBufferSDMA:
+        case hipCopyBufferP2P: {
+          // Narrow to H<->D for swap and single-sided indirect. Dual-sided
+          // indirect skips the type-equality check (both operands are holders).
           amd::Memory* sMem = srcMemories[i];
           amd::Memory* dMem = dstMemories[i];
-          if (sMem == nullptr || dMem == nullptr || getMemoryType(sMem) == getMemoryType(dMem)) {
+          if (sMem == nullptr || dMem == nullptr ||
+              (!isDualSidedIndirect && getMemoryType(sMem) == getMemoryType(dMem))) {
             return hipErrorNotSupported;
           }
           break;
         }
-        case hipCopyBufferP2P:
-          break;
         case hipHostToHost:
         case hipWriteBuffer:
         case hipReadBuffer:
@@ -3155,10 +3147,15 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
       case hipCopyBufferSDMA: {
         const hipMemoryType src_memory_type = getMemoryType(srcMemories[i]);
         const hipMemoryType dst_memory_type = getMemoryType(dstMemories[i]);
+        // For dual-sided indirect both operands are pointer-holders, so neither
+        // holder identifies the device the real buffers live on; execute on the
+        // stream's device (the real VAs are dereferenced on-device there).
         const int device_id =
-            (src_memory_type == hipMemoryTypeDevice && dst_memory_type == hipMemoryTypeHost)
-                ? srcMemories[i]->getUserData().deviceId
-                : dstMemories[i]->getUserData().deviceId;
+            isDualSidedIndirect
+                ? stream.DeviceId()
+                : (src_memory_type == hipMemoryTypeDevice && dst_memory_type == hipMemoryTypeHost)
+                      ? srcMemories[i]->getUserData().deviceId
+                      : dstMemories[i]->getUserData().deviceId;
         copy_ops_by_device[device_id].emplace_back(srcMemories[i], dstMemories[i], srcOffsets[i],
                                                    dstOffsets[i], sizes[i], metadata);
         break;

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -176,6 +176,89 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       }
     }
 
+    typedef struct IndirectCopyBufferBatchDescriptor {
+      ulong source_address;       // holder VA if src indirect, else real VA
+      ulong destination_address;  // holder VA if dst indirect, else real VA
+      ulong size;                 // copy size in bytes
+      uint indirect_mode;         // bit0 = src indirect, bit1 = dst indirect
+    } IndirectCopyBufferBatchDescriptor;
+
+    __kernel void __amd_rocclr_copyBufferBatchIndirect(
+        __global const IndirectCopyBufferBatchDescriptor *descriptors,
+        uint workgroup_size,
+        uint copy_stride) {
+      uint work_item_id = __builtin_amdgcn_workitem_id_x();
+      uint group_ordinal = __builtin_amdgcn_workgroup_id_x();
+      uint descriptor_index = __builtin_amdgcn_workgroup_id_y();
+
+      IndirectCopyBufferBatchDescriptor descriptor = descriptors[descriptor_index];
+      // Access the indirect pointer based on the indirect_mode's bit
+      __global uchar *real_src =
+          (descriptor.indirect_mode & 1)
+              ? (__global uchar *)(*(__global ulong *)descriptor.source_address)
+              : (__global uchar *)descriptor.source_address;
+      __global uchar *real_dst =
+          (descriptor.indirect_mode & 2)
+              ? (__global uchar *)(*(__global ulong *)descriptor.destination_address)
+              : (__global uchar *)descriptor.destination_address;
+      ulong copy_index = ((ulong)group_ordinal * workgroup_size) + work_item_id;
+
+      // Figure out the largest overlapping power of two between the addresses
+      // This must be computed on the device, as it is not known until kernel
+      // launch
+      ulong combined = (ulong)real_src | (ulong)real_dst;
+      ulong lowest_set_bit = combined & (~combined + 1);
+      uint aligned_element_size =
+          (combined == 0) ? 1 : (uint)min(lowest_set_bit, (ulong)sizeof(ulong2));
+      ulong aligned_element_count = descriptor.size / aligned_element_size;
+      uint trailing_byte_count = (uint)(descriptor.size % aligned_element_size);
+
+      if (aligned_element_size == sizeof(ulong2)) {
+        __global ulong2 *source_data = (__global ulong2 *)(real_src);
+        __global ulong2 *destination_data = (__global ulong2 *)(real_dst);
+        while (copy_index < aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else if (aligned_element_size == sizeof(ulong)) {
+        __global ulong *source_data = (__global ulong *)(real_src);
+        __global ulong *destination_data = (__global ulong *)(real_dst);
+        while (copy_index < aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else if (aligned_element_size == sizeof(uint)) {
+        __global uint *source_data = (__global uint *)(real_src);
+        __global uint *destination_data = (__global uint *)(real_dst);
+        while (copy_index < aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else if (aligned_element_size == sizeof(ushort)) {
+        __global ushort *source_data = (__global ushort *)(real_src);
+        __global ushort *destination_data = (__global ushort *)(real_dst);
+        while (copy_index < aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else {
+        __global uchar *source_data = (__global uchar *)(real_src);
+        __global uchar *destination_data = (__global uchar *)(real_dst);
+        while (copy_index < aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      }
+      if ((trailing_byte_count != 0) && (group_ordinal == 0) &&
+          (work_item_id == 0)) {
+        ulong tail_start = aligned_element_count * aligned_element_size;
+        ulong tail_end = tail_start + trailing_byte_count;
+        for (ulong i = tail_start; i < tail_end; ++i) {
+          real_dst[i] = real_src[i];
+        }
+      }
+    }
+
     __kernel void __amd_rocclr_copyBufferAligned(__global uint* src, __global uint* dst,
                                                  ulong srcOrigin, ulong dstOrigin, ulong size,
                                                  uint alignment) {

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3195,8 +3195,8 @@ bool KernelBlitManager::ShaderIndirectCopyBufferBatch(
         destination_device_memory->virtualAddress() + copy_operation.dstOffset;
 
     // indirect_mode bit0 = src indirect, bit1 = dst indirect (matches blitcl.cpp).
-    // v1 routing only ever produces IndirectSrc/IndirectDst, but map SrcDst too
-    // since the kernel and descriptor already support it as a trivial future add.
+    // All three indirect modes are routed here; IndirectSrcDst sets both bits so
+    // the kernel dereferences both holders on-device.
     uint32_t indirect_mode = 0;
     switch (copy_operation.metadata.copyOpType_) {
       case amd::CopyMetadata::kCopyOpIndirectSrc:
@@ -3216,13 +3216,11 @@ bool KernelBlitManager::ShaderIndirectCopyBufferBatch(
         (source_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
     const bool destination_svm_atomics =
         (destination_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
-    // Same formula as ShaderSwapBufferBatch, evaluated on (holder, real) memory
-    // for the current IndirectSrc/IndirectDst-only routing. This is provably
-    // always true today -- the indirect side's holder must satisfy
-    // isHostMemDirectAccess() to be a valid device-usable VA under the address
-    // contract -- but it is kept in this general form so it stays correct if
-    // IndirectSrcDst / relaxed H<->D narrowing is added later and both sides can
-    // be plain device buffers.
+    // Same formula as ShaderSwapBufferBatch, evaluated on both memory objects.
+    // For single-sided indirect one operand is the holder and the other the real
+    // buffer; for dual-sided IndirectSrcDst both are holders. Evaluating the
+    // formula over both operands keeps it correct across all three modes,
+    // including when both real buffers are plain device buffers (D<->D).
     needs_system_scope |=
         (!source_svm_atomics && source_device_memory->isHostMemDirectAccess()) ||
         (!destination_svm_atomics && destination_device_memory->isHostMemDirectAccess()) ||
@@ -3308,11 +3306,13 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
     bool isLinearCopyOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpLinear;
-    // kCopyOpIndirectSrcDst is not shader-routed in v1 (unreachable via the current
-    // H<->D holder narrowing anyway); it falls through to the p2p/SDMA path below.
-    // TODO: Develop indirect src dst shader support
+    // All indirect modes are shader-routable: the kernel dereferences the
+    // holder(s) on-device per the indirect_mode bits (bit0 src, bit1 dst), so
+    // dual-sided IndirectSrcDst (indirect_mode == 3) is handled the same as the
+    // single-sided modes.
     bool isIndirectOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectSrc ||
-                        op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectDst;
+                        op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectDst ||
+                        op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectSrcDst;
 
     if (isIndirectOp && useShaderIndirectPath(op.size, op.metadata)) {
       indirectShaderOps.push_back(op);

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2761,6 +2761,14 @@ struct CopyBufferBatchDescriptor {
   uint32_t trailing_byte_count;
 };
 
+// This layout must match the struct in blitcl.cpp
+struct IndirectCopyBufferBatchDescriptor {
+  uint64_t source_address;
+  uint64_t destination_address;
+  uint64_t size;
+  uint32_t indirect_mode;
+};
+
 // ================================================================================================
 bool KernelBlitManager::useShaderCopyBufferPath(const Memory& srcMemory, const Memory& dstMemory,
                                                 size_t size, amd::CopyMetadata copyMetadata,
@@ -3139,6 +3147,134 @@ bool KernelBlitManager::ReadBufferBatch(const std::vector<amd::BatchReadMemoryOp
 }
 
 // ================================================================================================
+bool KernelBlitManager::useShaderIndirectPath(size_t size, const amd::CopyMetadata& metadata) const {
+  const bool isSdmaPref =
+      metadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA;
+  const bool isBlitPref =
+      metadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::BLIT;
+  if (!dev().settings().sdma_indirect_supported_) return true;  // no HW indirect -> shader always
+
+  if (isSdmaPref) return false;                             // explicit CE   -> SDMA
+  if (isBlitPref) return true;                              // explicit BLIT -> shader
+  return size <= dev().settings().sdmaIndirectThreshold_;    // else size-based
+}
+
+// ================================================================================================
+bool KernelBlitManager::ShaderIndirectCopyBufferBatch(
+    const std::vector<amd::BatchCopyOp>& copy_operations) const {
+  std::scoped_lock transfer_operations_lock(lockXferOps_);
+
+  constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
+  constexpr uint32_t kLocalWorkSize = 512;
+  const uint32_t max_workgroups_per_copy = std::max<uint32_t>(
+      dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
+  const size_t descriptor_bytes =
+      copy_operations.size() * sizeof(IndirectCopyBufferBatchDescriptor);
+  void* descriptor_buffer = gpu().allocKernArg(descriptor_bytes, kCBAlignment);
+  IndirectCopyBufferBatchDescriptor* descriptors =
+      static_cast<IndirectCopyBufferBatchDescriptor*>(descriptor_buffer);
+  size_t descriptor_index = 0;
+  uint64_t max_aligned_element_count = 0;
+  bool needs_system_scope = false;
+  bool attach_signal = false;
+
+  for (const auto& copy_operation : copy_operations) {
+    device::Memory* source_device_memory =
+        copy_operation.srcMemory->getDeviceMemory(
+            *copy_operation.srcMemory->getContext().devices()[0]);
+    device::Memory* destination_device_memory =
+        copy_operation.dstMemory->getDeviceMemory(
+            *copy_operation.dstMemory->getContext().devices()[0]);
+
+    // Holder VA on the indirect side, real VA on the direct side -- identical
+    // address contract to the SDMA indirect path: the kernel dereferences the
+    // holder itself, on-device, so the value stored host-side is used verbatim.
+    const uint64_t source_address =
+        source_device_memory->virtualAddress() + copy_operation.srcOffset;
+    const uint64_t destination_address =
+        destination_device_memory->virtualAddress() + copy_operation.dstOffset;
+
+    // indirect_mode bit0 = src indirect, bit1 = dst indirect (matches blitcl.cpp).
+    // v1 routing only ever produces IndirectSrc/IndirectDst, but map SrcDst too
+    // since the kernel and descriptor already support it as a trivial future add.
+    uint32_t indirect_mode = 0;
+    switch (copy_operation.metadata.copyOpType_) {
+      case amd::CopyMetadata::kCopyOpIndirectSrc:
+        indirect_mode = 1;
+        break;
+      case amd::CopyMetadata::kCopyOpIndirectDst:
+        indirect_mode = 2;
+        break;
+      case amd::CopyMetadata::kCopyOpIndirectSrcDst:
+        indirect_mode = 3;
+        break;
+      default:
+        break;
+    }
+
+    const bool source_svm_atomics =
+        (source_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
+    const bool destination_svm_atomics =
+        (destination_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
+    // Same formula as ShaderSwapBufferBatch, evaluated on (holder, real) memory
+    // for the current IndirectSrc/IndirectDst-only routing. This is provably
+    // always true today -- the indirect side's holder must satisfy
+    // isHostMemDirectAccess() to be a valid device-usable VA under the address
+    // contract -- but it is kept in this general form so it stays correct if
+    // IndirectSrcDst / relaxed H<->D narrowing is added later and both sides can
+    // be plain device buffers.
+    needs_system_scope |=
+        (!source_svm_atomics && source_device_memory->isHostMemDirectAccess()) ||
+        (!destination_svm_atomics && destination_device_memory->isHostMemDirectAccess()) ||
+        !copy_operation.metadata.isAsync_;
+    attach_signal |= !copy_operation.metadata.isAsync_;
+
+    // Grid sizing is optimistic (assume kMaxAlignment(16)-byte elements): the
+    // real alignment is only knowable on-device, after the holder is
+    // dereferenced. Unaligned copies still complete correctly through the
+    // strided loop in the kernel; they just do more serialized work per thread.
+    const uint64_t optimistic_aligned_element_count =
+        std::max<uint64_t>(copy_operation.size / kMaxAlignment, 1);
+    max_aligned_element_count =
+        std::max(max_aligned_element_count, optimistic_aligned_element_count);
+
+    descriptors[descriptor_index++] = {
+        source_address, destination_address, copy_operation.size, indirect_mode};
+  }
+
+  uint32_t workgroup_count = static_cast<uint32_t>(
+      std::min<uint64_t>(max_workgroups_per_copy,
+                         amd::alignUp(max_aligned_element_count,
+                                      static_cast<uint64_t>(kLocalWorkSize)) /
+                             kLocalWorkSize));
+  workgroup_count = std::max<uint32_t>(workgroup_count, 1);
+  const uint32_t copy_stride = workgroup_count * kLocalWorkSize;
+
+  amd::Kernel* const kernel = kernels_[BlitCopyBufferBatchIndirect];
+  constexpr bool kDirectVa = true;
+  setArgument(kernel, 0, sizeof(cl_mem), descriptor_buffer, 0, nullptr,
+              kDirectVa);
+
+  setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
+  setArgument(kernel, 2, sizeof(copy_stride), &copy_stride);
+
+  size_t global_work_size[2] = {copy_stride, copy_operations.size()};
+  size_t local_work_size[2] = {kLocalWorkSize, 1};
+  amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
+
+  address parameters = captureArguments(kernel);
+  if (needs_system_scope) {
+    gpu().addSystemScope();
+  }
+  bool submit_result =
+      gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0,
+                                 nullptr, nullptr, attach_signal);
+  releaseArguments(parameters);
+
+  return submit_result;
+}
+
+// ================================================================================================
 bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOps) const {
   if (copyOps.empty()) {
     return true;
@@ -3156,6 +3292,7 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
   std::vector<amd::BatchCopyOp> d2dCopyOps;
   std::vector<amd::BatchCopyOp> p2pCopyOps;
+  std::vector<amd::BatchCopyOp> indirectShaderOps;
 
   for (const auto& op : copyOps) {
     device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
@@ -3171,11 +3308,16 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
     bool isLinearCopyOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpLinear;
-    // ShaderCopyBufferBatch only describes linear copies; route swap/other ops through DMA.
-    bool useShaderCopyPath =
-        isLinearCopyOp && useShaderCopyBufferPath(srcMem, dstMem, op.size, op.metadata);
+    // kCopyOpIndirectSrcDst is not shader-routed in v1 (unreachable via the current
+    // H<->D holder narrowing anyway); it falls through to the p2p/SDMA path below.
+    // TODO: Develop indirect src dst shader support
+    bool isIndirectOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectSrc ||
+                        op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectDst;
 
-    if (useShaderCopyPath) {
+    if (isIndirectOp && useShaderIndirectPath(op.size, op.metadata)) {
+      indirectShaderOps.push_back(op);
+    } else if (isLinearCopyOp && useShaderCopyBufferPath(srcMem, dstMem, op.size, op.metadata)) {
+      // ShaderCopyBufferBatch only describes linear copies; route swap/other ops through DMA.
       d2dCopyOps.push_back(op);
     } else {
       p2pCopyOps.push_back(op);
@@ -3189,18 +3331,25 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   if (!p2pCopyOps.empty()) {
     // Always pass prior wait events to maintain stream ordering for the batch.
     if (!hsaCopyBatch(p2pCopyOps, &priorWaitEvents, &batchSignals)) {
-      // Swap ops cannot fall back to shader copy (it only does one-directional
-      // copy, not a bidirectional swap). Fail the entire batch if any swap op
-      // was in the SDMA batch that failed.
-      bool hasSwap = false;
+      // Swap and indirect ops cannot fall back to plain copyBuffer:
+      //  - Swap: bidirectional exchange; copyBuffer only does a
+      //    one-directional copy, will cause a race condition if you use two.
+      //  - Indirect: srcMemory or dstMemory is a pointer holding a pointer to
+      //    the actual memory. So we cannot fall back to a general memory copy
+      // Fail the entire batch if any such op was in the SDMA batch that failed.
+      bool hasNonFallbackableOp = false;
       for (const auto& op : p2pCopyOps) {
-        if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap) {
-          hasSwap = true;
+        if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap ||
+            op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectSrc ||
+            op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectDst ||
+            op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpIndirectSrcDst) {
+          hasNonFallbackableOp = true;
           break;
         }
       }
-      if (hasSwap) {
-        LogError("KernelBlitManager::copyBufferBatch: SDMA batch with swap ops failed");
+      if (hasNonFallbackableOp) {
+        LogError(
+            "KernelBlitManager::copyBufferBatch: SDMA batch with swap/indirect ops failed");
         return false;
       }
       LogWarning(
@@ -3212,10 +3361,10 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
     }
   }
 
-  // Dispatch intra-device copies for overlap with SDMA.
+  // Dispatch intra-device copies and shader indirect ops for overlap with SDMA.
   // Set engine to Compute so WaitingSignal(Compute) inside copyBuffer does not
   // see an engine switch and does not add the batch's current_id_ as a dependency.
-  if (!d2dCopyOps.empty()) {
+  if (!d2dCopyOps.empty() || !indirectShaderOps.empty()) {
     gpu().Barriers().SetActiveEngine(HwQueueEngine::Compute);
     // Re-add priorSignal as external so intra copies depend on prior stream operations.
     if (priorSignal != nullptr) {
@@ -3233,6 +3382,20 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       if (!ShaderCopyBufferBatch(copy_ops_by_size)) {
         LogError("KernelBlitManager::ShaderCopyBufferBatch: Intra-device batch "
                  "copy failed!");
+        return false;
+      }
+    }
+
+    std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>>
+        indirect_ops_by_size;
+    for (const auto& op : indirectShaderOps) {
+      indirect_ops_by_size[op.size].push_back(op);
+    }
+
+    for (const auto& entry : indirect_ops_by_size) {
+      if (!ShaderIndirectCopyBufferBatch(entry.second)) {
+        LogError("KernelBlitManager::ShaderIndirectCopyBufferBatch: Intra-device batch "
+                 "indirect copy failed!");
         return false;
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -303,6 +303,7 @@ class KernelBlitManager : public DmaBlitManager {
     StreamOpsIncrement,
     StreamOpsDecrement,
     BlitCopyBufferBatch,
+    BlitCopyBufferBatchIndirect,
     BlitLinearTotal,
     FillImage = BlitLinearTotal,
     BlitCopyImage,
@@ -628,6 +629,12 @@ class KernelBlitManager : public DmaBlitManager {
   //! Copies a batch of raw virtual-address ranges using the shader path
   bool ShaderCopyBufferBatchRaw(const std::vector<BatchRawCopyOp>& copy_ops) const;
 
+  //! Returns true if a batch indirect copy should use the shader path.
+  bool useShaderIndirectPath(size_t size, const amd::CopyMetadata& metadata) const;
+
+  //! Copies a batch of indirect (pointer-holder) buffer ops using a shader dispatch
+  bool ShaderIndirectCopyBufferBatch(const std::vector<amd::BatchCopyOp>& copy_operations) const;
+
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,
                        size_t sizeBytes) const;
@@ -653,6 +660,7 @@ static const char* BlitName[KernelBlitManager::BlitTotal] = {
     "__amd_rocclr_initHeap",           "__amd_rocclr_batchMemOp",
     "__amd_rocclr_streamOpsIncrement", "__amd_rocclr_streamOpsDecrement",
     "__amd_rocclr_copyBufferBatch",
+    "__amd_rocclr_copyBufferBatchIndirect",
     "__amd_rocclr_fillImage",          "__amd_rocclr_copyImage",
     "__amd_rocclr_copyImage1DA",       "__amd_rocclr_copyImageToBuffer",
     "__amd_rocclr_copyBufferToImage"};

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -47,6 +47,7 @@ Settings::Settings() {
       flagIsDefault(GPU_PINNED_MIN_XFER_SIZE) ? 64 * Ki : GPU_PINNED_MIN_XFER_SIZE * Mi;
 
   sdmaCopyThreshold_ = GPU_FORCE_BLIT_COPY_SIZE * Ki;
+  sdmaIndirectThreshold_ = GPU_FORCE_BLIT_INDIRECT_SIZE * Ki;
 
   // Don't support Denormals for single precision by default
   singleFpDenorm_ = false;

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -58,8 +58,9 @@ class Settings : public device::Settings {
   size_t pinnedXferSize_;     //!< Pinned buffer size for transfer
   size_t pinnedMinXferSize_;  //!< Minimal buffer size for pinned transfer
 
-  size_t sdmaCopyThreshold_;   //!< Use SDMA to copy above this size
-  size_t sdma_p2p_threshold_;  //!< Use SDMA in P2P above this size
+  size_t sdmaCopyThreshold_;      //!< Use SDMA to copy above this size
+  size_t sdmaIndirectThreshold_;  //!< Use SDMA for batch indirect copies above this size
+  size_t sdma_p2p_threshold_;     //!< Use SDMA in P2P above this size
 
   uint32_t hmmFlags_;       //!< HMM functionality control flags
   uint32_t limit_blit_wg_;  //!< The number of workgroups for blit execution

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -178,6 +178,8 @@ release(uint, HIP_HIDDEN_FREE_MEM, 0,                                         \
         "0 = Disable")                                                        \
 release(size_t, GPU_FORCE_BLIT_COPY_SIZE, 16,                                 \
         "Use Blit until this size(in KB) for copies")                         \
+release(size_t, GPU_FORCE_BLIT_INDIRECT_SIZE, 16,                             \
+        "Use shader blit for batch indirect copies until this size (in KB)")  \
 release(uint, ROC_ACTIVE_WAIT_TIMEOUT, 0,                                     \
         "Forces active wait of GPU interrup for the timeout(us)")             \
 release(bool, ROC_ENABLE_LARGE_BAR, true,                                     \

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -849,6 +849,8 @@ memory:
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_D2D_MixedMulticastSources:
     <<: *level_2
+    # ROCM-29275
+    disabled: [gfx1250]
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_P2P_Swap:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -902,16 +902,7 @@ memory:
   Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect:
     <<: *level_2
     tags: [transfer]
-  Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix: *level_2
-  Unit_hipMemcpyBatchAsync_Indirect_Dst_UnalignedMatrix: *level_2
-  Unit_hipMemcpyBatchAsync_Indirect_MultiOp: *level_2
-  Unit_hipMemcpyBatchAsync_IndirectSrcDst:
-    <<: *level_2
-    tags: [transfer]
-  Unit_hipMemcpyBatchAsync_IndirectSrcDst_D2D:
-    <<: *level_2
-    tags: [transfer]
-  Unit_hipMemcpyBatchAsync_Indirect_SrcDst_UnalignedMatrix: *level_2
+  Unit_hipMemcpyBatchAsync_Indirect_UnalignedMatrix: *level_2
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -902,6 +902,9 @@ memory:
   Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect:
     <<: *level_2
     tags: [transfer]
+  Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix: *level_2
+  Unit_hipMemcpyBatchAsync_Indirect_Dst_UnalignedMatrix: *level_2
+  Unit_hipMemcpyBatchAsync_Indirect_MultiOp: *level_2
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -861,6 +861,9 @@ memory:
   Unit_hipMemcpyBatchAsync_P2P_Multicast_Large:
     <<: *level_3
     tags: [transfer, multigpu]
+  Unit_hipMemcpyBatchAsync_P2P_IndirectCopy:
+    <<: *level_2
+    tags: [transfer, multigpu]
   Unit_hipMemcpyBatchAsync_Negative:
     <<: *level_2
     tags: [transfer]
@@ -885,10 +888,16 @@ memory:
   Unit_hipMemcpyBatchAsync_P2P_Functional:
     <<: *level_2
     tags: [transfer, multigpu]
-  Unit_hipMemcpyBatchAsync_IndirectDst:
+  Unit_hipMemcpyBatchAsync_IndirectCopy:
     <<: *level_2
     tags: [transfer]
-  Unit_hipMemcpyBatchAsync_IndirectSrc:
+  Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer:
+    <<: *level_2
+    tags: [transfer, stream]
+  Unit_hipMemcpyBatchAsync_ExtOp_Negative:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemsetD2D8_BasicFunctional:

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -905,6 +905,13 @@ memory:
   Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix: *level_2
   Unit_hipMemcpyBatchAsync_Indirect_Dst_UnalignedMatrix: *level_2
   Unit_hipMemcpyBatchAsync_Indirect_MultiOp: *level_2
+  Unit_hipMemcpyBatchAsync_IndirectSrcDst:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_IndirectSrcDst_D2D:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_Indirect_SrcDst_UnalignedMatrix: *level_2
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -974,7 +974,9 @@ static void RunIndirectCopyTest(unsigned int flags, size_t count, size_t size_in
                                 LinearAllocs alloc_type_src, LinearAllocs alloc_type_dst) {
   const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
   const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
-  const hipError_t expected_error = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
+  const bool is_dual_sided_indirect = is_indirect_src && is_indirect_dst;
+  const hipError_t expected_error =
+      getIndirectExpectedReturn(alloc_type_src, alloc_type_dst, 0, 0, is_dual_sided_indirect);
 
   IndirectCopyBuffers buffers =
       makeIndirectCopyBuffers(count, size_in_bytes, alloc_type_src, alloc_type_dst);
@@ -1130,7 +1132,9 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
 
   const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
   const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
-  const hipError_t expected_return = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
+  const bool is_dual_sided_indirect = is_indirect_src && is_indirect_dst;
+  const hipError_t expected_return =
+      getIndirectExpectedReturn(alloc_type_src, alloc_type_dst, 0, 0, is_dual_sided_indirect);
 
   IndirectCopyBuffers buffers =
       makeIndirectCopyBuffers(count, kSizeInBytes, alloc_type_src, alloc_type_dst);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -972,20 +972,20 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_MixedMulticastSources) {
 
 static void RunIndirectCopyTest(unsigned int flags, size_t count, size_t size_in_bytes,
                                 LinearAllocs alloc_type_src, LinearAllocs alloc_type_dst) {
-  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
-  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
+  const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
   const hipError_t expected_error = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
 
   IndirectCopyBuffers buffers =
       makeIndirectCopyBuffers(count, size_in_bytes, alloc_type_src, alloc_type_dst);
 
   for (size_t i = 0; i < count; ++i) {
-    if (indirect_src) {
+    if (is_indirect_src) {
       buffers.batch_src_ptrs[i] =
           addPointerSlot(buffers.slots, buffers.src_ptrs[i], alloc_type_src);
     }
 
-    if (indirect_dst) {
+    if (is_indirect_dst) {
       buffers.batch_dst_ptrs[i] =
           addPointerSlot(buffers.slots, buffers.dst_ptrs[i], alloc_type_dst);
     }
@@ -1128,8 +1128,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
   constexpr uint64_t kBlocked = 1;
   constexpr uint64_t kReleased = 0;
 
-  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
-  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
+  const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
   const hipError_t expected_return = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
 
   IndirectCopyBuffers buffers =
@@ -1142,7 +1142,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
   for (size_t i = 0; i < count; ++i) {
     // The slots start out pointing at decoys instead of the real buffers, so a slot read taken
     // before the addresses are published gives a wrong result rather than a crash.
-    if (indirect_src) {
+    if (is_indirect_src) {
       LinearAllocGuard<unsigned char> decoy(alloc_type_src, kSizeInBytes);
       fillBuffer(decoy.ptr(), decoy_values, alloc_type_src);
       buffers.batch_src_ptrs[i] = addPointerSlot(buffers.slots, decoy.ptr(), alloc_type_src);
@@ -1150,7 +1150,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
       buffers.allocations.push_back(std::move(decoy));
     }
 
-    if (indirect_dst) {
+    if (is_indirect_dst) {
       LinearAllocGuard<unsigned char> decoy(alloc_type_dst, kSizeInBytes);
       buffers.batch_dst_ptrs[i] = addPointerSlot(buffers.slots, decoy.ptr(), alloc_type_dst);
       slots_to_publish.emplace_back(buffers.batch_dst_ptrs[i], buffers.dst_ptrs[i]);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -1298,22 +1298,50 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
 #endif
 
 #if HT_AMD
+// The three indirect modes exercised by the unaligned matrix below. Each names which side(s) the
+// batch reaches through a pointer slot; the direct side carries its own offset.
+enum class IndirectMode { Src, Dst, SrcDst };
+
+// The per-mode setup the unaligned matrix varies over: the source and destination allocation types,
+// which side(s) are indirect, the ExtOp flags, and a label for CAPTURE.
+struct IndirectModeConfig {
+  LinearAllocs src_alloc;
+  LinearAllocs dst_alloc;
+  bool indirect_src;
+  bool indirect_dst;
+  unsigned int flags;
+  const char* name;
+};
+
+inline IndirectModeConfig indirectModeConfig(IndirectMode mode) {
+  switch (mode) {
+    case IndirectMode::Src:
+      return {LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc, true, false,
+              hipMemcpyFlagExtOpIndirectSrc, "Src"};
+    case IndirectMode::Dst:
+      return {LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc, false, true,
+              hipMemcpyFlagExtOpIndirectDst, "Dst"};
+    case IndirectMode::SrcDst:
+    default:
+      return {LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc, true, true,
+              hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst, "SrcDst"};
+  }
+}
+
 /**
  * Test Description
  * ------------------------
- * - Parameterized H->D IndirectSrc copy correctness over mismatched src/dst byte
- *   offsets and two transfer sizes that straddle the GPU_FORCE_BLIT_INDIRECT_SIZE
- *   threshold (4096 routes to the shader path; 65536 routes to SDMA on gfx1250 and
- *   to the shader path on pre-gfx1250).
+ * - Parameterized indirect copy correctness over the three indirect modes (IndirectSrc H->D,
+ *   IndirectDst D->H, dual-sided H->D), mismatched src/dst byte offsets, and two transfer sizes
+ *   that straddle the GPU_FORCE_BLIT_INDIRECT_SIZE threshold (4096 routes to the shader path;
+ *   65536 routes to SDMA on gfx1250 and to the shader path on pre-gfx1250).
  *
- *   The source is passed indirectly: a sizeof(void*) pinned holder slot stores the
- *   real host source address (h_base + src_off); the destination is passed
- *   directly as d_base + dst_off. Each host/device allocation is size+64 bytes.
- *   The full host allocation is filled with 0xAA and the full device allocation
- *   with 0xBB. After the copy, the destination region [dst_off, dst_off+size) must
- *   equal 0xAA, all device bytes OUTSIDE that region (padding) must remain
- *   unchanged at 0xBB, and the host source buffer must be entirely unchanged at
- *   0xAA -- this is a copy, not a swap.
+ *   Every indirect side is passed through a sizeof(void*) pinned holder slot storing the real
+ *   (offset) address; the direct side, if any, carries its offset directly. Each allocation is
+ *   size+kPad bytes; the source is filled 0xAA and the destination 0xBB. After the copy the
+ *   destination region [dst_off, dst_off+size) must equal the source fill, the destination bytes
+ *   outside that region (padding) must keep the destination fill, and the whole source buffer must
+ *   be unchanged -- this is a copy, not a swap.
  *
  * Test source
  * ------------------------
@@ -1322,11 +1350,13 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix) {
-  constexpr uint8_t kHostFill = 0xAA;
-  constexpr uint8_t kDevFill = 0xBB;
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_UnalignedMatrix) {
+  constexpr unsigned char kSrcFill = 0xAA;
+  constexpr unsigned char kDstFill = 0xBB;
   constexpr size_t kPad = 64;
 
+  const IndirectMode mode =
+      GENERATE(IndirectMode::Src, IndirectMode::Dst, IndirectMode::SrcDst);
   const std::pair<size_t, size_t> off =
       GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
                std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
@@ -1336,493 +1366,48 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix) {
   const size_t size = GENERATE(size_t{4096}, size_t{65536});
   const size_t src_off = off.first;
   const size_t dst_off = off.second;
+  const IndirectModeConfig cfg = indirectModeConfig(mode);
+  CAPTURE(cfg.name, src_off, dst_off, size);
 
-  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
+  LinearAllocGuard<unsigned char> src(cfg.src_alloc, size + kPad);
+  LinearAllocGuard<unsigned char> dst(cfg.dst_alloc, size + kPad);
+  fillBuffer(src.ptr(), std::vector<unsigned char>(size + kPad, kSrcFill), cfg.src_alloc);
+  fillBuffer(dst.ptr(), std::vector<unsigned char>(size + kPad, kDstFill), cfg.dst_alloc);
 
-  void* h_base = nullptr;
-  void* d_base = nullptr;
-  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
-  HIP_CHECK(hipMalloc(&d_base, size + kPad));
+  // Bake the offset into the address the batch sees. An indirect side hands over a pinned holder
+  // slot that dereferences to the real address; a direct side hands over the real address itself.
+  std::vector<LinearAllocGuard<void*>> slots;
+  void* real_src = src.ptr() + src_off;
+  void* real_dst = dst.ptr() + dst_off;
+  void* batch_src =
+      cfg.indirect_src ? addPointerSlot(slots, real_src, LinearAllocs::hipHostMalloc) : real_src;
+  void* batch_dst =
+      cfg.indirect_dst ? addPointerSlot(slots, real_dst, LinearAllocs::hipHostMalloc) : real_dst;
 
-  std::memset(h_base, kHostFill, size + kPad);
-  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
-
-  // Bake the offset into the REAL address stored behind the holder; the direct
-  // side pointer carries its own offset directly.
-  void* real_src = static_cast<uint8_t*>(h_base) + src_off;
-  void* direct_dst = static_cast<uint8_t*>(d_base) + dst_off;
-
-  void* src_slot = nullptr;
-  HIP_CHECK(hipHostMalloc(&src_slot, sizeof(void*)));
-  std::memcpy(src_slot, &real_src, sizeof(void*));
-
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  void* dsts[] = {direct_dst};
-  void* srcs[] = {src_slot};
+  StreamGuard stream_guard(Streams::created);
+  void* dsts[] = {batch_dst};
+  void* srcs[] = {batch_src};
   size_t sizes[] = {size};
-  size_t attrsIdxs[] = {0};
+  size_t attrs_idxs[] = {0};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, cfg.flags};
 
-  hipMemcpyAttributes attr{};
-  attr.flags = hipMemcpyFlagExtOpIndirectSrc;
-  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
-
-  size_t failIdx = 0;
-  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
-  if (err == hipErrorNotSupported) {
-    HIP_CHECK(hipStreamDestroy(stream));
-    HIP_CHECK(hipHostFree(src_slot));
-    HIP_CHECK(hipFree(d_base));
-    HIP_CHECK(hipHostFree(h_base));
-    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
-    return;
-  }
-  HIP_CHECK(err);
-  HIP_CHECK(hipStreamSynchronize(stream));
-
-  // Copy the full device buffer back so padding can be verified too.
-  std::vector<uint8_t> devResult(size + kPad);
-  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
-  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
-
-  for (size_t i = 0; i < size + kPad; i++) {
-    const bool in_dev_region = (i >= dst_off) && (i < dst_off + size);
-    const uint8_t expected_dev = in_dev_region ? kHostFill : kDevFill;
-    INFO("dev byte " << i << " (region=" << in_dev_region
-                     << ") = " << static_cast<int>(devResult[i]) << " expected "
-                     << static_cast<int>(expected_dev));
-    REQUIRE(devResult[i] == expected_dev);
-
-    // This is a copy, not a swap: the host source must be entirely unchanged.
-    INFO("host byte " << i << " = " << static_cast<int>(hostResult[i]) << " expected "
-                      << static_cast<int>(kHostFill));
-    REQUIRE(hostResult[i] == kHostFill);
-  }
-
-  HIP_CHECK(hipFree(d_base));
-  HIP_CHECK(hipHostFree(h_base));
-  HIP_CHECK(hipHostFree(src_slot));
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-
-/**
- * Test Description
- * ------------------------
- * - Parameterized D->H IndirectDst copy correctness over mismatched src/dst byte
- *   offsets and two transfer sizes that straddle the GPU_FORCE_BLIT_INDIRECT_SIZE
- *   threshold (4096 routes to the shader path; 65536 routes to SDMA on gfx1250 and
- *   to the shader path on pre-gfx1250).
- *
- *   The destination is passed indirectly: a sizeof(void*) pinned holder slot
- *   stores the real host destination address (h_base + dst_off); the source is
- *   passed directly as d_base + src_off. Each host/device allocation is size+64
- *   bytes. The full device allocation is filled with 0xAA and the full host
- *   allocation with 0xBB. After the copy, the host region [dst_off, dst_off+size)
- *   must equal 0xAA, all host bytes OUTSIDE that region (padding) must remain
- *   unchanged at 0xBB, and the device source buffer must be entirely unchanged at
- *   0xAA -- this is a copy, not a swap.
- *
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_Dst_UnalignedMatrix) {
-  constexpr uint8_t kDevFill = 0xAA;
-  constexpr uint8_t kHostFill = 0xBB;
-  constexpr size_t kPad = 64;
-
-  const std::pair<size_t, size_t> off =
-      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
-               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
-               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
-               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
-               std::make_pair(size_t{2}, size_t{2}));
-  const size_t size = GENERATE(size_t{4096}, size_t{65536});
-  const size_t src_off = off.first;
-  const size_t dst_off = off.second;
-
-  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
-
-  void* d_base = nullptr;
-  void* h_base = nullptr;
-  HIP_CHECK(hipMalloc(&d_base, size + kPad));
-  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
-
-  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
-  std::memset(h_base, kHostFill, size + kPad);
-
-  // Bake the offset into the REAL address stored behind the holder; the direct
-  // side pointer carries its own offset directly.
-  void* direct_src = static_cast<uint8_t*>(d_base) + src_off;
-  void* real_dst = static_cast<uint8_t*>(h_base) + dst_off;
-
-  void* dst_slot = nullptr;
-  HIP_CHECK(hipHostMalloc(&dst_slot, sizeof(void*)));
-  std::memcpy(dst_slot, &real_dst, sizeof(void*));
-
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  void* dsts[] = {dst_slot};
-  void* srcs[] = {direct_src};
-  size_t sizes[] = {size};
-  size_t attrsIdxs[] = {0};
-
-  hipMemcpyAttributes attr{};
-  attr.flags = hipMemcpyFlagExtOpIndirectDst;
-  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
-
-  size_t failIdx = 0;
-  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
-  if (err == hipErrorNotSupported) {
-    HIP_CHECK(hipStreamDestroy(stream));
-    HIP_CHECK(hipHostFree(dst_slot));
-    HIP_CHECK(hipHostFree(h_base));
-    HIP_CHECK(hipFree(d_base));
-    SUCCEED("hipMemcpyFlagExtOpIndirectDst is not supported on this device");
-    return;
-  }
-  HIP_CHECK(err);
-  HIP_CHECK(hipStreamSynchronize(stream));
-
-  // Copy the device source back in full to confirm it is unchanged, and read
-  // the host destination directly.
-  std::vector<uint8_t> devResult(size + kPad);
-  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
-  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
-
-  for (size_t i = 0; i < size + kPad; i++) {
-    const bool in_host_region = (i >= dst_off) && (i < dst_off + size);
-    const uint8_t expected_host = in_host_region ? kDevFill : kHostFill;
-    INFO("host byte " << i << " (region=" << in_host_region
-                      << ") = " << static_cast<int>(hostResult[i]) << " expected "
-                      << static_cast<int>(expected_host));
-    REQUIRE(hostResult[i] == expected_host);
-
-    // This is a copy, not a swap: the device source must be entirely unchanged.
-    INFO("dev byte " << i << " = " << static_cast<int>(devResult[i]) << " expected "
-                     << static_cast<int>(kDevFill));
-    REQUIRE(devResult[i] == kDevFill);
-  }
-
-  HIP_CHECK(hipFree(d_base));
-  HIP_CHECK(hipHostFree(h_base));
-  HIP_CHECK(hipHostFree(dst_slot));
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-
-/**
- * Test Description
- * ------------------------
- * - Verify hipMemcpyBatchAsync with multiple independent H->D IndirectSrc ops in
- *   a single call.
- *
- *   Four independent host(holder)->device pairs are copied in one call, each with
- *   a distinct sentinel value; all four must be correct after synchronization,
- *   and each host source must remain unchanged since this is a copy, not a swap.
- *
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_MultiOp) {
-  constexpr size_t kNumOps = 4;
-  constexpr size_t kNumElements = 1024;
-  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
-
-  // Each op has a distinct sentinel value to confirm independence.
-  constexpr int kHostVals[kNumOps] = {10, 20, 30, 40};
-
-  void* h_bufs[kNumOps] = {};
-  void* d_bufs[kNumOps] = {};
-  void* slots[kNumOps] = {};
-
-  for (size_t op = 0; op < kNumOps; ++op) {
-    HIP_CHECK(hipHostMalloc(&h_bufs[op], kSizeBytes));
-    HIP_CHECK(hipMalloc(&d_bufs[op], kSizeBytes));
-    HIP_CHECK(hipHostMalloc(&slots[op], sizeof(void*)));
-
-    std::vector<int> hi(kNumElements, kHostVals[op]);
-    std::memcpy(h_bufs[op], hi.data(), kSizeBytes);
-    // The holder stores the REAL host source address for this op.
-    std::memcpy(slots[op], &h_bufs[op], sizeof(void*));
-  }
-
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  // All ops share the same IndirectSrc attribute (index 0).
-  size_t sizes[kNumOps];
-  size_t attrsIdxs[kNumOps];
-  for (size_t op = 0; op < kNumOps; ++op) {
-    sizes[op] = kSizeBytes;
-    attrsIdxs[op] = 0;
-  }
-
-  hipMemcpyAttributes attr{};
-  attr.flags = hipMemcpyFlagExtOpIndirectSrc;
-  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
-
-  size_t failIdx = 0;
+  size_t fail_idx = 0;
   hipError_t err =
-      hipMemcpyBatchAsync(d_bufs, slots, sizes, kNumOps, &attr, attrsIdxs, 1, &failIdx, stream);
+      hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrs_idxs, 1, &fail_idx, stream_guard.stream());
   if (err == hipErrorNotSupported) {
-    HIP_CHECK(hipStreamDestroy(stream));
-    for (size_t op = 0; op < kNumOps; ++op) {
-      HIP_CHECK(hipHostFree(slots[op]));
-      HIP_CHECK(hipFree(d_bufs[op]));
-      HIP_CHECK(hipHostFree(h_bufs[op]));
-    }
-    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
+    SUCCEED("indirect copy is not supported on this device");
     return;
   }
   HIP_CHECK(err);
-  HIP_CHECK(hipStreamSynchronize(stream));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
 
-  // Verify every op independently; the host sources are unchanged (copy, not swap).
-  for (size_t op = 0; op < kNumOps; ++op) {
-    std::vector<int> resultDev(kNumElements);
-    HIP_CHECK(hipMemcpy(resultDev.data(), d_bufs[op], kSizeBytes, hipMemcpyDeviceToHost));
-    const int* resultHost = static_cast<const int*>(h_bufs[op]);
-    for (size_t i = 0; i < kNumElements; i++) {
-      INFO("op=" << op << " dev[" << i << "]=" << resultDev[i] << " (expected " << kHostVals[op]
-                 << ")");
-      REQUIRE(resultDev[i] == kHostVals[op]);
-      INFO("op=" << op << " host[" << i << "]=" << resultHost[i] << " (expected " << kHostVals[op]
-                 << ")");
-      REQUIRE(resultHost[i] == kHostVals[op]);
-    }
-  }
+  // Destination: the copied region took the source fill, the padding kept its own fill.
+  std::vector<unsigned char> dst_expected(size + kPad, kDstFill);
+  std::fill_n(dst_expected.begin() + dst_off, size, kSrcFill);
+  requireBufferEquals(dst.ptr(), dst_expected, cfg.dst_alloc);
 
-  for (size_t op = 0; op < kNumOps; ++op) {
-    HIP_CHECK(hipHostFree(slots[op]));
-    HIP_CHECK(hipFree(d_bufs[op]));
-    HIP_CHECK(hipHostFree(h_bufs[op]));
-  }
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-
-/**
- * Test Description
- * ------------------------
- * - Verifies dual-sided indirect (hipMemcpyFlagExtOpIndirectSrc |
- *   hipMemcpyFlagExtOpIndirectDst) where BOTH the source and destination are
- *   pinned pointer-holders. The real source is a pinned host buffer and the real
- *   destination is a device buffer; the kernel dereferences both holders
- *   on-device (indirect_mode == 3). After the copy the real device destination
- *   must hold the pattern and the real host source must be unchanged (copy, not
- *   swap).
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrcDst) {
-  constexpr size_t copy_size = kSmallCopySize;
-  const size_t copy_elements = copy_size / sizeof(int);
-
-  StreamGuard stream_guard(Streams::created);
-  LinearAllocGuard<int> src(LinearAllocs::hipHostMalloc, copy_size);  // real source (host)
-  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);      // real dest (device)
-  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
-  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
-
-  std::fill_n(src.host_ptr(), copy_elements, kPatternValue);
-
-  void* src_ptr = src.ptr();
-  void* dst_ptr = dst.ptr();
-  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
-  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
-
-  std::vector<void*> dst_ptrs{dst_slot.ptr()};
-  std::vector<void*> src_ptrs{src_slot.ptr()};
-  std::vector<size_t> sizes{copy_size};
-  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {},
-                           hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst};
-  size_t attrs_idx = 0;
-
-  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
-                                          &attrs_idx, 1, nullptr, stream_guard.stream());
-  if (status == hipErrorNotSupported) {
-    SUCCEED("dual-sided indirect is not supported on this device");
-  } else {
-    HIP_CHECK(status);
-    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    // Verify the REAL device destination, not the holder.
-    std::vector<void*> real_dst_ptrs{dst.ptr()};
-    VerifyDeviceBuffers(real_dst_ptrs, copy_size, kPatternValue, /*add_index*/ false);
-    // Copy, not swap: the real host source must be unchanged.
-    VerifyArrayFromBothEnds(src.host_ptr(), copy_elements, kPatternValue, 0);
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- * - Verifies dual-sided indirect with both real buffers on the device (D->D).
- *   This exercises the case the H<->D holder narrowing previously made
- *   unreachable: both holders are pinned host allocations (equal memory type),
- *   but the real buffers behind them are both device buffers. After the copy the
- *   real device destination must hold the pattern and the real device source must
- *   be unchanged.
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrcDst_D2D) {
-  constexpr size_t copy_size = kSmallCopySize;
-  const size_t copy_elements = copy_size / sizeof(int);
-
-  StreamGuard stream_guard(Streams::created);
-  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, copy_size);  // real source (device)
-  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);  // real dest (device)
-  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
-  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
-
-  std::vector<int> host_pattern(copy_elements, kPatternValue);
-  HIP_CHECK(hipMemcpy(src.ptr(), host_pattern.data(), copy_size, hipMemcpyHostToDevice));
-
-  void* src_ptr = src.ptr();
-  void* dst_ptr = dst.ptr();
-  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
-  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
-
-  std::vector<void*> dst_ptrs{dst_slot.ptr()};
-  std::vector<void*> src_ptrs{src_slot.ptr()};
-  std::vector<size_t> sizes{copy_size};
-  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {},
-                           hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst};
-  size_t attrs_idx = 0;
-
-  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
-                                          &attrs_idx, 1, nullptr, stream_guard.stream());
-  if (status == hipErrorNotSupported) {
-    SUCCEED("dual-sided indirect is not supported on this device");
-  } else {
-    HIP_CHECK(status);
-    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    std::vector<void*> real_dst_ptrs{dst.ptr()};
-    std::vector<void*> real_src_ptrs{src.ptr()};
-    VerifyDeviceBuffers(real_dst_ptrs, copy_size, kPatternValue, /*add_index*/ false);
-    VerifyDeviceBuffers(real_src_ptrs, copy_size, kPatternValue, /*add_index*/ false);
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- * - Parameterized dual-sided indirect (H->D) copy correctness over mismatched
- *   src/dst byte offsets and two transfer sizes that straddle the
- *   GPU_FORCE_BLIT_INDIRECT_SIZE threshold. BOTH the source and destination are
- *   pinned pointer-holders; the offset is baked into the REAL address stored
- *   behind each holder. The device destination region must equal the host fill,
- *   the device padding must be unchanged, and the host source must be unchanged
- *   (copy, not swap).
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_SrcDst_UnalignedMatrix) {
-  constexpr uint8_t kHostFill = 0xAA;
-  constexpr uint8_t kDevFill = 0xBB;
-  constexpr size_t kPad = 64;
-
-  const std::pair<size_t, size_t> off =
-      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
-               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
-               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
-               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
-               std::make_pair(size_t{2}, size_t{2}));
-  const size_t size = GENERATE(size_t{4096}, size_t{65536});
-  const size_t src_off = off.first;
-  const size_t dst_off = off.second;
-
-  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
-
-  void* h_base = nullptr;
-  void* d_base = nullptr;
-  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
-  HIP_CHECK(hipMalloc(&d_base, size + kPad));
-
-  std::memset(h_base, kHostFill, size + kPad);
-  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
-
-  // Bake each offset into the REAL address stored behind its holder.
-  void* real_src = static_cast<uint8_t*>(h_base) + src_off;
-  void* real_dst = static_cast<uint8_t*>(d_base) + dst_off;
-
-  void* src_slot = nullptr;
-  void* dst_slot = nullptr;
-  HIP_CHECK(hipHostMalloc(&src_slot, sizeof(void*)));
-  HIP_CHECK(hipHostMalloc(&dst_slot, sizeof(void*)));
-  std::memcpy(src_slot, &real_src, sizeof(void*));
-  std::memcpy(dst_slot, &real_dst, sizeof(void*));
-
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  void* dsts[] = {dst_slot};
-  void* srcs[] = {src_slot};
-  size_t sizes[] = {size};
-  size_t attrsIdxs[] = {0};
-
-  hipMemcpyAttributes attr{};
-  attr.flags = hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;
-  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
-
-  size_t failIdx = 0;
-  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
-  if (err == hipErrorNotSupported) {
-    HIP_CHECK(hipStreamDestroy(stream));
-    HIP_CHECK(hipHostFree(src_slot));
-    HIP_CHECK(hipHostFree(dst_slot));
-    HIP_CHECK(hipFree(d_base));
-    HIP_CHECK(hipHostFree(h_base));
-    SUCCEED("dual-sided indirect is not supported on this device");
-    return;
-  }
-  HIP_CHECK(err);
-  HIP_CHECK(hipStreamSynchronize(stream));
-
-  // Copy the full device buffer back so padding can be verified too.
-  std::vector<uint8_t> devResult(size + kPad);
-  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
-  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
-
-  for (size_t i = 0; i < size + kPad; i++) {
-    const bool in_dev_region = (i >= dst_off) && (i < dst_off + size);
-    const uint8_t expected_dev = in_dev_region ? kHostFill : kDevFill;
-    INFO("dev byte " << i << " (region=" << in_dev_region
-                     << ") = " << static_cast<int>(devResult[i]) << " expected "
-                     << static_cast<int>(expected_dev));
-    REQUIRE(devResult[i] == expected_dev);
-
-    // This is a copy, not a swap: the host source must be entirely unchanged.
-    INFO("host byte " << i << " = " << static_cast<int>(hostResult[i]) << " expected "
-                      << static_cast<int>(kHostFill));
-    REQUIRE(hostResult[i] == kHostFill);
-  }
-
-  HIP_CHECK(hipFree(d_base));
-  HIP_CHECK(hipHostFree(h_base));
-  HIP_CHECK(hipHostFree(src_slot));
-  HIP_CHECK(hipHostFree(dst_slot));
-  HIP_CHECK(hipStreamDestroy(stream));
+  // Copy, not swap: the source buffer is entirely unchanged.
+  requireBufferEquals(src.ptr(), std::vector<unsigned char>(size + kPad, kSrcFill), cfg.src_alloc);
 }
 #endif
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -970,67 +970,43 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_MixedMulticastSources) {
   }
 }
 
-// Batch of copies that reach their buffers through a pointer slot on the sides selected by `flags`.
-// Each slot is allocated with the same allocation type as the buffer it references, so an indirect
-// side keeps the source and destination pairing of the direct copy it replaces.
 static void RunIndirectCopyTest(unsigned int flags, size_t count, size_t size_in_bytes,
                                 LinearAllocs alloc_type_src, LinearAllocs alloc_type_dst) {
   const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
   const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
   const hipError_t expected_error = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
 
-  const std::vector<unsigned char> zeros(size_in_bytes, 0);
-  std::vector<std::vector<unsigned char>> initial_values;
-  std::vector<void*> src_ptrs(count);
-  std::vector<void*> dst_ptrs(count);
-  std::vector<void*> batch_src_ptrs(count);
-  std::vector<void*> batch_dst_ptrs(count);
-  std::vector<LinearAllocGuard<unsigned char>> allocations;
-  std::vector<LinearAllocGuard<void*>> slots;
-
-  HIP_CHECK(hipSetDevice(0));
-  StreamGuard stream_guard(Streams::created);
+  IndirectCopyBuffers buffers =
+      makeIndirectCopyBuffers(count, size_in_bytes, alloc_type_src, alloc_type_dst);
 
   for (size_t i = 0; i < count; ++i) {
-    initial_values.emplace_back(size_in_bytes, static_cast<unsigned char>(10 + i));
-
-    LinearAllocGuard<unsigned char> src_alloc(alloc_type_src, size_in_bytes);
-    src_ptrs[i] = src_alloc.ptr();
-    allocations.push_back(std::move(src_alloc));
-    fillBuffer(src_ptrs[i], initial_values[i], alloc_type_src);
-
-    LinearAllocGuard<unsigned char> dst_alloc(alloc_type_dst, size_in_bytes);
-    dst_ptrs[i] = dst_alloc.ptr();
-    allocations.push_back(std::move(dst_alloc));
-    fillBuffer(dst_ptrs[i], zeros, alloc_type_dst);
-
-    batch_src_ptrs[i] = src_ptrs[i];
-    batch_dst_ptrs[i] = dst_ptrs[i];
-
     if (indirect_src) {
-      batch_src_ptrs[i] = addPointerSlot(slots, src_ptrs[i], alloc_type_src);
+      buffers.batch_src_ptrs[i] =
+          addPointerSlot(buffers.slots, buffers.src_ptrs[i], alloc_type_src);
     }
 
     if (indirect_dst) {
-      batch_dst_ptrs[i] = addPointerSlot(slots, dst_ptrs[i], alloc_type_dst);
+      buffers.batch_dst_ptrs[i] =
+          addPointerSlot(buffers.slots, buffers.dst_ptrs[i], alloc_type_dst);
     }
   }
 
+  StreamGuard stream_guard(Streams::created);
   std::vector<size_t> sizes(count, size_in_bytes);
   hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
   size_t attrs_idxs[1] = {0};
 
-  HIP_CHECK_ERROR(
-      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
-                          attrs_idxs, 1, nullptr, stream_guard.stream()),
-      expected_error);
+  HIP_CHECK_ERROR(hipMemcpyBatchAsync(buffers.batch_dst_ptrs.data(), buffers.batch_src_ptrs.data(),
+                                      sizes.data(), count, &attr, attrs_idxs, 1, nullptr,
+                                      stream_guard.stream()),
+                  expected_error);
 
   // Unsupported allocation combinations are asserted to fail above; only the supported ones move
   // data worth verifying.
   if (expected_error == hipSuccess) {
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
     for (size_t i = 0; i < count; ++i) {
-      requireBufferEquals(dst_ptrs[i], initial_values[i], alloc_type_dst);
+      requireBufferEquals(buffers.dst_ptrs[i], buffers.initial_values[i], alloc_type_dst);
     }
   }
 }
@@ -1078,7 +1054,6 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy) {
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_ExtOp_Negative) {
   constexpr size_t kSizeInBytes = 4096;
 
-  HIP_CHECK(hipSetDevice(0));
   StreamGuard stream_guard(Streams::created);
   LinearAllocGuard<unsigned char> src(LinearAllocs::hipHostMalloc, kSizeInBytes);
   LinearAllocGuard<unsigned char> dst(LinearAllocs::hipMalloc, kSizeInBytes);
@@ -1114,60 +1089,15 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_ExtOp_Negative) {
   }
 }
 
-namespace {
-
-// Signal memory that blocks `waiting_stream` until `release_stream` releases it. The destructor
-// releases the signal and drains both streams, so a failed assertion cannot leave the signal
-// blocked: destroying a stream that is still waiting never returns, and the signal memory has to
-// outlive the wait packet that references it.
-class SignalGuard {
- public:
-  SignalGuard(hipStream_t waiting_stream, hipStream_t release_stream)
-      : waiting_stream_{waiting_stream}, release_stream_{release_stream} {
-    HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&signal_), sizeof(uint64_t),
-                                    hipMallocSignalMemory));
-    uint64_t blocked = kBlocked;
-    __atomic_store(signal_, &blocked, __ATOMIC_RELEASE);
-  }
-
-  SignalGuard(const SignalGuard&) = delete;
-  SignalGuard& operator=(const SignalGuard&) = delete;
-
-  ~SignalGuard() {
-    // Cast to void to suppress nodiscard warnings; a destructor cannot assert.
-    static_cast<void>(release());
-    static_cast<void>(hipStreamSynchronize(release_stream_));
-    static_cast<void>(hipStreamSynchronize(waiting_stream_));
-    static_cast<void>(hipFree(signal_));
-  }
-
-  hipError_t enqueueWait() {
-    return hipStreamWaitValue64(waiting_stream_, signal_, kReleased, hipStreamWaitValueEq);
-  }
-
-  hipError_t release() {
-    return hipStreamWriteValue64(release_stream_, signal_, kReleased, hipStreamWriteValueDefault);
-  }
-
- private:
-  static constexpr uint64_t kBlocked = 1;
-  static constexpr uint64_t kReleased = 0;
-
-  hipStream_t waiting_stream_;
-  hipStream_t release_stream_;
-  uint64_t* signal_ = nullptr;
-};
-
-}  // namespace
-
 /**
  * Test Description
  * ------------------------
- * - Verifies that an indirect copy reads its pointer slot when the copy runs rather than when
- * hipMemcpyBatchAsync is called: the batch is enqueued behind a stream wait and a second stream
- * points the slots at the real buffers afterwards. Each slot starts out pointing at a decoy buffer,
- * so a copy that reads its slot before the publishing writes moves the wrong data instead of
- * dereferencing an unwritten slot.
+ * Verifies that an indirect copy dereferences its pointer slot on the device when the copy runs,
+ * not on the host when hipMemcpyBatchAsync is called. The other indirect tests fill their slots
+ * before the call and so pass under either behavior; here the batch is enqueued behind a stream
+ * wait and a second stream publishes the real buffer addresses into the slots afterwards, so only
+ * a copy that reads its slot at execution time finds them.
+ *
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -1176,7 +1106,6 @@ class SignalGuard {
  *  - HIP_VERSION >= 7.1
  */
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
-  HIP_CHECK(hipSetDevice(0));
   int wait_value_supported = 0;
   HIP_CHECK(
       hipDeviceGetAttribute(&wait_value_supported, hipDeviceAttributeCanUseStreamWaitValue, 0));
@@ -1184,94 +1113,98 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
     HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
-  const size_t count = GENERATE(1, 3, 8);
+  const size_t count = GENERATE(1, 8);
   const unsigned int flags =
       GENERATE(as<unsigned int>{}, hipMemcpyFlagExtOpIndirectSrc, hipMemcpyFlagExtOpIndirectDst,
                hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
-  CAPTURE(count, flags);
 
-  // The ExtOp path accepts only device and pinned host pairings on a single GPU, and stream memory
-  // operations can publish into a slot allocated on either side of it.
-  constexpr LinearAllocs kAllocTypeSrc = LinearAllocs::hipHostMalloc;
-  constexpr LinearAllocs kAllocTypeDst = LinearAllocs::hipMalloc;
+  const LinearAllocs alloc_type_src =
+      GENERATE(LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc);
+  const LinearAllocs alloc_type_dst =
+      GENERATE(LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc);
+  CAPTURE(count, flags, alloc_type_src, alloc_type_dst);
+
   constexpr size_t kSizeInBytes = 4096;
+  constexpr uint64_t kBlocked = 1;
+  constexpr uint64_t kReleased = 0;
 
   const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
   const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
-  const hipError_t expected_error = getIndirectExpectedReturn(kAllocTypeSrc, kAllocTypeDst);
+  const hipError_t expected_return = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
 
-  const std::vector<unsigned char> zeros(kSizeInBytes, 0);
+  IndirectCopyBuffers buffers =
+      makeIndirectCopyBuffers(count, kSizeInBytes, alloc_type_src, alloc_type_dst);
+
   const std::vector<unsigned char> decoy_values(kSizeInBytes, 0xCD);
-  std::vector<std::vector<unsigned char>> initial_values;
-  std::vector<void*> src_ptrs(count);
-  std::vector<void*> dst_ptrs(count);
-  std::vector<void*> batch_src_ptrs(count);
-  std::vector<void*> batch_dst_ptrs(count);
+  // Each entry pairs a slot with the real address it must receive once the batch is enqueued.
   std::vector<std::pair<void*, void*>> slots_to_publish;
-  std::vector<LinearAllocGuard<unsigned char>> allocations;
-  std::vector<LinearAllocGuard<void*>> slots;
-
-  StreamGuard copy_stream(Streams::created);
-  StreamGuard publish_stream(Streams::created);
-  SignalGuard signal(copy_stream.stream(), publish_stream.stream());
 
   for (size_t i = 0; i < count; ++i) {
-    initial_values.emplace_back(kSizeInBytes, static_cast<unsigned char>(10 + i));
-
-    LinearAllocGuard<unsigned char> src_alloc(kAllocTypeSrc, kSizeInBytes);
-    src_ptrs[i] = src_alloc.ptr();
-    allocations.push_back(std::move(src_alloc));
-    fillBuffer(src_ptrs[i], initial_values[i], kAllocTypeSrc);
-
-    LinearAllocGuard<unsigned char> dst_alloc(kAllocTypeDst, kSizeInBytes);
-    dst_ptrs[i] = dst_alloc.ptr();
-    allocations.push_back(std::move(dst_alloc));
-    fillBuffer(dst_ptrs[i], zeros, kAllocTypeDst);
-
-    batch_src_ptrs[i] = src_ptrs[i];
-    batch_dst_ptrs[i] = dst_ptrs[i];
-
-    // A slot published early reads the decoy, which the verification below catches: the source
-    // decoy carries a pattern the destination must not receive, and a destination decoy diverts the
-    // copy away from the destination buffer, which stays zeroed.
+    // The slots start out pointing at decoys instead of the real buffers, so a slot read taken
+    // before the addresses are published gives a wrong result rather than a crash.
     if (indirect_src) {
-      LinearAllocGuard<unsigned char> decoy(kAllocTypeSrc, kSizeInBytes);
-      fillBuffer(decoy.ptr(), decoy_values, kAllocTypeSrc);
-      batch_src_ptrs[i] = addPointerSlot(slots, decoy.ptr(), kAllocTypeSrc);
-      slots_to_publish.emplace_back(batch_src_ptrs[i], src_ptrs[i]);
-      allocations.push_back(std::move(decoy));
+      LinearAllocGuard<unsigned char> decoy(alloc_type_src, kSizeInBytes);
+      fillBuffer(decoy.ptr(), decoy_values, alloc_type_src);
+      buffers.batch_src_ptrs[i] = addPointerSlot(buffers.slots, decoy.ptr(), alloc_type_src);
+      slots_to_publish.emplace_back(buffers.batch_src_ptrs[i], buffers.src_ptrs[i]);
+      buffers.allocations.push_back(std::move(decoy));
     }
 
     if (indirect_dst) {
-      LinearAllocGuard<unsigned char> decoy(kAllocTypeDst, kSizeInBytes);
-      batch_dst_ptrs[i] = addPointerSlot(slots, decoy.ptr(), kAllocTypeDst);
-      slots_to_publish.emplace_back(batch_dst_ptrs[i], dst_ptrs[i]);
-      allocations.push_back(std::move(decoy));
+      LinearAllocGuard<unsigned char> decoy(alloc_type_dst, kSizeInBytes);
+      buffers.batch_dst_ptrs[i] = addPointerSlot(buffers.slots, decoy.ptr(), alloc_type_dst);
+      slots_to_publish.emplace_back(buffers.batch_dst_ptrs[i], buffers.dst_ptrs[i]);
+      buffers.allocations.push_back(std::move(decoy));
     }
   }
+
+  StreamGuard copy_stream(Streams::created);
+  StreamGuard publish_stream(Streams::created);
+
+  // The value hipStreamWaitValue64 polls has to live in signal memory.
+  uint64_t* signal = nullptr;
+  HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&signal), sizeof(uint64_t),
+                                  hipMallocSignalMemory));
+  __atomic_store_n(signal, kBlocked, __ATOMIC_RELEASE);
 
   std::vector<size_t> sizes(count, kSizeInBytes);
   hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
   size_t attrs_idxs[1] = {0};
 
-  HIP_CHECK(signal.enqueueWait());
-  HIP_CHECK_ERROR(
-      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
-                          attrs_idxs, 1, nullptr, copy_stream.stream()),
-      expected_error);
+  // The publishing writes have to be submitted only after hipMemcpyBatchAsync has returned.
+  // Submitting them first would let them land before the call, and a slot read at call time would
+  // then find the real address anyway. Blocking copy_stream is what keeps the batch from running
+  // before writes.
+  HIP_CHECK(hipStreamWaitValue64(copy_stream.stream(), signal, kReleased, hipStreamWaitValueEq));
 
+  const hipError_t batch_status =
+      hipMemcpyBatchAsync(buffers.batch_dst_ptrs.data(), buffers.batch_src_ptrs.data(),
+                          sizes.data(), count, &attr, attrs_idxs, 1, nullptr, copy_stream.stream());
+
+  hipError_t publish_status = hipSuccess;
   for (const auto& [slot, buffer] : slots_to_publish) {
-    HIP_CHECK(hipStreamWriteValue64(publish_stream.stream(), slot,
-                                    static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(buffer)),
-                                    hipStreamWriteValueDefault));
+    if (publish_status != hipSuccess) break;
+    const uint64_t address = static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(buffer));
+    publish_status =
+        hipStreamWriteValue64(publish_stream.stream(), slot, address, hipStreamWriteValueDefault);
   }
-  HIP_CHECK(signal.release());
-  HIP_CHECK(hipStreamSynchronize(publish_stream.stream()));
-  HIP_CHECK(hipStreamSynchronize(copy_stream.stream()));
+  const hipError_t publish_sync_status = hipStreamSynchronize(publish_stream.stream());
 
-  if (expected_error == hipSuccess) {
+  // Signal memory is host accessible, so releasing from the host cannot fail and cannot throw. The
+  // publishing writes have already landed because publish_stream has drained.
+  __atomic_store_n(signal, kReleased, __ATOMIC_RELEASE);
+
+  const hipError_t copy_sync_status = hipStreamSynchronize(copy_stream.stream());
+  HIP_CHECK(hipFree(signal));
+
+  HIP_CHECK(publish_status);
+  HIP_CHECK(publish_sync_status);
+  HIP_CHECK(copy_sync_status);
+  HIP_CHECK_ERROR(batch_status, expected_return);
+
+  if (expected_return == hipSuccess) {
     for (size_t i = 0; i < count; ++i) {
-      requireBufferEquals(dst_ptrs[i], initial_values[i], kAllocTypeDst);
+      requireBufferEquals(buffers.dst_ptrs[i], buffers.initial_values[i], alloc_type_dst);
     }
   }
 }
@@ -1279,7 +1212,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
 /**
  * Test Description
  * ------------------------
- * - Verifies one batch that carries plain copies, swaps and indirect-source copies, each kind under
+ * Verifies one batch that carries plain copies, swaps and indirect-source copies, each kind under
  * its own attribute entry spanning several copies.
  * Test source
  * ------------------------
@@ -1290,11 +1223,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
   constexpr size_t kSizeInBytes = 4096;
-  // Each attribute entry covers a run of copies rather than a single one, so the batch exercises
-  // the walk from a copy index to the attribute entry that governs it.
   constexpr size_t kCopiesPerAttr = 2;
 
-  // The batch is rejected as a whole when either ExtOp packet is missing on this device.
   const hipError_t swap_error =
       getSwapExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc);
   const hipError_t indirect_error =
@@ -1319,38 +1249,29 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
   std::vector<Expectation> expectations;
 
   const std::vector<unsigned char> zeros(kSizeInBytes, 0);
-  const auto addBuffer = [&](const LinearAllocs alloc_type,
-                             const std::vector<unsigned char>& contents) {
-    LinearAllocGuard<unsigned char> alloc(alloc_type, kSizeInBytes);
-    void* ptr = alloc.ptr();
-    allocations.push_back(std::move(alloc));
-    fillBuffer(ptr, contents, alloc_type);
-    return ptr;
-  };
 
   for (size_t i = 0; i < kCopiesPerAttr; ++i) {
     const std::vector<unsigned char> pattern(kSizeInBytes, static_cast<unsigned char>(10 + i));
-    src_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, pattern));
-    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, zeros));
+    src_ptrs.push_back(addBuffer(allocations, pattern, LinearAllocs::hipMalloc));
+    dst_ptrs.push_back(addBuffer(allocations, zeros, LinearAllocs::hipMalloc));
     expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, pattern});
   }
 
-  // A swap leaves each endpoint holding what the other one started with.
   for (size_t i = 0; i < kCopiesPerAttr; ++i) {
     const std::vector<unsigned char> device_pattern(kSizeInBytes,
                                                     static_cast<unsigned char>(20 + i));
     const std::vector<unsigned char> host_pattern(kSizeInBytes, static_cast<unsigned char>(30 + i));
-    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, device_pattern));
-    src_ptrs.push_back(addBuffer(LinearAllocs::hipHostMalloc, host_pattern));
+    dst_ptrs.push_back(addBuffer(allocations, device_pattern, LinearAllocs::hipMalloc));
+    src_ptrs.push_back(addBuffer(allocations, host_pattern, LinearAllocs::hipHostMalloc));
     expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, host_pattern});
     expectations.push_back({src_ptrs.back(), LinearAllocs::hipHostMalloc, device_pattern});
   }
 
   for (size_t i = 0; i < kCopiesPerAttr; ++i) {
     const std::vector<unsigned char> pattern(kSizeInBytes, static_cast<unsigned char>(40 + i));
-    void* indirect_src = addBuffer(LinearAllocs::hipHostMalloc, pattern);
+    void* indirect_src = addBuffer(allocations, pattern, LinearAllocs::hipHostMalloc);
     src_ptrs.push_back(addPointerSlot(slots, indirect_src, LinearAllocs::hipHostMalloc));
-    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, zeros));
+    dst_ptrs.push_back(addBuffer(allocations, zeros, LinearAllocs::hipMalloc));
     expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, pattern});
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -969,54 +970,76 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_MixedMulticastSources) {
   }
 }
 
-/**
- * Test Description
- * ------------------------
- * - Verifies H2D hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectSrc copies
- * from the host buffer referenced by a pinned pointer slot.
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrc) {
-  constexpr size_t copy_size = kSmallCopySize;
+// Batch of copies that reach their buffers through a pointer slot on the sides selected by `flags`.
+// Each slot is allocated with the same allocation type as the buffer it references, so an indirect
+// side keeps the source and destination pairing of the direct copy it replaces.
+static void RunIndirectCopyTest(unsigned int flags, size_t count, size_t size_in_bytes,
+                                LinearAllocs alloc_type_src, LinearAllocs alloc_type_dst) {
+  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
+  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const hipError_t expected_error = getIndirectExpectedReturn(alloc_type_src, alloc_type_dst);
 
+  const std::vector<unsigned char> zeros(size_in_bytes, 0);
+  std::vector<std::vector<unsigned char>> initial_values;
+  std::vector<void*> src_ptrs(count);
+  std::vector<void*> dst_ptrs(count);
+  std::vector<void*> batch_src_ptrs(count);
+  std::vector<void*> batch_dst_ptrs(count);
+  std::vector<LinearAllocGuard<unsigned char>> allocations;
+  std::vector<LinearAllocGuard<void*>> slots;
+
+  HIP_CHECK(hipSetDevice(0));
   StreamGuard stream_guard(Streams::created);
-  LinearAllocGuard<int> src(LinearAllocs::hipHostMalloc, copy_size);
-  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);
-  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
 
-  const size_t copy_elements = copy_size / sizeof(int);
-  std::fill_n(src.host_ptr(), copy_elements, kPatternValue);
+  for (size_t i = 0; i < count; ++i) {
+    initial_values.emplace_back(size_in_bytes, static_cast<unsigned char>(10 + i));
 
-  void* src_ptr = src.ptr();
-  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
+    LinearAllocGuard<unsigned char> src_alloc(alloc_type_src, size_in_bytes);
+    src_ptrs[i] = src_alloc.ptr();
+    allocations.push_back(std::move(src_alloc));
+    fillBuffer(src_ptrs[i], initial_values[i], alloc_type_src);
 
-  std::vector<void*> dst_ptrs{dst.ptr()};
-  std::vector<void*> src_ptrs{src_slot.ptr()};
-  std::vector<size_t> sizes{copy_size};
-  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectSrc};
-  size_t attrs_idx = 0;
+    LinearAllocGuard<unsigned char> dst_alloc(alloc_type_dst, size_in_bytes);
+    dst_ptrs[i] = dst_alloc.ptr();
+    allocations.push_back(std::move(dst_alloc));
+    fillBuffer(dst_ptrs[i], zeros, alloc_type_dst);
 
-  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
-                                          &attrs_idx, 1, nullptr, stream_guard.stream());
-  if (status == hipErrorNotSupported) {
-    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
-  } else {
-    HIP_CHECK(status);
+    batch_src_ptrs[i] = src_ptrs[i];
+    batch_dst_ptrs[i] = dst_ptrs[i];
+
+    if (indirect_src) {
+      batch_src_ptrs[i] = addPointerSlot(slots, src_ptrs[i], alloc_type_src);
+    }
+
+    if (indirect_dst) {
+      batch_dst_ptrs[i] = addPointerSlot(slots, dst_ptrs[i], alloc_type_dst);
+    }
+  }
+
+  std::vector<size_t> sizes(count, size_in_bytes);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
+  size_t attrs_idxs[1] = {0};
+
+  HIP_CHECK_ERROR(
+      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
+                          attrs_idxs, 1, nullptr, stream_guard.stream()),
+      expected_error);
+
+  // Unsupported allocation combinations are asserted to fail above; only the supported ones move
+  // data worth verifying.
+  if (expected_error == hipSuccess) {
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    VerifyDeviceBuffers(dst_ptrs, copy_size);
+    for (size_t i = 0; i < count; ++i) {
+      requireBufferEquals(dst_ptrs[i], initial_values[i], alloc_type_dst);
+    }
   }
 }
 
 /**
  * Test Description
  * ------------------------
- * - Verifies D2H hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectDst copies
- * into the host buffer referenced by a pinned pointer slot.
+ * - Verifies batched copies that reach their buffers through pointer slots across generated
+ * indirect flag combinations, copy counts, sizes and per-side allocation types.
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -1024,36 +1047,331 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrc) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectDst) {
-  constexpr size_t copy_size = kSmallCopySize;
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy) {
+  const unsigned int flags =
+      GENERATE(as<unsigned int>{}, hipMemcpyFlagExtOpIndirectSrc, hipMemcpyFlagExtOpIndirectDst,
+               hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
+  const size_t count = GENERATE(1, 3, 8);
+  const size_t size_in_bytes = GENERATE(as<size_t>{}, 1, 63, 4096);
+  const LinearAllocs alloc_type_src =
+      GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc);
+  const LinearAllocs alloc_type_dst =
+      GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc);
+  CAPTURE(flags, count, size_in_bytes, alloc_type_src, alloc_type_dst);
 
+  RunIndirectCopyTest(flags, count, size_in_bytes, alloc_type_src, alloc_type_dst);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that hipMemcpyBatchAsync rejects the ExtOp attribute combinations that no device
+ * accepts: swap paired with an indirect flag in one entry, and a pointer slot too small to hold a
+ * pointer.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_ExtOp_Negative) {
+  constexpr size_t kSizeInBytes = 4096;
+
+  HIP_CHECK(hipSetDevice(0));
   StreamGuard stream_guard(Streams::created);
-  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, copy_size);
-  LinearAllocGuard<int> dst(LinearAllocs::hipHostMalloc, copy_size);
-  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+  LinearAllocGuard<unsigned char> src(LinearAllocs::hipHostMalloc, kSizeInBytes);
+  LinearAllocGuard<unsigned char> dst(LinearAllocs::hipMalloc, kSizeInBytes);
 
-  const size_t copy_elements = copy_size / sizeof(int);
-  std::vector<int> host_pattern(copy_elements, kPatternValue);
-  HIP_CHECK(hipMemcpy(src.ptr(), host_pattern.data(), copy_size, hipMemcpyHostToDevice));
-  std::fill_n(dst.host_ptr(), copy_elements, 0);
+  std::array<void*, 1> src_ptrs{src.ptr()};
+  std::array<void*, 1> dst_ptrs{dst.ptr()};
+  std::array<size_t, 1> sizes{kSizeInBytes};
+  std::array<hipMemcpyAttributes, 1> attrs{
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault}};
+  std::array<size_t, 1> attrs_idxs{0};
 
-  void* dst_ptr = dst.ptr();
-  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
+  SECTION("Swap combined with indirect in one attribute entry") {
+    const unsigned int indirect_flags =
+        GENERATE(as<unsigned int>{}, hipMemcpyFlagExtOpIndirectSrc, hipMemcpyFlagExtOpIndirectDst,
+                 hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
+    attrs[0].flags = hipMemcpyFlagExtOpSwap | indirect_flags;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(),
+                                        dst_ptrs.size(), attrs.data(), attrs_idxs.data(),
+                                        attrs.size(), nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
 
-  std::vector<void*> src_ptrs{src.ptr()};
-  std::vector<void*> dst_ptrs{dst_slot.ptr()};
-  std::vector<size_t> sizes{copy_size};
-  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectDst};
-  size_t attrs_idx = 0;
+  // An indirect side is range-checked against sizeof(void*) rather than against the copy size, so
+  // this is rejected for holding less than a pointer even though it is smaller than the copy too.
+  SECTION("Pointer slot smaller than a pointer") {
+    LinearAllocGuard<unsigned char> short_slot(LinearAllocs::hipHostMalloc, sizeof(void*) / 2);
+    src_ptrs[0] = short_slot.ptr();
+    attrs[0].flags = hipMemcpyFlagExtOpIndirectSrc;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(),
+                                        dst_ptrs.size(), attrs.data(), attrs_idxs.data(),
+                                        attrs.size(), nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+}
 
-  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
-                                          &attrs_idx, 1, nullptr, stream_guard.stream());
-  if (status == hipErrorNotSupported) {
-    SUCCEED("hipMemcpyFlagExtOpIndirectDst is not supported on this device");
-  } else {
-    HIP_CHECK(status);
+namespace {
+
+// Signal memory that blocks `waiting_stream` until `release_stream` releases it. The destructor
+// releases the signal and drains both streams, so a failed assertion cannot leave the signal
+// blocked: destroying a stream that is still waiting never returns, and the signal memory has to
+// outlive the wait packet that references it.
+class SignalGuard {
+ public:
+  SignalGuard(hipStream_t waiting_stream, hipStream_t release_stream)
+      : waiting_stream_{waiting_stream}, release_stream_{release_stream} {
+    HIP_CHECK(hipExtMallocWithFlags(reinterpret_cast<void**>(&signal_), sizeof(uint64_t),
+                                    hipMallocSignalMemory));
+    uint64_t blocked = kBlocked;
+    __atomic_store(signal_, &blocked, __ATOMIC_RELEASE);
+  }
+
+  SignalGuard(const SignalGuard&) = delete;
+  SignalGuard& operator=(const SignalGuard&) = delete;
+
+  ~SignalGuard() {
+    // Cast to void to suppress nodiscard warnings; a destructor cannot assert.
+    static_cast<void>(release());
+    static_cast<void>(hipStreamSynchronize(release_stream_));
+    static_cast<void>(hipStreamSynchronize(waiting_stream_));
+    static_cast<void>(hipFree(signal_));
+  }
+
+  hipError_t enqueueWait() {
+    return hipStreamWaitValue64(waiting_stream_, signal_, kReleased, hipStreamWaitValueEq);
+  }
+
+  hipError_t release() {
+    return hipStreamWriteValue64(release_stream_, signal_, kReleased, hipStreamWriteValueDefault);
+  }
+
+ private:
+  static constexpr uint64_t kBlocked = 1;
+  static constexpr uint64_t kReleased = 0;
+
+  hipStream_t waiting_stream_;
+  hipStream_t release_stream_;
+  uint64_t* signal_ = nullptr;
+};
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that an indirect copy reads its pointer slot when the copy runs rather than when
+ * hipMemcpyBatchAsync is called: the batch is enqueued behind a stream wait and a second stream
+ * points the slots at the real buffers afterwards. Each slot starts out pointing at a decoy buffer,
+ * so a copy that reads its slot before the publishing writes moves the wrong data instead of
+ * dereferencing an unwritten slot.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectCopy_StreamOrderedPointer) {
+  HIP_CHECK(hipSetDevice(0));
+  int wait_value_supported = 0;
+  HIP_CHECK(
+      hipDeviceGetAttribute(&wait_value_supported, hipDeviceAttributeCanUseStreamWaitValue, 0));
+  if (wait_value_supported == 0) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+  }
+
+  const size_t count = GENERATE(1, 3, 8);
+  const unsigned int flags =
+      GENERATE(as<unsigned int>{}, hipMemcpyFlagExtOpIndirectSrc, hipMemcpyFlagExtOpIndirectDst,
+               hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
+  CAPTURE(count, flags);
+
+  // The ExtOp path accepts only device and pinned host pairings on a single GPU, and stream memory
+  // operations can publish into a slot allocated on either side of it.
+  constexpr LinearAllocs kAllocTypeSrc = LinearAllocs::hipHostMalloc;
+  constexpr LinearAllocs kAllocTypeDst = LinearAllocs::hipMalloc;
+  constexpr size_t kSizeInBytes = 4096;
+
+  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
+  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const hipError_t expected_error = getIndirectExpectedReturn(kAllocTypeSrc, kAllocTypeDst);
+
+  const std::vector<unsigned char> zeros(kSizeInBytes, 0);
+  const std::vector<unsigned char> decoy_values(kSizeInBytes, 0xCD);
+  std::vector<std::vector<unsigned char>> initial_values;
+  std::vector<void*> src_ptrs(count);
+  std::vector<void*> dst_ptrs(count);
+  std::vector<void*> batch_src_ptrs(count);
+  std::vector<void*> batch_dst_ptrs(count);
+  std::vector<std::pair<void*, void*>> slots_to_publish;
+  std::vector<LinearAllocGuard<unsigned char>> allocations;
+  std::vector<LinearAllocGuard<void*>> slots;
+
+  StreamGuard copy_stream(Streams::created);
+  StreamGuard publish_stream(Streams::created);
+  SignalGuard signal(copy_stream.stream(), publish_stream.stream());
+
+  for (size_t i = 0; i < count; ++i) {
+    initial_values.emplace_back(kSizeInBytes, static_cast<unsigned char>(10 + i));
+
+    LinearAllocGuard<unsigned char> src_alloc(kAllocTypeSrc, kSizeInBytes);
+    src_ptrs[i] = src_alloc.ptr();
+    allocations.push_back(std::move(src_alloc));
+    fillBuffer(src_ptrs[i], initial_values[i], kAllocTypeSrc);
+
+    LinearAllocGuard<unsigned char> dst_alloc(kAllocTypeDst, kSizeInBytes);
+    dst_ptrs[i] = dst_alloc.ptr();
+    allocations.push_back(std::move(dst_alloc));
+    fillBuffer(dst_ptrs[i], zeros, kAllocTypeDst);
+
+    batch_src_ptrs[i] = src_ptrs[i];
+    batch_dst_ptrs[i] = dst_ptrs[i];
+
+    // A slot published early reads the decoy, which the verification below catches: the source
+    // decoy carries a pattern the destination must not receive, and a destination decoy diverts the
+    // copy away from the destination buffer, which stays zeroed.
+    if (indirect_src) {
+      LinearAllocGuard<unsigned char> decoy(kAllocTypeSrc, kSizeInBytes);
+      fillBuffer(decoy.ptr(), decoy_values, kAllocTypeSrc);
+      batch_src_ptrs[i] = addPointerSlot(slots, decoy.ptr(), kAllocTypeSrc);
+      slots_to_publish.emplace_back(batch_src_ptrs[i], src_ptrs[i]);
+      allocations.push_back(std::move(decoy));
+    }
+
+    if (indirect_dst) {
+      LinearAllocGuard<unsigned char> decoy(kAllocTypeDst, kSizeInBytes);
+      batch_dst_ptrs[i] = addPointerSlot(slots, decoy.ptr(), kAllocTypeDst);
+      slots_to_publish.emplace_back(batch_dst_ptrs[i], dst_ptrs[i]);
+      allocations.push_back(std::move(decoy));
+    }
+  }
+
+  std::vector<size_t> sizes(count, kSizeInBytes);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
+  size_t attrs_idxs[1] = {0};
+
+  HIP_CHECK(signal.enqueueWait());
+  HIP_CHECK_ERROR(
+      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
+                          attrs_idxs, 1, nullptr, copy_stream.stream()),
+      expected_error);
+
+  for (const auto& [slot, buffer] : slots_to_publish) {
+    HIP_CHECK(hipStreamWriteValue64(publish_stream.stream(), slot,
+                                    static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(buffer)),
+                                    hipStreamWriteValueDefault));
+  }
+  HIP_CHECK(signal.release());
+  HIP_CHECK(hipStreamSynchronize(publish_stream.stream()));
+  HIP_CHECK(hipStreamSynchronize(copy_stream.stream()));
+
+  if (expected_error == hipSuccess) {
+    for (size_t i = 0; i < count; ++i) {
+      requireBufferEquals(dst_ptrs[i], initial_values[i], kAllocTypeDst);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies one batch that carries plain copies, swaps and indirect-source copies, each kind under
+ * its own attribute entry spanning several copies.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
+  constexpr size_t kSizeInBytes = 4096;
+  // Each attribute entry covers a run of copies rather than a single one, so the batch exercises
+  // the walk from a copy index to the attribute entry that governs it.
+  constexpr size_t kCopiesPerAttr = 2;
+
+  // The batch is rejected as a whole when either ExtOp packet is missing on this device.
+  const hipError_t swap_error =
+      getSwapExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc);
+  const hipError_t indirect_error =
+      getIndirectExpectedReturn(LinearAllocs::hipHostMalloc, LinearAllocs::hipMalloc);
+  const hipError_t expected_error = (swap_error == hipSuccess && indirect_error == hipSuccess)
+                                        ? hipSuccess
+                                        : hipErrorNotSupported;
+
+  HIP_CHECK(hipSetDevice(0));
+  StreamGuard stream_guard(Streams::created);
+
+  struct Expectation {
+    void* buffer;
+    LinearAllocs alloc_type;
+    std::vector<unsigned char> contents;
+  };
+
+  std::vector<LinearAllocGuard<unsigned char>> allocations;
+  std::vector<LinearAllocGuard<void*>> slots;
+  std::vector<void*> src_ptrs;
+  std::vector<void*> dst_ptrs;
+  std::vector<Expectation> expectations;
+
+  const std::vector<unsigned char> zeros(kSizeInBytes, 0);
+  const auto addBuffer = [&](const LinearAllocs alloc_type,
+                             const std::vector<unsigned char>& contents) {
+    LinearAllocGuard<unsigned char> alloc(alloc_type, kSizeInBytes);
+    void* ptr = alloc.ptr();
+    allocations.push_back(std::move(alloc));
+    fillBuffer(ptr, contents, alloc_type);
+    return ptr;
+  };
+
+  for (size_t i = 0; i < kCopiesPerAttr; ++i) {
+    const std::vector<unsigned char> pattern(kSizeInBytes, static_cast<unsigned char>(10 + i));
+    src_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, pattern));
+    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, zeros));
+    expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, pattern});
+  }
+
+  // A swap leaves each endpoint holding what the other one started with.
+  for (size_t i = 0; i < kCopiesPerAttr; ++i) {
+    const std::vector<unsigned char> device_pattern(kSizeInBytes,
+                                                    static_cast<unsigned char>(20 + i));
+    const std::vector<unsigned char> host_pattern(kSizeInBytes, static_cast<unsigned char>(30 + i));
+    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, device_pattern));
+    src_ptrs.push_back(addBuffer(LinearAllocs::hipHostMalloc, host_pattern));
+    expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, host_pattern});
+    expectations.push_back({src_ptrs.back(), LinearAllocs::hipHostMalloc, device_pattern});
+  }
+
+  for (size_t i = 0; i < kCopiesPerAttr; ++i) {
+    const std::vector<unsigned char> pattern(kSizeInBytes, static_cast<unsigned char>(40 + i));
+    void* indirect_src = addBuffer(LinearAllocs::hipHostMalloc, pattern);
+    src_ptrs.push_back(addPointerSlot(slots, indirect_src, LinearAllocs::hipHostMalloc));
+    dst_ptrs.push_back(addBuffer(LinearAllocs::hipMalloc, zeros));
+    expectations.push_back({dst_ptrs.back(), LinearAllocs::hipMalloc, pattern});
+  }
+
+  std::vector<size_t> sizes(dst_ptrs.size(), kSizeInBytes);
+  std::array<hipMemcpyAttributes, 3> attrs{
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap},
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectSrc},
+  };
+  std::array<size_t, 3> attrs_idxs{0, kCopiesPerAttr, 2 * kCopiesPerAttr};
+
+  HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(),
+                                      dst_ptrs.size(), attrs.data(), attrs_idxs.data(),
+                                      attrs.size(), nullptr, stream_guard.stream()),
+                  expected_error);
+
+  if (expected_error == hipSuccess) {
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    VerifyArrayFromBothEnds(dst.host_ptr(), copy_elements, kPatternValue, 0);
+    for (const Expectation& expectation : expectations) {
+      requireBufferEquals(expectation.buffer, expectation.contents, expectation.alloc_type);
+    }
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -1296,6 +1296,320 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect) {
   }
 }
 #endif
+
+#if HT_AMD
+/**
+ * Test Description
+ * ------------------------
+ * - Parameterized H->D IndirectSrc copy correctness over mismatched src/dst byte
+ *   offsets and two transfer sizes that straddle the GPU_FORCE_BLIT_INDIRECT_SIZE
+ *   threshold (4096 routes to the shader path; 65536 routes to SDMA on gfx1250 and
+ *   to the shader path on pre-gfx1250).
+ *
+ *   The source is passed indirectly: a sizeof(void*) pinned holder slot stores the
+ *   real host source address (h_base + src_off); the destination is passed
+ *   directly as d_base + dst_off. Each host/device allocation is size+64 bytes.
+ *   The full host allocation is filled with 0xAA and the full device allocation
+ *   with 0xBB. After the copy, the destination region [dst_off, dst_off+size) must
+ *   equal 0xAA, all device bytes OUTSIDE that region (padding) must remain
+ *   unchanged at 0xBB, and the host source buffer must be entirely unchanged at
+ *   0xAA -- this is a copy, not a swap.
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_Src_UnalignedMatrix) {
+  constexpr uint8_t kHostFill = 0xAA;
+  constexpr uint8_t kDevFill = 0xBB;
+  constexpr size_t kPad = 64;
+
+  const std::pair<size_t, size_t> off =
+      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
+               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
+               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
+               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
+               std::make_pair(size_t{2}, size_t{2}));
+  const size_t size = GENERATE(size_t{4096}, size_t{65536});
+  const size_t src_off = off.first;
+  const size_t dst_off = off.second;
+
+  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
+
+  void* h_base = nullptr;
+  void* d_base = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
+  HIP_CHECK(hipMalloc(&d_base, size + kPad));
+
+  std::memset(h_base, kHostFill, size + kPad);
+  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
+
+  // Bake the offset into the REAL address stored behind the holder; the direct
+  // side pointer carries its own offset directly.
+  void* real_src = static_cast<uint8_t*>(h_base) + src_off;
+  void* direct_dst = static_cast<uint8_t*>(d_base) + dst_off;
+
+  void* src_slot = nullptr;
+  HIP_CHECK(hipHostMalloc(&src_slot, sizeof(void*)));
+  std::memcpy(src_slot, &real_src, sizeof(void*));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {direct_dst};
+  void* srcs[] = {src_slot};
+  size_t sizes[] = {size};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpIndirectSrc;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipHostFree(src_slot));
+    HIP_CHECK(hipFree(d_base));
+    HIP_CHECK(hipHostFree(h_base));
+    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
+    return;
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Copy the full device buffer back so padding can be verified too.
+  std::vector<uint8_t> devResult(size + kPad);
+  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
+  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
+
+  for (size_t i = 0; i < size + kPad; i++) {
+    const bool in_dev_region = (i >= dst_off) && (i < dst_off + size);
+    const uint8_t expected_dev = in_dev_region ? kHostFill : kDevFill;
+    INFO("dev byte " << i << " (region=" << in_dev_region
+                     << ") = " << static_cast<int>(devResult[i]) << " expected "
+                     << static_cast<int>(expected_dev));
+    REQUIRE(devResult[i] == expected_dev);
+
+    // This is a copy, not a swap: the host source must be entirely unchanged.
+    INFO("host byte " << i << " = " << static_cast<int>(hostResult[i]) << " expected "
+                      << static_cast<int>(kHostFill));
+    REQUIRE(hostResult[i] == kHostFill);
+  }
+
+  HIP_CHECK(hipFree(d_base));
+  HIP_CHECK(hipHostFree(h_base));
+  HIP_CHECK(hipHostFree(src_slot));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Parameterized D->H IndirectDst copy correctness over mismatched src/dst byte
+ *   offsets and two transfer sizes that straddle the GPU_FORCE_BLIT_INDIRECT_SIZE
+ *   threshold (4096 routes to the shader path; 65536 routes to SDMA on gfx1250 and
+ *   to the shader path on pre-gfx1250).
+ *
+ *   The destination is passed indirectly: a sizeof(void*) pinned holder slot
+ *   stores the real host destination address (h_base + dst_off); the source is
+ *   passed directly as d_base + src_off. Each host/device allocation is size+64
+ *   bytes. The full device allocation is filled with 0xAA and the full host
+ *   allocation with 0xBB. After the copy, the host region [dst_off, dst_off+size)
+ *   must equal 0xAA, all host bytes OUTSIDE that region (padding) must remain
+ *   unchanged at 0xBB, and the device source buffer must be entirely unchanged at
+ *   0xAA -- this is a copy, not a swap.
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_Dst_UnalignedMatrix) {
+  constexpr uint8_t kDevFill = 0xAA;
+  constexpr uint8_t kHostFill = 0xBB;
+  constexpr size_t kPad = 64;
+
+  const std::pair<size_t, size_t> off =
+      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
+               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
+               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
+               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
+               std::make_pair(size_t{2}, size_t{2}));
+  const size_t size = GENERATE(size_t{4096}, size_t{65536});
+  const size_t src_off = off.first;
+  const size_t dst_off = off.second;
+
+  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
+
+  void* d_base = nullptr;
+  void* h_base = nullptr;
+  HIP_CHECK(hipMalloc(&d_base, size + kPad));
+  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
+
+  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
+  std::memset(h_base, kHostFill, size + kPad);
+
+  // Bake the offset into the REAL address stored behind the holder; the direct
+  // side pointer carries its own offset directly.
+  void* direct_src = static_cast<uint8_t*>(d_base) + src_off;
+  void* real_dst = static_cast<uint8_t*>(h_base) + dst_off;
+
+  void* dst_slot = nullptr;
+  HIP_CHECK(hipHostMalloc(&dst_slot, sizeof(void*)));
+  std::memcpy(dst_slot, &real_dst, sizeof(void*));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {dst_slot};
+  void* srcs[] = {direct_src};
+  size_t sizes[] = {size};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpIndirectDst;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipHostFree(dst_slot));
+    HIP_CHECK(hipHostFree(h_base));
+    HIP_CHECK(hipFree(d_base));
+    SUCCEED("hipMemcpyFlagExtOpIndirectDst is not supported on this device");
+    return;
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Copy the device source back in full to confirm it is unchanged, and read
+  // the host destination directly.
+  std::vector<uint8_t> devResult(size + kPad);
+  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
+  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
+
+  for (size_t i = 0; i < size + kPad; i++) {
+    const bool in_host_region = (i >= dst_off) && (i < dst_off + size);
+    const uint8_t expected_host = in_host_region ? kDevFill : kHostFill;
+    INFO("host byte " << i << " (region=" << in_host_region
+                      << ") = " << static_cast<int>(hostResult[i]) << " expected "
+                      << static_cast<int>(expected_host));
+    REQUIRE(hostResult[i] == expected_host);
+
+    // This is a copy, not a swap: the device source must be entirely unchanged.
+    INFO("dev byte " << i << " = " << static_cast<int>(devResult[i]) << " expected "
+                     << static_cast<int>(kDevFill));
+    REQUIRE(devResult[i] == kDevFill);
+  }
+
+  HIP_CHECK(hipFree(d_base));
+  HIP_CHECK(hipHostFree(h_base));
+  HIP_CHECK(hipHostFree(dst_slot));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify hipMemcpyBatchAsync with multiple independent H->D IndirectSrc ops in
+ *   a single call.
+ *
+ *   Four independent host(holder)->device pairs are copied in one call, each with
+ *   a distinct sentinel value; all four must be correct after synchronization,
+ *   and each host source must remain unchanged since this is a copy, not a swap.
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_MultiOp) {
+  constexpr size_t kNumOps = 4;
+  constexpr size_t kNumElements = 1024;
+  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
+
+  // Each op has a distinct sentinel value to confirm independence.
+  constexpr int kHostVals[kNumOps] = {10, 20, 30, 40};
+
+  void* h_bufs[kNumOps] = {};
+  void* d_bufs[kNumOps] = {};
+  void* slots[kNumOps] = {};
+
+  for (size_t op = 0; op < kNumOps; ++op) {
+    HIP_CHECK(hipHostMalloc(&h_bufs[op], kSizeBytes));
+    HIP_CHECK(hipMalloc(&d_bufs[op], kSizeBytes));
+    HIP_CHECK(hipHostMalloc(&slots[op], sizeof(void*)));
+
+    std::vector<int> hi(kNumElements, kHostVals[op]);
+    std::memcpy(h_bufs[op], hi.data(), kSizeBytes);
+    // The holder stores the REAL host source address for this op.
+    std::memcpy(slots[op], &h_bufs[op], sizeof(void*));
+  }
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // All ops share the same IndirectSrc attribute (index 0).
+  size_t sizes[kNumOps];
+  size_t attrsIdxs[kNumOps];
+  for (size_t op = 0; op < kNumOps; ++op) {
+    sizes[op] = kSizeBytes;
+    attrsIdxs[op] = 0;
+  }
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpIndirectSrc;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err =
+      hipMemcpyBatchAsync(d_bufs, slots, sizes, kNumOps, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    for (size_t op = 0; op < kNumOps; ++op) {
+      HIP_CHECK(hipHostFree(slots[op]));
+      HIP_CHECK(hipFree(d_bufs[op]));
+      HIP_CHECK(hipHostFree(h_bufs[op]));
+    }
+    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
+    return;
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Verify every op independently; the host sources are unchanged (copy, not swap).
+  for (size_t op = 0; op < kNumOps; ++op) {
+    std::vector<int> resultDev(kNumElements);
+    HIP_CHECK(hipMemcpy(resultDev.data(), d_bufs[op], kSizeBytes, hipMemcpyDeviceToHost));
+    const int* resultHost = static_cast<const int*>(h_bufs[op]);
+    for (size_t i = 0; i < kNumElements; i++) {
+      INFO("op=" << op << " dev[" << i << "]=" << resultDev[i] << " (expected " << kHostVals[op]
+                 << ")");
+      REQUIRE(resultDev[i] == kHostVals[op]);
+      INFO("op=" << op << " host[" << i << "]=" << resultHost[i] << " (expected " << kHostVals[op]
+                 << ")");
+      REQUIRE(resultHost[i] == kHostVals[op]);
+    }
+  }
+
+  for (size_t op = 0; op < kNumOps; ++op) {
+    HIP_CHECK(hipHostFree(slots[op]));
+    HIP_CHECK(hipFree(d_bufs[op]));
+    HIP_CHECK(hipHostFree(h_bufs[op]));
+  }
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+#endif
+
 /**
  * End doxygen group MemoryTest.
  * @}

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -1608,6 +1608,222 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_MultiOp) {
   }
   HIP_CHECK(hipStreamDestroy(stream));
 }
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies dual-sided indirect (hipMemcpyFlagExtOpIndirectSrc |
+ *   hipMemcpyFlagExtOpIndirectDst) where BOTH the source and destination are
+ *   pinned pointer-holders. The real source is a pinned host buffer and the real
+ *   destination is a device buffer; the kernel dereferences both holders
+ *   on-device (indirect_mode == 3). After the copy the real device destination
+ *   must hold the pattern and the real host source must be unchanged (copy, not
+ *   swap).
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrcDst) {
+  constexpr size_t copy_size = kSmallCopySize;
+  const size_t copy_elements = copy_size / sizeof(int);
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipHostMalloc, copy_size);  // real source (host)
+  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);      // real dest (device)
+  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  std::fill_n(src.host_ptr(), copy_elements, kPatternValue);
+
+  void* src_ptr = src.ptr();
+  void* dst_ptr = dst.ptr();
+  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
+  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
+
+  std::vector<void*> dst_ptrs{dst_slot.ptr()};
+  std::vector<void*> src_ptrs{src_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {},
+                           hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("dual-sided indirect is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    // Verify the REAL device destination, not the holder.
+    std::vector<void*> real_dst_ptrs{dst.ptr()};
+    VerifyDeviceBuffers(real_dst_ptrs, copy_size, kPatternValue, /*add_index*/ false);
+    // Copy, not swap: the real host source must be unchanged.
+    VerifyArrayFromBothEnds(src.host_ptr(), copy_elements, kPatternValue, 0);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies dual-sided indirect with both real buffers on the device (D->D).
+ *   This exercises the case the H<->D holder narrowing previously made
+ *   unreachable: both holders are pinned host allocations (equal memory type),
+ *   but the real buffers behind them are both device buffers. After the copy the
+ *   real device destination must hold the pattern and the real device source must
+ *   be unchanged.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrcDst_D2D) {
+  constexpr size_t copy_size = kSmallCopySize;
+  const size_t copy_elements = copy_size / sizeof(int);
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, copy_size);  // real source (device)
+  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);  // real dest (device)
+  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  std::vector<int> host_pattern(copy_elements, kPatternValue);
+  HIP_CHECK(hipMemcpy(src.ptr(), host_pattern.data(), copy_size, hipMemcpyHostToDevice));
+
+  void* src_ptr = src.ptr();
+  void* dst_ptr = dst.ptr();
+  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
+  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
+
+  std::vector<void*> dst_ptrs{dst_slot.ptr()};
+  std::vector<void*> src_ptrs{src_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {},
+                           hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("dual-sided indirect is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    std::vector<void*> real_dst_ptrs{dst.ptr()};
+    std::vector<void*> real_src_ptrs{src.ptr()};
+    VerifyDeviceBuffers(real_dst_ptrs, copy_size, kPatternValue, /*add_index*/ false);
+    VerifyDeviceBuffers(real_src_ptrs, copy_size, kPatternValue, /*add_index*/ false);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Parameterized dual-sided indirect (H->D) copy correctness over mismatched
+ *   src/dst byte offsets and two transfer sizes that straddle the
+ *   GPU_FORCE_BLIT_INDIRECT_SIZE threshold. BOTH the source and destination are
+ *   pinned pointer-holders; the offset is baked into the REAL address stored
+ *   behind each holder. The device destination region must equal the host fill,
+ *   the device padding must be unchanged, and the host source must be unchanged
+ *   (copy, not swap).
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Indirect_SrcDst_UnalignedMatrix) {
+  constexpr uint8_t kHostFill = 0xAA;
+  constexpr uint8_t kDevFill = 0xBB;
+  constexpr size_t kPad = 64;
+
+  const std::pair<size_t, size_t> off =
+      GENERATE(std::make_pair(size_t{0}, size_t{0}), std::make_pair(size_t{4}, size_t{4}),
+               std::make_pair(size_t{0}, size_t{15}), std::make_pair(size_t{1}, size_t{15}),
+               std::make_pair(size_t{3}, size_t{11}), std::make_pair(size_t{3}, size_t{9}),
+               std::make_pair(size_t{1}, size_t{0}), std::make_pair(size_t{8}, size_t{8}),
+               std::make_pair(size_t{2}, size_t{2}));
+  const size_t size = GENERATE(size_t{4096}, size_t{65536});
+  const size_t src_off = off.first;
+  const size_t dst_off = off.second;
+
+  INFO("src_off=" << src_off << " dst_off=" << dst_off << " size=" << size);
+
+  void* h_base = nullptr;
+  void* d_base = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_base, size + kPad));
+  HIP_CHECK(hipMalloc(&d_base, size + kPad));
+
+  std::memset(h_base, kHostFill, size + kPad);
+  HIP_CHECK(hipMemset(d_base, kDevFill, size + kPad));
+
+  // Bake each offset into the REAL address stored behind its holder.
+  void* real_src = static_cast<uint8_t*>(h_base) + src_off;
+  void* real_dst = static_cast<uint8_t*>(d_base) + dst_off;
+
+  void* src_slot = nullptr;
+  void* dst_slot = nullptr;
+  HIP_CHECK(hipHostMalloc(&src_slot, sizeof(void*)));
+  HIP_CHECK(hipHostMalloc(&dst_slot, sizeof(void*)));
+  std::memcpy(src_slot, &real_src, sizeof(void*));
+  std::memcpy(dst_slot, &real_dst, sizeof(void*));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {dst_slot};
+  void* srcs[] = {src_slot};
+  size_t sizes[] = {size};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1, &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipHostFree(src_slot));
+    HIP_CHECK(hipHostFree(dst_slot));
+    HIP_CHECK(hipFree(d_base));
+    HIP_CHECK(hipHostFree(h_base));
+    SUCCEED("dual-sided indirect is not supported on this device");
+    return;
+  }
+  HIP_CHECK(err);
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Copy the full device buffer back so padding can be verified too.
+  std::vector<uint8_t> devResult(size + kPad);
+  HIP_CHECK(hipMemcpy(devResult.data(), d_base, size + kPad, hipMemcpyDeviceToHost));
+  const uint8_t* hostResult = static_cast<const uint8_t*>(h_base);
+
+  for (size_t i = 0; i < size + kPad; i++) {
+    const bool in_dev_region = (i >= dst_off) && (i < dst_off + size);
+    const uint8_t expected_dev = in_dev_region ? kHostFill : kDevFill;
+    INFO("dev byte " << i << " (region=" << in_dev_region
+                     << ") = " << static_cast<int>(devResult[i]) << " expected "
+                     << static_cast<int>(expected_dev));
+    REQUIRE(devResult[i] == expected_dev);
+
+    // This is a copy, not a swap: the host source must be entirely unchanged.
+    INFO("host byte " << i << " = " << static_cast<int>(hostResult[i]) << " expected "
+                      << static_cast<int>(kHostFill));
+    REQUIRE(hostResult[i] == kHostFill);
+  }
+
+  HIP_CHECK(hipFree(d_base));
+  HIP_CHECK(hipHostFree(h_base));
+  HIP_CHECK(hipHostFree(src_slot));
+  HIP_CHECK(hipHostFree(dst_slot));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
 #endif
 
 /**

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -181,8 +181,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Multicast_Large) {
 
 static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size_in_bytes,
                                    int device_for_src, int device_for_dst) {
-  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
-  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
+  const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
   const hipError_t expected_error =
       getIndirectExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipMalloc, device_for_src,
                                 device_for_dst, device_for_dst);
@@ -194,13 +194,13 @@ static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size
                               LinearAllocs::hipMalloc, device_for_src, device_for_dst);
 
   for (size_t i = 0; i < count; ++i) {
-    if (indirect_src) {
+    if (is_indirect_src) {
       HIP_CHECK(hipSetDevice(device_for_src));
       buffers.batch_src_ptrs[i] =
           addPointerSlot(buffers.slots, buffers.src_ptrs[i], LinearAllocs::hipMalloc);
     }
 
-    if (indirect_dst) {
+    if (is_indirect_dst) {
       HIP_CHECK(hipSetDevice(device_for_dst));
       buffers.batch_dst_ptrs[i] =
           addPointerSlot(buffers.slots, buffers.dst_ptrs[i], LinearAllocs::hipMalloc);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -183,9 +183,10 @@ static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size
                                    int device_for_src, int device_for_dst) {
   const bool is_indirect_src = flags & hipMemcpyFlagExtOpIndirectSrc;
   const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
+  const bool is_dual_sided_indirect = is_indirect_src && is_indirect_dst;
   const hipError_t expected_error =
       getIndirectExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipMalloc, device_for_src,
-                                device_for_dst);
+                                device_for_dst, is_dual_sided_indirect);
 
   EnablePeerAccess({{device_for_dst, device_for_src}});
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -178,4 +178,101 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Multicast_Large) {
 
   RunMulticastCopyP2pTest(count, size_in_bytes, 0, 1);
 }
+
+// Cross-GPU batch whose entries reach their buffers through a pointer slot on the sides selected by
+// `flags`. Each slot is allocated on the device holding the buffer it references, so an indirect
+// side keeps the peer-to-peer pairing of the direct copy it replaces. Peer access is enabled from
+// `device_for_dst` to `device_for_src`; the stream is created on `device_for_dst`.
+static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size_in_bytes,
+                                   int device_for_src, int device_for_dst) {
+  const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
+  const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
+  const hipError_t expected_error =
+      getIndirectExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipMalloc, device_for_src,
+                                device_for_dst, /*stream_device=*/device_for_dst);
+
+  std::vector<std::vector<unsigned char>> initial_values;
+  std::vector<void*> src_ptrs(count);
+  std::vector<void*> dst_ptrs(count);
+  std::vector<void*> batch_src_ptrs(count);
+  std::vector<void*> batch_dst_ptrs(count);
+  std::vector<LinearAllocGuard<unsigned char>> allocations;
+  std::vector<LinearAllocGuard<void*>> slots;
+
+  EnablePeerAccess({{device_for_dst, device_for_src}});
+
+  HIP_CHECK(hipSetDevice(device_for_dst));
+  StreamGuard stream_guard(Streams::created);
+
+  for (size_t i = 0; i < count; ++i) {
+    initial_values.emplace_back(size_in_bytes, static_cast<unsigned char>(10 + i));
+
+    HIP_CHECK(hipSetDevice(device_for_src));
+    LinearAllocGuard<unsigned char> src_alloc(LinearAllocs::hipMalloc, size_in_bytes);
+    src_ptrs[i] = src_alloc.ptr();
+    allocations.push_back(std::move(src_alloc));
+    fillBuffer(src_ptrs[i], initial_values[i], LinearAllocs::hipMalloc);
+    batch_src_ptrs[i] = src_ptrs[i];
+
+    if (indirect_src) {
+      batch_src_ptrs[i] = addPointerSlot(slots, src_ptrs[i], LinearAllocs::hipMalloc);
+    }
+
+    HIP_CHECK(hipSetDevice(device_for_dst));
+    LinearAllocGuard<unsigned char> dst_alloc(LinearAllocs::hipMalloc, size_in_bytes);
+    dst_ptrs[i] = dst_alloc.ptr();
+    allocations.push_back(std::move(dst_alloc));
+    HIP_CHECK(hipMemset(dst_ptrs[i], 0, size_in_bytes));
+    batch_dst_ptrs[i] = dst_ptrs[i];
+
+    if (indirect_dst) {
+      batch_dst_ptrs[i] = addPointerSlot(slots, dst_ptrs[i], LinearAllocs::hipMalloc);
+    }
+  }
+
+  HIP_CHECK(hipSetDevice(device_for_dst));
+  std::vector<size_t> sizes(count, size_in_bytes);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
+  size_t attrs_idxs[1] = {0};
+
+  HIP_CHECK_ERROR(
+      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
+                          attrs_idxs, 1, nullptr, stream_guard.stream()),
+      expected_error);
+
+  if (expected_error == hipSuccess) {
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    for (size_t i = 0; i < count; ++i) {
+      requireBufferEquals(dst_ptrs[i], initial_values[i], LinearAllocs::hipMalloc);
+    }
+  }
+
+  DisablePeerAccess({{device_for_dst, device_for_src}});
+}
+
+/**
+ * Cross-GPU batched copy that reaches its buffers through pointer slots, on the peer GPU for an
+ * indirect source and on the local GPU for an indirect destination.
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_IndirectCopy) {
+  if (HipTest::getDeviceCount() < 2) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+  }
+
+  int can_access_peer = 0;
+  HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 1, 0));
+
+  if (!can_access_peer) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+  }
+
+  const unsigned int flags =
+      GENERATE(as<unsigned int>{}, hipMemcpyFlagExtOpIndirectSrc, hipMemcpyFlagExtOpIndirectDst,
+               hipMemcpyFlagExtOpIndirectSrc | hipMemcpyFlagExtOpIndirectDst);
+  const size_t count = GENERATE(1, 3, 8);
+  const size_t size_in_bytes = GENERATE(as<size_t>{}, 1, 63, 4096);
+  CAPTURE(flags, count, size_in_bytes);
+
+  RunIndirectCopyP2pTest(flags, count, size_in_bytes, 0, 1);
+}
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -179,71 +179,49 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Multicast_Large) {
   RunMulticastCopyP2pTest(count, size_in_bytes, 0, 1);
 }
 
-// Cross-GPU batch whose entries reach their buffers through a pointer slot on the sides selected by
-// `flags`. Each slot is allocated on the device holding the buffer it references, so an indirect
-// side keeps the peer-to-peer pairing of the direct copy it replaces. Peer access is enabled from
-// `device_for_dst` to `device_for_src`; the stream is created on `device_for_dst`.
 static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size_in_bytes,
                                    int device_for_src, int device_for_dst) {
   const bool indirect_src = (flags & hipMemcpyFlagExtOpIndirectSrc) != 0;
   const bool indirect_dst = (flags & hipMemcpyFlagExtOpIndirectDst) != 0;
   const hipError_t expected_error =
       getIndirectExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipMalloc, device_for_src,
-                                device_for_dst, /*stream_device=*/device_for_dst);
-
-  std::vector<std::vector<unsigned char>> initial_values;
-  std::vector<void*> src_ptrs(count);
-  std::vector<void*> dst_ptrs(count);
-  std::vector<void*> batch_src_ptrs(count);
-  std::vector<void*> batch_dst_ptrs(count);
-  std::vector<LinearAllocGuard<unsigned char>> allocations;
-  std::vector<LinearAllocGuard<void*>> slots;
+                                device_for_dst, device_for_dst);
 
   EnablePeerAccess({{device_for_dst, device_for_src}});
 
-  HIP_CHECK(hipSetDevice(device_for_dst));
-  StreamGuard stream_guard(Streams::created);
+  IndirectCopyBuffers buffers =
+      makeIndirectCopyBuffers(count, size_in_bytes, LinearAllocs::hipMalloc,
+                              LinearAllocs::hipMalloc, device_for_src, device_for_dst);
 
   for (size_t i = 0; i < count; ++i) {
-    initial_values.emplace_back(size_in_bytes, static_cast<unsigned char>(10 + i));
-
-    HIP_CHECK(hipSetDevice(device_for_src));
-    LinearAllocGuard<unsigned char> src_alloc(LinearAllocs::hipMalloc, size_in_bytes);
-    src_ptrs[i] = src_alloc.ptr();
-    allocations.push_back(std::move(src_alloc));
-    fillBuffer(src_ptrs[i], initial_values[i], LinearAllocs::hipMalloc);
-    batch_src_ptrs[i] = src_ptrs[i];
-
     if (indirect_src) {
-      batch_src_ptrs[i] = addPointerSlot(slots, src_ptrs[i], LinearAllocs::hipMalloc);
+      HIP_CHECK(hipSetDevice(device_for_src));
+      buffers.batch_src_ptrs[i] =
+          addPointerSlot(buffers.slots, buffers.src_ptrs[i], LinearAllocs::hipMalloc);
     }
 
-    HIP_CHECK(hipSetDevice(device_for_dst));
-    LinearAllocGuard<unsigned char> dst_alloc(LinearAllocs::hipMalloc, size_in_bytes);
-    dst_ptrs[i] = dst_alloc.ptr();
-    allocations.push_back(std::move(dst_alloc));
-    HIP_CHECK(hipMemset(dst_ptrs[i], 0, size_in_bytes));
-    batch_dst_ptrs[i] = dst_ptrs[i];
-
     if (indirect_dst) {
-      batch_dst_ptrs[i] = addPointerSlot(slots, dst_ptrs[i], LinearAllocs::hipMalloc);
+      HIP_CHECK(hipSetDevice(device_for_dst));
+      buffers.batch_dst_ptrs[i] =
+          addPointerSlot(buffers.slots, buffers.dst_ptrs[i], LinearAllocs::hipMalloc);
     }
   }
 
   HIP_CHECK(hipSetDevice(device_for_dst));
+  StreamGuard stream_guard(Streams::created);
   std::vector<size_t> sizes(count, size_in_bytes);
   hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flags};
   size_t attrs_idxs[1] = {0};
 
-  HIP_CHECK_ERROR(
-      hipMemcpyBatchAsync(batch_dst_ptrs.data(), batch_src_ptrs.data(), sizes.data(), count, &attr,
-                          attrs_idxs, 1, nullptr, stream_guard.stream()),
-      expected_error);
+  HIP_CHECK_ERROR(hipMemcpyBatchAsync(buffers.batch_dst_ptrs.data(), buffers.batch_src_ptrs.data(),
+                                      sizes.data(), count, &attr, attrs_idxs, 1, nullptr,
+                                      stream_guard.stream()),
+                  expected_error);
 
   if (expected_error == hipSuccess) {
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
     for (size_t i = 0; i < count; ++i) {
-      requireBufferEquals(dst_ptrs[i], initial_values[i], LinearAllocs::hipMalloc);
+      requireBufferEquals(buffers.dst_ptrs[i], buffers.initial_values[i], LinearAllocs::hipMalloc);
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -185,7 +185,7 @@ static void RunIndirectCopyP2pTest(unsigned int flags, size_t count, size_t size
   const bool is_indirect_dst = flags & hipMemcpyFlagExtOpIndirectDst;
   const hipError_t expected_error =
       getIndirectExpectedReturn(LinearAllocs::hipMalloc, LinearAllocs::hipMalloc, device_for_src,
-                                device_for_dst, device_for_dst);
+                                device_for_dst);
 
   EnablePeerAccess({{device_for_dst, device_for_src}});
 

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -124,11 +124,13 @@ inline void DisablePeerAccess(const std::vector<std::pair<int, int>>& peer_pairs
   }
 }
 
-// Every ExtOp flag rides the SDMA batch path, which only carries transfers between device memory
-// and pinned host memory, plus peer device-to-device copies. Pageable memory, host-to-host and
-// same-device device-to-device pairings are rejected before the architecture is consulted.
+// Every ExtOp flag rides the batch path, which only carries transfers between device memory and
+// pinned host memory, plus peer device-to-device copies. Pageable memory and host-to-host pairings
+// are always rejected. Same-device device-to-device is rejected for swap and single-sided indirect
+// (both narrow to host<->device), but dual-sided indirect carries it through the indirect blit path.
 inline bool extOpPairingSupported(const LinearAllocs alloc_type_a, const LinearAllocs alloc_type_b,
-                                  const bool is_p2p) {
+                                  const bool is_p2p,
+                                  const bool is_dual_sided_indirect = false) {
   if (alloc_type_a == LinearAllocs::malloc || alloc_type_b == LinearAllocs::malloc) {
     return false;
   }
@@ -138,7 +140,7 @@ inline bool extOpPairingSupported(const LinearAllocs alloc_type_a, const LinearA
   }
 
   if (alloc_type_a == LinearAllocs::hipMalloc && alloc_type_b == LinearAllocs::hipMalloc &&
-      !is_p2p) {
+      !is_p2p && !is_dual_sided_indirect) {
     return false;
   }
 
@@ -174,10 +176,11 @@ inline hipError_t getSwapExpectedReturn(const LinearAllocs alloc_type_a,
 
 inline hipError_t getIndirectExpectedReturn(const LinearAllocs alloc_type_src,
                                             const LinearAllocs alloc_type_dst,
-                                            const int device_src = 0, const int device_dst = 0) {
+                                            const int device_src = 0, const int device_dst = 0,
+                                            const bool is_dual_sided_indirect = false) {
   const bool is_p2p = device_src != device_dst;
 
-  if (!extOpPairingSupported(alloc_type_src, alloc_type_dst, is_p2p)) {
+  if (!extOpPairingSupported(alloc_type_src, alloc_type_dst, is_p2p, is_dual_sided_indirect)) {
     return hipErrorNotSupported;
   }
 

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -40,6 +40,22 @@ inline void requireBufferEquals(const void* buffer, const std::vector<unsigned c
   REQUIRE(diff.first == host_out.end());
 }
 
+// Allocate the pointer slot that an indirect copy dereferences to reach `target`, keep it alive in
+// `slots` and return the slot address to hand to hipMemcpyBatchAsync in place of `target`.
+inline void* addPointerSlot(std::vector<LinearAllocGuard<void*>>& slots, void* target,
+                            const LinearAllocs alloc_type) {
+  LinearAllocGuard<void*> slot(alloc_type, sizeof(void*));
+  void* slot_ptr = slot.ptr();
+
+  // The contents of a slot are the address it holds, so the bytes written are the object
+  // representation of `target` rather than a payload the caller supplies.
+  const auto* address = reinterpret_cast<const unsigned char*>(&target);
+  fillBuffer(slot_ptr, std::vector<unsigned char>(address, address + sizeof(void*)), alloc_type);
+
+  slots.push_back(std::move(slot));
+  return slot_ptr;
+}
+
 // Enable peer access from the first device of each pair to the second. Tolerates pairs whose peer
 // access is already enabled so tests can share device state without failing.
 inline void EnablePeerAccess(const std::vector<std::pair<int, int>>& peer_pairs) {
@@ -59,23 +75,36 @@ inline void DisablePeerAccess(const std::vector<std::pair<int, int>>& peer_pairs
   }
 }
 
-// A swap exchanges both endpoints, so the two sides are symmetric and named a/b rather than src/dst.
-inline hipError_t getSwapExpectedReturn(const LinearAllocs allocTypeA, const LinearAllocs allocTypeB,
-                                        const int deviceA = 0, const int deviceB = 0) {
+// Every ExtOp flag rides the SDMA batch path, which only carries transfers between device memory
+// and pinned host memory, plus peer device-to-device copies. Pageable memory, host-to-host and
+// same-device device-to-device pairings are rejected before the architecture is consulted.
+inline bool extOpPairingSupported(const LinearAllocs alloc_type_a, const LinearAllocs alloc_type_b,
+                                  const bool is_p2p) {
+  if (alloc_type_a == LinearAllocs::malloc || alloc_type_b == LinearAllocs::malloc) {
+    return false;
+  }
+
+  if (alloc_type_a == LinearAllocs::hipHostMalloc && alloc_type_b == LinearAllocs::hipHostMalloc) {
+    return false;
+  }
+
+  if (alloc_type_a == LinearAllocs::hipMalloc && alloc_type_b == LinearAllocs::hipMalloc &&
+      !is_p2p) {
+    return false;
+  }
+
+  return true;
+}
+
+// A swap exchanges both endpoints, so the two sides are symmetric and named a/b rather than
+// src/dst.
+inline hipError_t getSwapExpectedReturn(const LinearAllocs alloc_type_a,
+                                        const LinearAllocs alloc_type_b, const int device_a = 0,
+                                        const int device_b = 0) {
   // The swap endpoints are peer-to-peer when they live on different devices.
-  const bool is_p2p = deviceA != deviceB;
+  const bool is_p2p = device_a != device_b;
 
-  // Support for H2H will be implemented later.
-  if (allocTypeA == LinearAllocs::malloc || allocTypeB == LinearAllocs::malloc) {
-    return hipErrorNotSupported;
-  }
-
-  if (allocTypeA == LinearAllocs::hipHostMalloc && allocTypeB == LinearAllocs::hipHostMalloc) {
-    return hipErrorNotSupported;
-  }
-
-  // Support for D2D will be implemented later.
-  if (allocTypeA == LinearAllocs::hipMalloc && allocTypeB == LinearAllocs::hipMalloc && !is_p2p) {
+  if (!extOpPairingSupported(alloc_type_a, alloc_type_b, is_p2p)) {
     return hipErrorNotSupported;
   }
 
@@ -87,9 +116,31 @@ inline hipError_t getSwapExpectedReturn(const LinearAllocs allocTypeA, const Lin
     return (major == 9 && minor >= 4) || (major == 12 && minor >= 5);
   };
 
-  if (supportsSwap(deviceA) && supportsSwap(deviceB)) {
+  if (supportsSwap(device_a) && supportsSwap(device_b)) {
     return hipSuccess;
   }
 
   return hipErrorNotSupported;
+}
+
+// An indirect copy is classified from the pointers handed to hipMemcpyBatchAsync, so the allocation
+// types below are those of the pointer slot on an indirect side and of the buffer on a direct side.
+// Only the device of the stream the batch is enqueued on decides indirect support, so a peer copy
+// whose buffers live elsewhere still follows `stream_device`.
+inline hipError_t getIndirectExpectedReturn(const LinearAllocs alloc_type_src,
+                                            const LinearAllocs alloc_type_dst,
+                                            const int device_src = 0, const int device_dst = 0,
+                                            const int stream_device = 0) {
+  const bool is_p2p = device_src != device_dst;
+
+  if (!extOpPairingSupported(alloc_type_src, alloc_type_dst, is_p2p)) {
+    return hipErrorNotSupported;
+  }
+
+  // Mirrors CLR's sdma_indirect_supported_ check (rocclr/device/rocm/rocsettings.cpp), which is
+  // gfx1250 only. Keep in sync if CLR adds architectures.
+  int major, minor;
+  HIP_CHECK(hipDeviceComputeCapability(&major, &minor, stream_device));
+
+  return (major == 12 && minor == 5) ? hipSuccess : hipErrorNotSupported;
 }

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -172,10 +172,6 @@ inline hipError_t getSwapExpectedReturn(const LinearAllocs alloc_type_a,
   return hipErrorNotSupported;
 }
 
-// An indirect copy is classified from the pointers handed to hipMemcpyBatchAsync, so the allocation
-// types below are those of the pointer slot on an indirect side and of the buffer on a direct side.
-// Only the device of the stream the batch is enqueued on decides indirect support, so a peer copy
-// whose buffers live elsewhere still follows `stream_device`.
 inline hipError_t getIndirectExpectedReturn(const LinearAllocs alloc_type_src,
                                             const LinearAllocs alloc_type_dst,
                                             const int device_src = 0, const int device_dst = 0,

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -174,18 +174,12 @@ inline hipError_t getSwapExpectedReturn(const LinearAllocs alloc_type_a,
 
 inline hipError_t getIndirectExpectedReturn(const LinearAllocs alloc_type_src,
                                             const LinearAllocs alloc_type_dst,
-                                            const int device_src = 0, const int device_dst = 0,
-                                            const int stream_device = 0) {
+                                            const int device_src = 0, const int device_dst = 0) {
   const bool is_p2p = device_src != device_dst;
 
   if (!extOpPairingSupported(alloc_type_src, alloc_type_dst, is_p2p)) {
     return hipErrorNotSupported;
   }
 
-  // Mirrors CLR's sdma_indirect_supported_ check (rocclr/device/rocm/rocsettings.cpp), which is
-  // gfx1250 only. Keep in sync if CLR adds architectures.
-  int major, minor;
-  HIP_CHECK(hipDeviceComputeCapability(&major, &minor, stream_device));
-
-  return (major == 12 && minor == 5) ? hipSuccess : hipErrorNotSupported;
+  return hipSuccess;
 }

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -40,6 +40,16 @@ inline void requireBufferEquals(const void* buffer, const std::vector<unsigned c
   REQUIRE(diff.first == host_out.end());
 }
 
+// Allocate a buffer holding `contents`, keep it alive in `allocations` and return its address.
+inline void* addBuffer(std::vector<LinearAllocGuard<unsigned char>>& allocations,
+                       const std::vector<unsigned char>& contents, const LinearAllocs alloc_type) {
+  LinearAllocGuard<unsigned char> alloc(alloc_type, contents.size());
+  void* ptr = alloc.ptr();
+  allocations.push_back(std::move(alloc));
+  fillBuffer(ptr, contents, alloc_type);
+  return ptr;
+}
+
 // Allocate the pointer slot that an indirect copy dereferences to reach `target`, keep it alive in
 // `slots` and return the slot address to hand to hipMemcpyBatchAsync in place of `target`.
 inline void* addPointerSlot(std::vector<LinearAllocGuard<void*>>& slots, void* target,
@@ -47,13 +57,52 @@ inline void* addPointerSlot(std::vector<LinearAllocGuard<void*>>& slots, void* t
   LinearAllocGuard<void*> slot(alloc_type, sizeof(void*));
   void* slot_ptr = slot.ptr();
 
-  // The contents of a slot are the address it holds, so the bytes written are the object
-  // representation of `target` rather than a payload the caller supplies.
   const auto* address = reinterpret_cast<const unsigned char*>(&target);
   fillBuffer(slot_ptr, std::vector<unsigned char>(address, address + sizeof(void*)), alloc_type);
 
   slots.push_back(std::move(slot));
   return slot_ptr;
+}
+
+// Buffers and pointer arrays for one indirect-copy batch.
+struct IndirectCopyBuffers {
+  // The buffers the copies must read from and write to. Destinations start zeroed.
+  std::vector<void*> src_ptrs;
+  std::vector<void*> dst_ptrs;
+  // The pointers hipMemcpyBatchAsync receives.
+  std::vector<void*> batch_src_ptrs;
+  std::vector<void*> batch_dst_ptrs;
+  // The pattern written to the src.
+  std::vector<std::vector<unsigned char>> initial_values;
+  // Keeps the source and destination buffers alive.
+  std::vector<LinearAllocGuard<unsigned char>> allocations;
+  // Keeps alive the slots the caller took from addPointerSlot.
+  std::vector<LinearAllocGuard<void*>> slots;
+};
+
+// Allocate and initialize `count` source and destination buffers.
+inline IndirectCopyBuffers makeIndirectCopyBuffers(const size_t count, const size_t size_in_bytes,
+                                                   const LinearAllocs alloc_type_src,
+                                                   const LinearAllocs alloc_type_dst,
+                                                   const int device_src = 0,
+                                                   const int device_dst = 0) {
+  const std::vector<unsigned char> zeros(size_in_bytes, 0);
+  IndirectCopyBuffers buffers;
+
+  for (size_t i = 0; i < count; ++i) {
+    buffers.initial_values.emplace_back(size_in_bytes, static_cast<unsigned char>(10 + i));
+
+    HIP_CHECK(hipSetDevice(device_src));
+    buffers.src_ptrs.push_back(
+        addBuffer(buffers.allocations, buffers.initial_values.back(), alloc_type_src));
+
+    HIP_CHECK(hipSetDevice(device_dst));
+    buffers.dst_ptrs.push_back(addBuffer(buffers.allocations, zeros, alloc_type_dst));
+  }
+
+  buffers.batch_src_ptrs = buffers.src_ptrs;
+  buffers.batch_dst_ptrs = buffers.dst_ptrs;
+  return buffers;
 }
 
 // Enable peer access from the first device of each pair to the second. Tolerates pairs whose peer


### PR DESCRIPTION
## Motivation

Adds the indirect blit kernel

## Technical Details

Adds __amd_rocclr_copyBufferBatchIndirect to the blit kernels, this is used for unaligned and small memory copies.

## Issue Tracking

JIRA ID: ROCM-27454

## Test Plan

Added additional testing, specifically alignment tests

## Test Result

Pass locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
