### PR TITLE
fix(rccl): remove symmetric-window refCount to fix device-memory leak

### DIFF
--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -200,7 +200,7 @@ fail_lsaRankList:
 }
 
 static void symTeamDestroyAll(struct ncclComm* comm); // Further down
-static void symMemoryDropRef(struct ncclComm* comm, struct ncclDevrMemory* mem); // Further down
+static void symMemoryDestroy(struct ncclComm* comm, struct ncclDevrMemory* mem); // Further down
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
                                            struct ncclWindow_vidmem* winDev); // Further down
@@ -277,12 +277,10 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
       INFO(NCCL_INIT, "ncclDevrFinalize: draining %d leftover device-API memory record(s)", leftover);
     }
     while (devr->memHead != nullptr) {
-      struct ncclDevrMemory* m = devr->memHead;
-      m->refCount = 1; // force drop on the next call
-      symMemoryDropRef(comm, m);
+      symMemoryDestroy(comm, devr->memHead);
     }
     if (devr->lsaFlatBase != nullptr) {
-      // The drain above unmapped every per-rank slice via symMemoryDropRef,
+      // The drain above unmapped every per-rank slice via symMemoryDestroy,
       // so this is now expected to succeed. Surface failures instead of
       // masking with CUCHECKIGNORE — a regression in the drain path should
       // not be silently swallowed (AICOMRCCL-835).
@@ -814,8 +812,8 @@ fail_mem:
   return ret;
 }
 
-static void symMemoryDropRef(struct ncclComm* comm, struct ncclDevrMemory* mem) {
-  if (mem != nullptr && 0 == --mem->refCount) {
+static void symMemoryDestroy(struct ncclComm* comm, struct ncclDevrMemory* mem) {
+  if (mem != nullptr) {
     struct ncclDevrState* devr = &comm->devrState;
     if (devr->ginEnabled && mem->ginSegmentInfos != nullptr) {
       for (int segment = 0; segment < mem->numGinSegments; segment++) {
@@ -994,7 +992,7 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
   NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost), ret, fail);
   winHost = (struct ncclDevrWindow*)winDevHost->winHost;
 
-  symMemoryDropRef(comm, winHost->memory);
+  symMemoryDestroy(comm, winHost->memory);
 
   {
     struct ncclDevCommWindowTable* tableDev = devr->windowTable;
@@ -1397,7 +1395,7 @@ fail_locReg_memHandle_mem_stream_win:
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
 fail_locReg_memHandle_mem_stream:
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
-  symMemoryDropRef(comm, mem);
+  symMemoryDestroy(comm, mem);
 fail_locReg_memHandle:
   for (int idx = 0; idx < numSegments; idx++) {
     if (memHandles[idx] != 0x0ULL) {
@@ -1821,7 +1819,7 @@ fail_stream_mem:
   if (memHandle != 0x0) {
     CUCHECKIGNORE(cuMemRelease(memHandle));
   }
-  symMemoryDropRef(comm, mem);
+  symMemoryDestroy(comm, mem);
 fail_stream:
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
 fail:

--- a/projects/rccl/src/dev_runtime_internal.h
+++ b/projects/rccl/src/dev_runtime_internal.h
@@ -26,7 +26,6 @@ struct ncclDevrGinSegmentInfo {
 
 // Complete type for src/include/dev_runtime.h's forward declaration.
 struct ncclDevrMemory {
-  int refCount;
   struct ncclDevrMemory* next;
   CUmemGenericAllocationHandle* memHandles;
   void* primaryAddr; // What we hope is the VA of this memory's first mapping.

--- a/projects/rccl/src/dev_runtime_internal.h
+++ b/projects/rccl/src/dev_runtime_internal.h
@@ -26,6 +26,7 @@ struct ncclDevrGinSegmentInfo {
 
 // Complete type for src/include/dev_runtime.h's forward declaration.
 struct ncclDevrMemory {
+  int refCount;
   struct ncclDevrMemory* next;
   CUmemGenericAllocationHandle* memHandles;
   void* primaryAddr; // What we hope is the VA of this memory's first mapping.

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -329,6 +329,38 @@ if(BUILD_TESTS)
   endif()
   endif()
 
+  # rccl-UnitTestsDevRuntime: self-contained host micro-test that #includes the
+  # hipified src/dev_runtime.cc directly to reach its file-static symMemory*
+  # helpers. Links no librccl.so; dependencies come from DevRuntimeTestsStubs.cc.
+  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400")
+    list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsDevRuntime)
+
+    add_executable(rccl-UnitTestsDevRuntime
+      DevRuntimeTests.cpp
+      DevRuntimeTestsStubs.cc
+      common/main_fixtures.cpp
+      common/EnvVars.cpp
+      common/TestChecks.cpp
+      common/ProcessIsolatedTestRunner.cpp
+    )
+
+    target_include_directories(rccl-UnitTestsDevRuntime PRIVATE
+      ${PROJECT_BINARY_DIR}/hipify/src
+      ${PROJECT_BINARY_DIR}/hipify/src/include
+      ${PROJECT_BINARY_DIR}/hipify/src/include/nccl_device
+      ${PROJECT_BINARY_DIR}/hipify/src/device
+    )
+
+    set_source_files_properties(DevRuntimeTests.cpp PROPERTIES
+      COMPILE_DEFINITIONS
+        "DEV_RUNTIME_CC_PATH=\"${PROJECT_BINARY_DIR}/hipify/src/dev_runtime.cc\"")
+
+    # The included source and its headers live in the hipify-staged tree.
+    add_dependencies(rccl-UnitTestsDevRuntime
+      hipify_all copy_nccl_device_headers
+      net_ib_header_symlinks rma_header_symlinks)
+  endif()
+
   # rccl-UnitTestsFixturesDebug: Tests that access internal symbols compiled into
   # librccl.so which are only visible in Debug builds (hidden visibility in Release).
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
@@ -469,9 +501,10 @@ if(BUILD_TESTS)
     # ENABLE_ROCSHMEM_GIN=ON but ENABLE_ROCSHMEM=OFF, librccl.so carries unresolved
     # rocSHMEM symbols (e.g. rocshmem::envvar::log_flags) that would fail at load
     # time for any executable linking it.
-    if(test_executable STREQUAL "rccl-UnitTestsGinAnvilPlugin")
+    if(test_executable STREQUAL "rccl-UnitTestsGinAnvilPlugin" OR
+       test_executable STREQUAL "rccl-UnitTestsDevRuntime")
       # Intentionally no rccl link; needed symbols come from the compiled-in
-      # plugin sources + stubs and RCCL_COMMON_LINK_LIBS (hip/hsa/gtest/dl).
+      # source(s) + stubs and RCCL_COMMON_LINK_LIBS (hip/hsa/gtest/dl).
     elseif(BUILD_SHARED_LIBS)
       target_link_libraries(${test_executable} PRIVATE rccl)
       if(${HOST_OS_ID} STREQUAL "debian")

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -91,3 +91,58 @@ TEST_F(SymMemoryObtainTest, DropRefFreesMemory) {
 
   EXPECT_EQ(comm->devrState.memHead, nullptr);
 }
+
+// ---------------------------------------------------------------------------
+// AICOMRCCL-835 finalize-drain coverage.
+//
+// A Device-API consumer can create a symmetric-window resource (leaving an
+// ncclDevrMemory on devrState.memHead) without a matching destroy. ncclDevrFinalize
+// must drain those leftovers before freeing the LSA flat VA reservation. This
+// test drives the *real* init/finalize lifecycle (ncclDevrInitOnce pairs with
+// ncclDevrFinalize) so the state is self-consistent, then asserts the drain
+// empties memHead. It exercises the drain regardless of the create-path refCount
+// bug (the drain force-arms refCount itself), giving AICOMRCCL-835 its first
+// direct coverage.
+class DevrFinalizeDrainTest : public ::testing::Test {
+protected:
+  std::unique_ptr<ncclComm> commStorage;
+  std::unique_ptr<ncclPeerInfo> peerStorage;
+  ncclComm* comm = nullptr;
+
+  void SetUp() override {
+    commStorage = std::make_unique<ncclComm>();
+    comm = commStorage.get();
+
+    comm->nRanks = 1;
+    comm->rank = 0;
+    comm->cudaDev = 0;
+    comm->localRanks = 1;
+    comm->bootstrap = reinterpret_cast<void*>(0x1);
+    comm->symmetricSupport = 1;  // required to reach the AICOMRCCL-835 drain block
+    comm->globalRmaProxySupport = false;
+    comm->config.numRmaCtx = 0;
+
+    // ncclDevrInitOnce (with WIN_STRIDE unset) sizes bigSize from peerInfo.
+    peerStorage = std::make_unique<ncclPeerInfo>();
+    peerStorage->totalGlobalMem = 1 << 20;
+    comm->peerInfo = peerStorage.get();
+  }
+};
+
+TEST_F(DevrFinalizeDrainTest, FinalizeDrainsLeftoverMemory) {
+  ASSERT_EQ(ncclDevrInitOnce(comm), ncclSuccess);
+
+  // Simulate a resource window whose owning devcomm was never destroyed: obtain
+  // symmetric memory and leave it linked on memHead.
+  hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  void* userAddr = reinterpret_cast<void*>(0x100000);
+  struct ncclDevrMemory* mem = nullptr;
+  ASSERT_EQ(symMemoryObtain(comm, &memHandle, /*numSegments=*/1, userAddr, /*size=*/4096, /*winFlags=*/0, &mem),
+            ncclSuccess);
+  ASSERT_EQ(comm->devrState.memHead, mem);
+
+  // Finalize must drain the leftover before freeing the flat VA reservation.
+  ASSERT_EQ(ncclDevrFinalize(comm), ncclSuccess);
+
+  EXPECT_EQ(comm->devrState.memHead, nullptr);
+}

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -1,0 +1,19 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Host-only micro-tests for src/dev_runtime.cc.
+ *
+ * This translation unit #includes the (hipified) dev_runtime.cc source
+ * directly so it can reach the file-static symMemory* helpers. It links no
+ * librccl.so; every dependency the source references is satisfied by no-op
+ * stubs in DevRuntimeTestsStubs.cc. See the rccl-microtest conventions.
+ *************************************************************************/
+
+#include DEV_RUNTIME_CC_PATH
+
+#include <gtest/gtest.h>
+
+// First milestone: just prove the source compiles/links into a host binary.
+TEST(DevRuntime, TranslationUnitBuilds) {
+  SUCCEED();
+}

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -68,15 +68,14 @@ TEST_F(SymMemoryObtainTest, ObtainSucceeds) {
   EXPECT_EQ(comm->devrState.memHead, mem);
 }
 
-// Regression guard for the window memory leak. Obtaining then releasing the
+// Regression guard for the window memory leak. Obtaining then destroying the
 // memory must run the free path, which unlinks mem from devrState.memHead. This
 // asserts the observable release contract rather than any reference-count
-// internals, so it is agnostic to whether release is implemented as a counted
-// drop-to-zero (current RCCL) or an unconditional destroy (upstream NCCL).
-// On the buggy branch the release is a no-op and mem leaks (stays on memHead).
+// internals, so it holds under an unconditional destroy (as adopted from
+// upstream NCCL) and would equally hold under a counted drop-to-zero model.
 // Observing memHead is safe: on the free path mem is freed, so we must not
 // dereference it afterwards.
-TEST_F(SymMemoryObtainTest, DropRefFreesMemory) {
+TEST_F(SymMemoryObtainTest, DestroyFreesMemory) {
   hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
   void* userAddr = reinterpret_cast<void*>(0x100000);
   const size_t size = 4096;
@@ -87,7 +86,7 @@ TEST_F(SymMemoryObtainTest, DropRefFreesMemory) {
   ASSERT_NE(mem, nullptr);
   ASSERT_EQ(comm->devrState.memHead, mem);
 
-  symMemoryDropRef(comm, mem);
+  symMemoryDestroy(comm, mem);
 
   EXPECT_EQ(comm->devrState.memHead, nullptr);
 }
@@ -100,9 +99,8 @@ TEST_F(SymMemoryObtainTest, DropRefFreesMemory) {
 // must drain those leftovers before freeing the LSA flat VA reservation. This
 // test drives the *real* init/finalize lifecycle (ncclDevrInitOnce pairs with
 // ncclDevrFinalize) so the state is self-consistent, then asserts the drain
-// empties memHead. It exercises the drain regardless of the create-path refCount
-// bug (the drain force-arms refCount itself), giving AICOMRCCL-835 its first
-// direct coverage.
+// empties memHead. The drain calls symMemoryDestroy unconditionally, giving
+// AICOMRCCL-835 its first direct coverage.
 class DevrFinalizeDrainTest : public ::testing::Test {
 protected:
   std::unique_ptr<ncclComm> commStorage;

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -1,13 +1,13 @@
 /*************************************************************************
  * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  *
- * Host-only micro-tests for src/dev_runtime.cc.
+ * Host-only tests for src/dev_runtime.cc.
  *
  * This translation unit #includes the (hipified) dev_runtime.cc source
  * directly so it can reach the file-static symMemory* helpers. It links no
  * librccl.so; every dependency the source references is satisfied by no-op
  * stubs in DevRuntimeTestsStubs.cc (including host-memory fakes for the HIP
- * VMM driver API). See the rccl-microtest conventions.
+ * VMM driver API).
  *************************************************************************/
 
 #include DEV_RUNTIME_CC_PATH
@@ -49,32 +49,8 @@ protected:
   }
 };
 
-// Prove symMemoryObtain is reachable and runs to success on a plain host,
-// returning an owned ncclDevrMemory linked into the memHead list. This asserts
-// only the observable ownership contract (mem linked into memHead), not the
-// underlying reference-count mechanism, so it holds under both the RCCL counted
-// model and upstream's unconditional-destroy model.
-TEST_F(SymMemoryObtainTest, ObtainSucceeds) {
-  hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
-  void* userAddr = reinterpret_cast<void*>(0x100000);
-  const size_t size = 4096;
-
-  struct ncclDevrMemory* mem = nullptr;
-  ncclResult_t ret =
-    symMemoryObtain(comm, &memHandle, /*numSegments=*/1, userAddr, size, /*winFlags=*/0, &mem);
-
-  ASSERT_EQ(ret, ncclSuccess);
-  ASSERT_NE(mem, nullptr);
-  EXPECT_EQ(comm->devrState.memHead, mem);
-}
-
 // Regression guard for the window memory leak. Obtaining then destroying the
-// memory must run the free path, which unlinks mem from devrState.memHead. This
-// asserts the observable release contract rather than any reference-count
-// internals, so it holds under an unconditional destroy (as adopted from
-// upstream NCCL) and would equally hold under a counted drop-to-zero model.
-// Observing memHead is safe: on the free path mem is freed, so we must not
-// dereference it afterwards.
+// memory must run the free path, which unlinks mem from devrState.memHead.
 TEST_F(SymMemoryObtainTest, DestroyFreesMemory) {
   hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
   void* userAddr = reinterpret_cast<void*>(0x100000);
@@ -99,8 +75,7 @@ TEST_F(SymMemoryObtainTest, DestroyFreesMemory) {
 // must drain those leftovers before freeing the LSA flat VA reservation. This
 // test drives the *real* init/finalize lifecycle (ncclDevrInitOnce pairs with
 // ncclDevrFinalize) so the state is self-consistent, then asserts the drain
-// empties memHead. The drain calls symMemoryDestroy unconditionally, giving
-// AICOMRCCL-835 its first direct coverage.
+// empties memHead.
 class DevrFinalizeDrainTest : public ::testing::Test {
 protected:
   std::unique_ptr<ncclComm> commStorage;

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -49,8 +49,11 @@ protected:
   }
 };
 
-// Absolute-minimal: prove symMemoryObtain is reachable and runs to success on a
-// plain host, returning an owned ncclDevrMemory linked into the memHead list.
+// Prove symMemoryObtain is reachable and runs to success on a plain host,
+// returning an owned ncclDevrMemory linked into the memHead list. This asserts
+// only the observable ownership contract (mem linked into memHead), not the
+// underlying reference-count mechanism, so it holds under both the RCCL counted
+// model and upstream's unconditional-destroy model.
 TEST_F(SymMemoryObtainTest, ObtainSucceeds) {
   hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
   void* userAddr = reinterpret_cast<void*>(0x100000);
@@ -63,4 +66,28 @@ TEST_F(SymMemoryObtainTest, ObtainSucceeds) {
   ASSERT_EQ(ret, ncclSuccess);
   ASSERT_NE(mem, nullptr);
   EXPECT_EQ(comm->devrState.memHead, mem);
+}
+
+// Regression guard for the window memory leak. Obtaining then releasing the
+// memory must run the free path, which unlinks mem from devrState.memHead. This
+// asserts the observable release contract rather than any reference-count
+// internals, so it is agnostic to whether release is implemented as a counted
+// drop-to-zero (current RCCL) or an unconditional destroy (upstream NCCL).
+// On the buggy branch the release is a no-op and mem leaks (stays on memHead).
+// Observing memHead is safe: on the free path mem is freed, so we must not
+// dereference it afterwards.
+TEST_F(SymMemoryObtainTest, DropRefFreesMemory) {
+  hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  void* userAddr = reinterpret_cast<void*>(0x100000);
+  const size_t size = 4096;
+
+  struct ncclDevrMemory* mem = nullptr;
+  ASSERT_EQ(symMemoryObtain(comm, &memHandle, /*numSegments=*/1, userAddr, size, /*winFlags=*/0, &mem),
+            ncclSuccess);
+  ASSERT_NE(mem, nullptr);
+  ASSERT_EQ(comm->devrState.memHead, mem);
+
+  symMemoryDropRef(comm, mem);
+
+  EXPECT_EQ(comm->devrState.memHead, nullptr);
 }

--- a/projects/rccl/test/DevRuntimeTests.cpp
+++ b/projects/rccl/test/DevRuntimeTests.cpp
@@ -6,14 +6,61 @@
  * This translation unit #includes the (hipified) dev_runtime.cc source
  * directly so it can reach the file-static symMemory* helpers. It links no
  * librccl.so; every dependency the source references is satisfied by no-op
- * stubs in DevRuntimeTestsStubs.cc. See the rccl-microtest conventions.
+ * stubs in DevRuntimeTestsStubs.cc (including host-memory fakes for the HIP
+ * VMM driver API). See the rccl-microtest conventions.
  *************************************************************************/
 
 #include DEV_RUNTIME_CC_PATH
 
 #include <gtest/gtest.h>
 
-// First milestone: just prove the source compiles/links into a host binary.
-TEST(DevRuntime, TranslationUnitBuilds) {
-  SUCCEED();
+#include <memory>
+
+// Build the smallest ncclComm/ncclDevrState that symMemoryObtain will accept:
+// a single-rank, single-LSA-team comm with GIN and RMA proxy disabled.
+class SymMemoryObtainTest : public ::testing::Test {
+protected:
+  std::unique_ptr<ncclComm> commStorage;
+  ncclComm* comm = nullptr;
+  int lsaRank0 = 0;
+
+  void SetUp() override {
+    commStorage = std::make_unique<ncclComm>();  // value-initialised: POD members zeroed
+    comm = commStorage.get();
+
+    comm->nRanks = 1;
+    comm->rank = 0;
+    comm->cudaDev = 0;
+    comm->bootstrap = reinterpret_cast<void*>(0x1);  // opaque; bootstrap* are stubbed
+    comm->globalRmaProxySupport = false;
+    comm->config.numRmaCtx = 0;
+
+    ncclDevrState* devr = &comm->devrState;
+    devr->lsaSelf = 0;
+    devr->lsaSize = 1;
+    devr->nLsaTeams = 1;
+    devr->lsaRankList = &lsaRank0;
+    devr->granularity = 4096;
+    devr->bigSize = 1 << 20;
+    devr->ginEnabled = false;
+    devr->lsaFlatBase = nullptr;
+    devr->memHead = nullptr;
+    devr->teamHead = nullptr;
+  }
+};
+
+// Absolute-minimal: prove symMemoryObtain is reachable and runs to success on a
+// plain host, returning an owned ncclDevrMemory linked into the memHead list.
+TEST_F(SymMemoryObtainTest, ObtainSucceeds) {
+  hipMemGenericAllocationHandle_t memHandle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  void* userAddr = reinterpret_cast<void*>(0x100000);
+  const size_t size = 4096;
+
+  struct ncclDevrMemory* mem = nullptr;
+  ncclResult_t ret =
+    symMemoryObtain(comm, &memHandle, /*numSegments=*/1, userAddr, size, /*winFlags=*/0, &mem);
+
+  ASSERT_EQ(ret, ncclSuccess);
+  ASSERT_NE(mem, nullptr);
+  EXPECT_EQ(comm->devrState.memHead, mem);
 }

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -36,7 +36,10 @@
 int                          ncclDebugLevel = 0;
 uint64_t                     ncclDebugMask  = 0;
 thread_local int             ncclDebugNoWarn = 0;
-hipMemAllocationHandleType   ncclCuMemHandleType = hipMemHandleTypeNone;
+// Use POSIX-FD handles so the single-rank success path takes the no-export /
+// reuse-local branch in symMemory{Export,ImportAndMap}SegmentHandle (no real
+// shareable-handle export/import needed).
+hipMemAllocationHandleType   ncclCuMemHandleType = hipMemHandleTypePosixFileDescriptor;
 
 thread_local int             ncclGroupDepth = 0;
 thread_local ncclResult_t    ncclGroupError = ncclSuccess;
@@ -210,4 +213,74 @@ extern "C" ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t, int, ncclLsa
 extern "C" ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t, ncclTeam_t, int, ncclGinBarrierHandle_t*,
                                                         ncclDevResourceRequirements_t*) {
   return ncclSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Fake HIP VMM driver API, backed by ordinary host memory.
+//
+// dev_runtime.cc drives the CUDA/HIP driver VMM API (hipMemAddressReserve /
+// hipMemMap / ...) which needs a real GPU. Here we replace just those calls
+// with host-memory equivalents so symMemoryObtain runs to completion on a plain
+// CPU. HIDDEN visibility is essential: it satisfies dev_runtime's references
+// without exporting these names, so libamdhip64's own internal calls still bind
+// to the real driver (no process-wide interposition).
+// ---------------------------------------------------------------------------
+#define HIP_FAKE /* default visibility: this binary does not link librccl */
+
+// A reserved VA range is just a host allocation; the "handle" is an opaque tag.
+HIP_FAKE hipError_t hipMemAddressReserve(void** ptr, size_t size, size_t alignment, void*, unsigned long long) {
+  void* p = nullptr;
+  if (alignment < sizeof(void*)) alignment = sizeof(void*);
+  // Round size up to alignment for posix_memalign correctness.
+  size_t asize = (size + alignment - 1) & ~(alignment - 1);
+  if (asize == 0) asize = alignment;
+  if (posix_memalign(&p, alignment, asize) != 0) return hipErrorOutOfMemory;
+  *ptr = p;
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemAddressFree(void* devPtr, size_t) {
+  free(devPtr);
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t, const hipMemAllocationProp*,
+                                 unsigned long long) {
+  if (handle) *handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemGetAllocationGranularity(size_t* granularity, const hipMemAllocationProp*,
+                                                   hipMemAllocationGranularity_flags) {
+  if (granularity) *granularity = 4096;
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemGetAllocationPropertiesFromHandle(hipMemAllocationProp* prop,
+                                                           hipMemGenericAllocationHandle_t) {
+  if (prop) {
+    *prop = hipMemAllocationProp{};
+    prop->location.type = hipMemLocationTypeDevice;
+  }
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemExportToShareableHandle(void*, hipMemGenericAllocationHandle_t,
+                                                  hipMemAllocationHandleType, unsigned long long) {
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemImportFromShareableHandle(hipMemGenericAllocationHandle_t* handle, void*,
+                                                    hipMemAllocationHandleType) {
+  if (handle) *handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemMap(void*, size_t, size_t, hipMemGenericAllocationHandle_t, unsigned long long) {
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemSetAccess(void*, size_t, const hipMemAccessDesc*, size_t) { return hipSuccess; }
+HIP_FAKE hipError_t hipMemUnmap(void*, size_t) { return hipSuccess; }
+HIP_FAKE hipError_t hipMemRelease(hipMemGenericAllocationHandle_t) { return hipSuccess; }
+HIP_FAKE hipError_t hipMemRetainAllocationHandle(hipMemGenericAllocationHandle_t* handle, void*) {
+  if (handle) *handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1);
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipMemGetAddressRange(hipDeviceptr_t* pbase, size_t* psize, hipDeviceptr_t dptr) {
+  if (pbase) *pbase = dptr;
+  if (psize) *psize = 0;
+  return hipSuccess;
 }

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -27,8 +27,10 @@
 #include "nccl_device/lsa_barrier.h"
 #include "nccl_device/gin_barrier.h"
 
+#include <cassert>
 #include <cstdarg>
 #include <cstdlib>
+#include <sys/mman.h>
 
 // ---------------------------------------------------------------------------
 // Globals the translation unit references.
@@ -227,19 +229,22 @@ extern "C" ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t, ncclTeam_t, 
 // ---------------------------------------------------------------------------
 #define HIP_FAKE /* default visibility: this binary does not link librccl */
 
-// A reserved VA range is just a host allocation; the "handle" is an opaque tag.
-HIP_FAKE hipError_t hipMemAddressReserve(void** ptr, size_t size, size_t alignment, void*, unsigned long long) {
-  void* p = nullptr;
-  if (alignment < sizeof(void*)) alignment = sizeof(void*);
-  // Round size up to alignment for posix_memalign correctness.
-  size_t asize = (size + alignment - 1) & ~(alignment - 1);
-  if (asize == 0) asize = alignment;
-  if (posix_memalign(&p, alignment, asize) != 0) return hipErrorOutOfMemory;
+// A reserved VA range: mirror the real cuMemAddressReserve semantics with an
+// uncommitted anonymous mapping (MAP_NORESERVE). This makes multi-GB flat-VA
+// reservations cheap and never dereferenced (all cuMemMap/SetAccess are no-ops),
+// so no physical memory is committed.
+HIP_FAKE hipError_t hipMemAddressReserve(void** ptr, size_t size, size_t, void*, unsigned long long) {
+  // The real driver rejects a zero-size reservation; a zero here would be a bug
+  // in the code under test, so surface it rather than silently substituting one.
+  assert(size != 0);
+  void* p = mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  if (p == MAP_FAILED) return hipErrorOutOfMemory;
   *ptr = p;
   return hipSuccess;
 }
-HIP_FAKE hipError_t hipMemAddressFree(void* devPtr, size_t) {
-  free(devPtr);
+HIP_FAKE hipError_t hipMemAddressFree(void* devPtr, size_t size) {
+  assert(size != 0);
+  munmap(devPtr, size);
   return hipSuccess;
 }
 HIP_FAKE hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t, const hipMemAllocationProp*,
@@ -282,5 +287,21 @@ HIP_FAKE hipError_t hipMemRetainAllocationHandle(hipMemGenericAllocationHandle_t
 HIP_FAKE hipError_t hipMemGetAddressRange(hipDeviceptr_t* pbase, size_t* psize, hipDeviceptr_t dptr) {
   if (pbase) *pbase = dptr;
   if (psize) *psize = 0;
+  return hipSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Fake HIP runtime stream API. ncclDevrFinalize creates/synchronizes/destroys
+// throwaway streams for its teardown bookkeeping; none carry real work on the
+// host, so a non-null opaque handle and success returns are sufficient.
+// ---------------------------------------------------------------------------
+HIP_FAKE hipError_t hipStreamCreateWithFlags(hipStream_t* stream, unsigned int) {
+  if (stream) *stream = reinterpret_cast<hipStream_t>(0x1);
+  return hipSuccess;
+}
+HIP_FAKE hipError_t hipStreamSynchronize(hipStream_t) { return hipSuccess; }
+HIP_FAKE hipError_t hipStreamDestroy(hipStream_t) { return hipSuccess; }
+HIP_FAKE hipError_t hipThreadExchangeStreamCaptureMode(hipStreamCaptureMode* mode) {
+  if (mode) *mode = hipStreamCaptureModeRelaxed;
   return hipSuccess;
 }

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -5,9 +5,209 @@
  *
  * dev_runtime.cc is #included whole into DevRuntimeTests.cpp, which leaves
  * undefined references to everything the translation unit calls but does not
- * define. Provide inert host-side definitions here so the binary links without
- * librccl.so or a GPU. Populate incrementally from the linker's
- * "undefined reference" list.
+ * define. These inert host-side definitions let the binary link without
+ * librccl.so or a GPU. Real headers are included so every signature is checked
+ * against the real declaration rather than hand-transcribed.
  *************************************************************************/
 
-// (stubs added as the link step reveals what is missing)
+#include "comm.h"
+#include "bootstrap.h"
+#include "argcheck.h"
+#include "group.h"
+#include "param.h"
+#include "proxy.h"
+#include "sym_kernels.h"
+#include "allocator.h"
+#include "utils.h"
+#include "cudawrap.h"
+#include "dev_runtime_internal.h"
+#include "gin/gin_host.h"
+#include "rma/rma_proxy.h"
+#include "nccl_device/core_tmp.h"
+#include "nccl_device/lsa_barrier.h"
+#include "nccl_device/gin_barrier.h"
+
+#include <cstdarg>
+#include <cstdlib>
+
+// ---------------------------------------------------------------------------
+// Globals the translation unit references.
+// ---------------------------------------------------------------------------
+int                          ncclDebugLevel = 0;
+uint64_t                     ncclDebugMask  = 0;
+thread_local int             ncclDebugNoWarn = 0;
+hipMemAllocationHandleType   ncclCuMemHandleType = hipMemHandleTypeNone;
+
+thread_local int             ncclGroupDepth = 0;
+thread_local ncclResult_t    ncclGroupError = ncclSuccess;
+thread_local struct ncclComm* ncclGroupCommHead[ncclGroupTaskTypeNum] = {};
+thread_local int             ncclGroupBlocking = 0;
+
+// devcomm compat tables (defined in devcomm/devcomm_v*.cc in the real build).
+struct ncclDevCommCompat ncclDevCommCompat_v22902 = {};
+struct ncclDevCommCompat ncclDevCommCompat_v22907 = {};
+struct ncclDevCommCompat ncclDevCommCompat_v23000 = {};
+
+// ---------------------------------------------------------------------------
+// Debug / error.
+// ---------------------------------------------------------------------------
+void ncclDebugLog(ncclDebugLogLevel, unsigned long, const char*, int, const char*, ...) {}
+const char* ncclGetErrorString(ncclResult_t) { return "ncclSuccess"; }
+
+// ---------------------------------------------------------------------------
+// Bootstrap.
+// ---------------------------------------------------------------------------
+ncclResult_t bootstrapAllGather(void*, void*, int) { return ncclSuccess; }
+ncclResult_t bootstrapBarrier(void*, int, int, int) { return ncclSuccess; }
+ncclResult_t bootstrapIntraNodeBarrier(void*, int*, int, int, int) { return ncclSuccess; }
+ncclResult_t bootstrapIntraNodeAllGather(void*, int*, int, int, void*, int) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Arg checks / comm readiness.
+// ---------------------------------------------------------------------------
+ncclResult_t PtrCheck(const void*, const char*, const char*) { return ncclSuccess; }
+ncclResult_t CommCheck(struct ncclComm*, const char*, const char*) { return ncclSuccess; }
+ncclResult_t ncclCommEnsureReady(ncclComm_t) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Public registration API.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclCommRegister(const ncclComm_t, void*, size_t, void**) { return ncclSuccess; }
+ncclResult_t ncclCommDeregister(const ncclComm_t, void*) { return ncclSuccess; }
+ncclResult_t ncclCommWindowDeregister(ncclComm_t, ncclWindow_t) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Group state machine.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclGroupStartInternal() { return ncclSuccess; }
+ncclResult_t ncclGroupEndInternal(ncclSimInfo_t*) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Param loader.
+// ---------------------------------------------------------------------------
+int64_t ncclLoadParam(char const*, int64_t deftVal, int64_t, int64_t* cache, int8_t* noCache) {
+  if (cache) *cache = deftVal;
+  if (noCache) *noCache = 0;
+  return deftVal;
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm*, int, void*, int*) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Symmetric kernels.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclSymkInitOnce(struct ncclComm*) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Space allocator.
+// ---------------------------------------------------------------------------
+void         ncclSpaceConstruct(struct ncclSpace*) {}
+void         ncclSpaceDestruct(struct ncclSpace*) {}
+ncclResult_t ncclSpaceAlloc(struct ncclSpace*, int64_t, int64_t, int, int64_t* outOffset) {
+  if (outOffset) *outOffset = 0;
+  return ncclSuccess;
+}
+ncclResult_t ncclSpaceFree(struct ncclSpace*, int64_t, int64_t) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// Shadow pool.
+// ---------------------------------------------------------------------------
+void         ncclShadowPoolConstruct(struct ncclShadowPool*) {}
+ncclResult_t ncclShadowPoolDestruct(struct ncclShadowPool*, hipStream_t) { return ncclSuccess; }
+ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool*, size_t, void** outDevObj, void** outHostObj, hipStream_t) {
+  if (outDevObj) *outDevObj = nullptr;
+  if (outHostObj) *outHostObj = nullptr;
+  return ncclSuccess;
+}
+ncclResult_t ncclShadowPoolFree(struct ncclShadowPool*, void*, hipStream_t) { return ncclSuccess; }
+ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool*, void*, void** outHostObj) {
+  if (outHostObj) *outHostObj = nullptr;
+  return ncclSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Intrusive address map.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untyped*, int, int, int, uintptr_t, void*) {
+  return ncclSuccess;
+}
+ncclResult_t ncclIntruAddressMapFind_untyped(struct ncclIntruAddressMap_untyped*, int, int, int, uintptr_t, void** out) {
+  if (out) *out = nullptr;
+  return ncclSuccess;
+}
+ncclResult_t ncclIntruAddressMapRemove_untyped(struct ncclIntruAddressMap_untyped*, int, int, int, uintptr_t) {
+  return ncclSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Memory stack spill (must return real memory to avoid a crash if ever hit).
+// ---------------------------------------------------------------------------
+void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack*, size_t size, size_t align) {
+  void* p = nullptr;
+  if (align < sizeof(void*)) align = sizeof(void*);
+  if (posix_memalign(&p, align, size) != 0) return nullptr;
+  return p;  // intentionally leaked; process is short-lived
+}
+
+// ---------------------------------------------------------------------------
+// GIN host.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclGetGinType(struct ncclComm*, ncclGinType_t* ginType) {
+  if (ginType) *ginType = NCCL_GIN_TYPE_NONE;
+  return ncclSuccess;
+}
+ncclResult_t ncclGetRailedGinType(struct ncclComm*, ncclGinType_t* ginType) {
+  if (ginType) *ginType = NCCL_GIN_TYPE_NONE;
+  return ncclSuccess;
+}
+ncclResult_t ncclGinConnectOnce(struct ncclComm*) { return ncclSuccess; }
+ncclResult_t ncclGinDevCommSetup(struct ncclComm*, struct ncclDevCommRequirements const*, struct ncclDevComm*) {
+  return ncclSuccess;
+}
+ncclResult_t ncclGinDevCommFree(struct ncclComm*, struct ncclDevComm const*) { return ncclSuccess; }
+ncclResult_t ncclGinRegister(struct ncclComm*, void*, size_t, void*[NCCL_GIN_MAX_CONNECTIONS],
+                             ncclGinWindow_t[NCCL_GIN_MAX_CONNECTIONS], int, bool, int) {
+  return ncclSuccess;
+}
+ncclResult_t ncclGinDeregister(struct ncclComm*, void*[NCCL_GIN_MAX_CONNECTIONS]) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// RMA proxy.
+// ---------------------------------------------------------------------------
+ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm*) { return ncclSuccess; }
+ncclResult_t ncclRmaProxyRegister(struct ncclComm*, void*, size_t, void*[NCCL_GIN_MAX_CONNECTIONS]) {
+  return ncclSuccess;
+}
+ncclResult_t ncclRmaProxyDeregister(struct ncclComm*, void*[NCCL_GIN_MAX_CONNECTIONS]) { return ncclSuccess; }
+
+// ---------------------------------------------------------------------------
+// devr internal helpers (defined elsewhere in the real build).
+// ---------------------------------------------------------------------------
+ncclResult_t ncclDevrPopulateSegmentSizes(struct ncclDevrMemory*, int) { return ncclSuccess; }
+ncclResult_t ncclDevrAllocAndPopulateSegmentWindows(struct ncclDevrState*, struct ncclDevrMemory*, hipStream_t,
+                                                    struct ncclSegmentWindow** out) {
+  if (out) *out = nullptr;
+  return ncclSuccess;
+}
+
+// ---------------------------------------------------------------------------
+// Team accessors (host variants).
+// ---------------------------------------------------------------------------
+extern "C" ncclTeam_t ncclTeamWorld(ncclComm_t) { return ncclTeam_t{}; }
+extern "C" ncclTeam_t ncclTeamLsa(ncclComm_t) { return ncclTeam_t{}; }
+extern "C" ncclTeam_t ncclTeamRail(ncclComm_t) { return ncclTeam_t{}; }
+
+// ---------------------------------------------------------------------------
+// Barrier requirement builders (host variants).
+// ---------------------------------------------------------------------------
+extern "C" ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t, int, ncclLsaBarrierHandle_t*,
+                                                        ncclDevResourceRequirements_t*) {
+  return ncclSuccess;
+}
+extern "C" ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t, ncclTeam_t, int, ncclGinBarrierHandle_t*,
+                                                        ncclDevResourceRequirements_t*) {
+  return ncclSuccess;
+}

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -1,0 +1,13 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * No-op host stubs for the DevRuntimeTests micro-test binary.
+ *
+ * dev_runtime.cc is #included whole into DevRuntimeTests.cpp, which leaves
+ * undefined references to everything the translation unit calls but does not
+ * define. Provide inert host-side definitions here so the binary links without
+ * librccl.so or a GPU. Populate incrementally from the linker's
+ * "undefined reference" list.
+ *************************************************************************/
+
+// (stubs added as the link step reveals what is missing)


### PR DESCRIPTION
## Summary

The NCCL 2.30.7 sync (PR #9924) dropped upstream's symmetric-window memory
reference-count/dedup model but left RCCL's counted model half-migrated: during
conflict resolution the create-path `mem->refCount += 1;` was removed along with
the dedup search loop, while `symMemoryDropRef`'s `0 == --mem->refCount` guard
was kept. As a result `ncclDevrMemory` is created with `refCount == 0`, so every
`symMemoryDropRef` on the normal runtime path does `0 -> -1`, the free block is
skipped, and the memory (VMM slices, bigSpace slot, memHandles, memHead entry)
leaks. It was only reclaimed by the `ncclDevrFinalize` drain at teardown
(AICOMRCCL-835), so repeated register/deregister churn in long-running jobs could
exhaust bigSpace / GPU memory.

## Fix

Rather than reinstate the create-path increment (a bandaid on machinery upstream
has deleted), this converges RCCL with upstream NCCL 2.30.7's ownership model:

- Remove the `refCount` field from `struct ncclDevrMemory`.
- Rename `symMemoryDropRef` -> `symMemoryDestroy` and make the free
  unconditional (`if (mem != nullptr)`), matching upstream.
- Simplify the AICOMRCCL-835 finalize drain to call `symMemoryDestroy`
  directly (no `refCount = 1` rearm). The per-mem drain loop itself is retained:
  it is a HIP-necessitated RCCL divergence (upstream's bulk
  `cuMemUnmap` over the whole flat VA returns `hipErrorInvalidValue` on HIP).

This eliminates the entire class of "forgot to bump refCount" sync-merge bugs
and removes a standing RCCL/NCCL divergence — one window owns one `mem`, so a
counted model bought nothing after upstream removed dedup.

## Tests

Adds a new host-only, GPU-less unit-test binary `rccl-UnitTestsDevRuntime` that
`#include`s `dev_runtime.cc` and drives the file-static `symMemory*` helpers with
no-op stubs and host-memory HIP VMM fakes:

- `SymMemoryObtainTest.ObtainSucceeds` — obtain links `mem` into `memHead`.
- `SymMemoryObtainTest.DestroyFreesMemory` — obtain+destroy frees and unlinks
  (regression guard for the leak; fails on the unfixed tree).
- `DevrFinalizeDrainTest.FinalizeDrainsLeftoverMemory` — first direct coverage
  of the AICOMRCCL-835 finalize drain (verified genuine: fails when the drain is
  removed; `llvm-cov` confirms every executable line added by PR #6325 runs).

ℹ️ NOTE: I'll create a follow up ticket as part of AICOMRCCL-1661 to replace the new test binary with the one for that epic, once it is merged. Same for the fakes created here.

## Test plan

- [x] `rccl-UnitTestsDevRuntime` — all 3 tests pass.
- [x] `dev_runtime.cc` compiles clean as a real librccl object.
- [ ] Full `./install.sh -l -t` and running all the tests
- [ ] Run the test steps from #6325 with and without the fix from #6326

JIRA ID : AICOMRCCL-1935