### PR TITLE
[RCCL] JIRA ID AICOMRCCL-1900 Fix P2P alltoall hang when p2pnChannelsPerPeer exceeds kernel-args budget

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1335,6 +1335,20 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, comm->p2pnChannels);
   }
 
+  // A P2P plan emits one work batch per channel (nChannelsMax == p2pnChannelsPerPeer)
+  // and those batches must live inside the kernel-args region. If p2pnChannelsPerPeer
+  // exceeds what the args budget can hold, scheduleP2pTasksToPlan() can never satisfy
+  // ncclTestBudget() for even a single op, so it returns without draining any task and
+  // ncclLaunchPrepare() spins forever (observed as a hang on small-rank alltoall when
+  // MAXCHANNELS is large). Clamp to the args-bytes limit, keeping a power of two so the
+  // device-side ncclP2pChannelToPart inverse stays valid.
+  {
+    size_t argsBytes = std::min<size_t>(ncclParamWorkArgsBytes(), ncclMaxKernelArgsSize(comm->cudaArch));
+    int maxArgsChannels = pow2Down(ncclDevMaxChannelsForArgsBytes(argsBytes));
+    if (maxArgsChannels < 1) maxArgsChannels = 1;
+    comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, maxArgsChannels);
+  }
+
   // Init channels that weren't used so far
   for (int c = comm->nChannels; c < std::max(comm->nChannels, comm->p2pnChannels); c++) NCCLCHECK(initChannel(comm, c));
 


### PR DESCRIPTION
## Motivation

Fix ncclAlltoAllv hangs on gfx950 after gfx1250 merge

## Technical Details

A P2P plan emits one work batch per channel (nChannelsMax == p2pnChannelsPerPeer), and those batches must fit inside the kernel-args region. On large-MAXCHANNELS builds (e.g. gfx950, MAXCHANNELS=512) with small rank counts, ncclTopoComputeP2pChannels could leave p2pnChannelsPerPeer larger than ncclDevMaxChannelsForArgsBytes(). In that case scheduleP2pTasksToPlan() never satisfies ncclTestBudget() for even a single op, returns without draining any task, and ncclLaunchPrepare() spins forever creating empty plans (observed as a hang in the AlltoAllv unit tests at SP/1-rank).

Clamp p2pnChannelsPerPeer to the args-bytes limit (kept a power of two so the device-side ncclP2pChannelToPart inverse stays valid). The general path previously lacked this cap that the Rome branch already applied.

## Issue Tracking

AICOMRCCL-1900

## Test Plan

Run alltoallv UT

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
