### PR TITLE
ci: add Express Train cherry-pick trigger

### DIFF
--- a/.github/workflows/express_train_request.yml
+++ b/.github/workflows/express_train_request.yml
@@ -1,0 +1,57 @@
+# Generated callers must pin both rockrel references below to the same reviewed
+# immutable commit SHA. Use scripts/render_express_train_workflow.py.
+name: Express Train cherry-pick request
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-24.04
+    outputs:
+      trains: ${{ steps.labels.outputs.trains }}
+    steps:
+      - name: Select Express Train labels from event metadata
+        id: labels
+        env:
+          ACTION: ${{ github.event.action }}
+          EVENT_LABEL: ${{ github.event.label.name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          labels = json.loads(os.environ["PR_LABELS"])
+          event_label = os.environ.get("EVENT_LABEL", "")
+          if event_label.startswith("express-train:"):
+              labels.append(event_label)
+          trains = sorted({label.split(":", 1)[1] for label in labels if label.startswith("express-train:")})
+          print(f"trains={json.dumps(trains)}")
+          PY
+
+  process:
+    needs: discover
+    if: needs.discover.outputs.trains != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        train: ${{ fromJSON(needs.discover.outputs.trains) }}
+    uses: ROCm/rockrel/.github/workflows/express_train_cherry_pick.yml@ac438b9eb759b4c4acbcf3e5b917e7ce0360d516
+    with:
+      source_pr: ${{ github.event.pull_request.html_url }}
+      train_id: ${{ matrix.train }}
+      automation_ref: ac438b9eb759b4c4acbcf3e5b917e7ce0360d516
+      mode: create-draft
+      event_action: ${{ github.event.action }}
+    secrets:
+      ROCM_CHERRYPICK_APP_ID: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
+      ROCM_CHERRYPICK_APP_PRIVATE_KEY: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+      ROCM_CHERRYPICK_JIRA_URL: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+      ROCM_CHERRYPICK_JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the thin, GitHub-native pull_request_target trigger for Express Train labels. All qualification, Git, and draft-only behavior remains centralized in ROCm/rockrel.

## Security

- never checks out or executes source PR head code
- passes only named secrets
- pins rockrel to immutable commit ac438b9eb759b4c4acbcf3e5b917e7ce0360d516
- fans out only labels in the express-train namespace
- generated cherry-pick PRs remain drafts

## Validation

- rendered from the reviewed rockrel template
- actionlint passes
- immutable pin and forbidden-reference assertions pass
- git diff --check passes

## Dependency

Depends on draft ROCm/rockrel#93 and organization GitHub App/secret configuration. The initial train is validate-only, so this workflow cannot mint a write token or create a cherry-pick branch yet.

This PR is intentionally a draft. Do not mark it ready before operator and security review.