### PR TITLE
[rocjitsu] Apply MUBUF LDS-load instruction offset to the LDS address

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -6390,7 +6390,7 @@ class CodeGenerator:
             if counter is not None:
                 L.append(f'    d->wait_counter_type = {counter};')
             L.append('    d->lds_dst = true;')
-            L.append('    d->lds_base = wf.m0() + wf.lds_base();')
+            L.append('    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();')
             L.append(f'    d->mtype = {self._mtype_expr()};')
             L.append(f'    d->non_temporal = {nt};')
             L.append(f'    {addr_fn}(inst_, wf, *d);')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/mubuf_exec.cpp
@@ -32,7 +32,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -59,7 +59,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -86,7 +86,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -113,7 +113,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -280,7 +280,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -307,7 +307,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -335,7 +335,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -362,7 +362,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -390,7 +390,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -417,7 +417,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -444,7 +444,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -471,7 +471,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -688,7 +688,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -716,7 +716,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -744,7 +744,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -773,7 +773,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -802,7 +802,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -830,7 +830,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf_exec.cpp
@@ -32,7 +32,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -59,7 +59,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -86,7 +86,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -113,7 +113,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -280,7 +280,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -307,7 +307,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -335,7 +335,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -362,7 +362,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -390,7 +390,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -417,7 +417,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -444,7 +444,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -471,7 +471,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -688,7 +688,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -716,7 +716,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -744,7 +744,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -773,7 +773,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -802,7 +802,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -830,7 +830,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf_exec.cpp
@@ -34,7 +34,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -61,7 +61,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -88,7 +88,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -115,7 +115,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -282,7 +282,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -309,7 +309,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -337,7 +337,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -364,7 +364,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -392,7 +392,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -419,7 +419,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -446,7 +446,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -473,7 +473,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -690,7 +690,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -718,7 +718,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -746,7 +746,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -775,7 +775,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -804,7 +804,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -832,7 +832,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf_exec.cpp
@@ -34,7 +34,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -61,7 +61,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -88,7 +88,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -115,7 +115,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -282,7 +282,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -309,7 +309,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -337,7 +337,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -364,7 +364,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -392,7 +392,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -419,7 +419,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -446,7 +446,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -473,7 +473,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -690,7 +690,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -718,7 +718,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -746,7 +746,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -775,7 +775,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -804,7 +804,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -832,7 +832,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/mubuf_exec.cpp
@@ -33,7 +33,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -60,7 +60,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -87,7 +87,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -114,7 +114,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -241,7 +241,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -268,7 +268,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -296,7 +296,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -323,7 +323,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -351,7 +351,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -378,7 +378,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -405,7 +405,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -432,7 +432,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -649,7 +649,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -677,7 +677,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -705,7 +705,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -734,7 +734,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -763,7 +763,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -791,7 +791,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/mubuf_exec.cpp
@@ -33,7 +33,7 @@ void BufferLoadFormatXMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -60,7 +60,7 @@ void BufferLoadFormatXyMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -87,7 +87,7 @@ void BufferLoadFormatXyzMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -114,7 +114,7 @@ void BufferLoadFormatXyzwMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -241,7 +241,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -268,7 +268,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -296,7 +296,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -323,7 +323,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -351,7 +351,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -378,7 +378,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -405,7 +405,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -432,7 +432,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -649,7 +649,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -677,7 +677,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -705,7 +705,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -734,7 +734,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -763,7 +763,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -791,7 +791,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->is_load = true;
     d->wait_counter_type = amdgpu::WaitCounterType::VMCNT;
     d->lds_dst = true;
-    d->lds_base = wf.m0() + wf.lds_base();
+    d->lds_base = wf.m0() + inst_.offset + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2197,6 +2197,9 @@ constexpr uint32_t v_add_u32(uint32_t vdst, uint32_t s0, uint32_t vs1) {
 constexpr uint32_t v_cndmask_b32(uint32_t vdst, uint32_t s0, uint32_t vs1) {
   return vop2(0, vdst, s0, vs1);
 }
+constexpr uint32_t v_lshlrev_b32(uint32_t vdst, uint32_t s0, uint32_t vs1) {
+  return vop2(18, vdst, s0, vs1);
+}
 
 // VOPC: encoding[31:25]=0x3E, op[24:17], vsrc1[16:9], src0[8:0]
 constexpr uint32_t vopc(uint32_t op, uint32_t src0, uint32_t vsrc1) {
@@ -2224,6 +2227,20 @@ constexpr uint32_t flat_lo(uint32_t op, uint32_t seg = 0, uint32_t sc0 = 0) {
 }
 constexpr uint32_t flat_hi(uint32_t vdst, uint32_t data, uint32_t addr, uint32_t saddr = 0x7F) {
   return (vdst << 24) | (saddr << 16) | (data << 8) | addr;
+}
+
+// MUBUF (64-bit): CDNA layout.
+// dword0: offset[11:0], offen[12], idxen[13], sc0[14], sc1[15], lds[16], nt[17],
+//         op[24:18], encoding[31:26]=0x38
+// dword1: vaddr[7:0], vdata[15:8], srsrc[20:16], acc[23], soffset[31:24]
+constexpr uint32_t mubuf_lo(uint32_t op, uint32_t offset = 0, uint32_t offen = 0,
+                            uint32_t idxen = 0, uint32_t lds = 0) {
+  return (0x38u << 26) | (op << 18) | (lds << 16) | (idxen << 13) | (offen << 12) |
+         (offset & 0xFFFu);
+}
+constexpr uint32_t mubuf_hi(uint32_t vdata, uint32_t vaddr, uint32_t srsrc,
+                            uint32_t soffset = INLINE_CONST(0)) {
+  return (soffset << 24) | (srsrc << 16) | (vdata << 8) | vaddr;
 }
 
 constexpr uint32_t S_WAITCNT_0 = sopp(12, 0);
@@ -3070,6 +3087,61 @@ TEST(AtomicStressTest, GlobalAtomicAdd_MultiWorkgroup) {
 
   uint32_t final_val = f.mem()->read32(TARGET_ADDR);
   EXPECT_EQ(final_val, 1256u) << "1000 + 256 global atomic adds = 1256";
+}
+
+// buffer_load_dword lds: offset:0 -> LDS+0x200, offset:256 -> LDS+0x300; M0 supplies the base.
+TEST(MubufLdsTest, LoadDwordLdsAppliesInstOffset) {
+  constexpr uint64_t kSrcAddr = 0x2000ULL;
+  constexpr uint32_t kRowBytes = 64 * sizeof(uint32_t);
+  constexpr uint32_t kLdsBase = 0x200; // M0
+  constexpr uint32_t kSrd = 4;         // s[4:7]
+  constexpr uint32_t kBufferLoadDword = 20;
+  constexpr uint32_t kM0 = 124;
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+
+  using namespace enc;
+  const uint32_t code[] = {
+      s_mov_b32(SGPR(kSrd), 255),
+      static_cast<uint32_t>(kSrcAddr), // SRD base
+      s_mov_b32(SGPR(kSrd + 1), INLINE_CONST(0)),
+      s_mov_b32(SGPR(kSrd + 2), 255),
+      2 * kRowBytes, // num_records
+      s_mov_b32(SGPR(kSrd + 3), 255),
+      0x00020000u, // word3: dword format
+      s_mov_b32(kM0, 255),
+      kLdsBase,
+      v_lshlrev_b32(1, INLINE_CONST(2), 0), // v1 = lane * 4
+      mubuf_lo(kBufferLoadDword, /*offset=*/0, /*offen=*/1, /*idxen=*/0, /*lds=*/1),
+      mubuf_hi(/*vdata=*/0, /*vaddr=*/1, kSrd / 4),
+      mubuf_lo(kBufferLoadDword, /*offset=*/kRowBytes, /*offen=*/1, /*idxen=*/0, /*lds=*/1),
+      mubuf_hi(/*vdata=*/0, /*vaddr=*/1, kSrd / 4),
+      S_WAITCNT_0,
+      S_ENDPGM,
+  };
+
+  for (std::string_view arch : {"cdna1", "cdna2", "cdna3", "cdna4"}) {
+    SCOPED_TRACE(arch);
+    VmFixture f(arch);
+    uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+
+    for (uint32_t lane = 0; lane < 64; ++lane) {
+      f.mem()->write32(kSrcAddr + lane * 4, 0xA0000000u | lane);
+      f.mem()->write32(kSrcAddr + kRowBytes + lane * 4, 0xB0000000u | lane);
+    }
+    for (uint32_t i = 0; i < 2 * kRowBytes; i += 4)
+      f.cu()->lds().write32(kLdsBase + i, kSentinel);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    queue.dispatch(ko, 64, 64);
+    ASSERT_NO_THROW(f.engine->run());
+
+    for (uint32_t lane = 0; lane < 64; ++lane) {
+      EXPECT_EQ(f.cu()->lds().read32(kLdsBase + lane * 4), 0xA0000000u | lane)
+          << "row 0 lane " << lane;
+      EXPECT_EQ(f.cu()->lds().read32(kLdsBase + kRowBytes + lane * 4), 0xB0000000u | lane)
+          << "row 1 lane " << lane;
+    }
+  }
 }
 
 // Verify that ds_read_b64_tr_b16 with acc=1 writes to AccVGPR (vb+256+vdst),


### PR DESCRIPTION
## Motivation

`buffer_load_* ... lds` ignores the instruction's immediate `offset` when computing the LDS destination address in the simulator. Per the CDNA3/CDNA4 ISA reference guides, §9.1.9 "Memory Buffer Load to LDS":

```
LDS_ADDR = LDSbase + LDS_offset (M0) + inst_offset + (TIDinWave * 4)
MEM_ADDR = Base + mem_offset (soffset) + inst_offset + off_vgpr + stride * (idx_vgpr + TIDinWave)
```

`inst_offset` feeds both addresses (LLVM `IntrinsicsAMDGPU.td`, `int_amdgcn_load_to_lds`, which also covers buffer fat pointers: "imm offset (applied to both input and LDS address)"). Kernels that set M0 once and issue several `buffer_load_dword ... offen offset:0/256/512 lds` to fill consecutive LDS tiles therefore kept overwriting the first tile under the simulator.

## Technical Details

- `lib/python/amdisa/codegen/_generator.py`: the MUBUF LDS-load template now sets `d->lds_base = wf.m0() + inst_.offset + wf.lds_base()`. `soffset` and the VGPR offset stay memory-side only, matching the formula above.
- Regenerated `generated/{cdna1,cdna2,cdna3,cdna4,rdna1,rdna2}/mubuf_exec.cpp` (documented `python -m amdisa --multi ... --gen-isas` flow + clang-format). With the in-tree ISA XMLs the unmodified generator reproduces every checked-in `mubuf*` file byte-for-byte; the only resulting change is that one line in the 18 `buffer_load_*` LDS branches per file. gfx1250's `*_load_async_to_lds_*` (per-lane VGPR LDS address, separate template) and rdna3_5's `buffer_load_lds_*` stubs (`UnimplementedInst`) are untouched; rdna3/rdna4 generate no MUBUF LDS-load path.
- `tests/amdgpu_vm_test.cpp`: `MubufLdsTest.LoadDwordLdsAppliesInstOffset` (CPU-only, cdna1-4): M0 = 0x200, two encoded `buffer_load_dword v1, s[4:7], 0 offen [offset:256] lds` from two distinct source rows, all 64 lanes of both LDS rows checked.

## Issue Tracking

No existing issue; related: #5747 (workgroup `lds_base` term on the same path).

## Test Plan

- `rocjitsu_tests --gtest_filter='MubufLdsTest.*'` before and after the generator change.
- `python -m pytest lib/python/amdisa/tests` and full `ctest` for regressions.

## Test Result

- `MubufLdsTest.LoadDwordLdsAppliesInstOffset`: on unmodified `develop` it fails for all four CDNA targets (lane 0: LDS+0x200 reads 0xB0000000 instead of 0xA0000000 because the `offset:256` load overwrote row 0; LDS+0x300 still holds the 0xDEADBEEF fill); passes with this change.
- Cross-checked on gfx950 hardware (ROCm 7.2.0) with an equivalent inline-asm kernel: the two rows land at LDS+0 and LDS+256 on hardware; the simulator matches only with this change.
- Full `ctest`: no status changes versus `develop` other than the added `MubufLdsTest.LoadDwordLdsAppliesInstOffset`.
- `python -m pytest lib/python/amdisa/tests`: 1319 passed, 46 skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
