### PR TITLE
rocrtst: size and zero kernarg buffers from the kernel's kernarg segment

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
@@ -225,10 +225,25 @@ void MemoryAccessTest::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent,
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
 
+    // Create the executable, get symbol by name and load the code object.
+    // This must happen before the kernarg buffer is allocated so that the
+    // kernel's kernarg segment size is known.
+    set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+    set_kernel_name("gpuReadWrite");
+    err = rocrtst::LoadKernelFromObjFile(this, &gpuAgent);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
     // Allocate the kernel argument buffer from the kernarg_pool.
-    err = hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+    // The kernel's kernarg segment is larger than the explicit arguments: it
+    // also holds the hidden arguments (global offsets, printf buffer, ...).
+    // Allocate the full segment reported by the code object and zero it, so
+    // the hidden arguments are not read back as stale kernarg pool contents.
+    const size_t kernarg_buf_size =
+        std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+    err = hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                         reinterpret_cast<void **>(&kernArgs));
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    memset(kernArgs, 0, kernarg_buf_size);
 
     // initialize the host buffers
     for (int i = 0; i < kMemoryAllocSize; ++i) {
@@ -268,12 +283,6 @@ void MemoryAccessTest::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent,
     kernArgs->b = cpuResult;  // system memory passed to gpu for write
     kernArgs->c = gpuResult;  // gpu memory to verify that gpu read system data
 
-
-    // Create the executable, get symbol by name and load the code object
-    set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-    set_kernel_name("gpuReadWrite");
-    err = rocrtst::LoadKernelFromObjFile(this, &gpuAgent);
-    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
     // Fill the dispatch packet with
     // workgroup_size, grid_size, kernelArgs and completion signal
@@ -604,10 +613,24 @@ void MemoryAccessTest::MemoryAccessCoherentTest(void) {
                                             &kernarg_pool);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
+  // - create kernel object for dispatch.  This must happen before the kernarg
+  // buffer is allocated so that the kernel's kernarg segment size is known.
+  set_kernel_file_name("vector_copy_kernels.hsaco");
+  set_kernel_name("vector_copy");
+  err = rocrtst::LoadKernelFromObjFile(this, &gpus[0]);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  err = hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  err = hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                       reinterpret_cast<void **>(&k_Args));
-  ASSERT_EQ(err, HSA_STATUS_SUCCESS);  
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  memset(k_Args, 0, kernarg_buf_size);
 
   err = hsa_amd_agents_allow_access(1, &gpus[0], NULL, k_Args);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
@@ -638,12 +661,6 @@ void MemoryAccessTest::MemoryAccessCoherentTest(void) {
   // - Place Dispatch packet into the queue
   hsa_kernel_dispatch_packet_t dispatch_pkt;
   memset(&dispatch_pkt, 0, sizeof(dispatch_pkt));
-
-  // - create kernel object for dispatch
-  set_kernel_file_name("vector_copy_kernels.hsaco");
-  set_kernel_name("vector_copy");
-  err = rocrtst::LoadKernelFromObjFile(this, &gpus[0]);
-  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   // initialize aql packet
   dispatch_pkt.workgroup_size_x = 256;

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_allocation.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_allocation.cc
@@ -225,11 +225,6 @@ void MemoryAllocationTest::GroupMemoryDynamicAllocation(hsa_agent_t cpuAgent,
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
 
-    // Allocate the kernel argument buffer from the kernarg_pool.
-    err = hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
-                                        reinterpret_cast<void **>(&kernArgs));
-    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-
     // initialize the host buffers
     for (int i = 0; i < kMemoryAllocSize; ++i) {
       // unsigned int seed = time(NULL);
@@ -254,15 +249,8 @@ void MemoryAllocationTest::GroupMemoryDynamicAllocation(hsa_agent_t cpuAgent,
     // Allow gpuAgent access to all allocated system memory.
     err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, Indata);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-    err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArgs);
-    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
     uint32_t grp_offset = group_segment_size();
-    kernArgs->a = Indata;
-    // gpu memory where data will be copied from dynamically group memory
-    kernArgs->b = OutData;
-    kernArgs->grp_offset = grp_offset;
-    kernArgs->count = kMemoryAllocSize;
 
     // Fill up the kernel packet except header
     err = rocrtst::InitializeAQLPacket(this, &aql());
@@ -273,6 +261,28 @@ void MemoryAllocationTest::GroupMemoryDynamicAllocation(hsa_agent_t cpuAgent,
     set_kernel_name("group_memory_dynamic");
     err = rocrtst::LoadKernelFromObjFile(this, &gpuAgent);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+    // Allocate the kernel argument buffer from the kernarg_pool.  This is done
+    // after the code object is loaded so that the kernel's kernarg segment
+    // size is known.  That segment is larger than the explicit arguments: it
+    // also holds the hidden arguments (global offsets, printf buffer, ...).
+    // Allocate the full segment and zero it, so the hidden arguments are not
+    // read back as stale kernarg pool contents.
+    const size_t kernarg_buf_size =
+        std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+    err = hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
+                                        reinterpret_cast<void **>(&kernArgs));
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+    memset(kernArgs, 0, kernarg_buf_size);
+
+    err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArgs);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+    kernArgs->a = Indata;
+    // gpu memory where data will be copied from dynamically group memory
+    kernArgs->b = OutData;
+    kernArgs->grp_offset = grp_offset;
+    kernArgs->count = kMemoryAllocSize;
 
     // The total byte size of group memory, static + dynamic
     uint32_t total_grp_byte_size = group_segment_size() + kMemoryAllocSize * sizeof(uint32_t);

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
@@ -265,12 +265,9 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
 
-  // Allocate the kernel argument buffer from the kernarg_pool.
+  // The kernarg buffer is allocated further down, once the code object has
+  // been loaded and the kernel's kernarg segment size is known.
   args *kernArguments = NULL;
-  err = hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
-                                     reinterpret_cast<void **>(&kernArguments));
-  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-
 
   memset(oldValues, 0, kMemoryAllocSize);
   memset(expecteddata, 0, kMemoryAllocSize);
@@ -345,20 +342,6 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, oldrefdata);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-  err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArguments);
-  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-
-  kernArguments->a = refSysdata;
-  if (access != HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
-    kernArguments->b = gpuRefData;
-  } else {
-    kernArguments->b = g_gpuRefData;
-  }
-  kernArguments->c = oldValues;
-
-  if (testtype_ != INC && testtype_ != DEC) {
-    kernArguments->d = kValue;
-  }
 
   // Create the executable, get symbol by name and load the code object
   set_kernel_file_name("atomicOperations_kernels.hsaco");
@@ -431,6 +414,34 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
 
   err = rocrtst::LoadKernelFromObjFile(this, &gpuAgent);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  // Allocate the kernel argument buffer from the kernarg_pool.  This is done
+  // after the code object is loaded so that the kernel's kernarg segment size
+  // is known.  That segment is larger than the explicit arguments: it also
+  // holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment and zero it, so the hidden arguments are not
+  // read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  err = hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
+                                     reinterpret_cast<void **>(&kernArguments));
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  memset(kernArguments, 0, kernarg_buf_size);
+
+  err = hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArguments);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  kernArguments->a = refSysdata;
+  if (access != HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
+    kernArguments->b = gpuRefData;
+  } else {
+    kernArguments->b = g_gpuRefData;
+  }
+  kernArguments->c = oldValues;
+
+  if (testtype_ != INC && testtype_ != DEC) {
+    kernArguments->d = kValue;
+  }
 
   // Fill up the kernel packet except header
   err = rocrtst::InitializeAQLPacket(this, &aql());

--- a/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
@@ -210,19 +210,28 @@ void SvmMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_poo
   memset(host_data->result, 0, sizeof(host_data->result));
   memset(dev_data->result, 0, sizeof(dev_data->result));
 
+  // Create the executable, get symbol by name and load the code object.
+  // This must happen before the kernarg buffer is allocated so that the
+  // kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &agent));
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgs)));
+  memset(kernArgs, 0, kernarg_buf_size);
 
   ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &agent, NULL, kernArgs));
   kernArgs->a = host_data->data;
   kernArgs->b = host_data->result;  // system memory passed to gpu for write
   kernArgs->c = dev_data->result;   // gpu memory to verify that gpu read system data
-
-  // Create the executable, get symbol by name and load the code object
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &agent));
 
   ASSERT_SUCCESS(hsa_signal_create(1, 0, NULL, &signal));
 
@@ -652,11 +661,19 @@ void SvmMemoryTestBasic::TestSVMBatchDiscard(hsa_agent_t agent, hsa_amd_memory_p
     int* c;
   } args;
 
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args));
+
   for (int i = 0; i < kNumRegions; i++) {
     // allocate kernel arguments
     args* kernArgs = nullptr;
-    ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args), 0,
+    ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                                 reinterpret_cast<void**>(&kernArgs)));
+    memset(kernArgs, 0, kernarg_buf_size);
     ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &agent, NULL, kernArgs));
 
     // setup kernel args to write to this region

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -854,9 +854,23 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
 
   ASSERT_SUCCESS(hsa_amd_vmem_set_access(dev_data, sizeof(*dev_data), permsAccess, 2));
 
+  // Create the executable, get symbol by name and load the code object.
+  // This must happen before the kernarg buffer is allocated so that the
+  // kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgsVirt)));
+  memset(kernArgsVirt, 0, kernarg_buf_size);
 
   // initialize the host buffers
   for (int i = 0; i < kMemoryAllocSize; ++i) {
@@ -873,11 +887,6 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   kernArgsVirt->a = host_data->data;
   kernArgsVirt->b = host_data->result;  // system memory passed to gpu for write
   kernArgsVirt->c = dev_data->result;   // gpu memory to verify that gpu read system data
-
-  // Create the executable, get symbol by name and load the code object
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Fill the dispatch packet with
   // workgroup_size, grid_size, kernelArgs and completion signal
@@ -1097,9 +1106,23 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   ASSERT_SUCCESS(
       hsa_amd_vmem_set_access(dev_data, sizeof(*dev_data), permsAccess, ARRAY_SIZE(permsAccess)));
 
+  // Create the executable, get symbol by name and load the code object.
+  // This must happen before the kernarg buffer is allocated so that the
+  // kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgsVirt)));
+  memset(kernArgsVirt, 0, kernarg_buf_size);
 
   // create completion signal
   ASSERT_SUCCESS(hsa_signal_create(1, 0, NULL, &signal));
@@ -1126,11 +1149,6 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   kernArgsVirt->a = dev_data->data;
   kernArgsVirt->b = host_data->gpuWrite;  // system memory passed to gpu for write
   kernArgsVirt->c = dev_data->result;     // gpu memory to verify that gpu read system data
-
-  // Create the executable, get symbol by name and load the code object
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Fill the dispatch packet with
   // workgroup_size, grid_size, kernelArgs and completion signal
@@ -1597,19 +1615,27 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(hsa_agent_t cpuAgent, hsa_agent_t
     host_data[i] = i;
   }
 
-  // Allocate kernel arguments
+  // Load kernel.  This must happen before the kernarg buffer is allocated so
+  // that the kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
+  // Allocate kernel arguments.
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
   args_t* kernArgs = nullptr;
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgs)));
+  memset(kernArgs, 0, kernarg_buf_size);
   ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArgs));
 
   // Create completion signal
   ASSERT_SUCCESS(hsa_signal_create(1, 0, NULL, &signal));
-
-  // Load kernel
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Setup kernel args to write to addr1
   kernArgs->a = host_data;
@@ -2414,10 +2440,23 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   memset(vmem_data->output, 0, sizeof(vmem_data->output));
   memset(host_data->result, 0, sizeof(host_data->result));
 
-  // Allocate kernel arguments
+  // Load the kernel.  This must happen before the kernarg buffer is allocated
+  // so that the kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpu_agent));
+
+  // Allocate kernel arguments.
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
   args_t* kernArgs = nullptr;
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgs)));
+  memset(kernArgs, 0, kernarg_buf_size);
   ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &gpu_agent, NULL, kernArgs));
 
   // Kernel: c[i] = a[i]; b[i] = i;
@@ -2427,11 +2466,6 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   kernArgs->a = vmem_data->input;
   kernArgs->b = vmem_data->output;
   kernArgs->c = host_data->result;
-
-  // Load the kernel
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpu_agent));
 
   // Create completion signal
   hsa_signal_t signal = {0};

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -846,9 +846,23 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
 
   ASSERT_SUCCESS(hsa_amd_vmem_set_access(dev_data, sizeof(*dev_data), permsAccess, 2));
 
+  // Create the executable, get symbol by name and load the code object.
+  // This must happen before the kernarg buffer is allocated so that the
+  // kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgsVirt)));
+  memset(kernArgsVirt, 0, kernarg_buf_size);
 
   // initialize the host buffers
   for (int i = 0; i < kMemoryAllocSize; ++i) {
@@ -865,11 +879,6 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   kernArgsVirt->a = host_data->data;
   kernArgsVirt->b = host_data->result;  // system memory passed to gpu for write
   kernArgsVirt->c = dev_data->result;   // gpu memory to verify that gpu read system data
-
-  // Create the executable, get symbol by name and load the code object
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Fill the dispatch packet with
   // workgroup_size, grid_size, kernelArgs and completion signal
@@ -1089,9 +1098,23 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   ASSERT_SUCCESS(
       hsa_amd_vmem_set_access(dev_data, sizeof(*dev_data), permsAccess, ARRAY_SIZE(permsAccess)));
 
+  // Create the executable, get symbol by name and load the code object.
+  // This must happen before the kernarg buffer is allocated so that the
+  // kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
   // Allocate the kernel argument buffer from the kernarg_pool.
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgsVirt)));
+  memset(kernArgsVirt, 0, kernarg_buf_size);
 
   // create completion signal
   ASSERT_SUCCESS(hsa_signal_create(1, 0, NULL, &signal));
@@ -1118,11 +1141,6 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   kernArgsVirt->a = dev_data->data;
   kernArgsVirt->b = host_data->gpuWrite;  // system memory passed to gpu for write
   kernArgsVirt->c = dev_data->result;     // gpu memory to verify that gpu read system data
-
-  // Create the executable, get symbol by name and load the code object
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Fill the dispatch packet with
   // workgroup_size, grid_size, kernelArgs and completion signal
@@ -1590,19 +1608,27 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(hsa_agent_t cpuAgent, hsa_agent_t
     host_data[i] = i;
   }
 
-  // Allocate kernel arguments
+  // Load kernel.  This must happen before the kernarg buffer is allocated so
+  // that the kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
+
+  // Allocate kernel arguments.
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
   args_t* kernArgs = nullptr;
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgs)));
+  memset(kernArgs, 0, kernarg_buf_size);
   ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &gpuAgent, NULL, kernArgs));
 
   // Create completion signal
   ASSERT_SUCCESS(hsa_signal_create(1, 0, NULL, &signal));
-
-  // Load kernel
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpuAgent));
 
   // Setup kernel args to write to addr1
   kernArgs->a = host_data;
@@ -2396,10 +2422,23 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   memset(vmem_data->output, 0, sizeof(vmem_data->output));
   memset(host_data->result, 0, sizeof(host_data->result));
 
-  // Allocate kernel arguments
+  // Load the kernel.  This must happen before the kernarg buffer is allocated
+  // so that the kernel's kernarg segment size is known.
+  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
+  set_kernel_name("gpuReadWrite");
+  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpu_agent));
+
+  // Allocate kernel arguments.
+  // The kernel's kernarg segment is larger than the explicit arguments: it
+  // also holds the hidden arguments (global offsets, printf buffer, ...).
+  // Allocate the full segment reported by the code object and zero it, so
+  // the hidden arguments are not read back as stale kernarg pool contents.
+  const size_t kernarg_buf_size =
+      std::max(static_cast<size_t>(kernarg_size()), sizeof(args_t));
   args_t* kernArgs = nullptr;
-  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
+  ASSERT_SUCCESS(hsa_amd_memory_pool_allocate(kernarg_pool, kernarg_buf_size, 0,
                                               reinterpret_cast<void**>(&kernArgs)));
+  memset(kernArgs, 0, kernarg_buf_size);
   ASSERT_SUCCESS(hsa_amd_agents_allow_access(1, &gpu_agent, NULL, kernArgs));
 
   // Kernel: c[i] = a[i]; b[i] = i;
@@ -2409,11 +2448,6 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   kernArgs->a = vmem_data->input;
   kernArgs->b = vmem_data->output;
   kernArgs->c = host_data->result;
-
-  // Load the kernel
-  set_kernel_file_name("gpuReadWrite_kernels.hsaco");
-  set_kernel_name("gpuReadWrite");
-  ASSERT_SUCCESS(rocrtst::LoadKernelFromObjFile(this, &gpu_agent));
 
   // Create completion signal
   hsa_signal_t signal = {0};


### PR DESCRIPTION
## Motivation

Several rocrtst functional tests allocate their kernel argument buffer as `sizeof(args_t)` — the explicit arguments only — and never zero it:

```cpp
err = hsa_amd_memory_pool_allocate(kernarg_pool, sizeof(args_t), 0,
                                   reinterpret_cast<void **>(&kernArgs));
```

The kernels' kernarg segments are larger than that, because the compiler appends hidden arguments (global offsets, printf buffer, ...). For `gpuReadWrite` in `MemoryAccessTest::GPUAccessToCPUMemoryTest`:

| | bytes |
|---|---|
| kernel's declared `.kernarg_segment_size` | 80 |
| allocated (`sizeof(args_t)` — 3 pointers, `aligned(16)`) | 32 |
| actually written (`a`, `b`, `c`) | 24 |

`hidden_global_offset_x` sits at offset 24 and is never initialized, so whatever was previously in the kernarg pool is read back as a hidden argument.

This is latent wherever freed pool pages are returned zeroed, which is why it has gone unnoticed. Where they are not, the kernel adds the stale value to the base pointer and accesses out of range.

## Technical Details

Observed as a segfault in `rocrtstFunc.MemoryAccessTests` on a target whose runtime recycles freed pool pages without scrubbing them. An earlier subtest in the same test (`CPUAccessToGPUMemoryTest`) fills a large buffer with an incrementing dword pattern and frees it; those pages are then handed back for the kernarg allocation. `hidden_global_offset_x` read back as `0x00a82c06`, the kernel computed `a + 4*0xa82c06`, and the resulting address faulted. Zeroing bytes 24–47 of the kernarg buffer at runtime under a debugger makes the test pass, confirming the diagnosis.

**Fix:** load the code object *before* allocating, so the kernel's kernarg segment size is known, then allocate `max(kernarg_size(), sizeof(args_t))` and `memset` it to zero before storing the explicit arguments. Querying the code object rather than hardcoding a hidden-argument tail keeps this correct across code-object-version changes.

Applied to all ten affected call sites in `memory_access.cc` (2), `memory_allocation.cc` (1), `memory_atomics.cc` (1), `svm_memory.cc` (2) and `virtual_memory.cc` (4).

Two files needed care rather than a mechanical hoist: `memory_atomics.cc` selects its kernel name inside the per-operation if/else chain, and `memory_allocation.cc` reads `group_segment_size()` before the load — in both, only the allocation and argument stores moved below the existing load, preserving all other ordering.

Each kernel's actual `kernarg_segment_size` was confirmed with `llvm-readelf --notes`. Sites in `cu_masking.cc`, `queue_create.cc`, `counted_queues.cc`, `metadata_prefetch.cc`, `test_case_template.cc`, `gpu_coredump.cc` and `signal_kernel.cc` were checked and are already correct.

Fixing only the first site was not sufficient — the run then failed at the next undersized site, which had been shadowed by the earlier fault.

Two adjacent issues noted but deliberately **not** addressed here (both recorded in the linked issue):

- `memory_allocation.cc` reads `group_segment_size()` before the code object is loaded, and `BaseRocR`'s constructor never initializes `group_segment_size_` — so `kernArgs->grp_offset` is an uninitialized read today.
- `rocrtst::AllocAndSetKernArgs()` copies exactly `arg_size` bytes and zeroes no tail, so callers passing `sizeof(args_t)` hit this same class of bug.

## Issue Tracking

ISSUE ID : https://github.com/ROCm/rocm-systems/issues/10134

Closes #10134

## Test Plan

Build rocrtst standalone and run the `quick` ctest label, A/B with and without the change on the same build tree, on a target that does not zero recycled pool pages (so the latent bug is actually exercised).

## Test Result

- A/B on the originally crashing site, same build tree: without the fix, segfault (exit 139); with it, `[ OK ]`, exit 0.
- Full `quick` label afterwards: **4/4 ctest suites, 16/16 gtests passing.**
- Exercised and passing: both `memory_access.cc` sites, `memory_allocation.cc`, all ten `Memory_Atomic_*`, and all three `SvmMemory_*`.

**Not verified:** the four `virtual_memory.cc` sites are compile-only — those tests are skipped in the environment used, and force-enabling them aborts earlier for an unrelated reason (the installed ROCr predates the source and lacks `HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED`), so those edits were never reached at runtime. Not run on any other target, and no ASAN/static build.

> Note on the automated **Unit Test** policy warning: every file changed here *is* a test — these are the rocrtst functional test suites themselves. The change is a correctness fix to existing tests, so there is no separate `test_*.cc` to add.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
