### PR TITLE
[doc] Update exec_mode description from 'cycle' to 'clocked'

### DIFF
--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -56,7 +56,7 @@ The example above is intentionally minimal and single-threaded.
 |---|---|---|
 | `max_ticks` | int | Maximum simulation ticks (0 = unlimited) |
 | `num_threads` | int | Simdojo engine partitions (one per XCD when partitioned) |
-| `exec_mode` | string | `"functional"` or `"cycle"` |
+| `exec_mode` | string | `"functional"` or `"clocked"` |
 | `vm.arch` | string | Architecture: `cdna3`, `cdna4`, etc. |
 
 ### Simulation threading

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -56,8 +56,12 @@ The example above is intentionally minimal and single-threaded.
 |---|---|---|
 | `max_ticks` | int | Maximum simulation ticks (0 = unlimited) |
 | `num_threads` | int | Simdojo engine partitions (one per XCD when partitioned) |
-| `exec_mode` | string | `"functional"` or `"clocked"` |
+| `exec_mode` | string | Execution mode. Use `"clocked"` for clocked execution; `"functional"` is the default/fallback. |
 | `vm.arch` | string | Architecture: `cdna3`, `cdna4`, etc. |
+
+`exec_mode` is matched literally: only the exact string `"clocked"` selects
+clocked mode. If the field is omitted, set to `"functional"`, or given any
+other value, the simulator runs in functional mode.
 
 ### Simulation threading
 


### PR DESCRIPTION
According to the actual implementation, it should be either "functional" or "clocked", see https://github.com/ROCm/rocm-systems/blob/7ab250c95106c0abe70c255aad2d6a100cd2a851/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp#L693-L695

It uses "functional" if the string is not "clocked".