### PR TITLE
fix(rocr): Export NUMA dependency regardless of BUILD_SHARED_LIBS (#9716)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists.txt
@@ -248,18 +248,16 @@ else()
     find_package(NUMA)
     if(NUMA_FOUND)
       set(NUMA "${NUMA_LIBRARIES}")
-      # In BUILD_SHARED_LIBS mode hsakmt-config.cmake loads hsakmtTargets.cmake.
-      # Because hsakmt is static, its private imported dependencies are exported
-      # through LINK_ONLY and must be recreated by the package config. The
-      # staticdrm package path links the raw library name instead.
-      if(BUILD_SHARED_LIBS)
-        foreach(_numa_library IN LISTS NUMA_LIBRARIES)
-          if(TARGET "${_numa_library}")
-            set(HSAKMT_FIND_NUMA_DEPENDENCY ON)
-            break()
-          endif()
-        endforeach()
-      endif()
+      # When NUMA was found as a target, ensure consumers can find it too
+      # by having hsakmt-config.cmake call find_dependency(NUMA).
+      # This is needed regardless of BUILD_SHARED_LIBS because hsakmt's
+      # exported targets reference numa::numa.
+      foreach(_numa_library IN LISTS NUMA_LIBRARIES)
+        if(TARGET "${_numa_library}")
+          set(HSAKMT_FIND_NUMA_DEPENDENCY ON)
+          break()
+        endif()
+      endforeach()
     else()
       find_library(NUMA NAMES numa REQUIRED)
     endif()

--- a/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
+++ b/projects/rocr-runtime/libhsakmt/hsakmt-config.cmake.in
@@ -9,7 +9,8 @@ include( CMakeFindDependencyMacro )
 if(@HSAKMT_FIND_NUMA_DEPENDENCY@)
   # A ROCm distribution that bundles libnuma installs its package config under
   # lib/rocm_sysdeps, which is not on a consumer's default search path.
-  find_dependency(NUMA PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
+  # Force CONFIG mode to ensure the imported target (numa::numa) is created.
+  find_dependency(NUMA CONFIG PATHS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps")
 endif()
 
 # If the option is ON link other dependent libraries dynamically


### PR DESCRIPTION
Cherry-picks commit `b3252f064cedf9d03ad764af5310a15324b7ff51` from [ROCm/rocm-systems#9716](https://github.com/ROCm/rocm-systems/pull/9716) into `release/bkc/therock-10.1-20260811` for candidate build `10.1.0a20260811`.

**Draft: awaiting Express Train operator review. Do not mark ready or merge until correctness is confirmed.**

## Motivation

Export hsakmt's NUMA dependency whenever NUMA is represented by an imported target, independent of `BUILD_SHARED_LIBS`, so downstream `find_package(hsakmt)` resolves `numa::numa`.

## Technical Details

Carries the source merge commit's first-parent change unchanged using `git cherry-pick -x -m 1`.

## Issue Tracking

JIRA ID : ROCM-28573

## Test Plan

- Verify source first-parent/release patch identity and whitespace.
- Run standalone libhsakmt configure/build/install and downstream `find_package(hsakmt)` coverage in PR CI.

## Test Result

- Cherry-pick applied without conflicts; stable patch ID and changed-file set match.
- `git diff --check` passes.
- The monorepo formatter attempts unrelated whole-file changes to pre-existing CMake formatting and warns about repository-defined commands; those hook edits were discarded.
- Build/install/consumer validation remains pending PR CI.

## Dependencies and ordering

No dependencies or special ordering requirements identified.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] PR is intentionally left in draft for operator review.
