### PR TITLE
ci(rocprofiler-compute): Resolve ROCm sysdeps in the tool CMake project

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -231,7 +231,6 @@ jobs:
           git config --global --add safe.directory ${PWD}
           PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH \
           LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib:$LD_LIBRARY_PATH \
-          PKG_CONFIG_PATH=${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib/pkgconfig:$PKG_CONFIG_PATH \
           python3 ./tools/run-ci.py \
             --name "ROCm/rocprofiler-compute-${{ github.ref_name }}-ubuntu-${{ matrix.system.os-release }}-${{ matrix.system.gpu }}" \
             --actor "${{ github.actor }}" \
@@ -242,7 +241,6 @@ jobs:
             -- \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
-            -DCMAKE_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib/rocm_sysdeps/lib \
             -DENABLE_TESTS=ON \
             -DINSTALL_TESTS=ON \
             -DPYTEST_NUMPROCS=8 \

--- a/.github/workflows/rocprofiler-compute-rhel.yml
+++ b/.github/workflows/rocprofiler-compute-rhel.yml
@@ -76,7 +76,7 @@ jobs:
           yum -y install cmake3
           yum -y install which
           yum -y install glibc-langpack-en
-          yum -y install elfutils-devel pkgconf-pkg-config
+          yum -y install elfutils-devel zlib-devel pkgconf-pkg-config
 
       - name: Install ROCm Packages
         timeout-minutes: 30

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -176,7 +176,6 @@ jobs:
 
           export PATH="${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}"
           export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocm_sysdeps/lib:${{ steps.sanitizer_runtime.outputs.sanitizer_lib_dir }}:${LD_LIBRARY_PATH:-}"
-          export PKG_CONFIG_PATH="${ROCM_PATH}/lib/rocm_sysdeps/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
           c_compiler="$(command -v amdclang)"
           cxx_compiler="$(command -v amdclang++)"
@@ -195,7 +194,6 @@ jobs:
             "-DCMAKE_HIP_COMPILER=${cxx_compiler}" \
             -DCMAKE_BUILD_TYPE=Debug \
             "-DCMAKE_PREFIX_PATH=${ROCM_PATH}" \
-            "-DCMAKE_LIBRARY_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib" \
             -DENABLE_TESTS=ON \
             -DINSTALL_TESTS=ON \
             "-DENABLE_SANITIZER=${{ matrix.sanitizer.enable_sanitizer }}" \

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -85,7 +85,7 @@ jobs:
           apt-get install -y /tmp/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
           apt-get update
           apt install -y rocm-dev
-          apt install -y libdw-dev pkg-config
+          apt install -y libdw-dev zlib1g-dev pkg-config
           echo "✅ ROCm Dependencies Installed!"
 
       - name: Install Python
@@ -147,7 +147,7 @@ jobs:
           apt-get install -y /tmp/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
           apt-get update
           apt install -y rocm-dev
-          apt install -y libdw-dev pkg-config
+          apt install -y libdw-dev zlib1g-dev pkg-config
           echo "✅ ROCm Dependencies Installed!"
 
       - name: Python dependency installs

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -53,7 +53,7 @@ jobs:
           apt-get install -y git
           apt-get install -y python3-pip
           apt-get install -y cmake
-          apt-get install -y libdw-dev pkg-config
+          apt-get install -y libdw-dev zlib1g-dev pkg-config
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/projects/rocprofiler-compute/src/lib/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/CMakeLists.txt
@@ -11,6 +11,18 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} "/opt/rocm/")
 
+# TheRock ROCm bundles elfutils and zlib under lib/rocm_sysdeps; prefer them
+# when present, otherwise fall through to the distro packages.
+foreach(rocm_root IN LISTS CMAKE_PREFIX_PATH)
+    if(IS_DIRECTORY "${rocm_root}/lib/rocm_sysdeps/lib")
+        list(PREPEND CMAKE_LIBRARY_PATH "${rocm_root}/lib/rocm_sysdeps/lib")
+        set(ENV{PKG_CONFIG_PATH}
+            "${rocm_root}/lib/rocm_sysdeps/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"
+        )
+        break()
+    endif()
+endforeach()
+
 # libdw has no upstream CMake config and the SDK's bundled Findlibdw.cmake is
 # brittle across pkg-config / multiarch layouts. Define libdw::libdw via
 # pkg-config up front so the SDK's internal find_package(libdw) check finds


### PR DESCRIPTION
## Motivation

`NativeToolFinder` builds the collector at test time with a bare `cmake -S src/lib -B src/lib/_build`, which receives no CMake flags. #10170 supplied the sysdeps path via the workflows, so that second build never saw it and failed to link once `libdw-dev` was dropped. Moving the detection into the project fixes both builds and users building against TheRock outside CI.

## Technical Details

- Detect `${ROCm}/lib/rocm_sysdeps` in `src/lib/CMakeLists.txt` and prefer it for `libdw`, `libelf`, and `zlib`; fall back to distro packages when absent
- Drop the now-redundant `PKG_CONFIG_PATH` and `CMAKE_LIBRARY_PATH` plumbing from the CI and sanitizer workflows; `LD_LIBRARY_PATH` and `pkg-config` stay
- Add zlib dev packages to the rhel, tarball, and ubuntu-jammy workflows
- Works with both tarball and pip wheel ROCm layouts, since detection keys off the `CMAKE_PREFIX_PATH` entries the file already builds

## Issue Tracking

JIRA ID : N/A

## Test Plan

- Build `src/lib` from scratch with `PKG_CONFIG_PATH` and `CMAKE_LIBRARY_PATH` unset, reproducing the runtime build's environment
- Inspect the resulting `librocprofiler-compute-tool.so` linkage
- Confirm the fallback path with no sysdeps tree present

## Test Result

- Works locally against a wheel ROCm install. Configure and build succeed with no env set, and the collector records `NEEDED librocm_sysdeps_dw.so.1` with a RUNPATH into sysdeps, chosen over the system `libdw` present on the box
- With no sysdeps tree, `libdw`/`libelf` resolve from the distro packages

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.