### PR TITLE
rocdbgapi: add a process id argument to convert_address_space

### DIFF
--- a/projects/rocdbgapi/CHANGELOG.md
+++ b/projects/rocdbgapi/CHANGELOG.md
@@ -3,7 +3,11 @@
 Full documentation for AMD Debugger API is available at
 [rocm.docs.amd.com/rocdbgapi](https://rocm.docs.amd.com/projects/ROCdbgapi/en/latest/index.html).
 
-## rocm-dbgapi-0.80 for ROCm-X
+## rocm-dbgapi-0.81 for ROCm-X
+### Changed
+- Add `process_id` argument to `amd_dbgapi_convert_address_space`.
+
+## rocm-dbgapi-0.80
 ### Added
 - amd_dbgapi_process_get_info() adds a new query to get a mask spanning
   over all the bits used by all the address spaces.  The query is called

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -6220,9 +6220,9 @@ typedef uint64_t amd_dbgapi_segment_address_t;
  * local address spaces.
  *
  * \param[in] wave_id The wave that is using the address.  If the \p
- * address_space is ::AMD_DBGAPI_ADDRESS_SPACE_GLOBAL then \p wave_id may be
- * ::AMD_DBGAPI_WAVE_NONE, as the address space does not depend on the active
- * wave, in which case \p process_id is used.
+ * source_address_space_id is ::AMD_DBGAPI_ADDRESS_SPACE_GLOBAL then \p wave_id
+ * may be ::AMD_DBGAPI_WAVE_NONE, as the address space does not depend on the
+ * active wave, in which case \p process_id is used.
  *
  * \param[in] lane_id The lane of the \p wave_id that is using the address.  If
  * the \p address_space does not depend on the active lane then this may be

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -665,6 +665,12 @@ typedef unsigned long amd_dbgapi_DWORD;
  */
 #define AMD_DBGAPI_VERSION_0_80
 
+/**
+ * The function was introduced in version 0.81 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.81"``.
+ */
+#define AMD_DBGAPI_VERSION_0_81
+
 /** @} */
 
 /** \ingroup callbacks_group
@@ -6219,9 +6225,14 @@ typedef uint64_t amd_dbgapi_segment_address_t;
  * space may alias with an address in the \p global, \p private_swizzled, or \p
  * local address spaces.
  *
+ * \param[in] process_id The process that the \p source_segment_address
+ * belongs to.
+ *
  * \param[in] wave_id The wave that is using the address.  If the \p
- * source_address_space_id is ::AMD_DBGAPI_ADDRESS_SPACE_GLOBAL then \p wave_id
- * may be ::AMD_DBGAPI_WAVE_NONE, as the address space does not depend on the
+ * source_address_space_id is ::AMD_DBGAPI_ADDRESS_SPACE_GLOBAL or
+ * ::AMD_DBGAPI_ADDRESS_SPACE_GENERIC whereas \p destination_address_space_id
+ * is ::AMD_DBGAPI_ADDRESS_SPACE_GLOBAL, then \p wave_id may be
+ * ::AMD_DBGAPI_WAVE_NONE, as the address space does not depend on the
  * active wave, in which case \p process_id is used.
  *
  * \param[in] lane_id The lane of the \p wave_id that is using the address.  If
@@ -6264,6 +6275,10 @@ typedef uint64_t amd_dbgapi_segment_address_t;
  * destination_segment_address and \p destination_contiguous_bytes are
  * unaltered.
  *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID \p process_id is
+ * invalid.  \p destination_segment_address and \p
+ * destination_contiguous_bytes are unaltered.
+ *
  * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_WAVE_ID \p wave_id is invalid, or
  * \p wave_id is ::AMD_DBGAPI_WAVE_NONE and \p source_address_space_id or \p
  * destination_address_space_id depends on the active wave.
@@ -6298,17 +6313,20 @@ typedef uint64_t amd_dbgapi_segment_address_t;
  * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY \p
  * source_address_space_id or \p destination_address_space_id address spaces
  * are not supported by the architecture of \p wave_id (if not
- * ::AMD_DBGAPI_WAVE_NONE).  \p destination_segment_address and \p
- * destination_contiguous_bytes are unaltered.
+ * ::AMD_DBGAPI_WAVE_NONE), or the wave denoted by \p wave_id does not
+ * belong to the process denoted by \p process_id.  \p
+ * destination_segment_address and \p destination_contiguous_bytes are
+ * unaltered.
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_convert_address_space (
-    amd_dbgapi_wave_id_t wave_id, amd_dbgapi_lane_id_t lane_id,
+    amd_dbgapi_process_id_t process_id, amd_dbgapi_wave_id_t wave_id,
+    amd_dbgapi_lane_id_t lane_id,
     amd_dbgapi_address_space_id_t source_address_space_id,
     amd_dbgapi_segment_address_t source_segment_address,
     amd_dbgapi_address_space_id_t destination_address_space_id,
     amd_dbgapi_segment_address_t *destination_segment_address,
     amd_dbgapi_size_t *destination_contiguous_bytes)
-    AMD_DBGAPI_VERSION_0_62;
+    AMD_DBGAPI_VERSION_0_81;
 
 /**
  * The dependency when reading or writing a specific segment address of an

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -6398,7 +6398,9 @@ typedef enum
  * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY \p
  * address_space_id depends on the active wave but \p wave_id is
  * ::AMD_DBGAPI_WAVE_NONE, or \p address_space_id is not supported by the
- * architecture of \p wave_id.  \p segment_address_dependencies is unaltered.
+ * architecture of \p wave_id, or the wave denoted by \p wave_id does not
+ * belong to the process denoted by \p process_id.
+ * \p segment_address_dependencies is unaltered.
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_address_dependency (
   amd_dbgapi_process_id_t process_id,

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -49,7 +49,6 @@ global: amd_dbgapi_classify_instruction;
 @AMD_DBGAPI_NAME@_0.62 {
 global: amd_dbgapi_address_class_get_info;
         amd_dbgapi_address_space_get_info;
-        amd_dbgapi_convert_address_space;
         amd_dbgapi_prefetch_register;
         amd_dbgapi_read_register;
         amd_dbgapi_watchpoint_get_info;
@@ -105,3 +104,7 @@ global:	amd_dbgapi_address_dependency;
 @AMD_DBGAPI_NAME@_0.80 {
 global: amd_dbgapi_process_get_info;
 } @AMD_DBGAPI_NAME@_0.79;
+
+@AMD_DBGAPI_NAME@_0.81 {
+global: amd_dbgapi_convert_address_space;
+} @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -1354,9 +1354,17 @@ amd_dbgapi_address_dependency (
         if (wave_id != AMD_DBGAPI_WAVE_NONE)
           THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_WAVE_ID);
 
-        if (address_space->address_dependency (segment_address)
-            != AMD_DBGAPI_SEGMENT_ADDRESS_DEPENDENCE_PROCESS)
-          THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY);
+        /* Without a wave, we do not know which agent to use.  Try all
+           agents.  Results should be consistent.  */
+        for (auto &agent : process->range<agent_t> ())
+          {
+            auto [lowered_aspace, lowered_addr]
+              = address_space->lower (agent, segment_address);
+
+            if (lowered_aspace.address_dependency (lowered_addr)
+                != AMD_DBGAPI_SEGMENT_ADDRESS_DEPENDENCE_PROCESS)
+              THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY);
+          }
 
         *segment_address_dependency
           = AMD_DBGAPI_SEGMENT_ADDRESS_DEPENDENCE_PROCESS;

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -1156,7 +1156,8 @@ amd_dbgapi_dwarf_address_space_to_address_space (
 
 amd_dbgapi_status_t AMD_DBGAPI
 amd_dbgapi_convert_address_space (
-  amd_dbgapi_wave_id_t wave_id, amd_dbgapi_lane_id_t lane_id,
+  amd_dbgapi_process_id_t process_id, amd_dbgapi_wave_id_t wave_id,
+  amd_dbgapi_lane_id_t lane_id,
   amd_dbgapi_address_space_id_t source_address_space_id,
   amd_dbgapi_segment_address_t source_segment_address,
   amd_dbgapi_address_space_id_t destination_address_space_id,
@@ -1164,8 +1165,9 @@ amd_dbgapi_convert_address_space (
   amd_dbgapi_size_t *destination_contiguous_bytes)
 {
   TRACE_BEGIN (
-    param_in (wave_id), param_in (lane_id), param_in (source_address_space_id),
-    param_in (source_segment_address), param_in (destination_address_space_id),
+    param_in (process_id), param_in (wave_id), param_in (lane_id),
+    param_in (source_address_space_id), param_in (source_segment_address),
+    param_in (destination_address_space_id),
     param_in (destination_segment_address),
     param_in (destination_contiguous_bytes));
   TRY
@@ -1176,6 +1178,11 @@ amd_dbgapi_convert_address_space (
     if (destination_segment_address == nullptr
         || destination_contiguous_bytes == nullptr)
       THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
+
+    process_t *process = process_t::find (process_id);
+
+    if (process == nullptr)
+      THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID);
 
     const address_space_t *source_address_space
       = find (source_address_space_id);
@@ -1190,7 +1197,8 @@ amd_dbgapi_convert_address_space (
 
     if (wave != nullptr)
       {
-        if (!wave->architecture ().is_address_space_supported (
+        if (&(wave->process ()) != process
+            || !wave->architecture ().is_address_space_supported (
               *destination_address_space)
             || !wave->architecture ().is_address_space_supported (
               *source_address_space))
@@ -1204,15 +1212,35 @@ amd_dbgapi_convert_address_space (
     else if (lane_id != AMD_DBGAPI_LANE_NONE)
       THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_LANE_ID);
 
-    /* Handle global->global conversions early since it does not require to
-       pass in a wave_id.  */
-    if (source_address_space->kind () == address_space_t::kind_t::global
-        && destination_address_space->kind ()
-             == address_space_t::kind_t::global)
+    /* Handle global->global and generic->global conversions early
+       since it does not require to pass in a wave_id.  */
+    if ((source_address_space->kind () == address_space_t::kind_t::generic
+         || source_address_space->kind () == address_space_t::kind_t::global)
+        && (destination_address_space->kind ()
+            == address_space_t::kind_t::global))
       {
+        /* Without a wave, we do not know which agent to use.  All
+           agents should give the same result for the conversion to
+           global to be valid.  */
+        for (auto &agent : process->range<agent_t> ())
+          {
+            auto [lowered_aspace, lowered_addr]
+              = source_address_space->lower (agent, source_segment_address);
+
+            if (lowered_aspace.kind () != address_space_t::kind_t::global
+                || lowered_addr != source_segment_address)
+              THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
+          }
+
         *destination_segment_address = source_segment_address;
-        *destination_contiguous_bytes
-          = source_address_space->last_address () - source_segment_address + 1;
+
+        if (*destination_segment_address
+            == destination_address_space->null_address ())
+          *destination_contiguous_bytes = 0;
+        else
+          *destination_contiguous_bytes
+            = destination_address_space->last_address ()
+            - *destination_segment_address + 1;
       }
     else
       {
@@ -1227,6 +1255,7 @@ amd_dbgapi_convert_address_space (
       }
   }
   CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID,
          AMD_DBGAPI_STATUS_ERROR_INVALID_WAVE_ID,
          AMD_DBGAPI_STATUS_ERROR_INVALID_LANE_ID,
          AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_ID,

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -1363,7 +1363,8 @@ amd_dbgapi_address_dependency (
       }
     else
       {
-        if (!wave->architecture ().is_address_space_supported (*address_space))
+        if (!wave->architecture ().is_address_space_supported (*address_space)
+            || &(wave->process ()) != process)
           THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY);
 
         auto [lowered_address_space, lowered_address]


### PR DESCRIPTION
## Motivation

Add a process id argument to `convert_address_space`, so that generic -> global conversions can be made when wave is not available.

## Technical Details

When a generic address points to the global address space, wave may not be available, since the address does not depend on a wave in that case. Accept a process id and use it. See the patches for more details.

## Issue Tracking

JIRA ID: AIROCGDB-644

## Test Plan

Tested by ROCgdb PR https://github.com/ROCm/ROCgdb/pull/255.

## Test Result

Pass.
