### PR TITLE
fix(clr): disable blit kernarg preload on gfx950

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -259,6 +259,7 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
   const bool isGfx94x = gfxipMajor == 9 && gfxipMinor >= 4 &&
                         (gfxStepping == 0 || gfxStepping == 1 || gfxStepping == 2);
   const bool isGfx90a = (gfxipMajor == 9 && gfxipMinor == 0 && gfxStepping == 10);
+  const bool isGfx95x = (gfxipMajor == 9 && gfxipMinor == 5);
   const bool isGfx125x = (gfxipMajor == 12) && ((gfxipMinor >= 5));
 
   auto kernelArgImpl = KernelArgImpl::HostKernelArgs;
@@ -275,9 +276,14 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
 
   // Enable device kernel args by default on gfx94x/gfx125x. Device-memory AQL
   // ring buffers are controlled separately via DEBUG_CLR_AQL_DEV_QUEUE below.
+  // kernel_arg_opt_ also requests hardware kernarg preload for the blit program
+  // (device.cpp passes -amdgpu-kernarg-preload-count). Leave it off on gfx95x: CP/SPI
+  // can deliver a stale preloaded dword to individual waves there, and a wave whose
+  // end_ptr is stale branches past its stores, silently dropping one wavefront of the
+  // copy. See ROCM-26300.
   if (isGfx94x || isGfx125x) {
     kernel_arg_impl_ = kernelArgImpl;
-    kernel_arg_opt_ = true;
+    kernel_arg_opt_ = !isGfx95x;
   }
 
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {


### PR DESCRIPTION
## Motivation

Silent data corruption on gfx950 (MI350X). After a GPU takes a storm of VM faults, the
next same-device `hipMemcpyAsync` drops whole wavefronts of the copy - no fault, no error
return, nothing in dmesg. It surfaced as RCCL `AllGather.OutOfPlace` returning wrong data
whenever kfdtest ran earlier on the same boot, which is the normal CI ordering, and the
only known recovery was a reboot.

This PR removes the exposure so CI and users stop silently getting bad data.

## Technical Details

`kernel_arg_opt_` causes `Device::BlitProgram::create()` (`rocclr/device/device.cpp:810`)
to append `-Wb,-amdgpu-kernarg-preload-count=8` to the **blit program only**, and
`rocclr/device/rocm/rocsettings.cpp:277-279` sets that flag true for gfx950 -
`isGfx94x` is misnamed and matches major 9 / minor >= 4 / stepping 0.

With preload active, CP/MEC firmware and SPI deliver the blit kernel's arguments into user
SGPRs at wave launch instead of the shader loading them. On gfx950, after a fault storm,
individual waves launch with a stale preloaded `end_ptr`. `__amd_rocclr_copyBuffer` gates
every store on that value:

```
v_cmp_gt_u64_e32   vcc, s[10:11], v[2:3]     ; s[10:11] = preloaded end_ptr
s_and_saveexec_b64 s[0:1], vcc
s_cbranch_execz                              ; wave skips the entire copy loop
```

Such a wave performs zero stores, raises no fault and logs nothing, leaving exactly
64 lanes x 16 B = 1024 B of the destination unwritten.

The change splits the two settings and leaves preload off for gfx95x:

```c
const bool isGfx95x = (gfxipMajor == 9 && gfxipMinor == 5);
if (isGfx94x || isGfx125x) {
  kernel_arg_impl_ = kernelArgImpl;
  kernel_arg_opt_  = !isGfx95x;
}
```

`kernel_arg_impl_ = DeviceKernelArgs` is deliberately left unchanged - only the preload
request is implicated.

Blast radius: `kernel_arg_opt_` has four references repo-wide (declaration
`device.hpp:730`, setters `rocsettings.cpp:248`/`:279`, single consumer `device.cpp:810`).
It reaches only ROCclr's internal blit program, so user kernels, user kernarg handling,
launch latency and compute throughput cannot be affected.

**This is a workaround for a firmware defect, not a fix for it.** The underlying poisoned
state in the CP kernarg-fetch path is per-GPU, survives process teardown, and decays over
subsequent dispatches; any other consumer of kernarg preload on gfx950 remains exposed. A
CP firmware ticket covers the root cause.

## Issue Tracking

ROCM-26300

## Test Plan

All on an 8x MI350X gfx950 box (Ubuntu 24.04.3, kernel 6.12.29, amdgpu DKMS
6.19.0-2374403, ROCm 10.0.0). Because the poisoned state decays after a few operations,
every arm re-triggers first and is judged on run #1; arms are contention-guarded against
the CI containers sharing the box.

1. Reported failure: `KFDExceptionTest.FaultStorm`, then
   `rccl-UnitTests --gtest_filter=AllGather.OutOfPlace` (1 rank, ncclFloat16, 1048576
   elements), stock vs preload-off, with a stock control on both sides.
2. Minimal detector: a HIP probe issuing the same 2 MiB D2D copy with the destination
   pre-filled with a sentinel, so "never written" is distinguishable from "written with
   zeros". Fanned out over all 8 GPUs.
3. Causal isolation: a HIP kernel byte-identical to `__amd_rocclr_copyBuffer`, at the same
   grid and on the same queue, rebuilt at a range of
   `-mllvm -amdgpu-kernarg-preload-count=N` values.
4. Performance: interleaved A/B rep-by-rep, 15 reps per arm, at 4 KiB / 64 KiB / 2 MiB /
   64 MiB.
5. ASIC guard: standalone check of the predicate across gfx90a/940/941/942/950/1030/1100/1250.
6. Build: clr configured and compiled from this branch.
7. Driver/box health: full kfdtest under `FILTER[gfx950]`.

## Test Result

**Reported failure fixed** (run #1 is the detector):

| round | stock | preload off |
|---|---|---|
| 1 | FAIL FAIL pass | pass pass pass |
| 2 | FAIL FAIL FAIL | pass pass pass |

**Causal in both directions.** Turning preload *on* in a previously immune replica makes
it reproduce, and the failure appears exactly when `end_ptr` enters the preloaded window
(layout: `src` d0-1, `dst` d2-3, `end_ptr` d4-5). All 8 GPUs, fresh trigger per arm:

| preload_length | covers | round 1 | round 2 |
|---|---|---|---|
| 0 | nothing | 0/8 | 0/8 |
| 4 | src + dst | 0/8 | 0/8 |
| 6 | + end_ptr | 7/8 | 8/8 |
| 8 | all args | 7/8 | 5/8 |

Real-`hipMemcpy` control in the same rounds: 8/8 dirty (73 and 57 holes), so the clean arms
are genuine and not a decayed trigger.

**Performance** - interleaved A/B, 15 reps per arm, medians:

| size | stock | preload off | delta |
|---|---|---|---|
| 4 KiB | 1.7 GB/s | 1.8 GB/s | no resolvable difference |
| 64 KiB | 27.8 GB/s | 27.1 GB/s | within spread |
| 2 MiB | 854.2 GB/s | 869.7 GB/s | within noise |
| 64 MiB | 3530.7 GB/s | 3507.9 GB/s | -0.65% |

Wave count is capped at 2048 for any copy >= 2 MiB
(`globalWorkSize = min(blitWg * 512, nelem)`), so the added compatibility-prologue cost is
fixed per copy rather than proportional. Removing preload also drops the kernel from 14 to
12 VGPRs.

**ASIC guard** - only gfx950 changes:

```
gfx940 / gfx941 / gfx942   kernel_arg_opt_  true  -> true
gfx950                     kernel_arg_opt_  true  -> false
gfx1250                    kernel_arg_opt_  true  -> true
gfx90a / gfx1030 / gfx1100        false -> false
```

**Build**: clr configures and compiles clean from this branch (RC=0,
`libamdhip64.so.7.16.0`).

**kfdtest**: 177 run / 177 passed / 0 failed, dmesg clean apart from the deliberate
negative tests' own output. Noted for completeness only - kfdtest goes libhsakmt -> KFD and
never loads HIP/ROCclr, so it cannot exercise this change in either direction.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
