### PR TITLE
test(rccl): cover finalize after a failed net plugin init (AICOMRCCL-1891)

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -410,6 +410,7 @@ if(BUILD_TESTS)
       TopoEnvPolicyTests.cpp
       TopoNicFusionTests.cpp
       NetSocketTests.cpp
+      PluginCompatV10_test.cpp
       PluginCompatV11_test.cpp
       ProxyTests.cpp
       RcclWrapTests.cpp
@@ -452,9 +453,11 @@ if(BUILD_TESTS)
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-    # PluginCompatV11_test.cpp resolves its in-process mock plugin symbols via
-    # dlsym(dlopen(NULL), ...), which only sees the executable's dynamic symbols.
+    # PluginCompatV10_test.cpp / PluginCompatV11_test.cpp resolve their in-process
+    # mock plugin symbols via dlsym(dlopen(NULL), ...), which only sees the
+    # executable's dynamic symbols.
     target_link_options(rccl-UnitTestsFixturesDebug PRIVATE
+      -Wl,--export-dynamic-symbol=ncclNetPlugin_v10
       -Wl,--export-dynamic-symbol=ncclNetPlugin_v11
       -Wl,--export-dynamic-symbol=ncclCollNetPlugin_v11)
   endif()

--- a/projects/rccl/test/NetPluginReloadTests.cpp
+++ b/projects/rccl/test/NetPluginReloadTests.cpp
@@ -15,6 +15,14 @@
 // when a plugin inits but fails assignment (e.g. incompatible UNPACK version),
 // ncclNetPluginFinalize() must run before probing the next plugin; netName mismatch
 // must skip init entirely.
+//
+// NetPluginInitFail — AICOMRCCL-1891 (NCCL 2.29.7 net.cc fix): ncclNetPluginInit()
+// used to call finalize() unconditionally on its failure path, so a plugin whose
+// init() failed was finalized without ever having been initialized. For a v10 (or
+// older) plugin that crashes outright: the compat layer in src/plugin/net/net_v10.cc
+// only fills ncclNet.finalize once ncclNet_v10->init() has succeeded, so the call
+// went through a null function pointer. The guard must suppress finalize() after a
+// failed init() while still running it when init() succeeded and devices() failed.
 
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
@@ -196,6 +204,84 @@ TEST(NetPluginAssignFail, SurvivesMultipleCommCycles) {
         << "each comm cycle must init the external plugin once";
     EXPECT_EQ(countLines(finalizeFile.path()), kNumCommCycles)
         << "each failed assignment must finalize the external plugin once";
+  });
+}
+
+TEST(NetPluginInitFail, DoesNotFinalizeAfterFailedInit) {
+  RUN_ISOLATED_TEST("NetPluginInitFail.DoesNotFinalizeAfterFailedInit", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_init_fail_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_init_fail_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid()) << "failed to create init counter file";
+    ASSERT_TRUE(finalizeFile.valid()) << "failed to create finalize counter file";
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "init_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    // The comm must still come up: a plugin that fails init is disabled, and RCCL
+    // falls back to the internal IB/Socket plugins.
+    initAndDestroyComm();
+
+    EXPECT_EQ(countLines(initFile.path()), 1)
+        << "external plugin init must be attempted once";
+    EXPECT_EQ(countLines(finalizeFile.path()), 0)
+        << "finalize() must not run for an init() that failed";
+  });
+}
+
+TEST(NetPluginInitFail, FailedPluginIsNotRetriedOrFinalized) {
+  RUN_ISOLATED_TEST("NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_init_fail_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_init_fail_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid());
+    ASSERT_TRUE(finalizeFile.valid());
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "init_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    for (int cycle = 0; cycle < kNumCommCycles; ++cycle) initAndDestroyComm();
+
+    // netPluginLibs[] is process-global, so the failure marks the plugin disabled
+    // for good: later comms skip it instead of re-running init.
+    EXPECT_EQ(countLines(initFile.path()), 1)
+        << "a plugin disabled by a failed init must not be re-inited by later comms";
+    EXPECT_EQ(countLines(finalizeFile.path()), 0)
+        << "no comm cycle may finalize a plugin that was never initialized";
+  });
+}
+
+TEST(NetPluginInitFail, FinalizesWhenDevicesFailsAfterInit) {
+  RUN_ISOLATED_TEST("NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit", []() {
+    if (auto reason = gpuSkipReason(); !reason.empty()) GTEST_SKIP() << reason;
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+    ScopedTempFile initFile("/tmp/rccl_net_dev_fail_init_XXXXXX");
+    ScopedTempFile finalizeFile("/tmp/rccl_net_dev_fail_fin_XXXXXX");
+    ASSERT_TRUE(initFile.valid());
+    ASSERT_TRUE(finalizeFile.valid());
+
+    ASSERT_EQ(setenv("RCCL_NET_TEST_PLUGIN_MODE", "devices_fail", 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_INIT_FILE", initFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("RCCL_NET_TEST_FINALIZE_FILE", finalizeFile.path().c_str(), 1), 0);
+    ASSERT_EQ(setenv("NCCL_NET_PLUGIN", "STATIC_PLUGIN", 1), 0);
+
+    initAndDestroyComm();
+
+    // Same failure path as above, but init() did succeed, so the context exists and
+    // has to be released. This is what keeps the guard from becoming a leak.
+    EXPECT_EQ(countLines(initFile.path()), 1)
+        << "external plugin init must run before devices() is probed";
+    EXPECT_EQ(countLines(finalizeFile.path()), 1)
+        << "finalize() must release the context when devices() fails after a good init()";
   });
 }
 

--- a/projects/rccl/test/PluginCompatV10_test.cpp
+++ b/projects/rccl/test/PluginCompatV10_test.cpp
@@ -1,0 +1,163 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Regression test for AICOMRCCL-1891 (NCCL 2.29.7 net.cc fix): RCCL must not call
+// ncclNet.finalize() after a failed ncclNet_v10->init().
+//
+// The v10 plugin ABI has no finalize() at all, so the compat layer in
+// src/plugin/net/net_v10.cc synthesizes one and stores it in ncclNet.finalize
+// together with the rest of the vtable, but only once ncclNet_v10->init() has
+// succeeded. A failed init therefore leaves ncclNet.finalize null, and the pre-fix
+// ncclNetPluginInit() called it unconditionally on its failure path: a call through
+// a null function pointer.
+//
+// Uses the same in-process mock approach as PluginCompatV11_test: it exports the
+// ncclNetPlugin_v10 symbol the compat layer resolves via dlsym, hands it a
+// dlopen(NULL) handle, and drives init() directly. No GPU or real plugin required.
+
+#include <gtest/gtest.h>
+
+#include <dlfcn.h>
+
+#include "nccl.h"
+#include "nccl_net.h"
+
+// Compat-layer entry point from librccl.so (net_v10.cc); a global-namespace C++
+// function, so this prototype matches the (Debug) library's mangled symbol.
+ncclNet_t* getNcclNet_v10(void* lib);
+
+namespace RcclUnitTesting {
+namespace {
+
+// Flipped by the test to make the mock plugin's init() fail on demand.
+bool gMockV10InitFails = false;
+int gMockV10InitCalls = 0;
+
+ncclResult_t mockNetInit(ncclDebugLogger_t, ncclProfilerCallback_t) {
+  ++gMockV10InitCalls;
+  return gMockV10InitFails ? ncclSystemError : ncclSuccess;
+}
+
+// Distinct non-null stubs, so "wired up" can be told apart from "still null".
+ncclResult_t mockNetDevices(int* ndev) { if (ndev) { *ndev = 1; } return ncclSuccess; }
+ncclResult_t mockNetGetProperties(int, ncclNetProperties_v10_t*) { return ncclSuccess; }
+ncclResult_t mockNetListen(int, void*, void**) { return ncclSuccess; }
+ncclResult_t mockNetConnect(int, ncclNetCommConfig_v10_t*, void*, void**, ncclNetDeviceHandle_v10_t**) { return ncclSuccess; }
+ncclResult_t mockNetAccept(void*, void**, ncclNetDeviceHandle_v10_t**) { return ncclSuccess; }
+ncclResult_t mockNetRegMr(void*, void*, size_t, int, void**) { return ncclSuccess; }
+ncclResult_t mockNetRegMrDmaBuf(void*, void*, size_t, int, uint64_t, int, void**) { return ncclSuccess; }
+ncclResult_t mockNetDeregMr(void*, void*) { return ncclSuccess; }
+ncclResult_t mockNetIsend(void*, void*, size_t, int, void*, void*, void**) { return ncclSuccess; }
+ncclResult_t mockNetIrecv(void*, int, void**, size_t*, int*, void**, void**, void**) { return ncclSuccess; }
+ncclResult_t mockNetIflush(void*, int, void**, int*, void**, void**) { return ncclSuccess; }
+ncclResult_t mockNetTest(void*, int*, int*) { return ncclSuccess; }
+ncclResult_t mockNetCloseSend(void*) { return ncclSuccess; }
+ncclResult_t mockNetCloseRecv(void*) { return ncclSuccess; }
+ncclResult_t mockNetCloseListen(void*) { return ncclSuccess; }
+ncclResult_t mockNetGetDeviceMr(void*, void*, void**) { return ncclSuccess; }
+ncclResult_t mockNetIrecvConsumed(void*, int, void*) { return ncclSuccess; }
+ncclResult_t mockNetMakeVDevice(int*, ncclNetVDeviceProps_v10_t*) { return ncclSuccess; }
+
+} // namespace
+} // namespace RcclUnitTesting
+
+// This symbol is what getNcclNet_v10() looks up via dlsym(). The CMake target
+// exports it (--export-dynamic-symbol) so it lands in the test executable's
+// dynamic symbol table; it must be named exactly, so we place it at global scope
+// with C linkage and default visibility.
+extern "C" {
+
+__attribute__((visibility("default")))
+ncclNet_v10_t ncclNetPlugin_v10 = {
+  "mock_v10_net",                        // name
+  RcclUnitTesting::mockNetInit,          // init
+  RcclUnitTesting::mockNetDevices,       // devices
+  RcclUnitTesting::mockNetGetProperties, // getProperties
+  RcclUnitTesting::mockNetListen,        // listen
+  RcclUnitTesting::mockNetConnect,       // connect
+  RcclUnitTesting::mockNetAccept,        // accept
+  RcclUnitTesting::mockNetRegMr,         // regMr
+  RcclUnitTesting::mockNetRegMrDmaBuf,   // regMrDmaBuf
+  RcclUnitTesting::mockNetDeregMr,       // deregMr
+  RcclUnitTesting::mockNetIsend,         // isend
+  RcclUnitTesting::mockNetIrecv,         // irecv
+  RcclUnitTesting::mockNetIflush,        // iflush
+  RcclUnitTesting::mockNetTest,          // test
+  RcclUnitTesting::mockNetCloseSend,     // closeSend
+  RcclUnitTesting::mockNetCloseRecv,     // closeRecv
+  RcclUnitTesting::mockNetCloseListen,   // closeListen
+  RcclUnitTesting::mockNetGetDeviceMr,   // getDeviceMr
+  RcclUnitTesting::mockNetIrecvConsumed, // irecvConsumed
+  RcclUnitTesting::mockNetMakeVDevice,   // makeVDevice
+};
+
+} // extern "C"
+
+namespace RcclUnitTesting {
+
+// The compat layer keeps one process-global vtable and refcount, so the whole
+// contract is walked in a single test rather than split across tests that would
+// depend on each other's execution order.
+TEST(PluginCompatV10, FinalizeIsNullUntilInitSucceeds) {
+  void* self = dlopen(nullptr, RTLD_NOW | RTLD_GLOBAL);
+  ASSERT_NE(self, nullptr) << "dlopen(NULL) failed: " << dlerror();
+
+  ncclNet_t* net = getNcclNet_v10(self);
+  ASSERT_NE(net, nullptr)
+    << "getNcclNet_v10 returned null; the in-process ncclNetPlugin_v10 symbol "
+       "was not resolved (is the test linked with -rdynamic?)";
+
+  // init() is the only entry point the compat layer may publish up front: it is
+  // the callback that performs the lazy initialization.
+  ASSERT_NE(net->init, nullptr) << "compat layer must set ncclNet.init";
+  ASSERT_EQ(net->finalize, nullptr)
+    << "finalize must stay null before init(); the v10 ABI has no finalize, so the "
+       "compat layer can only publish its own once init() has succeeded";
+
+  // The compat layer dereferences config, so a real one is required here.
+  ncclNetCommConfig_t config = {};
+  config.trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
+
+  gMockV10InitFails = true;
+  gMockV10InitCalls = 0;
+
+  void* ctx = nullptr;
+  EXPECT_NE(net->init(&ctx, /*commId=*/0, &config,
+                      /*logFunction=*/nullptr, /*profFunction=*/nullptr),
+            ncclSuccess)
+    << "compat layer must propagate the plugin's init() failure";
+  EXPECT_EQ(gMockV10InitCalls, 1) << "the underlying v10 init() must have been called";
+
+  // The crux of AICOMRCCL-1891: after a failed init there is still no finalize to
+  // call, so ncclNetPluginInit()'s failure path must not attempt one. Without the
+  // guard in src/plugin/net.cc that call segfaults here.
+  EXPECT_EQ(net->finalize, nullptr) << "finalize must stay null after a failed init()";
+  EXPECT_EQ(net->devices, nullptr) << "no entry point may be published by a failed init()";
+
+  // A failed init must not have counted towards the compat layer's refcount: if it
+  // had, this retry would short-circuit and leave the vtable unpopulated.
+  gMockV10InitFails = false;
+
+  ASSERT_EQ(net->init(&ctx, /*commId=*/0, &config,
+                      /*logFunction=*/nullptr, /*profFunction=*/nullptr),
+            ncclSuccess);
+  EXPECT_EQ(gMockV10InitCalls, 2)
+    << "a failed init() must not leave the plugin marked as initialized";
+
+  EXPECT_NE(net->finalize, nullptr) << "finalize null after a successful init()";
+  EXPECT_NE(net->devices, nullptr) << "devices null after a successful init()";
+
+  // Release the context the successful init() allocated and rebalance the refcount.
+  // Note that finalize() drops the refcount but leaves the process-global vtable
+  // populated, so the "finalize is null after a failed init" check above only holds
+  // on the first run in a process; this test relies on the harness forking a fresh
+  // process per case and must not be run twice in one process (e.g. --gtest_repeat).
+  if (net->finalize) EXPECT_EQ(net->finalize(ctx), ncclSuccess);
+
+  dlclose(self);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/plugin/net_reload_plugin.cpp
+++ b/projects/rccl/test/plugin/net_reload_plugin.cpp
@@ -13,9 +13,15 @@
 // Compiled as C++ (the RCCL project only enables CXX/HIP), so the plugin symbol
 // is exported with C linkage and default visibility for RCCL's dlsym() lookup.
 //
-// RCCL_NET_TEST_PLUGIN_MODE=assign_fail selects an incompatible UNPACK device
-// version (assignment rejected after init) and records init/finalize via
-// RCCL_NET_ASSIGN_FAIL_{INIT,FINALIZE}_FILE (NCCL 2.28.7 net.cc fix).
+// RCCL_NET_TEST_PLUGIN_MODE selects a failure to inject:
+//   assign_fail   - incompatible UNPACK device version, so assignment is rejected
+//                   after a successful init (NCCL 2.28.7 net.cc fix). Records
+//                   init/finalize via RCCL_NET_ASSIGN_FAIL_{INIT,FINALIZE}_FILE.
+//   init_fail     - init() reports an error (AICOMRCCL-1891 / NCCL 2.29.7 net.cc
+//                   fix: finalize() must not run for an init() that failed).
+//   devices_fail  - init() succeeds but devices() reports an error, which is the
+//                   companion case where finalize() must still run.
+// Both new modes record via RCCL_NET_TEST_{INIT,FINALIZE}_FILE.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,6 +34,13 @@
 
 static char kPluginName[] = "ReloadTest";
 
+enum PluginTestMode {
+  kModeDefault,
+  kModeAssignFail,
+  kModeInitFail,
+  kModeDevicesFail,
+};
+
 static void recordLine(const char* envVar) {
   const char* path = getenv(envVar);
   if (path == nullptr) return;
@@ -39,9 +52,13 @@ static void recordLine(const char* envVar) {
   fclose(f);
 }
 
-static int assignFailMode() {
+static PluginTestMode testMode() {
   const char* mode = getenv("RCCL_NET_TEST_PLUGIN_MODE");
-  return mode && strcmp(mode, "assign_fail") == 0;
+  if (mode == nullptr) return kModeDefault;
+  if (strcmp(mode, "assign_fail") == 0) return kModeAssignFail;
+  if (strcmp(mode, "init_fail") == 0) return kModeInitFail;
+  if (strcmp(mode, "devices_fail") == 0) return kModeDevicesFail;
+  return kModeDefault;
 }
 
 __hidden ncclResult_t pluginInit(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config,
@@ -49,16 +66,25 @@ __hidden ncclResult_t pluginInit(void** ctx, uint64_t commId, ncclNetCommConfig_
   (void)ctx; (void)commId; (void)config; (void)logFunction; (void)profFunction;
   recordLine("RCCL_NET_RELOAD_COUNTER_FILE");
   recordLine("RCCL_NET_ASSIGN_FAIL_INIT_FILE");
+  recordLine("RCCL_NET_TEST_INIT_FILE");
+  // Recorded before failing, so a test can tell "init was never attempted" apart
+  // from "init was attempted and rejected".
+  if (testMode() == kModeInitFail) return ncclSystemError;
   return ncclSuccess;
 }
 
 __hidden ncclResult_t pluginFinalize(void* ctx) {
   (void)ctx;
   recordLine("RCCL_NET_ASSIGN_FAIL_FINALIZE_FILE");
+  recordLine("RCCL_NET_TEST_FINALIZE_FILE");
   return ncclSuccess;
 }
 
-__hidden ncclResult_t pluginDevices(int* ndev) { *ndev = 1; return ncclSuccess; }
+__hidden ncclResult_t pluginDevices(int* ndev) {
+  if (testMode() == kModeDevicesFail) return ncclSystemError;
+  *ndev = 1;
+  return ncclSuccess;
+}
 
 __hidden ncclResult_t pluginGetProperties(int dev, ncclNetProperties_v12_t* props) {
   props->name = kPluginName;
@@ -72,7 +98,7 @@ __hidden ncclResult_t pluginGetProperties(int dev, ncclNetProperties_v12_t* prop
   props->latency = 0;
   props->maxComms = 1024 * 1024;
   props->maxRecvs = NCCL_PLUGIN_MAX_RECVS;
-  if (assignFailMode()) {
+  if (testMode() == kModeAssignFail) {
     props->netDeviceType = NCCL_NET_DEVICE_UNPACK;
     props->netDeviceVersion = NCCL_NET_DEVICE_UNPACK_VERSION - 1;
   } else {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -985,6 +985,20 @@
         {"name": "AsymmetricVisibility.CommInitRankAllReduce", "description": "ROCM-27034: RCCL comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES", "test_filter": "AsymmetricVisibility.CommInitRankAllReduce"}
       ]
     },
+    "plugin_compat_v10": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 60,
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds", "description": "AICOMRCCL-1891: the v10 compat layer publishes its synthesized finalize only after ncclNet_v10->init() succeeds, so a failed init must leave ncclNet.finalize null and must not count towards the compat refcount", "test_filter": "PluginCompatV10.FinalizeIsNullUntilInitSucceeds"}
+      ]
+    },
     "plugin_compat_v11": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixturesDebug",
@@ -1026,7 +1040,10 @@
         {"name": "NetPluginReload.CustomPluginReloadsAfterCommDestroy", "description": "AICOMRCCL-1534: a non-default NCCL_NET_PLUGIN must remain reloadable after the communicator that first used it is destroyed", "test_filter": "NetPluginReload.CustomPluginReloadsAfterCommDestroy"},
         {"name": "NetPluginAssignFail.FinalizesOnFailedAssignment", "description": "NCCL 2.28.7: ncclNetPluginFinalize() runs when plugin init succeeds but assignment fails (incompatible UNPACK version)", "test_filter": "NetPluginAssignFail.FinalizesOnFailedAssignment"},
         {"name": "NetPluginAssignFail.NetNameMismatchSkipsInit", "description": "NCCL 2.28.7: comm config netName mismatch skips external plugin init entirely", "test_filter": "NetPluginAssignFail.NetNameMismatchSkipsInit"},
-        {"name": "NetPluginAssignFail.SurvivesMultipleCommCycles", "description": "NCCL 2.28.7: failed assignment cleanup leaves no orphaned state across multiple comm cycles", "test_filter": "NetPluginAssignFail.SurvivesMultipleCommCycles"}
+        {"name": "NetPluginAssignFail.SurvivesMultipleCommCycles", "description": "NCCL 2.28.7: failed assignment cleanup leaves no orphaned state across multiple comm cycles", "test_filter": "NetPluginAssignFail.SurvivesMultipleCommCycles"},
+        {"name": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit", "description": "AICOMRCCL-1891 / NCCL 2.29.7: ncclNetPluginInit() must not call finalize() for a plugin whose init() failed (crashes on v10 and older, where the compat layer leaves ncclNet.finalize null until init() succeeds)", "test_filter": "NetPluginInitFail.DoesNotFinalizeAfterFailedInit"},
+        {"name": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized", "description": "AICOMRCCL-1891 / NCCL 2.29.7: a plugin disabled by a failed init() is neither re-inited nor finalized by later comm cycles", "test_filter": "NetPluginInitFail.FailedPluginIsNotRetriedOrFinalized"},
+        {"name": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit", "description": "AICOMRCCL-1891 / NCCL 2.29.7: the finalize() guard must not suppress cleanup when init() succeeded and devices() failed", "test_filter": "NetPluginInitFail.FinalizesWhenDevicesFailsAfterInit"}
       ]
     },
     "debug_tests": {
@@ -3708,6 +3725,12 @@
       "name": "Unit Tests - Fixtures (Debug)",
       "description": "Non-MPI unit tests accessing internal symbols (Debug only)",
       "config": "unit_tests_fixtures_debug",
+      "enabled": true
+    },
+    {
+      "name": "Plugin Compat v10 - Finalize After Failed Init",
+      "description": "AICOMRCCL-1891: v10 net plugin compat layer leaves finalize null after a failed init, so RCCL must not call it (Debug only)",
+      "config": "plugin_compat_v10",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

`ncclNetPluginInit()` used to call the plugin's `finalize()` unconditionally on its
failure path, so a plugin whose `init()` had failed was finalized without ever
having been initialized. The guard that prevents this arrived with the NCCL 2.29.7
port and had no test coverage, so it was protected only by nobody touching that
line.

## Technical Details

The v10 compat layer (`src/plugin/net/net_v10.cc`) publishes its synthesized
`ncclNet.finalize` only after `ncclNet_v10->init()` has succeeded, so on the
pre-guard failure path that call went through a null function pointer. Tests only,
no source changes.

Two layers of coverage:

* `NetPluginInitFail` in `test/NetPluginReloadTests.cpp` drives the external mock
  plugin through a failed `init()` and asserts that `finalize()` never runs, that
  the disabled plugin is not re-inited by later comms, and that `finalize()` does
  still run when `init()` succeeded and `devices()` failed, so the guard cannot
  regress into a leak. Added alongside the existing `NetPluginAssignFail` suite,
  which covers the mirror-image NCCL 2.28.7 case where `finalize()` must run after
  a successful `init()`. No existing test is modified.
* `test/PluginCompatV10_test.cpp` is an in-process whitebox test for the v10 compat
  layer itself, in the same style as `PluginCompatV11_test.cpp`: `finalize` stays
  null before and after a failed `init()`, and a failed `init()` does not count
  towards the compat refcount, so a later `init()` still populates the vtable.
  Debug-only, since it calls `getNcclNet_v10()` directly.

`test/plugin/net_reload_plugin.cpp` is the mock plugin the first suite drives, so it
gains the two failure modes those tests need: `init_fail`, where `init()` returns an
error, and `devices_fail`, where `init()` succeeds and `devices()` returns an error.
Its mode selector becomes an enum because there are now four modes instead of a
boolean; the existing `assign_fail` behaviour is unchanged. Both new suites are
registered in `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`.

## Issue Tracking

JIRA ID : AICOMRCCL-1891

## Test Plan

Built on gfx942, Release and Debug, and verified that the new assertions are
load-bearing rather than vacuous:

1. Release, guard in place: run `NetPluginReload*`, `NetPluginAssignFail*` and
   `NetPluginInitFail*`.
2. Release, guard temporarily reverted in `src/plugin/net.cc`: rerun the same
   filter, expecting the two new finalize-count assertions to fail.
3. Debug: run `PluginCompatV10.*` and `PluginCompatV11.*`.
4. Debug, compat layer temporarily mutated to publish `finalize` before `init()`
   and to count a failed `init()` towards the refcount: rerun `PluginCompatV10.*`,
   expecting it to fail.
5. Debug, surrounding suites for regressions: `PluginCompat*`, `NetSocket*`,
   `Transport*`, `Proxy*`, `SocketPoll*`, `Ipcsocket*`, `TopoEnvPolicy*`,
   `NetDevsPolicy*`.

## Test Result

1. 7/7 passed, including the four pre-existing tests in the two older suites.
2. Failed as expected: `DoesNotFinalizeAfterFailedInit` and
   `FailedPluginIsNotRetriedOrFinalized` both reported a finalize count of 1 where
   0 is required. `FinalizesWhenDevicesFailsAfterInit` still passed, which is
   correct since the guard does not affect that path.
3. 3/3 passed.
4. Failed as expected on all three load-bearing assertions: finalize non-null after
   a failed init, the mock's init not re-entered on retry, and the vtable left
   unpopulated by the short-circuited retry.
5. 54/54 passed, with `TransportTest.CollNetRecvSetup` excluded. That test
   segfaults on unmodified `develop` in this Debug binary, as does
   `Rcclwrap.RcclSetPipelining_Invalid_DType`; both were confirmed to crash in a
   build without this PR's files and are unrelated to these changes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
