### PR TITLE
Disable Unit_hipMemcpyBatchAsync_Swap on gfx1250 (#9923)

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -836,6 +836,8 @@ memory:
   Unit_hipMemcpyBatchAsync_D2D_Functional: *level_2
   Unit_hipMemcpyBatchAsync_Swap:
     <<: *level_2
+    # ROCM-29275
+    disabled: [gfx1250]
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_Multicast:
     <<: *level_2
@@ -850,6 +852,8 @@ memory:
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_P2P_Swap:
     <<: *level_2
+    # ROCM-29275
+    disabled: [gfx1250]
     tags: [transfer, multigpu]
   Unit_hipMemcpyBatchAsync_P2P_Multicast:
     <<: *level_2


### PR DESCRIPTION
Cherry-picks commit `072cc5726456abd4c4b042dd10fea59a5b6d20aa` from [ROCm/rocm-systems#9923](https://github.com/ROCm/rocm-systems/pull/9923) into `release/bkc/therock-10.1-20260811` for candidate build `10.1.0a20260811`.

**Draft: awaiting Express Train operator review. Do not mark ready or merge until correctness is confirmed.**

## Motivation

Disable the failing `Unit_hipMemcpyBatchAsync_Swap` and P2P swap cases on gfx1250 while retaining them on other architectures.

## Technical Details

Carries the source PR unchanged as a single `git cherry-pick -x` commit. This is the hip-tests config companion to ROCm/TheRock#7268; neither PR has an ordering dependency.

## Issue Tracking

JIRA ID : ROCM-29275

## Test Plan

- Verify source/release patch identity and whitespace.
- Load `memory.yaml` through hip-tests' official definition-combining loader and assert both cases resolve to `disabled: [gfx1250]`.
- Rely on PR CI for hip-tests build and hardware coverage.

## Test Result

- Cherry-pick applied without conflicts; stable patch ID and changed-file set match.
- `git diff --check` and the official combined-config loader validation pass.
- The generic standalone YAML hook reports the pre-existing external `*level_2` anchor; the repository loader resolves it successfully. Other applicable file-integrity hooks pass.
- Hardware validation remains pending PR CI.

## Dependencies and ordering

No mandatory ordering requirements. Companion change: ROCm/TheRock#7268.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] PR is intentionally left in draft for operator review.
