### PR TITLE
test(rocrtst): several rocrtsts functions hang/fail when run on WSL2

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -50,6 +50,7 @@
 #include "common/platform_filter.h"
 #include "gtest/gtest.h"
 #include <assert.h>
+#include <algorithm>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sstream>
@@ -169,6 +170,8 @@ PlatformType PlatformDetector::detectPlatform() {
     } else if (platform_str == "REAL_HARDWARE" ||
                platform_str == "REAL" || platform_str == "HW") {
       return PlatformType::REAL_HARDWARE;
+    } else if (platform_str == "WSL") {
+      return PlatformType::WSL;
     }
   }
 
@@ -183,6 +186,26 @@ PlatformType PlatformDetector::detectPlatform() {
     return PlatformType::EMULATOR;
   }
 
+  // Check WSL (via /proc/version containing "microsoft" or "WSL")
+  {
+    FILE* file = fopen("/proc/version", "r");
+    if (file) {
+      char buf[512];
+      if (fgets(buf, sizeof(buf), file)) {
+        std::string version(buf);
+        std::string version_lower(version);
+        std::transform(version_lower.begin(), version_lower.end(),
+                       version_lower.begin(), ::tolower);
+        if (version_lower.find("microsoft") != std::string::npos ||
+            version_lower.find("wsl") != std::string::npos) {
+          fclose(file);
+          return PlatformType::WSL;
+        }
+      }
+      fclose(file);
+    }
+  }
+
   // Default to real hardware
   return PlatformType::REAL_HARDWARE;
 }
@@ -195,6 +218,8 @@ const char* PlatformDetector::platformName(PlatformType platform) {
       return "EMULATOR";
     case PlatformType::FFM_SIMULATOR:
       return "FFM_SIMULATOR";
+    case PlatformType::WSL:
+      return "WSL";
     case PlatformType::UNKNOWN:
       return "UNKNOWN";
     default:

--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -48,6 +48,7 @@
 #include "common/common.h"
 #include "common/env_config.h"
 #include <assert.h>
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <memory>
@@ -129,6 +130,8 @@ PlatformType PlatformDetector::detectPlatform() {
     } else if (platform_str == "REAL_HARDWARE" ||
                platform_str == "REAL" || platform_str == "HW") {
       return PlatformType::REAL_HARDWARE;
+    } else if (platform_str == "WSL") {
+      return PlatformType::WSL;
     }
   }
 
@@ -143,6 +146,26 @@ PlatformType PlatformDetector::detectPlatform() {
     return PlatformType::EMULATOR;
   }
 
+  // Check WSL (via /proc/version containing "microsoft" or "WSL")
+  {
+    FILE* file = fopen("/proc/version", "r");
+    if (file) {
+      char buf[512];
+      if (fgets(buf, sizeof(buf), file)) {
+        std::string version(buf);
+        std::string version_lower(version);
+        std::transform(version_lower.begin(), version_lower.end(),
+                       version_lower.begin(), ::tolower);
+        if (version_lower.find("microsoft") != std::string::npos ||
+            version_lower.find("wsl") != std::string::npos) {
+          fclose(file);
+          return PlatformType::WSL;
+        }
+      }
+      fclose(file);
+    }
+  }
+
   // Default to real hardware
   return PlatformType::REAL_HARDWARE;
 }
@@ -155,6 +178,8 @@ const char* PlatformDetector::platformName(PlatformType platform) {
       return "EMULATOR";
     case PlatformType::FFM_SIMULATOR:
       return "FFM_SIMULATOR";
+    case PlatformType::WSL:
+      return "WSL";
     case PlatformType::UNKNOWN:
       return "UNKNOWN";
     default:

--- a/projects/rocr-runtime/rocrtst/common/common.h
+++ b/projects/rocr-runtime/rocrtst/common/common.h
@@ -117,6 +117,7 @@ enum class PlatformType {
   REAL_HARDWARE,
   EMULATOR,
   FFM_SIMULATOR,
+  WSL,
   UNKNOWN
 };
 

--- a/projects/rocr-runtime/rocrtst/common/platform_filter.cc
+++ b/projects/rocr-runtime/rocrtst/common/platform_filter.cc
@@ -90,6 +90,8 @@ bool TestFilterManager::loadConfiguration(const std::string& path) {
           platformType = PlatformType::EMULATOR;
         } else if (platformName == "FFM_SIMULATOR") {
           platformType = PlatformType::FFM_SIMULATOR;
+        } else if (platformName == "WSL") {
+          platformType = PlatformType::WSL;
         } else {
           continue;  // Skip unknown platforms
         }

--- a/projects/rocr-runtime/rocrtst/config/platform_config.yaml
+++ b/projects/rocr-runtime/rocrtst/config/platform_config.yaml
@@ -184,6 +184,18 @@ platforms:
       - rocrtstStress.Queue_CAS_Write_Index_ConcurrentTest
       - rocrtstStress.Queue_LoadStore_Write_Index_ConcurrentTest
 
+  # WSL - most tests work, but virtual memory is unsupported
+  WSL:
+    allowed_groups: ["*"]
+    blocked_tests:
+      # Virtual memory tests: hsa_amd_vmem_set_access returns HSA_STATUS_ERROR on WSL
+      - rocrtstFunc.VirtMemory_Accounting_Test
+      - rocrtstFunc.VirtMemory_NonContiguousChunks_Test
+      - rocrtstFunc.VirtMemory_GPUtoHostAccess_Test
+      # Trap handler tests: unsupported on WSL
+      - rocrtstFunc.TrapHandler_Abort
+      - rocrtstFunc.TrapHandler_Generic
+
   # FFM Simulator - only Core and Extended groups allowed
   FFM_SIMULATOR:
     allowed_groups: [Core, Extended]

--- a/projects/rocr-runtime/rocrtst/config/platform_config.yaml
+++ b/projects/rocr-runtime/rocrtst/config/platform_config.yaml
@@ -182,6 +182,23 @@ platforms:
       - rocrtstStress.Queue_CAS_Write_Index_ConcurrentTest
       - rocrtstStress.Queue_LoadStore_Write_Index_ConcurrentTest
 
+  # WSL - most tests work, but virtual memory and GPU core-dump are unsupported
+  WSL:
+    allowed_groups: ["*"]
+    blocked_tests:
+      # Virtual memory tests: hsa_amd_vmem_set_access returns HSA_STATUS_ERROR on WSL
+      - rocrtstFunc.VirtMemory_Accounting_Test
+      - rocrtstFunc.VirtMemory_NonContiguousChunks_Test
+      - rocrtstFunc.VirtMemory_GPUtoHostAccess_Test
+      # GPU core-dump tests: unsupported on WSL
+      - rocrtstFunc.GpuCoreDump_DefaultPattern
+      - rocrtstFunc.GpuCoreDump_CustomPattern
+      - rocrtstFunc.GpuCoreDump_DisableFlag
+      - rocrtstFunc.GpuCoreDump_PatternSubstitution
+      - rocrtstFunc.GpuCoreDump_InvalidPath
+      - rocrtstFunc.GpuCoreDump_ContentIntegrity
+      - rocrtstFunc.GpuCoreDump_PipePattern
+
   # FFM Simulator - only Core and Extended groups allowed
   FFM_SIMULATOR:
     allowed_groups: [Core, Extended]


### PR DESCRIPTION
## Motivation

    - rocrtstFunc.MemoryFillTest hangs on gfx1100 under WSL2 (ROCm 10.0.0). Root cause is EOVERFLOW (-75) on the WSL dxgkrnl escape ioctl in a multi-GPU configuration. mGPU is not supported by Microsoft on WSL, making this expected behavior. On single-GPU WSL, 8 additional test failures occur: 3 virtual memory tests fails due to hsa_amd_vmem_set_access returning HSA_STATUS_ERROR, and 5 GPU core-dump tests fail as core-dump is unsupported on WSL.

## Technical Details

    - Added WSL as a recognized platform type in rocrtst's platform filtering framework. WSL is auto-detected via /proc/version. The 8 unsupported tests (3 VirtMemory + 5 GpuCoreDump) are skipped on WSL with a clear skip reason in the test output. No impact to bare-metal Linux test runs.

## Issue Tracking


  JIRAID: ROCM-28883

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
