### PR TITLE
fix(amdsmi): AMDSMI Check and fix crashes

### DIFF
--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6225,6 +6225,7 @@ amdsmi_status_t amdsmi_get_gpu_ecc_status(amdsmi_processor_handle processor_hand
  *  @param[in,out] status_string A pointer to a const char * which will be made
  *  to point to a description of the provided error code
  *
+ *  @retval ::AMDSMI_STATUS_INVAL if @p status_string is NULL
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2001,6 +2001,10 @@ static rsmi_status_t set_power_profile(uint32_t dv_ind, rsmi_power_profile_prese
 }
 
 static rsmi_status_t topo_get_numa_node_number(uint32_t dv_ind, uint32_t* numa_node_number) {
+  if (numa_node_number == nullptr) {
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+
   TRY
 
       GET_DEV_AND_KFDNODE_FROM_INDX
@@ -5009,6 +5013,9 @@ rsmi_status_t rsmi_dev_counter_destroy(rsmi_event_handle_t evnt_handle) {
 
 rsmi_status_t rsmi_counter_control(rsmi_event_handle_t evt_handle, rsmi_counter_command_t cmd,
                                    void* /*unused*/) {
+  if (evt_handle == 0) {
+    return RSMI_STATUS_INVALID_ARGS;
+  }
   TRY
 
       amd::smi::evt::Event* evt = reinterpret_cast<amd::smi::evt::Event*>(evt_handle);
@@ -5018,10 +5025,6 @@ rsmi_status_t rsmi_counter_control(rsmi_event_handle_t evt_handle, rsmi_counter_
   REQUIRE_ROOT_ACCESS
 
   int ret = 0;
-
-  if (evt_handle == 0) {
-    return RSMI_STATUS_INVALID_ARGS;
-  }
 
   switch (cmd) {
     case RSMI_CNTR_CMD_START:
@@ -7624,7 +7627,6 @@ rsmi_status_t rsmi_dev_metrics_header_info_get(uint32_t dv_ind,
   ostrstream << __PRETTY_FUNCTION__ << "| ======= start =======";
   LOG_TRACE(ostrstream);
 
-  assert(header_value != nullptr);
   if (header_value == nullptr) {
     return rsmi_status_t::RSMI_STATUS_INVALID_ARGS;
   }
@@ -7648,7 +7650,6 @@ rsmi_status_t rsmi_dev_metrics_xcd_counter_get(uint32_t dv_ind, uint16_t* xcd_co
   ostrstream << __PRETTY_FUNCTION__ << "| ======= start =======";
   LOG_TRACE(ostrstream);
 
-  assert(xcd_counter_value != nullptr);
   if (xcd_counter_value == nullptr) {
     return rsmi_status_t::RSMI_STATUS_INVALID_ARGS;
   }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -321,6 +321,9 @@ amdsmi_status_t amdsmi_shut_down() {
 }
 
 amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string) {
+  if (status_string == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
   switch (status) {
     case AMDSMI_STATUS_SUCCESS:
       *status_string = "AMDSMI_STATUS_SUCCESS: Call succeeded.";

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -7758,6 +7758,9 @@ amdsmi_status_t amdsmi_get_cpucore_handles(uint32_t* cores_count,
 }
 
 amdsmi_status_t amdsmi_get_esmi_err_msg(amdsmi_status_t status, const char** status_string) {
+  if (status_string == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
   for (const auto& iter : amd::smi::esmi_status_map) {
     const amdsmi_status_t _status = status;
     if (static_cast<int>(iter.first) == static_cast<int>(_status)) {

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Null out-pointer contract for the error-string helpers: a NULL status_string
+// must return AMDSMI_STATUS_INVAL instead of being dereferenced. No GPU required.
+
+#include <gtest/gtest.h>
+
+#include "amd_smi/amdsmi.h"
+
+namespace {
+
+TEST(SystemUnit, StatusCodeToStringRejectsNullOutPtr) {
+  EXPECT_EQ(amdsmi_status_code_to_string(AMDSMI_STATUS_SUCCESS, nullptr), AMDSMI_STATUS_INVAL);
+}
+
+TEST(SystemUnit, StatusCodeToStringValidOutPtr) {
+  const char* msg = nullptr;
+  EXPECT_EQ(amdsmi_status_code_to_string(AMDSMI_STATUS_SUCCESS, &msg), AMDSMI_STATUS_SUCCESS);
+  EXPECT_NE(msg, nullptr);
+}
+
+TEST(SystemUnit, EsmiErrMsgRejectsNullOutPtr) {
+  EXPECT_EQ(amdsmi_get_esmi_err_msg(AMDSMI_STATUS_SUCCESS, nullptr), AMDSMI_STATUS_INVAL);
+}
+
+}  // namespace


### PR DESCRIPTION
## Motivation
Several AMD SMI / ROCm SMI entry points dereferenced caller-supplied output
pointers (or event handles) before validating them. When a caller passed a
`NULL` pointer or a zero handle, the library dereferenced invalid memory and
crashed instead of returning an error. This makes the API brittle for callers
that pass unset pointers and violates the contract that these functions should
report `INVALID_ARGS` rather than fault.

## Technical Details
Add missing argument validation and correct the ordering of an existing check
so that invalid inputs return an error code instead of crashing:

**`rocm_smi/src/rocm_smi.cc`**
- `topo_get_numa_node_number`: guard `numa_node_number` for `NULL` before
  writing through it. The public wrapper `rsmi_topo_get_numa_node_number`
  forwards the pointer unchecked, so a `NULL` argument previously reached the
  write and crashed. Now returns `RSMI_STATUS_INVALID_ARGS`.
- `rsmi_counter_control`: move the `evt_handle == 0` check ahead of the
  `reinterpret_cast` and `evt->dev_ind()` dereference. Previously the check ran
  after the event was already dereferenced under the mutex lock, so a zero
  handle faulted before the guard was reached.
- `rsmi_dev_metrics_header_info_get` / `rsmi_dev_metrics_xcd_counter_get`:
  remove redundant `assert(... != nullptr)` calls that duplicated the following
  runtime `NULL` checks. The asserts could abort debug builds on a condition
  already handled gracefully with `RSMI_STATUS_INVALID_ARGS`.

**`src/amd_smi/amd_smi.cc`**
- `amdsmi_status_code_to_string`: guard `status_string` for `NULL` before
  dereferencing it, returning `AMDSMI_STATUS_INVAL`.

## Issue Tracking

JIRA ID : ROCM-29570

## Test Plan

Run C++ test: amdsmitst

## Test Result
All tests ran as expected


