### PR TITLE
fix(rocr) : Skip failing rocr tests on WSL

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -47,6 +47,8 @@
 /// Implementation of utility functions used by RocR applications
 #include "common/common.h"
 #include "common/env_config.h"
+#include "common/platform_filter.h"
+#include "gtest/gtest.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -124,7 +126,19 @@ bool isWslEnvironment() {
 
 bool SkipOnWsl(const char* reason) {
   if (!isWslEnvironment()) return false;
-  std::cout << "[ SKIPPED ] " << reason << std::endl;
+
+  // This gtest predates GTEST_SKIP(), so register the skip with the rocrtst
+  // SkippedTestTracker (shown in the end-of-run summary) rather than silently
+  // returning green.
+  std::string test_name = "unknown";
+  const ::testing::TestInfo* info =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  if (info != nullptr) {
+    test_name = std::string(info->test_case_name()) + "." + info->name();
+  }
+
+  SkippedTestTracker::getInstance().recordSkip(test_name, reason);
+  std::cout << "[ SKIPPED ] " << test_name << " : " << reason << std::endl;
   return true;
 }
 

--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -48,6 +48,8 @@
 #include "common/common.h"
 #include "common/env_config.h"
 #include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <sstream>
 #include <string>
 #include <memory>
@@ -100,6 +102,30 @@ bool isEmuModeEnabled() {
   }
 
   return emu_mode;
+}
+
+bool isWslEnvironment() {
+  static bool checked = false;
+  static bool is_wsl = false;
+
+  if (!checked) {
+    // Mirror ROCr's own WSL/DXG detection (ThunkLoader::whoami): the DXG backend
+    // is used when /dev/dxg is present, which is what breaks these tests.
+    int fd = open("/dev/dxg", O_RDWR);
+    if (fd >= 0) {
+      close(fd);
+      is_wsl = true;
+    }
+    checked = true;
+  }
+
+  return is_wsl;
+}
+
+bool SkipOnWsl(const char* reason) {
+  if (!isWslEnvironment()) return false;
+  std::cout << "[ SKIPPED ] " << reason << std::endl;
+  return true;
 }
 
 bool PlatformDetector::isFFMEnvironment() {

--- a/projects/rocr-runtime/rocrtst/common/common.h
+++ b/projects/rocr-runtime/rocrtst/common/common.h
@@ -142,6 +142,16 @@ public:
 /// \returns true if emulator mode is detected
 bool isEmuModeEnabled();
 
+/// Check if running under Windows Subsystem for Linux (WSL / DXG backend).
+/// \returns true if a WSL environment is detected
+bool isWslEnvironment();
+
+/// If running on WSL/DXG, print a "[ SKIPPED ]" line with the reason and return
+/// true so the caller can return early; returns false otherwise.
+/// \param reason Why the test is skipped on WSL
+/// \returns true if the test should be skipped (WSL detected)
+bool SkipOnWsl(const char* reason);
+
 /// Fill in the pool_info_t structure for the provided pool.
 /// \param[in] pool Pool for which information will be retrieved
 /// \param[out] pool_i Pointer to structure where pool info will be stored

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -337,7 +337,7 @@ TEST(rocrtstFunc, Memory_Max_Mem) {
 }
 
 TEST(rocrtstFunc, Memory_Available) {
-    if (rocrtst::SkipOnWsl("Memory_Available: MEMORY_AVAIL uses WDDM adapter-wide dynamic accounting on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("MEMORY_AVAIL uses WDDM adapter-wide dynamic accounting on WSL/DXG")) return;
     MemoryTest mt;
 
     if (!RunCustomTestProlog(&mt)) return;
@@ -360,7 +360,7 @@ TEST(rocrtstFunc, BarrierPkt_TimeStamp) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_DefaultPattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestDefaultPattern();
@@ -368,7 +368,7 @@ TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_CustomPattern) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_CustomPattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestCustomPattern();
@@ -376,7 +376,7 @@ TEST(rocrtstFunc, GpuCoreDump_CustomPattern) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_DisableFlag) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_DisableFlag: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestDisableFlag();
@@ -384,7 +384,7 @@ TEST(rocrtstFunc, GpuCoreDump_DisableFlag) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_PatternSubstitution) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_PatternSubstitution: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestPatternSubstitution();
@@ -392,7 +392,7 @@ TEST(rocrtstFunc, GpuCoreDump_PatternSubstitution) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_InvalidPath) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_InvalidPath: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestInvalidPath();
@@ -400,7 +400,7 @@ TEST(rocrtstFunc, GpuCoreDump_InvalidPath) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_ContentIntegrity) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_ContentIntegrity: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestCoreDumpContentIntegrity();
@@ -408,7 +408,7 @@ TEST(rocrtstFunc, GpuCoreDump_ContentIntegrity) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_PipePattern) {
-    if (rocrtst::SkipOnWsl("GpuCoreDump_PipePattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestPipePattern();
@@ -511,7 +511,7 @@ TEST(rocrtstFunc, TrapHandler_NoTrap) {
 }
 
 TEST(rocrtstFunc, TrapHandler_Abort) {
-    if (rocrtst::SkipOnWsl("TrapHandler_Abort: GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
     TrapHandlerTest th;
     if (!RunCustomTestProlog(&th)) return;
     th.TestTrapAbort();
@@ -519,7 +519,7 @@ TEST(rocrtstFunc, TrapHandler_Abort) {
 }
 
 TEST(rocrtstFunc, TrapHandler_Generic) {
-    if (rocrtst::SkipOnWsl("TrapHandler_Generic: GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
     TrapHandlerTest th;
     if (!RunCustomTestProlog(&th)) return;
     th.TestTrapGeneric();
@@ -647,7 +647,7 @@ TEST(rocrtstFunc, VirtMemory_Access_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_Accounting_Test) {
-    if (rocrtst::SkipOnWsl("VirtMemory_Accounting_Test: vmem MEMORY_AVAIL accounting unavailable on WSL/DXG")) return;
+    if (rocrtst::SkipOnWsl("vmem MEMORY_AVAIL accounting unavailable on WSL/DXG")) return;
     VirtMemoryTestBasic vmt;
 
     if (!RunCustomTestProlog(&vmt)) return;
@@ -664,7 +664,7 @@ TEST(rocrtstFunc, VirtMemory_Aliasing_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_NonContiguousChunks_Test) {
-  if (rocrtst::SkipOnWsl("VirtMemory_NonContiguousChunks_Test: CPU-agent vmem set_access unavailable on WSL/DXG")) return;
+  if (rocrtst::SkipOnWsl("CPU-agent vmem set_access unavailable on WSL/DXG")) return;
   VirtMemoryTestBasic vmt;
 
   if (!RunCustomTestProlog(&vmt)) return;
@@ -673,7 +673,7 @@ TEST(rocrtstFunc, VirtMemory_NonContiguousChunks_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_GPUtoHostAccess_Test) {
-  if (rocrtst::SkipOnWsl("VirtMemory_GPUtoHostAccess_Test: CPU-agent vmem set_access unavailable on WSL/DXG")) return;
+  if (rocrtst::SkipOnWsl("CPU-agent vmem set_access unavailable on WSL/DXG")) return;
   VirtMemoryTestBasic vmt;
 
   if (!RunCustomTestProlog(&vmt)) return;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -337,6 +337,7 @@ TEST(rocrtstFunc, Memory_Max_Mem) {
 }
 
 TEST(rocrtstFunc, Memory_Available) {
+    if (rocrtst::SkipOnWsl("Memory_Available: MEMORY_AVAIL uses WDDM adapter-wide dynamic accounting on WSL/DXG")) return;
     MemoryTest mt;
 
     if (!RunCustomTestProlog(&mt)) return;
@@ -359,6 +360,7 @@ TEST(rocrtstFunc, BarrierPkt_TimeStamp) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_DefaultPattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestDefaultPattern();
@@ -366,6 +368,7 @@ TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_CustomPattern) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_CustomPattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestCustomPattern();
@@ -373,6 +376,7 @@ TEST(rocrtstFunc, GpuCoreDump_CustomPattern) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_DisableFlag) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_DisableFlag: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestDisableFlag();
@@ -380,6 +384,7 @@ TEST(rocrtstFunc, GpuCoreDump_DisableFlag) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_PatternSubstitution) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_PatternSubstitution: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestPatternSubstitution();
@@ -387,6 +392,7 @@ TEST(rocrtstFunc, GpuCoreDump_PatternSubstitution) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_InvalidPath) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_InvalidPath: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestInvalidPath();
@@ -394,6 +400,7 @@ TEST(rocrtstFunc, GpuCoreDump_InvalidPath) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_ContentIntegrity) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_ContentIntegrity: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestCoreDumpContentIntegrity();
@@ -401,6 +408,7 @@ TEST(rocrtstFunc, GpuCoreDump_ContentIntegrity) {
 }
 
 TEST(rocrtstFunc, GpuCoreDump_PipePattern) {
+    if (rocrtst::SkipOnWsl("GpuCoreDump_PipePattern: GPU coredump-on-exception unavailable on WSL/DXG")) return;
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;
     gcd.TestPipePattern();
@@ -503,6 +511,7 @@ TEST(rocrtstFunc, TrapHandler_NoTrap) {
 }
 
 TEST(rocrtstFunc, TrapHandler_Abort) {
+    if (rocrtst::SkipOnWsl("TrapHandler_Abort: GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
     TrapHandlerTest th;
     if (!RunCustomTestProlog(&th)) return;
     th.TestTrapAbort();
@@ -510,6 +519,7 @@ TEST(rocrtstFunc, TrapHandler_Abort) {
 }
 
 TEST(rocrtstFunc, TrapHandler_Generic) {
+    if (rocrtst::SkipOnWsl("TrapHandler_Generic: GPU trap exceptions not delivered to runtime on WSL/DXG")) return;
     TrapHandlerTest th;
     if (!RunCustomTestProlog(&th)) return;
     th.TestTrapGeneric();
@@ -637,6 +647,7 @@ TEST(rocrtstFunc, VirtMemory_Access_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_Accounting_Test) {
+    if (rocrtst::SkipOnWsl("VirtMemory_Accounting_Test: vmem MEMORY_AVAIL accounting unavailable on WSL/DXG")) return;
     VirtMemoryTestBasic vmt;
 
     if (!RunCustomTestProlog(&vmt)) return;
@@ -653,6 +664,7 @@ TEST(rocrtstFunc, VirtMemory_Aliasing_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_NonContiguousChunks_Test) {
+  if (rocrtst::SkipOnWsl("VirtMemory_NonContiguousChunks_Test: CPU-agent vmem set_access unavailable on WSL/DXG")) return;
   VirtMemoryTestBasic vmt;
 
   if (!RunCustomTestProlog(&vmt)) return;
@@ -661,6 +673,7 @@ TEST(rocrtstFunc, VirtMemory_NonContiguousChunks_Test) {
 }
 
 TEST(rocrtstFunc, VirtMemory_GPUtoHostAccess_Test) {
+  if (rocrtst::SkipOnWsl("VirtMemory_GPUtoHostAccess_Test: CPU-agent vmem set_access unavailable on WSL/DXG")) return;
   VirtMemoryTestBasic vmt;
 
   if (!RunCustomTestProlog(&vmt)) return;


### PR DESCRIPTION
## Motivation

- Some rocrtst suite test cannot work on WSL
- Skip those tests by detecting WSL 

## Technical Details
- following tests fail on WSL due to limitation of the platform 
rocrtstFunc.Memory_Available
rocrtstFunc.GpuCoreDump_DefaultPattern
rocrtstFunc.GpuCoreDump_CustomPattern
rocrtstFunc.GpuCoreDump_PatternSubstitution
rocrtstFunc.GpuCoreDump_ContentIntegrity
rocrtstFunc.GpuCoreDump_PipePattern
rocrtstFunc.TrapHandler_Abort
rocrtstFunc.TrapHandler_Generic
rocrtstFunc.VirtMemory_Accounting_Test
rocrtstFunc.VirtMemory_NonContiguousChunks_Test
rocrtstFunc.VirtMemory_GPUtoHostAccess_Test

## Issue Tracking

JIRA ID : AILIROCR-551

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
