### PR TITLE
[rocjitsu][docs] Refresh architecture support documentation

### DIFF
--- a/emulation/README.md
+++ b/emulation/README.md
@@ -12,7 +12,7 @@
     - [DBT](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/) — Dynamic binary translation: encoding and semantic translation.
     - [Patch / DBI](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/) — Patch points and (planned) instrumentation, spill/restore.
   - [Analysis Layer](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/) — Register liveness, def-use chains, hazard scheduling, lane permutation. See [liveness.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp) and [def_use_chain.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/def_use_chain.cpp).
-  - [ISA Layer](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/) — Per-ISA decoders, operand types, machine instruction structs, encoding formats (CDNA1–4, RDNA1–4, RDNA3.5). Entry points: [decoder.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp), [rj_decode.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp); per-arch tables in [arch/](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/).
+  - [ISA Layer](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/) — Per-ISA decoders, operand types, machine instruction structs, encoding formats (CDNA1–5, RDNA1–4). Entry points: [decoder.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp), [rj_decode.cpp](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp); per-arch tables in [arch/](emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/).
   - [simdojo](emulation/rocjitsu/lib/simdojo/) — Decoupled parallel discrete-event simulation engine that orchestrates composable models. See [DESIGN.md](emulation/rocjitsu/lib/simdojo/DESIGN.md) and [src/](emulation/rocjitsu/lib/simdojo/src/) ([simulation.cpp](emulation/rocjitsu/lib/simdojo/src/simulation.cpp), [topology.cpp](emulation/rocjitsu/lib/simdojo/src/topology.cpp), [component.cpp](emulation/rocjitsu/lib/simdojo/src/component.cpp)).
   - [amdisa](emulation/rocjitsu/lib/python/amdisa/) — Python codegen that consumes AMD machine-readable ISA specs to auto-generate decoders, semantics, encoding/legalization tables, and cross-ISA translators. Key modules: [parser.py](emulation/rocjitsu/lib/python/amdisa/parser.py), [semantics.py](emulation/rocjitsu/lib/python/amdisa/semantics.py), [encoding_translator_codegen.py](emulation/rocjitsu/lib/python/amdisa/encoding_translator_codegen.py), [legalization_codegen.py](emulation/rocjitsu/lib/python/amdisa/legalization_codegen.py), [cross_isa.py](emulation/rocjitsu/lib/python/amdisa/cross_isa.py), [codegen/](emulation/rocjitsu/lib/python/amdisa/codegen/).
   - [rocjitsu_vllm](emulation/rocjitsu/lib/python/rocjitsu_vllm/) — Python integration glue for running vLLM on top of rocjitsu.
@@ -106,7 +106,7 @@ flowchart TB
                 CODEAPI --> DBI --> ANA
             end
             subgraph ISA["ISA Layer"]
-                I1["Per-ISA: decoders, execution, operand types, machine instr structs, encoding formats<br/>9 ISAs: CDNA1–4, RDNA1–4, RDNA3.5"]
+                I1["Per-ISA: decoders, execution, operand types, machine instr structs, encoding formats<br/>CDNA1–5, RDNA1–4"]
                 subgraph AMDISA["amdisa (Python codegen)"]
                     AM1["Leverages the AMD machine-readable ISA specs to auto-generate<br/>ISA description and semantics for simulation, instrumentation, and translation"]
                 end

--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -24,7 +24,7 @@ real hardware. Supports three execution strategies:
 | RDNA1&trade; | gfx1010 | GFX10 | Experimental |
 | RDNA2&trade; | gfx1030 | GFX10 | Experimental |
 | RDNA3&trade; | gfx110x | GFX11 | Beta |
-| RDNA3.5&trade; | gfx1150 | GFX11.5 | Experimental |
+| RDNA3.5&trade; | gfx1151 | GFX11.5 | Experimental |
 | RDNA4&trade; | gfx120x | GFX12 | Beta |
 | RISC-V | RV64I | RV | Experimental |
 

--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -14,19 +14,21 @@ real hardware. Supports three execution strategies:
 
 ## Supported architectures
 
-| Architecture | GFX Target | ISA Family | Simulation | DBT | DBI |
-|---|---|---|---|---|---|
-| CDNA1&trade; | gfx908 | GFX9 | Experimental | Experimental | Planned |
-| CDNA2&trade; | gfx90a | GFX9 | Experimental | Experimental | Planned |
-| CDNA3&trade; | gfx94x | GFX9 | Experimental | Experimental | Planned |
-| CDNA4&trade; | gfx950 | GFX9 | Beta | Experimental | Planned |
-| RDNA1&trade; | gfx1010 | GFX10 | Experimental | Experimental | Planned |
-| RDNA2&trade; | gfx1030 | GFX10 | Experimental | Experimental | Planned |
-| RDNA3&trade; | gfx1100 | GFX11 | Experimental | Experimental | Planned |
-| RDNA3.5&trade; | gfx1150 | GFX11 | Experimental | Experimental | Planned |
-| RDNA4&trade; | gfx1200 | GFX12 | Experimental | Experimental | Planned |
-| CDNA5&trade; | gfx1250 | GFX12 | Experimental | Experimental | Planned |
-| RISC-V | RV64I | RV | Experimental | &mdash; | &mdash; |
+| Architecture | GFX Target | ISA Family | Simulation |
+|---|---|---|---|
+| CDNA1&trade; | gfx908 | GFX9 | Experimental |
+| CDNA2&trade; | gfx90a | GFX9 | Experimental |
+| CDNA3&trade; | gfx94x | GFX9 | Beta |
+| CDNA4&trade; | gfx950 | GFX9 | Beta |
+| CDNA5&trade; | gfx1250 | GFX12.5 | Beta |
+| RDNA1&trade; | gfx1010 | GFX10 | Experimental |
+| RDNA2&trade; | gfx1030 | GFX10 | Experimental |
+| RDNA3&trade; | gfx110x | GFX11 | Beta |
+| RDNA3.5&trade; | gfx1150 | GFX11.5 | Experimental |
+| RDNA4&trade; | gfx120x | GFX12 | Beta |
+| RISC-V | RV64I | RV | Experimental |
+
+CDNA4&trade; to CDNA3&trade; dynamic binary translation is experimental.
 
 <!-- \NPI new GPU: add a row to the supported-architectures table above. -->
 

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -1,23 +1,39 @@
 # Configuration
 
-Simulation topologies are defined declaratively in JSON. The config
-specifies the component hierarchy, link connectivity, and simulation
-parameters.
+Rocjitsu behavior is configured declaratively in JSON. Simulator configs
+specify the component hierarchy, link connectivity, and simulation parameters;
+DBT guest configs select the guest and host targets and execution backend.
 
-## Config files
+## Simulator configs
 
-Pre-built configs are in `configs/`:
+Pre-built simulator configs are in `configs/`:
 
 | File | Description |
 |---|---|
+| `gfx942_cdna3.json` | Single CDNA3 GPU (standalone simulation) |
+| `gfx942_cdna3_kmd.json` | Single CDNA3 GPU (daemon/KFD mode) |
 | `gfx950_cdna4.json` | Single CDNA4 GPU (standalone simulation) |
 | `gfx950_cdna4_kmd.json` | Single CDNA4 GPU (daemon/KFD mode) |
 | `gfx950_cdna4_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
-| `gfx942_cdna3.json` | Single CDNA3 GPU (standalone simulation) |
-| `gfx942_cdna3_kmd.json` | Single CDNA3 GPU (daemon/KFD mode) |
 | `gfx1250.json` | Single gfx1250 GPU (standalone simulation, no KMD) |
+| `gfx1100_w7900.json` | Single RDNA3 GPU (standalone simulation) |
+| `gfx1151.json` | Single RDNA3.5 GPU (standalone simulation) |
+| `gfx1201_r9700.json` | Single RDNA4 GPU (standalone simulation) |
+
+## DBT guest configs
+
+The checked-in [DBT guest-mode](rocjitsu_dbt_guest.md) configs cover hardware
+and simulated host execution:
+
+| File | Description |
+|---|---|
+| `guest_gfx950_on_gfx942.json` | CDNA4 guest on a CDNA3 hardware host |
+| `guest_gfx950_on_simulated_gfx942.json` | CDNA4 guest on a simulated CDNA3 host |
+| `guest_gfx950_on_gfx1201.json` | CDNA4 guest on an RDNA4 hardware host |
 
 ## JSON structure
+
+The remaining sections describe simulator topology configs.
 
 ```json
 {


### PR DESCRIPTION
Align the public documentation with the simulator and translation coverage currently represented in the tree.

Mark CDNA3, CDNA4, CDNA5, RDNA3, and RDNA4 simulation support as Beta; keep CDNA5 scoped to gfx1250; use family target names where appropriate; remove the DBT and DBI table columns; and document the experimental CDNA4-to-CDNA3 translation path.

Refresh the emulation overview without a brittle ISA count, and expand the configuration guide to list every checked-in simulator and DBT guest configuration.