### PR TITLE
fix(rocprofiler-sdk): (rocpd) move otf2 and pandas to local imports

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
@@ -24,8 +24,6 @@
 ###############################################################################
 
 import os
-import otf2
-from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
 import shutil
 import time
 from collections import defaultdict
@@ -100,6 +98,13 @@ def allocation_level_type_name(level, type):
 
 
 def write_otf2(importData, config):
+    try:
+        import otf2
+        from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
+    except ImportError:
+        raise ImportError(
+            "otf2 module not found. Conversion to OTF2 format is not possible. Please install it using 'pip install otf2'\n"
+        )
 
     timer_resolution = 1_000_000_000
     trace_dir = getattr(config, "output_path", "./otf_traces")

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
@@ -101,10 +101,10 @@ def write_otf2(importData, config):
     try:
         import otf2
         from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
-            "otf2 module not found. Conversion to OTF2 format is not possible. Please install it using 'pip install otf2'\n"
-        )
+            "otf2 module not found. Please install it using 'pip install otf2' to convert to OTF2 format"
+        ) from e
 
     timer_resolution = 1_000_000_000
     trace_dir = getattr(config, "output_path", "./otf_traces")

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -71,9 +71,14 @@ def export_sqlite_query(
     """
 
     try:
-        import pandas as pd
-
         conn = conn.connection if isinstance(conn, RocpdImportData) else conn
+
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError(
+                "pandas module not found. Output to other formats requires pandas. Please install it using 'pip install pandas'\n"
+            )
 
         # 1) Run the query via pandas
         df = pd.read_sql_query(query, conn, params=params)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -69,16 +69,15 @@ def export_sqlite_query(
     dashboard_template_path (a Jinja2 template file). If omitted,
     a built-in default template is used.
     """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas module not found. Please install it using 'pip install pandas' to export to other formats"
+        ) from e
 
     try:
         conn = conn.connection if isinstance(conn, RocpdImportData) else conn
-
-        try:
-            import pandas as pd
-        except ImportError as e:
-            raise ImportError(
-                "pandas module not found. Please install it using 'pip install pandas' to export to other formats"
-            ) from e
 
         # 1) Run the query via pandas
         df = pd.read_sql_query(query, conn, params=params)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -75,10 +75,10 @@ def export_sqlite_query(
 
         try:
             import pandas as pd
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
-                "pandas module not found. Output to other formats requires pandas. Please install it using 'pip install pandas'\n"
-            )
+                "pandas module not found. Please install it using 'pip install pandas' to export to other formats"
+            ) from e
 
         # 1) Run the query via pandas
         df = pd.read_sql_query(query, conn, params=params)


### PR DESCRIPTION
## Motivation

Make local import since otf2 is optional conversion anyway.

## Technical Details

The eager import of otf2 is causing problems with rocpd when that module is not installed.  Moving to local import and advising user to `pip install otf2` if import fails.  Likewise for pandas.

## Issue Tracking

JIRA ID: ROCM-28653

## Test Plan

N/A, this is a minor refactor.  Simply ensure all rocpd tests still work/pass.

## Test Result

Locally, all rocpd tests passing.  Should be fine on CI as well.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
