### PR TITLE
fix(clr): disable blit kernarg preload on gfx950

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -259,6 +259,7 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
   const bool isGfx94x = gfxipMajor == 9 && gfxipMinor >= 4 &&
                         (gfxStepping == 0 || gfxStepping == 1 || gfxStepping == 2);
   const bool isGfx90a = (gfxipMajor == 9 && gfxipMinor == 0 && gfxStepping == 10);
+  const bool isGfx95x = (gfxipMajor == 9 && gfxipMinor == 5);
   const bool isGfx125x = (gfxipMajor == 12) && ((gfxipMinor >= 5));
 
   auto kernelArgImpl = KernelArgImpl::HostKernelArgs;
@@ -275,9 +276,14 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
 
   // Enable device kernel args by default on gfx94x/gfx125x. Device-memory AQL
   // ring buffers are controlled separately via DEBUG_CLR_AQL_DEV_QUEUE below.
+  // kernel_arg_opt_ also requests hardware kernarg preload for the blit program
+  // (device.cpp passes -amdgpu-kernarg-preload-count). Leave it off on gfx95x: CP/SPI
+  // can deliver a stale preloaded dword to individual waves there, and a wave whose
+  // end_ptr is stale branches past its stores, silently dropping one wavefront of the
+  // copy. See ROCM-26300.
   if (isGfx94x || isGfx125x) {
     kernel_arg_impl_ = kernelArgImpl;
-    kernel_arg_opt_ = true;
+    kernel_arg_opt_ = !isGfx95x;
   }
 
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {


### PR DESCRIPTION
kernel_arg_opt_ makes device.cpp compile the blit program with -amdgpu-kernarg-preload-count=8, so CP/MEC firmware and SPI deliver the blit kernel's arguments in user SGPRs at wave launch instead of the shader loading them.

On gfx950, after a GPU has taken a storm of VM faults, individual waves launch with a stale preloaded end_ptr. __amd_rocclr_copyBuffer gates every store on that value, so such a wave branches past the copy loop, executes no stores, raises no fault and logs nothing. The result is silent data corruption: a device-to-device hipMemcpyAsync returns with scattered holes, each exactly one wavefront wide (64 lanes x 16 B = 1024 B).

Reproduced on 8x MI350X by running KFDExceptionTest.FaultStorm and then any same-device D2D copy; the first copy after the trigger has never passed. A HIP kernel byte-identical to the blit, at the same grid and on the same queue, is unaffected until it too is built with kernarg preload, at which point it reproduces - and it stays clean while the preloaded window covers only src and dst, failing once end_ptr enters it.

Keep kernel_arg_impl_ (device kernel args) as is; only the preload request is implicated. Measured cost of turning it off, interleaved A/B, 15 reps per arm: -0.65% at 64 MiB and no resolvable difference at 4 KiB, 64 KiB or 2 MiB.

This is a workaround for a firmware defect, not a fix for it. The underlying poisoned state in the CP kernarg-fetch path is per-GPU, survives process teardown, and decays over subsequent dispatches; any other consumer of kernarg preload on gfx950 remains exposed. A CP firmware ticket covers that.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
