### PR TITLE
fix(clr) - elegantly return err when kernels are unsupported

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -537,11 +537,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
   if (module != nullptr) {
     std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
-      hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
-      if (err != hipSuccess) {
-        return err;
-      }
-    }
+     IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
   } else {
     // Module was nullptr
     return hipErrorInvalidDeviceFunction;

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -538,7 +538,6 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
     std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
       hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
-
       if (err != hipSuccess) {
         return err;
       }
@@ -563,7 +562,7 @@ hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFun
   // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
   if (*(module) == nullptr) {
-    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+    IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
   }
 
   return it->second->GetStatFuncAttr(func_attr, deviceId);
@@ -594,7 +593,7 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
   // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
   if (*(module) == nullptr) {
-    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+    IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
   }
 
   amd::Memory* mem = nullptr;
@@ -643,7 +642,7 @@ hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
         // Lazy load
         FatBinaryInfo** module = var->ModuleInfo();
         if (*(module) == nullptr) {
-          std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+          IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
         }
         hip::Stream* stream = g_devices.at(deviceId)->NullStream();
         if (stream == nullptr) {

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -538,6 +538,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
     std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
      IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
+    }
   } else {
     // Module was nullptr
     return hipErrorInvalidDeviceFunction;

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -720,19 +720,15 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   const auto [hip_error, func] = [&]() -> std::pair<hipError_t, hipFunction_t> {
     hipFunction_t f;
     const hipError_t err = PlatformState::Instance().StatCO().GetFunc(&f, hostFunction, deviceId);
-    
-    // Propagate specific invalid code object errors
-    if (err == hipErrorInvalidKernelFile ||
-        err == hipErrorInvalidDeviceFunction ||
-        err == hipErrorInvalidImage) {
-      return {err, nullptr};
-    }
-    
+
     // If successful lookup with valid function, use it
     if (err == hipSuccess && f) {
       return {hipSuccess, f};
     }
-    
+    if (err != hipSuccess) {
+      return {err, nullptr};
+    }
+
     // Fallback: assume it's a hip function type
     return {hipSuccess, reinterpret_cast<hipFunction_t>(const_cast<void*>(hostFunction))};
   }();

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -720,12 +720,12 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   const auto [hip_error, func] = [&]() -> std::pair<hipError_t, hipFunction_t> {
     hipFunction_t f;
     const hipError_t err = PlatformState::Instance().StatCO().GetFunc(&f, hostFunction, deviceId);
-      
+
     // Propagate specific invalid code object errors
     if (err == hipErrorInvalidKernelFile ||
         err == hipErrorInvalidDeviceFunction ||
         err == hipErrorInvalidImage ||
-        err == hipErrorNotSupported) {
+        err == hipErrorNotSupported) {  // ROCM_KPACK_ENABLED=OFF
       return {err, nullptr};
     }
     // If successful lookup with valid function, use it
@@ -733,7 +733,7 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
       return {hipSuccess, f};
     }
 
-      // Fallback: assume it's a hip function type
+    // Fallback: assume it's a hip function type
     return {hipSuccess, reinterpret_cast<hipFunction_t>(const_cast<void*>(hostFunction))};
   }();
 

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -720,16 +720,20 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   const auto [hip_error, func] = [&]() -> std::pair<hipError_t, hipFunction_t> {
     hipFunction_t f;
     const hipError_t err = PlatformState::Instance().StatCO().GetFunc(&f, hostFunction, deviceId);
-
+      
+    // Propagate specific invalid code object errors
+    if (err == hipErrorInvalidKernelFile ||
+        err == hipErrorInvalidDeviceFunction ||
+        err == hipErrorInvalidImage ||
+        err == hipErrorNotSupported) {
+      return {err, nullptr};
+    }
     // If successful lookup with valid function, use it
     if (err == hipSuccess && f) {
       return {hipSuccess, f};
     }
-    if (err != hipSuccess) {
-      return {err, nullptr};
-    }
 
-    // Fallback: assume it's a hip function type
+      // Fallback: assume it's a hip function type
     return {hipSuccess, reinterpret_cast<hipFunction_t>(const_cast<void*>(hostFunction))};
   }();
 


### PR DESCRIPTION
## Motivation
kernels with Kpack and hip runtime built with ROCM_KPACK_ENABLED=OFF. ideally hip runtime should be built with ROCM_KPACK_ENABLED=ON as per Rock, but we should not crash the app if its not built with it

## Technical Details
kernels/apps built with ROCM_KPACK_ENABLED=ON and when executed on hip runtime with ROCM_KPACK_ENABLED=OFF  crashes. this PR gracefully handles the incompatible kernels and returns an error 

## Issue Tracking
JIRA ID: ROCM-29380

## Test Plan
hip-tests should continue to build/test fine. 

## Test Result
hip-tests should continue to build/test fine. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
