### PR TITLE
test(rccl): Validate the external one-sided RMA plugin path

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -225,6 +225,7 @@ if(BUILD_TESTS)
     StandaloneTests.cpp
     DdaIpcTests.cpp
     NetPluginReloadTests.cpp
+    RmaExternalPluginLoadTests.cpp
     plugin/net_reload_plugin.cpp
     ProfilerPluginCloseTests.cpp
     CpuAffinityTests.cpp
@@ -663,6 +664,8 @@ if(BUILD_TESTS)
       NChannelsPerNetPeerMPITests.cpp
       RegistrationMPITests.cpp
       HostApiMPITests.cpp
+      RmaExternalPluginPutSignalMPITests.cpp
+      plugin/net_reload_plugin.cpp
       mem_manager/SuspendResumeMPITests.cpp
       RevokeMPITests.cpp
       ce/CeMPITests.cpp
@@ -678,6 +681,14 @@ if(BUILD_TESTS)
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})
+
+    # plugin/net_reload_plugin.cpp is compiled into rccl-UnitTestsMPI so
+    # RmaExternalPluginPutSignalMPITests can load its ncclRmaPlugin_v13 in-process
+    # via STATIC_PLUGIN (dlopen(NULL))
+    target_link_options(rccl-UnitTestsMPI PRIVATE
+      "LINKER:--export-dynamic-symbol=ncclGinPlugin_v13"
+      "LINKER:--export-dynamic-symbol=ncclRmaPlugin_v13")
+
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsMPI)
 
     # Hand the in-tree Inspector plugin to InspectorPromP2pMPITests so it can

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -225,7 +225,6 @@ if(BUILD_TESTS)
     StandaloneTests.cpp
     DdaIpcTests.cpp
     NetPluginReloadTests.cpp
-    RmaExternalPluginLoadTests.cpp
     plugin/net_reload_plugin.cpp
     ProfilerPluginCloseTests.cpp
     CpuAffinityTests.cpp

--- a/projects/rccl/test/RmaExternalPluginPutSignalMPITests.cpp
+++ b/projects/rccl/test/RmaExternalPluginPutSignalMPITests.cpp
@@ -1,0 +1,198 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file RmaExternalPluginPutSignalMPITests.cpp
+ * @brief Fire-and-forget invocation check: the one-sided RMA host APIs must
+ *        reach an externally loaded GIN/RMA plugin's put/signal primitives.
+ *
+ * This is intentionally NOT a data-path test. The stub plugin in
+ * test/plugin/net_reload_plugin.cpp (ncclRmaPlugin_v13) implements iput /
+ * iputSignal / iget as inert no-ops that move no data and raise no signal --
+ * a loopback memcpy/atomic cannot service a real cross-rank put/signal because
+ * the proxy hands the plugin the *peer's* exchanged handle. Real data-path
+ * correctness is validated separately with a real plugin on real IB.
+ *
+ * What this test proves: calling ncclPutSignal / ncclSignal on the sender
+ * actually routes through the external plugin's primitives. The stub records
+ * each iput/iputSignal invocation by appending a line to the file named in
+ * RCCL_RMA_RELOAD_COUNTER_FILE; after the sender synchronizes its stream we
+ * assert that file grew. There is deliberately:
+ *   - NO ncclWaitSignal (the receiver never consumes the signal, so a no-op
+ *     stub cannot hang the test), and
+ *   - NO data / signal validation.
+ *
+ * Requirements to actually exercise the plugin (supplied by the test-runner
+ * entry, see tools/scripts/test_runner/configs/mi300x_mellanox_ib.json):
+ *   - NCCL_GIN_ENABLE=1, NCCL_GIN_PLUGIN=STATIC_PLUGIN so the in-binary
+ *     ncclRmaPlugin_v13 is discovered/loaded/assigned.
+ *   - RCCL_RMA_RELOAD_COUNTER_FILE=<per-node path> so invocations are recorded.
+ *   - A cross-LSA-team peer (e.g. 2 nodes x 1 GPU) so the RMA proxy path -- and
+ *     therefore the plugin's iput/iputSignal -- is taken rather than the local
+ *     copy-engine path. If no external plugin/counter file is configured the
+ *     test skips.
+ *
+ * Run (example):
+ *   mpirun -np 2 ./rccl-UnitTestsMPI \
+ *     --gtest_filter=RmaExternalPluginPutSignalTest.*
+ */
+
+#if defined(MPI_TESTS_ENABLED) && defined(RCCL_ENABLE_HOST_API_TESTS)
+
+#include "MPITestBase.hpp"
+#include "MPIHelpers.hpp"
+#include "ResourceGuards.hpp"
+#include "HostApiHelpers.hpp"
+#include "TestChecks.hpp"
+
+#include <hip/hip_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLHostApiHelpers;
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+constexpr size_t kTransferSize = 256;             // bytes per PUT (data value is irrelevant)
+constexpr size_t kWinSize      = 2 * kTransferSize; // send region + recv region
+constexpr size_t kSendOffset   = 0;               // sender carves src from here
+constexpr size_t kRecvOffset   = kTransferSize;   // peer's (nominal) dest region
+constexpr int    kSigIdx       = 0;
+constexpr int    kCtx          = 0;
+constexpr unsigned int kFlags  = 0;
+
+inline int winMode()
+{
+    static int cumem_ = -1;
+    if (cumem_ < 0) {
+        const char* e = getenv("NCCL_CUMEM_ENABLE");
+        cumem_ = e ? (atoi(e) != 0) : true;
+    }
+    return cumem_ ? NCCL_WIN_COLL_SYMMETRIC : NCCL_WIN_DEFAULT;
+}
+
+long countLines(const char* path)
+{
+    FILE* f = fopen(path, "r");
+    if (f == nullptr) return 0;
+    long n = 0;
+    int c;
+    while ((c = fgetc(f)) != EOF)
+        if (c == '\n') ++n;
+    fclose(f);
+    return n;
+}
+
+void resetCounterFile(const char* path)
+{
+    FILE* f = fopen(path, "w");
+    if (f != nullptr) fclose(f);
+}
+} // namespace
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+class RmaExternalPluginPutSignalTest : public MPITestBase
+{
+protected:
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    }
+
+    int rank() const
+    {
+        int r = -1;
+        ncclCommUserRank(
+            const_cast<RmaExternalPluginPutSignalTest*>(this)->getActiveCommunicator(), &r);
+        return r;
+    }
+};
+
+// ============================================================================
+// IssuesPutSignalToStub
+// ============================================================================
+
+/**
+ * @test RmaExternalPluginPutSignalTest.IssuesPutSignalToStub
+ * @brief Rank 0 issues ncclPutSignal + ncclSignal to rank 1 (no wait); assert
+ *        the external stub plugin's put/signal primitives were invoked.
+ */
+TEST_F(RmaExternalPluginPutSignalTest, IssuesPutSignalToStub)
+{
+    const char* counterPath = getenv("RCCL_RMA_RELOAD_COUNTER_FILE");
+    if (counterPath == nullptr)
+    {
+        GTEST_SKIP() << "RCCL_RMA_RELOAD_COUNTER_FILE not set: external RMA stub "
+                        "plugin not configured (set NCCL_GIN_PLUGIN=STATIC_PLUGIN "
+                        "and this env var to run).";
+    }
+
+    if (!validateTestPrerequisites(/*min=*/2, /*max=*/2))
+    {
+        GTEST_SKIP() << "Need exactly 2 MPI processes";
+    }
+
+    const int    myRank = rank();
+    ncclComm_t   comm   = getActiveCommunicator();
+    hipStream_t  stream = getActiveStream();
+
+    if (myRank == 0)
+        resetCounterFile(counterPath);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    void* winBuf = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, allocFineGrainBuffer(&winBuf, kWinSize));
+    auto winBufGuard = makeScopeGuard([&]() { freeFineGrainBuffer(winBuf); });
+
+    ncclWindow_t win = nullptr;
+    NcclWindowGuard wg(comm, winBuf, kWinSize, &win, winMode());
+    ASSERT_MPI_NE(win, nullptr);
+    ASSERT_MPI_EQ(ncclSuccess, wg.initResult());
+
+    ncclResult_t putRes = ncclSuccess;
+    ncclResult_t sigRes = ncclSuccess;
+    if (myRank == 0)
+    {
+        void* srcBuf = static_cast<uint8_t*>(winBuf) + kSendOffset;
+        putRes = ncclPutSignal(
+            srcBuf, kTransferSize, ncclUint8,
+            /*peer=*/1, win, /*peerWinOffset=*/kRecvOffset,
+            kSigIdx, kCtx, kFlags, comm, stream);
+        sigRes = ncclSignal(/*peer=*/1, kSigIdx, kCtx, kFlags, comm, stream);
+    }
+    ASSERT_MPI_EQ(ncclSuccess, putRes);
+    ASSERT_MPI_EQ(ncclSuccess, sigRes);
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool pluginInvoked = true; // ranks other than 0 pass trivially
+    if (myRank == 0)
+    {
+        long invocations = countLines(counterPath);
+        pluginInvoked = (invocations >= 1);
+        TEST_INFO("rank 0: external RMA plugin put/signal primitives invoked %ld time(s) "
+                  "(expected >= 1). If 0, ensure the peer is cross-LSA-team so the proxy "
+                  "path -- not the local copy engine -- services the put/signal.",
+                  invocations);
+    }
+    ASSERT_MPI_TRUE(pluginInvoked);
+}
+
+} // namespace RcclUnitTesting
+
+#endif // MPI_TESTS_ENABLED && RCCL_ENABLE_HOST_API_TESTS

--- a/projects/rccl/test/RmaExternalPluginPutSignalMPITests.cpp
+++ b/projects/rccl/test/RmaExternalPluginPutSignalMPITests.cpp
@@ -27,8 +27,10 @@
  *
  * Requirements to actually exercise the plugin (supplied by the test-runner
  * entry, see tools/scripts/test_runner/configs/mi300x_mellanox_ib.json):
- *   - NCCL_GIN_ENABLE=1, NCCL_GIN_PLUGIN=STATIC_PLUGIN so the in-binary
- *     ncclRmaPlugin_v13 is discovered/loaded/assigned.
+ *   - NCCL_GIN_ENABLE=1, NCCL_GIN_PLUGIN=STATIC_PLUGIN, and
+ *     NCCL_RMA_PLUGIN=STATIC_PLUGIN so the in-binary ncclRmaPlugin_v13
+ *     is discovered/loaded/assigned (GIN and RMA have separate plugin
+ *     loaders since the v14 GIN/RMA split).
  *   - RCCL_RMA_RELOAD_COUNTER_FILE=<per-node path> so invocations are recorded.
  *   - A cross-LSA-team peer (e.g. 2 nodes x 1 GPU) so the RMA proxy path -- and
  *     therefore the plugin's iput/iputSignal -- is taken rather than the local
@@ -138,8 +140,8 @@ TEST_F(RmaExternalPluginPutSignalTest, IssuesPutSignalToStub)
     if (counterPath == nullptr)
     {
         GTEST_SKIP() << "RCCL_RMA_RELOAD_COUNTER_FILE not set: external RMA stub "
-                        "plugin not configured (set NCCL_GIN_PLUGIN=STATIC_PLUGIN "
-                        "and this env var to run).";
+                        "plugin not configured (set NCCL_GIN_PLUGIN=STATIC_PLUGIN, "
+                        "NCCL_RMA_PLUGIN=STATIC_PLUGIN, and this env var to run).";
     }
 
     if (!validateTestPrerequisites(/*min=*/2, /*max=*/2))

--- a/projects/rccl/test/plugin/net_reload_plugin.cpp
+++ b/projects/rccl/test/plugin/net_reload_plugin.cpp
@@ -4,13 +4,36 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Minimal external RCCL net plugin used only by NetPluginReloadTests
-// (AICOMRCCL-1534). It reports one device so RCCL selects it as the active net
-// plugin, and records every real init() call by appending a line to the file
-// named in RCCL_NET_RELOAD_COUNTER_FILE. The test counts those lines to detect
-// whether the plugin is reloaded after a communicator is destroyed.
+// Minimal external RCCL test plugins. This single translation unit hosts two
+// independent, self-contained plugins that share the same reload-counter
+// mechanism (recordLine appends "1\n" to the file named in an env var so a test
+// can count how many times a callback fired):
 //
-// Compiled as C++ (the RCCL project only enables CXX/HIP), so the plugin symbol
+//   1. Net plugin (ncclNetPlugin_v12) used by NetPluginReloadTests
+//      (AICOMRCCL-1534). It reports one device so RCCL selects it as the active
+//      net plugin, and records every real init() call via
+//      RCCL_NET_RELOAD_COUNTER_FILE. The test counts those lines to detect
+//      whether the plugin is reloaded after a communicator is destroyed.
+//      RCCL_NET_TEST_PLUGIN_MODE=assign_fail selects an incompatible UNPACK
+//      device version (assignment rejected after init) and records
+//      init/finalize via RCCL_NET_ASSIGN_FAIL_{INIT,FINALIZE}_FILE
+//      (NCCL 2.28.7 net.cc fix).
+//
+//   2. One-sided RMA plugin (ncclGinPlugin_v13 / ncclRmaPlugin_v13, an
+//      ncclGin_v13_t vtable) used by RmaExternalPluginLoad.* to validate only the
+//      loader/assign path in src/plugin/gin.cc: src/plugin/gin/gin_v13.cc resolves
+//      the symbols via dlsym, gin.cc promotes the RMA plugin to InitReady, calls
+//      init()/devices(), and assigns the vtable to comm->rmaState.rmaProxyState.
+//      init() records that it ran via RCCL_RMA_RELOAD_INIT_FILE. The RMA DATA path
+//      (iput/iputSignal/iget) is NOT implemented here (a loopback memcpy/atomic
+//      cannot service a real cross-rank put/signal): those ops move no data and
+//      raise no signal, and the data path is validated separately with a real
+//      plugin on real IB. They DO record their invocation via
+//      RCCL_RMA_RELOAD_COUNTER_FILE (iputSignal also RCCL_RMA_SIGNAL_COUNTER_FILE)
+//      so RmaExternalPluginPutSignal.* can prove the host put/signal APIs reach
+//      the plugin primitives (a fire-and-forget check: no wait, no validation).
+//
+// Compiled as C++ (the RCCL project only enables CXX/HIP), so each plugin symbol
 // is exported with C linkage and default visibility for RCCL's dlsym() lookup.
 //
 // RCCL_NET_TEST_PLUGIN_MODE selects a failure to inject:
@@ -22,11 +45,19 @@
 //   devices_fail  - init() succeeds but devices() reports an error, which is the
 //                   companion case where finalize() must still run.
 // Both new modes record via RCCL_NET_TEST_{INIT,FINALIZE}_FILE.
+//
+// Both plugins share the real RCCL plugin headers (nccl_net.h transitively
+// provides the v12 net ABI, net_device.h and the GIN proxy constants); this
+// keeps the two vtables in one consistent header world so they can live in a
+// single translation unit without the example net headers redefining the v12
+// net types that gin_v13.h also pulls in.
 
+#include <cstdint>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "net.h" // from plugins/net/example/nccl
+#include "nccl_net.h"     // ncclNet_v12_t + v12 net ABI, NCCL_NET_DEVICE_*
+#include "gin/gin_v13.h"  // ncclGin_v13_t, ncclGinConfig_v13_t
 
 #define __hidden __attribute__((visibility("hidden")))
 #define __exported __attribute__((visibility("default")))
@@ -157,3 +188,196 @@ extern "C" __exported const ncclNet_v12_t ncclNetPlugin_v12 = {
   pluginFinalize,
   pluginSetNetAttr,
 };
+
+// ---------------------------------------------------------------------------
+// One-sided RMA plugin (ncclGinPlugin_v13 / ncclRmaPlugin_v13)
+// ---------------------------------------------------------------------------
+//
+namespace rma_stub {
+
+char kRmaPluginName[] = "RmaReloadStub";
+
+struct StubMr {
+  void* base;
+  size_t size;
+};
+
+struct StubComm {
+  int rank;
+  int nranks;
+};
+
+struct StubCtx {
+  StubComm* comm;
+};
+
+int gRequestSentinel = 0;
+
+__hidden ncclResult_t stubInit(void** ctx, uint64_t /*commId*/, ncclDebugLogger_t /*logFunction*/) {
+  recordLine("RCCL_RMA_RELOAD_INIT_FILE");
+  if (ctx) *ctx = new StubComm{0, 1};
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubDevices(int* ndev) {
+  if (ndev) *ndev = 1;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubGetProperties(int dev, ncclNetProperties_v12_t* props) {
+  memset(props, 0, sizeof(*props));
+  props->name = kRmaPluginName;
+  props->pciPath = nullptr;
+  props->guid = 0;
+  props->ptrSupport = NCCL_PTR_HOST | NCCL_PTR_CUDA;
+  props->regIsGlobal = 0;
+  props->forceFlush = 0;
+  props->speed = 100000;
+  props->port = 0;
+  props->latency = 0;
+  props->maxComms = 1024 * 1024;
+  props->maxRecvs = 1;
+  // Selecting the proxy backend is gated on this device type.
+  props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
+  props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+  props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
+  props->maxCollBytes = NCCL_MAX_NET_SIZE_BYTES;
+  props->maxMultiRequestSize = 1;
+  props->vProps.ndevs = 1;
+  props->vProps.devs[0] = dev;
+  props->railId = NCCL_NET_ID_UNDEF;
+  props->planeId = NCCL_NET_ID_UNDEF;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubListen(void* /*ctx*/, int /*dev*/, void* handle, void** listenComm) {
+  if (handle) memset(handle, 0, NCCL_NET_HANDLE_MAXSIZE);
+  if (listenComm) *listenComm = new StubComm{0, 1};
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubConnect(void* /*ctx*/, void* /*handles*/[], int nranks, int rank, void* /*listenComm*/,
+                                  void** collComm) {
+  if (collComm) *collComm = new StubComm{rank, nranks};
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubCreateContext(void* collComm, ncclGinConfig_v13_t* /*config*/, void** ginCtx,
+                                        ncclNetDeviceHandle_v11_t** devHandle) {
+  if (ginCtx) *ginCtx = new StubCtx{static_cast<StubComm*>(collComm)};
+  if (devHandle) *devHandle = nullptr;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubRegMrSym(void* /*collComm*/, void* data, size_t size, int /*type*/, uint64_t /*mrFlags*/,
+                                   void** mhandle, void** ginHandle) {
+  StubMr* mr = new StubMr{data, size};
+  if (mhandle) *mhandle = mr;
+  if (ginHandle) *ginHandle = mr;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t /*offset*/,
+                                         int /*fd*/, uint64_t mrFlags, void** mhandle, void** ginHandle) {
+  return stubRegMrSym(collComm, data, size, type, mrFlags, mhandle, ginHandle);
+}
+
+__hidden ncclResult_t stubDeregMrSym(void* /*collComm*/, void* mhandle) {
+  delete static_cast<StubMr*>(mhandle);
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubDestroyContext(void* ginCtx) {
+  delete static_cast<StubCtx*>(ginCtx);
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubCloseColl(void* collComm) {
+  delete static_cast<StubComm*>(collComm);
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubCloseListen(void* listenComm) {
+  delete static_cast<StubComm*>(listenComm);
+  return ncclSuccess;
+}
+
+// Data ops move NO data and raise NO signal
+__hidden ncclResult_t stubIput(void* /*ginCtx*/, int /*context*/, uint64_t /*srcOff*/, void* /*srcMhandle*/,
+                               size_t /*size*/, uint64_t /*dstOff*/, void* /*dstMhandle*/, uint32_t /*rank*/,
+                               void** request) {
+  recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
+  if (request) *request = &gRequestSentinel;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubIputSignal(void* /*ginCtx*/, int /*context*/, uint64_t /*srcOff*/, void* /*srcMhandle*/,
+                                     size_t /*size*/, uint64_t /*dstOff*/, void* /*dstMhandle*/, uint32_t /*rank*/,
+                                     uint64_t /*signalOff*/, void* /*signalMhandle*/, uint64_t /*signalValue*/,
+                                     uint32_t /*signalOp*/, void** request) {
+  recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
+  recordLine("RCCL_RMA_SIGNAL_COUNTER_FILE");
+  if (request) *request = &gRequestSentinel;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubIget(void* /*ginCtx*/, int /*context*/, uint64_t /*remoteOff*/, void* /*remoteMhandle*/,
+                               size_t /*size*/, uint64_t /*localOff*/, void* /*localMhandle*/, uint32_t /*rank*/,
+                               void** request) {
+  recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
+  if (request) *request = &gRequestSentinel;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubIflush(void* /*ginCtx*/, int /*context*/, void* /*mhandle*/, uint32_t /*rank*/,
+                                 void** request) {
+  if (request) *request = &gRequestSentinel;
+  return ncclSuccess;
+}
+
+// Every op is synchronous, so requests are always complete.
+__hidden ncclResult_t stubTest(void* /*collComm*/, void* /*request*/, int* done) {
+  if (done) *done = 1;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubGinProgress(void* /*ginCtx*/) { return ncclSuccess; }
+
+__hidden ncclResult_t stubQueryLastError(void* /*ginCtx*/, bool* hasError) {
+  if (hasError) *hasError = false;
+  return ncclSuccess;
+}
+
+__hidden ncclResult_t stubFinalize(void* ctx) {
+  delete static_cast<StubComm*>(ctx);
+  return ncclSuccess;
+}
+
+const ncclGin_v13_t kStubVtable = {
+  kRmaPluginName,
+  stubInit,
+  stubDevices,
+  stubGetProperties,
+  stubListen,
+  stubConnect,
+  stubCreateContext,
+  stubRegMrSym,
+  stubRegMrSymDmaBuf,
+  stubDeregMrSym,
+  stubDestroyContext,
+  stubCloseColl,
+  stubCloseListen,
+  stubIput,
+  stubIputSignal,
+  stubIget,
+  stubIflush,
+  stubTest,
+  stubGinProgress,
+  stubQueryLastError,
+  stubFinalize,
+};
+
+} // namespace rma_stub
+
+extern "C" __exported const ncclGin_v13_t ncclGinPlugin_v13 = rma_stub::kStubVtable;
+extern "C" __exported const ncclGin_v13_t ncclRmaPlugin_v13 = rma_stub::kStubVtable;

--- a/projects/rccl/test/plugin/net_reload_plugin.cpp
+++ b/projects/rccl/test/plugin/net_reload_plugin.cpp
@@ -193,29 +193,27 @@ extern "C" __exported const ncclNet_v12_t ncclNetPlugin_v12 = {
 // One-sided RMA plugin (ncclGinPlugin_v13 / ncclRmaPlugin_v13)
 // ---------------------------------------------------------------------------
 //
-namespace rma_stub {
+static char kRmaPluginName[] = "RmaReloadStub";
 
-char kRmaPluginName[] = "RmaReloadStub";
-
-struct StubMr {
+struct RmaStubMr {
   void* base;
   size_t size;
 };
 
-struct StubComm {
+struct RmaStubComm {
   int rank;
   int nranks;
 };
 
-struct StubCtx {
-  StubComm* comm;
+struct RmaStubCtx {
+  RmaStubComm* comm;
 };
 
-int gRequestSentinel = 0;
+static int gRmaRequestSentinel = 0;
 
 __hidden ncclResult_t stubInit(void** ctx, uint64_t /*commId*/, ncclDebugLogger_t /*logFunction*/) {
   recordLine("RCCL_RMA_RELOAD_INIT_FILE");
-  if (ctx) *ctx = new StubComm{0, 1};
+  if (ctx) *ctx = new RmaStubComm{0, 1};
   return ncclSuccess;
 }
 
@@ -252,26 +250,26 @@ __hidden ncclResult_t stubGetProperties(int dev, ncclNetProperties_v12_t* props)
 
 __hidden ncclResult_t stubListen(void* /*ctx*/, int /*dev*/, void* handle, void** listenComm) {
   if (handle) memset(handle, 0, NCCL_NET_HANDLE_MAXSIZE);
-  if (listenComm) *listenComm = new StubComm{0, 1};
+  if (listenComm) *listenComm = new RmaStubComm{0, 1};
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubConnect(void* /*ctx*/, void* /*handles*/[], int nranks, int rank, void* /*listenComm*/,
                                   void** collComm) {
-  if (collComm) *collComm = new StubComm{rank, nranks};
+  if (collComm) *collComm = new RmaStubComm{rank, nranks};
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubCreateContext(void* collComm, ncclGinConfig_v13_t* /*config*/, void** ginCtx,
                                         ncclNetDeviceHandle_v11_t** devHandle) {
-  if (ginCtx) *ginCtx = new StubCtx{static_cast<StubComm*>(collComm)};
+  if (ginCtx) *ginCtx = new RmaStubCtx{static_cast<RmaStubComm*>(collComm)};
   if (devHandle) *devHandle = nullptr;
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubRegMrSym(void* /*collComm*/, void* data, size_t size, int /*type*/, uint64_t /*mrFlags*/,
                                    void** mhandle, void** ginHandle) {
-  StubMr* mr = new StubMr{data, size};
+  RmaStubMr* mr = new RmaStubMr{data, size};
   if (mhandle) *mhandle = mr;
   if (ginHandle) *ginHandle = mr;
   return ncclSuccess;
@@ -283,22 +281,22 @@ __hidden ncclResult_t stubRegMrSymDmaBuf(void* collComm, void* data, size_t size
 }
 
 __hidden ncclResult_t stubDeregMrSym(void* /*collComm*/, void* mhandle) {
-  delete static_cast<StubMr*>(mhandle);
+  delete static_cast<RmaStubMr*>(mhandle);
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubDestroyContext(void* ginCtx) {
-  delete static_cast<StubCtx*>(ginCtx);
+  delete static_cast<RmaStubCtx*>(ginCtx);
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubCloseColl(void* collComm) {
-  delete static_cast<StubComm*>(collComm);
+  delete static_cast<RmaStubComm*>(collComm);
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubCloseListen(void* listenComm) {
-  delete static_cast<StubComm*>(listenComm);
+  delete static_cast<RmaStubComm*>(listenComm);
   return ncclSuccess;
 }
 
@@ -307,7 +305,7 @@ __hidden ncclResult_t stubIput(void* /*ginCtx*/, int /*context*/, uint64_t /*src
                                size_t /*size*/, uint64_t /*dstOff*/, void* /*dstMhandle*/, uint32_t /*rank*/,
                                void** request) {
   recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
-  if (request) *request = &gRequestSentinel;
+  if (request) *request = &gRmaRequestSentinel;
   return ncclSuccess;
 }
 
@@ -317,7 +315,7 @@ __hidden ncclResult_t stubIputSignal(void* /*ginCtx*/, int /*context*/, uint64_t
                                      uint32_t /*signalOp*/, void** request) {
   recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
   recordLine("RCCL_RMA_SIGNAL_COUNTER_FILE");
-  if (request) *request = &gRequestSentinel;
+  if (request) *request = &gRmaRequestSentinel;
   return ncclSuccess;
 }
 
@@ -325,13 +323,13 @@ __hidden ncclResult_t stubIget(void* /*ginCtx*/, int /*context*/, uint64_t /*rem
                                size_t /*size*/, uint64_t /*localOff*/, void* /*localMhandle*/, uint32_t /*rank*/,
                                void** request) {
   recordLine("RCCL_RMA_RELOAD_COUNTER_FILE");
-  if (request) *request = &gRequestSentinel;
+  if (request) *request = &gRmaRequestSentinel;
   return ncclSuccess;
 }
 
 __hidden ncclResult_t stubIflush(void* /*ginCtx*/, int /*context*/, void* /*mhandle*/, uint32_t /*rank*/,
                                  void** request) {
-  if (request) *request = &gRequestSentinel;
+  if (request) *request = &gRmaRequestSentinel;
   return ncclSuccess;
 }
 
@@ -349,35 +347,32 @@ __hidden ncclResult_t stubQueryLastError(void* /*ginCtx*/, bool* hasError) {
 }
 
 __hidden ncclResult_t stubFinalize(void* ctx) {
-  delete static_cast<StubComm*>(ctx);
+  delete static_cast<RmaStubComm*>(ctx);
   return ncclSuccess;
 }
 
-const ncclGin_v13_t kStubVtable = {
-  kRmaPluginName,
-  stubInit,
-  stubDevices,
-  stubGetProperties,
-  stubListen,
-  stubConnect,
-  stubCreateContext,
-  stubRegMrSym,
-  stubRegMrSymDmaBuf,
-  stubDeregMrSym,
-  stubDestroyContext,
-  stubCloseColl,
-  stubCloseListen,
-  stubIput,
-  stubIputSignal,
-  stubIget,
-  stubIflush,
-  stubTest,
-  stubGinProgress,
-  stubQueryLastError,
-  stubFinalize,
-};
+#define RMA_RELOAD_STUB_VTABLE_FIELDS \
+  kRmaPluginName, \
+  stubInit, \
+  stubDevices, \
+  stubGetProperties, \
+  stubListen, \
+  stubConnect, \
+  stubCreateContext, \
+  stubRegMrSym, \
+  stubRegMrSymDmaBuf, \
+  stubDeregMrSym, \
+  stubDestroyContext, \
+  stubCloseColl, \
+  stubCloseListen, \
+  stubIput, \
+  stubIputSignal, \
+  stubIget, \
+  stubIflush, \
+  stubTest, \
+  stubGinProgress, \
+  stubQueryLastError, \
+  stubFinalize
 
-} // namespace rma_stub
-
-extern "C" __exported const ncclGin_v13_t ncclGinPlugin_v13 = rma_stub::kStubVtable;
-extern "C" __exported const ncclGin_v13_t ncclRmaPlugin_v13 = rma_stub::kStubVtable;
+extern "C" __exported const ncclGin_v13_t ncclGinPlugin_v13 = { RMA_RELOAD_STUB_VTABLE_FIELDS };
+extern "C" __exported const ncclGin_v13_t ncclRmaPlugin_v13 = { RMA_RELOAD_STUB_VTABLE_FIELDS };

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -929,6 +929,29 @@
       ]
     },
 
+    "rma_external_plugin_put_signal": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_PLUGIN": "STATIC_PLUGIN",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_WIN_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "RCCL_RMA_USE_DMABUF": "1",
+        "RCCL_RMA_RELOAD_COUNTER_FILE": "/tmp/rccl_rma_reload_put_signal_counter.txt"
+      },
+      "description": "Validate the EXTERNAL one-sided RMA plugin loader/assign path",
+      "tests": [
+        {"name": "Rma_ExternalPluginIssuesPutSignalToStub", "description": "rank 0 ncclPutSignal + ncclSignal (no wait) must invoke the external stub plugin's iput/iputSignal primitives", "test_filter": "RmaExternalPluginPutSignalTest.IssuesPutSignalToStub"}
+      ]
+    },
+
     "unit_tests_standard": {
       "is_gtest": true,
       "binary": "rccl-UnitTests",
@@ -4552,6 +4575,12 @@
       "name": "SparseSendRecv",
       "description": "Test sparse send/recv functionality over multiple plans",
       "config": "sparse_send_recv",
+      "enabled": true
+    },
+    {
+      "name": "RMA External Plugin - Put Signal",
+      "description": "Validate the EXTERNAL one-sided RMA plugin loader/assign path",
+      "config": "rma_external_plugin_put_signal",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -940,6 +940,7 @@
       "env_variables": {
         "NCCL_GIN_ENABLE": "1",
         "NCCL_GIN_PLUGIN": "STATIC_PLUGIN",
+        "NCCL_RMA_PLUGIN": "STATIC_PLUGIN",
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_WIN_ENABLE": "1",
         "NCCL_DMABUF_ENABLE": "1",


### PR DESCRIPTION
## Motivation

Validate that one-sided RMA can now use an external network plugin.

## Technical Details

Added stub RMA plugin and test checking that external plugin could be used.

## Issue Tracking

JIRA ID: AICOMRCCL-1833

## Test Plan

Manual validation

Test suite | Layout | Binary | Result
-- | -- | -- | --
RmaExternalPluginPutSignalTest.* | 2 nodes × 1 proc/node | rccl-UnitTestsMPI | 1/1 PASSED 
NetPluginReload.* | 1 node, 1 process  | rccl-UnitTests | 1/1 PASSED 
NetPluginAssignFail.* | 1 node, 1 process | rccl-UnitTests | 3/3 PASSED 


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
