### PR TITLE
feat(clr): occupancy-aware concurrent cooperative grid.sync dispatch

### DIFF
--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -480,6 +480,23 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
     return hipErrorOutOfMemory;
   }
 
+  // Record device-wide coop capacity (same value the static check uses) so the device layer can
+  // gate the AQL barrier bit on in-flight occupancy (see submitKernel).
+  if (params & amd::NDRangeKernelCommand::CooperativeGroups) {
+    const amd::Device& device = stream->vdev()->device();
+    int num_blocks = 0;
+    int max_blocks_per_grid = 0;
+    int best_block_size = 0;
+    const int block_size = static_cast<int>(launch_params.local_.product());
+    if (block_size > 0 &&
+        hip_impl::ihipOccupancyMaxActiveBlocksPerMultiprocessor(
+            &num_blocks, &max_blocks_per_grid, &best_block_size, device, f, block_size,
+            launch_params.sharedMemBytes_, false) == hipSuccess &&
+        max_blocks_per_grid > 0) {
+      kernelCommand->setCoopMaxGridBlocks(static_cast<uint32_t>(max_blocks_per_grid));
+    }
+  }
+
   command = kernelCommand;
 
   return hipSuccess;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1430,7 +1430,14 @@ AqlSlotReservation VirtualGPU::ReserveAqlSlots(size_t packet_count) {
 
 // ================================================================================================
 void VirtualGPU::OptimizeStreamOrderingBarrier(
-    uint16_t& header, const AqlSlotReservation& reservation) const {
+    uint16_t& header, const AqlSlotReservation& reservation) {
+  // Coop dispatch (ordering rides the completion-signal chain): clear the bit only if this grid
+  // fits alongside the in-flight coop grids, else keep it so it waits for them to retire.
+  if (coop_concurrent_dispatch_) {
+    if (coopAdmitFits(coop_pending_fraction_)) header &= ~kBarrierBit;
+    return;
+  }
+
   if (!roc_device_.settings().aql_barrier_opt_) {
     return;
   }
@@ -1465,6 +1472,33 @@ void VirtualGPU::RecordAqlPacketHeader(const AqlSlotReservation& reservation,
 // ================================================================================================
 void VirtualGPU::CompleteAqlSubmission(const AqlSlotReservation& reservation) {
   last_aql_packet_slot_ = reservation.start_slot + reservation.packet_count - 1;
+}
+
+// ================================================================================================
+bool VirtualGPU::coopAdmitFits(double grid_fraction) {
+  // Prune retired grids (signal drained to <= 0), summing the fraction still resident.
+  double in_flight = 0.0;
+  for (auto it = coop_inflight_.begin(); it != coop_inflight_.end();) {
+    if (Hsa::signal_load_relaxed(it->first->signal_) <= 0) {
+      it->first->release();
+      it = coop_inflight_.erase(it);
+    } else {
+      in_flight += it->second;
+      ++it;
+    }
+  }
+  // Epsilon admits exact fits (e.g. 1/2+1/2); in_flight counts only unretired grids, so it never
+  // over-subscribes -- co-resident coop grids always reach grid.sync (no deadlock).
+  return (in_flight + grid_fraction <= 1.0 + 1e-6);
+}
+
+// ================================================================================================
+void VirtualGPU::coopTrackInflight(double grid_fraction) {
+  ProfilingSignal* sig = Barriers().GetLastSignal();
+  if (sig != nullptr) {
+    sig->retain();  // block ring reuse so we can poll it for retirement
+    coop_inflight_.emplace_back(sig, grid_fraction);
+  }
 }
 
 // ================================================================================================
@@ -5091,18 +5125,45 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
       static_cast<KernelBlitManager&>(queue->blitMgr()).RunGwsInit(workgroups - 1);
     }
 
-    // Sync AQL packets
+    // Reuse the barrier-bit-opt gate (aql_barrier_opt_). Overlap only on SW grid.sync ASICs
+    // (!gwsInitSupported_), where the coop queue need not be held exclusive.
+    const bool coop_concurrent =
+        dev().settings().aql_barrier_opt_ && !dev().settings().gwsInitSupported_;
+
+    // grid_fraction = blocks/capacity (1.0 if unknown -> serialize); coopAdmitFits polls it at
+    // ring-reservation time under the coop blit lock (no atomics needed).
+    double grid_fraction = 1.0;
+    if (coop_concurrent) {
+      const uint32_t capacity = vcmd.coopMaxGridBlocks();
+      grid_fraction =
+          (capacity > 0) ? static_cast<double>(vcmd.numWorkgroups()) / capacity : 1.0;
+      queue->coop_pending_fraction_ = grid_fraction;
+      queue->coop_concurrent_dispatch_ = true;
+    }
+
+    // Standard barrier header; OptimizeStreamOrderingBarrier decides the bit.
     queue->setAqlHeader(dispatchPacketHeader_);
 
-    // Submit kernel to HW
+    // attach_signal makes the dispatch carry its own completion signal (the fence's return-dep role).
     if (!queue->submitKernelInternal(vcmd.sizes(), vcmd.kernel(), vcmd.parameters(),
                                      static_cast<void*>(as_cl(&vcmd.event())),
-                                     vcmd.sharedMemBytes(), &vcmd)) {
+                                     vcmd.sharedMemBytes(), &vcmd, nullptr,
+                                     /*attach_signal=*/coop_concurrent)) {
       LogError("AQL dispatch failed!");
       vcmd.setStatus(CL_INVALID_OPERATION);
     }
-    // Wait for the execution on the device queue. Keep the current queue in-order
-    queue->releaseGpuMemoryFence(kSkipCpuWait);
+    // Clear the marker so the fence/dependency packets below take the normal ordering path.
+    queue->coop_concurrent_dispatch_ = false;
+    // Skip the post-dispatch fence when concurrent: ordering rides the completion-signal chain and
+    // visibility the consumer's terminal fence; its only other effect was serializing the next grid.
+    if (!coop_concurrent) {
+      queue->releaseGpuMemoryFence(kSkipCpuWait);
+    }
+
+    // Record this grid as in-flight so later dispatches gate on the occupancy it holds.
+    if (coop_concurrent) {
+      queue->coopTrackInflight(grid_fraction);
+    }
 
     // Add a dependency into the current queue on the coop queue
     Barriers().AddExternalSignal(queue->Barriers().GetLastSignal());

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -758,9 +758,16 @@ class VirtualGPU : public device::VirtualDevice {
   //! Snapshot shared barrier state before atomically reserving AQL queue slots.
   AqlSlotReservation ReserveAqlSlots(size_t packet_count);
 
-  //! Clear a caller-requested barrier when prior queue state already preserves stream ordering.
-  void OptimizeStreamOrderingBarrier(uint16_t& header,
-                                     const AqlSlotReservation& reservation) const;
+  //! Clear a caller-requested barrier when prior queue state already preserves stream ordering,
+  //! or when the dispatch is coop-concurrent (ordering carried by the completion-signal chain).
+  void OptimizeStreamOrderingBarrier(uint16_t& header, const AqlSlotReservation& reservation);
+
+  //! Occupancy-aware coop gate; hold the coop queue's blit lock. Prune retired grids and return
+  //! whether this grid fits alongside the in-flight coop ones. Called at ring-reservation time.
+  bool coopAdmitFits(double grid_fraction);
+  //! Retain this dispatch's completion signal as in-flight; call right after the coop dispatch so
+  //! GetLastSignal() is this grid's signal.
+  void coopTrackInflight(double grid_fraction);
 
   //! Record a final packet header in the shared HW-queue barrier state.
   void RecordAqlPacketHeader(const AqlSlotReservation& reservation, size_t packet_offset,
@@ -899,6 +906,14 @@ class VirtualGPU : public device::VirtualDevice {
   std::shared_ptr<std::atomic<uint64_t>> largest_aql_barrier_bit_slot_;
   //! Final AQL slot submitted by this stream, or kInvalidAqlSlot before its first packet.
   uint64_t last_aql_packet_slot_ = kInvalidAqlSlot;
+  //! In-flight coop grids (retained completion signal, occupancy fraction); retaining the signal
+  //! blocks ring reuse so its value stays pollable until the grid retires. Guarded by the blit lock.
+  std::vector<std::pair<ProfilingSignal*, double>> coop_inflight_;
+  //! Occupancy fraction of the coop grid being dispatched; coopAdmitFits reads it at reservation time.
+  double coop_pending_fraction_ = 1.0;
+  //! Set only for the duration of a coop-concurrent kernel dispatch so OptimizeStreamOrderingBarrier
+  //! takes the occupancy-gated path; reset right after submit so later packets use the normal path.
+  bool coop_concurrent_dispatch_ = false;
   alignas(64) hsa_barrier_and_packet_t barrier_packet_ {};
   alignas(64) hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1488,6 +1488,9 @@ class NDRangeKernelCommand : public Command {
   uint64_t allGridSum_;      //!< A sum of all grids in multi GPU launch
   uint32_t firstDevice_;     //!< Device index of the first device in the gridc
   uint32_t numWorkgroups_;   //!< Total number of workgroups in the current launch
+  //! Device-wide max co-resident blocks for a coop launch (0=unknown). Set at construction (before
+  //! enqueue) and read at submit (after dequeue), so the queue handoff already publishes it.
+  uint32_t coopMaxGridBlocks_ = 0;
   DynDataPrefetchConfig dynDataPrefetchConfig_;  //!< Dynamic data prefetch configuration
 
  public:
@@ -1557,6 +1560,10 @@ class NDRangeKernelCommand : public Command {
   uint64_t firstDevice() const { return firstDevice_; }
 
   uint32_t numWorkgroups() const { return numWorkgroups_; }
+
+  //! Device-wide capacity (max co-resident blocks) for this cooperative launch; 0 if unknown.
+  uint32_t coopMaxGridBlocks() const { return coopMaxGridBlocks_; }
+  void setCoopMaxGridBlocks(uint32_t blocks) { coopMaxGridBlocks_ = blocks; }
 
   const DynDataPrefetchConfig& dynDataPrefetchConfig() const { return dynDataPrefetchConfig_; }
   void setDynDataPrefetchConfig(const DynDataPrefetchConfig& cfg) { dynDataPrefetchConfig_ = cfg; }

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -291,7 +291,7 @@ release(uint, DEBUG_CLR_AQL_DEV_QUEUE, 0,                                     \
         "(1=enabled, 0=force system mem (default))")                          \
 release(uint, DEBUG_CLR_USE_MOVDIR64B, 1,                                     \
         "Use MOVDIR64B full-packet writes for AQL + metadata rings"           \
-        "(1=enabled (default), 0=non-temporal store path)")                   \
+        "(1=enabled (default), 0=non-temporal store path)")
 
 namespace amd {
 

--- a/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
@@ -103,6 +103,37 @@ cooperativeGrps:
   Unit_hipLaunchCooperativeKernel_Basic:
     <<: *level_2
     tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_Correctness:
+    <<: *level_2
+    # Concurrent cooperative grids sized near occupancy; ASAN shrinks occupancy
+    # which can prevent co-residency and deadlock grid.sync().
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering:
+    <<: *level_2
+    # Same-stream coop dispatch chain sized near occupancy; ASAN shrinks occupancy.
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_EqualGrids:
+    <<: *level_2
+    # Equal coop grids sized near occupancy; ASAN shrinks occupancy.
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_Oversubscription:
+    <<: *level_2
+    # Oversubscribed coop grids; ASAN shrinks occupancy and can deadlock grid.sync().
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_QueuedConcurrency:
+    <<: *level_2
+    # Three coop grids past capacity; ASAN shrinks occupancy and can deadlock grid.sync().
+    disabled: [asan]
+    tags: [cooperative, launch]
+  Unit_ConcurrentCooperativeKernel_GridSync_MixedRegularCoop:
+    <<: *level_2
+    # Mixed regular/coop chain sized near occupancy; ASAN shrinks occupancy.
+    disabled: [asan]
+    tags: [cooperative, launch]
   Unit_hipLaunchCooperativeKernelMultiDevice_Basic:
     <<: *level_2
     # Kernel uses runtime sized shared memory which is not adjusted to handle ASAN extra memory requirements

--- a/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SRC
   cg_ballot.cc
   cg_any_all.cc
   split_barrier.cc
+  concurrent_grid_sync.cc
 )
 
 set(AMD_TEST_SRC 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/concurrent_grid_sync.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/concurrent_grid_sync.cc
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Coop concurrency tests: grid.sync() stays correct across streams under fits, oversubscription,
+// queued admission, same-stream chaining, and regular/coop mixing. Correctness asserted; overlap INFO.
+
+#include <hip_test_common.hh>
+#include <hip/hip_cooperative_groups.h>
+
+#include <chrono>
+
+namespace cg = cooperative_groups;
+
+static constexpr size_t kBufferLen = 1024 * 1024;
+
+// Grid-wide reduction that calls grid.sync() twice per iteration; the iteration
+// loop lengthens the kernel so concurrent overlap (when enabled) is measurable.
+__global__ void reduce_grid_sync(const int* buf, size_t n, unsigned long long* partial,
+                                 unsigned long long* result, int iters) {
+  extern __shared__ unsigned long long sm[];
+
+  cg::thread_block tb = cg::this_thread_block();
+  cg::grid_group gg = cg::this_grid();
+
+  const auto tid = gg.thread_rank();
+  const auto stride = gg.size();
+  const auto local_tid = tb.thread_rank();
+  const auto block_size = tb.size();
+  const auto grid_blocks = gridDim.x;
+
+  for (int it = 0; it < iters; ++it) {
+    unsigned long long sum = 0;
+    for (size_t i = tid; i < n; i += stride) {
+      sum += buf[i];
+    }
+    sm[local_tid] = sum;
+    tb.sync();
+
+    if (local_tid == 0) {
+      unsigned long long block_sum = 0;
+      for (unsigned int t = 0; t < block_size; ++t) {
+        block_sum += sm[t];
+      }
+      partial[blockIdx.x] = block_sum;
+    }
+    gg.sync();
+
+    if (tid == 0) {
+      unsigned long long total = 0;
+      for (unsigned int b = 0; b < grid_blocks; ++b) {
+        total += partial[b];
+      }
+      *result = total;
+    }
+    gg.sync();
+  }
+}
+
+namespace {
+
+struct CoopWork {
+  int* buf_d = nullptr;
+  unsigned long long* partial_d = nullptr;
+  unsigned long long* result_h = nullptr;  // pinned host buffer
+  unsigned long long* result_d = nullptr;  // device-visible alias of result_h
+  hipStream_t stream = nullptr;
+  dim3 grid;
+  dim3 block;
+  size_t shmem = 0;
+};
+
+void SetupWork(CoopWork& w, const int* host_buf, size_t buffer_bytes, dim3 grid, dim3 block) {
+  w.grid = grid;
+  w.block = block;
+  w.shmem = block.x * sizeof(unsigned long long);
+  HIP_CHECK(hipMalloc(&w.buf_d, buffer_bytes));
+  HIP_CHECK(hipMemcpy(w.buf_d, host_buf, buffer_bytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMalloc(&w.partial_d, grid.x * sizeof(unsigned long long)));
+  HIP_CHECK(hipHostMalloc(&w.result_h, sizeof(unsigned long long)));
+  *w.result_h = 0;
+  HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&w.result_d), w.result_h, 0));
+  HIP_CHECK(hipStreamCreate(&w.stream));
+}
+
+void LaunchWork(CoopWork& w, int iters) {
+  size_t n = kBufferLen;
+  void* params[5] = {&w.buf_d, &n, &w.partial_d, &w.result_d, &iters};
+  HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(reduce_grid_sync), w.grid, w.block,
+                                       params, w.shmem, w.stream));
+}
+
+void TeardownWork(CoopWork& w) {
+  HIP_CHECK(hipStreamDestroy(w.stream));
+  HIP_CHECK(hipHostFree(w.result_h));
+  HIP_CHECK(hipFree(w.partial_d));
+  HIP_CHECK(hipFree(w.buf_d));
+}
+
+}  // namespace
+
+// Two cooperative grids on two streams, launched back to back before either is
+// synchronized. Verifies grid.sync() correctness under concurrent submission.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_Correctness) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t buffer_bytes = kBufferLen * sizeof(int);
+  std::vector<int> host_buf(kBufferLen);
+  for (size_t i = 0; i < kBufferLen; ++i) {
+    host_buf[i] = static_cast<int>(i);
+  }
+  const unsigned long long expected =
+      (static_cast<unsigned long long>(kBufferLen) * (kBufferLen - 1)) / 2;
+
+  const uint32_t block_x = GENERATE(64u, 128u, 256u);
+  const dim3 block(block_x);
+
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_cu, reduce_grid_sync, block.x, block.x * sizeof(unsigned long long)));
+  REQUIRE(blocks_per_cu > 0);
+
+  // Two DIFFERENT grid sizes (full/4, full/2) that together fit in cooperative
+  // occupancy, so each grid.sync() must use its own workgroup count.
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const uint32_t grid0_blocks = static_cast<uint32_t>(std::max(1, full_blocks / 4));
+  const uint32_t grid1_blocks = std::min(
+      static_cast<uint32_t>(full_blocks),
+      std::max(grid0_blocks + 1u, static_cast<uint32_t>(full_blocks / 2)));
+  const dim3 grid0(grid0_blocks);
+  const dim3 grid1(grid1_blocks);
+  REQUIRE((grid0.x != grid1.x || full_blocks <= 1));
+
+  const int iters = 4;
+
+  INFO("block=" << block.x << " grid0=" << grid0.x << " grid1=" << grid1.x
+                << " (full coop grid=" << full_blocks << ") iters=" << iters);
+
+  CoopWork w0, w1;
+  SetupWork(w0, host_buf.data(), buffer_bytes, grid0, block);
+  SetupWork(w1, host_buf.data(), buffer_bytes, grid1, block);
+
+  // Launch both before synchronizing so the runtime is free to overlap them.
+  const auto t_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_concurrent =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  // Informational: serialized baseline for the same total work.
+  *w0.result_h = 0;
+  *w1.result_h = 0;
+  const auto s_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_serial =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - s_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  INFO("concurrent=" << t_concurrent << "ms serialized=" << t_serial << "ms speedup="
+                     << (t_concurrent > 0.0 ? t_serial / t_concurrent : 0.0) << "x");
+  WARN("concurrent=" << t_concurrent << "ms serialized=" << t_serial << "ms speedup="
+                     << (t_concurrent > 0.0 ? t_serial / t_concurrent : 0.0)
+                     << "x (overlap requires DEBUG_CLR_AQL_BARRIER_OPT=1 on SW grid.sync ASICs)");
+
+  TeardownWork(w0);
+  TeardownWork(w1);
+}
+
+// Two EQUAL coop grids (full/4 each, co-reside). Equal durations -> ~2x overlap ceiling (vs ~1.5x
+// for the unequal 1/4+1/2 case). Correctness asserted; speedup INFO only.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_EqualGrids) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t buffer_bytes = kBufferLen * sizeof(int);
+  std::vector<int> host_buf(kBufferLen);
+  for (size_t i = 0; i < kBufferLen; ++i) {
+    host_buf[i] = static_cast<int>(i);
+  }
+  const unsigned long long expected =
+      (static_cast<unsigned long long>(kBufferLen) * (kBufferLen - 1)) / 2;
+
+  const uint32_t block_x = GENERATE(64u, 128u, 256u);
+  const dim3 block(block_x);
+
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_cu, reduce_grid_sync, block.x, block.x * sizeof(unsigned long long)));
+  REQUIRE(blocks_per_cu > 0);
+
+  // Two identical grids at full/4; combined half of capacity so they co-reside.
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const uint32_t grid_blocks = static_cast<uint32_t>(std::max(1, full_blocks / 4));
+  const dim3 grid(grid_blocks);
+
+  const int iters = 4;
+
+  INFO("block=" << block.x << " grid0=grid1=" << grid.x
+                << " (full coop grid=" << full_blocks << ") iters=" << iters);
+
+  CoopWork w0, w1;
+  SetupWork(w0, host_buf.data(), buffer_bytes, grid, block);
+  SetupWork(w1, host_buf.data(), buffer_bytes, grid, block);
+
+  const auto t_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_concurrent =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  *w0.result_h = 0;
+  *w1.result_h = 0;
+  const auto s_start = std::chrono::steady_clock::now();
+  LaunchWork(w0, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  const auto t_serial =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - s_start).count();
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  WARN("equal-grid concurrent=" << t_concurrent << "ms serialized=" << t_serial << "ms speedup="
+                                << (t_concurrent > 0.0 ? t_serial / t_concurrent : 0.0)
+                                << "x (equal grids -> ~2x ceiling; requires DEBUG_CLR_AQL_BARRIER_OPT=1)");
+
+  TeardownWork(w0);
+  TeardownWork(w1);
+}
+
+// Two coop grids that oversubscribe capacity (~3/4 each). The gate must keep the second's barrier
+// bit so it waits (partial admission would deadlock grid.sync). Completing with correct sums proves it.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_Oversubscription) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t buffer_bytes = kBufferLen * sizeof(int);
+  std::vector<int> host_buf(kBufferLen);
+  for (size_t i = 0; i < kBufferLen; ++i) {
+    host_buf[i] = static_cast<int>(i);
+  }
+  const unsigned long long expected =
+      (static_cast<unsigned long long>(kBufferLen) * (kBufferLen - 1)) / 2;
+
+  const dim3 block(128);
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_cu, reduce_grid_sync, block.x, block.x * sizeof(unsigned long long)));
+  REQUIRE(blocks_per_cu > 0);
+
+  // Each grid ~3/4 of full coop occupancy: individually launchable, but together ~1.5x
+  // capacity so they cannot be co-resident.
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const uint32_t grid_blocks = static_cast<uint32_t>(std::max(1, (full_blocks * 3) / 4));
+  const dim3 grid(grid_blocks);
+  const int iters = 4;
+
+  INFO("block=" << block.x << " grid=" << grid.x << " (full coop grid=" << full_blocks
+                << ") aggregate=" << (2.0 * grid.x / std::max(1, full_blocks)) << "x iters=" << iters);
+
+  CoopWork w0, w1;
+  SetupWork(w0, host_buf.data(), buffer_bytes, grid, block);
+  SetupWork(w1, host_buf.data(), buffer_bytes, grid, block);
+
+  // Both launched before any sync. Must complete (no deadlock) with correct results.
+  LaunchWork(w0, iters);
+  LaunchWork(w1, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+
+  TeardownWork(w0);
+  TeardownWork(w1);
+}
+
+// Three coop grids at ~50/25/30% (105% aggregate) on three streams: first two co-reside, the
+// third queues until room frees. All finish with correct sums (no partial-admission deadlock).
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_QueuedConcurrency) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  const size_t buffer_bytes = kBufferLen * sizeof(int);
+  std::vector<int> host_buf(kBufferLen);
+  for (size_t i = 0; i < kBufferLen; ++i) {
+    host_buf[i] = static_cast<int>(i);
+  }
+  const unsigned long long expected =
+      (static_cast<unsigned long long>(kBufferLen) * (kBufferLen - 1)) / 2;
+
+  const dim3 block(128);
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_cu, reduce_grid_sync, block.x, block.x * sizeof(unsigned long long)));
+  REQUIRE(blocks_per_cu > 0);
+
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const uint32_t g0 = static_cast<uint32_t>(std::max(1, (full_blocks * 50) / 100));
+  const uint32_t g1 = static_cast<uint32_t>(std::max(1, (full_blocks * 25) / 100));
+  const uint32_t g2 = static_cast<uint32_t>(std::max(1, (full_blocks * 30) / 100));
+  const int iters = 4;
+
+  INFO("full coop grid=" << full_blocks << " g0=" << g0 << " g1=" << g1 << " g2=" << g2
+                         << " aggregate=" << (1.0 * (g0 + g1 + g2) / std::max(1, full_blocks))
+                         << "x iters=" << iters);
+
+  CoopWork w0, w1, w2;
+  SetupWork(w0, host_buf.data(), buffer_bytes, dim3(g0), block);
+  SetupWork(w1, host_buf.data(), buffer_bytes, dim3(g1), block);
+  SetupWork(w2, host_buf.data(), buffer_bytes, dim3(g2), block);
+
+  LaunchWork(w0, iters);
+  LaunchWork(w1, iters);
+  LaunchWork(w2, iters);
+  HIP_CHECK(hipStreamSynchronize(w0.stream));
+  HIP_CHECK(hipStreamSynchronize(w1.stream));
+  HIP_CHECK(hipStreamSynchronize(w2.stream));
+
+  CHECK(*w0.result_h == expected);
+  CHECK(*w1.result_h == expected);
+  CHECK(*w2.result_h == expected);
+
+  TeardownWork(w0);
+  TeardownWork(w1);
+  TeardownWork(w2);
+}
+
+// Read-modify-write accumulate with a grid.sync() each iteration. Correct only if
+// no other grid touches the same elements concurrently.
+__global__ void accumulate_grid_sync(unsigned long long* data, size_t n, int iters) {
+  cg::grid_group gg = cg::this_grid();
+  const auto tid = gg.thread_rank();
+  const auto stride = gg.size();
+  for (int it = 0; it < iters; ++it) {
+    for (size_t i = tid; i < n; i += stride) {
+      data[i] = data[i] + 1ull;  // non-atomic on purpose: races if grids overlap
+    }
+    gg.sync();
+  }
+}
+
+// Same-stream chain of coop dispatches must stay ordered (each sees prior writes).
+// Relaxed ordering would race the RMW and drop updates, failing the exact-sum check.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_SameStreamOrdering) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  size_t n = 256 * 1024;
+  const dim3 block(128);
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_cu, accumulate_grid_sync,
+                                                         block.x, 0));
+  REQUIRE(blocks_per_cu > 0);
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const dim3 grid(static_cast<uint32_t>(std::max(1, full_blocks / 2)));
+
+  unsigned long long* data_d = nullptr;
+  HIP_CHECK(hipMalloc(&data_d, n * sizeof(unsigned long long)));
+  HIP_CHECK(hipMemset(data_d, 0, n * sizeof(unsigned long long)));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  const int kLaunches = 8;
+  int iters = 8;
+  for (int l = 0; l < kLaunches; ++l) {
+    void* params[3] = {&data_d, &n, &iters};
+    HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(accumulate_grid_sync), grid, block,
+                                         params, 0, stream));
+  }
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  std::vector<unsigned long long> data_h(n);
+  HIP_CHECK(hipMemcpy(data_h.data(), data_d, n * sizeof(unsigned long long), hipMemcpyDeviceToHost));
+
+  const unsigned long long expected =
+      static_cast<unsigned long long>(kLaunches) * static_cast<unsigned long long>(iters);
+  size_t mismatches = 0;
+  for (size_t i = 0; i < n; ++i) {
+    if (data_h[i] != expected) ++mismatches;
+  }
+  INFO("grid=" << grid.x << " launches=" << kLaunches << " iters=" << iters
+               << " expected=" << expected << " mismatches=" << mismatches);
+  CHECK(mismatches == 0);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(data_d));
+}
+
+// Plain (non-cooperative) kernel that adds a constant to every element.
+__global__ void increment_regular(unsigned long long* data, size_t n, unsigned long long add) {
+  size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t stride = static_cast<size_t>(gridDim.x) * blockDim.x;
+  for (size_t i = tid; i < n; i += stride) {
+    data[i] += add;
+  }
+}
+
+// One stream mixing regular(+1) -> coop(+iters) -> regular(+1). Order must hold both ways across the
+// coop boundary (completion-signal chain carries the return dep now the fence is skipped); else wrong sum.
+HIP_TEST_CASE(Unit_ConcurrentCooperativeKernel_GridSync_MixedRegularCoop) {
+  int device = 0;
+  HIP_CHECK(hipGetDevice(&device));
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  if (!props.cooperativeLaunch) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
+  }
+
+  size_t n = 256 * 1024;
+  const dim3 block(128);
+  int blocks_per_cu = 0;
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_cu, accumulate_grid_sync,
+                                                         block.x, 0));
+  REQUIRE(blocks_per_cu > 0);
+  const int full_blocks = props.multiProcessorCount * blocks_per_cu;
+  const dim3 coop_grid(static_cast<uint32_t>(std::max(1, full_blocks / 2)));
+  const dim3 reg_block(256);
+  const dim3 reg_grid(256);
+
+  unsigned long long* data_d = nullptr;
+  HIP_CHECK(hipMalloc(&data_d, n * sizeof(unsigned long long)));
+  HIP_CHECK(hipMemset(data_d, 0, n * sizeof(unsigned long long)));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  const int kRounds = 4;
+  int iters = 4;
+  for (int r = 0; r < kRounds; ++r) {
+    hipLaunchKernelGGL(increment_regular, reg_grid, reg_block, 0, stream, data_d, n, 1ull);
+    void* params[3] = {&data_d, &n, &iters};
+    HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(accumulate_grid_sync), coop_grid,
+                                         block, params, 0, stream));
+    hipLaunchKernelGGL(increment_regular, reg_grid, reg_block, 0, stream, data_d, n, 1ull);
+  }
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  std::vector<unsigned long long> data_h(n);
+  HIP_CHECK(hipMemcpy(data_h.data(), data_d, n * sizeof(unsigned long long), hipMemcpyDeviceToHost));
+
+  // Each round adds 1 (regular) + iters (coop) + 1 (regular).
+  const unsigned long long expected =
+      static_cast<unsigned long long>(kRounds) * (2ull + static_cast<unsigned long long>(iters));
+  size_t mismatches = 0;
+  for (size_t i = 0; i < n; ++i) {
+    if (data_h[i] != expected) ++mismatches;
+  }
+  INFO("coop_grid=" << coop_grid.x << " rounds=" << kRounds << " iters=" << iters
+                    << " expected=" << expected << " mismatches=" << mismatches);
+  CHECK(mismatches == 0);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(data_d));
+}


### PR DESCRIPTION
## Motivation
Independent cooperative-group dispatches (kernels calling `grid.sync()`) were
always serialized on the cooperative queue, even when they were independent and
the device had spare occupancy. This forces otherwise-overlappable grids to run
back-to-back. This change lets such grids overlap when occupancy permits, so
co-resident coop grids fill each other's synchronization idle bubbles.

## Technical Details

Builds on the merged AQL barrier-bit optimization (#9895) and reuses its
`DEBUG_CLR_AQL_BARRIER_OPT` flag — no new knob. Engages only on
software-`grid.sync` ASICs, where the cooperative queue need not be exclusive.

- Each coop grid carries an occupancy fraction = `blocks / device coop capacity`
  (capacity from the launch-time occupancy calc; unknown → 1.0 → serialize).
- At ring-reservation time the runtime prunes retired grids, sums the fractions
  still resident, and clears the AQL barrier bit only when
  `in_flight + grid_fraction <= 1.0`; grids that don't fit keep the bit and wait.
- Never over-subscribes, so every co-resident grid is guaranteed to reach
  `grid.sync()` — no deadlock. Admission is all-or-nothing.
- Ordering rides each dispatch's completion signal and visibility the consumer's
  acquire fence, so the post-dispatch serializing fence is skipped in the
  concurrent path. In-flight bookkeeping is single-threaded (one coop queue
  under its lock), so no atomics are needed.

## Test Plan

- coopGrpTest.
- Run the new cooperative-concurrency cases with `DEBUG_CLR_AQL_BARRIER_OPT=1`;
  assert correctness/ordering, report overlap as INFO.
- Re-run existing cooperative-grid tests with the flag on to check for regressions.

## Test Result

- coopGrpTest build: passed.
- Cooperative-concurrency cases (flag on): passed (6 cases).
- Existing cooperative-grid tests (flag on): no regression.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
