### PR TITLE
ci(rocprofiler-compute): Link libdw from TheRock sysdeps

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           apt-get update
-          apt install -y libdw-dev pkg-config
+          apt install -y pkg-config
           echo "✅ ROCm Dependencies Installed!"
 
       - name: Install Latest Nightly ROCm
@@ -231,6 +231,7 @@ jobs:
           git config --global --add safe.directory ${PWD}
           PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH \
           LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib:$LD_LIBRARY_PATH \
+          PKG_CONFIG_PATH=${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib/pkgconfig:$PKG_CONFIG_PATH \
           python3 ./tools/run-ci.py \
             --name "ROCm/rocprofiler-compute-${{ github.ref_name }}-ubuntu-${{ matrix.system.os-release }}-${{ matrix.system.gpu }}" \
             --actor "${{ github.actor }}" \
@@ -241,6 +242,7 @@ jobs:
             -- \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib \
             -DENABLE_TESTS=ON \
             -DINSTALL_TESTS=ON \
             -DPYTEST_NUMPROCS=8 \

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           apt-get update
-          apt-get install -y libdw-dev pkg-config
+          apt-get install -y pkg-config
           echo "✅ Dependencies Installed!"
 
       - name: Install latest nightly ROCm
@@ -176,6 +176,7 @@ jobs:
 
           export PATH="${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}"
           export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocm_sysdeps/lib:${{ steps.sanitizer_runtime.outputs.sanitizer_lib_dir }}:${LD_LIBRARY_PATH:-}"
+          export PKG_CONFIG_PATH="${ROCM_PATH}/lib/rocm_sysdeps/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
           c_compiler="$(command -v amdclang)"
           cxx_compiler="$(command -v amdclang++)"
@@ -194,6 +195,7 @@ jobs:
             "-DCMAKE_HIP_COMPILER=${cxx_compiler}" \
             -DCMAKE_BUILD_TYPE=Debug \
             "-DCMAKE_PREFIX_PATH=${ROCM_PATH}" \
+            "-DCMAKE_LIBRARY_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib" \
             -DENABLE_TESTS=ON \
             -DINSTALL_TESTS=ON \
             "-DENABLE_SANITIZER=${{ matrix.sanitizer.enable_sanitizer }}" \


### PR DESCRIPTION
## Motivation

The CI and sanitizer workflows unpack TheRock nightly ROCm, which already ships elfutils under `lib/rocm_sysdeps`. Building the native collector against that copy keeps the toolchain consistent with the ROCm stack under test and removes the distro `libdw-dev` dependency.

## Technical Details

- Point `PKG_CONFIG_PATH` and `CMAKE_LIBRARY_PATH` at `${ROCM_PATH}/lib/rocm_sysdeps/lib` in `rocprofiler-compute-continuous-integration.yml` and `rocprofiler-compute-sanitizers.yml`
- Drop `libdw-dev` from those workflows; `pkg-config` is still required by `src/lib/CMakeLists.txt`
- `CMAKE_LIBRARY_PATH` is required because TheRock's `libdw.pc` and `libelf.pc` carry a leaked absolute `libdir` from the build machine. `PKG_CONFIG_PATH` alone resolves the headers from sysdeps but the library from `/usr/lib`
- The rhel, ubuntu-jammy, and tarball workflows install classic ROCm and have no sysdeps tree, so they keep their distro dev packages

## Issue Tracking

JIRA ID : N/A

## Test Plan

- Configure and build `src/lib` locally with the flags the workflows now pass, against a TheRock ROCm install
- Inspect the resulting `librocprofiler-compute-tool.so` linkage

## Test Result

- Works locally. Configure reports `Found libdw: .../rocm_sysdeps/lib/libdw.so`, the build links clean, and the collector records `NEEDED librocm_sysdeps_dw.so.1` resolving inside sysdeps with no system libdw

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
