### PR TITLE
fix(rocr): Keep build-machine paths out of the hsakmt export (ROCM-29513)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists.txt
@@ -243,7 +243,18 @@ else()
 
   find_package(PkgConfig)
   if (UNIX)
-    # Check for libraries required for building
+    # hsakmt is a static library, so every item in its link interface is
+    # re-emitted verbatim into the installed hsakmtTargets.cmake as
+    # $<LINK_ONLY:...> and is then resolved on the *consumer's* machine.
+    # Anything build-machine specific therefore must not reach the interface:
+    # an absolute /usr/lib64/libc.so found on a RHEL builder does not exist on
+    # a Debian/Ubuntu multiarch host, and a pkg-config -L pointing into the CI
+    # runner's workspace exists nowhere at all.  Both break the link for every
+    # consumer of the exported target (ROCM-29513).  Propagate plain link item
+    # names instead and let each consumer's toolchain resolve them per-distro.
+
+    # Check for libraries required for building.  Only the presence of libc is
+    # asserted here; the resolved path is deliberately not propagated.
     find_library(LIBC NAMES c REQUIRED)
     find_package(NUMA)
     if(NUMA_FOUND)
@@ -261,8 +272,22 @@ else()
     else()
       find_library(NUMA NAMES numa REQUIRED)
     endif()
-    message(STATUS "LIBC: " ${LIBC})
+    message(STATUS "LIBC (presence check only, links as plain 'c'): " ${LIBC})
     message(STATUS "NUMA: " ${NUMA})
+
+    # An imported target is safe to propagate as-is: hsakmt-config.cmake
+    # recreates it through find_dependency(NUMA) before loading the export.
+    # Anything else has resolved to an absolute path on this machine, so
+    # export the plain link item instead.
+    set(NUMA_LINK_ITEMS "")
+    foreach(_numa_library IN LISTS NUMA)
+      if(TARGET "${_numa_library}")
+        list(APPEND NUMA_LINK_ITEMS "${_numa_library}")
+      else()
+        list(APPEND NUMA_LINK_ITEMS "numa")
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES NUMA_LINK_ITEMS)
 
     ## If environment variable DRM_DIR is set, the script
     ## will pick up the corresponding libraries from that path.
@@ -277,9 +302,33 @@ else()
     include_directories(${DRM_AMDGPU_INCLUDE_DIRS})
     include_directories(${DRM_INCLUDE_DIRS})
 
+    # Separate pkg-config's link flags into the -l items consumers need and the
+    # -L search paths, which are valid only on this build machine.  The search
+    # paths still have to reach in-tree consumers (hsa-runtime64 links
+    # hsakmt::hsakmt from the build tree), so keep them behind BUILD_INTERFACE:
+    # they apply while building and vanish from the installed export.
+    set(DRM_LINK_ITEMS "")
+    set(DRM_SEARCH_PATHS "")
+    foreach(_drm_ldflag IN LISTS DRM_LDFLAGS DRM_AMDGPU_LDFLAGS)
+      if(_drm_ldflag MATCHES "^-L")
+        list(APPEND DRM_SEARCH_PATHS "${_drm_ldflag}")
+      else()
+        list(APPEND DRM_LINK_ITEMS "${_drm_ldflag}")
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES DRM_SEARCH_PATHS)
+
     target_link_libraries ( ${HSAKMT_TARGET}
-      PRIVATE ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} pthread rt ${LIBC} ${NUMA} ${CMAKE_DL_LIBS}
+      PRIVATE ${DRM_LINK_ITEMS} pthread rt c ${NUMA_LINK_ITEMS} ${CMAKE_DL_LIBS}
     )
+
+    # One entry per path: a genex wrapping a ;-separated list would rely on
+    # CMake's list splitting looking inside $<...>, which is needless subtlety.
+    foreach(_drm_search_path IN LISTS DRM_SEARCH_PATHS)
+      target_link_libraries ( ${HSAKMT_TARGET}
+        INTERFACE "$<BUILD_INTERFACE:${_drm_search_path}>"
+      )
+    endforeach()
 
     target_compile_options(${HSAKMT_TARGET} PRIVATE ${DRM_CFLAGS} ${HSAKMT_C_FLAGS})
 


### PR DESCRIPTION
JIRA ID : ROCM-29513

## Problem

`hsakmt` is a static library, so its `PRIVATE` link libraries are re-emitted verbatim into the installed `hsakmtTargets.cmake` as `$<LINK_ONLY:...>` and resolved on the **consumer's** machine. Three build-machine-specific items leak into that interface. From the shipped ROCm 10.1.0 package:

```cmake
INTERFACE_LINK_LIBRARIES "-L/__w/rockrel/rockrel/build/third-party/sysdeps/linux/libdrm/build/stage/lib/rocm_sysdeps/lib/pkgconfig/../../lib;$<LINK_ONLY:-ldrm>;-L/__w/rockrel/rockrel/build/...;$<LINK_ONLY:-ldrm_amdgpu>;$<LINK_ONLY:pthread>;$<LINK_ONLY:rt>;/usr/lib64/libc.so;$<LINK_ONLY:numa::numa>;$<LINK_ONLY:dl>"
```

1. **`/usr/lib64/libc.so`** — `find_library(LIBC NAMES c)` resolves to an absolute path. On the RHEL-based release builder that is `/usr/lib64/libc.so`, which does not exist on a Debian/Ubuntu multiarch host (libc is at `/usr/lib/x86_64-linux-gnu/libc.so`).
2. **`-L/__w/rockrel/rockrel/build/...`** — the libdrm pkg-config search paths are the CI runner's workspace, which exists on no customer machine.
3. **absolute libnuma path** — `find_library(NUMA NAMES numa)` when NUMA is not found as an imported target. 0adba114d0 (#8559) fixed the imported-target case; this covers the remaining one.

Every CMake consumer of the exported target fails at link. Compilation succeeds; only the link step breaks:

```
make[2]: *** No rule to make target '/usr/lib64/libc.so', needed by 'kfdtest'.  Stop.
```

This is ASIC-independent and reproduces on any clean Debian/Ubuntu host. Hosts that appear to work are masking it with a manually created `/usr/lib64/libc.so` symlink — check `ls -l /usr/lib64/libc.so` before concluding it does not reproduce.

## Fix

Propagate plain link item names and let each consumer's toolchain resolve them per-distro:

- Link plain `c` instead of the resolved absolute path. `find_library(LIBC ...)` is retained purely for its configure-time presence check.
- Split the pkg-config LDFLAGS: `-l` items stay in the interface, `-L` search paths move behind `$<BUILD_INTERFACE:>`. They are still needed in the build tree, where `hsa-runtime64` links `hsakmt::hsakmt` directly, but vanish from the installed export.
- Map a non-target NUMA result to plain `numa`. An imported target is still propagated as-is, since `hsakmt-config.cmake` recreates it via `find_dependency(NUMA)`.

Resulting installed export, with no machine-specific content left:

```cmake
INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:-ldrm>;$<LINK_ONLY:-ldrm_amdgpu>;$<LINK_ONLY:pthread>;$<LINK_ONLY:rt>;$<LINK_ONLY:c>;$<LINK_ONLY:numa>;$<LINK_ONLY:dl>"
```

## Testing

On Ubuntu 24.04.3 multiarch, no `/usr/lib64/libc.so` symlink present:

- **Reproduced** the reported failure verbatim — a minimal CMake consumer against the shipped-style export fails with `No rule to make target '/usr/lib64/libc.so'`.
- **Consumer links** against the fixed export; resulting link line is `-ldrm -ldrm_amdgpu -lpthread -lrt -lc -lnuma -ldl`, fully distro-neutral.
- **kfdtest**, the consumer the ticket reports as blocked, builds clean against the fixed export and runs on hardware (MI300X): `KFDTopologyTest` 8/8 pass.
- **No in-tree regression** — full `rocr-runtime` build succeeds and `hsa-runtime64`'s link line still carries the libdrm search path from `$<BUILD_INTERFACE:>`.

## Notes

`hsakmt-staticdrm` has the same class of `-L` leak in its exported interface, but there the search paths are load-bearing for `-Wl,-Bstatic` resolution of `libdrm.a`, so changing it carries real risk. Left as a follow-up.

Fixes ROCM-29513. Likely also resolves ROCM-28933; related to ROCM-28623.