### PR TITLE
fix(rocprofiler-sdk): allow PYTHON_EXECUTABLES to be passed in from TheRock

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -42,12 +42,14 @@ endif()
 macro(rocprofiler_find_python3 _VERSION)
     rocprofiler_reset_python3_cache()
 
-    # If an explicit executor list was provided (e.g. from TheRock via
+    # If an explicit executable list was provided (e.g. from TheRock via
     # -DROCPROFILER_PYTHON_EXECUTABLES), pre-seed Python3_EXECUTABLE for this version
     # before calling find_package. This is necessary for Python versions that CMake's
     # FindPython3 does not auto-discover (e.g. Python 3.14+ on manylinux where an older
     # CMake has no knowledge of the new install path).
     if(DEFINED ROCPROFILER_PYTHON_EXECUTABLES)
+        string(REGEX MATCH "^[0-9]+\\.[0-9]+" _rocprofiler_requested_major_minor
+                     "${_VERSION}")
         foreach(_rocprofiler_candidate_exe IN LISTS ROCPROFILER_PYTHON_EXECUTABLES)
             execute_process(
                 COMMAND
@@ -57,8 +59,9 @@ macro(rocprofiler_find_python3 _VERSION)
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 RESULT_VARIABLE _rocprofiler_candidate_result
                 ERROR_QUIET)
-            if(_rocprofiler_candidate_result EQUAL 0 AND "${_rocprofiler_candidate_ver}"
-                                                         STREQUAL "${_VERSION}")
+            if(_rocprofiler_candidate_result EQUAL 0
+               AND "${_rocprofiler_candidate_ver}" STREQUAL
+                   "${_rocprofiler_requested_major_minor}")
                 set(Python3_EXECUTABLE
                     "${_rocprofiler_candidate_exe}"
                     CACHE FILEPATH "" FORCE)
@@ -68,6 +71,7 @@ macro(rocprofiler_find_python3 _VERSION)
         unset(_rocprofiler_candidate_exe)
         unset(_rocprofiler_candidate_ver)
         unset(_rocprofiler_candidate_result)
+        unset(_rocprofiler_requested_major_minor)
     endif()
 
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -42,6 +42,34 @@ endif()
 macro(rocprofiler_find_python3 _VERSION)
     rocprofiler_reset_python3_cache()
 
+    # If an explicit executor list was provided (e.g. from TheRock via
+    # -DROCPROFILER_PYTHON_EXECUTABLES), pre-seed Python3_EXECUTABLE for this version
+    # before calling find_package. This is necessary for Python versions that CMake's
+    # FindPython3 does not auto-discover (e.g. Python 3.14+ on manylinux where an older
+    # CMake has no knowledge of the new install path).
+    if(DEFINED ROCPROFILER_PYTHON_EXECUTABLES)
+        foreach(_rocprofiler_candidate_exe IN LISTS ROCPROFILER_PYTHON_EXECUTABLES)
+            execute_process(
+                COMMAND
+                    "${_rocprofiler_candidate_exe}" -c
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+                OUTPUT_VARIABLE _rocprofiler_candidate_ver
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _rocprofiler_candidate_result
+                ERROR_QUIET)
+            if(_rocprofiler_candidate_result EQUAL 0 AND "${_rocprofiler_candidate_ver}"
+                                                         STREQUAL "${_VERSION}")
+                set(Python3_EXECUTABLE
+                    "${_rocprofiler_candidate_exe}"
+                    CACHE FILEPATH "" FORCE)
+                break()
+            endif()
+        endforeach()
+        unset(_rocprofiler_candidate_exe)
+        unset(_rocprofiler_candidate_ver)
+        unset(_rocprofiler_candidate_result)
+    endif()
+
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
         find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
                      COMPONENTS ${ROCPROFILER_BUILD_Find_Python3_COMPONENTS})


### PR DESCRIPTION
## Motivation

When adding Python 3.14 support for roctx and rocpd in TheRock, we need to allow them to pass in a hint to the python executable.

## Technical Details

CMake 3.27 (used in the manylinux build container) was released in July 2023 — before Python 3.14 existed. Its FindPython3 module doesn't know to probe /opt/python/cp314-cp314/ on manylinux, so it falls back to the system /bin/python3 (wrong version) and fails. For 3.10–3.13, CMake already had those paths baked into its discovery logic.

rocprofiler_find_python3 now checks ROCPROFILER_PYTHON_EXECUTABLES after the cache reset. If a matching executable is found for the requested version, it pre-seeds Python3_EXECUTABLE in the CMake cache before calling find_package. CMake then uses the explicitly provided path instead of trying to auto-discover — bypassing the CMake version limitation entirely.

Needed in conjunction with this TheRock PR https://github.com/ROCm/TheRock/pull/7350 to fix Python 3.14 support for roctx and rocpd in TheRock builds.

In TheRock multi-arch CI build, seeing error log like this, when adding Python 3.14:

```
[rocprofiler-sdk configure] CMake Warning (dev) at cmake/Modules/rocprofiler-sdk-utilities.cmake:43 (message):
[rocprofiler-sdk configure]   /__w/TheRock/TheRock/build/dist/rocm/bin/rocminfo returned 1
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure]   stderr:
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure]   stdout:
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure]   ROCk module is NOT loaded, possibly no GPU devices
[rocprofiler-sdk configure] Call Stack (most recent call first):
[rocprofiler-sdk configure]   cmake/Modules/rocprofiler-sdk-utilities.cmake:120 (rocprofiler_sdk_get_gfx_architectures)
[rocprofiler-sdk configure]   source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt:59 (rocprofiler_sdk_sqtt_triple_buffer_disabled)
[rocprofiler-sdk configure] This warning is for project developers.  Use -Wno-dev to suppress it.
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure] -- Resolving super-project find_package(rocprofiler-register REQUIRED BYPASS_PROVIDER NO_DEFAULT_PATH PATHS /__w/TheRock/TheRock/build/base/rocprofiler-register/dist/lib/cmake/rocprofiler-register)
[rocprofiler-sdk configure] -- Resolving super-project find_package(rocprofiler-register REQUIRED BYPASS_PROVIDER NO_DEFAULT_PATH PATHS /__w/TheRock/TheRock/build/base/rocprofiler-register/dist/lib/cmake/rocprofiler-register)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Building rocprofiler-sdk roctx python bindings for python 3.10
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_package(Python3) (not found in super-project ZLIB;zstd;NUMA;BZip2;liblzma;LibElf;libdw;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocm-kpack;rocprofiler-register;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc;rocprof-trace-decoder;yaml-cpp;SQLite3)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h;HINTS;/opt/python/cp310-cp310/include/python3.10;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_SYSTEM_PATH ): /opt/python/cp310-cp310/include/python3.10
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h ): /opt/python/cp310-cp310/include/python3.10
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Building rocprofiler-sdk roctx python bindings for python 3.11
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_package(Python3) (not found in super-project ZLIB;zstd;NUMA;BZip2;liblzma;LibElf;libdw;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocm-kpack;rocprofiler-register;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc;rocprof-trace-decoder;yaml-cpp;SQLite3)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h;HINTS;/opt/python/cp311-cp311/include/python3.11;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_SYSTEM_PATH ): /opt/python/cp311-cp311/include/python3.11
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h ): /opt/python/cp311-cp311/include/python3.11
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Building rocprofiler-sdk roctx python bindings for python 3.12
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_package(Python3) (not found in super-project ZLIB;zstd;NUMA;BZip2;liblzma;LibElf;libdw;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocm-kpack;rocprofiler-register;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc;rocprof-trace-decoder;yaml-cpp;SQLite3)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h;HINTS;/opt/python/cp312-cp312/include/python3.12;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_SYSTEM_PATH ): /opt/python/cp312-cp312/include/python3.12
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h ): /opt/python/cp312-cp312/include/python3.12
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Building rocprofiler-sdk roctx python bindings for python 3.13
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_package(Python3) (not found in super-project ZLIB;zstd;NUMA;BZip2;liblzma;LibElf;libdw;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocm-kpack;rocprofiler-register;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc;rocprof-trace-decoder;yaml-cpp;SQLite3)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h;HINTS;/opt/python/cp313-cp313/include/python3.13;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_SYSTEM_PATH ): /opt/python/cp313-cp313/include/python3.13
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h ): /opt/python/cp313-cp313/include/python3.13
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Building rocprofiler-sdk roctx python bindings for python 3.14
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_package(Python3) (not found in super-project ZLIB;zstd;NUMA;BZip2;liblzma;LibElf;libdw;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocm-kpack;rocprofiler-register;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc;rocprof-trace-decoder;yaml-cpp;SQLite3)
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h;HINTS;ENV;Python3_ROOT_DIR;PATHS;PATH_SUFFIXES;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_SYSTEM_PATH ): _Python3_INCLUDE_DIR-NOTFOUND
[rocprofiler-sdk configure] -- [rocprofiler-sdk][python] Resolving system find_path(_Python3_INCLUDE_DIR NAMES Python.h ): _Python3_INCLUDE_DIR-NOTFOUND
[rocprofiler-sdk configure] CMake Error at /usr/local/therock-tools/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
[rocprofiler-sdk configure]   Could NOT find Python3 (missing: Python3_EXECUTABLE Python3_INCLUDE_DIRS
[rocprofiler-sdk configure]   Interpreter Development.Module) (Required is version range
[rocprofiler-sdk configure]   "3.14.0...3.14.999")
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure]       Reason given by package: 
[rocprofiler-sdk configure]           Interpreter: Wrong version for the interpreter "/bin/python3"
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure] Call Stack (most recent call first):
[rocprofiler-sdk configure]   /usr/local/therock-tools/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
[rocprofiler-sdk configure]   /usr/local/therock-tools/share/cmake-3.27/Modules/FindPython/Support.cmake:3824 (find_package_handle_standard_args)
[rocprofiler-sdk configure]   /usr/local/therock-tools/share/cmake-3.27/Modules/FindPython3.cmake:545 (include)
[rocprofiler-sdk configure]   /__w/TheRock/TheRock/cmake/therock_subproject_dep_provider.cmake:73 (find_package)
[rocprofiler-sdk configure]   source/lib/python/utilities.cmake:49 (find_package)
[rocprofiler-sdk configure]   source/lib/python/utilities.cmake:101 (rocprofiler_find_python3)
[rocprofiler-sdk configure]   source/lib/python/roctx/CMakeLists.txt:6 (rocprofiler_roctx_python_bindings)
[rocprofiler-sdk configure] 
[rocprofiler-sdk configure] 
```

## Issue Tracking

ISSUE ID https://github.com/ROCm/TheRock/issues/7398

## Test Plan

N/A, this is just an optional ENV var passed in

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
