### PR TITLE
libhsakmt: Drop PROT_EXEC from queue allocator anonymous mapping

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -359,8 +359,8 @@ static void *allocate_exec_aligned_memory_cpu(uint32_t size)
 	 *
 	 * MAP_ANONYMOUS initializes the memory to zero.
 	 */
-	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-				MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+			MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
 	if (ptr == MAP_FAILED)
 		return NULL;


### PR DESCRIPTION
## Motivation

RWX Anonymous Memory Mapping in libhsakmt Queue Allocator defeats W^X protection. A memory page should never be simultaneously Writable and Executable.

## Technical Details

Map the region with PROT_READ | PROT_WRITE to remove the RWX mapping. A memory page should never be simultaneously Writable and Executable.

## Issue Tracking

ROCM-26864

## Test Plan

No functional change: the CPU/ATS path only runs on legacy ATS hardware and never executes from these pages.