### PR TITLE
[rocjitsu] Stabilize simulated doorbell lifecycle

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -214,35 +214,47 @@ jobs:
           ROCMINFO=RocminfoTest
           RCCL_DAEMON=RcclDaemonTest
           EXCLUDED_TESTS="${ROCMINFO}|${RCCL_DAEMON}"
-          SANITIZER_EXCLUDED_TESTS=(
-            "HsaTest\.InitSucceeded"
-            "HsaTest\.GpuAgentFound"
+          COMMON_SANITIZER_EXCLUDED_TESTS=(
             # The hardware-backed tools-hook test cannot initialize ROCR when
             # the launcher and hook use a sanitizer-instrumented process image.
             "HsaHooksTest\.TranslateGfx950Mfma16x16ThroughToolsLib"
             "Cdna4ToCdna3SimulatedDispatchTest\..*"
             "Cdna4ToCdna3DbtGuestTest\..*"
-            "HipMemcpyTest\.RoundTripFloat"
-            "HipMemcpyTest\.RoundTripInt"
-            "HipMemcpyTest\.DeviceToDevice"
-            "HipVectorAddTest\.CorrectResult"
-            "DaemonTest\.HipVectorAdd"
-            "DaemonTest\.HipMemcpyRoundTripFloat"
-            "DaemonTest\.HipMemcpyRoundTripInt"
-            "DaemonTest\.HipMemcpyDeviceToDevice"
-            "DaemonTest\.TwoIndependentClients"
             "DaemonTest\.LoggingPlugin"
             "BfeRegressionTest\.ThreadIdxY"
             "LoggingTest\.dispatch_logged"
             "CvtNarrow\.AllTests"
             "RaceTest\..*"
           )
+          CLANG_ASAN_UBSAN_EXCLUDED_TESTS=(
+            "${COMMON_SANITIZER_EXCLUDED_TESTS[@]}"
+            # Direct HIP clients hang in the Clang sanitizer lane. The daemon
+            # variants complete their functional checks, but the unsymbolized
+            # ROCr library reports process-exit allocations that cannot be
+            # suppressed without hiding all leaks originating in ROCr.
+            "HipMemcpyTest\.RoundTripFloat"
+            "HipMemcpyTest\.RoundTripInt"
+            "HipMemcpyTest\.DeviceToDevice"
+            "HipVectorAddTest\.CorrectResult"
+            "DaemonTest\.HipMemcpyRoundTripFloat"
+            "DaemonTest\.HipMemcpyRoundTripInt"
+            "DaemonTest\.HipMemcpyDeviceToDevice"
+            "DaemonTest\.TwoIndependentClients"
+          )
           TSAN_EXCLUDED_TESTS=(
-            "${SANITIZER_EXCLUDED_TESTS[@]}"
+            "${COMMON_SANITIZER_EXCLUDED_TESTS[@]}"
             # Hardware dispatch reports a TSan race while ROCr tears down its
             # async-event bookkeeping, outside rocjitsu-owned code.
             "HsaTranslateTest\.TranslateAndDispatchVectorAdd"
             "HsaTranslateTest\.TranslateAndDispatchMfma16x16"
+            # Direct HIP test discovery initializes the instrumented ROCr client,
+            # which reports a ConcurrentAsyncEvents race; vector add also exposes
+            # unsynchronized simulator/client buffer access. The daemon variants
+            # use the separately synchronized RPC path and remain enabled.
+            "HipMemcpyTest\.RoundTripFloat"
+            "HipMemcpyTest\.RoundTripInt"
+            "HipMemcpyTest\.DeviceToDevice"
+            "HipVectorAddTest\.CorrectResult"
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"
@@ -251,13 +263,21 @@ jobs:
           TEST_REGEX="${{ matrix.test_regex }}"
           CMAKE_CONFIG_FLAGS=()
           if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
-            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${SANITIZER_EXCLUDED_TESTS[*]}")"
+            if [[ -z "${{ matrix.cxx_compiler }}" || "${{ matrix.cxx_compiler }}" == *clang* ]]; then
+              EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${CLANG_ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
+            else
+              EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${COMMON_SANITIZER_EXCLUDED_TESTS[*]}")"
+            fi
             CMAKE_CONFIG_FLAGS+=(
               -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
             )
           fi
           if [[ "${{ matrix.enable_tsan }}" == "1" ]]; then
+            # The CP reads a stable MAP_SHARED alias rather than the client's
+            # virtual address. TSan keys shadow state by address and therefore
+            # cannot validate the store/load synchronization across those two
+            # aliases; these tests cover lifecycle and teardown races only.
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${TSAN_EXCLUDED_TESTS[*]}")"
           fi
           if [[ -n "${{ matrix.c_compiler }}" ]]; then

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -1136,6 +1136,14 @@ bool GuestKfd::is_doorbell_range(const void *addr, size_t length) const {
   return execution_driver_ && execution_driver_->is_doorbell_range(addr, length);
 }
 
+void *GuestKfd::mmap_replacing_client_doorbell_views(void *addr, size_t length, int prot, int flags,
+                                                     int fd, off_t offset) {
+  if (execution_driver_)
+    return execution_driver_->mmap_replacing_client_doorbell_views(addr, length, prot, flags, fd,
+                                                                   offset);
+  return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
+}
+
 bool GuestKfd::handles_drm_render_minor(uint32_t minor) const {
   if (ready_.load(std::memory_order_acquire) && minor == guest_.drm_render_minor)
     return true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -73,6 +73,10 @@ public:
   /// @brief Return true if a mapping range overlaps a protected doorbell.
   [[nodiscard]] bool is_doorbell_range(const void *addr, size_t length) const override;
 
+  /// @brief Forward fixed-map replacement to the simulated execution driver when present.
+  void *mmap_replacing_client_doorbell_views(void *addr, size_t length, int prot, int flags, int fd,
+                                             off_t offset) override;
+
   /// @brief Return true when @p minor is the configured guest render node.
   [[nodiscard]] bool handles_drm_render_minor(uint32_t minor) const override;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -2966,6 +2966,10 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
       }
     }
   }
+  if ((flags & MAP_FIXED) && addr) {
+    if (auto *driver = InterposerContext::ctx.driver())
+      return driver->mmap_replacing_client_doorbell_views(addr, length, prot, flags, fd, offset);
+  }
   return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -44,9 +44,19 @@ class KfdProcess {
 public:
   /// @brief Per-GPU state within a process.
   struct PerGpuState {
-    void *doorbell_page = nullptr;
+    /// @brief One live client mapping of the canonical doorbell backing.
+    struct DoorbellView {
+      void *page = nullptr;
+      uint64_t gpu_va = 0;
+    };
+
+    /// @brief Canonical shared backing retained for the process lifetime.
+    int doorbell_memfd = -1;
+    /// @brief Every client doorbell view still owned by the mapping layer.
+    std::vector<DoorbellView> doorbell_views;
+    /// @brief Stable driver-side alias used exclusively by the command processor.
+    void *doorbell_monitor_page = nullptr;
     size_t doorbell_page_size = 0;
-    uint64_t doorbell_gpu_va = 0;
     uint64_t next_doorbell_offset = 0;
     std::vector<uint32_t> free_doorbell_offsets;
     uint64_t scratch_backing_va = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
@@ -97,6 +97,12 @@ public:
   /// @brief Return true if a memory range is a KFD doorbell mapping.
   [[nodiscard]] virtual bool is_doorbell_range(const void *addr, size_t length) const = 0;
 
+  /// @brief Perform an ordinary fixed mmap while retiring replaced client doorbell views.
+  /// @details Simulator-backed drivers remove overlapping client views from KFD ownership before
+  /// the mapping is replaced. Drivers without simulated execution pass the mmap through unchanged.
+  virtual void *mmap_replacing_client_doorbell_views(void *addr, size_t length, int prot, int flags,
+                                                     int fd, off_t offset) = 0;
+
   /// @brief Return true if this driver should synthesize /dev/dri/renderD@p minor.
   [[nodiscard]] virtual bool handles_drm_render_minor(uint32_t minor) const = 0;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -59,6 +59,7 @@ RJ_DIAGNOSTIC_POP
 #endif
 #include <thread>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -112,6 +113,80 @@ namespace {
 void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
   return libc_passthrough().mmap(addr, length, prot, flags, fd, offset);
 }
+
+/// @brief Return whether two non-empty half-open address ranges overlap.
+/// @details Uses subtraction instead of computing either end address, avoiding
+/// integer overflow for a malformed range near UINTPTR_MAX.
+bool ranges_overlap(const void *lhs, size_t lhs_size, const void *rhs, size_t rhs_size) {
+  if (lhs_size == 0 || rhs_size == 0)
+    return false;
+  const auto lhs_base = reinterpret_cast<uintptr_t>(lhs);
+  const auto rhs_base = reinterpret_cast<uintptr_t>(rhs);
+  return lhs_base <= rhs_base ? rhs_base - lhs_base < lhs_size : lhs_base - rhs_base < rhs_size;
+}
+
+/// @brief Return whether one non-empty address range fully contains another.
+/// @details Like ranges_overlap(), avoids computing an end address so malformed
+/// ranges near UINTPTR_MAX cannot wrap around.
+bool range_contains(const void *outer, size_t outer_size, const void *inner, size_t inner_size) {
+  if (outer_size == 0 || inner_size == 0)
+    return false;
+  const auto outer_base = reinterpret_cast<uintptr_t>(outer);
+  const auto inner_base = reinterpret_cast<uintptr_t>(inner);
+  if (inner_base < outer_base)
+    return false;
+  const auto offset = inner_base - outer_base;
+  return offset <= outer_size && inner_size <= outer_size - offset;
+}
+
+/// @brief Move-only owner for an mmap until it is published into driver state.
+class UniqueMapping {
+public:
+  UniqueMapping() = default;
+  UniqueMapping(void *addr, size_t size) : addr_(addr), size_(size) {}
+  ~UniqueMapping() { reset(); }
+
+  UniqueMapping(const UniqueMapping &) = delete;
+  UniqueMapping &operator=(const UniqueMapping &) = delete;
+
+  UniqueMapping(UniqueMapping &&other) noexcept
+      : addr_(std::exchange(other.addr_, MAP_FAILED)), size_(std::exchange(other.size_, 0)) {}
+  UniqueMapping &operator=(UniqueMapping &&other) noexcept {
+    if (this != &other) {
+      reset();
+      addr_ = std::exchange(other.addr_, MAP_FAILED);
+      size_ = std::exchange(other.size_, 0);
+    }
+    return *this;
+  }
+
+  [[nodiscard]] explicit operator bool() const { return addr_ != MAP_FAILED; }
+  [[nodiscard]] void *get() const { return addr_; }
+  [[nodiscard]] void *release() {
+    size_ = 0;
+    return std::exchange(addr_, MAP_FAILED);
+  }
+  void reset(void *addr = MAP_FAILED, size_t size = 0) {
+    if (addr_ != MAP_FAILED)
+      libc_passthrough().munmap(addr_, size_);
+    addr_ = addr;
+    size_ = size;
+  }
+
+private:
+  void *addr_ = MAP_FAILED;
+  size_t size_ = 0;
+};
+
+struct PassthroughFdTraits {
+  using handle_type = int;
+
+  static handle_type invalid() noexcept { return -1; }
+  static bool is_valid(handle_type fd) noexcept { return fd >= 0; }
+  static void close(handle_type fd) noexcept { static_cast<void>(libc_passthrough().close(fd)); }
+};
+
+using UniqueDriverFd = util::BasicUniqueHandle<PassthroughFdTraits>;
 
 /// @brief fstat via the real libc, bypassing the interposer.
 /// @details Like safe_mmap: the interposer exports fstat with default visibility,
@@ -460,18 +535,78 @@ bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
   // unprotected against a client mprotect). Snapshot each page/size under
   // alloc_mutex_ so a concurrent dispatch_mmap/dispatch_munmap (which mutate these
   // under the same lock) cannot tear the pointer/size read.
-  const auto query_base = reinterpret_cast<uintptr_t>(addr);
-  const auto query_end = query_base + length;
   std::lock_guard<std::mutex> lock(p->alloc_mutex_);
   for (const auto &gs : p->gpu_state_) {
-    if (!gs.doorbell_page || gs.doorbell_page_size == 0)
-      continue;
-    const auto base = reinterpret_cast<uintptr_t>(gs.doorbell_page);
-    const auto end = base + gs.doorbell_page_size;
-    if (query_base < end && query_end > base)
+    if (ranges_overlap(addr, length, gs.doorbell_monitor_page, gs.doorbell_page_size))
       return true;
+    for (const auto &view : gs.doorbell_views)
+      if (ranges_overlap(addr, length, view.page, gs.doorbell_page_size))
+        return true;
   }
   return false;
+}
+
+void *SimulatedKfd::mmap_replacing_client_doorbell_views(void *addr, size_t length, int prot,
+                                                         int flags, int fd, off_t offset) {
+  auto proc = find_process(local_process_id_);
+  if (!proc)
+    return safe_mmap(addr, length, prot, flags, fd, offset);
+
+  // Serialize the replacement with KFD teardown and doorbell mmap. Keep alloc_mutex_ held through
+  // the real mmap so mprotect/munmap cannot observe a retired view before MAP_FIXED has replaced
+  // it.
+  std::lock_guard<std::mutex> op_lock(proc->op_mutex_);
+  std::lock_guard<std::mutex> alloc_lock(proc->alloc_mutex_);
+
+  for (const auto &gs : proc->gpu_state_) {
+    if (ranges_overlap(addr, length, gs.doorbell_monitor_page, gs.doorbell_page_size)) {
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+    for (const auto &view : gs.doorbell_views) {
+      if (ranges_overlap(addr, length, view.page, gs.doorbell_page_size) &&
+          !range_contains(addr, length, view.page, gs.doorbell_page_size)) {
+        // Doorbell GPU mappings and ownership are tracked for the complete
+        // client view. Replacing only part would leave the remaining CPU range
+        // live but no longer tracked or GPU-mapped.
+        errno = EINVAL;
+        return MAP_FAILED;
+      }
+    }
+  }
+
+  struct RetiredView {
+    size_t gpu_ordinal;
+    size_t page_size;
+    KfdProcess::PerGpuState::DoorbellView view;
+  };
+  std::vector<RetiredView> retired;
+  for (size_t ord = 0; ord < proc->gpu_state_.size(); ++ord) {
+    auto &gs = proc->gpu_state_[ord];
+    for (auto view = gs.doorbell_views.begin(); view != gs.doorbell_views.end();) {
+      if (!ranges_overlap(addr, length, view->page, gs.doorbell_page_size)) {
+        ++view;
+        continue;
+      }
+      retired.push_back({.gpu_ordinal = ord, .page_size = gs.doorbell_page_size, .view = *view});
+      view = gs.doorbell_views.erase(view);
+    }
+  }
+
+  for (const auto &entry : retired)
+    unmap_from_gpu(*proc, entry.view.gpu_va, entry.page_size);
+
+  void *mapped = safe_mmap(addr, length, prot, flags, fd, offset);
+  if (mapped != MAP_FAILED)
+    return mapped;
+
+  int mmap_errno = errno;
+  for (const auto &entry : retired) {
+    map_to_gpu(*proc, entry.view.gpu_va, entry.view.page, entry.page_size, amdgpu::Mtype::UC);
+    proc->gpu_state_[entry.gpu_ordinal].doorbell_views.push_back(entry.view);
+  }
+  errno = mmap_errno;
+  return MAP_FAILED;
 }
 
 bool SimulatedKfd::ensure_fd_created() {
@@ -905,28 +1040,41 @@ int SimulatedKfd::close(uint32_t process_id) {
         });
   }
 
-  // Tear down doorbell pages. The mapped page pointer lives in gpu_state_ (not in
-  // allocations_), so the generic host_ptr teardown above does not cover it — hence
-  // this separate loop. The doorbell page is always driver-created (dispatch_mmap
-  // maps it via safe_mmap in BOTH modes: a memfd MAP_SHARED page in daemon mode, a
-  // fresh MAP_ANONYMOUS page in non-daemon mode), so the driver owns it and must
-  // reclaim it unconditionally on close. Snapshot and clear the fields under
-  // alloc_mutex_ (the lock the doorbell readers use —
-  // is_doorbell_range/dispatch_mmap/dispatch_munmap), then munmap outside the lock
-  // so the syscall does not run while alloc_mutex_ is held.
-  for (auto &gs : proc.gpu_state_) {
-    void *doorbell_page;
+  // Doorbell mappings live in gpu_state_, not allocations_. Snapshot and clear
+  // every client view plus the stable monitor alias under alloc_mutex_, then
+  // release the GPU and CPU mappings outside the lock.
+  for (size_t ord = 0; ord < proc.gpu_state_.size(); ++ord) {
+    auto &gs = proc.gpu_state_[ord];
+    int doorbell_memfd;
+    void *doorbell_monitor_page;
     size_t doorbell_page_size;
+    std::vector<KfdProcess::PerGpuState::DoorbellView> doorbell_views;
     {
       std::lock_guard<std::mutex> alk(proc.alloc_mutex_);
-      doorbell_page = gs.doorbell_page;
+      doorbell_memfd = gs.doorbell_memfd;
+      doorbell_monitor_page = gs.doorbell_monitor_page;
       doorbell_page_size = gs.doorbell_page_size;
-      gs.doorbell_page = nullptr;
-      gs.doorbell_gpu_va = 0;
+      doorbell_views = std::move(gs.doorbell_views);
+      gs.doorbell_memfd = -1;
+      gs.doorbell_monitor_page = nullptr;
       gs.doorbell_page_size = 0;
     }
-    if (doorbell_page && doorbell_page_size)
-      libc_passthrough().munmap(doorbell_page, doorbell_page_size);
+    update_cp_doorbell_base(static_cast<uint32_t>(ord), process_id, nullptr);
+    for (const auto &view : doorbell_views) {
+      if (view.gpu_va && doorbell_page_size)
+        unmap_from_gpu(proc, view.gpu_va, doorbell_page_size);
+      if (view.page != MAP_FAILED && doorbell_page_size)
+        libc_passthrough().munmap(view.page, doorbell_page_size);
+    }
+    if (doorbell_monitor_page && doorbell_page_size)
+      libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
+    if (doorbell_memfd >= 0) {
+      {
+        std::lock_guard<std::mutex> flk(owned_fds_mutex_);
+        owned_fds_.erase(doorbell_memfd);
+      }
+      libc_passthrough().close(doorbell_memfd);
+    }
   }
 
   leaked_queues = queue_ids.size();
@@ -1142,93 +1290,195 @@ void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, i
     uint64_t encoded_gpu =
         (static_cast<uint64_t>(offset) & ~KFD_MMAP_TYPE_MASK) >> KFD_MMAP_GPU_ID_SHIFT;
     uint32_t db_gpu_id = static_cast<uint32_t>(encoded_gpu);
+    if (!find_gpu(db_gpu_id)) {
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
     uint32_t ord = gpu_ordinal(db_gpu_id);
 
+    // Serialize the canonical backing, both mappings, GPU page-table publication,
+    // and CP base update against process teardown and another doorbell mmap.
+    std::lock_guard<std::mutex> op_lock(proc.op_mutex_);
+    if (proc.event_state_.is_closing()) {
+      errno = ENODEV;
+      return MAP_FAILED;
+    }
+
     int doorbell_fd = -1;
+    int source_doorbell_fd = -1;
+    void *monitor_ptr = nullptr;
+    size_t published_size = 0;
     {
       std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
-      for (auto &[handle, alloc] : proc.allocations_) {
-        if ((alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) && alloc.gpu_id == db_gpu_id) {
-          doorbell_fd = alloc.memfd;
-          break;
+      auto &gs = proc.gpu(ord);
+      doorbell_fd = gs.doorbell_memfd;
+      monitor_ptr = gs.doorbell_monitor_page;
+      published_size = gs.doorbell_page_size;
+      if (doorbell_fd < 0) {
+        for (auto &[handle, alloc] : proc.allocations_) {
+          if ((alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) && alloc.gpu_id == db_gpu_id) {
+            source_doorbell_fd = alloc.memfd;
+            break;
+          }
         }
       }
     }
 
-    if (doorbell_fd >= 0) {
-      off_t cur_size = 0;
-      {
-        struct stat st {};
-        if (safe_fstat(doorbell_fd, &st) == 0)
-          cur_size = st.st_size;
-      }
-      if (static_cast<off_t>(length) > cur_size) {
-        if (ftruncate(doorbell_fd, static_cast<off_t>(length)) != 0) {
-          errno = ENOMEM;
+    UniqueDriverFd new_doorbell_fd;
+    if (doorbell_fd < 0) {
+      // Retain a private descriptor even when a KFD doorbell allocation supplied
+      // the source. The allocation can be freed independently; this duplicate keeps
+      // the canonical backing valid until the per-process doorbell state is torn down.
+      UniqueDriverFd created_source;
+      if (source_doorbell_fd < 0) {
+        // Local-mode ROCr can request a doorbell mmap without first allocating a
+        // KFD doorbell object. Give that path the same persistent shared backing.
+        created_source.reset(memfd_create("rocjitsu_doorbell", MFD_CLOEXEC | MFD_ALLOW_SEALING));
+        if (!created_source)
           return MAP_FAILED;
-        }
+        source_doorbell_fd = created_source.get();
       }
-      // Initialize doorbell backing to 0xFF via a temporary mapping. This
-      // avoids SIGBUS on the final MAP_SHARED mmap on Linux 6.17+ where
-      // shmem large folio allocation can fail during a bulk memset on a
-      // freshly-mapped region. Writing through a separate PROT_WRITE
-      // mapping forces page allocation before the final shared mapping.
-      auto *init_ptr = static_cast<uint8_t *>(
-          safe_mmap(nullptr, length, PROT_WRITE, MAP_SHARED, doorbell_fd, 0));
-      if (init_ptr != MAP_FAILED) {
-        std::memset(init_ptr, 0xFF, length);
-        libc_passthrough().munmap(init_ptr, length);
-      }
+      new_doorbell_fd.reset(safe_fcntl(source_doorbell_fd, F_DUPFD_CLOEXEC, 4096));
+      if (!new_doorbell_fd && created_source)
+        new_doorbell_fd = std::move(created_source);
+      if (!new_doorbell_fd)
+        return MAP_FAILED;
+      doorbell_fd = new_doorbell_fd.get();
+    }
+
+    // A process/GPU owns exactly one monitor view. Doorbell mappings have a fixed
+    // KFD page size; rejecting a conflicting remap avoids invalidating live queue
+    // offsets or changing the address polled by the CP.
+    if (monitor_ptr && published_size != length) {
+      new_doorbell_fd.reset();
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+    // MAP_FIXED replaces every existing mapping in its target range. Never let a
+    // client-selected address replace the CP's private alias; that would leave
+    // live queues polling an invalid address.
+    if ((flags & MAP_FIXED) && ranges_overlap(addr, length, monitor_ptr, published_size)) {
+      new_doorbell_fd.reset();
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+
+    off_t cur_size = 0;
+    {
+      struct stat st {};
+      if (safe_fstat(doorbell_fd, &st) == 0)
+        cur_size = st.st_size;
+    }
+    if (static_cast<off_t>(length) > cur_size &&
+        ftruncate(doorbell_fd, static_cast<off_t>(length)) != 0) {
+      int saved_errno = errno;
+      new_doorbell_fd.reset();
+      errno = saved_errno;
+      return MAP_FAILED;
     }
 
     int db_mflags = MAP_SHARED;
     if (flags & MAP_FIXED)
       db_mflags |= MAP_FIXED;
 
-    void *ptr = safe_mmap(addr, length, PROT_READ | PROT_WRITE,
-                          doorbell_fd >= 0 ? db_mflags : (db_mflags | MAP_ANONYMOUS),
-                          doorbell_fd >= 0 ? doorbell_fd : -1, 0);
-    if (ptr != MAP_FAILED) {
-      // Initialize doorbell backing to 0xFF so each uint64_t slot starts
-      // at ~0ULL, matching the HwQueue::last_doorbell sentinel. Without
-      // this, MAP_ANONYMOUS gives zero-filled pages and the CP's first
-      // scan falsely consumes the 0 vs ~0 transition, leaving
-      // last_doorbell==0. When ROCR later rings the doorbell with
-      // write_idx==0 (first packet), the CP sees no change and never
-      // processes the submission.
-      std::memset(ptr, 0xFF, length);
+    UniqueMapping new_monitor_mapping;
+    if (!monitor_ptr) {
+      // Initialize doorbell backing to 0xFF via the CP's permanent mapping so
+      // every slot matches the HwQueue::last_doorbell sentinel. This also avoids
+      // SIGBUS on the final MAP_SHARED mmap on Linux 6.17+ where
+      // shmem large folio allocation can fail during a bulk memset on a
+      // freshly-mapped region. Writing through a separate PROT_WRITE
+      // mapping forces page allocation before the client mapping is published. Keeping this
+      // alias gives the simulated CP a stable device-side view even while the
+      // runtime is creating or replacing its own mapping of the same memfd.
+      void *new_monitor = MAP_FAILED;
+      void *forced_monitor_addr =
+          next_doorbell_monitor_mmap_addr_.exchange(nullptr, std::memory_order_acq_rel);
+      if (fail_next_doorbell_monitor_mmap_.exchange(false, std::memory_order_acq_rel)) {
+        errno = ENOMEM;
+      } else {
+        int monitor_flags = MAP_SHARED;
+        if (forced_monitor_addr)
+          monitor_flags |= MAP_FIXED_NOREPLACE;
+        new_monitor = safe_mmap(forced_monitor_addr, length, PROT_READ | PROT_WRITE, monitor_flags,
+                                doorbell_fd, 0);
+      }
+      new_monitor_mapping.reset(new_monitor, length);
+      if (!new_monitor_mapping) {
+        int saved_errno = errno;
+        new_doorbell_fd.reset();
+        errno = saved_errno;
+        return MAP_FAILED;
+      }
 
-      // Hold op_mutex_ across the whole publish -> map_to_gpu -> set_doorbell_base
-      // sequence so a concurrent close() (which tears down doorbells under
-      // op_mutex_) cannot clear+munmap this page between publishing it and handing
-      // it to the CP, which would leave the CP with a dangling doorbell_base.
-      // op_mutex_ is the outer lock (op_mutex_ -> alloc_mutex_, matching close());
-      // set_doorbell_base takes hw_queue_mutex_, which is never held while taking
-      // op_mutex_, so there is no inversion. alloc_mutex_ is taken only for the
-      // field publish and released before set_doorbell_base (hw_queue_mutex_).
-      std::lock_guard<std::mutex> op_lock(proc.op_mutex_);
-      {
-        std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
-        // If close() has begun tearing this process down, do NOT publish a new
-        // doorbell page: it would never be reclaimed (leaked) and would hand the
-        // CP a base for a dying process. Fail the mmap instead. is_closing() is
-        // set by close() under op_mutex_, which we now hold, so this check is
-        // race-free against teardown.
-        if (proc.event_state_.is_closing()) {
-          libc_passthrough().munmap(ptr, length);
-          errno = ENODEV;
+      // Allocate the stable alias before the destructive client MAP_FIXED. If
+      // the kernel placed an alias in the requested client range, retain it as
+      // a reservation while establishing another. Once an alias lands fully
+      // outside the target, the reservations can be released and the final
+      // fixed mapping cannot replace the CP's private alias.
+      std::vector<UniqueMapping> monitor_reservations;
+      while ((flags & MAP_FIXED) &&
+             ranges_overlap(addr, length, new_monitor_mapping.get(), length)) {
+        monitor_reservations.push_back(std::move(new_monitor_mapping));
+        new_monitor_mapping.reset(
+            safe_mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_SHARED, doorbell_fd, 0), length);
+        if (!new_monitor_mapping) {
+          int saved_errno = errno;
+          new_monitor_mapping.reset();
+          monitor_reservations.clear();
+          new_doorbell_fd.reset();
+          errno = saved_errno;
           return MAP_FAILED;
         }
-        auto &gs = proc.gpu(ord);
-        gs.doorbell_page = ptr;
-        gs.doorbell_page_size = length;
-        gs.doorbell_gpu_va = reinterpret_cast<uint64_t>(ptr);
       }
-      // Use the local ptr (== the doorbell_gpu_va just written) rather than
-      // re-reading gs.doorbell_gpu_va without alloc_mutex_.
-      map_to_gpu(proc, reinterpret_cast<uint64_t>(ptr), ptr, length, amdgpu::Mtype::UC);
-      update_cp_doorbell_base(ord, proc.process_id(), ptr);
+      monitor_ptr = new_monitor_mapping.get();
+      std::memset(monitor_ptr, 0xFF, length);
     }
+
+    UniqueMapping client_mapping(
+        safe_mmap(addr, length, PROT_READ | PROT_WRITE, db_mflags, doorbell_fd, 0), length);
+    if (!client_mapping) {
+      int mmap_errno = errno;
+      new_monitor_mapping.reset();
+      new_doorbell_fd.reset();
+      errno = mmap_errno;
+      return MAP_FAILED;
+    }
+    void *ptr = client_mapping.get();
+    if (ranges_overlap(ptr, length, monitor_ptr, length)) {
+      client_mapping.reset();
+      new_monitor_mapping.reset();
+      new_doorbell_fd.reset();
+      errno = EINVAL;
+      return MAP_FAILED;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+      auto &gs = proc.gpu(ord);
+      if (new_doorbell_fd) {
+        assert(gs.doorbell_memfd < 0);
+        gs.doorbell_memfd = new_doorbell_fd.release();
+        {
+          std::lock_guard<std::mutex> flk(owned_fds_mutex_);
+          owned_fds_.insert(gs.doorbell_memfd);
+        }
+      } else {
+        assert(gs.doorbell_memfd == doorbell_fd);
+      }
+      assert(!gs.doorbell_monitor_page || gs.doorbell_monitor_page == monitor_ptr);
+      if (std::ranges::none_of(gs.doorbell_views,
+                               [ptr](const auto &view) { return view.page == ptr; })) {
+        gs.doorbell_views.push_back({.page = ptr, .gpu_va = reinterpret_cast<uint64_t>(ptr)});
+      }
+      gs.doorbell_monitor_page = monitor_ptr;
+      gs.doorbell_page_size = length;
+    }
+
+    static_cast<void>(new_monitor_mapping.release());
+    static_cast<void>(client_mapping.release());
+    map_to_gpu(proc, reinterpret_cast<uint64_t>(ptr), ptr, length, amdgpu::Mtype::UC);
+    update_cp_doorbell_base(ord, proc.process_id(), monitor_ptr);
     return ptr;
   }
 
@@ -1383,32 +1633,51 @@ int SimulatedKfd::munmap(uint32_t process_id, void *addr, size_t length) {
 int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   {
     uint32_t doorbell_ord = 0;
+    uint64_t doorbell_gpu_va = 0;
+    int doorbell_memfd = -1;
+    void *doorbell_monitor_page = nullptr;
     size_t doorbell_page_size = 0;
     bool is_doorbell = false;
+    bool last_doorbell_view = false;
     {
       std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+      for (const auto &gs : proc.gpu_state_) {
+        if (ranges_overlap(addr, length, gs.doorbell_monitor_page, gs.doorbell_page_size)) {
+          errno = EPERM;
+          return -1;
+        }
+      }
       for (size_t ord = 0; ord < proc.gpu_state_.size(); ++ord) {
         auto &gs = proc.gpu(ord);
-        if (gs.doorbell_page == addr) {
-          if (!proc.event_state_.is_closing()) {
-            errno = EPERM;
-            return -1;
-          }
-          uint64_t gpu_va = gs.doorbell_gpu_va;
-          doorbell_page_size = gs.doorbell_page_size;
-          gs.doorbell_page = nullptr;
-          gs.doorbell_gpu_va = 0;
-          gs.doorbell_page_size = 0;
-          if (gpu_va && doorbell_page_size)
-            unmap_from_gpu(proc, gpu_va, doorbell_page_size);
-          doorbell_ord = static_cast<uint32_t>(ord);
-          is_doorbell = true;
-          break;
+        auto view = std::ranges::find_if(
+            gs.doorbell_views, [addr](const auto &candidate) { return candidate.page == addr; });
+        if (view == gs.doorbell_views.end())
+          continue;
+        if (!proc.event_state_.is_closing()) {
+          errno = EPERM;
+          return -1;
         }
+        doorbell_gpu_va = view->gpu_va;
+        doorbell_page_size = gs.doorbell_page_size;
+        gs.doorbell_views.erase(view);
+        last_doorbell_view = gs.doorbell_views.empty();
+        if (last_doorbell_view) {
+          doorbell_memfd = gs.doorbell_memfd;
+          doorbell_monitor_page = gs.doorbell_monitor_page;
+          gs.doorbell_memfd = -1;
+          gs.doorbell_monitor_page = nullptr;
+          gs.doorbell_page_size = 0;
+        }
+        doorbell_ord = static_cast<uint32_t>(ord);
+        is_doorbell = true;
+        break;
       }
     }
     if (is_doorbell) {
-      // Clear the CP's doorbell base for this process BEFORE munmapping the page.
+      if (doorbell_gpu_va && doorbell_page_size)
+        unmap_from_gpu(proc, doorbell_gpu_va, doorbell_page_size);
+
+      // Clear the CP's doorbell base for this process BEFORE munmapping its alias.
       // The doorbell poll thread reads and dereferences doorbell_base under the CP's
       // hw_queue_mutex_ (scan_doorbells); if we munmapped first, the poll thread
       // could deref the freed page in the window before the base is cleared and
@@ -1420,12 +1689,23 @@ int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
       // alloc_mutex_ under hw_queue_mutex_ (allocate_scratch_backing), so holding
       // alloc_mutex_ across update_cp_doorbell_base (hw_queue_mutex_) would be an
       // alloc_mutex_->hw_queue_mutex_ inversion that can deadlock.
-      update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
+      if (last_doorbell_view)
+        update_cp_doorbell_base(doorbell_ord, proc.process_id(), nullptr);
+      if (doorbell_monitor_page && doorbell_page_size)
+        libc_passthrough().munmap(doorbell_monitor_page, doorbell_page_size);
       // Unmap the exact page we mapped: use the recorded doorbell page size, not
       // the caller-provided length. A length that differs from the tracked mapping
       // would otherwise partially unmap the CPU page and leave it inconsistent with
       // the GPU page-table unmap above.
-      libc_passthrough().munmap(addr, doorbell_page_size ? doorbell_page_size : length);
+      if (addr != MAP_FAILED && doorbell_page_size)
+        libc_passthrough().munmap(addr, doorbell_page_size);
+      if (doorbell_memfd >= 0) {
+        {
+          std::lock_guard<std::mutex> flk(owned_fds_mutex_);
+          owned_fds_.erase(doorbell_memfd);
+        }
+        libc_passthrough().close(doorbell_memfd);
+      }
       return 0;
     }
   }
@@ -1877,10 +2157,10 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
     // val==last_doorbell, no edge is detected, and the submission is never fetched
     // — a lost doorbell that hangs the waiter in hsa_signal_wait. Restoring the
     // sentinel keeps the "first real ring is always an edge" invariant.
-    if (recycled_offset && gs.doorbell_page &&
+    if (recycled_offset && gs.doorbell_monitor_page &&
         db_offset + sizeof(uint64_t) <= gs.doorbell_page_size) {
       std::atomic_ref<uint64_t>(
-          *reinterpret_cast<uint64_t *>(static_cast<char *>(gs.doorbell_page) + db_offset))
+          *reinterpret_cast<uint64_t *>(static_cast<char *>(gs.doorbell_monitor_page) + db_offset))
           .store(~uint64_t(0), std::memory_order_release);
     }
 
@@ -1896,7 +2176,8 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
     // page before creating queues, and queue creation for a process is single-
     // threaded (serialized by op_mutex_), so no concurrent dispatch_mmap re-maps
     // the doorbell in the unlock->register window.
-    hw.doorbell_base = gs.doorbell_page;
+    assert(gs.doorbell_views.empty() || gs.doorbell_monitor_page);
+    hw.doorbell_base = gs.doorbell_monitor_page;
     hw.last_doorbell = ~uint64_t(0);
     hw.host_accessible = true;
     hw.is_sdma = (args->queue_type == 1 /*KFD_IOC_QUEUE_TYPE_SDMA*/ ||
@@ -4411,7 +4692,17 @@ int SimulatedKfd::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const 
     uint64_t encoded_gpu =
         (static_cast<uint64_t>(offset) & ~KFD_MMAP_TYPE_MASK) >> KFD_MMAP_GPU_ID_SHIFT;
     uint32_t db_gpu_id = static_cast<uint32_t>(encoded_gpu);
+    if (!find_gpu(db_gpu_id))
+      return -1;
     std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
+    const auto &gs = proc.gpu(gpu_ordinal(db_gpu_id));
+    if (gs.doorbell_memfd >= 0) {
+      util::Logger::cp("MEMFD_LOOKUP: pid=", proc.process_id(),
+                       " DOORBELL canonical gpu_id=", db_gpu_id, " memfd=", gs.doorbell_memfd);
+      return gs.doorbell_memfd;
+    }
+    // Compatibility fallback for callers that query the backing before the
+    // mmap path has published the canonical descriptor.
     for (auto &[handle, alloc] : proc.allocations_) {
       if ((alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) && alloc.gpu_id == db_gpu_id) {
         util::Logger::cp("MEMFD_LOOKUP: pid=", proc.process_id(), " DOORBELL match handle=", handle,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -138,6 +138,14 @@ public:
   void setup_topology(const config::KfdDeviceConfig &dev, uint32_t num_xcc);
   void setup_topology(const std::vector<config::KfdDeviceConfig> &devs, uint32_t num_xcc);
   bool is_doorbell_range(const void *addr, size_t length) const override;
+
+  /// @brief Perform an ordinary MAP_FIXED mmap while retiring replaced client doorbell views.
+  /// @details The interposer routes non-KFD fixed mappings here so a successful replacement no
+  /// longer remains protected or teardown-owned as a doorbell. The canonical backing and private
+  /// command-processor alias are retained. A failed mmap restores the retired GPU mappings/views.
+  void *mmap_replacing_client_doorbell_views(void *addr, size_t length, int prot, int flags, int fd,
+                                             off_t offset) override;
+
   uint32_t gpu_id() const { return gpus_.empty() ? 0 : gpus_[0].gpu_id; }
   uint32_t num_gpus() const { return static_cast<uint32_t>(gpus_.size()); }
   const Sysfs &topology() const { return topology_; }
@@ -167,6 +175,20 @@ public:
   /// @details Introspection for tests/diagnostics. Each live KFD fd (the primary
   /// plus every dup) holds one reference; the process is destroyed at zero.
   [[nodiscard]] uint32_t local_open_ref_count() const;
+
+  /// @brief Make the next private doorbell-monitor mmap fail with ENOMEM.
+  /// @details One-shot test seam for verifying failure atomicity before a
+  /// destructive client MAP_FIXED mapping.
+  void fail_next_doorbell_monitor_mmap_for_testing() {
+    fail_next_doorbell_monitor_mmap_.store(true, std::memory_order_release);
+  }
+
+  /// @brief Place the next private doorbell-monitor mmap at @p addr.
+  /// @details Uses MAP_FIXED_NOREPLACE so this test seam never destroys an
+  /// unexpected mapping while deterministically exercising alias relocation.
+  void force_next_doorbell_monitor_mmap_at_for_testing(void *addr) {
+    next_doorbell_monitor_mmap_addr_.store(addr, std::memory_order_release);
+  }
 
   [[nodiscard]] bool owns_fd(int fd) const override;
   std::string redirect_sysfs_path(const char *path) const override;
@@ -425,6 +447,8 @@ private:
   std::vector<GpuDevice> gpus_;
   bool daemon_mode_ = false;
   std::atomic<int> fd_{-1};
+  std::atomic<bool> fail_next_doorbell_monitor_mmap_{false};
+  std::atomic<void *> next_doorbell_monitor_mmap_addr_{nullptr};
 
   /// @brief Process table mapping process_id to KfdProcess.
   /// @details Protected by process_mutex_ for concurrent daemon access.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -582,10 +582,10 @@ void CommandProcessor::register_queue(HwQueue queue) {
   }
   // Start (or restart) the doorbell poll thread for KFD (host-accessible) queues
   // AFTER releasing hw_queue_mutex_. ensure_doorbell_monitor() serializes on its
-  // own doorbell_thread_mutex_ and may join a monitor that self-exited when the
-  // previous last queue was destroyed; joining while holding hw_queue_mutex_ could
-  // deadlock against that exiting monitor's final scan. Internal test queues inject
-  // doorbell events directly via schedule_event_now() and need no monitor.
+  // own doorbell_thread_mutex_. Keeping that lock order consistent with the stop
+  // path avoids joining a monitor while holding the queue mutex it needs to finish
+  // a scan. Internal test queues inject doorbell events directly via
+  // schedule_event_now() and need no monitor.
   if (start_poll)
     ensure_doorbell_monitor();
 }
@@ -626,34 +626,45 @@ bool CommandProcessor::signal_queue_exception(uint32_t queue_id, uint32_t proces
 }
 
 void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) {
-  // Holds hw_queue_mutex_ across with_wave_state_locked(), which is the order
-  // the dispatch path uses too (handle_doorbell -> dispatch_workgroups ->
-  // dispatch_wf). Nothing takes them the other way any more: a wave reaching
-  // s_endpgm under the wave-state lock queues its completion instead of sending
-  // it, and WaveStateGuard delivers it after that lock is dropped. Keep it that
-  // way -- a CU-side call back into the CP while the wave-state lock is held
-  // would deadlock a DESTROY_QUEUE against the engine worker.
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-  for (auto *cu : cus_) {
-    cu->with_wave_state_locked([&] {
-      for (uint32_t slot = 0; slot < cu->num_wf_slots(); ++slot) {
-        auto *wave = cu->wf(slot);
-        if (!wave->is_halted() && wave->process_id() == process_id && wave->queue_id() == queue_id)
-          wave->halt();
+  {
+    // Holds hw_queue_mutex_ across with_wave_state_locked(), which is the order
+    // the dispatch path uses too (handle_doorbell -> dispatch_workgroups ->
+    // dispatch_wf). Nothing takes them the other way any more: a wave reaching
+    // s_endpgm under the wave-state lock queues its completion instead of sending
+    // it, and WaveStateGuard delivers it after that lock is dropped. Keep it that
+    // way -- a CU-side call back into the CP while the wave-state lock is held
+    // would deadlock a DESTROY_QUEUE against the engine worker.
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    for (auto *cu : cus_) {
+      cu->with_wave_state_locked([&] {
+        for (uint32_t slot = 0; slot < cu->num_wf_slots(); ++slot) {
+          auto *wave = cu->wf(slot);
+          if (!wave->is_halted() && wave->process_id() == process_id &&
+              wave->queue_id() == queue_id)
+            wave->halt();
+        }
+      });
+    }
+    for (size_t i = 0; i < hw_queues_.size(); ++i) {
+      if (hw_queues_[i].queue_id == queue_id && hw_queues_[i].process_id == process_id) {
+        hw_queues_.erase(hw_queues_.begin() + static_cast<ptrdiff_t>(i));
+        new_queue_states_.erase(new_queue_states_.begin() + static_cast<ptrdiff_t>(i));
+        break;
       }
-    });
-  }
-  for (size_t i = 0; i < hw_queues_.size(); ++i) {
-    if (hw_queues_[i].queue_id == queue_id && hw_queues_[i].process_id == process_id) {
-      hw_queues_.erase(hw_queues_.begin() + static_cast<ptrdiff_t>(i));
-      new_queue_states_.erase(new_queue_states_.begin() + static_cast<ptrdiff_t>(i));
-      break;
     }
   }
-  // Don't stop the doorbell monitor here — the join can deadlock when
-  // the poller thread is mid-iteration (holding engine or event state
-  // locks). The ~CommandProcessor destructor joins the thread safely
-  // after all client activity has ceased.
+
+  // Reap the monitor when the last host queue is removed. This runs after
+  // releasing hw_queue_mutex_: the poller needs that mutex to finish its current
+  // scan. The poll loop may also be in the engine event-queue path or the
+  // interrupt/event-state callback, but neither path enters a KFD ioctl or acquires
+  // KfdProcess::op_mutex_, which the production callers hold here. Preserve that
+  // invariant: no poll-loop callback may wait for a lock held by an
+  // unregister_queue() caller. The synchronous join makes queue-destroy latency
+  // include at most the current poll iteration and its bounded callbacks. The
+  // helper rechecks the queue set while holding the lifecycle mutex, so a concurrent
+  // registration either keeps this monitor alive or starts a new one after the join.
+  stop_doorbell_monitor_if_idle();
 }
 
 void CommandProcessor::update_queue(uint32_t queue_id, uint32_t process_id, uint64_t ring_base_va,
@@ -754,27 +765,33 @@ void CommandProcessor::ensure_doorbell_monitor() {
   // each pass, so it will pick up the queue this call just added.)
   if (doorbell_running_)
     return;
-  // No monitor is running. If a previous one self-exited (it saw the last
-  // host-accessible queue destroyed) its jthread is joinable-but-finished; join it
-  // here before launching a fresh one so the handle does not leak. request_stop()
-  // is harmless on an already-returned thread and makes the join immediate.
-  if (doorbell_thread_.joinable()) {
-    doorbell_thread_.request_stop();
-    doorbell_thread_.join();
-  }
   util::Logger::cp([&](auto &os) { os << std::format("{}: STARTING doorbell thread", name()); });
   // Construct the thread BEFORE setting doorbell_running_: if the jthread
   // constructor throws (std::system_error on thread-creation failure) the flag
   // must stay false so a later ensure_doorbell_monitor() retries instead of
-  // no-oping forever. We still hold doorbell_thread_mutex_, and the loop's
-  // self-exit path only clears the flag under a TRY-lock of that mutex, so the
-  // new thread cannot observe or clear doorbell_running_ until we release here.
+  // no-oping forever. We still hold doorbell_thread_mutex_, so teardown cannot
+  // observe the new handle until both it and the running flag are published.
+  assert(!doorbell_thread_.joinable());
   doorbell_thread_ = std::jthread([this](std::stop_token stop) { doorbell_poll_loop(stop); });
   doorbell_running_ = true;
 }
 
 void CommandProcessor::stop_doorbell_monitor() {
   std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
+  if (doorbell_thread_.joinable()) {
+    doorbell_thread_.request_stop();
+    doorbell_thread_.join();
+  }
+  doorbell_running_ = false;
+}
+
+void CommandProcessor::stop_doorbell_monitor_if_idle() {
+  std::lock_guard<std::mutex> thread_lock(doorbell_thread_mutex_);
+  {
+    std::lock_guard<std::recursive_mutex> queue_lock(hw_queue_mutex_);
+    if (has_kfd_queues())
+      return;
+  }
   if (doorbell_thread_.joinable()) {
     doorbell_thread_.request_stop();
     doorbell_thread_.join();
@@ -853,53 +870,6 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   // flag re-read on some iterations (an early continue before the retry check) would
   // reintroduce a lost-wakeup.
   while (!stop.stop_requested()) {
-    // Self-exit once this CP owns no host-accessible queue. Destroying the last
-    // such queue does NOT join this thread (that join could deadlock against a
-    // monitor mid-iteration inside engine/event code), so the monitor must retire
-    // itself instead of idling forever at the 100us cadence.
-    //
-    // Acquire doorbell_thread_mutex_ with TRY-lock, never a blocking lock: a
-    // concurrent stop_doorbell_monitor() holds that mutex while it join()s this very
-    // thread, so a blocking acquire here would deadlock (it waits for the mutex; the
-    // joiner waits for us to return). A failed try means another lifecycle path owns
-    // the mutex right now — either stop_doorbell_monitor() (which has already issued
-    // request_stop(), so the top-of-loop stop check retires us next turn) or
-    // ensure_doorbell_monitor() (which is only inspecting/starting the monitor). In
-    // both cases deferring this exit check one 100us iteration is harmless. When the
-    // try succeeds and the queue set has no host-accessible queue and no retry is
-    // pending (a stall/invalid retry is still in-flight work), clear doorbell_running_
-    // and return; the lock releases as the stack unwinds. A later
-    // ensure_doorbell_monitor() reaps this exited jthread and starts a fresh one.
-    {
-      std::unique_lock<std::mutex> tlock(doorbell_thread_mutex_, std::try_to_lock);
-      if (tlock.owns_lock()) {
-        // has_kfd_queues() is the dominant exit guard: it is read under
-        // hw_queue_mutex_, atomically with the queue vector that register_queue()/
-        // unregister_queue() mutate, so the monitor never retires while a
-        // host-accessible queue is live. The two retry flags are a conservative
-        // backstop read in the same critical section. Their SETTERS run under
-        // hw_queue_mutex_ (invalid_pending_ in fetch_from_queue; stall_pending_ via
-        // arm_stall_recheck, itself gated on has_kfd_queues()), but handle_doorbell
-        // CLEARS them at entry without the lock, so a flag read here is not perfectly
-        // serialized against a clear. That is harmless: while any queue is live the
-        // has_kfd_queues() term keeps should_exit false regardless of the flags, and
-        // once no host-accessible queue remains no further retry can be armed, so
-        // dropping a stale pending flag at exit forfeits nothing real.
-        bool should_exit;
-        {
-          std::lock_guard<std::recursive_mutex> qlock(hw_queue_mutex_);
-          should_exit = !has_kfd_queues() && !invalid_pending_.load(std::memory_order_acquire) &&
-                        !stall_pending_.load(std::memory_order_acquire);
-        }
-        if (should_exit) {
-          util::Logger::cp([&](auto &os) {
-            os << std::format("{}: doorbell monitor self-exit (no KFD queues)", name());
-          });
-          doorbell_running_ = false;
-          return;
-        }
-      }
-    }
     bool doorbell_changed = scan_doorbells();
     // Retry on a pending INVALID packet (the runtime has not finished writing it
     // yet) OR a pending barrier/dependency stall (waiting on a signal a peer rank
@@ -950,17 +920,19 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
     if (poll_count % 5000 == 1) {
       std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
       for (auto &q : hw_queues_) {
-        uint64_t val = 0;
+        uint64_t current = q.last_doorbell;
         if (q.host_accessible && q.doorbell_base) {
-          val = std::atomic_ref<uint64_t>(
-                    *reinterpret_cast<uint64_t *>(static_cast<char *>(q.doorbell_base) +
-                                                  q.doorbell_offset))
-                    .load(std::memory_order_acquire);
+          current = std::atomic_ref<uint64_t>(
+                        *reinterpret_cast<uint64_t *>(static_cast<char *>(q.doorbell_base) +
+                                                      q.doorbell_offset))
+                        .load(std::memory_order_acquire);
+        } else if (!q.host_accessible && q.doorbell_va != 0) {
+          current = read_gpu_u64(q.doorbell_va, q.process_id);
         }
         util::Logger::cp([&](auto &os) {
-          os << std::format("{}: DOORBELL_POLL pid={} qid={} val={:#x} last={:#x} db_base={} "
-                            "db_off={} polls={}",
-                            name(), q.process_id, q.queue_id, val, q.last_doorbell,
+          os << std::format("{}: DOORBELL_POLL pid={} qid={} current={:#x} last={:#x} "
+                            "monitor_base={} db_off={} polls={}",
+                            name(), q.process_id, q.queue_id, current, q.last_doorbell,
                             reinterpret_cast<uintptr_t>(q.doorbell_base), q.doorbell_offset,
                             poll_count);
         });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -227,12 +227,17 @@ public:
   /// @brief Test-only view of the doorbell monitor lifecycle flag.
   ///
   /// @details Exposes doorbell_running_ so a regression test can observe the
-  /// monitor retiring after the last host-accessible queue is destroyed and
+  /// monitor stopping after the last host-accessible queue is destroyed and
   /// restarting when a new one registers. Read under doorbell_thread_mutex_ so it
-  /// never races the loop's self-exit or ensure_doorbell_monitor().
+  /// never races monitor teardown or ensure_doorbell_monitor().
   [[nodiscard]] bool doorbell_monitor_running_for_test() {
     std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
     return doorbell_running_;
+  }
+  /// @brief Test-only check that teardown reaped the monitor's thread handle.
+  [[nodiscard]] bool doorbell_monitor_joinable_for_test() {
+    std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
+    return doorbell_thread_.joinable();
   }
 
   /// @brief Test-only view of one queue's debugger suspension gate.
@@ -452,12 +457,16 @@ private:
   void write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid);
 
   void stop_doorbell_monitor();
-  /// @brief Start the doorbell monitor if one is not already running, reaping a
-  /// previously self-exited thread first. Serialized by doorbell_thread_mutex_.
-  /// @details Caller MUST NOT hold hw_queue_mutex_: this may join a monitor that
-  /// self-exited, and that monitor's final self-exit check takes hw_queue_mutex_,
-  /// so joining under it would deadlock. This also fixes the lock order to
-  /// doorbell_thread_mutex_ -> hw_queue_mutex_ (never the reverse).
+  /// @brief Stop and join the monitor only when no host-accessible queue remains.
+  /// @details Caller MUST NOT hold hw_queue_mutex_: this helper takes that mutex
+  /// to recheck the queue set, then may join a poller that needs the same mutex to
+  /// finish its current scan. Serializing the recheck with startup ensures a
+  /// concurrently registered queue cannot be left without a polling thread.
+  void stop_doorbell_monitor_if_idle();
+  /// @brief Start the doorbell monitor if one is not already running.
+  /// @details Serialized by doorbell_thread_mutex_. Caller MUST NOT hold
+  /// hw_queue_mutex_ so lifecycle operations consistently acquire
+  /// doorbell_thread_mutex_ before hw_queue_mutex_.
   void ensure_doorbell_monitor();
   bool scan_doorbells();
 
@@ -485,17 +494,12 @@ private:
   void doorbell_poll_loop(std::stop_token stop);
 
   // The doorbell monitor's lifecycle is serialized by its OWN mutex, deliberately
-  // distinct from hw_queue_mutex_. An empty monitor exits itself when it observes
-  // the last host-accessible queue gone (so unregister_queue never has to join a
-  // thread that may be mid-iteration inside engine/event code — that join could
-  // deadlock, which is why queue destruction only removes queue state). A later
-  // register_queue reaps the already-exited jthread and starts a fresh one. Taking
-  // doorbell_thread_mutex_ (never nested under hw_queue_mutex_) keeps concurrent
-  // register/unregister from racing on doorbell_thread_ and doorbell_running_.
+  // distinct from hw_queue_mutex_. Queue removal releases hw_queue_mutex_ before
+  // stopping and joining the monitor, so an in-progress scan can finish. The
+  // lifecycle path then rechecks the queue set while startup is excluded; this
+  // keeps a concurrent registration from losing its monitor.
   std::mutex doorbell_thread_mutex_;
-  // True while a monitor is running or about to run. The monitor clears it under
-  // doorbell_thread_mutex_ just before returning, so ensure_doorbell_monitor() can
-  // tell a live monitor from a self-exited one that still needs joining.
+  // True while the lifecycle owns a running monitor.
   bool doorbell_running_ = false;
   std::jthread doorbell_thread_;
 };

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -3782,7 +3782,7 @@ TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
 }
 
 TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {
-  // Regression for the leaked idle CP doorbell poller: the monitor must self-exit
+  // Regression for the idle CP doorbell poller: the monitor must stop and be joined
   // once the last host-accessible (KFD) queue is destroyed, and a later queue
   // registration must start a fresh monitor. Uses only the queue-registration
   // lifecycle (no dispatch), so the monitor thread runs on its own and its state
@@ -3808,8 +3808,10 @@ TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {
   EXPECT_TRUE(wait_for_monitor(true)) << "registering a KFD queue must start the monitor";
 
   cp->unregister_queue(queue.queue_id, queue.process_id);
-  EXPECT_FALSE(wait_for_monitor(false))
-      << "monitor must self-exit after the last host-accessible queue is destroyed";
+  EXPECT_FALSE(cp->doorbell_monitor_running_for_test())
+      << "monitor must stop after the last host-accessible queue is destroyed";
+  EXPECT_FALSE(cp->doorbell_monitor_joinable_for_test())
+      << "the stopped monitor must be joined before queue teardown returns";
 
   // A new queue landing on a CP whose monitor retired must get polling back.
   amdgpu::HwQueue queue2{};
@@ -3820,7 +3822,47 @@ TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {
   EXPECT_TRUE(wait_for_monitor(true)) << "a new KFD queue must restart a retired monitor";
 
   cp->unregister_queue(queue2.queue_id, queue2.process_id);
-  EXPECT_FALSE(wait_for_monitor(false)) << "monitor must retire again after the last queue";
+  EXPECT_FALSE(cp->doorbell_monitor_running_for_test())
+      << "monitor must retire again after the last queue";
+  EXPECT_FALSE(cp->doorbell_monitor_joinable_for_test())
+      << "the restarted monitor must also be joined during teardown";
+}
+
+TEST(DoorbellMonitorLifecycle, ConcurrentLastQueueRemovalAndRegistrationKeepsMonitorRunning) {
+  VmFixture f("cdna4", /*num_cus=*/1);
+  amdgpu::CommandProcessor *cp = f.cp();
+
+  for (uint32_t iteration = 0; iteration < 50; ++iteration) {
+    amdgpu::HwQueue old_queue{};
+    old_queue.process_id = 1;
+    old_queue.queue_id = iteration * 2 + 1;
+    old_queue.host_accessible = true;
+    cp->register_queue(old_queue);
+
+    amdgpu::HwQueue new_queue{};
+    new_queue.process_id = 1;
+    new_queue.queue_id = iteration * 2 + 2;
+    new_queue.host_accessible = true;
+
+    std::barrier start(3);
+    std::thread remove_last([&] {
+      start.arrive_and_wait();
+      cp->unregister_queue(old_queue.queue_id, old_queue.process_id);
+    });
+    std::thread register_next([&] {
+      start.arrive_and_wait();
+      cp->register_queue(new_queue);
+    });
+    start.arrive_and_wait();
+    remove_last.join();
+    register_next.join();
+
+    ASSERT_TRUE(cp->doorbell_monitor_running_for_test())
+        << "registration racing last-queue removal lost the monitor at iteration " << iteration;
+    cp->unregister_queue(new_queue.queue_id, new_queue.process_id);
+    ASSERT_FALSE(cp->doorbell_monitor_running_for_test());
+    ASSERT_FALSE(cp->doorbell_monitor_joinable_for_test());
+  }
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -28,12 +28,15 @@ RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
+#include <cerrno>
 #include <cstdlib>
 #include <filesystem>
 #include <thread>
 #include <vector>
 
+#include <sys/mman.h>
 #include <unistd.h>
 
 namespace {
@@ -92,6 +95,459 @@ TEST_F(SimulatedKfdTest, OpenAndClose) {
 
   int ret = t.driver()->close();
   EXPECT_EQ(ret, 0);
+}
+
+TEST_F(SimulatedKfdTest, DoorbellClientRemapKeepsDriverAliasStableWhenOffsetRecycles) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *client_page = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                                   doorbell_mmap_offset);
+  ASSERT_NE(client_page, MAP_FAILED);
+
+  alignas(4096) std::array<uint8_t, 4096> ring{};
+  alignas(uint64_t) uint64_t read_pointer = 0;
+  alignas(uint64_t) uint64_t write_pointer = 0;
+
+  kfd_ioctl_create_queue_args first_queue{};
+  first_queue.ring_base_address = reinterpret_cast<uint64_t>(ring.data());
+  first_queue.ring_size = ring.size();
+  first_queue.read_pointer_address = reinterpret_cast<uint64_t>(&read_pointer);
+  first_queue.write_pointer_address = reinterpret_cast<uint64_t>(&write_pointer);
+  first_queue.gpu_id = driver->gpu_id();
+  first_queue.queue_type = KFD_IOC_QUEUE_TYPE_COMPUTE;
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_CREATE_QUEUE, &first_queue), 0);
+
+  kfd_ioctl_destroy_queue_args destroy_first{};
+  destroy_first.queue_id = first_queue.queue_id;
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_DESTROY_QUEUE, &destroy_first), 0);
+
+  // Leave a non-sentinel value in the freed slot, then exercise the driver's
+  // re-mmap path. The backing and monitor alias must survive this client-view
+  // replacement rather than being recreated or orphaned.
+  auto *doorbell_slot = reinterpret_cast<uint64_t *>(
+      static_cast<char *>(client_page) + (first_queue.doorbell_offset % doorbell_page_size));
+  std::atomic_ref<uint64_t>(*doorbell_slot).store(0, std::memory_order_release);
+  ASSERT_EQ(driver->mmap(client_page, doorbell_page_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_FIXED, doorbell_mmap_offset),
+            client_page);
+
+  // Replace the client address with an inaccessible anonymous mapping, exactly
+  // as a runtime remap can replace the view returned by KFD. Driver-side queue
+  // initialization must never dereference this address.
+  ASSERT_EQ(::mmap(client_page, doorbell_page_size, PROT_NONE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+            client_page);
+
+  kfd_ioctl_create_queue_args second_queue{};
+  second_queue.ring_base_address = reinterpret_cast<uint64_t>(ring.data());
+  second_queue.ring_size = ring.size();
+  second_queue.read_pointer_address = reinterpret_cast<uint64_t>(&read_pointer);
+  second_queue.write_pointer_address = reinterpret_cast<uint64_t>(&write_pointer);
+  second_queue.gpu_id = driver->gpu_id();
+  second_queue.queue_type = KFD_IOC_QUEUE_TYPE_COMPUTE;
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_CREATE_QUEUE, &second_queue), 0);
+  EXPECT_EQ(second_queue.doorbell_offset, first_queue.doorbell_offset);
+
+  // Restore the client view and verify that recycled-slot initialization went
+  // through the stable alias into the same canonical backing.
+  ASSERT_EQ(driver->mmap(client_page, doorbell_page_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_FIXED, doorbell_mmap_offset),
+            client_page);
+  doorbell_slot = reinterpret_cast<uint64_t *>(static_cast<char *>(client_page) +
+                                               (second_queue.doorbell_offset % doorbell_page_size));
+  EXPECT_EQ(std::atomic_ref<uint64_t>(*doorbell_slot).load(std::memory_order_acquire),
+            ~uint64_t(0));
+
+  kfd_ioctl_destroy_queue_args destroy_second{};
+  destroy_second.queue_id = second_queue.queue_id;
+  EXPECT_EQ(driver->ioctl(AMDKFD_IOC_DESTROY_QUEUE, &destroy_second), 0);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, AdditionalDoorbellMmapKeepsEarlierClientViewLive) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *first = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                             doorbell_mmap_offset);
+  ASSERT_NE(first, MAP_FAILED);
+  void *second = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              doorbell_mmap_offset);
+  ASSERT_NE(second, MAP_FAILED);
+  ASSERT_NE(second, first);
+
+  auto *first_slot = static_cast<uint64_t *>(first);
+  auto *second_slot = static_cast<uint64_t *>(second);
+  std::atomic_ref<uint64_t>(*first_slot).store(0x123456789abcdef0ULL, std::memory_order_release);
+  EXPECT_EQ(std::atomic_ref<uint64_t>(*second_slot).load(std::memory_order_acquire),
+            0x123456789abcdef0ULL);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, FirstFixedDoorbellMmapKeepsMonitorAliasPrivate) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *target = ::mmap(nullptr, doorbell_page_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(target, MAP_FAILED);
+  ASSERT_EQ(::munmap(target, doorbell_page_size), 0);
+
+  driver->force_next_doorbell_monitor_mmap_at_for_testing(target);
+  ASSERT_EQ(driver->mmap(target, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                         doorbell_mmap_offset),
+            target);
+  auto process = driver->find_process(driver->local_process_id());
+  ASSERT_NE(process, nullptr);
+  void *monitor = process->gpu(0).doorbell_monitor_page;
+  ASSERT_NE(monitor, nullptr);
+  EXPECT_NE(monitor, target);
+
+  EXPECT_EQ(driver->mmap(target, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                         doorbell_mmap_offset),
+            target);
+  EXPECT_EQ(process->gpu(0).doorbell_monitor_page, monitor);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, FailedMonitorMmapPreservesFixedTarget) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *target = ::mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(target, MAP_FAILED);
+  auto *bytes = static_cast<uint8_t *>(target);
+  bytes[0] = 0x5a;
+  bytes[doorbell_page_size - 1] = 0xa5;
+
+  driver->fail_next_doorbell_monitor_mmap_for_testing();
+  errno = 0;
+  EXPECT_EQ(driver->mmap(target, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                         doorbell_mmap_offset),
+            MAP_FAILED);
+  EXPECT_EQ(errno, ENOMEM);
+
+  unsigned char residency = 0;
+  EXPECT_EQ(::mincore(target, doorbell_page_size, &residency), 0);
+  EXPECT_EQ(bytes[0], 0x5a);
+  EXPECT_EQ(bytes[doorbell_page_size - 1], 0xa5);
+  bytes[0] = 0x3c;
+
+  auto process = driver->find_process(driver->local_process_id());
+  ASSERT_NE(process, nullptr);
+  EXPECT_EQ(process->gpu(0).doorbell_monitor_page, nullptr);
+  EXPECT_EQ(process->gpu(0).doorbell_memfd, -1);
+  EXPECT_TRUE(process->gpu(0).doorbell_views.empty());
+
+  EXPECT_EQ(driver->close(), 0);
+  EXPECT_EQ(bytes[0], 0x3c);
+  EXPECT_EQ(::munmap(target, doorbell_page_size), 0);
+}
+
+TEST_F(SimulatedKfdTest, DoorbellMonitorRejectsOverlappingMunmapWhileQueueIsLive) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = 2 * static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+  ASSERT_NE(driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                         doorbell_mmap_offset),
+            MAP_FAILED);
+
+  alignas(4096) std::array<uint8_t, 4096> ring{};
+  alignas(uint64_t) uint64_t read_pointer = 0;
+  alignas(uint64_t) uint64_t write_pointer = 0;
+  kfd_ioctl_create_queue_args queue{};
+  queue.ring_base_address = reinterpret_cast<uint64_t>(ring.data());
+  queue.ring_size = ring.size();
+  queue.read_pointer_address = reinterpret_cast<uint64_t>(&read_pointer);
+  queue.write_pointer_address = reinterpret_cast<uint64_t>(&write_pointer);
+  queue.gpu_id = driver->gpu_id();
+  queue.queue_type = KFD_IOC_QUEUE_TYPE_COMPUTE;
+  ASSERT_EQ(driver->ioctl(AMDKFD_IOC_CREATE_QUEUE, &queue), 0);
+
+  auto process = driver->find_process(driver->local_process_id());
+  ASSERT_NE(process, nullptr);
+  void *monitor = process->gpu(0).doorbell_monitor_page;
+  ASSERT_NE(monitor, nullptr);
+
+  errno = 0;
+  EXPECT_EQ(driver->munmap(monitor, doorbell_page_size), -1);
+  EXPECT_EQ(errno, EPERM);
+
+  errno = 0;
+  EXPECT_EQ(driver->munmap(static_cast<char *>(monitor) + host_page_size,
+                           static_cast<size_t>(host_page_size)),
+            -1);
+  EXPECT_EQ(errno, EPERM);
+
+  const auto containing_base = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(monitor) -
+                                                        static_cast<size_t>(host_page_size));
+  errno = 0;
+  EXPECT_EQ(
+      driver->munmap(containing_base, doorbell_page_size + 2 * static_cast<size_t>(host_page_size)),
+      -1);
+  EXPECT_EQ(errno, EPERM);
+  EXPECT_EQ(process->gpu(0).doorbell_monitor_page, monitor);
+  EXPECT_TRUE(driver->is_doorbell_range(monitor, doorbell_page_size));
+
+  kfd_ioctl_destroy_queue_args destroy{};
+  destroy.queue_id = queue.queue_id;
+  EXPECT_EQ(driver->ioctl(AMDKFD_IOC_DESTROY_QUEUE, &destroy), 0);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, FixedAnonymousMmapRetiresOnlyReplacedDoorbellView) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  void *first = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                             doorbell_mmap_offset);
+  ASSERT_NE(first, MAP_FAILED);
+  void *second = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              doorbell_mmap_offset);
+  ASSERT_NE(second, MAP_FAILED);
+  ASSERT_NE(second, first);
+
+  errno = 0;
+  EXPECT_EQ(driver->mmap_replacing_client_doorbell_views(
+                first, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, -1, 0),
+            MAP_FAILED);
+  EXPECT_EQ(errno, EBADF);
+  EXPECT_TRUE(driver->is_doorbell_range(first, doorbell_page_size));
+  EXPECT_TRUE(driver->is_doorbell_range(second, doorbell_page_size));
+
+  ASSERT_EQ(driver->mmap_replacing_client_doorbell_views(
+                first, doorbell_page_size, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+            first);
+  EXPECT_FALSE(driver->is_doorbell_range(first, doorbell_page_size));
+  EXPECT_TRUE(driver->is_doorbell_range(second, doorbell_page_size));
+  EXPECT_EQ(::mprotect(first, doorbell_page_size, PROT_READ), 0);
+  EXPECT_EQ(::mprotect(first, doorbell_page_size, PROT_READ | PROT_WRITE), 0);
+  EXPECT_EQ(driver->munmap(first, doorbell_page_size), -ENOENT);
+  EXPECT_EQ(::munmap(first, doorbell_page_size), 0);
+
+  ASSERT_EQ(driver->mmap_replacing_client_doorbell_views(
+                first, doorbell_page_size, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+            first);
+  *static_cast<uint8_t *>(first) = 0x5a;
+  EXPECT_EQ(driver->close(), 0);
+
+  unsigned char residency = 0;
+  ASSERT_EQ(::mincore(first, doorbell_page_size, &residency), 0)
+      << "closing KFD must not unmap the anonymous replacement";
+  EXPECT_EQ(*static_cast<uint8_t *>(first), 0x5a);
+  EXPECT_EQ(::munmap(first, doorbell_page_size), 0);
+}
+
+TEST_F(SimulatedKfdTest, PartialFixedMmapKeepsMultiPageDoorbellView) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = 2 * static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+  void *client = driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              doorbell_mmap_offset);
+  ASSERT_NE(client, MAP_FAILED);
+
+  auto *first_page = static_cast<uint8_t *>(client);
+  auto *second_page = first_page + host_page_size;
+  *first_page = 0x5a;
+  *second_page = 0xa5;
+
+  errno = 0;
+  EXPECT_EQ(driver->mmap_replacing_client_doorbell_views(
+                second_page, static_cast<size_t>(host_page_size), PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+            MAP_FAILED);
+  EXPECT_EQ(errno, EINVAL);
+  EXPECT_TRUE(driver->is_doorbell_range(client, doorbell_page_size));
+  EXPECT_EQ(*first_page, 0x5a);
+  EXPECT_EQ(*second_page, 0xa5);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, GuestFixedMmapRetiresSimulatedDoorbellView) {
+  rj_vm_t *raw_vm = nullptr;
+  ASSERT_EQ(rj_vm_create(CONFIG_PATH.c_str(), RJ_VM_MODE_LOCAL, &raw_vm), ROCJITSU_STATUS_SUCCESS);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> vm(raw_vm, &rj_vm_destroy);
+  ASSERT_NE(vm, nullptr);
+  ASSERT_NE(vm->vm, nullptr);
+  auto *execution_driver = vm->vm->driver();
+  ASSERT_NE(execution_driver, nullptr);
+
+  rocjitsu::config::DbtGuestConfig config;
+  config.enabled = true;
+  config.guest_isa = "gfx950";
+  config.host.isa = "gfx950";
+  config.host.gpu_id = execution_driver->gpu_id();
+  config.host.backend = rocjitsu::config::DbtExecutionBackend::Simulator;
+  config.guest_device = vm->loaded.device;
+  config.guest_device.gpu_id += 1;
+  config.guest_device.drm_render_minor += 1;
+
+  rocjitsu::GuestKfd guest(std::move(config), execution_driver);
+  ASSERT_TRUE(guest.prepare_for_discovery());
+  const int app_fd = guest.open();
+  ASSERT_GE(app_fd, 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(execution_driver->gpu_id()));
+  void *client = guest.mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                            doorbell_mmap_offset);
+  ASSERT_NE(client, MAP_FAILED);
+
+  ASSERT_EQ(
+      guest.mmap_replacing_client_doorbell_views(client, doorbell_page_size, PROT_READ | PROT_WRITE,
+                                                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+      client);
+  EXPECT_FALSE(guest.is_doorbell_range(client, doorbell_page_size));
+  EXPECT_EQ(::mprotect(client, doorbell_page_size, PROT_READ), 0);
+  EXPECT_EQ(::mprotect(client, doorbell_page_size, PROT_READ | PROT_WRITE), 0);
+  *static_cast<uint8_t *>(client) = 0x5a;
+
+  EXPECT_EQ(::close(app_fd), 0);
+  EXPECT_EQ(guest.close(), 0);
+  unsigned char residency = 0;
+  ASSERT_EQ(::mincore(client, doorbell_page_size, &residency), 0)
+      << "guest close must not unmap the anonymous replacement";
+  EXPECT_EQ(*static_cast<uint8_t *>(client), 0x5a);
+  EXPECT_EQ(::munmap(client, doorbell_page_size), 0);
+}
+
+TEST_F(SimulatedKfdTest, ProcessAddressedDoorbellMmapPublishesCanonicalMemfd) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  const uint32_t process_id = driver->open_process();
+  ASSERT_NE(process_id, 0u);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+
+  ASSERT_NE(driver->mmap(process_id, nullptr, doorbell_page_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, doorbell_mmap_offset),
+            MAP_FAILED);
+  EXPECT_GE(driver->get_mmap_memfd(process_id, doorbell_mmap_offset), 0)
+      << "daemon fd passing must use the canonical backing created by mmap";
+  EXPECT_EQ(driver->close(process_id), 0);
+}
+
+TEST_F(SimulatedKfdTest, UnknownDoorbellGpuDoesNotUseCanonicalBacking) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t valid_offset = static_cast<off_t>(rocjitsu::KFD_MMAP_TYPE_DOORBELL |
+                                                rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+  ASSERT_NE(
+      driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED, valid_offset),
+      MAP_FAILED);
+  ASSERT_GE(driver->get_mmap_memfd(valid_offset), 0);
+
+  const uint32_t unknown_gpu_id = driver->gpu_id() + 1;
+  const off_t unknown_offset = static_cast<off_t>(rocjitsu::KFD_MMAP_TYPE_DOORBELL |
+                                                  rocjitsu::kfd_mmap_gpu_id(unknown_gpu_id));
+  EXPECT_EQ(driver->get_mmap_memfd(unknown_offset), -1);
+  errno = 0;
+  EXPECT_EQ(
+      driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED, unknown_offset),
+      MAP_FAILED);
+  EXPECT_EQ(errno, EINVAL);
+  EXPECT_EQ(driver->close(), 0);
+}
+
+TEST_F(SimulatedKfdTest, FixedDoorbellMmapCannotReplaceMonitorAlias) {
+  auto t = create_test_vm();
+  auto *driver = t.driver();
+  ASSERT_NE(driver, nullptr);
+  ASSERT_GE(driver->open(), 0);
+
+  const long host_page_size = ::sysconf(_SC_PAGESIZE);
+  ASSERT_GT(host_page_size, 0);
+  const size_t doorbell_page_size = static_cast<size_t>(host_page_size);
+  const off_t doorbell_mmap_offset = static_cast<off_t>(
+      rocjitsu::KFD_MMAP_TYPE_DOORBELL | rocjitsu::kfd_mmap_gpu_id(driver->gpu_id()));
+  ASSERT_NE(driver->mmap(nullptr, doorbell_page_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                         doorbell_mmap_offset),
+            MAP_FAILED);
+
+  auto process = driver->find_process(driver->local_process_id());
+  ASSERT_NE(process, nullptr);
+  void *monitor = process->gpu(0).doorbell_monitor_page;
+  ASSERT_NE(monitor, nullptr);
+  EXPECT_TRUE(driver->is_doorbell_range(monitor, doorbell_page_size));
+
+  errno = 0;
+  EXPECT_EQ(driver->mmap(monitor, doorbell_page_size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_FIXED, doorbell_mmap_offset),
+            MAP_FAILED);
+  EXPECT_EQ(errno, EINVAL);
+  EXPECT_EQ(process->gpu(0).doorbell_monitor_page, monitor);
+  EXPECT_EQ(driver->close(), 0);
 }
 
 TEST_F(SimulatedKfdTest, GuestDiscoveryOpenIsReleasedOnLastClose) {


### PR DESCRIPTION
The simulated command processor used the client-visible doorbell mapping as its polling address. ROCr can replace that mapping while queues are live, leaving the poller with a stale address. The doorbell monitor could also outlive the final host queue and continue running during process teardown.

Keep one canonical per-GPU doorbell backing and a stable shared driver view for every command-processor access. Client remaps now only republish the client view, recycled queue slots are initialized through the stable view, and unmap or close reclaims both mappings and the retained descriptor. Stop and join the monitor when the final host queue is removed, and restart it when a new queue is registered.

Add lifecycle and remap-recycle regressions, split sanitizer-specific exclusions by observed behavior, and re-enable the HSA and daemon tests that now pass reliably.