### PR TITLE
[RCCL]: Add baseline MPI test suite for QP sharing

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -464,6 +464,7 @@ set(SRC_FILES
   transport/net_ib/p2p_resiliency_recovery.h
   transport/net_ib/reg.cc
   transport/net_ib_cast/net_ib_cast_inspect.h
+  transport/net_ib_cast/net_ib_qp_sharing_inspect.h
   transport/net_ib_cast/net_ib_fault_inject.h
   transport/net_ib/gdaki/gin_host_gdaki.h
   transport/net_socket.cc

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(NET_IB_CAST_SOURCES
     src/transport/net_ib_limits.h
     src/transport/net_ib_cast/net_ib_cast_inspect.h
+    src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
     src/transport/net_ib_cast/net_ib_ops_fault.h
     src/transport/net_ib_cast/common_cast.h
     src/transport/net_ib_cast/connect_cast.h

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_QP_SHARING_INSPECT_H_
+#define RCCL_NET_IB_QP_SHARING_INSPECT_H_
+
+#include <stdint.h>
+#include "net_ib_limits.h"
+
+#ifdef __cplusplus
+#include "nccl.h"  /* ncclResult_t */
+extern "C" {
+#else
+#include "nccl.h"
+#endif
+
+/*
+ * Test-only introspection API for QP sharing (RCCL_IB_COMM_NGROUPS).
+ * Shared between librccl.so and the unit tests so the struct layout
+ * and signatures cannot diverge.
+ */
+
+struct ncclIbQpSharingState {
+  uint16_t commId;             /* 0 = not shared */
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;     /* -1 = not shared */
+  int      refcount;           /* comms sharing this physical QP (0 if not shared) */
+  int      cqRefcount;         /* comms sharing this group's CQ (0 if not shared) */
+  int      nqps;
+  uint32_t qpn[NCCL_IB_MAX_QPS];
+};
+
+/* Copy QP-sharing state out of a connected sendComm or recvComm.
+ * Returns ncclInvalidArgument on null pointers. */
+ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* RCCL_NET_IB_QP_SHARING_INSPECT_H_ */

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "qp_sharing.h"
+#include "net_ib_qp_sharing_inspect.h"
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -201,4 +202,46 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
         }
         g_IbCastSharedQpPool[i].used = false;
     }
+}
+
+// =============================================================================
+// Test introspection API — exposes internal QP-sharing pool state from a
+// sendComm/recvComm handle. Only intended for unit tests; not part of the
+// public net plugin ABI.
+// Struct definition and function prototype live in
+// src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h.
+// =============================================================================
+
+// ncclIbCastGetQpSharingState — copy QP-sharing pool state out of a comm.
+// comm must be a valid ncclIbSendComm*/ncclIbRecvComm* obtained from
+// IbCastConnect/IbCastAccept (base is the first member of both, so a bare
+// ncclIbNetCommBase* cast is safe regardless of direction).
+// Returns ncclInvalidArgument if comm or out is null.
+extern "C" ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out) {
+    if (!comm || !out) return ncclInvalidArgument;
+    struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+
+    out->commId = base->commId;
+    out->isSharedQpPrimary = base->isSharedQpPrimary;
+    out->sharedGroupIdx = base->sharedGroupIdx;
+    out->nqps = base->nqps;
+    out->refcount = 0;
+    out->cqRefcount = 0;
+
+    int n = (base->nqps < NCCL_IB_MAX_QPS) ? base->nqps : NCCL_IB_MAX_QPS;
+    for (int i = 0; i < n; i++) {
+        struct ncclIbQp* qp = base->activeQps[i];
+        out->qpn[i] = (qp && qp->qp) ? qp->qp->qp_num : 0;
+    }
+
+    if (base->sharedGroupIdx >= 0 && n > 0 && base->activeQps[0] && base->activeQps[0]->qp) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(base->activeQps[0]->qp->qp_num, base->isSend);
+        if (slot) {
+            out->refcount = slot->refcount;
+            out->cqRefcount = slot->cqRefcount;
+        }
+    }
+
+    return ncclSuccess;
 }

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -118,7 +118,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/gensrc # for rccl_bfloat16.h
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h, net_ib_qp_sharing_inspect.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
@@ -562,6 +562,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/OpsFaultUnitTests.cpp
       transport/GinMPI/GinMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
+      transport/NetIbMPI/QpSharingTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -161,6 +161,78 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "NCCL_DMABUF_ENABLE=1"
       - "RCCL_MPI_LOG_ALL_RANKS=1"
+  # The QP-sharing functional gate. The same five tests run at three values of
+  # RCCL_IB_COMM_NGROUPS: expectations are derived from ngroups by the reference
+  # model (test/transport/NetIbMPI/QpShareRefModel.hpp), so no test is pinned to
+  # a value and none skips outside one. RCCL_PARAM caches both tunables per
+  # process, which is why ngroups varies across categories rather than within a
+  # test. See test/transport/NetIbMPI/QpSharingTestGuide.md.
+  quick_env_qpshare_ngroups1:
+    description: "QP sharing gate, maximum concentration: NGROUPS=1 puts every connection in group 0, so the whole functional set runs on one shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling; measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement (the under-provisioned point is gated separately by quick_env_qpshare_undersized_depth)."
+    test_patterns: &qpshare_functional_tests
+      - "NetIbMPITest.QpShareAlgoLayoutSweep:NetIbMPITest.QpShareAlgoChurnLayout:NetIbMPITest.QpShareDataAllConnsTransfer:NetIbMPITest.QpShareDataUnsharedGroups:NetIbMPITest.QpShareDataFlushRouting"
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups2:
+    description: "QP sharing gate, smallest mixed configuration: NGROUPS=2 places a PRIMARY-only group beside a PRIMARY+SECONDARY group — the first point at which group-index arithmetic can be wrong without being invisible. Same five functional tests."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups16:
+    description: "QP sharing gate, wide configuration: at NGROUPS=16 the connection counts straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. Same five functional tests. Expected green, but INTERMITTENTLY CRASHES — measured 2 runs in 18 on AINIC (2026-08-17) — on a use-after-free in the group teardown path, so a signal-kill here is that known defect rather than a new regression. The qpshare_uaf_teardown category below reproduces the same bug deterministically and is the acceptance criterion for it; do not add a retry here to make this category look stable."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_undersized_depth:
+    description: "QP sharing under-provisioned point: NGROUPS=1 at the default depth multiplier (1), so 128 comms share a QP whose queues were sized for one. The invariant is unchanged — no (ngroups, depth, nconns) combination may fail to connect or corrupt a transfer; the transport is expected to size for the group or degrade to an unshared QP via the existing qp_sharing_skip_sender path in connect.cc. It does not do that today, so this category is EXPECTED RED: it is the acceptance criterion for the saturation-fallback fix, deliberately gating rather than disabled. Measured 2026-08-17 on AINIC: 112 comms/group at depth 1 is fine and 128 is not, hence the pinned count — the default counts elsewhere in the suite do not reach the ceiling. The break lands in the data phase (ibv_post_send ENOMEM) after every connection has established, so it is silent until traffic flows."
+    test_patterns:
+      - "NetIbMPITest.QpShareDataAllConnsTransfer"
+    exclude_windows: *mpi_exclude_windows
+    # Deliberately NOT *mpi_quick_labels: this category is expected red, and a
+    # permanently-red entry in the smoke/precheck gate gets muted, which is how
+    # an acceptance criterion quietly stops being one. Selectable and
+    # excludable via the qpshare_known_red label instead.
+    labels: &qpshare_known_red_labels
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "QPSHARE_TEST_NCONNS=128"
+  quick_env_qpshare_depth_ceiling:
+    description: "QP sharing depth-multiplier ceiling — the same missing capacity check from the opposite side. The multiplier is applied to the QP work-queue sizing as given, so a value the device cannot allocate kills the FIRST connection instead of being clamped to the device limit; nothing is shared yet at that point, so a saturation fallback would not help either. EXPECTED RED, acceptance criterion for clamping the multiplier. Root cause measured 2026-08-17 on AINIC: the shared CQ is sized 768 × NCCL_IB_QPS_PER_CONNECTION × RCCL_IB_QP_DEPTH_MULTIPLIER entries (connect.cc:949, :1730) and passed to ibv_create_cq unchecked against device_attr.max_cqe. Bisected against that device's max_cqe of 65435: qps × depth = 85 passes, 86 fails, on both the qps=1 and qps=2 paths, so the usable depth is floor(max_cqe / (768 × qps)) — 85 at QPS=1, 42 at the default QPS of 2. Both knobs are pinned here because they multiply into the same limit. The ceiling is hardware-dependent — on a NIC with a larger max_cqe this category passes until the multiplier is raised past floor(max_cqe / 768)."
+    test_patterns:
+      - "NetIbMPITest.QpShareDataAllConnsTransfer"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_known_red_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=96"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+      - "QPSHARE_TEST_NCONNS=2"
   standard:
     description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
@@ -347,6 +419,63 @@ test_categories:
       - "RCCL_LL128_FORCE_ENABLE=1"
       - "NCCL_PROTO=LL128"
       - "NCCL_ALGO=Tree"
+  # The stress tests are split across two categories on purpose. The ctest
+  # generator joins a category's test_patterns with ':' into ONE --gtest_filter,
+  # i.e. one process (shared/ctest/parse_test_categories.py, positive_string),
+  # and gtest runs registration order, not filter order. QpShareStressConnectionChurn
+  # leaves the process unusable, so any test registered after it in the same
+  # process never reports. Keeping churn in its own category is what makes the
+  # batch result observable at all -- do not merge these back together.
+  qpshare_stress:
+    description: "QP sharing stress, everything except connection churn: many-connection load, shared-RQ saturation, and batch create/destroy under sharing. Scale with QPSHARE_TEST_NCONNS and QPSHARE_TEST_ITERS; the defaults are what this category gates on. One EXPECTED RED. StressBatchCreateDestroy: one PD leaked in total (rank 0, before=1 after=2) at the default batch of 10. The leak rate is a function of live comms per group at teardown, not of RCCL_IB_COMM_NGROUPS directly: a protection-domain reference is taken per comm but released once per group, so the release only reaches zero -- and only then attempts the ibv_dealloc_pd that fails -- when a group held exactly one comm. QPSHARE_TEST_NCONNS=1 or 2 therefore leaks one PD per batch rather than one in total. Same underlying bug as qpshare_stress_churn, at its mildest rate."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressManyConns:NetIbMPITest.QpShareStressSharedRqSaturation:NetIbMPITest.QpShareStressBatchCreateDestroy"
+    exclude_windows: *mpi_exclude_windows
+    labels:
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  qpshare_stress_churn:
+    description: "QP sharing connection churn, isolated in its own category because it crashes the process. EXPECTED RED, kept as the acceptance criterion for the sharing-specific protection-domain leak. One comm is live at a time, so every earlier cycle was fully closed, yet one PD is leaked per cycle with a matching ibv_dealloc_pd() failure. On this device (max_pd=1024) connect then fails at iteration 1022 of 2048 with no diagnostic from the transport, and the following connect segfaults rather than failing cleanly. The iteration number is device-specific: it is max_pd, not a fixed constant. Not shared-QP pool exhaustion despite IBCAST_MAX_SHARED_QPS also being 1024 -- no 'pool full' WARN is ever emitted, and a full pool cannot fail a connect in the first place, since the NULL return from IbCastRegisterSharedQp is ignored at connect.cc:1109."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressConnectionChurn"
+    exclude_windows: *mpi_exclude_windows
+    labels:
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  # Deterministic form of the crash that hits quick_env_qpshare_ngroups16 about
+  # once in nine runs. Same test, same tunables; the only difference is
+  # MALLOC_PERTURB_=165, which tells glibc to overwrite freed heap with 0xa5 so
+  # the stale read faults instead of usually finding intact memory. Measured
+  # 2026-08-17 on AINIC: 6/6 crashes with the poison, 0/6 without it.
+  qpshare_uaf_teardown:
+    description: "QP sharing use-after-free in group teardown. EXPECTED RED, and it dies by signal rather than by a failed assertion — the process is gone before gtest can report. IbCastRegisterSharedQp stores &comm->devs[devIdx].base in the shared-QP pool slot (connect.cc:1105); IbCastCloseSend/IbCastCloseRecv free(comm) (connect.cc:2140/:2235); IbCastCleanupGroupCqs then reads primaryDevBase->ibDevN through that freed pointer (qp_sharing.cc:193) and locks IbCastDevs[ibDevN].mutex with the resulting index (:194). Backtrace: pthread_mutex_lock ← IbCastCleanupGroupCqs+0x248 ← IbCastCloseRecv+0x373. Acceptance criterion for storing ibDevN by value in the pool slot. When testing a fix, re-run two controls beside it: the same filter without MALLOC_PERTURB_ (must still pass) and non-sharing NetIb tests with the poison on (must be unaffected — they are today). MALLOC_PERTURB_ is a glibc feature and is inert elsewhere, so on a non-glibc platform this category degrades into a duplicate of quick_env_qpshare_ngroups16 and stops being a reliable gate."
+    test_patterns:
+      - "NetIbMPITest.QpShareAlgoChurnLayout"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_known_red_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+      - "MALLOC_PERTURB_=165"
 
 execution_settings:
   mpi_launch:
@@ -363,6 +492,11 @@ execution_settings:
     quick_env_net_graph_register: 1200
     quick_env_netib_xfer_trace: 1200
     quick_env_netib_xfer_log_ranks: 1200
+    quick_env_qpshare_ngroups1: 1200
+    quick_env_qpshare_ngroups2: 1200
+    quick_env_qpshare_ngroups16: 1200
+    quick_env_qpshare_undersized_depth: 1200
+    quick_env_qpshare_depth_ceiling: 1200
     standard: 1200
     comprehensive: 1200
     comprehensive_disable_env: 1200
@@ -374,3 +508,6 @@ execution_settings:
     full_pow2_tree_ll: 1200
     full_pow2_ring_ll128: 1200
     full_pow2_tree_ll128: 1200
+    qpshare_stress: 3600
+    qpshare_stress_churn: 3600
+    qpshare_uaf_teardown: 1200

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -11,6 +11,8 @@
 #include <hip/hip_runtime.h>
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "DeviceBufferHelpers.hpp"
@@ -83,6 +85,47 @@ using namespace RCCLTestHelpers;
                          << (long long)(min_us) << " us (current: " << _v << ")";        \
         }                                                                                \
     } while (0)
+
+// Skip a QP-sharing test when RCCL_IB_COMM_NGROUPS is absent/disabled, or when
+// a feature known to be mutually exclusive with sharing (resiliency, CAST
+// scheduler) is enabled alongside it. Must be called from the test body (not
+// a helper), because GTEST_SKIP() only interrupts execution when expanded
+// inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
+// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
+// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+//
+// NIC Fusion is deliberately NOT checked here: a merged device changes which
+// physical NIC a comm lands on, so a fused run is out of scope rather than
+// skippable, and the presets pin NCCL_IB_MERGE_NICS=0 / clear
+// NCCL_NET_FORCE_MERGE instead.
+#define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
+    do {                                                                                   \
+        const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
+        if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
+            GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
+                            "Use qpshare_* configs in net_ib_transport.json.";              \
+        }                                                                                   \
+        auto _qpshareIsSetTo1 = [](const char* name) {                                     \
+            const char* v = getenv(name);                                                  \
+            return v && v[0] && strcmp(v, "1") == 0;                                       \
+        };                                                                                  \
+        if (_qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_FAILOVER") ||                        \
+            _qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_RECOVERY")) {                         \
+            GTEST_SKIP() << "QP sharing tests do not support resiliency combos yet.";      \
+        }                                                                                   \
+        if (_qpshareIsSetTo1("RCCL_IB_QP_SCHED_ENABLE")) {                                 \
+            GTEST_SKIP() << "QP sharing tests do not support CAST scheduler combos yet.";  \
+        }                                                                                   \
+    } while (0)
+
+// There is deliberately no QPSHARE_REQUIRE_NGROUPS_*/QPSHARE_REQUIRE_DEPTH_*
+// family here. Guards of that shape skip a QP-sharing test precisely when the
+// parameters would break the transport, which hides the defect instead of
+// reporting it -- handling a badly-sized tunable (down to disabling sharing) is
+// the transport's responsibility, not the test's. Tests derive their expected
+// layout from RCCL_IB_COMM_NGROUPS via QpShareRefModel instead, so they are
+// valid at every value of both tunables. What a run did *not* manage to
+// exercise is reported by ReportQpShareCoverage(), not skipped.
 
 // External NET IB plugin
 extern ncclNet_t ncclNetIb;
@@ -202,6 +245,13 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
+
+    // ExpectQpShareLayout re-checks every live comm after every create and
+    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
+    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
+    // each TEST_F.
+    static constexpr int kMaxLayoutFailures = 40;
+    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -702,6 +752,208 @@ protected:
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
+    // Non-fatal, rank-agreed variant of SetupCastConnection.
+    //
+    // SetupCastConnection asserts on failure, and a gtest ASSERT_ inside a void
+    // helper only returns from the helper -- it skips the trailing
+    // MPI_Barrier, so the peer rank blocks there forever and the whole mpirun
+    // has to be killed by a timeout. That is unacceptable for a suite whose job
+    // is to explore parameter space: an under-provisioned (ngroups, depth,
+    // nconns) point must produce a clean FAILED, not a hang.
+    //
+    // Returns true only when BOTH ranks established their side (agreed via
+    // MPI_LAND, so the two ranks never disagree about whether the connection
+    // exists). On false, each rank has closed whatever it managed to open and
+    // all three out-params are left null, so the caller can stop cleanly.
+    bool TryCastConnection(int dev,
+                           void** listenComm, void** sendComm, void** recvComm) {
+        const int rank = MPIEnvironment::world_rank;
+        const int peer = 1 - rank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+        int ok = 1;
+
+        if (rank == 0) {
+            if (CreateListenComm(dev, &handle, listenComm) != ncclSuccess || *listenComm == nullptr)
+                ok = 0;
+            // Sent unconditionally: rank 1 is already blocked in MPI_Recv, and
+            // a zeroed handle makes its connect fail rather than hang.
+            MPI_Send(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *recvComm == nullptr; i++) {
+                if (AcceptConnection(*listenComm, recvComm) != ncclSuccess) ok = 0;
+                else if (*recvComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*recvComm == nullptr) ok = 0;
+        } else {
+            MPI_Recv(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *sendComm == nullptr; i++) {
+                if (ConnectToRemote(dev, &handle, sendComm) != ncclSuccess) ok = 0;
+                else if (*sendComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*sendComm == nullptr) ok = 0;
+        }
+
+        int bothOk = 0;
+        MPI_Allreduce(&ok, &bothOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        if (!bothOk) {
+            if (*recvComm)   { CloseRecvComm(*recvComm);     *recvComm   = nullptr; }
+            if (*listenComm) { CloseListenComm(*listenComm); *listenComm = nullptr; }
+            if (*sendComm)   { CloseSendComm(*sendComm);     *sendComm   = nullptr; }
+        }
+        return bothOk != 0;
+    }
+
+    // Close one cast connection with no memory handle and no barrier. Each rank
+    // holds only its own comms (rank 0: listen+recv, rank 1: send), so the null
+    // checks make this rank-conditional without a rank test. Non-fatal: a close
+    // failure must not strand the peer at the next barrier.
+    void CloseCastConnection(void* listenComm, void* sendComm, void* recvComm) {
+        if (recvComm)   EXPECT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        if (listenComm) EXPECT_EQ(CloseListenComm(listenComm), ncclSuccess);
+        if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+
+    // Highest refcount across the given comms: the sharing depth this run
+    // actually achieved. 1 means no QP ended up shared.
+    int MaxObservedSharingDepth(const std::vector<void*>& comms) {
+        int m = 0;
+        for (void* c : comms) {
+            if (c == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(c);
+            m = std::max(m, st.refcount);
+        }
+        return m;
+    }
+
+    // Report what a QP-sharing run actually exercised.
+    //
+    // Replaces the old "skip when ngroups >= nconns" guard: a configuration in
+    // which nothing ends up shared is a legitimate point to test (the data path
+    // must still work), but a green result from it must not be mistaken for
+    // evidence that sharing works. maxCommsPerGroup is the achieved sharing
+    // depth -- 1 means no QP was shared at all.
+    //
+    // Goes to stdout on rank 0 (visible in mpirun logs, greppable by
+    // tools/scripts/qpshare/qpshare_validate.sh) and into the gtest XML.
+    void ReportQpShareCoverage(const char* what, int nconns, int maxCommsPerGroup,
+                               int spread = -1) {
+        const int ng = QpShareEnvNGroups();
+        const int dm = QpShareEnvDepthMultiplier();
+        RecordProperty("qpshare_ngroups", ng);
+        RecordProperty("qpshare_depth_multiplier", dm);
+        RecordProperty("qpshare_nconns", nconns);
+        RecordProperty("qpshare_max_comms_per_group", maxCommsPerGroup);
+        if (spread >= 0) RecordProperty("qpshare_group_spread", spread);
+        if (MPIEnvironment::world_rank != 0) return;
+        printf("[QPSHARE-COV] %s ngroups=%d depth=%d nconns=%d max_comms_per_group=%d",
+               what, ng, dm, nconns, maxCommsPerGroup);
+        if (spread >= 0) printf(" group_spread=%d", spread);
+        if (maxCommsPerGroup <= 1)
+            printf("  (NO QP WAS SHARED -- unshared data path only)");
+        printf("\n");
+        fflush(stdout);
+    }
+
+    // Compare every live comm's actual sharing state against the reference
+    // model, including cross-comm QP identity: comms in the same group must sit
+    // on one physical QP, comms in different groups must not.
+    //
+    // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
+    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
+    // Non-fatal throughout, so a layout divergence is reported for every comm
+    // rather than only the first, and both ranks always reach the next barrier.
+    // Deliberately contains no ASSERT_* and no collective: callers invoke it
+    // between an MPI_Barrier and the next operation, and an ASSERT_* here would
+    // return from the caller's *helper*, not the test, skipping that barrier on
+    // one rank and converting a readable layout failure into a two-rank hang.
+    //
+    // Divergence reporting is capped (kMaxLayoutFailures). Callers re-check
+    // every live comm after every create and destroy, so a transport that gets
+    // the layout wrong from the first connection produces O(n^2) failures --
+    // ~10k lines at ngroups=32 -- and the first, most diagnostic one scrolls
+    // away. After the cap the checks stop and the test still fails, once.
+    void ExpectQpShareLayout(const std::vector<void*>& comms,
+                             const std::vector<QpShareRefModel::Placement>& places,
+                             const QpShareRefModel& model,
+                             const char* stage) {
+        EXPECT_EQ(comms.size(), places.size()) << stage;
+        if (comms.size() != places.size()) return;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
+        const int partsOnEntry = CurrentTestFailureParts();
+        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
+            const int g = places[i].group;
+
+            EXPECT_EQ(st.sharedGroupIdx, g)
+                << stage << ": conn " << i << " group mismatch";
+            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
+                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
+                << " (group " << g << ")";
+            EXPECT_EQ(st.refcount, model.Load(g))
+                << stage << ": conn " << i << " refcount does not match the "
+                << "number of live comms in group " << g;
+            // cqRefcount is a second, independent counter over the same set of
+            // comms: connect.cc increments refcount and cqRefcount together on
+            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
+            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
+            // They must therefore always agree. It is worth asserting
+            // separately because cqRefcount alone gates IbCastCleanupGroupCqs
+            // -- the release path that leaks a protection domain today (report
+            // ISSUE-3). A drift between the two would say which counter is
+            // wrong, which the PD leak by itself does not.
+            EXPECT_EQ(st.cqRefcount, st.refcount)
+                << stage << ": conn " << i << " in group " << g
+                << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                << st.refcount << ". These count the same comms and are"
+                << " maintained in lockstep; cqRefcount alone decides when the"
+                << " group's CQ and PD are released, so a drift here either"
+                << " frees a CQ that is still in use or never frees it.";
+            EXPECT_NE(st.commId, 0)
+                << stage << ": conn " << i << " has no commId -- it silently fell "
+                << "back off the sharing path";
+
+            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
+            auto it = groupQpn.find(g);
+            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
+            else EXPECT_EQ(st.qpn[0], it->second)
+                << stage << ": conn " << i << " is in group " << g
+                << " but not on that group's physical QP";
+        }
+        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
+            auto b = a;
+            for (++b; b != groupQpn.end(); ++b) {
+                EXPECT_NE(a->second, b->second)
+                    << stage << ": groups " << a->first << " and " << b->first
+                    << " unexpectedly share one physical QP";
+            }
+        }
+        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
+            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
+                   " further per-comm layout checks suppressed for this test."
+                   " The test still fails -- read the FIRST divergence above,"
+                   " not the last: every later one is downstream of it.\n",
+                   kMaxLayoutFailures, stage);
+            fflush(stdout);
+        }
+    }
+
+    // Failure records logged so far by the currently running test. Used as a
+    // cheap delta counter; gtest exposes no "did that block just fail" query.
+    static int CurrentTestFailureParts() {
+        const ::testing::TestInfo* info =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        if (info == nullptr || info->result() == nullptr) return 0;
+        const ::testing::TestResult* res = info->result();
+        int n = 0;
+        for (int i = 0; i < res->total_part_count(); i++)
+            if (res->GetTestPartResult(i).failed()) n++;
+        return n;
+    }
+
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.
     // Both ranks call this together. actualNqps is broadcast so rank 0 can coordinate.
     // buf/mhandle must already be registered against the caller's comm.
@@ -718,6 +970,16 @@ protected:
         MPI_Bcast(&nqps, 1, MPI_INT, 1, MPI_COMM_WORLD);
         EXPECT_GT(nqps, 0);
         return nqps;
+    }
+
+    // Read QP-sharing pool state directly from a connected sendComm/recvComm.
+    // Unlike GetActualNqps(), no warmup send/recv is required: PRIMARY/SECONDARY
+    // role, groupIdx, refcount, and QP handles are all fixed at connect()/accept()
+    // time (see connect.cc groupIdx assignment), not populated lazily by traffic.
+    struct ncclIbQpSharingState GetActualQpSharingState(void* comm) {
+        struct ncclIbQpSharingState state = {};
+        EXPECT_EQ(ncclIbCastGetQpSharingState(comm, &state), ncclSuccess);
+        return state;
     }
 
     // Read RCCL_IB_QP_SCHED_SPLIT_DATA_MIN from the environment.
@@ -838,6 +1100,16 @@ protected:
         if (!before.valid() || !after.valid()) {
             GTEST_LOG_(WARNING) << "RDMA resource counting unavailable on this node; "
                                 << "leak check skipped for: " << label;
+            // Also announce it on stdout in a greppable form. This check is the
+            // ONLY failure signal for QpShareStressBatchCreateDestroy, so when
+            // `rdma resource show` is missing that test goes green while
+            // verifying nothing -- which reads exactly like the PD leak having
+            // been fixed. qpshare_validate.sh greps for this token and
+            // downgrades the run rather than trusting the green.
+            printf("[QPSHARE-COV] LEAKCHECK-UNAVAILABLE rank=%d at=%s"
+                   "  (iproute2 `rdma resource show` not usable here; QP/CQ/MR/PD"
+                   " leak assertions did not run)\n", rank, label);
+            fflush(stdout);
             return;
         }
         EXPECT_EQ(after.qp, before.qp)

--- a/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+#define RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+
+#ifdef MPI_TESTS_ENABLED
+
+/*
+ * Re-export the shared struct and function declarations from the library's
+ * internal header.  Using the same header in both the library (qp_sharing.cc)
+ * and the tests guarantees that the ABI can never silently diverge.
+ */
+#include "net_ib_qp_sharing_inspect.h"
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
@@ -1,0 +1,151 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+#define RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+
+#include <cstdlib>
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+
+#ifdef MPI_TESTS_ENABLED
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Environment readers
+//
+// RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER are plain RCCL_PARAMs
+// (qp_sharing.cc) -- only the RCCL_ prefix is honoured, there is no NCCL_ alias
+// for either despite what the feature commit message says. RCCL_PARAM caches
+// both for the process lifetime, so a test may read them once and assume they
+// hold for its whole run. That also means a sweep over either value needs one
+// process (one mpirun) per point; see tools/scripts/qpshare/qpshare_validate.sh.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static inline int QpShareEnvInt(const char* name, int fallback) {
+    const char* v = getenv(name);
+    if (!v || v[0] == '\0') return fallback;
+    return static_cast<int>(std::atoll(v));
+}
+
+static inline int QpShareEnvNGroups() {
+    return QpShareEnvInt("RCCL_IB_COMM_NGROUPS", 0);
+}
+
+// connect.cc clamps the multiplier to >= 1 before scaling CQ/WR depth, so 0 or
+// a negative value behaves exactly like the default of 1.
+static inline int QpShareEnvDepthMultiplier() {
+    return std::max(1, QpShareEnvInt("RCCL_IB_QP_DEPTH_MULTIPLIER", 1));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// QpShareRefModel -- expected group layout, derived from RCCL_IB_COMM_NGROUPS
+//
+// Encodes the assignment rule the transport implements today (connect.cc):
+//
+//     groupIdx = IbCastCountPeerTotalRefcount(...) % ngroups
+//
+// i.e. occupancy-modulo -- the next comm joins the group selected by the total
+// number of *live* refcounts to that peer, not by a monotonic counter and not
+// by picking the least-loaded group. It does not balance under churn, and that
+// is deliberately reproduced here rather than corrected: this model exists to
+// lock current behaviour so a net_ib_cast change cannot move it silently. A
+// divergence between model and implementation is a regression signal, not a
+// verdict on whether the rule is the right one. Changing the rule means
+// changing this header in the same commit, on purpose.
+//
+// This is not a tautology despite mirroring the rule. The model tracks group
+// loads from the create/destroy sequence the test issued; the implementation
+// rederives the index by scanning the live shared-QP pool. A refcount that
+// survives teardown, or a freed pool slot that is still counted, makes the two
+// disagree -- which is precisely the defect class QP sharing has today.
+// ─────────────────────────────────────────────────────────────────────────────
+class QpShareRefModel {
+public:
+    // Where one comm landed. Both fields are fixed at connect()/accept() time,
+    // exactly like ncclIbQpSharingState::sharedGroupIdx / isSharedQpPrimary:
+    // releasing the PRIMARY of a group does not promote a SECONDARY.
+    struct Placement {
+        int  group   = -1;
+        bool primary = false;
+    };
+
+    explicit QpShareRefModel(int ngroups)
+        : ngroups_(ngroups > 0 ? ngroups : 1), loads_(ngroups_, 0) {}
+
+    // Model the next successful connect(). Call this immediately before the
+    // real connection is established, in the same order the test issues them.
+    Placement AssignOnCreate() {
+        Placement p;
+        p.group   = TotalRefs() % ngroups_;
+        p.primary = (loads_[p.group] == 0);
+        loads_[p.group]++;
+        peakLoad_ = std::max(peakLoad_, loads_[p.group]);
+        return p;
+    }
+
+    // Model a comm teardown. Pass the Placement returned by AssignOnCreate().
+    void Release(const Placement& p) {
+        if (p.group < 0 || p.group >= ngroups_) return;
+        if (loads_[p.group] > 0) loads_[p.group]--;
+    }
+
+    int NGroups() const { return ngroups_; }
+
+    // Live comms in `group` -- the expected ncclIbQpSharingState::refcount for
+    // every comm currently in it.
+    int Load(int group) const {
+        if (group < 0 || group >= ngroups_) return -1;
+        return loads_[group];
+    }
+
+    int TotalRefs() const {
+        int sum = 0;
+        for (int l : loads_) sum += l;
+        return sum;
+    }
+
+    // Busiest group -- the achieved sharing depth, and the value
+    // RCCL_IB_QP_DEPTH_MULTIPLIER must currently cover. Simulated rather than
+    // computed as ceil(nconns/ngroups), because occupancy-modulo does not
+    // balance once teardowns are interleaved with creates.
+    int MaxLoad() const {
+        int m = 0;
+        for (int l : loads_) m = std::max(m, l);
+        return m;
+    }
+
+    // Busiest any group ever got, over the whole create/destroy sequence.
+    //
+    // This, not MaxLoad(), is the sharing depth a run achieved. MaxLoad() is
+    // instantaneous: a churn test that stacked three comms on one group and
+    // then released two reports MaxLoad()==1, and the coverage line then prints
+    // "NO QP WAS SHARED" for a run that plainly did share. Measured: churn at
+    // ngroups=2 reported max_comms_per_group=1 beside group_spread=3, which
+    // cannot both be true of the same instant.
+    int PeakLoad() const { return peakLoad_; }
+
+    int MinLoad() const {
+        int m = loads_.empty() ? 0 : loads_[0];
+        for (int l : loads_) m = std::min(m, l);
+        return m;
+    }
+
+    // Imbalance across groups. Reported by the tests, never asserted: how
+    // evenly occupancy-modulo spreads comms is a property worth measuring (it
+    // drives the depth multiplier a given ngroups demands) but not one this
+    // suite is entitled to dictate.
+    int Spread() const { return MaxLoad() - MinLoad(); }
+
+private:
+    int              ngroups_;
+    std::vector<int> loads_;
+    int              peakLoad_ = 0;
+};
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_QP_SHARE_REF_MODEL_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
@@ -1,0 +1,1102 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// MPI test suite for QP sharing (RCCL_IB_COMM_NGROUPS /
+// RCCL_IB_QP_DEPTH_MULTIPLIER).  2-rank, single-IB-device (dev=0) --
+// fan-in/fan-out/all-to-all coverage is deferred to a follow-up.  The CAST
+// scheduler (RCCL_IB_QP_SCHED_ENABLE) and resiliency (PORT_FAILOVER /
+// PORT_RECOVERY) are mutually exclusive with sharing at the source level and
+// are skipped by QPSHARE_ENV_CHECK_OR_SKIP, the only skip guard in this file.
+//
+// NIC Fusion is a different case and is NOT guarded: nothing in the test
+// binary detects it, and a merged device changes which physical NIC a comm
+// lands on, so a fused run measures something other than what these tests
+// describe. The presets therefore pin NCCL_IB_MERGE_NICS=0 and clear
+// NCCL_NET_FORCE_MERGE (net_ib_transport.json, test_categories_mpi.yaml).
+// Running this suite by hand without those two is unsupported, not skipped.
+//
+// Three categories:
+//
+//   QpShareAlgo*    group-assignment and PRIMARY/SECONDARY bookkeeping,
+//                   validated against QpShareRefModel. No data phase.
+//   QpShareData*    the data path must be correct at every parameter point.
+//   QpShareStress*  scale and churn, with the scale under env control.
+//
+// Every test derives its expectations from RCCL_IB_COMM_NGROUPS rather than
+// pinning one hand-picked value, so all three categories are valid at any
+// (ngroups, depth, nconns). Nothing here skips because a parameter combination
+// looks difficult: the invariant this suite exists to enforce is that *no*
+// combination may fail to connect or corrupt a transfer. If a combination
+// breaks the transport, that must be visible as a FAILED test -- either the
+// transport is fixed, or the limitation is documented in
+// test/transport/NetIbMPI/QpSharingValidationReport.md. Where a run cannot exercise sharing at
+// all (ngroups >= nconns), it says so on a [QPSHARE-COV] line instead of
+// passing silently.
+//
+// Both tunables are RCCL_PARAM-backed and therefore cached for the process
+// lifetime (src/include/param.h): a sweep over either needs one mpirun per
+// point. The connection count is *not* cached and can be varied in-process,
+// which is why it is an ordinary env knob (QPSHARE_TEST_NCONNS /
+// QPSHARE_TEST_ITERS). See tools/scripts/qpshare/qpshare_validate.sh and
+// test/transport/NetIbMPI/QpSharingTestGuide.md.
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
+
+#ifdef MPI_TESTS_ENABLED
+
+namespace {
+
+// Connections opened by the algo sweep: enough for every group to hold two
+// comms plus one, so PRIMARY-only, PRIMARY+SECONDARY and (at ngroups=1)
+// deep-stacking layouts all occur in one run. Capped so a large ngroups does
+// not turn a state-only test into a connection-setup benchmark.
+constexpr int kAlgoMaxConns = 64;
+
+// Live connections held by the churn test. Kept at two per group so the test
+// stays about pool bookkeeping rather than about RQ depth.
+constexpr int kChurnMaxLive = 32;
+
+// Connections the flush test may open. It needs ngroups+1 to guarantee one
+// shared pair; past this cap it reports that no pair was formed rather than
+// opening an unbounded number of GDR-registered connections.
+constexpr int kFlushMaxConns = 128;
+
+int Clamp(int v, int lo, int hi) { return std::max(lo, std::min(hi, v)); }
+
+std::string Stage(const char* what, int i) {
+    return std::string(what) + " " + std::to_string(i);
+}
+
+// One rank's view of a set of cast connections, paired with the reference
+// model's prediction for each.
+struct QpShareConns {
+    std::vector<void*> listen;
+    std::vector<void*> send;
+    std::vector<void*> recv;
+    std::vector<void*> mine;   // recvComm on rank 0, sendComm on rank 1
+    std::vector<QpShareRefModel::Placement> place;
+
+    size_t size() const { return mine.size(); }
+
+    void Add(int rank, void* l, void* s, void* r, QpShareRefModel::Placement p) {
+        listen.push_back(l);
+        send.push_back(s);
+        recv.push_back(r);
+        mine.push_back(rank == 0 ? r : s);
+        place.push_back(p);
+    }
+
+    void Erase(size_t i) {
+        listen.erase(listen.begin() + i);
+        send.erase(send.begin() + i);
+        recv.erase(recv.begin() + i);
+        mine.erase(mine.begin() + i);
+        place.erase(place.begin() + i);
+    }
+};
+
+}  // namespace
+
+// =============================================================================
+// Test: QpShareAlgoLayoutSweep  (category: algo)
+//
+// The group-assignment contract, validated at whatever RCCL_IB_COMM_NGROUPS is
+// configured. Opens connections one at a time up to min(2*ngroups+1, 64), and
+// after every single create re-checks *every* live comm against
+// QpShareRefModel: group index, PRIMARY/SECONDARY role, refcount, commId, and
+// the physical-QP identity relation (same group => same QP, different groups
+// => different QPs). Then tears down in creation order -- which releases each
+// group's PRIMARY while its SECONDARYs are still live -- re-checking after
+// every destroy.
+//
+// Subsumes the old QpShareNGroupsOne (ngroups=1), QpSharePrimarySecondaryMix
+// (ngroups=2) and QpShareNGroupsExceedsConns (ngroups > nconns) as three
+// points of the same sweep rather than three hand-computed layouts.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoLayoutSweep) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int target  = std::min(2 * ngroups + 1, kAlgoMaxConns);
+    if (2 * ngroups + 1 > kAlgoMaxConns && rank == 0) {
+        printf("[QPSHARE-COV] algo sweep capped at %d conns (ngroups=%d would need %d "
+               "for two per group)\n", kAlgoMaxConns, ngroups, 2 * ngroups + 1);
+    }
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < target; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << target << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << ". It would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ". Sharing must never make connect() fail: size the shared QP for the "
+                   "group, or fall back to an unshared QP when it cannot be sized.";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after create", c).c_str());
+    }
+
+    ReportQpShareCoverage("algo_layout_sweep", static_cast<int>(cs.size()),
+                          model.PeakLoad(), model.Spread());
+
+    // Teardown from the front: releases group PRIMARYs ahead of their
+    // SECONDARYs, which is where refcount and pool bookkeeping are most likely
+    // to diverge from the model.
+    for (int c = 0; cs.size() > 0; c++) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after destroy", c).c_str());
+    }
+}
+
+// =============================================================================
+// Test: QpShareAlgoChurnLayout  (category: algo)
+//
+// Group assignment under interleaved create/destroy, including releases from
+// the middle of the live set rather than only the tail. This is where
+// occupancy-modulo (groupIdx = live totalRefs % ngroups) stops looking like
+// round-robin: after a non-tail release the next comm can land back in a group
+// that already has members while another sits empty. That behaviour is
+// reproduced by QpShareRefModel and asserted; the resulting imbalance is
+// measured and reported (group_spread) but deliberately not asserted -- how
+// evenly the rule spreads comms is a design question, not this suite's call.
+//
+// Also the sharpest check on pool bookkeeping: a slot freed on close but still
+// counted by IbCastCountPeerTotalRefcount shifts every subsequent assignment
+// and shows up here as a group mismatch.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoChurnLayout) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int maxLive = Clamp(2 * ngroups, 2, kChurnMaxLive);
+    const int steps   = 3 * maxLive + 6;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    int  observedSpread = 0;
+    bool broke          = false;
+
+    // Deterministic and rank-identical: the decision depends only on `step` and
+    // the live count, both of which evolve the same way on both ranks.
+    for (int step = 0; step < steps && !broke; step++) {
+        const bool create = cs.size() == 0 ||
+                            (static_cast<int>(cs.size()) < maxLive && (step % 3) != 2);
+        if (create) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "step " << step << ": connect failed with " << cs.size()
+                    << " live comms at RCCL_IB_COMM_NGROUPS=" << ngroups
+                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                    << " (would have been comm #" << (model.Load(p.group) + 1)
+                    << " in group " << p.group << ")";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+        } else {
+            // Rotating, non-tail victim: exercises releasing a comm that still
+            // has live neighbours in its group.
+            const size_t victim = static_cast<size_t>(step / 2) % cs.size();
+            model.Release(cs.place[victim]);
+            CloseCastConnection(cs.listen[victim], cs.send[victim], cs.recv[victim]);
+            cs.Erase(victim);
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+        observedSpread = std::max(observedSpread, model.Spread());
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("churn step", step).c_str());
+    }
+
+    ReportQpShareCoverage("algo_churn_layout", static_cast<int>(cs.size()),
+                          model.PeakLoad(), observedSpread);
+
+    while (cs.size() > 0) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataAllConnsTransfer  (category: data path)
+//
+// The core data-path gate: at the configured (ngroups, depth), open nconns
+// connections and require every one of them to connect and to move data
+// correctly across a size sweep covering zero-length, single-byte and
+// powers-of-two +/-1 up to 1 MB.
+//
+// This is also where an under-sized RCCL_IB_QP_DEPTH_MULTIPLIER is caught.
+// Every comm joining a shared QP unconditionally preposts a full
+// NET_IB_MAX_REQUESTS worth of receive WQEs, while the QP's max_recv_wr is
+// sized once, at PRIMARY creation, as NET_IB_MAX_REQUESTS * multiplier -- so
+// once a group holds more comms than the queue covers, the device runs out of
+// work-queue room and returns ENOMEM. This test asserts that does NOT happen:
+// the transport is expected either to size the queue for the group or to fall
+// back to an unshared QP, not to break. It replaces the old
+// QpShareDepthMultiplierDefault, which asserted the failure and thereby froze
+// the limitation into the suite as if it were intended.
+//
+// Measured 2026-08-17 on AINIC (see test/transport/NetIbMPI/QpSharingValidationReport.md), the
+// test is red at both ends of the depth range and for different reasons:
+//   * too many comms per QP -- 112 comms/group at the default multiplier is
+//     fine, 128 is not, and the break lands in the DATA phase as ibv_post_send
+//     ENOMEM rather than at connect. Raising the multiplier to 2 fixes 128.
+//   * multiplier too large for the device -- the FIRST connect fails outright.
+//     The shared CQ is sized 3 * NET_IB_MAX_REQUESTS * qps * depth = 768*qps*
+//     depth entries (connect.cc:949, :1730) and never clamped to max_cqe, so
+//     the ceiling is floor(max_cqe / (768*qps)): 85 at qps=1 and 42 at the
+//     default qps=2, bisected exactly on a NIC reporting max_cqe=65435.
+// Both are the same missing behaviour seen from opposite sides: the depth
+// multiplier is applied as given, with no capacity check and no fallback.
+//
+// nconns defaults to a value that forces at least one group to be shared;
+// override with QPSHARE_TEST_NCONNS. Reaching the saturation ceiling needs a
+// large value (128 at the default multiplier); reaching the create-time ceiling
+// needs only 2 connections and a large RCCL_IB_QP_DEPTH_MULTIPLIER.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    // ngroups+2 would put at least two comms in some group -- but only while the
+    // ceiling does not bind. Above ngroups=30 the clamp holds nconns at 32 with
+    // more groups than connections, so occupancy-modulo gives every comm its own
+    // group and NOTHING is shared. That is a legitimate point to run (the data
+    // path must still be correct) and the sweep matrix does reach it at
+    // ngroups=200, so it is not hypothetical. It is not silent either: the
+    // [QPSHARE-COV] line below reports the achieved depth and says
+    // "NO QP WAS SHARED" outright. Raise QPSHARE_TEST_NCONNS past ngroups to
+    // force sharing at large ngroups; the ceiling is here to bound runtime, not
+    // to characterise the feature.
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS",
+                                                  Clamp(ngroups + 2, 4, 32)));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << nconns << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << " -- it would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ", and the shared QP is sized for " << QpShareEnvDepthMultiplier()
+                << ". A tunable that cannot be honoured must degrade to an unshared QP, "
+                   "not fail the connection."
+                << (c == 0
+                        ? " This is the FIRST connection, so nothing is shared yet:"
+                          " the depth multiplier itself exceeds what the device can"
+                          " allocate. The shared CQ is sized 768 x"
+                          " NCCL_IB_QPS_PER_CONNECTION x depth entries and is not"
+                          " clamped to the device max_cqe, so the two knobs share"
+                          " one ceiling -- this needs clamping, not a saturation"
+                          " fallback."
+                        : "");
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "all conns established");
+    ReportQpShareCoverage("data_all_conns_transfer", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        const std::vector<size_t> kSizes = {0, 1, 127, 128, 4095, 4096, 65535, 65536, 1 << 20};
+        const size_t kMaxSz = kSizes.back();
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMaxSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMaxSz));
+        std::vector<void*> mhandles(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            ASSERT_EQ(RegisterMemory(cs.mine[c], regBuf, kMaxSz, NCCL_PTR_HOST, &mhandles[c]),
+                      ncclSuccess);
+        }
+
+        constexpr int kTagBase = 5300;
+        for (size_t i = 0; i < kSizes.size(); i++) {
+            for (int c = 0; c < established; c++) {
+                if (rank == 0) memset(recvBufs[c].data(), 0, kSizes[i]);
+                DoSendRecv(cs.send[c], cs.recv[c],
+                           sendBufs[c].data(), recvBufs[c].data(),
+                           kSizes[i], kTagBase + static_cast<int>(i) * established + c,
+                           mhandles[c], mhandles[c],
+                           /*patternSeed=*/static_cast<int>(i) * 31 + c);
+            }
+        }
+
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataUnsharedGroups  (category: data path)
+//
+// The nconns <= ngroups regime, where occupancy-modulo gives every connection
+// a group of its own and no QP is shared at all. Worth a test in its own
+// right: enabling RCCL_IB_COMM_NGROUPS must not disturb the ordinary unshared
+// data path, and every comm must come up as a solo PRIMARY on a distinct
+// physical QP rather than quietly stacking.
+//
+// nconns is derived as min(ngroups, 8) so the test is in the unshared regime
+// whatever ngroups is set to -- there is nothing to skip.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = Clamp(ngroups, 1, 8);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " -- nothing is even shared at this connection count";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "unshared groups established");
+    for (int c = 0; c < established; c++) {
+        EXPECT_EQ(model.Load(cs.place[c].group), 1)
+            << "test bug: conn " << c << " was expected to be alone in its group";
+        EXPECT_TRUE(cs.place[c].primary);
+    }
+    ReportQpShareCoverage("data_unshared_groups", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 64 * 1024;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            ASSERT_EQ(RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]),
+                      ncclSuccess);
+        }
+        constexpr int kTagBase = 5100;
+        for (int c = 0; c < established; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], sendBufs[c].data(), recvBufs[c].data(),
+                       kMsgSz, kTagBase + c, mhandles[c], mhandles[c],
+                       /*patternSeed=*/c + 11);
+        }
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataFlushRouting  (category: data path)
+//
+// GDR flush completion routing across a shared CQ. A flush QP is per-comm and
+// is not itself shared, but its completion still lands on the group's shared
+// CQ, so it must be identified via the commId bits in wr_id
+// (IbCastStripCommId / IbCastRouteCommFromWrId, qp_sharing.cc) rather than
+// attributed to whichever comm happens to be polling. This test posts iflush()
+// for a PRIMARY and its SECONDARY back to back, leaving both outstanding
+// before waiting on either -- two flush completions pending on one shared CQ
+// is exactly the scenario the routing fix targets. A regression shows up as a
+// timed-out or misattributed wait, or as the wrong buffer's data failing
+// verification.
+//
+// The shared pair is located from the reference model rather than hardcoded,
+// so the test works at any ngroups: opening ngroups+1 connections guarantees
+// one group holds two.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::min(ngroups + 1, kFlushMaxConns);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    ncclNetProperties_t props;
+    ASSERT_EQ(GetDeviceProperties(0, &props), ncclSuccess);
+    if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+        // Hardware capability, not a tunable: without GDR there is no flush to
+        // route. This is the one thing in the suite a parameter cannot fix.
+        GTEST_SKIP() << "GDR not supported on this device, skipping flush routing test";
+    }
+
+    // 1 MB per connection is a realistic GDR transfer, but at large ngroups the
+    // connection count is what matters, not the payload size.
+    const size_t kSz = (nconns <= 8) ? (1024 * 1024) : (64 * 1024);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "flush conns established");
+
+    // Locate a PRIMARY/SECONDARY pair and an unshared baseline from the model.
+    int primaryIdx = -1, secondaryIdx = -1, baselineIdx = -1;
+    for (int c = 0; c < established && secondaryIdx < 0; c++) {
+        if (cs.place[c].primary) continue;
+        secondaryIdx = c;
+        for (int q = 0; q < c; q++)
+            if (cs.place[q].group == cs.place[c].group && cs.place[q].primary) primaryIdx = q;
+    }
+    if (primaryIdx >= 0)
+        for (int c = 0; c < established; c++)
+            if (cs.place[c].group != cs.place[primaryIdx].group) { baselineIdx = c; break; }
+
+    const bool havePair = (primaryIdx >= 0 && secondaryIdx >= 0);
+    ReportQpShareCoverage("data_flush_routing", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+    if (!havePair && rank == 0) {
+        printf("[QPSHARE-COV] data_flush_routing: no PRIMARY/SECONDARY pair formed at "
+               "ngroups=%d with %d conns (cap %d) -- shared-CQ flush routing was NOT "
+               "exercised; only the unshared flush path was\n",
+               ngroups, established, kFlushMaxConns);
+        fflush(stdout);
+    }
+
+    if (established > 0) {
+        std::vector<void*> devBufs(established, nullptr);
+        std::vector<DeviceBufferAutoGuard> bufGuards;
+        bufGuards.reserve(established);
+        std::vector<void*> mhandles(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            ASSERT_EQ(hipMalloc(&devBufs[c], kSz), hipSuccess);
+            bufGuards.push_back(makeDeviceBufferAutoGuard(devBufs[c]));
+            ASSERT_EQ(RegisterMemory(cs.mine[c], devBufs[c], kSz, NCCL_PTR_CUDA, &mhandles[c]),
+                      ncclSuccess);
+            if (rank == 1) {
+                ASSERT_EQ(initializeBufferWithPattern<uint8_t>(devBufs[c], kSz,
+                                                               makeBytePattern(c + 700)),
+                          hipSuccess);
+            }
+        }
+
+        // Transfer every connection concurrently (post-all, wait-all).
+        std::vector<void*> reqs(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            if (rank == 0) PostSingleRecv(cs.recv[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+            else           PostSendWithRetry(cs.send[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++) {
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kLargeTransferTimeoutMs), ncclSuccess)
+                << "conn " << c << " transfer completion";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0 && havePair) {
+            void* fReqP = nullptr; void* fReqS = nullptr;
+            int fszP = static_cast<int>(kSz), fszS = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[primaryIdx], 1, &devBufs[primaryIdx], &fszP,
+                                &mhandles[primaryIdx], &fReqP), ncclSuccess);
+            EXPECT_EQ(FlushRecv(cs.recv[secondaryIdx], 1, &devBufs[secondaryIdx], &fszS,
+                                &mhandles[secondaryIdx], &fReqS), ncclSuccess);
+            EXPECT_NE(fReqP, nullptr);
+            EXPECT_NE(fReqS, nullptr);
+
+            // Wait SECONDARY first: completions must be routed by commId, not by
+            // the order the requests were posted or polled.
+            int wS = 0, wP = 0;
+            EXPECT_EQ(WaitForCompletion(fReqS, &wS, kLargeTransferTimeoutMs), ncclSuccess)
+                << "SECONDARY (conn " << secondaryIdx << ") flush completion misrouted or lost";
+            EXPECT_EQ(WaitForCompletion(fReqP, &wP, kLargeTransferTimeoutMs), ncclSuccess)
+                << "PRIMARY (conn " << primaryIdx << ") flush completion misrouted or lost";
+
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[primaryIdx], kSz,
+                                                  makeBytePattern(primaryIdx + 700)))
+                << "PRIMARY conn " << primaryIdx << " data wrong after flush -- cross-comm misroute";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[secondaryIdx], kSz,
+                                                  makeBytePattern(secondaryIdx + 700)))
+                << "SECONDARY conn " << secondaryIdx << " data wrong after flush -- cross-comm misroute";
+        }
+
+        // Unshared baseline: flush on a solo group must behave exactly like the
+        // non-sharing path. Falls back to conn 0 when every comm shares a group.
+        const int soloIdx = (baselineIdx >= 0) ? baselineIdx : (havePair ? -1 : 0);
+        if (rank == 0 && soloIdx >= 0) {
+            void* fReq = nullptr;
+            int fsz = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[soloIdx], 1, &devBufs[soloIdx], &fsz,
+                                &mhandles[soloIdx], &fReq), ncclSuccess);
+            int w = 0;
+            EXPECT_EQ(WaitForCompletion(fReq, &w, kLargeTransferTimeoutMs), ncclSuccess)
+                << "unshared baseline conn " << soloIdx << " flush completion";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[soloIdx], kSz,
+                                                  makeBytePattern(soloIdx + 700)));
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressManyConns  (category: stress)
+//
+// Flagship regression guard: many connections to one peer under sustained
+// batched concurrent traffic on all of them. At ngroups=2 the default 100
+// connections put ~50 comms on each shared QP.
+//
+// Scale with QPSHARE_TEST_NCONNS. The default is what CI gates on; a developer
+// tuning the feature can push it up to find where it breaks, or down to
+// bisect a failure quickly.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressManyConns) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 100));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                          << " (comm #" << (model.Load(p.group) + 1) << " in group "
+                          << p.group << ")";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "stress conns established");
+    ReportQpShareCoverage("stress_many_conns", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr int    kNMsgs = 20;
+        constexpr size_t kMsgSz = 4096;
+        constexpr size_t kBufSz = kNMsgs * kMsgSz;
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kBufSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kBufSz));
+        for (int c = 0; c < established; c++) {
+            for (size_t i = 0; i < kBufSz; i++)
+                sendBufs[c][i] = static_cast<char>(((i + c) * 5 + 11) & 0xFF);
+            memset(recvBufs[c].data(), 0, kBufSz);
+        }
+
+        std::vector<void*> mhandles(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            ASSERT_EQ(RegisterMemory(cs.mine[c], regBuf, kBufSz, NCCL_PTR_HOST, &mhandles[c]),
+                      ncclSuccess);
+        }
+
+        constexpr int kTagBase = 6000;
+        for (int c = 0; c < established; c++) {
+            CastDoBatchSendRecv(rank, cs.send[c], cs.recv[c],
+                                sendBufs[c].data(), recvBufs[c].data(),
+                                kMsgSz, kNMsgs, kTagBase + c * kNMsgs, mhandles[c]);
+        }
+
+        if (rank == 0) {
+            for (int c = 0; c < established; c++)
+                EXPECT_EQ(memcmp(recvBufs[c].data(), sendBufs[c].data(), kBufSz), 0)
+                    << "data corruption on conn " << c;
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressSharedRqSaturation  (category: stress)
+//
+// Deliberately tries to starve the shared receive queue: one message posted
+// from every connection simultaneously (post-all before any wait), repeated
+// over several rounds. Expect a clean pass -- prepost is mandatory under
+// sharing (common.cc), which keeps the RQ full regardless of which comm's
+// traffic actually lands. A failure here is a real regression, not an
+// expected limitation.
+//
+// Scale with QPSHARE_TEST_NCONNS (connections) and QPSHARE_TEST_ITERS (rounds).
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 50));
+    const int rounds  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ReportQpShareCoverage("stress_rq_saturation", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 512;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            ASSERT_EQ(RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]),
+                      ncclSuccess);
+        }
+
+        constexpr int kTagBase = 7000;
+        for (int round = 0; round < rounds; round++) {
+            std::vector<void*> reqs(established, nullptr);
+            const int tagRoundBase = kTagBase + round * established;
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    void*  bufs[1]    = {recvBufs[c].data()};
+                    size_t sizes[1]   = {kMsgSz};
+                    int    tags[1]    = {tagRoundBase + c};
+                    void*  handles[1] = {mhandles[c]};
+                    ASSERT_EQ(PostRecv(cs.recv[c], 1, bufs, sizes, tags, handles, &reqs[c]),
+                              ncclSuccess);
+                    ASSERT_NE(reqs[c], nullptr);
+                }
+            } else {
+                for (int c = 0; c < established; c++) {
+                    fillHostBufferWithPattern<uint8_t>(sendBufs[c].data(), kMsgSz,
+                                                       makeBytePattern(round * established + c));
+                    PostSendWithRetry(cs.send[c], sendBufs[c].data(), kMsgSz,
+                                      tagRoundBase + c, mhandles[c], &reqs[c]);
+                }
+            }
+            for (int c = 0; c < established; c++) {
+                int sz = 0;
+                EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kStressTimeoutMs), ncclSuccess)
+                    << "round " << round << " conn " << c;
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    size_t errIdx; uint8_t errExp, errGot;
+                    EXPECT_TRUE(verifyHostBufferData<uint8_t>(
+                        recvBufs[c].data(), kMsgSz, makeBytePattern(round * established + c),
+                        0, 0.0, &errIdx, &errExp, &errGot))
+                        << "round " << round << " conn " << c << " data mismatch at byte " << errIdx;
+                }
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressConnectionChurn  (category: stress)
+//
+// Sequential connect -> transfer -> close cycles, by default 2048 of them.
+// Only one connection is live at a time, so nothing accumulates that the
+// transport is entitled to keep -- every cycle is fully torn down before the
+// next begins. What the checkpoints measure is whether that teardown returns
+// the device resources it took.
+//
+// Measured on AINIC/ionic (see QpSharingValidationReport.md): under sharing
+// each cycle leaks exactly one protection domain, announced by an
+// "ibv_dealloc_pd failed with error Device or resource busy" WARN, and connect
+// stops working at iteration 1022 -- the device's max_pd is 1024. At that point
+// the connect side emits "ibv_alloc_pd failed with error No space left on
+// device", exactly once. Measured 1023 dealloc failures and 1 alloc failure per
+// rank over 2048 requested iterations.
+//
+// The shared-QP pool (IBCAST_MAX_SHARED_QPS, also 1024) is NOT what binds here:
+// "pool full" is emitted zero times in the same run, and a full pool could not
+// fail a connect in any case -- IbCastRegisterSharedQp's NULL return is ignored
+// at connect.cc:1109. The two ceilings coincide numerically, so do not read the
+// iteration number alone as evidence of either; read the WARN texts.
+//
+// Reading those WARNs requires per-rank logs. The failing alloc_pd happens on
+// the connect-side rank, and mpirun's merged stdout carries only rank 0 here,
+// which is why this failure looked for a while like it had no diagnostic at
+// all. Use -x NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log, not a merged log.
+//
+// Iterations are set by QPSHARE_TEST_ITERS; drop it well below 1024 to confirm
+// the pre-exhaustion path is healthy (the leak is still visible in the
+// checkpoints there), raise it to find the exact boundary.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank  = MPIEnvironment::world_rank;
+    const int iters = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 2048));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 1024;
+    std::vector<char> buf(sz);
+
+    // Warmup connect+transfer+close so driver-internal CQs settle before baselining.
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            // A failure this early means the pool was already exhausted by an
+            // earlier test in this process -- the pool is a process-global that
+            // is never reset between TEST_F cases.
+            ADD_FAILURE() << "warmup connection failed before churn even started "
+                             "(shared-QP pool already exhausted by an earlier test "
+                             "in this process?)";
+            return;
+        }
+        void* mh = nullptr;
+        ASSERT_EQ(RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh),
+                  ncclSuccess);
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/599, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Checkpoint every quarter, so a failure localises without depending on the
+    // iteration count being the default.
+    const int stride = std::max(1, iters / 4);
+
+    for (int iter = 0; iter < iters; iter++) {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            ADD_FAILURE()
+                << "connect failed at churn iteration " << iter << " of " << iters
+                << ". Only one connection is live at a time, so every earlier"
+                   " cycle was fully closed: a resource acquired per cycle was"
+                   " not returned. Check the PD-leak checkpoints above and run"
+                   " with NCCL_DEBUG=WARN -- one leaked protection domain per"
+                   " cycle reaches the device max_pd (1024 on AINIC/ionic) at"
+                   " iteration 1022. The transport does report it, but on the"
+                   " connect-side rank and only once:"
+                   " \"Call to ibv_alloc_pd failed with error No space left on"
+                   " device\". A merged mpirun log usually carries rank 0 only,"
+                   " so pass -x NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log and read"
+                   " the per-rank files -- the absence of a WARN in the merged"
+                   " log is not evidence that none was emitted";
+            break;
+        }
+        void* comm = (rank == 0) ? r : s;
+        void* mh   = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, buf.data(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/iter % 1000, mh, mh, iter);
+
+        const bool checkpoint = ((iter + 1) % stride == 0) || (iter == iters - 1);
+        if (checkpoint) {
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comm);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at iter " << iter
+                << " -- the comm is live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0)
+                << "commId cleared at iter " << iter
+                << " -- the comm silently fell off the sharing path";
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+
+        if (checkpoint) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("churn@" + std::to_string(iter + 1)).c_str());
+        }
+    }
+
+    // Exactly one comm is live at any instant, so this test never stacks two
+    // comms on one QP -- achieved sharing depth is 1 by construction, not by
+    // accident, and the "NO QP WAS SHARED" banner is the correct label. Report
+    // it rather than leaving the driver's max/grp column blank: a blank column
+    // invites the reading that churn says something about sharing depth. It
+    // does not. It exercises the create/destroy lifecycle of a shared group
+    // whose membership never exceeds one, which is the occupancy that reaches
+    // the group-release path on every single cycle (report ISSUE-3).
+    ReportQpShareCoverage("stress_connection_churn", iters, /*maxCommsPerGroup=*/1);
+}
+
+// =============================================================================
+// Test: QpShareStressBatchCreateDestroy  (category: stress)
+//
+// Resource lifetime under a bursty cadence: batches of connections created
+// together, used, and destroyed together. Defaults to 110 batches of 10.
+// RDMA-resource and refcount checkpoints every 25 batches.
+//
+// What this test is positioned to catch is anything that survives a completed
+// batch, which is why the checkpoints compare RDMA object counts against a
+// pre-batch baseline. Measured 2026-08-17 on AINIC: it reports a
+// protection-domain leak that reproduces with sharing on and not with sharing
+// off -- the same leak QpShareStressConnectionChurn hits, but at a rate set by
+// group OCCUPANCY (comms per group), i.e. by batch size AND ngroups together.
+// A PD reference is taken once per comm but released once per GROUP, so a
+// group holding k comms returns k-1 fewer references than it took; only a
+// group that held exactly one comm even reaches the dealloc, and that dealloc
+// then fails EBUSY because the per-comm MRs are still registered. Measured
+// 2026-08-17 on AINIC, same 10 connections x 20 batches:
+//
+//   ngroups=10 -> 1 comm/group  -> before=1 after=21, 21 dealloc WARNs/rank
+//   ngroups=2  -> 5 comms/group -> before=1 after=2,   1 dealloc WARN/rank
+//
+// so "leaks less" at low ngroups is not health, it is the release path being
+// reached less often. See test/transport/NetIbMPI/QpSharingValidationReport.md.
+//
+// Batch count from QPSHARE_TEST_ITERS, batch size from QPSHARE_TEST_NCONNS.
+// Unlike the sequential churn test this one holds several comms live at once,
+// so the batch size also has to fit the configured depth multiplier.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank     = MPIEnvironment::world_rank;
+    const int ngroups  = QpShareEnvNGroups();
+    const int batches  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 110));
+    const int perBatch = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 512;
+    std::vector<char> buf(sz);
+
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            ADD_FAILURE() << "warmup connection failed before batching even started "
+                             "(shared-QP pool already exhausted by an earlier test "
+                             "in this process?)";
+            return;
+        }
+        void* mh = nullptr;
+        ASSERT_EQ(RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh),
+                  ncclSuccess);
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/699, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool broke = false;
+    int  peakDepth = 0;   // deepest any group got in any batch
+    int  peakSpread = 0;
+    for (int batch = 0; batch < batches && !broke; batch++) {
+        QpShareRefModel model(ngroups);
+        QpShareConns    cs;
+        std::vector<void*> mhandles;
+
+        for (int c = 0; c < perBatch; c++) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "connect failed at batch " << batch << " of " << batches
+                    << ", connection " << c << " of " << perBatch
+                    << " (cumulative connection #" << (batch * perBatch + c)
+                    << "). ngroups=" << ngroups << " depth="
+                    << QpShareEnvDepthMultiplier()
+                    << ". Every previous batch was fully torn down, so a failure "
+                       "here means a per-batch resource was not returned -- check "
+                       "the RDMA-count checkpoints above for which one.";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+            void* mh = nullptr;
+            ASSERT_EQ(RegisterMemory(cs.mine.back(), buf.data(), sz, NCCL_PTR_HOST, &mh),
+                      ncclSuccess);
+            mhandles.push_back(mh);
+        }
+
+        const int live = static_cast<int>(cs.size());
+        peakDepth  = std::max(peakDepth, model.PeakLoad());
+        peakSpread = std::max(peakSpread, model.Spread());
+        for (int c = 0; c < live; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], buf.data(), buf.data(), sz,
+                       /*tag=*/c, mhandles[c], mhandles[c], batch * perBatch + c);
+        }
+
+        const bool checkpoint = ((batch + 1) % 25 == 0) || (batch == batches - 1);
+        if (checkpoint && live > 0) {
+            // Every batch starts from an empty live set, so the layout must be
+            // identical to batch 0's. Drift here means teardown left refcounts
+            // behind that IbCastCountPeerTotalRefcount still sees.
+            ExpectQpShareLayout(cs.mine, cs.place, model,
+                                Stage("batch checkpoint", batch).c_str());
+            struct ncclIbQpSharingState st = GetActualQpSharingState(cs.mine[0]);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at batch " << batch
+                << " -- comms are live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0) << "commId cleared at batch " << batch;
+        }
+
+        for (int c = 0; c < live; c++) {
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            CloseCastConnection(cs.listen[c], cs.send[c], cs.recv[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (checkpoint && !broke) {
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("batch@" + std::to_string(batch + 1)).c_str());
+        }
+    }
+
+    // Depth reached inside a batch, which is what sets how often the
+    // group-release path runs: perBatch/ngroups comms per group means only
+    // 1-in-that-many teardowns reaches it. At the default 10 conns / ngroups=2
+    // that is the mild leak rate; at ngroups=10 every group holds one comm and
+    // the rate is the churn test's. Reported so the two are comparable.
+    ReportQpShareCoverage("stress_batch_create_destroy", perBatch, peakDepth, peakSpread);
+}
+
+#endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -498,6 +498,228 @@
       ]
     },
 
+    "qpshare_ngroups1": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one. At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted. At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS. At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each. At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable. At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups2": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one. NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted. NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS. NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each. NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable. NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups16": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one. NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted. NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS. NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each. NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable. NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling. Measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement -- the under-provisioned point is gated separately by qpshare_undersized_depth.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_undersized_depth": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "QPSHARE_TEST_NCONNS": "128"
+      },
+      "tests": [
+        {
+          "name": "QpShare_DataAllConnsTransfer_Depth1",
+          "description": "The under-provisioned point: NGROUPS=1 at the default RCCL_IB_QP_DEPTH_MULTIPLIER of 1, so 128 comms share a QP whose queues were sized for one. The invariant does not change -- no (NGROUPS, depth, nconns) combination may fail to connect or corrupt a transfer; the transport is expected to size for the group or degrade to an unshared QP through the existing qp_sharing_skip_sender path (connect.cc) rather than run the device out of work-queue room. It does not do that today, so this preset is EXPECTED RED. Measured 2026-08-17 on AINIC: 112 comms in one group at depth 1 is fine and 128 is not, which is why the count is pinned here -- the small counts the rest of the suite uses do not reach the ceiling. The break lands in the DATA phase as ibv_post_send ENOMEM, after every connection has established, so it is a silent-until-traffic failure rather than a refused connect. Raising the multiplier to 2 makes the same 128 comms pass, so the tunable works; what is missing is a capacity check when it has not been raised. Acceptance criterion for the saturation-fallback fix, deliberately gating rather than disabled or documented away as a limitation.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        }
+      ]
+    },
+
+    "qpshare_depth_ceiling": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "96",
+        "NCCL_IB_QPS_PER_CONNECTION": "1",
+        "QPSHARE_TEST_NCONNS": "2"
+      },
+      "tests": [
+        {
+          "name": "QpShare_DataAllConnsTransfer_DepthCeiling",
+          "description": "The same missing capacity check seen from the opposite side: a depth multiplier larger than the device can allocate. The multiplier is applied to the QP's work-queue sizing as given, so an unhonourable value kills the FIRST connection outright instead of clamping to the device limit or falling back to an unshared QP -- and it fails before anything is shared, so no saturation fallback would help. Root cause measured 2026-08-17 on AINIC: the shared CQ is sized 3 x NET_IB_MAX_REQUESTS(256) x NCCL_IB_QPS_PER_CONNECTION x RCCL_IB_QP_DEPTH_MULTIPLIER = 768 x qps x depth entries (connect.cc:949 sender, :1730 receiver) and passed to ibv_create_cq with no comparison against device_attr.max_cqe. Bisected against that device's max_cqe of 65435: qps x depth = 85 passes at 65280 entries and 86 fails at 66048, identically on the qps=1 and qps=2 paths, so the usable depth is floor(max_cqe / (768 x qps)) -- 85 at QPS=1 and only 42 at the default QPS of 2. Both knobs are pinned in this preset because they multiply into the same limit. EXPECTED RED; acceptance criterion for clamping the multiplier to the queried device limit. The ceiling is device-specific: on a NIC with a larger max_cqe this preset passes, so raise the multiplier past floor(max_cqe / 768) rather than assuming 96 is universally over the line.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        }
+      ]
+    },
+
+    "qpshare_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "QpShare_StressManyConns",
+          "description": "Sustained batched traffic over QPSHARE_TEST_NCONNS connections (default 100, so ~50 comms per group at NGROUPS=2). DEPTH_MULTIPLIER=64 carries headroom above the 50 required.",
+          "test_filter": "NetIbMPITest.QpShareStressManyConns"
+        },
+        {
+          "name": "QpShare_StressSharedRqSaturation",
+          "description": "Post-all-then-wait-all across every connection in a shared group, QPSHARE_TEST_ITERS rounds (default 10) over QPSHARE_TEST_NCONNS connections (default 50) -- deliberately tries to starve the shared RQ.",
+          "test_filter": "NetIbMPITest.QpShareStressSharedRqSaturation"
+        },
+        {
+          "name": "QpShare_StressBatchCreateDestroy",
+          "description": "QPSHARE_TEST_ITERS batches (default 110) of QPSHARE_TEST_NCONNS connections (default 10), with the layout revalidated against a fresh reference model at batch checkpoints -- every batch starts from an empty live set, so drift means teardown left refcounts behind -- and RDMA object counts compared against a pre-batch baseline. What it reports is a protection-domain leak. This is the same PD-lifetime bug as QpShare_StressConnectionChurn, at a rate set by group OCCUPANCY (comms per group), i.e. by batch size AND NGROUPS together -- not by either alone. A PD reference is taken once per comm (connect.cc:99) but released once per GROUP (qp_sharing.cc:198), so a group holding k comms returns k-1 fewer references than it took and only a group that held exactly one comm reaches the dealloc at all. Measured 2026-08-17 on AINIC, same 10 connections x 20 batches: NGROUPS=10 (1 comm/group) gives before=1 after=21 with 21 dealloc WARNs per rank, while NGROUPS=2 (5 comms/group) gives before=1 after=2 with 1 WARN. Leaking less at low NGROUPS is the release path being reached less often, not health. When the dealloc IS reached it fails EBUSY, because IbCastCleanupGroupCqs runs at connect.cc:2094/:2176 before the per-comm MR deregistration loop at :2104/:2182, and the failure is only WARNed -- IbCastCleanupGroupCqs itself returns void (qp_sharing.h:101) and the wrap_ibv_dealloc_pd result at qp_sharing.cc:199 is dropped outright, so pdRefs is left at 0 with a stale non-NULL IbCastDevs[].pd. Attribution does not depend on this suite: the sharing-unaware NetIbMPITest.ConnectionBatchCreateDestroy is clean on generic IB and on IB-CAST with sharing off, and shows the same leak with sharing on. EXPECTED RED; acceptance criterion for the PD-lifetime fix. Runs in its own mpirun, separate from QpShare_StressConnectionChurn, so the churn crash cannot mask it.",
+          "test_filter": "NetIbMPITest.QpShareStressBatchCreateDestroy"
+        }
+      ]
+    },
+    "qpshare_stress_churn": {
+      "extends": "net_ib_base",
+      "timeout": 1800,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "QpShare_StressConnectionChurn",
+          "description": "QPSHARE_TEST_ITERS connect/transfer/close cycles (default 2048). Only one connection is live at a time, so every cycle is fully torn down before the next begins and nothing is entitled to accumulate. Measured 2026-08-17 on AINIC: each cycle leaks exactly one protection domain (one comm per group, so the group teardown reaches the dealloc every time), each announced by 'ibv_dealloc_pd failed with error Device or resource busy errno 16' -- 1023 of them per rank -- and connect stops working at iteration 1022 of 2048, this device reporting max_pd=1024. This is the same PD-lifetime bug as QpShare_StressBatchCreateDestroy, at the occupancy that hits it hardest. It is NOT shared-QP pool exhaustion even though IBCAST_MAX_SHARED_QPS is also 1024: per-rank logs of that run contain zero 'pool full' WARNs, and a full pool could not fail a connect anyway since IbCastRegisterSharedQp's NULL return is ignored at connect.cc:1109. The failing connect DOES report itself, once, on the connect-side rank: 'Call to ibv_alloc_pd failed with error No space left on device'. It is invisible in a merged mpirun log, which carries rank 0 only -- pass -x NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log to see it. The process is not usable afterwards: the next connect attempt segfaults rather than failing cleanly, which is why this test has its own configuration and its own mpirun instead of sharing one with qpshare_stress. EXPECTED RED against that pre-existing transport bug, kept gating as its acceptance criterion. Set QPSHARE_TEST_ITERS well below 1024 to exercise the pre-exhaustion path; the leak is already visible in the checkpoints there.",
+          "test_filter": "NetIbMPITest.QpShareStressConnectionChurn"
+        }
+      ]
+    },
+
+    "qpshare_uaf_teardown": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0",
+        "MALLOC_PERTURB_": "165"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoChurnLayout_UafTeardown",
+          "description": "The deterministic form of a use-after-free that otherwise crashes qpshare_ngroups16 intermittently (measured 2 runs in 18 on AINIC, 2026-08-17). Same test and same tunables as that configuration; the only addition is MALLOC_PERTURB_=165, which makes glibc overwrite freed heap with 0xa5 so the stale read faults instead of usually reading intact memory. With it the crash is 6/6; without it 0/6 in the same session. Cause: IbCastRegisterSharedQp stores a pointer to the per-comm device block, &comm->devs[devIdx].base, in the shared-QP pool slot as primaryDevBase (connect.cc:1105). IbCastCloseSend/IbCastCloseRecv free(comm) at connect.cc:2140/:2235, and IbCastCleanupGroupCqs then dereferences that freed pointer to read primaryDevBase->ibDevN (qp_sharing.cc:193) and locks IbCastDevs[ibDevN].mutex (:194) with whatever garbage index came back. Backtrace lands in pthread_mutex_lock via IbCastCleanupGroupCqs+0x248 from IbCastCloseRecv+0x373. EXPECTED RED, and it does not fail an assertion -- the process dies, so the configuration reports a signal rather than a test failure. Acceptance criterion for storing ibDevN by value in the pool slot instead of a pointer into the comm. Controls to re-run alongside any fix attempt: the same filter without MALLOC_PERTURB_ (passes), and non-sharing NetIb tests with the poison on (unaffected). MALLOC_PERTURB_ is glibc-only and is inert on other allocators, so on a non-glibc platform this configuration silently degrades to being the same as qpshare_ngroups16.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        }
+      ]
+    },
+
     "cast_single_qp": {
       "extends": "cast_base",
       "timeout": 60,
@@ -1022,6 +1244,54 @@
       "name": "NET IB - CAST WRR only (QPS=2, splitData=0)",
       "description": "White-box WRR scheduler tests without split-data: weights distribution, doWrr toggle, splitData toggle, sched parms reflection",
       "config": "cast_wrr_no_split",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=1)",
+      "description": "QP-sharing gate at maximum concentration -- every connection on one shared QP. Layout sweep, churn layout, all-connection data path, unshared-regime data path and GDR flush routing, all with expectations derived from NGROUPS rather than pinned to it.",
+      "config": "qpshare_ngroups1",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=2)",
+      "description": "QP-sharing gate at the smallest mixed configuration: PRIMARY-only and PRIMARY+SECONDARY groups side by side. Same five functional tests.",
+      "config": "qpshare_ngroups2",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=16)",
+      "description": "QP-sharing gate at the wide configuration, straddling the shared and unshared regimes within one run. Same five functional tests. Expected green, but INTERMITTENTLY CRASHES -- measured 2 runs in 18 on AINIC (2026-08-17) -- on a use-after-free in the group teardown path. A signal-kill here is that known defect, not a new regression; the qpshare_uaf_teardown configuration reproduces it deterministically. Do not paper over it with a retry.",
+      "config": "qpshare_ngroups16",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (under-provisioned depth)",
+      "description": "128 comms in one group at the default depth multiplier. EXPECTED RED: the transport has no saturation fallback, so the connections establish and the data phase then fails with ENOMEM instead of the queue being sized for the group or the comm degrading to an unshared QP. Acceptance criterion for that fix, not a documented limitation.",
+      "config": "qpshare_undersized_depth",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (depth multiplier ceiling)",
+      "description": "The same missing capacity check from the other side: a depth multiplier the device cannot allocate. EXPECTED RED -- the first connection fails outright instead of the multiplier being clamped to the device limit. Ceiling is on depth x NCCL_IB_QPS_PER_CONNECTION and is hardware-dependent, so on a NIC with more work-queue room this preset passes until the multiplier is raised further.",
+      "config": "qpshare_depth_ceiling",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing Stress",
+      "description": "Many-connection load, shared-RQ saturation and batch create/destroy under sharing. One EXPECTED RED: StressBatchCreateDestroy, against a sharing-specific protection-domain leak whose rate is set by group occupancy (comms per group). Kept gating as an acceptance criterion for the PD-lifetime fix, not disabled. Connection churn is deliberately NOT in this configuration -- see the separate qpshare_stress_churn entry below.",
+      "config": "qpshare_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing Stress (connection churn)",
+      "description": "Connection churn under sharing, in its own configuration and therefore its own process. EXPECTED RED against the same PD-lifetime bug as qpshare_stress, at the occupancy that hits it hardest: one comm per group, so every cycle reaches the group teardown and leaks one PD, exhausting the device max_pd (1024) at iteration 1022. Separated from qpshare_stress because churn leaves the process unable to connect and the next attempt segfaults -- anything sharing a process with it would never report. Longer timeout (1800s) than the rest: 2048 connect/transfer/close cycles is minutes of wall time, not seconds.",
+      "config": "qpshare_stress_churn",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (use-after-free teardown)",
+      "description": "The deterministic form of the intermittent ngroups=16 crash: same test and tunables, plus MALLOC_PERTURB_=165 so the stale read into a freed comm faults every time (6/6 with the poison, 0/6 without). EXPECTED RED, reported as a signal rather than a test failure because the process dies. Acceptance criterion for storing ibDevN by value in the shared-QP pool slot instead of a pointer into the comm. glibc-only: on another allocator this degrades to a duplicate of qpshare_ngroups16.",
+      "config": "qpshare_uaf_teardown",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

This PR adds baseline QP sharing Unit tests

To run the tests:

1. Build RCCL with enabled unit tests:
`./install.sh --debug-fast -l -i -t --enable-mpi-tests '--prefix=<rccl_install_dir>`

2. Manual run of QP sharing tests:
```
#!/bin/bash
set -u
HOSTS=${HOSTS:-host_1:1,host_2:1}
IFACE=${IFACE:-eth0}
GID_INDEX=${GID_INDEX:-1}
BIN=${BIN:-$HOME/rccl_qpshare/bin/rccl-UnitTestsMPI}
RCCL_LIB=${RCCL_LIB:-$HOME/rccl_qpshare/lib}
MPI_HOME=${MPI_HOME:-$HOME/openmpi-5.0.9/install}
LOGDIR=${LOGDIR:-$HOME/qpshare_gate_logs}
EXTRA_MPI_ENV=${EXTRA_MPI_ENV:-}
export PATH=$MPI_HOME/bin:${PATH:-}
export LD_LIBRARY_PATH=$MPI_HOME/lib:$RCCL_LIB:${LD_LIBRARY_PATH:-}
[ -x "$BIN" ] || { echo "no test binary at $BIN"; exit 2; }
NTESTS=$("$BIN" --gtest_list_tests --gtest_filter='NetIbMPITest.QpShare*' 2>/dev/null | grep -c '^  ')
if [ "$NTESTS" -lt 9 ]; then
    echo "$BIN has $NTESTS QpShare tests, expected 9 -- wrong or stale binary."
    echo "Point BIN and RCCL_LIB at the same build, e.g."
    echo "  BIN=<build>/test/rccl-UnitTestsMPI RCCL_LIB=<build> $0"
    exit 2
fi
mkdir -p "$LOGDIR" || exit 2
FUNCTIONAL="NetIbMPITest.QpShareAlgoLayoutSweep:NetIbMPITest.QpShareAlgoChurnLayout:NetIbMPITest.QpShareDataAllConnsTransfer:NetIbMPITest.QpShareDataUnsharedGroups:NetIbMPITest.QpShareDataFlushRouting"
STRESS_FAST="NetIbMPITest.QpShareStressManyConns:NetIbMPITest.QpShareStressSharedRqSaturation"
# run <name> <timeout seconds> <env for this case> <gtest filter>
run() {
    echo
    echo "===== $1   [$3]"
    mkdir -p "$LOGDIR/$1"
    local envargs="" kv
    for kv in $3; do envargs="$envargs -x $kv"; done
    timeout --signal=TERM --kill-after=30 "$2" \
    mpirun --bind-to none -np 2 -H "$HOSTS" \
        -mca btl_tcp_if_include "$IFACE" --mca btl ^vader,openib \
        -x PATH -x LD_LIBRARY_PATH \
        -x NCCL_SOCKET_IFNAME="$IFACE" -x NCCL_IB_GID_INDEX="$GID_INDEX" \
        -x RCCL_AINIC_ROCE=1 -x NCCL_DEBUG=WARN \
        -x NCCL_DEBUG_FILE="$LOGDIR/$1/nccl_%h_%p.log" \
        -x NCCL_IB_MERGE_NICS=0 -x NCCL_NET_FORCE_MERGE= \
        $EXTRA_MPI_ENV $envargs \
        "$BIN" --gtest_filter="$4" < /dev/null
    echo "----- $1 exit=$?   per-rank logs: $LOGDIR/$1/"
}
run gate_ngroups1          300 "RCCL_IB_COMM_NGROUPS=1 RCCL_IB_QP_DEPTH_MULTIPLIER=8 NCCL_GDR_FLUSH_DISABLE=0" "$FUNCTIONAL"
run gate_ngroups2          300 "RCCL_IB_COMM_NGROUPS=2 RCCL_IB_QP_DEPTH_MULTIPLIER=8 NCCL_GDR_FLUSH_DISABLE=0" "$FUNCTIONAL"
run gate_ngroups16         300 "RCCL_IB_COMM_NGROUPS=16 RCCL_IB_QP_DEPTH_MULTIPLIER=8 NCCL_GDR_FLUSH_DISABLE=0" "$FUNCTIONAL"
# MALLOC_PERTURB_ makes glibc poison freed memory. It is a diagnostic, not a
# workload: it turns an intermittent use-after-free in the group-teardown path
# into a deterministic crash. Do not add it to the other cases.
run gate_uaf_teardown      300 "RCCL_IB_COMM_NGROUPS=16 RCCL_IB_QP_DEPTH_MULTIPLIER=8 NCCL_GDR_FLUSH_DISABLE=0 MALLOC_PERTURB_=165" "NetIbMPITest.QpShareAlgoChurnLayout"
run gate_saturation_depth1 300 "RCCL_IB_COMM_NGROUPS=1 QPSHARE_TEST_NCONNS=128" "NetIbMPITest.QpShareDataAllConnsTransfer"
run gate_depth_ceiling     300 "RCCL_IB_COMM_NGROUPS=1 RCCL_IB_QP_DEPTH_MULTIPLIER=96 NCCL_IB_QPS_PER_CONNECTION=1 QPSHARE_TEST_NCONNS=2" "NetIbMPITest.QpShareDataAllConnsTransfer"
# The stress cases take minutes
run gate_stress           1800 "RCCL_IB_COMM_NGROUPS=2 RCCL_IB_QP_DEPTH_MULTIPLIER=64 NCCL_IB_QPS_PER_CONNECTION=1" "$STRESS_FAST"
run gate_stress_batch     1800 "RCCL_IB_COMM_NGROUPS=2 RCCL_IB_QP_DEPTH_MULTIPLIER=64 NCCL_IB_QPS_PER_CONNECTION=1" "NetIbMPITest.QpShareStressBatchCreateDestroy"
run gate_stress_churn     1800 "RCCL_IB_COMM_NGROUPS=2 RCCL_IB_QP_DEPTH_MULTIPLIER=64 NCCL_IB_QPS_PER_CONNECTION=1" "NetIbMPITest.QpShareStressConnectionChurn"
```

## Technical Details

This pull request introduces a comprehensive test and introspection infrastructure for QP (Queue Pair) sharing in the NetIB-CAST transport layer, with a focus on enabling, validating, and stress-testing the QP sharing feature through new APIs, test utilities, and CI categories. The changes include a new test-only introspection API, expanded test coverage with new test files and categories, and robust environment checks for QP sharing compatibility.

**Key changes include:**

### QP Sharing Introspection API

- Added a new header `net_ib_qp_sharing_inspect.h` that defines a test-only introspection API (`ncclIbCastGetQpSharingState`) to expose internal QP-sharing state for unit tests. This API allows tests to verify the state of shared QPs without diverging from the actual implementation. [[1]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44) [[2]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R9) [[3]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R206-R247)

### Build System and Source Integration

- Integrated the new introspection header into the build system by updating the relevant `CMakeLists.txt` files to include `net_ib_qp_sharing_inspect.h` in both source and test builds, ensuring the API is available for unit tests. [[1]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR467) [[2]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR5) [[3]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517L121-R121) [[4]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517R565)

### Test Infrastructure and Coverage

- Introduced new test support and reference model headers (`NetIbQpSharingInspect.hpp`, `QpShareRefModel.hpp`) and integrated them into the NetIbMPI test base for validating QP sharing logic and expected layouts.
- Added a macro (`QPSHARE_ENV_CHECK_OR_SKIP`) to robustly skip QP sharing tests when incompatible environment variables or features are detected, ensuring tests are only run in valid configurations.
- Enhanced the NetIbMPITest fixture with layout failure reporting and capped error output for easier debugging of QP sharing issues.

### CI and Test Category Expansion

- Expanded the test suite with new QP sharing test files and categories, including functional, stress, and negative tests (e.g., under-provisioned, saturation, and teardown scenarios). These are integrated into `test_categories_mpi.yaml` with detailed descriptions, environment variables, and expected outcomes (including expected failures for known issues). [[1]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R164-R235) [[2]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R422-R478) [[3]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R495-R499) [[4]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R511-R513)

---

**Most important changes:**

#### QP Sharing Introspection and API

* Added `net_ib_qp_sharing_inspect.h` and implemented `ncclIbCastGetQpSharingState`, a test-only API for extracting QP sharing state from comm handles, enabling detailed white-box unit tests for QP sharing logic. [[1]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44) [[2]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R9) [[3]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R206-R247)

#### Build and Source Integration

* Updated `CMakeLists.txt` files to include the new introspection header in both source and test builds, ensuring the API is available for all relevant test targets. [[1]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR467) [[2]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR5) [[3]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517L121-R121) [[4]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517R565)

#### Test Infrastructure

* Integrated new QP sharing test utilities and reference models into the NetIbMPI test base, and added a macro to skip tests when the environment is not suitable for QP sharing. [[1]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR14-R15) [[2]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR89-R129)
* Enhanced test fixtures with failure tracking for QP sharing layout validation.

#### CI/Test Suite Expansion

* Added new QP sharing test files and expanded `test_categories_mpi.yaml` with detailed QP sharing test categories, covering functional, stress, and negative scenarios, including expected failures for known issues. [[1]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R164-R235) [[2]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R422-R478) [[3]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R495-R499) [[4]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R511-R513)

## Issue Tracking

AICOMNET-352

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
