### PR TITLE
Add symmetric buffer registration functional test

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -172,6 +172,7 @@ declare -A TEST_NUMBERS=(
   ["tile_reduce"]="155"
   ["tile_reduce_wave"]="156"
   ["tile_reduce_wg"]="157"
+  ["buffer_register_symmetric"]="162"
 )
 
 # Detect which runtime to use
@@ -252,6 +253,37 @@ AdjustGridBarrierProblemSize() {
 
 # Router function - dispatches to appropriate implementation
 ExecTest() {
+  if [[ "$1" == "buffer_register_symmetric" ]]; then
+    local selected_backend="${ROCSHMEM_BACKEND:-${ROCSHMEM_BACKEND_TYPE:-$TEST}}"
+    if [[ "$selected_backend" == ro* ]]; then
+      echo "Skip:   buffer_register_symmetric (RO backend is unsupported)"
+      return
+    fi
+
+    local rocm_version=""
+    if [[ -x "$ROCSHMEM_INFO" ]]; then
+      rocm_version=$("$ROCSHMEM_INFO" 2>/dev/null |
+        awk -F ':' '/^# ROCm[[:space:]]*:/{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); split($2, fields, " "); print fields[1]; exit}')
+    fi
+
+    local rocm_major=0
+    local rocm_minor=0
+    IFS='.' read -r rocm_major rocm_minor _ <<< "$rocm_version"
+    if (( rocm_major < 7 || (rocm_major == 7 && rocm_minor < 2) )); then
+      echo "Skip:   buffer_register_symmetric (requires ROCm 7.2 or newer)"
+      return
+    fi
+
+    if [ $USE_SLR -ne 1 ]; then
+      if ! command -v nm >/dev/null ||
+         ! nm -D "$APP" 2>/dev/null |
+           awk '$NF == "PMIx_Init" { found = 1 } END { exit !found }'; then
+        echo "Skip:   buffer_register_symmetric (MPI UUID bootstrap requires PMIx)"
+        return
+      fi
+    fi
+  fi
+
   if [ $USE_SLR -eq 1 ]; then
     ExecTest_SLR "$@"
   else
@@ -318,6 +350,9 @@ ExecTest_SLR() {
   fi
   if [[ -n "${ROCSHMEM_TEST_USE_DEFAULT_STREAM:-}" ]]; then
     env_vars+=("ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM")
+  fi
+  if [[ "$TEST_NAME" == "buffer_register_symmetric" ]]; then
+    env_vars+=("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix")
   fi
   # Note: ROCSHMEM_TEST_UUID not needed - SLR always uses uniqueid approach
 
@@ -457,6 +492,15 @@ ExecTest_MPI() {
 
   # Build command as an array to avoid command injection with eval
   local -a cmd
+  local -a test_env_args
+  test_env_args=()
+  if [[ "$TEST_NAME" == "buffer_register_symmetric" ]]; then
+    test_env_args+=(
+      -x "ROCSHMEM_TEST_UUID=1"
+      -x "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix"
+    )
+  fi
+
   cmd=( "$LAUNCHER"
         -n "$NUM_RANKS"
         -mca pml "${OMPI_MCA_pml:-ucx}"
@@ -467,6 +511,7 @@ ExecTest_MPI() {
         ${ROCSHMEM_MAX_NUM_HOST_CONTEXTS:+-x "ROCSHMEM_MAX_NUM_HOST_CONTEXTS=$ROCSHMEM_MAX_NUM_HOST_CONTEXTS"}
         ${ROCSHMEM_TEST_USE_DEFAULT_STREAM:+-x "ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM"}
         ${ROCSHMEM_TEST_UUID:+-x "ROCSHMEM_TEST_UUID=$ROCSHMEM_TEST_UUID"}
+        "${test_env_args[@]}"
         ${TIMEOUT:+--timeout "$TIMEOUT"}
         ${HOSTFILE:+--hostfile "$HOSTFILE"}
         --map-by numa
@@ -932,6 +977,7 @@ TestOther() {
   ##############################################################################
   ExecTest  "init"             2       1            1
   ExecTest  "library_info"     2       1            1
+  ExecTest  "buffer_register_symmetric" 2  1         1
   ExecTest  "hipmodule_init"   2       1            1
   ExecTest  "device_bitcode"   2       1            1
   ExecTest  "device_bitcode"   2       32           1024

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -274,6 +274,19 @@ ExecTest() {
       return
     fi
 
+    if ! command -v rocminfo >/dev/null 2>&1 ||
+       ! rocminfo 2>/dev/null |
+         awk -F ':' '
+           /^[[:space:]]*VMM Support[[:space:]]*:/ {
+             gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+             if (toupper($2) == "YES") found = 1
+           }
+           END { exit !found }
+         '; then
+      echo "Skip:   buffer_register_symmetric (HIP VMM is unavailable)"
+      return
+    fi
+
     if [ $USE_SLR -ne 1 ]; then
       if ! command -v nm >/dev/null ||
          ! nm -D "$APP" 2>/dev/null |
@@ -328,10 +341,7 @@ ExecTest_SLR() {
 
   NUM_WG=$(AdjustGridBarrierProblemSize "$TEST_NAME" "$NUM_WG" "$NUM_THREADS")
 
-  if [[ "" == "$ROCSHMEM_MAX_NUM_CONTEXTS" ]]
-  then
-    ROCSHMEM_MAX_NUM_CONTEXTS=$NUM_WG
-  fi
+  local max_num_contexts="${ROCSHMEM_MAX_NUM_CONTEXTS:-$NUM_WG}"
 
   # Build command as an array using SLR instead of MPI
   local -a cmd
@@ -340,7 +350,7 @@ ExecTest_SLR() {
   # Build environment variable list
   env_vars=(
     "ROCSHMEM_SLR_NP=$NUM_RANKS"
-    "ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
+    "ROCSHMEM_MAX_NUM_CONTEXTS=$max_num_contexts"
     "ROCSHMEM_HEAP_SIZE=$HEAP_SIZE"
   )
 
@@ -352,7 +362,13 @@ ExecTest_SLR() {
     env_vars+=("ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM")
   fi
   if [[ "$TEST_NAME" == "buffer_register_symmetric" ]]; then
-    env_vars+=("ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix")
+    env_vars+=(
+      "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix"
+      "ROCSHMEM_GDA_ENABLE_DMABUF=1"
+    )
+    if [[ "${selected_backend:-}" == gda* ]]; then
+      env_vars+=("ROCSHMEM_DISABLE_MIXED_IPC=1")
+    fi
   fi
   # Note: ROCSHMEM_TEST_UUID not needed - SLR always uses uniqueid approach
 
@@ -472,10 +488,7 @@ ExecTest_MPI() {
 
   NUM_WG=$(AdjustGridBarrierProblemSize "$TEST_NAME" "$NUM_WG" "$NUM_THREADS")
 
-  if [[ "" == "$ROCSHMEM_MAX_NUM_CONTEXTS" ]]
-  then
-    ROCSHMEM_MAX_NUM_CONTEXTS=$NUM_WG
-  fi
+  local max_num_contexts="${ROCSHMEM_MAX_NUM_CONTEXTS:-$NUM_WG}"
 
   # MPI Parameters
   LAUNCHER=mpirun
@@ -498,14 +511,18 @@ ExecTest_MPI() {
     test_env_args+=(
       -x "ROCSHMEM_TEST_UUID=1"
       -x "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix"
+      -x "ROCSHMEM_GDA_ENABLE_DMABUF=1"
     )
+    if [[ "${selected_backend:-}" == gda* ]]; then
+      test_env_args+=(-x "ROCSHMEM_DISABLE_MIXED_IPC=1")
+    fi
   fi
 
   cmd=( "$LAUNCHER"
         -n "$NUM_RANKS"
         -mca pml "${OMPI_MCA_pml:-ucx}"
         -mca osc "${OMPI_MCA_osc:-ucx}"
-        -x "ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
+        -x "ROCSHMEM_MAX_NUM_CONTEXTS=$max_num_contexts"
         -x "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384"
         -x "ROCSHMEM_HEAP_SIZE=${ROCSHMEM_HEAP_SIZE:-$HEAP_SIZE}"
         ${ROCSHMEM_MAX_NUM_HOST_CONTEXTS:+-x "ROCSHMEM_MAX_NUM_HOST_CONTEXTS=$ROCSHMEM_MAX_NUM_HOST_CONTEXTS"}
@@ -977,7 +994,9 @@ TestOther() {
   ##############################################################################
   ExecTest  "init"             2       1            1
   ExecTest  "library_info"     2       1            1
-  ExecTest  "buffer_register_symmetric" 2  1         1
+  ExecTest  "buffer_register_symmetric" 2  1         1       64
+  ExecTest  "buffer_register_symmetric" 2  2        64       64
+  ExecTest  "buffer_register_symmetric" 4  2        64       64
   ExecTest  "hipmodule_init"   2       1            1
   ExecTest  "device_bitcode"   2       1            1
   ExecTest  "device_bitcode"   2       32           1024

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(
     flood_amo_tester.cpp
     device_bitcode_tester.cpp
     library_info_tester.cpp
+    buffer_register_symmetric_tester.cpp
     fence_ordering_tester.cpp
     tile_rma_tester.cpp
     host_team_sync_barrier_tester.cpp

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -173,6 +173,7 @@ set(TEST_reducescatter_wave 154)
 set(TEST_tile_reduce 155)
 set(TEST_tile_reduce_wave 156)
 set(TEST_tile_reduce_wg 157)
+set(TEST_buffer_register_symmetric 162)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -467,7 +468,7 @@ endfunction()
 ###############################################################################
 
 function(add_rocshmem_functional_test)
-    set(options NO_VERIFY)
+    set(options NO_VERIFY UUID_ONLY)
     set(oneValueArgs NAME RANKS WORKGROUPS THREADS MAX_MSG_SIZE VOLUME_SIZE
                      LOCALBUFTYPE TIMEOUT TIER NUM_WF)  # TIER kept for backward compatibility but ignored
     set(multiValueArgs ENV_VARS EXTRA_LABELS BACKENDS GPUS TEST_VARIANTS)
@@ -504,6 +505,19 @@ function(add_rocshmem_functional_test)
 
     # Generate all variant combinations
     generate_variant_combinations("${global_variants}" "${test_variants}" variant_combinations)
+
+    # Some configurations, such as the VMM POSIX heap, cannot use rocSHMEM's
+    # MPI-based initialization path. Keep only UUID-based combinations for
+    # tests that declare that requirement.
+    if(TEST_UUID_ONLY)
+        set(uuid_combinations "")
+        foreach(combo ${variant_combinations})
+            if(combo STREQUAL "uuid" OR combo MATCHES "^uuid[+]")
+                list(APPEND uuid_combinations "${combo}")
+            endif()
+        endforeach()
+        set(variant_combinations "${uuid_combinations}")
+    endif()
 
     # Create a CTest test for each variant combination
     foreach(combo ${variant_combinations})
@@ -1417,6 +1431,44 @@ function(add_host_tests)
 endfunction()
 
 ###############################################################################
+# Symmetric User Buffer Tests
+###############################################################################
+
+function(add_symmetric_buffer_tests)
+    if(ROCM_MAJOR_VERSION LESS 7 OR
+       (ROCM_MAJOR_VERSION EQUAL 7 AND ROCM_MINOR_VERSION LESS 2))
+        message(STATUS
+            "Skipping buffer_register_symmetric functional test: "
+            "requires ROCm 7.2 or newer")
+        return()
+    endif()
+
+    # In MPI launcher mode test_driver's UUID bootstrap is implemented with
+    # PMIx. SLR always uses UUID initialization.
+    if(NOT USE_SLR_LAUNCHER AND NOT TARGET PMIx::pmix)
+        message(STATUS
+            "Skipping buffer_register_symmetric functional test: "
+            "MPI UUID bootstrap requires PMIx")
+        return()
+    endif()
+
+    begin_test_group(
+        CATEGORY "MEMORY"
+        TIER standard
+        BACKENDS "ipc;gda"
+        GPUS "all"
+        EXTRA_LABELS "RMA" "SYMMETRIC")
+        add_rocshmem_functional_test(
+            NAME buffer_register_symmetric
+            RANKS 2
+            WORKGROUPS 1
+            THREADS 1
+            UUID_ONLY
+            ENV_VARS "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix")
+    end_test_group()
+endfunction()
+
+###############################################################################
 # Register all tests
 ###############################################################################
 
@@ -1428,6 +1480,7 @@ function(register_all_functional_tests)
     add_coll_tests()
     add_stream_tests()
     add_other_tests()
+    add_symmetric_buffer_tests()
     add_heatmap_tests()
     add_tile_tests()
     add_host_tests()

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -1452,19 +1452,39 @@ function(add_symmetric_buffer_tests)
         return()
     endif()
 
+    # GDA must register VMM-backed memory through dmabuf. In a GDA-only build,
+    # force the NIC path so this test cannot pass through mixed IPC instead.
+    set(symmetric_buffer_env
+        "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix"
+        "ROCSHMEM_GDA_ENABLE_DMABUF=1")
+    if(USE_GDA AND NOT USE_IPC)
+        list(APPEND symmetric_buffer_env "ROCSHMEM_DISABLE_MIXED_IPC=1")
+    endif()
+
     begin_test_group(
         CATEGORY "MEMORY"
         TIER standard
         BACKENDS "ipc;gda"
         GPUS "all"
         EXTRA_LABELS "RMA" "SYMMETRIC")
-        add_rocshmem_functional_test(
-            NAME buffer_register_symmetric
-            RANKS 2
-            WORKGROUPS 1
-            THREADS 1
-            UUID_ONLY
-            ENV_VARS "ROCSHMEM_HEAP_ALLOCATOR_TYPE=vmm_posix")
+        foreach(ranks 2 4)
+            add_rocshmem_functional_test(
+                NAME buffer_register_symmetric
+                RANKS ${ranks}
+                WORKGROUPS 1
+                THREADS 1
+                MAX_MSG_SIZE 64
+                UUID_ONLY
+                ENV_VARS ${symmetric_buffer_env})
+            add_rocshmem_functional_test(
+                NAME buffer_register_symmetric
+                RANKS ${ranks}
+                WORKGROUPS 2
+                THREADS 64
+                MAX_MSG_SIZE 64
+                UUID_ONLY
+                ENV_VARS ${symmetric_buffer_env})
+        endforeach()
     end_test_group()
 endfunction()
 

--- a/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.cpp
@@ -1,0 +1,324 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include "buffer_register_symmetric_tester.hpp"
+
+#include <hip/hip_runtime.h>
+#include <rocshmem/rocshmem.hpp>
+
+#include <cstdio>
+
+using namespace rocshmem;
+
+namespace {
+
+constexpr int kValueBase = 1000;
+
+__global__ void BufferRegisterSymmetricTest(int *dest,
+                                            ShmemContextType ctx_type) {
+  __shared__ rocshmem_ctx_t ctx;
+  rocshmem_wg_ctx_create(ctx_type, &ctx);
+
+  if (hipBlockIdx_x == 0 && is_thread_zero_in_block()) {
+    int my_pe = rocshmem_ctx_my_pe(ctx);
+    int n_pes = rocshmem_ctx_n_pes(ctx);
+    int next_pe = (my_pe + 1) % n_pes;
+    rocshmem_ctx_int_p(ctx, dest, kValueBase + my_pe, next_pe);
+    rocshmem_ctx_quiet(ctx);
+  }
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+#if HIP_VERSION >= 70200000
+bool device_supports_vmm(int device_id) {
+  int supported = 0;
+  hipError_t err = hipDeviceGetAttribute(
+      &supported, hipDeviceAttributeVirtualMemoryManagementSupported,
+      device_id);
+  return err == hipSuccess && supported != 0;
+}
+
+bool vmm_alloc(void **ptr, hipMemGenericAllocationHandle_t *handle,
+               size_t requested_size, size_t *allocation_size, int device_id) {
+  hipMemAllocationProp prop = {};
+  prop.type = hipMemAllocationTypePinned;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
+  prop.allocFlags.gpuDirectRDMACapable = 1;
+
+  size_t granularity = 0;
+  if (hipMemGetAllocationGranularity(&granularity, &prop,
+                                     hipMemAllocationGranularityMinimum) !=
+          hipSuccess ||
+      granularity == 0) {
+    return false;
+  }
+
+  size_t size =
+      ((requested_size + granularity - 1) / granularity) * granularity;
+  if (hipMemCreate(handle, size, &prop, 0) != hipSuccess) {
+    return false;
+  }
+
+  void *address = nullptr;
+  if (hipMemAddressReserve(&address, size, 0, 0, 0) != hipSuccess) {
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  if (hipMemMap(address, size, 0, *handle, 0) != hipSuccess) {
+    (void)hipMemAddressFree(address, size);
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  hipMemAccessDesc access_desc[2] = {};
+  access_desc[0].location.type = hipMemLocationTypeDevice;
+  access_desc[0].location.id = device_id;
+  access_desc[0].flags = hipMemAccessFlagsProtReadWrite;
+  access_desc[1].location.type = hipMemLocationTypeHost;
+  access_desc[1].location.id = 0;
+  access_desc[1].flags = hipMemAccessFlagsProtReadWrite;
+
+  if (hipMemSetAccess(address, size, access_desc, 2) != hipSuccess) {
+    (void)hipMemUnmap(address, size);
+    (void)hipMemAddressFree(address, size);
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  *ptr = address;
+  *allocation_size = size;
+  return true;
+}
+
+void vmm_free(void *ptr, hipMemGenericAllocationHandle_t handle, size_t size) {
+  CHECK_HIP(hipMemUnmap(ptr, size));
+  CHECK_HIP(hipMemAddressFree(ptr, size));
+  CHECK_HIP(hipMemRelease(handle));
+}
+#endif
+
+}  // namespace
+
+BufferRegisterSymmetricTester::BufferRegisterSymmetricTester(
+    TesterArguments args)
+    : Tester(args) {
+  _type = BufferRegisterSymmetricTestType;
+  _print_results = false;
+  this->args.min_msg_size = sizeof(int);
+  max_msg_size = sizeof(int);
+
+  if (rocshmem_query_backend_type() == BackendType::RO_BACKEND) {
+    if (this->args.myid == 0) {
+      std::printf("buffer_register_symmetric: SKIPPED "
+                  "(reverse-offload backend is unsupported)\n");
+    }
+    skip_ = true;
+    return;
+  }
+
+#if HIP_VERSION < 70200000
+  if (this->args.myid == 0) {
+    std::printf("buffer_register_symmetric: SKIPPED "
+                "(requires ROCm 7.2 or newer)\n");
+  }
+  skip_ = true;
+  return;
+#else
+  if (!device_supports_vmm(device_id)) {
+    if (this->args.myid == 0) {
+      std::printf("buffer_register_symmetric: SKIPPED "
+                  "(GPU does not support HIP VMM)\n");
+    }
+    skip_ = true;
+    return;
+  }
+
+  if (!vmm_alloc(&original_, &handle_, sizeof(int), &allocation_size_,
+                 device_id)) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: VMM allocation failed\n",
+                 this->args.myid);
+    skip_ = true;
+    rocshmem_global_exit(1);
+    return;
+  }
+
+  registerBuffer();
+#endif
+}
+
+BufferRegisterSymmetricTester::~BufferRegisterSymmetricTester() {
+#if HIP_VERSION >= 70200000
+  if (alias_ != nullptr) {
+    unregisterBuffer();
+  }
+
+  if (original_ != nullptr) {
+    rocshmem_barrier_all();
+    vmm_free(original_, handle_, allocation_size_);
+    original_ = nullptr;
+  }
+#endif
+}
+
+void BufferRegisterSymmetricTester::resetBuffers(
+    [[maybe_unused]] uint64_t size) {
+#if HIP_VERSION >= 70200000
+  if (skip_) {
+    return;
+  }
+
+  CHECK_HIP(hipMemset(original_, 0xff, sizeof(int)));
+  CHECK_HIP(hipDeviceSynchronize());
+#endif
+}
+
+void BufferRegisterSymmetricTester::registerBuffer() {
+#if HIP_VERSION >= 70200000
+  if (skip_) {
+    return;
+  }
+
+  /*
+   * A granularity-aligned hipMalloc allocation isolates the non-VMM rejection
+   * from the API's independent length-alignment validation.
+   */
+  void *plain_buffer = nullptr;
+  CHECK_HIP(hipMalloc(&plain_buffer, allocation_size_));
+  void *plain_alias =
+      rocshmem_buffer_register_symmetric(plain_buffer, allocation_size_);
+  if (plain_alias != nullptr) {
+    int unregister_status =
+        rocshmem_buffer_unregister_symmetric(plain_alias);
+    if (unregister_status == ROCSHMEM_SUCCESS) {
+      CHECK_HIP(hipFree(plain_buffer));
+    }
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: accepted non-VMM memory\n",
+                 args.myid);
+    skip_ = true;
+    rocshmem_global_exit(1);
+    return;
+  }
+  CHECK_HIP(hipFree(plain_buffer));
+
+  alias_ = static_cast<int *>(
+      rocshmem_buffer_register_symmetric(original_, allocation_size_));
+  if (alias_ == nullptr) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: VMM registration failed\n",
+                 args.myid);
+    skip_ = true;
+    rocshmem_global_exit(1);
+    return;
+  }
+
+  if (alias_ == original_) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: returned the original "
+                 "address instead of a managed alias\n",
+                 args.myid);
+    pass_ = false;
+  }
+#endif
+}
+
+void BufferRegisterSymmetricTester::launchKernel(
+    [[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
+    [[maybe_unused]] int loop, [[maybe_unused]] uint64_t size) {
+#if HIP_VERSION >= 70200000
+  if (skip_) {
+    return;
+  }
+
+  hipLaunchKernelGGL(BufferRegisterSymmetricTest, gridSize, blockSize, 0, stream,
+                     alias_, _shmem_context);
+  num_msgs = 1;
+  num_timed_msgs = 1;
+#endif
+}
+
+void BufferRegisterSymmetricTester::verifyResults(
+    [[maybe_unused]] uint64_t size) {
+#if HIP_VERSION >= 70200000
+  if (skip_) {
+    return;
+  }
+
+  int received = -1;
+  CHECK_HIP(
+      hipMemcpy(&received, original_, sizeof(int), hipMemcpyDeviceToHost));
+  int previous_pe = (args.myid - 1 + args.numprocs) % args.numprocs;
+  int expected = kValueBase + previous_pe;
+  if (received != expected) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: received %d, expected "
+                 "%d from PE %d\n",
+                 args.myid, received, expected, previous_pe);
+    pass_ = false;
+  }
+#endif
+}
+
+void BufferRegisterSymmetricTester::unregisterBuffer() {
+#if HIP_VERSION >= 70200000
+  int unregister_status = rocshmem_buffer_unregister_symmetric(alias_);
+  if (unregister_status != ROCSHMEM_SUCCESS) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: unregister returned %d\n",
+                 args.myid, unregister_status);
+    rocshmem_global_exit(1);
+    return;
+  }
+  alias_ = nullptr;
+
+  constexpr int kPostUnregisterValue = 0x13579bdf;
+  int post_unregister_value = 0;
+  CHECK_HIP(hipMemcpy(original_, &kPostUnregisterValue, sizeof(int),
+                      hipMemcpyHostToDevice));
+  CHECK_HIP(hipMemcpy(&post_unregister_value, original_, sizeof(int),
+                      hipMemcpyDeviceToHost));
+  if (post_unregister_value != kPostUnregisterValue) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: original VMM allocation "
+                 "is unusable after unregister\n",
+                 args.myid);
+    pass_ = false;
+  }
+
+  if (!pass_) {
+    rocshmem_global_exit(1);
+    return;
+  }
+
+  if (args.myid == 0) {
+    std::printf("PASS: symmetric VMM buffer registration, remote RMA, and "
+                "unregistration succeeded\n");
+  }
+#endif
+}

--- a/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.cpp
@@ -27,26 +27,38 @@
 #include <hip/hip_runtime.h>
 #include <rocshmem/rocshmem.hpp>
 
+#include <algorithm>
 #include <cstdio>
+#include <limits>
+#include <vector>
 
 using namespace rocshmem;
 
 namespace {
 
-constexpr int kValueBase = 1000;
+unsigned char source_pattern(int pe, size_t worker, size_t byte) {
+  return static_cast<unsigned char>(
+      (static_cast<size_t>(pe) + worker + byte) & 0xff);
+}
 
-__global__ void BufferRegisterSymmetricTest(int *dest,
+__global__ void BufferRegisterSymmetricTest(unsigned char *dest,
+                                            const unsigned char *source,
+                                            size_t message_size,
                                             ShmemContextType ctx_type) {
   __shared__ rocshmem_ctx_t ctx;
   rocshmem_wg_ctx_create(ctx_type, &ctx);
 
-  if (hipBlockIdx_x == 0 && is_thread_zero_in_block()) {
-    int my_pe = rocshmem_ctx_my_pe(ctx);
-    int n_pes = rocshmem_ctx_n_pes(ctx);
-    int next_pe = (my_pe + 1) % n_pes;
-    rocshmem_ctx_int_p(ctx, dest, kValueBase + my_pe, next_pe);
-    rocshmem_ctx_quiet(ctx);
-  }
+  const size_t worker =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t offset = worker * message_size;
+  int my_pe = rocshmem_ctx_my_pe(ctx);
+  int n_pes = rocshmem_ctx_n_pes(ctx);
+  int next_pe = (my_pe + 1) % n_pes;
+
+  rocshmem_ctx_putmem(ctx, dest + offset, source + offset, message_size,
+                      next_pe);
+  rocshmem_ctx_quiet(ctx);
+  __syncthreads();
 
   rocshmem_wg_ctx_destroy(&ctx);
 }
@@ -54,10 +66,10 @@ __global__ void BufferRegisterSymmetricTest(int *dest,
 #if HIP_VERSION >= 70200000
 bool device_supports_vmm(int device_id) {
   int supported = 0;
-  hipError_t err = hipDeviceGetAttribute(
+  CHECK_HIP(hipDeviceGetAttribute(
       &supported, hipDeviceAttributeVirtualMemoryManagementSupported,
-      device_id);
-  return err == hipSuccess && supported != 0;
+      device_id));
+  return supported != 0;
 }
 
 bool vmm_alloc(void **ptr, hipMemGenericAllocationHandle_t *handle,
@@ -130,7 +142,21 @@ BufferRegisterSymmetricTester::BufferRegisterSymmetricTester(
   _type = BufferRegisterSymmetricTestType;
   _print_results = false;
   this->args.min_msg_size = sizeof(int);
-  max_msg_size = sizeof(int);
+  max_msg_size =
+      args.max_msg_size_set
+          ? std::max(args.max_msg_size, this->args.min_msg_size)
+          : this->args.min_msg_size;
+  worker_count_ = static_cast<size_t>(args.num_wgs) * args.wg_size;
+
+  if (worker_count_ == 0 ||
+      max_msg_size > std::numeric_limits<size_t>::max() / worker_count_) {
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: invalid buffer size\n",
+                 this->args.myid);
+    rocshmem_global_exit(1);
+    return;
+  }
+  const size_t requested_size = worker_count_ * max_msg_size;
 
   if (rocshmem_query_backend_type() == BackendType::RO_BACKEND) {
     if (this->args.myid == 0) {
@@ -141,24 +167,17 @@ BufferRegisterSymmetricTester::BufferRegisterSymmetricTester(
     return;
   }
 
-#if HIP_VERSION < 70200000
-  if (this->args.myid == 0) {
-    std::printf("buffer_register_symmetric: SKIPPED "
-                "(requires ROCm 7.2 or newer)\n");
-  }
-  skip_ = true;
-  return;
-#else
+#if HIP_VERSION >= 70200000
   if (!device_supports_vmm(device_id)) {
-    if (this->args.myid == 0) {
-      std::printf("buffer_register_symmetric: SKIPPED "
-                  "(GPU does not support HIP VMM)\n");
-    }
-    skip_ = true;
+    std::fprintf(stderr,
+                 "[PE %d] buffer_register_symmetric: GPU does not support "
+                 "HIP VMM; launcher preflight should have skipped this test\n",
+                 this->args.myid);
+    rocshmem_global_exit(1);
     return;
   }
 
-  if (!vmm_alloc(&original_, &handle_, sizeof(int), &allocation_size_,
+  if (!vmm_alloc(&original_, &handle_, requested_size, &allocation_size_,
                  device_id)) {
     std::fprintf(stderr,
                  "[PE %d] buffer_register_symmetric: VMM allocation failed\n",
@@ -168,7 +187,15 @@ BufferRegisterSymmetricTester::BufferRegisterSymmetricTester(
     return;
   }
 
+  source_ = static_cast<unsigned char *>(alloc_test_buffer(allocation_size_));
   registerBuffer();
+#else
+  if (this->args.myid == 0) {
+    std::printf("buffer_register_symmetric: SKIPPED "
+                "(requires ROCm 7.2 or newer)\n");
+  }
+  skip_ = true;
+  return;
 #endif
 }
 
@@ -183,18 +210,33 @@ BufferRegisterSymmetricTester::~BufferRegisterSymmetricTester() {
     vmm_free(original_, handle_, allocation_size_);
     original_ = nullptr;
   }
+  if (source_ != nullptr) {
+    free_test_buffer(source_);
+    source_ = nullptr;
+  }
 #endif
 }
 
 void BufferRegisterSymmetricTester::resetBuffers(
-    [[maybe_unused]] uint64_t size) {
+    uint64_t size) {
 #if HIP_VERSION >= 70200000
   if (skip_) {
     return;
   }
 
-  CHECK_HIP(hipMemset(original_, 0xff, sizeof(int)));
-  CHECK_HIP(hipDeviceSynchronize());
+  const size_t buffer_size = worker_count_ * size;
+  std::vector<unsigned char> source(buffer_size);
+  for (size_t worker = 0; worker < worker_count_; ++worker) {
+    for (size_t byte = 0; byte < size; ++byte) {
+      source[worker * size + byte] =
+          source_pattern(args.myid, worker, byte);
+    }
+  }
+
+  CHECK_HIP(hipMemsetAsync(original_, 0, buffer_size, stream));
+  CHECK_HIP(hipMemcpyAsync(source_, source.data(), buffer_size,
+                           hipMemcpyHostToDevice, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 #endif
 }
 
@@ -212,6 +254,8 @@ void BufferRegisterSymmetricTester::registerBuffer() {
   CHECK_HIP(hipMalloc(&plain_buffer, allocation_size_));
   void *plain_alias =
       rocshmem_buffer_register_symmetric(plain_buffer, allocation_size_);
+  // The expected rejection of non-VMM memory may leave a HIP error pending.
+  (void)hipGetLastError();
   if (plain_alias != nullptr) {
     int unregister_status =
         rocshmem_buffer_unregister_symmetric(plain_alias);
@@ -227,7 +271,7 @@ void BufferRegisterSymmetricTester::registerBuffer() {
   }
   CHECK_HIP(hipFree(plain_buffer));
 
-  alias_ = static_cast<int *>(
+  alias_ = static_cast<unsigned char *>(
       rocshmem_buffer_register_symmetric(original_, allocation_size_));
   if (alias_ == nullptr) {
     std::fprintf(stderr,
@@ -250,37 +294,48 @@ void BufferRegisterSymmetricTester::registerBuffer() {
 
 void BufferRegisterSymmetricTester::launchKernel(
     [[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
-    [[maybe_unused]] int loop, [[maybe_unused]] uint64_t size) {
+    int loop, uint64_t size) {
 #if HIP_VERSION >= 70200000
   if (skip_) {
     return;
   }
 
   hipLaunchKernelGGL(BufferRegisterSymmetricTest, gridSize, blockSize, 0, stream,
-                     alias_, _shmem_context);
-  num_msgs = 1;
-  num_timed_msgs = 1;
+                     alias_, source_, size, _shmem_context);
+  num_msgs = (loop + args.skip) * worker_count_;
+  num_timed_msgs = loop * worker_count_;
 #endif
 }
 
 void BufferRegisterSymmetricTester::verifyResults(
-    [[maybe_unused]] uint64_t size) {
+    uint64_t size) {
 #if HIP_VERSION >= 70200000
   if (skip_) {
     return;
   }
 
-  int received = -1;
-  CHECK_HIP(
-      hipMemcpy(&received, original_, sizeof(int), hipMemcpyDeviceToHost));
+  const size_t buffer_size = worker_count_ * size;
+  std::vector<unsigned char> received(buffer_size);
+  CHECK_HIP(hipMemcpy(received.data(), original_, buffer_size,
+                      hipMemcpyDeviceToHost));
   int previous_pe = (args.myid - 1 + args.numprocs) % args.numprocs;
-  int expected = kValueBase + previous_pe;
-  if (received != expected) {
-    std::fprintf(stderr,
-                 "[PE %d] buffer_register_symmetric: received %d, expected "
-                 "%d from PE %d\n",
-                 args.myid, received, expected, previous_pe);
-    pass_ = false;
+  for (size_t worker = 0; worker < worker_count_; ++worker) {
+    for (size_t byte = 0; byte < size; ++byte) {
+      const unsigned char expected =
+          source_pattern(previous_pe, worker, byte);
+      const unsigned char actual = received[worker * size + byte];
+      if (actual != expected) {
+        std::fprintf(
+            stderr,
+            "[PE %d] buffer_register_symmetric: offset %zu received %u, "
+            "expected %u from PE %d\n",
+            args.myid, worker * size + byte,
+            static_cast<unsigned int>(actual),
+            static_cast<unsigned int>(expected), previous_pe);
+        pass_ = false;
+        return;
+      }
+    }
   }
 #endif
 }
@@ -297,13 +352,16 @@ void BufferRegisterSymmetricTester::unregisterBuffer() {
   }
   alias_ = nullptr;
 
-  constexpr int kPostUnregisterValue = 0x13579bdf;
-  int post_unregister_value = 0;
-  CHECK_HIP(hipMemcpy(original_, &kPostUnregisterValue, sizeof(int),
-                      hipMemcpyHostToDevice));
-  CHECK_HIP(hipMemcpy(&post_unregister_value, original_, sizeof(int),
+  // Verify unregister leaves the original VMM allocation usable.
+  constexpr unsigned char kPostUnregisterValue = 0xa5;
+  CHECK_HIP(hipMemset(original_, kPostUnregisterValue, allocation_size_));
+  std::vector<unsigned char> post_unregister(allocation_size_);
+  CHECK_HIP(hipMemcpy(post_unregister.data(), original_, allocation_size_,
                       hipMemcpyDeviceToHost));
-  if (post_unregister_value != kPostUnregisterValue) {
+  if (!std::all_of(post_unregister.begin(), post_unregister.end(),
+                   [](unsigned char value) {
+                     return value == kPostUnregisterValue;
+                   })) {
     std::fprintf(stderr,
                  "[PE %d] buffer_register_symmetric: original VMM allocation "
                  "is unusable after unregister\n",
@@ -316,9 +374,17 @@ void BufferRegisterSymmetricTester::unregisterBuffer() {
     return;
   }
 
+  // Do not print PASS while another PE may still report a local failure.
+  rocshmem_barrier_all();
+
   if (args.myid == 0) {
-    std::printf("PASS: symmetric VMM buffer registration, remote RMA, and "
-                "unregistration succeeded\n");
+    if (args.verif) {
+      std::printf("PASS: symmetric VMM buffer registration, remote RMA, and "
+                  "unregistration succeeded\n");
+    } else {
+      std::printf("PASS: symmetric VMM buffer registration, RMA launch, and "
+                  "unregistration succeeded (data verification disabled)\n");
+    }
   }
 #endif
 }

--- a/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.hpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _BUFFER_REGISTER_SYMMETRIC_TESTER_HPP_
+#define _BUFFER_REGISTER_SYMMETRIC_TESTER_HPP_
+
+#include "tester.hpp"
+
+class BufferRegisterSymmetricTester : public Tester {
+ public:
+  explicit BufferRegisterSymmetricTester(TesterArguments args);
+  ~BufferRegisterSymmetricTester() override;
+
+ protected:
+  void resetBuffers(uint64_t size) override;
+  void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                    uint64_t size) override;
+  void verifyResults(uint64_t size) override;
+
+ private:
+  void registerBuffer();
+  void unregisterBuffer();
+
+  bool skip_{false};
+  bool pass_{true};
+  void *original_{nullptr};
+  int *alias_{nullptr};
+  size_t allocation_size_{0};
+#if HIP_VERSION >= 70200000
+  hipMemGenericAllocationHandle_t handle_{};
+#endif
+};
+
+#endif  // _BUFFER_REGISTER_SYMMETRIC_TESTER_HPP_

--- a/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/buffer_register_symmetric_tester.hpp
@@ -45,8 +45,10 @@ class BufferRegisterSymmetricTester : public Tester {
   bool skip_{false};
   bool pass_{true};
   void *original_{nullptr};
-  int *alias_{nullptr};
+  unsigned char *alias_{nullptr};
+  unsigned char *source_{nullptr};
   size_t allocation_size_{0};
+  size_t worker_count_{0};
 #if HIP_VERSION >= 70200000
   hipMemGenericAllocationHandle_t handle_{};
 #endif

--- a/projects/rocshmem/tests/functional_tests/test_wrapper.sh
+++ b/projects/rocshmem/tests/functional_tests/test_wrapper.sh
@@ -153,6 +153,29 @@ if [[ "$BACKEND" == "ro" ]]; then
     esac
 fi
 
+# The vmm_posix allocator aborts during rocSHMEM initialization on unsupported
+# hardware. Check VMM support first so CTest can report a proper skip instead.
+case "$TEST_NAME" in
+    buffer_register_symmetric_*)
+        if ! command -v rocminfo >/dev/null 2>&1 ||
+           ! rocminfo 2>/dev/null |
+             awk -F ':' '
+               /^[[:space:]]*VMM Support[[:space:]]*:/ {
+                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+                 if (toupper($2) == "YES") found = 1
+               }
+               END { exit !found }
+             '; then
+            echo "Skip: $TEST_NAME (HIP VMM is unavailable)"
+            exit $SKIP_CODE
+        fi
+
+        if [[ "$BACKEND" == "gda" ]]; then
+            export ROCSHMEM_DISABLE_MIXED_IPC=1
+        fi
+        ;;
+esac
+
 # AIROCSHMEM-120: RO get tests abort
 if [[ "$BACKEND" == "ro" ]]; then
     case "$TEST_NAME" in

--- a/projects/rocshmem/tests/functional_tests/test_wrapper.sh
+++ b/projects/rocshmem/tests/functional_tests/test_wrapper.sh
@@ -143,6 +143,16 @@ if [[ "$BACKEND" == "ro" || "$BACKEND" == "gda" ]]; then
     esac
 fi
 
+# Symmetric user-buffer registration is unsupported by the RO backend
+if [[ "$BACKEND" == "ro" ]]; then
+    case "$TEST_NAME" in
+        buffer_register_symmetric_*)
+            echo "Skip: $TEST_NAME (RO does not support symmetric buffer registration)"
+            exit $SKIP_CODE
+            ;;
+    esac
+fi
+
 # AIROCSHMEM-120: RO get tests abort
 if [[ "$BACKEND" == "ro" ]]; then
     case "$TEST_NAME" in

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -74,6 +74,7 @@
 #include "hipmodule_init_tester.hpp"
 #include "device_bitcode_tester.hpp"
 #include "library_info_tester.hpp"
+#include "buffer_register_symmetric_tester.hpp"
 #include "fence_ordering_tester.hpp"
 #include "tile_rma_tester.hpp"
 #include "tile_broadcast_tester.hpp"
@@ -864,6 +865,10 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       test_name = "Library Info Test";
       testers.push_back(new LibraryInfoTester(args));
       break;
+    case BufferRegisterSymmetricTestType:
+      test_name = "Buffer Register Symmetric Test";
+      testers.push_back(new BufferRegisterSymmetricTester(args));
+      break;
     case FenceOrderPutWaveSignalTestType:
       test_name = "Fence PutWaveSignal Ordering";
       testers.push_back(new FenceOrderingTester(args));
@@ -1165,6 +1170,7 @@ bool Tester::peLaunchesKernel() {
     case FloodFAddTestType:
     case FloodWaitAmoTestType:
     case DeviceBitcodeTestType:
+    case BufferRegisterSymmetricTestType:
     case FenceOrderPutWaveSignalTestType:
     case FenceOrderPutLargeSmallTestType:
     case FenceOrderFanoutTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -203,8 +203,8 @@
   X(QpPingPong,                158)  \
   X(QpPutNbi,                  159)  \
   X(SdmaPingPong,              160)  \
-  X(SdmaPutNbi,                161)
-
+  X(SdmaPutNbi,                161)  \
+  X(BufferRegisterSymmetric,   162)
 
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -352,6 +352,7 @@ void TesterArguments::get_arguments() {
     case FloodFAddTestType:
     case FloodWaitAmoTestType:
     case DeviceBitcodeTestType:
+    case BufferRegisterSymmetricTestType:
     case TeamCtxSharedInfraTestType:
     case FenceOrderFanoutTestType:
     case TeamSplit2DTestType:

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -92,6 +92,7 @@ test_categories:
       # Specialized tests
       - "shmemptr_.*"
       - "library_info_.*"
+      - "buffer_register_symmetric_.*"
       - "hipmodule_init_.*"
 
     labels:


### PR DESCRIPTION
## Motivation
- Add functional coverage for `rocshmem_buffer_register_symmetric` and verify registered VMM buffers work as remote RMA targets.

## Technical Details
- Adds a symmetric buffer registration functional test.
- Verifies non-VMM memory is rejected.
- Registers VMM memory and performs remote RMA through the returned alias.
- Verifies deregistration and continued access to the original allocation.
- Adds CTest and legacy functional driver integration.
- Supports IPC and GDA; skips unsupported configurations.

## Issue Tracking
- JIRA ID: AIROCSHMEM-490

## Test Plan
- Run the functional test with `IPC` and `GDA`.
- Verify registration, remote RMA, deregistration, and VMM cleanup.
- Confirm the test skips RO.

## Test Result
- Successfully tested with `IPC` and `GDA`.
- `RO` is skipped because symmetric buffer registration is unsupported.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
