### PR TITLE
test(amdsmi): add explicit status-acceptance harness and convert counter/power-profile tests

### DIFF
--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -44,6 +44,7 @@ import os
 import pathlib
 import sys
 import time
+import types
 import unittest
 
 
@@ -826,6 +827,8 @@ class Common:
         self.PASS = PASS
         self.FAIL = FAIL
         self.ANY_FAIL = "ANY_FAIL"
+        # Non-None only inside status_sweep(), see expect_status.
+        self._status_failures = None
 
         # Tests marked with either of these flags will be skipped
         # and need to be implemented later.
@@ -951,6 +954,15 @@ class Common:
             error_code = -1
         return error_code
 
+    @staticmethod
+    def _normalize_expected(expected):
+        """Resolve AmdSmiStatus enum members to their ERROR_MAP string name."""
+        if isinstance(expected, list):
+            return [ERROR_MAP.get(str(v.value), v) if hasattr(v, "value") else v for v in expected]
+        if hasattr(expected, "value"):
+            return ERROR_MAP.get(str(expected.value), expected)
+        return expected
+
     def check_ret(self, msg, exc, expected_code_name=None, printIt=True):
         # Returns True if the test FAILED (i.e. the result did not match expected).
         # Callers use the pattern: `if self.check_ret(...): raise_exception = e`
@@ -1015,6 +1027,154 @@ class Common:
                 print(f"{msg}\n", end="")
             print(f"{status_msg}", flush=True)
         return status_ret
+
+    # TODO(amdsmi_team): migrate the suite off check_ret, which tolerates NOT_SUPPORTED,
+    # NOT_YET_IMPLEMENTED and NO_HSMP_MSG_SUP for every call no matter what the caller
+    # expected. test_set_gpu_power_profile & test_gpu_counter are the first conversions.
+    @contextlib.contextmanager
+    def expect_status(self, msg, accept):
+        """Judge one amdsmi call against the statuses the caller declares correct.
+
+        Nothing is tolerated implicitly, unlike ``check_ret``: a status outside
+        *accept* fails, NOT_SUPPORTED included. Leaving ``PASS`` out (that is,
+        amdsmi.AmdSmiStatus.SUCCESS) is how a negative case is written, since
+        the call then fails by succeeding::
+
+            accept = [common.PASS, "AMDSMI_STATUS_NOT_SUPPORTED", amdsmi.AmdSmiStatus.NO_PERM]
+            with self.common.expect_status(msg, accept):
+                amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, mask)
+
+        An open ``status_sweep`` collects the failure and reports every one at
+        the end. Without one, it is raised here.
+
+        Args:
+            msg (str): header printed above the verdict, and the name a sweep
+                reports the call under. Keep it specific.
+            accept (str | list): every status treated as correct, as
+                ``AMDSMI_STATUS_*`` names or AmdSmiStatus members.
+
+        Yields:
+            SimpleNamespace: ``failed``, ``status_code``, ``status_name``,
+            ``accepted``, ``exception``. Reading it is optional; branch on
+            ``failed`` to skip work that a failed call made pointless.
+
+        Raises:
+            AssertionError: when no sweep is open to collect the failure.
+            Exception: anything the block raised without a status code, which is
+                a bug in the test body rather than an API result.
+        """
+        outcome = self._new_status_outcome(msg, accept)
+        try:
+            yield outcome
+        except Exception as exc:
+            if not hasattr(exc, "get_error_code"):
+                raise  # no status attached: a bug in the test body, not a result
+            self._record_raised_status(outcome, exc)
+        else:
+            self._record_returned_status(outcome)
+        self._print_status_outcome(outcome)
+        if outcome.failed:
+            self._note_status_failure(outcome)
+
+    @contextlib.contextmanager
+    def status_sweep(self):
+        """Collect every ``expect_status`` failure in the block and fail once at the end.
+
+        Without a sweep, an unaccepted status fails at the call that produced
+        it. Wrapping the loop lets it visit every device and parameter, so one
+        bad device cannot hide the rest::
+
+            with self.common.status_sweep():
+                for i, gpu in enumerate(self.common.processors):
+                    for name, mask, _cond in common.POWER_PROFILE_PRESET_MASKS:
+                        with self.common.expect_status(msg, accept):
+                            amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, mask)
+
+        An exception raised by the block itself propagates instead, discarding
+        the collected failures.
+
+        Raises:
+            AssertionError: naming every failed call, its status, and the
+                statuses it would have accepted. The first failure is chained,
+                so the traceback reaches the call that produced it.
+        """
+        outer = self._status_failures
+        self._status_failures = []
+        try:
+            yield
+        finally:
+            collected = self._status_failures
+            self._status_failures = outer
+        # Only reached when the body did not raise on its own.
+        if collected:
+            # Chain the first failure so the traceback reaches the call itself;
+            # a call that wrongly succeeded has no exception to chain.
+            cause = next((o.exception for o in collected if o.exception), None)
+            raise self._sweep_failure(collected) from cause
+
+    def _note_status_failure(self, outcome):
+        """Hand the failure to the active sweep, or fail now when there is none."""
+        if self._status_failures is None:
+            raise self._sweep_failure([outcome]) from outcome.exception
+        self._status_failures.append(outcome)
+
+    @staticmethod
+    def _sweep_failure(collected):
+        """Name every failed call, its status, and the statuses it would have accepted."""
+        plural = "call" if len(collected) == 1 else "calls"
+        lines = [f"{len(collected)} {plural} did not return an accepted status:"]
+        for out in collected:
+            lines.append(f"  {out.msg.strip().rstrip(':')} -> {out.status_code} {out.status_name}")
+            lines.append(f"      accepted: {', '.join(out.accepted)}")
+        return AssertionError("\n".join(lines))
+
+    def _new_status_outcome(self, msg, accept):
+        """Blank ``expect_status`` result for one call."""
+        # list() cannot split a bare name or enum member into its characters.
+        if not isinstance(accept, (list, tuple)):
+            accept = [accept]
+        accepted = self._normalize_expected(list(accept))
+        # A misspelled name normalizes untouched and would simply never match,
+        # failing the test for the wrong reason.
+        unknown = [name for name in accepted if name not in self.error_map.values()]
+        if unknown:
+            raise ValueError(f"expect_status got unknown status name(s): {unknown}")
+        return types.SimpleNamespace(
+            msg=msg,
+            status_code=None,
+            status_name=None,
+            accepted=accepted,
+            failed=False,
+            exception=None,
+        )
+
+    def _record_raised_status(self, outcome, exc):
+        """The call raised: keep the exception when its status is not accepted."""
+        outcome.status_code, outcome.status_name = self.get_error_code(exc)
+        outcome.failed = outcome.status_name not in outcome.accepted
+        if outcome.failed:
+            outcome.exception = exc
+
+    def _record_returned_status(self, outcome):
+        """The call returned, so name the success from the map the raised path uses."""
+        outcome.status_name = PASS
+        outcome.status_code = str(self.get_error_code_from_name(PASS))
+        outcome.failed = PASS not in outcome.accepted
+
+    def _print_status_outcome(self, outcome):
+        """Verdict line, then one line per accepted status."""
+        if self.verbose <= VERBOSITY_QUIET:
+            return
+        if outcome.msg:
+            print(f"{outcome.msg}\n", end="")
+        verdict = "TEST FAILURE" if outcome.failed else "TEST SUCCESS"
+        lines = [
+            f"\t{verdict}, AMDSMI API Returned {outcome.status_code:>2s}, {outcome.status_name}"
+        ]
+        for name in outcome.accepted:
+            code = str(self.get_error_code_from_name(name))
+            lines.append(f"\t              AMDSMI API Accepted {code:>2s}, {name}")
+        print("\n".join(lines), flush=True)
 
     def _check_amdgpu_driver(self):
         """Returns true if amdgpu is found in the list of initialized modules"""

--- a/projects/amdsmi/tests/python/common/common.py
+++ b/projects/amdsmi/tests/python/common/common.py
@@ -26,8 +26,8 @@ Owns three responsibilities:
     sys.path, and guards against a shadowing site-packages copy
     (see ROCM-1552 / PR #6359).
   * the ``Common`` helper base -- enum tables, ``Test_API_*`` drivers,
-    ``check_ret`` and friends, held as ``self.common`` by the API tests
-    (intentionally NOT a unittest.TestCase).
+    ``expect_status``/``status_sweep`` and the legacy ``check_ret``, held as
+    ``self.common`` by the API tests (intentionally NOT a unittest.TestCase).
   * the unittest runner machinery -- ``run_test_dir``,
     ``GTestSummaryRunner``, verbosity/-k/-l parsing and the help/legend
     printers used by the three top-level runners.
@@ -1053,19 +1053,15 @@ class Common:
             accept (str | list): every status treated as correct, as
                 ``AMDSMI_STATUS_*`` names or AmdSmiStatus members.
 
-        Yields:
-            SimpleNamespace: ``failed``, ``status_code``, ``status_name``,
-            ``accepted``, ``exception``. Reading it is optional; branch on
-            ``failed`` to skip work that a failed call made pointless.
-
         Raises:
             AssertionError: when no sweep is open to collect the failure.
+            ValueError: when *accept* names a status outside AMDSMI_STATUS_*.
             Exception: anything the block raised without a status code, which is
                 a bug in the test body rather than an API result.
         """
         outcome = self._new_status_outcome(msg, accept)
         try:
-            yield outcome
+            yield
         except Exception as exc:
             if not hasattr(exc, "get_error_code"):
                 raise  # no status attached: a bug in the test body, not a result
@@ -1086,7 +1082,7 @@ class Common:
 
             with self.common.status_sweep():
                 for i, gpu in enumerate(self.common.processors):
-                    for name, mask, _cond in common.POWER_PROFILE_PRESET_MASKS:
+                    for name, mask, _ in common.POWER_PROFILE_PRESET_MASKS:
                         with self.common.expect_status(msg, accept):
                             amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, mask)
 

--- a/projects/amdsmi/tests/python/functional/gpu/test_events.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_events.py
@@ -97,6 +97,10 @@ class TestGpuEvents(unittest.TestCase):
                     continue
 
                 for event_type_name, event_type, event_type_cond in common.EVENT_TYPES:
+                    # ASICs without GPU performance-counter support return
+                    # AMDSMI_STATUS_FILE_ERROR from the counter APIs; accept that
+                    # as a valid not-supported outcome rather than a failure.
+                    counter_expected = [event_type_cond, "AMDSMI_STATUS_FILE_ERROR"]
                     results[i][event_group_name][event_type_name] = {}
                     results[i][event_group_name][event_type_name]["handle"] = 0
                     results[i][event_group_name][event_type_name]["num_counts"] = 0
@@ -109,7 +113,7 @@ class TestGpuEvents(unittest.TestCase):
                         self.common.check_ret("", "", self.common.PASS)
                         results[i][event_group_name][event_type_name]["handle"] = id(event_handle)
                     except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, event_type_cond):
+                        if self.common.check_ret(msg, e, counter_expected):
                             self.raise_exception = e
                         # Record that these would have been tested if supported
                         msg_add = "\n\tAMDSMI API Returned AMDSMI_STATUS_NOT_SUPPORTED"
@@ -131,7 +135,7 @@ class TestGpuEvents(unittest.TestCase):
                         self.common.print(msg, ret)
                         self.common.check_ret("", "", self.common.PASS)
                     except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, event_type_cond):
+                        if self.common.check_ret(msg, e, counter_expected):
                             self.raise_exception = e
 
                     # Wait...
@@ -144,7 +148,7 @@ class TestGpuEvents(unittest.TestCase):
                         self.common.check_ret("", "", self.common.PASS)
                         results[i][event_group_name][event_type_name]["num_counts"] = ret
                     except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, event_type_cond):
+                        if self.common.check_ret(msg, e, counter_expected):
                             self.raise_exception = e
 
                     # Stop control counter
@@ -157,7 +161,7 @@ class TestGpuEvents(unittest.TestCase):
                         self.common.print(msg, ret)
                         self.common.check_ret("", "", self.common.PASS)
                     except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, event_type_cond):
+                        if self.common.check_ret(msg, e, counter_expected):
                             self.raise_exception = e
 
                     # Destroy control counter
@@ -167,7 +171,7 @@ class TestGpuEvents(unittest.TestCase):
                         self.common.print(msg, ret)
                         self.common.check_ret("", "", self.common.PASS)
                     except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, event_type_cond):
+                        if self.common.check_ret(msg, e, counter_expected):
                             self.raise_exception = e
 
         msg = "gpu counter results"

--- a/projects/amdsmi/tests/python/functional/gpu/test_events.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_events.py
@@ -20,17 +20,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """GPU events: GPU counter and event notification."""
 
-import time
 import unittest
 from collections import defaultdict
 
 import common.common as common
 from common.common import amdsmi
-
-# TODO(amdsmi_team): drive xGMI traffic across this window so the counter reads a
-# non-zero value. Until then only time_running is checked, which proves the perf event
-# was scheduled but not that it counted the right thing.
-_SAMPLE_WINDOW_S = 0.1
 
 
 def _event_group(event_type):
@@ -111,83 +105,97 @@ class TestGpuEvents(unittest.TestCase):
             controlled = True
         return controlled
 
-    def _run_counter(self, gpu, gpu_idx, event_type, type_name, usable):
+    def _run_counter(self, gpu, gpu_idx, event_type, type_name, supported):
         """Take one counter through create/start/read/stop/destroy.
 
-        Runs on unsupported hardware too: *usable* decides whether each call is expected
-        to succeed or to refuse. Returns the counter that was read, or None.
+        Runs on unsupported hardware too: *supported* decides whether each call is
+        expected to succeed or to refuse. Returns the counter that was read, or None.
         """
         handle = None
         msg = _api_msg("amdsmi_gpu_create_counter", gpu=gpu_idx, event_type=type_name)
-        create_accept = [amdsmi.AmdSmiStatus.SUCCESS, amdsmi.AmdSmiStatus.OUT_OF_RESOURCES]
-        with self.common.expect_status(msg, create_accept):
+        with self.common.expect_status(msg, amdsmi.AmdSmiStatus.SUCCESS):
             handle = amdsmi.amdsmi_gpu_create_counter(gpu, event_type)
         if handle is None:
             return None
 
-        if usable:
+        if supported:
             start_accept = amdsmi.AmdSmiStatus.SUCCESS
         else:
+            # No perf event source to open, so the sysfs read behind it returns
+            # ENOENT, which the library maps to NOT_SUPPORTED.
             start_accept = amdsmi.AmdSmiStatus.NOT_SUPPORTED
 
         started = self._control_counter(
             gpu_idx, type_name, handle, amdsmi.AmdSmiCounterCommand.CMD_START, start_accept
         )
 
-        if started:
-            time.sleep(_SAMPLE_WINDOW_S)
-            read_accept = amdsmi.AmdSmiStatus.SUCCESS
-            teardown_accept = amdsmi.AmdSmiStatus.SUCCESS
-        else:
-            # No perf fd to read or close, which each path reports as its own status.
-            read_accept = amdsmi.AmdSmiStatus.UNEXPECTED_SIZE
-            teardown_accept = amdsmi.AmdSmiStatus.FILE_ERROR
-
+        # Nothing was opened yet, so a teardown now reports the missing fd.
+        teardown_accept = amdsmi.AmdSmiStatus.FILE_ERROR
         counter = None
-        msg = _api_msg("amdsmi_gpu_read_counter", gpu=gpu_idx, event_type=type_name)
-        with self.common.expect_status(msg, read_accept):
-            counter = amdsmi.amdsmi_gpu_read_counter(handle)
-        if counter is not None:
-            self.common.print(f"\t\t{counter}")
+        try:
+            if started:
+                read_accept = amdsmi.AmdSmiStatus.SUCCESS
+                teardown_accept = amdsmi.AmdSmiStatus.SUCCESS
+            else:
+                # fd_ stayed -1, so every call below hits EBADF. read reports that as
+                # UNEXPECTED_SIZE because it collapses every error into that one status,
+                # while stop and destroy map it to FILE_ERROR.
+                read_accept = amdsmi.AmdSmiStatus.UNEXPECTED_SIZE
 
-        self._control_counter(
-            gpu_idx, type_name, handle, amdsmi.AmdSmiCounterCommand.CMD_STOP, teardown_accept
-        )
+            msg = _api_msg("amdsmi_gpu_read_counter", gpu=gpu_idx, event_type=type_name)
+            with self.common.expect_status(msg, read_accept):
+                counter = amdsmi.amdsmi_gpu_read_counter(handle)
+            if counter is not None:
+                self.common.print(f"\t\t{counter}")
 
-        msg = _api_msg("amdsmi_gpu_destroy_counter", gpu=gpu_idx, event_type=type_name)
-        with self.common.expect_status(msg, teardown_accept):
-            amdsmi.amdsmi_gpu_destroy_counter(handle)
+            self._control_counter(
+                gpu_idx, type_name, handle, amdsmi.AmdSmiCounterCommand.CMD_STOP, teardown_accept
+            )
+        finally:
+            msg = _api_msg("amdsmi_gpu_destroy_counter", gpu=gpu_idx, event_type=type_name)
+            with self.common.expect_status(msg, teardown_accept):
+                amdsmi.amdsmi_gpu_destroy_counter(handle)
 
         return counter
 
     def test_gpu_counter(self):
         """Exercise every xGMI/DF counter end to end, on supported and unsupported hardware."""
+        # TODO(amdsmi_team): this only judges the status of each call, so nothing here
+        # proves a counter counted anything. Improve it by running on xGMI-capable
+        # hardware with a workload driving xGMI traffic, then assert the value read
+        # back over a sample window.
         self.common.print_func_name("")
 
         # create_counter takes an event type, not a group, so collect the types per group.
         types_by_group = defaultdict(list)
-        for type_name, event_type, _type_cond in common.EVENT_TYPES:
+        for type_name, event_type, _ in common.EVENT_TYPES:
             types_by_group[_event_group(event_type)].append((type_name, event_type))
 
+        # Nothing iterates GRP_INVALID, so a type landing there would go untested. That
+        # means _event_group has drifted from the library's EvtGrpFromEvtID.
+        unclassified = types_by_group[amdsmi.AmdSmiEventGroup.GRP_INVALID]
+        self.assertFalse(unclassified, f"event types not mapped to a group: {unclassified}")
+
         results = {}
-        idle_counters = []
         with self.common.status_sweep():
             for gpu_idx, gpu in enumerate(self.common.processors):
                 self.common.print_device_header(gpu_idx)
                 results[gpu_idx] = {}
 
-                for group_name, group, _group_cond in common.EVENT_GROUPS:
+                for group_name, group, _ in common.EVENT_GROUPS:
                     supported, available = self._probe_counter_group(
                         gpu, gpu_idx, group, group_name
                     )
-                    usable = bool(supported and available)
                     events = {}
-
+                    supp_avail_print = (
+                        f" | Supported: {bool(supported)}, Available: {bool(available)}"
+                    )
+                    self.common.print(
+                        f"\t\tRunning counters for {group_name} events {supp_avail_print}"
+                    )
                     for type_name, event_type in types_by_group[group]:
-                        counter = self._run_counter(gpu, gpu_idx, event_type, type_name, usable)
+                        counter = self._run_counter(gpu, gpu_idx, event_type, type_name, supported)
                         events[type_name] = counter
-                        if counter and not counter["time_running"]:
-                            idle_counters.append(f"gpu={gpu_idx} {type_name}")
 
                     results[gpu_idx][group_name] = {
                         "supported": supported,
@@ -196,13 +204,6 @@ class TestGpuEvents(unittest.TestCase):
                     }
 
         self.common.print("gpu counter results", results)
-
-        if idle_counters:
-            raise AssertionError(
-                f"{len(idle_counters)} counter(s) reported time_running=0 after a "
-                f"{_SAMPLE_WINDOW_S}s sample window, so the perf event never ran: "
-                f"{', '.join(idle_counters)}"
-            )
         return
 
     def test_gpu_event(self):

--- a/projects/amdsmi/tests/python/functional/gpu/test_events.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_events.py
@@ -20,10 +20,38 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """GPU events: GPU counter and event notification."""
 
+import time
 import unittest
+from collections import defaultdict
 
 import common.common as common
 from common.common import amdsmi
+
+# TODO(amdsmi_team): drive xGMI traffic across this window so the counter reads a
+# non-zero value. Until then only time_running is checked, which proves the perf event
+# was scheduled but not that it counted the right thing.
+_SAMPLE_WINDOW_S = 0.1
+
+
+def _event_group(event_type):
+    """Mirror the library's fixed type->group binding (EvtGrpFromEvtID).
+
+    A type added upstream falls outside both ranges and surfaces as GRP_INVALID rather
+    than being folded silently into XGMI.
+    """
+    types = amdsmi.AmdSmiEventType
+    groups = amdsmi.AmdSmiEventGroup
+    if types.XGMI_0_NOP_TX <= event_type <= types.XGMI_1_BEATS_TX:
+        return groups.XGMI
+    if types.XGMI_DATA_OUT_0 <= event_type <= types.XGMI_DATA_OUT_5:
+        return groups.XGMI_DATA_OUT
+    return groups.GRP_INVALID
+
+
+def _api_msg(api, **args):
+    """Render the '### api(arg=value):' header printed above each call's verdict."""
+    rendered = ", ".join(f"{name}={value}" for name, value in args.items())
+    return f"\t### {api}({rendered}):"
 
 
 class TestGpuEvents(unittest.TestCase):
@@ -46,142 +74,136 @@ class TestGpuEvents(unittest.TestCase):
     def tearDown(self):
         amdsmi.amdsmi_shut_down()
 
+    def _probe_counter_group(self, gpu, gpu_idx, group, group_name):
+        """Ask whether an event group works here; returns (supported, available)."""
+        if group == amdsmi.AmdSmiEventGroup.GRP_INVALID:
+            # GRP_INVALID must never be reported as usable, so SUCCESS is left out.
+            accept = [amdsmi.AmdSmiStatus.NOT_SUPPORTED, amdsmi.AmdSmiStatus.INVAL]
+        else:
+            # An ASIC without DF/xGMI perf counters may legitimately answer "no".
+            accept = [amdsmi.AmdSmiStatus.SUCCESS, amdsmi.AmdSmiStatus.NOT_SUPPORTED]
+
+        supported = False
+        msg = _api_msg("amdsmi_gpu_counter_group_supported", gpu=gpu_idx, event_group=group_name)
+        with self.common.expect_status(msg, accept):
+            amdsmi.amdsmi_gpu_counter_group_supported(gpu, group)
+            supported = True
+
+        available = 0
+        msg = _api_msg("amdsmi_get_gpu_available_counters", gpu=gpu_idx, event_group=group_name)
+        with self.common.expect_status(msg, accept):
+            available = amdsmi.amdsmi_get_gpu_available_counters(gpu, group)
+        self.common.print(f"\t\tavailable counters: {available}")
+
+        return supported, available
+
+    def _control_counter(self, gpu_idx, type_name, handle, command, accept):
+        """Start or stop a counter, returns True when the command was accepted."""
+        msg = _api_msg(
+            "amdsmi_gpu_control_counter",
+            gpu=gpu_idx,
+            event_type=type_name,
+            counter_command=command.name,
+        )
+        controlled = False
+        with self.common.expect_status(msg, accept):
+            amdsmi.amdsmi_gpu_control_counter(handle, command)
+            controlled = True
+        return controlled
+
+    def _run_counter(self, gpu, gpu_idx, event_type, type_name, usable):
+        """Take one counter through create/start/read/stop/destroy.
+
+        Runs on unsupported hardware too: *usable* decides whether each call is expected
+        to succeed or to refuse. Returns the counter that was read, or None.
+        """
+        handle = None
+        msg = _api_msg("amdsmi_gpu_create_counter", gpu=gpu_idx, event_type=type_name)
+        create_accept = [amdsmi.AmdSmiStatus.SUCCESS, amdsmi.AmdSmiStatus.OUT_OF_RESOURCES]
+        with self.common.expect_status(msg, create_accept):
+            handle = amdsmi.amdsmi_gpu_create_counter(gpu, event_type)
+        if handle is None:
+            return None
+
+        if usable:
+            start_accept = amdsmi.AmdSmiStatus.SUCCESS
+        else:
+            start_accept = amdsmi.AmdSmiStatus.NOT_SUPPORTED
+
+        started = self._control_counter(
+            gpu_idx, type_name, handle, amdsmi.AmdSmiCounterCommand.CMD_START, start_accept
+        )
+
+        if started:
+            time.sleep(_SAMPLE_WINDOW_S)
+            read_accept = amdsmi.AmdSmiStatus.SUCCESS
+            teardown_accept = amdsmi.AmdSmiStatus.SUCCESS
+        else:
+            # No perf fd to read or close, which each path reports as its own status.
+            read_accept = amdsmi.AmdSmiStatus.UNEXPECTED_SIZE
+            teardown_accept = amdsmi.AmdSmiStatus.FILE_ERROR
+
+        counter = None
+        msg = _api_msg("amdsmi_gpu_read_counter", gpu=gpu_idx, event_type=type_name)
+        with self.common.expect_status(msg, read_accept):
+            counter = amdsmi.amdsmi_gpu_read_counter(handle)
+        if counter is not None:
+            self.common.print(f"\t\t{counter}")
+
+        self._control_counter(
+            gpu_idx, type_name, handle, amdsmi.AmdSmiCounterCommand.CMD_STOP, teardown_accept
+        )
+
+        msg = _api_msg("amdsmi_gpu_destroy_counter", gpu=gpu_idx, event_type=type_name)
+        with self.common.expect_status(msg, teardown_accept):
+            amdsmi.amdsmi_gpu_destroy_counter(handle)
+
+        return counter
+
     def test_gpu_counter(self):
+        """Exercise every xGMI/DF counter end to end, on supported and unsupported hardware."""
         self.common.print_func_name("")
 
+        # create_counter takes an event type, not a group, so collect the types per group.
+        types_by_group = defaultdict(list)
+        for type_name, event_type, _type_cond in common.EVENT_TYPES:
+            types_by_group[_event_group(event_type)].append((type_name, event_type))
+
         results = {}
-        for i, gpu in enumerate(self.common.processors):
-            self.common.print_device_header(i)
-            results[i] = {}
-            for event_group_name, event_group, event_group_cond in common.EVENT_GROUPS:
-                results[i][event_group_name] = {}
-                results[i][event_group_name]["supported"] = False
-                results[i][event_group_name]["counters"] = 0
+        idle_counters = []
+        with self.common.status_sweep():
+            for gpu_idx, gpu in enumerate(self.common.processors):
+                self.common.print_device_header(gpu_idx)
+                results[gpu_idx] = {}
 
-                # Is supported
-                msg = f"\t### amdsmi_gpu_counter_group_supported(gpu={i}, event_group={event_group_name}):"
-                try:
-                    event_handle = amdsmi.amdsmi_gpu_counter_group_supported(gpu, event_group)
-                    self.common.print(msg, event_handle)
-                    results[i][event_group_name]["supported"] = True
-                    self.common.check_ret("", "", self.common.PASS)
-                except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                    if self.common.check_ret(msg, e, event_group_cond):
-                        self.raise_exception = e
-
-                # Are counters available
-                msg = f"\t### amdsmi_get_gpu_available_counters(gpu={i}, event_group={event_group_name}):"
-                try:
-                    counters = amdsmi.amdsmi_get_gpu_available_counters(gpu, event_group)
-                    self.common.print(msg, counters)
-                    results[i][event_group_name]["counters"] = counters
-                    self.common.check_ret("", "", self.common.PASS)
-                except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                    if self.common.check_ret(msg, e, event_group_cond):
-                        self.raise_exception = e
-
-                # To continue, both have to pass
-                if (
-                    not results[i][event_group_name]["supported"]
-                    or not results[i][event_group_name]["counters"]
-                ):
-                    msg_add = ""
-                    if not results[i][event_group_name]["supported"]:
-                        msg_add = "\n\tAMDSMI API Returned AMDSMI_STATUS_NOT_SUPPORTED"
-                    # Record that these would have been tested if supported
-                    self.common.print(f"\t### amdsmi_gpu_create_counter(){msg_add}")
-                    self.common.print(f"\t### amdsmi_gpu_control_counter(){msg_add}")
-                    self.common.print(f"\t### amdsmi_gpu_read_counter(){msg_add}")
-                    self.common.print(f"\t### amdsmi_gpu_control_counter(){msg_add}")
-                    self.common.print(f"\t### amdsmi_gpu_destroy_counter(){msg_add}")
-                    continue
-
-                for event_type_name, event_type, event_type_cond in common.EVENT_TYPES:
-                    # ASICs without GPU performance-counter support return
-                    # AMDSMI_STATUS_FILE_ERROR from the counter APIs; accept that
-                    # as a valid not-supported outcome rather than a failure.
-                    counter_expected = [event_type_cond, "AMDSMI_STATUS_FILE_ERROR"]
-                    results[i][event_group_name][event_type_name] = {}
-                    results[i][event_group_name][event_type_name]["handle"] = 0
-                    results[i][event_group_name][event_type_name]["num_counts"] = 0
-
-                    # Create
-                    msg = f"\t### amdsmi_gpu_create_counter(gpu={i}, event_type={event_type_name}):"
-                    try:
-                        event_handle = amdsmi.amdsmi_gpu_create_counter(gpu, event_type)
-                        self.common.print(msg, id(event_handle))
-                        self.common.check_ret("", "", self.common.PASS)
-                        results[i][event_group_name][event_type_name]["handle"] = id(event_handle)
-                    except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, counter_expected):
-                            self.raise_exception = e
-                        # Record that these would have been tested if supported
-                        msg_add = "\n\tAMDSMI API Returned AMDSMI_STATUS_NOT_SUPPORTED"
-                        self.common.print(f"\t### amdsmi_gpu_control_counter(){msg_add}")
-                        self.common.print(f"\t### amdsmi_gpu_read_counter(){msg_add}")
-                        self.common.print(f"\t### amdsmi_gpu_control_counter(){msg_add}")
-                        self.common.print(f"\t### amdsmi_gpu_destroy_counter(){msg_add}")
-                        continue
-
-                    # Start a program that generates the events of interest
-
-                    # Start control counter
-                    counter_command_name, counter_command, counter_commands_cond = (
-                        common.COUNTER_COMMANDS[0]
+                for group_name, group, _group_cond in common.EVENT_GROUPS:
+                    supported, available = self._probe_counter_group(
+                        gpu, gpu_idx, group, group_name
                     )
-                    msg = f"\t### amdsmi_gpu_control_counter(event_handle={id(event_handle)}, counter_command={counter_command_name}):"
-                    try:
-                        ret = amdsmi.amdsmi_gpu_control_counter(event_handle, counter_command)
-                        self.common.print(msg, ret)
-                        self.common.check_ret("", "", self.common.PASS)
-                    except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, counter_expected):
-                            self.raise_exception = e
+                    usable = bool(supported and available)
+                    events = {}
 
-                    # Wait...
+                    for type_name, event_type in types_by_group[group]:
+                        counter = self._run_counter(gpu, gpu_idx, event_type, type_name, usable)
+                        events[type_name] = counter
+                        if counter and not counter["time_running"]:
+                            idle_counters.append(f"gpu={gpu_idx} {type_name}")
 
-                    # Read control counter
-                    msg = f"\t### amdsmi_gpu_read_counter(event_handle={id(event_handle)}):"
-                    try:
-                        ret = amdsmi.amdsmi_gpu_read_counter(event_handle)
-                        self.common.print(msg, ret)
-                        self.common.check_ret("", "", self.common.PASS)
-                        results[i][event_group_name][event_type_name]["num_counts"] = ret
-                    except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, counter_expected):
-                            self.raise_exception = e
+                    results[gpu_idx][group_name] = {
+                        "supported": supported,
+                        "available_counters": available,
+                        "events": events,
+                    }
 
-                    # Stop control counter
-                    counter_command_name, counter_command, counter_commands_cond = (
-                        common.COUNTER_COMMANDS[1]
-                    )
-                    msg = f"\t### amdsmi_gpu_control_counter(event_handle={id(event_handle)}, counter_command={counter_command_name}):"
-                    try:
-                        ret = amdsmi.amdsmi_gpu_control_counter(event_handle, counter_command)
-                        self.common.print(msg, ret)
-                        self.common.check_ret("", "", self.common.PASS)
-                    except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, counter_expected):
-                            self.raise_exception = e
+        self.common.print("gpu counter results", results)
 
-                    # Destroy control counter
-                    msg = f"\t### amdsmi_gpu_destroy_counter(event_handle={id(event_handle)}):"
-                    try:
-                        ret = amdsmi.amdsmi_gpu_destroy_counter(event_handle)
-                        self.common.print(msg, ret)
-                        self.common.check_ret("", "", self.common.PASS)
-                    except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
-                        if self.common.check_ret(msg, e, counter_expected):
-                            self.raise_exception = e
-
-        msg = "gpu counter results"
-        self.common.print(msg, results)
-
-        if self.raise_exception:
-            raise self.raise_exception
+        if idle_counters:
+            raise AssertionError(
+                f"{len(idle_counters)} counter(s) reported time_running=0 after a "
+                f"{_SAMPLE_WINDOW_S}s sample window, so the perf event never ran: "
+                f"{', '.join(idle_counters)}"
+            )
         return
-
-    # integration
 
     def test_gpu_event(self):
         self.common.print_func_name("")

--- a/projects/amdsmi/tests/python/functional/gpu/test_power.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_power.py
@@ -137,7 +137,7 @@ class TestGpuPower(unittest.TestCase):
         refused = [
             amdsmi.AmdSmiStatus.NOT_SUPPORTED,  # eg. guest devices, or sysfs node absent
             amdsmi.AmdSmiStatus.INPUT_OUT_OF_BOUNDS,  # eg. invalid input
-            amdsmi.AmdSmiStatus.NO_PERM,  # eg. ran w/o admin priv., or R/O sysfs
+            amdsmi.AmdSmiStatus.NO_PERM,  # eg. R/O sysfs in a container (EROFS)
         ]
         # All valid responses
         applied_or_refused = [amdsmi.AmdSmiStatus.SUCCESS, *refused]

--- a/projects/amdsmi/tests/python/functional/gpu/test_power.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_power.py
@@ -140,13 +140,20 @@ class TestGpuPower(unittest.TestCase):
                 power_profile_preset_mask,
                 power_profile_preset_masks_cond,
             ) in common.POWER_PROFILE_PRESET_MASKS:
+                # A device that does not support a given preset returns
+                # AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS; accept that as a valid
+                # not-supported outcome rather than a failure.
+                set_expected = [
+                    power_profile_preset_masks_cond,
+                    "AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS",
+                ]
                 msg = f"\t### amdsmi_set_gpu_power_profile(gpu={i}, power_profile_preset_mask={power_profile_preset_mask_name}):"
                 try:
                     amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, power_profile_preset_mask)
                     self.common.print(msg, "")
                     self.common.check_ret("", "", self.common.PASS)
                 except amdsmi.AmdSmiLibraryException as e:
-                    if self.common.check_ret(msg, e, power_profile_preset_masks_cond):
+                    if self.common.check_ret(msg, e, set_expected):
                         self.raise_exception = e
                 self.common.print("")
         if self.raise_exception:

--- a/projects/amdsmi/tests/python/functional/gpu/test_power.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_power.py
@@ -133,31 +133,24 @@ class TestGpuPower(unittest.TestCase):
 
     def test_set_gpu_power_profile(self):
         self.common.print_func_name("")
-        for i, gpu in enumerate(self.common.processors):
-            self.common.print_device_header(i)
-            for (
-                power_profile_preset_mask_name,
-                power_profile_preset_mask,
-                power_profile_preset_masks_cond,
-            ) in common.POWER_PROFILE_PRESET_MASKS:
-                # A device that does not support a given preset returns
-                # AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS; accept that as a valid
-                # not-supported outcome rather than a failure.
-                set_expected = [
-                    power_profile_preset_masks_cond,
-                    "AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS",
-                ]
-                msg = f"\t### amdsmi_set_gpu_power_profile(gpu={i}, power_profile_preset_mask={power_profile_preset_mask_name}):"
-                try:
-                    amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, power_profile_preset_mask)
-                    self.common.print(msg, "")
-                    self.common.check_ret("", "", self.common.PASS)
-                except amdsmi.AmdSmiLibraryException as e:
-                    if self.common.check_ret(msg, e, set_expected):
-                        self.raise_exception = e
-                self.common.print("")
-        if self.raise_exception:
-            raise self.raise_exception
+        # Valid rejections (although driver may include others)
+        refused = [
+            amdsmi.AmdSmiStatus.NOT_SUPPORTED,  # eg. guest devices, or sysfs node absent
+            amdsmi.AmdSmiStatus.INPUT_OUT_OF_BOUNDS,  # eg. invalid input
+            amdsmi.AmdSmiStatus.NO_PERM,  # eg. ran w/o admin priv., or R/O sysfs
+        ]
+        # All valid responses
+        applied_or_refused = [amdsmi.AmdSmiStatus.SUCCESS, *refused]
+        with self.common.status_sweep():
+            for i, gpu in enumerate(self.common.processors):
+                self.common.print_device_header(i)
+                for mask_name, mask, _ in common.POWER_PROFILE_PRESET_MASKS:
+                    accept = refused if mask_name == "INVALID" else applied_or_refused
+                    msg = (
+                        f"\t### amdsmi_set_gpu_power_profile(gpu={i}, "
+                        f"power_profile_preset_mask={mask_name}):"
+                    )
+                    with self.common.expect_status(msg, accept):
+                        amdsmi.amdsmi_set_gpu_power_profile(gpu, 0, mask)
+                    self.common.print("")
         return
-
-    # pisolates

--- a/projects/amdsmi/tests/python/unit/system/test_expect_status.py
+++ b/projects/amdsmi/tests/python/unit/system/test_expect_status.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Unit tests for the expect_status/status_sweep assertion harness.
+
+The two are tested together because expect_status changes behaviour depending on
+whether a sweep is open: on its own it raises at the failing call, inside a sweep
+it hands the failure over to be reported at the end.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from common.common import ERROR_MAP, PASS, VERBOSITY_QUIET, Common, amdsmi
+
+SUCCESS = amdsmi.AmdSmiStatus.SUCCESS
+INVAL = amdsmi.AmdSmiStatus.INVAL
+NOT_SUPPORTED = amdsmi.AmdSmiStatus.NOT_SUPPORTED
+
+
+def _harness():
+    """A Common carrying only what the status helpers read, so no device is touched."""
+    common = object.__new__(Common)
+    common.error_map = ERROR_MAP
+    common.verbose = VERBOSITY_QUIET
+    common._status_failures = None
+    return common
+
+
+def _raise(status):
+    """Fail a call the way the amdsmi wrapper does, with the status attached."""
+    raise amdsmi.AmdSmiLibraryException(status.value)
+
+
+class TestExpectStatusAlone(unittest.TestCase):
+    """Without a sweep, the verdict is delivered at the call that produced it."""
+
+    def setUp(self):
+        self.common = _harness()
+
+    def test_accepted_status_is_not_a_failure(self):
+        with self.common.expect_status("msg", NOT_SUPPORTED):
+            _raise(NOT_SUPPORTED)
+        return
+
+    def test_unaccepted_status_raises_naming_both_sides(self):
+        with self.assertRaises(AssertionError) as ctx:
+            with self.common.expect_status("msg", NOT_SUPPORTED):
+                _raise(INVAL)
+        message = str(ctx.exception)
+        self.assertIn("AMDSMI_STATUS_INVAL", message)
+        self.assertIn("AMDSMI_STATUS_NOT_SUPPORTED", message)
+        # Chained so the traceback still reaches the call that produced the status.
+        self.assertIsInstance(ctx.exception.__cause__, amdsmi.AmdSmiLibraryException)
+        return
+
+    def test_call_fails_by_succeeding_when_pass_is_left_out(self):
+        with self.assertRaises(AssertionError) as ctx:
+            with self.common.expect_status("msg", NOT_SUPPORTED):
+                pass
+        self.assertIn(PASS, str(ctx.exception))
+        return
+
+    def test_accept_is_taken_as_enum_or_name_and_scalar_or_list(self):
+        for accept in (SUCCESS, [SUCCESS], PASS, [PASS]):
+            with self.subTest(accept=accept):
+                with self.common.expect_status("msg", accept):
+                    pass
+        return
+
+    def test_unknown_status_name_is_rejected_before_the_call(self):
+        with self.assertRaises(ValueError):
+            with self.common.expect_status("msg", "AMDSMI_STATUS_NOPE"):
+                self.fail("the block must not run")
+        return
+
+    def test_exception_without_a_status_propagates(self):
+        # Raised here to stand in for a bug in a test body: it carries no status code,
+        # so it has to escape rather than be recorded as something the driver returned.
+        with self.assertRaises(KeyError):
+            with self.common.expect_status("msg", SUCCESS):
+                raise KeyError("not an amdsmi failure")
+        return
+
+
+class TestExpectStatusInSweep(unittest.TestCase):
+    """Inside a sweep, failures accumulate and are reported once at the end."""
+
+    def setUp(self):
+        self.common = _harness()
+
+    def test_sweep_reports_every_failed_call(self):
+        with self.assertRaises(AssertionError) as ctx:
+            with self.common.status_sweep():
+                for status in (INVAL, NOT_SUPPORTED):
+                    with self.common.expect_status(f"call {status.name}", SUCCESS):
+                        _raise(status)
+        message = str(ctx.exception)
+        self.assertIn("2 calls", message)
+        self.assertIn("call INVAL", message)
+        self.assertIn("call NOT_SUPPORTED", message)
+        return
+
+    def test_sweep_visits_every_call_despite_an_early_failure(self):
+        visited = []
+        with self.assertRaises(AssertionError):
+            with self.common.status_sweep():
+                for status in (INVAL, NOT_SUPPORTED):
+                    with self.common.expect_status("msg", SUCCESS):
+                        _raise(status)
+                    visited.append(status)
+        self.assertEqual(visited, [INVAL, NOT_SUPPORTED])
+        return
+
+    def test_sweep_without_failures_is_silent(self):
+        with self.common.status_sweep():
+            with self.common.expect_status("msg", SUCCESS):
+                pass
+        self.assertIsNone(self.common._status_failures)
+        return
+
+    def test_inner_sweep_failure_does_not_reach_the_outer_one(self):
+        with self.common.status_sweep():
+            with self.assertRaises(AssertionError):
+                with self.common.status_sweep():
+                    with self.common.expect_status("inner call", SUCCESS):
+                        _raise(INVAL)
+            # Leaving the outer sweep must stay silent, so it collected nothing.
+        self.assertIsNone(self.common._status_failures)
+        return
+
+    def test_body_exception_discards_what_the_sweep_collected(self):
+        with self.assertRaises(KeyError):
+            with self.common.status_sweep():
+                with self.common.expect_status("msg", SUCCESS):
+                    _raise(INVAL)
+                # Stands in for a bug in a test body, which wins over what was collected.
+                raise KeyError("not an amdsmi failure")
+        self.assertIsNone(self.common._status_failures)
+        return


### PR DESCRIPTION
## Motivation

`test_gpu_counter` and `test_set_gpu_power_profile` fail on hardware where the
underlying feature isn't fully supported. Skipping them would hide the failure
and drop the coverage, so instead every call declares which statuses it accepts:
unsupported hardware passes for the right reason, and anything else still fails.

Both tests previously used `check_ret`, which passes any call returning
`AMDSMI_STATUS_NOT_SUPPORTED`, `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` or
`AMDSMI_STATUS_NO_HSMP_MSG_SUP` — short-circuiting before it compares against
the expected status. A test had no control over that: it could state what it
expected, but those three were accepted anyway, so a real regression to any of
them was indistinguishable from unsupported hardware.

## Technical Details

**New harness** (`tests/python/common/common.py`)

- `expect_status(msg, accept)` — context manager asserting a single call returns
  one of the accepted statuses. Fails if the call succeeds when it shouldn't,
  and names both the expected and actual status on mismatch.
- `status_sweep()` — collects failures across many calls and reports them
  together, so one bad status doesn't mask the rest of the sweep.
- Accepts enums or status names, scalar or list. Unknown names raise
  `ValueError` before the block runs.
- `check_ret` is unchanged and still in use elsewhere; migrating the remaining
  call sites is follow-up work.

**`test_gpu_counter`** — rewritten rather than adjusted; expect a large diff.

- Judges all five calls per event type (create / start / read / stop / destroy)
  against statuses derived from whether the event group is supported, instead of
  checking only that nothing threw.
- `create_counter` accepts only `SUCCESS`. `OUT_OF_RESOURCES` is unreachable —
  `rsmi_dev_counter_create` null-checks `evnt_handle` after dereferencing it.
- Expected status keys off `supported` alone. No counter API reads the
  available-counter total, so `available` cannot change what the library
  returns.
- `destroy_counter` moved into a `finally`, so a non-status exception cannot
  leak the perf fd and its DF counter slot.
- Asserts no event type maps to `GRP_INVALID`. `_event_group` mirrors the
  library's `EvtGrpFromEvtID`; a drifting mirror would silently drop the type
  from coverage rather than fail.
- Dropped the 0.1s sample window and `time_running` assertion. Across 14 event
  types it cost ~1.4s per GPU to assert something a successful `CMD_START`
  already covers, and repeated reads consume the value delta. Left as a TODO for
  a follow-up that drives real xGMI traffic.

**`test_set_gpu_power_profile`** — each preset mask declares the statuses it
accepts; `INVALID` accepts only the refusal set.

**Unit tests** (`tests/python/unit/system/test_expect_status.py`, new)

11 hardware-free tests covering accept-list normalisation, collect-and-report,
nested sweep isolation, and the exceptions that must not be swallowed.

## Issue Tracking

JIRA ID: AILITOOLS-306

## Test Plan

- `sudo <test install location>/unit_tests.py -v` — harness unit tests, no GPU required
- `sudo <test install location>/integration_test.py -v` — counter and power-profile functional tests

hardware validated on: MI3x, Nv, MI2x.

## Test Result

See CI results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
