### PR TITLE
fix(rocr): Enable profiling on internal blit copy queues (#8793)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1585,7 +1585,22 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 }
 
 void AqlQueue::SetProfiling(bool enabled) {
+  bool need_update = false;
+  const bool cur = AMD_HSA_BITS_GET(amd_queue_.queue_properties,
+    AMD_QUEUE_PROPERTIES_ENABLE_PROFILING) != 0;
+
+  if (cur != enabled && LoadWriteIndexRelaxed() != 0) {
+    // If the queue is already enabled/disabled, we need to update the queue properties and we have already submitted packets,
+    // then we need to unmap and remap the queue for CP FW to re-read the queue properties.
+    need_update = true;
+  }
+
   Queue::SetProfiling(enabled);
+
+  if (need_update) {
+    Suspend();
+    Resume();
+  }
 
   if (enabled) agent_->CheckClockTicks();
   return;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -908,10 +908,21 @@ void GpuAgent::InitDma() {
     return queue;
   };
 
-  // Dedicated compute queue for host-to-device blits.
-  queues_[QueueBlitOnly].reset(queue_lambda);
+  // Enable profiling on the internal blit copy queues right after creation to avoid
+  // having to unmap and remap the queue for CP FW to re-read the queue properties when
+  // profiling is later turned on. If profiling is disabled later on these queues, then
+  // the queue unmap and remap will be triggered.
+  queues_[QueueBlitOnly].reset([queue_lambda]() {
+    auto queue = queue_lambda();
+    queue->SetProfiling(true);
+    return queue;
+  });
   // Share utility queue with device-to-host blits.
-  queues_[QueueUtility].reset(queue_lambda);
+  queues_[QueueUtility].reset([queue_lambda]() {
+    auto queue = queue_lambda();
+    queue->SetProfiling(true);
+    return queue;
+  });
 
   // Dedicated compute queue for PC Sampling CP-DMA commands. We need a dedicated queue that runs at
   // highest priority because we do not want the CP-DMA commands to be delayed/blocked due to


### PR DESCRIPTION
Cherry-picks commit `eae1629ff81717b62ffe098bfa1dc85e499b9c05` from [ROCm/rocm-systems#8793](https://github.com/ROCm/rocm-systems/pull/8793) into `release/bkc/therock-10.1-20260811` for candidate build `10.1.0a20260811`.

**Draft: awaiting Express Train operator review. Do not mark ready or merge until correctness is confirmed.**

## Motivation

Ensure internal blit copy queues latch profiling correctly, including late enable, disable, and re-enable flows.

## Technical Details

Carries the source merge commit's first-parent change unchanged using `git cherry-pick -x -m 1`.

## Issue Tracking

JIRA ID : ROCM-28243

## Test Plan

- Verify source first-parent/release patch identity and whitespace.
- Run ROCr build and profiling CI on the release branch.
- Preserve the source PR's gfx1250 late-enable and disable/re-enable test evidence.

## Test Result

- Cherry-pick applied without conflicts; stable patch ID and changed-file set match.
- `git diff --check` passes.
- Source PR reports passing gfx1250 late-enable, disable/re-enable, and pre-first-copy profiling cases; these were not rerun locally.
- The monorepo formatter attempts unrelated whole-file changes to pre-existing ROCr formatting, so those hook edits were discarded and are not part of this exact cherry-pick.
- Release-branch build/hardware validation remains pending PR CI.

## Dependencies and ordering

No dependencies or special ordering requirements identified.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] PR is intentionally left in draft for operator review.
