### PR TITLE
test(rccl): validate PutSignal and WaitSignal graph replay

### DIFF
--- a/projects/rccl/test/HostApiMPITests.cpp
+++ b/projects/rccl/test/HostApiMPITests.cpp
@@ -11,6 +11,7 @@
  * Tests cover:
  *   W1  - WindowRegisterDeregister: collective register/deregister lifecycle
  *   P1  - SinglePutRank0ToRank1:   basic ncclPutSignal + ncclWaitSignal
+ *   G1  - GraphCaptureReplayPutWait: capture once, replay and verify repeatedly
  *   P2  - PutWithNonZeroOffset:    peerWinOffset at kSize/2
  *   P3  - PutMultipleDataTypes:    float32, int32, float16 (raw bytes)
  *   S1  - SignalOnlyNoData:        ncclSignal with no data transfer
@@ -277,6 +278,119 @@ TEST_F(HostApiTest, SinglePutRank0ToRank1)
     ASSERT_MPI_TRUE(ok);
 
     TEST_INFO("P1 rank %d: SinglePutRank0ToRank1 passed.", myRank);
+}
+
+// ============================================================================
+// G1 — GraphCaptureReplayPutWait
+// ============================================================================
+
+/**
+ * @test HostApiTest.GraphCaptureReplayPutWait
+ * @brief Capture ncclPutSignal/ncclWaitSignal once and replay repeatedly.
+ *
+ * Rank 0 captures a PUT into rank 1's window while rank 1 captures the
+ * matching wait.  Each replay uses a different source pattern, proving that
+ * the graph performs a fresh transfer rather than exposing data left by the
+ * first launch.  No eager Put/Wait warm-up is issued before capture.
+ */
+TEST_F(HostApiTest, GraphCaptureReplayPutWait)
+{
+    constexpr int kReplayCount = 10;
+
+    if(!validateTestPrerequisites(/*min=*/2, /*max=*/2))
+    {
+        GTEST_SKIP() << "Need exactly 2 MPI processes";
+    }
+
+    const int   myRank = rank();
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    void* winBuf = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, allocFineGrainBuffer(&winBuf, kOneMB));
+    auto winBufGuard = makeScopeGuard([&]() { freeFineGrainBuffer(winBuf); });
+
+    ncclWindow_t win = nullptr;
+    NcclWindowGuard wg(comm, winBuf, kOneMB, &win, winMode());
+    ASSERT_MPI_NE(win, nullptr);
+    ASSERT_MPI_EQ(ncclSuccess, wg.initResult());
+
+    void* srcBuf = static_cast<uint8_t*>(winBuf) + kSendOffset;
+    void* dstBuf = static_cast<uint8_t*>(winBuf) + kRecvOffset;
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+    bool captureActive = false;
+
+    auto graphCleanup = makeScopeGuard([&]() {
+        if(captureActive)
+        {
+            hipGraph_t abandonedGraph = nullptr;
+            if(hipStreamEndCapture(stream, &abandonedGraph) == hipSuccess && abandonedGraph)
+                (void)hipGraphDestroy(abandonedGraph);
+        }
+        if(graphExec)
+            (void)hipGraphExecDestroy(graphExec);
+        if(graph)
+            (void)hipGraphDestroy(graph);
+    });
+
+    hipError_t captureRes = hipStreamBeginCapture(stream, hipStreamCaptureModeThreadLocal);
+    captureActive = (captureRes == hipSuccess);
+    ASSERT_MPI_EQ(hipSuccess, captureRes);
+
+    ncclResult_t rmaRes = ncclSuccess;
+    if(myRank == 0)
+    {
+        rmaRes = ncclPutSignal(srcBuf, kTransferSize, ncclUint8,
+                               /*peer=*/1, win, /*peerWinOffset=*/kRecvOffset,
+                               kSigIdx, kCtx, kFlags, comm, stream);
+    }
+    else
+    {
+        ncclWaitSignalDesc_t desc{/*opCnt=*/1, /*peer=*/0, kSigIdx, kCtx};
+        rmaRes = ncclWaitSignal(/*nDesc=*/1, &desc, comm, stream);
+    }
+    ASSERT_MPI_EQ(ncclSuccess, rmaRes);
+
+    captureRes = hipStreamEndCapture(stream, &graph);
+    captureActive = false;
+    ASSERT_MPI_EQ(hipSuccess, captureRes);
+    ASSERT_MPI_NE(nullptr, graph);
+
+    size_t numNodes = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numNodes));
+    ASSERT_MPI_GT(numNodes, 0u);
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    ASSERT_MPI_NE(nullptr, graphExec);
+
+    for(int replay = 0; replay < kReplayCount; ++replay)
+    {
+        const int seed = 17 + replay * 31;
+        if(myRank == 0)
+            FillBuf(srcBuf, kTransferSize, seed);
+        else
+            FillSentinel(dstBuf, kTransferSize, 0);
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, stream));
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+        const bool dataValid = (myRank != 1) || VerifyBuf(dstBuf, kTransferSize, seed);
+        ASSERT_MPI_TRUE(dataValid);
+        TEST_INFO("G1 rank %d: replay %d/%d passed.", myRank, replay + 1, kReplayCount);
+    }
+
+    hipError_t destroyRes = hipGraphExecDestroy(graphExec);
+    graphExec = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, destroyRes);
+
+    destroyRes = hipGraphDestroy(graph);
+    graph = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, destroyRes);
+
+    TEST_INFO("G1 rank %d: GraphCaptureReplayPutWait passed.", myRank);
 }
 
 // ============================================================================

--- a/projects/rccl/test/HostApiMPITests.cpp
+++ b/projects/rccl/test/HostApiMPITests.cpp
@@ -383,12 +383,14 @@ TEST_F(HostApiTest, GraphCaptureReplayPutWait)
     }
 
     hipError_t destroyRes = hipGraphExecDestroy(graphExec);
+    if(destroyRes == hipSuccess)
+        graphExec = nullptr;
     ASSERT_MPI_EQ(hipSuccess, destroyRes);
-    graphExec = nullptr;
 
     destroyRes = hipGraphDestroy(graph);
+    if(destroyRes == hipSuccess)
+        graph = nullptr;
     ASSERT_MPI_EQ(hipSuccess, destroyRes);
-    graph = nullptr;
 
     TEST_INFO("G1 rank %d: GraphCaptureReplayPutWait passed.", myRank);
 }

--- a/projects/rccl/test/HostApiMPITests.cpp
+++ b/projects/rccl/test/HostApiMPITests.cpp
@@ -373,7 +373,7 @@ TEST_F(HostApiTest, GraphCaptureReplayPutWait)
         else
             FillSentinel(dstBuf, kTransferSize, 0);
 
-        MPI_Barrier(MPI_COMM_WORLD);
+        ASSERT_MPI_SUCCESS(MPI_Barrier(MPI_COMM_WORLD));
         ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, stream));
         ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
@@ -383,12 +383,12 @@ TEST_F(HostApiTest, GraphCaptureReplayPutWait)
     }
 
     hipError_t destroyRes = hipGraphExecDestroy(graphExec);
-    graphExec = nullptr;
     ASSERT_MPI_EQ(hipSuccess, destroyRes);
+    graphExec = nullptr;
 
     destroyRes = hipGraphDestroy(graph);
-    graph = nullptr;
     ASSERT_MPI_EQ(hipSuccess, destroyRes);
+    graph = nullptr;
 
     TEST_INFO("G1 rank %d: GraphCaptureReplayPutWait passed.", myRank);
 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -789,6 +789,7 @@
       "tests": [
         {"name": "HostApi_WindowRegisterDeregister", "description": "Host API: window register/deregister", "test_filter": "HostApiTest.WindowRegisterDeregister"},
         {"name": "HostApi_SinglePutRank0ToRank1", "description": "Host API: single put rank0 to rank1", "test_filter": "HostApiTest.SinglePutRank0ToRank1"},
+        {"name": "HostApi_GraphCaptureReplayPutWait", "description": "Host API: graph capture and repeated replay of PutSignal/WaitSignal", "test_filter": "HostApiTest.GraphCaptureReplayPutWait", "timeout": 180},
         {"name": "HostApi_PutSignalEnqueueIsAsync", "description": "Host API: putSignal enqueue is async", "test_filter": "HostApiTest.PutSignalEnqueueIsAsync"},
         {"name": "HostApi_PutWithNonZeroOffset", "description": "Host API: put with non-zero offset", "test_filter": "HostApiTest.PutWithNonZeroOffset"},
         {"name": "HostApi_PutMultipleDataTypes", "description": "Host API: put multiple data types", "test_filter": "HostApiTest.PutMultipleDataTypes"},
@@ -826,6 +827,20 @@
       "env_variables": {
         "NCCL_CUMEM_ENABLE": "0"
       }
+    },
+    "host_api_graph_proxy": {
+      "extends": "net_ib_base",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "RCCL_RMA_USE_DMABUF": "1"
+      },
+      "tests": [
+        {"name": "HostApi_GraphCaptureReplayPutWait_Proxy", "description": "Host API: two-node proxy graph capture and repeated replay", "test_filter": "HostApiTest.GraphCaptureReplayPutWait"}
+      ]
     },
 
     "unit_tests_standard": {
@@ -4284,6 +4299,12 @@
       "name": "Host API Tests - Default",
       "description": "Host API tests with default memory support",
       "config": "host_api_tests_default",
+      "enabled": true
+    },
+    {
+      "name": "Host API Graph Capture - Proxy",
+      "description": "Two-node proxy graph capture and repeated replay for PutSignal/WaitSignal",
+      "config": "host_api_graph_proxy",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -4305,6 +4305,10 @@
       "name": "Host API Graph Capture - Proxy",
       "description": "Two-node proxy graph capture and repeated replay for PutSignal/WaitSignal",
       "config": "host_api_graph_proxy",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

NCCL 2.30 added graph capture and replay support for the one-sided `ncclPutSignal` and `ncclWaitSignal` Host APIs. RCCL had the implementation but no end-to-end regression coverage proving that captured operations execute again on every replay and release their persistent graph resources correctly.

## Technical Details

- Add a two-rank MPI test that captures `ncclPutSignal` on rank 0 and the matching `ncclWaitSignal` on rank 1 without an eager warm-up.
- Instantiate the graph once, replay it ten times with a different payload each time, and verify the receiver observes every new payload.
- Validate graph node creation and explicit graph/graph-exec destruction, with failure-safe cleanup for partially captured graphs.
- Register the test in the existing CUMEM on/off Host API suites and add a dedicated two-node proxy configuration.

## Issue Tracking

JIRA ID: AICOMRCCL-1832

## Test Plan

- Build `rccl-UnitTestsMPI` for gfx942 with MPI and Host API tests enabled.
- Run `HostApiTest.SinglePutRank0ToRank1` and `HostApiTest.GraphCaptureReplayPutWait` with two ranks on MI300X.
- Validate the test-runner JSON schema, inheritance, and enabled proxy suite.
- Run the graph test against runtimes before and after stream memory-operation capture support as a negative/positive control.

## Test Result

- Build: PASS.
- Eager Host API baseline: PASS.
- Post-support runtime: PASS, including 10/10 graph replays with distinct payloads.
- Pre-support runtime negative control: expected hang after RMA task scheduling; terminated by timeout with exit 137.
- Test-runner configuration: PASS; the proxy suite resolves to exactly one enabled two-node test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
