### PR TITLE
workaround(rocprofiler-systems): Remove `closeSymtab`

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -149,6 +149,8 @@ rocprofsys_get_is_executable(const std::string& _cmd, bool _default_v)
         if(Dyninst::SymtabAPI::Symtab::openFile(_symtab, _cmd.data()))
         {
             _is_executable = _symtab->isExecutable() && _symtab->isExec();
+            // Workaround introduced in ROCm/rocm-systems#10171
+            // Tracking with JIRA AIPROFSYST-730
             // Dyninst::SymtabAPI::Symtab::closeSymtab(_symtab);
         }
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -149,7 +149,7 @@ rocprofsys_get_is_executable(const std::string& _cmd, bool _default_v)
         if(Dyninst::SymtabAPI::Symtab::openFile(_symtab, _cmd.data()))
         {
             _is_executable = _symtab->isExecutable() && _symtab->isExec();
-            Dyninst::SymtabAPI::Symtab::closeSymtab(_symtab);
+            // Dyninst::SymtabAPI::Symtab::closeSymtab(_symtab);
         }
     }
     return _is_executable;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Since #9996 was merged, `trace-time-window` is failing in ASan:

See results from my investigation: https://github.com/ROCm/rocm-systems/pull/8749#issuecomment-5294669836

I've investigated the runtime-instrument/binary-rewrite failure. The condition fix (https://github.com/ROCm/rocm-systems/pull/9996/changes#diff-7aa9eb486d6498bd67d85737c680f982343d2304dcb9548367fbaebdd2f067d8R137) in https://github.com/ROCm/rocm-systems/pull/9996 enabled a previously-dead branch that now calls closeSymtab on the target binary before Dyninst opens it for the real rewrite. This is exposing an existing bug (the PR itself is NOT a problem).

Calling that is destructive: closeSymtab -> ~Symtab -> MappedFile::closeMappedFile -> munmap of the file image, but hte Elf_X object survives because Elf_X::end() is a no-op upstream. Dyninst's DwarfHandle::all_dwarf_handles cache is keyed only on filename, so the reopen returns the cached handle still pointing at the dead Elf_X. The crash lands when _fini triggers lazy type parsing and gelf_getehdr reads the unmapped image

Commenting out closeSymtab is a sound workaround for now (https://github.com/ROCm/rocm-systems/blame/develop/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp#L152) (it leaks one Symtab, mostly harmless), but the real fix belongs in Dyninst... createDwarfHandle must not reuse a cached handle bound to a different Elf_X.

I tested the workaround and the problem vanishes. I'll have to get to work on the dyninst side of things.

## Why only ASan ?

Because without ASan the kernel hands the same address back, so the dangling pointer accidentally lands on a valid, byte-identical remapping of the same file. The bug is always present ... ASan just stops it from being silently benign.

Here's the traced mmap/munmap sequence for the target binary, same build, same command, ASLR disabled in both:
```
without ASan                                  with ASan
  MMAP   0x7ffff7f76000  (109648)               MMAP   0x7ffff22ab000  (109648)
  MMAP   0x7ffff7082000  (second open)          MMAP   0x7ffff2290000  (second open)
  MUNMAP 0x7ffff7f76000  <- closeSymtab         MUNMAP 0x7ffff22ab000  <- closeSymtab
  MMAP   0x7ffff7f76000  <- SAME ADDRESS        MMAP   0x7fffefc0d000  <- different address
```
Causes failure.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

As a workaround, until I can handle dyninst, comment out `closeSymtab`.

(Yes there is a `close_symtab_file` function in our code, but that is unused, so I will not touch it).

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-730

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local + workflows

## Test Result
Local: Error no longer observed, tests pass 100% of the time.
Workflows: See logs
<!-- Briefly summarize test outcomes. -->

<img width="877" height="127" alt="image" src="https://github.com/user-attachments/assets/69d29547-cfc4-40d5-8266-be0ef4cd049c" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
