### PR TITLE
[rocjitsu] Apply async IOFFSET to LDS addresses

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -5847,6 +5847,7 @@ class CodeGenerator:
         L = []
         esz, ne = sem.elem_size, sem.num_elems
         _, _, nt = self._coherency_exprs()
+        stride = esz * ne
         L.append(
             '  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);'
         )
@@ -5869,7 +5870,7 @@ class CodeGenerator:
         L.append('  auto &cu = wf.cu();')
         L.append('  uint64_t exec = wf.exec();')
         L.append(
-            '  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.'
+            '  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.'
         )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vdst')};")
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
@@ -5877,7 +5878,9 @@ class CodeGenerator:
         L.append(
             '    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);'
         )
-        L.append('    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;')
+        L.append(
+            f'    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, {stride});'
+        )
         L.append('  }')
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -5903,14 +5906,20 @@ class CodeGenerator:
         L.append('  const auto &lds = cu.lds();')
         L.append('  uint64_t exec = wf.exec();')
         L.append(
-            '  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.'
+            '  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.'
         )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vsrc')};")
         L.append(f'  d->store_data.resize(wf.wf_size() * {stride});')
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('    if (!(exec & (1ULL << lane))) continue;')
         L.append(
-            '    uint32_t lds_addr = wf.lds_base() + amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);'
+            '    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);'
+        )
+        L.append(
+            f'    uint32_t lds_addr = async_lds_lane_address(inst_, wf, lane_lds_addr, {stride});'
+        )
+        L.append(
+            '    // Out-of-range LDS reads return zero; the global store still issues.'
         )
         L.append(f'    lds.read(lds_addr, &d->store_data[lane * {stride}], {stride});')
         L.append('  }')
@@ -5925,9 +5934,12 @@ class CodeGenerator:
         L.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
         L.append('    d->cu_path = wf.cu().full_path();')
         L.append('    uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);')
-        L.append(
-            '    int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);'
+        offset_expr = (
+            'signed_ioffset(inst_.ioffset)'
+            if self.isa_spec.arch_name == 'gfx1250'
+            else 'static_cast<int32_t>(inst_.ioffset << 8) >> 8'
         )
+        L.append(f'    int64_t offset = static_cast<int64_t>({offset_expr});')
         L.append('    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('      if (!(exec & (1ULL << lane))) continue;')
         L.append(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3926,6 +3926,88 @@ def test_gfx1250_cluster_load_generators_force_request_l1_bypass():
     assert 'd->request_force_l1_bypass = true;' not in global_async_body
 
 
+def test_gfx1250_async_lds_generators_apply_signed_ioffset():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        arch_name='gfx1250',
+        profile=Gfx1250Profile(),
+    )
+
+    expected_load_address = (
+        'd->per_lane_lds_addr[lane] = '
+        'async_lds_lane_address(inst_, wf, lane_lds_addr, 4);'
+    )
+
+    global_async = SimpleNamespace(
+        name='GLOBAL_LOAD_ASYNC_TO_LDS_B32',
+        elem_size=4,
+        num_elems=1,
+    )
+    global_async_body = codegen._gen_global_load_async_to_lds([], [], global_async)
+    assert expected_load_address in global_async_body
+
+    cluster_async_cases = [
+        ('CLUSTER_LOAD_ASYNC_TO_LDS_B8', 1, 1),
+        ('CLUSTER_LOAD_ASYNC_TO_LDS_B32', 4, 1),
+        ('CLUSTER_LOAD_ASYNC_TO_LDS_B64', 4, 2),
+        ('CLUSTER_LOAD_ASYNC_TO_LDS_B128', 4, 4),
+    ]
+    for name, elem_size, num_elems in cluster_async_cases:
+        cluster_async = SimpleNamespace(
+            name=name,
+            elem_size=elem_size,
+            num_elems=num_elems,
+        )
+        cluster_async_body = codegen._gen_global_load_async_to_lds(
+            [], [], cluster_async
+        )
+        assert (
+            'd->per_lane_lds_addr[lane] = '
+            f'async_lds_lane_address(inst_, wf, lane_lds_addr, {elem_size * num_elems});'
+            in cluster_async_body
+        )
+
+    global_store_cases = [
+        ('GLOBAL_STORE_ASYNC_FROM_LDS_B8', 1, 1),
+        ('GLOBAL_STORE_ASYNC_FROM_LDS_B32', 4, 1),
+        ('GLOBAL_STORE_ASYNC_FROM_LDS_B64', 4, 2),
+        ('GLOBAL_STORE_ASYNC_FROM_LDS_B128', 4, 4),
+    ]
+    for name, elem_size, num_elems in global_store_cases:
+        global_store = SimpleNamespace(
+            name=name,
+            elem_size=elem_size,
+            num_elems=num_elems,
+        )
+        global_store_body = codegen._gen_global_store_async_from_lds(
+            [], [], global_store
+        )
+        assert (
+            'uint32_t lds_addr = '
+            f'async_lds_lane_address(inst_, wf, lane_lds_addr, {elem_size * num_elems});'
+            in global_store_body
+        )
+
+    addtid_lines = []
+    codegen._append_global_addtid_addresses(addtid_lines)
+    assert (
+        '    int64_t offset = static_cast<int64_t>(signed_ioffset(inst_.ioffset));'
+        in addtid_lines
+    )
+
+    rdna4_codegen = object.__new__(CodeGenerator)
+    rdna4_codegen.isa_spec = SimpleNamespace(
+        arch_name='gfx1201',
+        profile=Rdna4Profile(),
+    )
+    rdna4_addtid_lines = []
+    rdna4_codegen._append_global_addtid_addresses(rdna4_addtid_lines)
+    assert (
+        '    int64_t offset = static_cast<int64_t>('
+        'static_cast<int32_t>(inst_.ioffset << 8) >> 8);' in rdna4_addtid_lines
+    )
+
+
 def test_gfx1250_buffer_cmpswap_payload_width_is_independent_of_element_width():
     codegen = object.__new__(CodeGenerator)
     codegen.isa_spec = SimpleNamespace(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/operand_types.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/lds.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
@@ -117,7 +118,7 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
   auto &cu = wf.cu();
   init_vector_mem_state(wf, d);
   uint64_t exec = d.exec_mask;
-  int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  int64_t offset = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   bool saddr_present = has_saddr(inst.saddr);
   uint64_t saddr_val = saddr_present ? read_sreg64_operand(wf, inst.saddr) : 0;
   uint32_t scale = saddr_present && inst.scale_offset ? scaled_vaddr_factor(d) : 1;
@@ -156,7 +157,7 @@ uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &
   uint32_t sbase = wf.sgpr_alloc().base + inst.sbase * 2;
   uint64_t base = (static_cast<uint64_t>(amdgpu::RegisterAccess(cu).read_sgpr(sbase + 1)) << 32) |
                   amdgpu::RegisterAccess(cu).read_sgpr(sbase);
-  int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  int64_t off = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   uint32_t scale = inst.scale_offset ? access_size_bytes : 1;
   if (has_smem_offset(inst.soffset))
     off += static_cast<int64_t>(read_sreg_m0_operand(wf, inst.soffset)) * scale;
@@ -176,12 +177,24 @@ void flat_calculate_addresses(const VglobalMachineInst &inst, amdgpu::Wavefront 
   flat_global_calculate_addresses(inst, wf, d, false);
 }
 
+uint32_t async_lds_lane_address(const VglobalMachineInst &inst, const amdgpu::Wavefront &wf,
+                                uint32_t lds_operand, uint32_t access_size_bytes) {
+  int64_t relative_addr = static_cast<int64_t>(lds_operand) + signed_ioffset(inst.ioffset);
+  if (relative_addr < 0 || static_cast<uint64_t>(relative_addr) + access_size_bytes > wf.lds_size())
+    return amdgpu::kInvalidLdsAddress;
+
+  uint64_t absolute_addr = static_cast<uint64_t>(wf.lds_base()) + relative_addr;
+  if (absolute_addr >= UINT32_MAX)
+    return amdgpu::kInvalidLdsAddress;
+  return static_cast<uint32_t>(absolute_addr);
+}
+
 void flat_calculate_addresses(const VscratchMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d) {
   auto &cu = wf.cu();
   init_vector_mem_state(wf, d);
   uint64_t exec = d.exec_mask;
-  int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  int64_t offset = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   uint64_t scratch_base = wf.scratch_base();
   uint32_t saddr_val = 0;
   if (has_saddr(inst.saddr))
@@ -225,7 +238,7 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
   uint32_t stride = buffer_stride(srd3);
   bool oob_raw = buffer_oob_raw(srd3);
   uint32_t soffset_val = has_smem_offset(inst.soffset) ? read_sreg_m0_operand(wf, inst.soffset) : 0;
-  int64_t ioff = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  int64_t ioff = static_cast<int64_t>(signed_ioffset(inst.ioffset));
   uint32_t vbase = 0;
   if (inst.idxen || inst.offen)
     vbase = resolved_vgpr_base(wf, inst.vaddr, amdgpu::VgprMsbRole::Src0);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
@@ -18,6 +18,9 @@ struct VectorMemState;
 
 namespace rocjitsu::cdna5 {
 
+/// @brief Sign-extend a CDNA5 24-bit IOFFSET field.
+inline int32_t signed_ioffset(uint32_t ioffset) { return static_cast<int32_t>(ioffset << 8) >> 8; }
+
 uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
                                 uint32_t access_size_bytes);
 
@@ -26,6 +29,14 @@ void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &w
 
 void flat_calculate_addresses(const VglobalMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);
+
+/// @brief Compute an absolute async LDS address within the workgroup allocation.
+///
+/// @returns amdgpu::kInvalidLdsAddress when any byte in the access is outside
+/// the allocation or the absolute address equals the reserved invalid value or
+/// cannot be represented in 32 bits.
+uint32_t async_lds_lane_address(const VglobalMachineInst &inst, const amdgpu::Wavefront &wf,
+                                uint32_t lds_operand, uint32_t access_size_bytes);
 
 void flat_calculate_addresses(const VscratchMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
@@ -470,7 +470,7 @@ void GlobalLoadAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_id = wf.wf_id();
     d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
-    int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+    int64_t offset = static_cast<int64_t>(signed_ioffset(inst_.ioffset));
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
       if (!(exec & (1ULL << lane)))
         continue;
@@ -498,7 +498,7 @@ void GlobalStoreAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_id = wf.wf_id();
     d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
-    int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+    int64_t offset = static_cast<int64_t>(signed_ioffset(inst_.ioffset));
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
       if (!(exec & (1ULL << lane)))
         continue;
@@ -1726,7 +1726,7 @@ void GlobalLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -1734,7 +1734,7 @@ void GlobalLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 1);
   }
   set_data(std::move(d));
 }
@@ -1753,7 +1753,7 @@ void GlobalLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -1761,7 +1761,7 @@ void GlobalLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 4);
   }
   set_data(std::move(d));
 }
@@ -1780,7 +1780,7 @@ void GlobalLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -1788,7 +1788,7 @@ void GlobalLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 8);
   }
   set_data(std::move(d));
 }
@@ -1807,7 +1807,7 @@ void GlobalLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -1815,7 +1815,7 @@ void GlobalLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 16);
   }
   set_data(std::move(d));
 }
@@ -1832,7 +1832,7 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -1840,7 +1840,9 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr = async_lds_lane_address(inst_, wf, lane_lds_addr, 1);
+    // Out-of-range LDS reads return zero; the global store still issues.
     lds.read(lds_addr, &d->store_data[lane * 1], 1);
   }
   set_data(std::move(d));
@@ -1858,7 +1860,7 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -1866,7 +1868,9 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr = async_lds_lane_address(inst_, wf, lane_lds_addr, 4);
+    // Out-of-range LDS reads return zero; the global store still issues.
     lds.read(lds_addr, &d->store_data[lane * 4], 4);
   }
   set_data(std::move(d));
@@ -1884,7 +1888,7 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -1892,7 +1896,9 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr = async_lds_lane_address(inst_, wf, lane_lds_addr, 8);
+    // Out-of-range LDS reads return zero; the global store still issues.
     lds.read(lds_addr, &d->store_data[lane * 8], 8);
   }
   set_data(std::move(d));
@@ -1910,7 +1916,7 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -1918,7 +1924,9 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr = async_lds_lane_address(inst_, wf, lane_lds_addr, 16);
+    // Out-of-range LDS reads return zero; the global store still issues.
     lds.read(lds_addr, &d->store_data[lane * 16], 16);
   }
   set_data(std::move(d));
@@ -1989,7 +1997,7 @@ void ClusterLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -1997,7 +2005,7 @@ void ClusterLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 1);
   }
   set_data(std::move(d));
 }
@@ -2019,7 +2027,7 @@ void ClusterLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2027,7 +2035,7 @@ void ClusterLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 4);
   }
   set_data(std::move(d));
 }
@@ -2049,7 +2057,7 @@ void ClusterLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2057,7 +2065,7 @@ void ClusterLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 8);
   }
   set_data(std::move(d));
 }
@@ -2079,7 +2087,7 @@ void ClusterLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
+  // CDNA5 ISA 10.8.1 and expressions 95-102 and 106-109 add IOFFSET to global and LDS addresses.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2087,7 +2095,7 @@ void ClusterLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = amdgpu::RegisterAccess(cu).read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
+    d->per_lane_lds_addr[lane] = async_lds_lane_address(inst_, wf, lane_lds_addr, 16);
   }
   set_data(std::move(d));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
@@ -35,34 +35,42 @@ void write_cluster_lds_target(const ClusterLdsMulticastTransaction &txn,
           "cluster LDS multicast payload too small: lane={} offset={} bytes={} payload={}", lane,
           data_offset, txn.bytes_per_lane, txn.payload.size()));
     }
-    uint32_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
-    if (uint64_t(lds_addr) + txn.bytes_per_lane > lds.size_bytes()) {
-      throw std::runtime_error(std::format(
-          "cluster LDS multicast target address out of range: lane={} target_wg={} addr={:#x} "
-          "bytes={} lds_size={}",
-          lane, target.wg_id, lds_addr, txn.bytes_per_lane, lds.size_bytes()));
+    uint64_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
+    if (txn.per_lane_addr && lds_addr == kInvalidLdsAddress)
+      continue;
+    if (lds_addr + txn.bytes_per_lane > lds.size_bytes()) {
+      if (!txn.per_lane_addr) {
+        throw std::runtime_error(std::format(
+            "cluster LDS multicast target out of range: lane={} wg={} address={:#x} bytes={} "
+            "LDS={}",
+            lane, target.wg_id, lds_addr, txn.bytes_per_lane, lds.size_bytes()));
+      }
+      continue;
     }
     for (uint32_t b = 0; b < txn.bytes_per_lane; ++b)
-      lds.write8(lds_addr + b, txn.payload[data_offset + b]);
+      lds.write8(static_cast<uint32_t>(lds_addr + b), txn.payload[data_offset + b]);
   }
 }
 
 } // namespace
 
-uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
-                                uint32_t source_lds_addr) {
+uint64_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
+                                uint64_t source_lds_addr) {
   if (source_lds_addr < source_lds_base) {
     throw std::runtime_error(std::format("cluster LDS source address {:#x} precedes base {:#x}",
                                          source_lds_addr, source_lds_base));
   }
-  return target_lds_base + (source_lds_addr - source_lds_base);
+  return static_cast<uint64_t>(target_lds_base) + (source_lds_addr - source_lds_base);
 }
 
-uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
+uint64_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
                                uint32_t target_lds_base) {
-  uint32_t source_lds_addr = txn.source_lds_base + lane * txn.bytes_per_lane;
-  if (txn.per_lane_addr)
+  uint64_t source_lds_addr = static_cast<uint64_t>(txn.source_lds_base) + lane * txn.bytes_per_lane;
+  if (txn.per_lane_addr) {
     source_lds_addr = txn.per_lane_lds_addr[lane];
+    if (source_lds_addr == kInvalidLdsAddress || source_lds_addr < txn.source_lds_base)
+      return kInvalidLdsAddress;
+  }
   return remap_cluster_lds_addr(txn.source_lds_base, target_lds_base, source_lds_addr);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
@@ -62,15 +62,15 @@ enum class [[nodiscard]] ClusterLdsMulticastResult {
 using ClusterLdsMulticastCompletion = std::function<void()>;
 
 /// @brief Remap a source WG LDS address into an equivalent target WG LDS window.
-uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
-                                uint32_t source_lds_addr);
+uint64_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
+                                uint64_t source_lds_addr);
 
 /// @brief Return the lane LDS address remapped into one target LDS window.
 ///
 /// @details Immediate functional writeback only uses this with the issuing
 /// participant's own target, where the remap is identity. Deferred/timing
 /// backends can reuse it when modeling peer-visible multicast responses.
-uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
+uint64_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
                                uint32_t target_lds_base);
 
 /// @brief Return true when the transaction mask selects the issuing workgroup.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1040,6 +1040,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = wg_wavefronts[w];
       wf->set_lds_base(lds_base);
+      wf->set_lds_size(aligned_lds_bytes_per_workgroup(entry));
       wf->set_lds(placement.lds);
       wf->set_dispatch_id(entry.dispatch_id);
       wf->set_process_id(entry.process_id);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds.h
@@ -14,6 +14,9 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+/// Reserved value used when an instruction lane has no valid LDS address.
+constexpr uint32_t kInvalidLdsAddress = UINT32_MAX;
+
 /// @brief Local Data Share (LDS) memory backing for a dispatch placement.
 ///
 /// @details CU-mode workgroups use the backing owned by one ComputeUnitCore.
@@ -44,7 +47,7 @@ public:
 
   /// @brief Read 16 bits (little-endian) from LDS. OOB returns 0.
   uint16_t read16(uint32_t addr) const {
-    if (addr + 1 >= data_.size())
+    if (!contains(addr, 2))
       return 0;
     uint16_t val;
     std::memcpy(&val, &data_[addr], 2);
@@ -53,14 +56,14 @@ public:
 
   /// @brief Write 16 bits (little-endian) to LDS. OOB writes are dropped.
   void write16(uint32_t addr, uint16_t val) {
-    if (addr + 1 >= data_.size())
+    if (!contains(addr, 2))
       return;
     std::memcpy(&data_[addr], &val, 2);
   }
 
   /// @brief Read 32 bits (little-endian) from LDS. OOB returns 0.
   uint32_t read32(uint32_t addr) const {
-    if (addr + 3 >= data_.size())
+    if (!contains(addr, 4))
       return 0;
     uint32_t val;
     std::memcpy(&val, &data_[addr], 4);
@@ -69,14 +72,14 @@ public:
 
   /// @brief Write 32 bits (little-endian) to LDS. OOB writes are dropped.
   void write32(uint32_t addr, uint32_t val) {
-    if (addr + 3 >= data_.size())
+    if (!contains(addr, 4))
       return;
     std::memcpy(&data_[addr], &val, 4);
   }
 
   /// @brief Read 64 bits (little-endian) from LDS. OOB returns 0.
   uint64_t read64(uint32_t addr) const {
-    if (addr + 7 >= data_.size())
+    if (!contains(addr, 8))
       return 0;
     uint64_t val;
     std::memcpy(&val, &data_[addr], 8);
@@ -85,14 +88,14 @@ public:
 
   /// @brief Write 64 bits (little-endian) to LDS. OOB writes are dropped.
   void write64(uint32_t addr, uint64_t val) {
-    if (addr + 7 >= data_.size())
+    if (!contains(addr, 8))
       return;
     std::memcpy(&data_[addr], &val, 8);
   }
 
   /// @brief Bulk read of arbitrary size from LDS. OOB returns 0.
   void read(uint32_t addr, uint8_t *dst, uint32_t size) const {
-    if (addr + size > data_.size()) {
+    if (!contains(addr, size)) {
       std::memset(dst, 0, size);
       return;
     }
@@ -101,7 +104,7 @@ public:
 
   /// @brief Bulk write of arbitrary size to LDS. OOB writes are dropped.
   void write(uint32_t addr, const uint8_t *src, uint32_t size) {
-    if (addr + size > data_.size())
+    if (!contains(addr, size))
       return;
     std::memcpy(&data_[addr], src, size);
   }
@@ -109,14 +112,14 @@ public:
   /// @brief MemoryInterface read (truncates addr to 32-bit local address).
   void read(uint64_t addr, uint8_t *dst, uint32_t size) override {
     auto a = static_cast<uint32_t>(addr);
-    assert(a + size <= data_.size());
+    assert(contains(a, size));
     std::memcpy(dst, &data_[a], size);
   }
 
   /// @brief MemoryInterface write (truncates addr to 32-bit local address).
   void write(uint64_t addr, const uint8_t *src, uint32_t size) override {
     auto a = static_cast<uint32_t>(addr);
-    assert(a + size <= data_.size());
+    assert(contains(a, size));
     std::memcpy(&data_[a], src, size);
   }
 
@@ -182,6 +185,10 @@ public:
   uint8_t *data() { return data_.data(); }
 
 private:
+  bool contains(uint32_t addr, uint32_t size) const {
+    return static_cast<uint64_t>(addr) + size <= data_.size();
+  }
+
   std::vector<uint8_t> data_;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -69,6 +69,8 @@ void write_lds_dst_load_direct(const VectorMemState &d, Lds &lds, uint32_t per_l
     }
     uint32_t lds_addr =
         d.lds_per_lane_addr ? d.per_lane_lds_addr[lane] : d.lds_base + lane * per_lane_bytes;
+    if (lds_addr == kInvalidLdsAddress)
+      continue;
     lds.write(lds_addr, &d.response_data[data_offset], per_lane_bytes);
   }
 }
@@ -100,6 +102,10 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
         std::memcpy(&v, &d.response_data[ln * per_lane_bytes], 4);
       uint32_t lds_addr =
           d.lds_per_lane_addr ? d.per_lane_lds_addr[ln] : d.lds_base + ln * per_lane_bytes;
+      if (lds_addr == kInvalidLdsAddress) {
+        os << std::format(" L{}:@{:#x}->lds[dropped]", ln, d.per_lane_addr[ln]);
+        continue;
+      }
       os << std::format(" L{}:@{:#x}->lds[{:#x}]={:#x}", ln, d.per_lane_addr[ln], lds_addr, v);
     }
   });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -111,6 +111,7 @@ public:
                                         wg.entry->sgprs_per_wf, wg.entry->vgprs_per_wf);
         assert(wf && "dispatch_wf failed after select_cu returned a CU");
         wf->set_lds_base(lds_base);
+        wf->set_lds_size(util::align_up(wg.entry->group_segment_fixed_size, 256u));
         wf->set_lds(placement->lds);
         wf->set_dispatch_id(wg.entry->dispatch_id);
         wf->set_process_id(wg.entry->process_id);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -170,6 +170,12 @@ public:
   /// @brief Set the per-WG LDS base offset.
   void set_lds_base(uint32_t base) { lds_base_ = base; }
 
+  /// @brief Return the aligned LDS allocation size for this workgroup.
+  uint32_t lds_size() const { return lds_size_; }
+
+  /// @brief Set the aligned LDS allocation size for this workgroup.
+  void set_lds_size(uint32_t size) { lds_size_ = size; }
+
   /// @brief Return the LDS backing selected for this workgroup placement.
   ///
   /// CU-mode workgroups use their owning CU's LDS. WGP-mode workgroups can
@@ -476,6 +482,7 @@ public:
     dispatch_id_ = 0;
     process_id_ = 0;
     lds_base_ = 0;
+    lds_size_ = 0;
     lds_ = nullptr;
     cluster_rank_ = 0;
     cluster_size_ = 1;
@@ -520,6 +527,7 @@ protected:
   uint32_t dispatch_id_ = 0;  ///< Dispatch ID (set per dispatch, unique per dispatch).
   uint32_t process_id_ = 0;   ///< Owning process ID (PASID analog, set per dispatch).
   uint32_t lds_base_ = 0;     ///< Per-WG LDS base offset (set per dispatch).
+  uint32_t lds_size_ = 0;     ///< Aligned per-WG LDS allocation size.
   Lds *lds_ = nullptr;        ///< Placement-selected LDS backing; nullptr means CU-local LDS.
   uint32_t cluster_rank_ = 0; ///< Workgroup rank inside the dispatch cluster.
   uint32_t cluster_size_ = 1; ///< Number of workgroups in the dispatch cluster.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/plugins/race_detector/plugin.h"
 
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/lds.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/log.h"
@@ -297,10 +298,14 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
           return;
       }
       uint32_t ldsAddrs[64];
-      for (uint32_t lane = 0; lane < wf.wf_size(); ++lane)
+      uint64_t validLaneMask = d.lane_mask;
+      for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
         ldsAddrs[lane] =
             d.lds_per_lane_addr ? d.per_lane_lds_addr[lane] : d.lds_base + lane * perLaneBytes;
-      rs->registerLdsEvent(wf.pc, MemoryEventType::GLOBAL_TO_LDS, {}, d.lane_mask, wf.wf_size(),
+        if (ldsAddrs[lane] == amdgpu::kInvalidLdsAddress)
+          validLaneMask &= ~(1ULL << lane);
+      }
+      rs->registerLdsEvent(wf.pc, MemoryEventType::GLOBAL_TO_LDS, {}, validLaneMask, wf.wf_size(),
                            std::span<const uint32_t>(ldsAddrs, wf.wf_size()), perLaneBytes);
     } else if (d.is_load && d.dst_reg_base >= wf.vgpr_alloc().base) {
       uint32_t logicalBase = d.dst_reg_base - wf.vgpr_alloc().base;

--- a/emulation/rocjitsu/tests/cdna5_cluster_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_cluster_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cdna5_sim_test_common.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 
 namespace {
 
@@ -68,6 +69,7 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
   ASSERT_NE(wf, nullptr);
   wf->set_exec(0x3u);
   wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_lds_size(256);
   wf->set_m0(0xffff0003u);
 
   constexpr uint64_t kGlobalBase = 0x180000u;
@@ -75,9 +77,9 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
   write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
 
   const uint32_t vgpr_base = wf->vgpr_alloc().base;
-  auto write_vgpr_lane_offsets = [&](uint32_t reg, uint32_t stride) {
-    cu->write_vgpr(vgpr_base + reg, 0, 0);
-    cu->write_vgpr(vgpr_base + reg, 1, stride);
+  auto write_vgpr_lane_offsets = [&](uint32_t reg, uint32_t stride, uint32_t base_offset = 0) {
+    cu->write_vgpr(vgpr_base + reg, 0, base_offset);
+    cu->write_vgpr(vgpr_base + reg, 1, base_offset + stride);
   };
   auto write_vgpr_lane_indices = [&](uint32_t reg) {
     cu->write_vgpr(vgpr_base + reg, 0, 0);
@@ -131,70 +133,87 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
     uint32_t lds_addr_reg;
     uint32_t global_stride;
     uint32_t lds_stride;
-    uint32_t offset;
+    uint32_t base_offset;
+    int32_t instruction_offset;
     bool scale_offset;
     bool cluster_multicast;
   };
 
   const AsyncCase async_cases[] = {
-      {{0xEE1A8000u, 0x00000000u, 0x00000000u},
-       "cluster_load_async_to_lds_b8",
-       1,
-       1,
-       0,
-       1,
-       1,
-       0,
-       false,
-       true},
-      {{0xEE180000u, 0x00000000u, 0x00000800u},
-       "global_load_async_to_lds_b32",
-       4,
-       1,
-       0,
-       16,
-       16,
-       8,
-       false,
-       false},
-      {{0xEE1AC000u, 0x00000000u, 0x00000800u},
-       "cluster_load_async_to_lds_b32",
-       4,
-       1,
-       0,
-       16,
-       16,
-       8,
-       false,
-       true},
-      {{0xEE1B0000u, 0x00000004u, 0x00000004u},
-       "cluster_load_async_to_lds_b64",
-       4,
-       2,
-       4,
-       16,
-       16,
-       0,
-       false,
-       true},
-      {{0xEE1B4000u, 0x00010001u, 0x00000000u},
-       "cluster_load_async_to_lds_b128",
-       4,
-       4,
-       1,
-       16,
-       16,
-       0,
-       true,
-       true},
+      {.words = {0xEE1A8000u, 0x00000000u, 0x00000000u},
+       .mnemonic = "cluster_load_async_to_lds_b8",
+       .elem_size = 1,
+       .num_elems = 1,
+       .lds_addr_reg = 0,
+       .global_stride = 1,
+       .lds_stride = 1,
+       .base_offset = 0,
+       .instruction_offset = 0,
+       .scale_offset = false,
+       .cluster_multicast = true},
+      {.words = {0xEE180000u, 0x00000000u, 0x00000800u},
+       .mnemonic = "global_load_async_to_lds_b32",
+       .elem_size = 4,
+       .num_elems = 1,
+       .lds_addr_reg = 0,
+       .global_stride = 16,
+       .lds_stride = 16,
+       .base_offset = 0,
+       .instruction_offset = 8,
+       .scale_offset = false,
+       .cluster_multicast = false},
+      {.words = {0xEE1AC000u, 0x00000000u, 0x00000800u},
+       .mnemonic = "cluster_load_async_to_lds_b32",
+       .elem_size = 4,
+       .num_elems = 1,
+       .lds_addr_reg = 0,
+       .global_stride = 16,
+       .lds_stride = 16,
+       .base_offset = 0,
+       .instruction_offset = 8,
+       .scale_offset = false,
+       .cluster_multicast = true},
+      {.words = {0xEE1AC000u, 0x00000000u, 0xFFFFC000u},
+       .mnemonic = "cluster_load_async_to_lds_b32",
+       .elem_size = 4,
+       .num_elems = 1,
+       .lds_addr_reg = 0,
+       .global_stride = 16,
+       .lds_stride = 16,
+       .base_offset = 128,
+       .instruction_offset = -64,
+       .scale_offset = false,
+       .cluster_multicast = true},
+      {.words = {0xEE1B0000u, 0x00000004u, 0x00000004u},
+       .mnemonic = "cluster_load_async_to_lds_b64",
+       .elem_size = 4,
+       .num_elems = 2,
+       .lds_addr_reg = 4,
+       .global_stride = 16,
+       .lds_stride = 16,
+       .base_offset = 0,
+       .instruction_offset = 0,
+       .scale_offset = false,
+       .cluster_multicast = true},
+      {.words = {0xEE1B4000u, 0x00010001u, 0x00000800u},
+       .mnemonic = "cluster_load_async_to_lds_b128",
+       .elem_size = 4,
+       .num_elems = 4,
+       .lds_addr_reg = 1,
+       .global_stride = 16,
+       .lds_stride = 16,
+       .base_offset = 0,
+       .instruction_offset = 8,
+       .scale_offset = true,
+       .cluster_multicast = true},
   };
 
   for (const AsyncCase &tc : async_cases) {
     if (tc.scale_offset) {
       write_vgpr_lane_indices(0);
-      write_vgpr_lane_offsets(tc.lds_addr_reg, 16);
+      write_vgpr_lane_offsets(tc.lds_addr_reg, 16, tc.base_offset);
     } else {
-      write_vgpr_lane_offsets(tc.lds_addr_reg, tc.global_stride);
+      write_vgpr_lane_offsets(tc.lds_addr_reg, tc.global_stride, tc.base_offset);
     }
 
     auto inst = decode_gfx1250(tc.words, tc.mnemonic);
@@ -214,36 +233,45 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
     EXPECT_EQ(state->request_force_l1_bypass, tc.cluster_multicast);
     EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
     EXPECT_EQ(state->lane_mask, 0x3u);
-    EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + tc.offset);
-    EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + tc.offset + tc.global_stride);
-    EXPECT_EQ(state->per_lane_lds_addr[0], wf->lds_base());
-    EXPECT_EQ(state->per_lane_lds_addr[1], wf->lds_base() + tc.lds_stride);
+    uint64_t expected_global_base = static_cast<uint64_t>(
+        static_cast<int64_t>(kGlobalBase + tc.base_offset) + tc.instruction_offset);
+    uint32_t expected_lds_offset = tc.base_offset + static_cast<uint32_t>(tc.instruction_offset);
+    EXPECT_EQ(state->per_lane_addr[0], expected_global_base);
+    EXPECT_EQ(state->per_lane_addr[1], expected_global_base + tc.global_stride);
+    EXPECT_EQ(state->per_lane_lds_addr[0], wf->lds_base() + expected_lds_offset);
+    EXPECT_EQ(state->per_lane_lds_addr[1], wf->lds_base() + expected_lds_offset + tc.lds_stride);
   }
 }
 
-TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsKeepsIoffsetOnGlobalDestination) {
+TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsAppliesIoffsetToGlobalAndLdsSource) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
   ASSERT_NE(wf, nullptr);
   wf->set_exec(0x3u);
   wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_lds_size(256);
 
   constexpr uint64_t kGlobalBase = 0x190000u;
   constexpr uint32_t kLane0Value = 0x12345678u;
   constexpr uint32_t kLane1Value = 0xabcdef01u;
-  constexpr uint32_t kIoffset = 8;
+  constexpr uint32_t kVgprOffset = 128;
+  constexpr int32_t kIoffset = -64;
+  constexpr uint32_t kEffectiveOffset =
+      static_cast<uint32_t>(static_cast<int32_t>(kVgprOffset) + kIoffset);
   write_wave_sgpr(*cu, *wf, 0, static_cast<uint32_t>(kGlobalBase));
   write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
 
   const uint32_t vgpr_base = wf->vgpr_alloc().base;
-  cu->write_vgpr(vgpr_base, 0, 0);
-  cu->write_vgpr(vgpr_base, 1, 16);
-  cu->lds().write32(wf->lds_base(), kLane0Value);
-  cu->lds().write32(wf->lds_base() + 16, kLane1Value);
+  cu->write_vgpr(vgpr_base, 0, kVgprOffset);
+  cu->write_vgpr(vgpr_base, 1, kVgprOffset + 16);
+  cu->lds().write32(wf->lds_base() + kVgprOffset, ~kLane0Value);
+  cu->lds().write32(wf->lds_base() + kVgprOffset + 16, ~kLane1Value);
+  cu->lds().write32(wf->lds_base() + kEffectiveOffset, kLane0Value);
+  cu->lds().write32(wf->lds_base() + kEffectiveOffset + 16, kLane1Value);
 
   auto inst =
-      decode_gfx1250({0xEE190000u, 0x00000000u, 0x00000800u}, "global_store_async_from_lds_b32");
+      decode_gfx1250({0xEE190000u, 0x00000000u, 0xFFFFC000u}, "global_store_async_from_lds_b32");
   ASSERT_NE(inst, nullptr);
   inst->execute(*inst, wf);
   auto *state = inst->data_as<amdgpu::VectorMemState>();
@@ -252,8 +280,8 @@ TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsKeepsIoffsetOnGlobalDestinatio
   EXPECT_FALSE(state->is_load);
   EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
   EXPECT_EQ(state->lane_mask, 0x3u);
-  EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + kIoffset);
-  EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + 16 + kIoffset);
+  EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + kEffectiveOffset);
+  EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + kEffectiveOffset + 16);
   ASSERT_GE(state->store_data.size(), 8u);
 
   uint32_t lane0_value = 0;
@@ -262,6 +290,51 @@ TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsKeepsIoffsetOnGlobalDestinatio
   std::memcpy(&lane1_value, &state->store_data[4], sizeof(lane1_value));
   EXPECT_EQ(lane0_value, kLane0Value);
   EXPECT_EQ(lane1_value, kLane1Value);
+}
+
+TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromOutOfRangeLdsSourceProducesZeroPayload) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x1u);
+  wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_lds_size(256);
+
+  constexpr uint64_t kGlobalBase = 0x1a0000u;
+  write_wave_sgpr(*cu, *wf, 0, static_cast<uint32_t>(kGlobalBase));
+  write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
+  cu->write_vgpr(wf->vgpr_alloc().base, 0, 256);
+
+  auto inst =
+      decode_gfx1250({0xEE190000u, 0x00000000u, 0x00000000u}, "global_store_async_from_lds_b32");
+  ASSERT_NE(inst, nullptr);
+  inst->execute(*inst, wf);
+  auto *state = inst->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->lane_mask, 0x1u);
+  ASSERT_GE(state->store_data.size(), sizeof(uint32_t));
+  uint32_t value = UINT32_MAX;
+  std::memcpy(&value, state->store_data.data(), sizeof(value));
+  EXPECT_EQ(value, 0u);
+}
+
+TEST(Gfx1250ExecutionTest, AsyncLdsAddressRejectsAccessOutsideAllocation) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_lds_size(256);
+
+  cdna5::VglobalMachineInst inst{};
+  inst.ioffset = 0xfffffcu;
+  EXPECT_EQ(cdna5::signed_ioffset(inst.ioffset), -4);
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 0, 4), amdgpu::kInvalidLdsAddress);
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 8, 4), wf->lds_base() + 4);
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 256, 4), wf->lds_base() + 252);
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 256, 16), amdgpu::kInvalidLdsAddress);
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 260, 4), amdgpu::kInvalidLdsAddress);
 }
 
 TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes) {
@@ -523,7 +596,7 @@ TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsUndersizedPa
   EXPECT_THROW((void)engine.submit(std::move(txn), []() {}), std::runtime_error);
 }
 
-TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsOutOfRangeTarget) {
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineDropsOutOfRangeTarget) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
 
@@ -539,7 +612,69 @@ TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsOutOfRangeTa
                   /*cluster_rank=*/0}};
 
   amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsStridedOutOfRangeTarget) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = 0;
+  txn.bytes_per_lane = 4;
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.payload.resize(4);
+  txn.targets = {{cu, /*wg_id=*/0, static_cast<uint32_t>(cu->lds().size_bytes()) - 2,
+                  /*cluster_rank=*/0}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
   EXPECT_THROW((void)engine.submit(std::move(txn), []() {}), std::runtime_error);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineDropsWidenedRemapOverflow) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  constexpr uint32_t kSentinel = 0xa5a5a5a5u;
+  cu->lds().write32(0, kSentinel);
+
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = 0x100;
+  txn.bytes_per_lane = 4;
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = 0xffffff00u;
+  txn.payload.resize(4, 0x5a);
+  txn.targets = {{cu, /*wg_id=*/0, /*lds_base=*/0x200, /*cluster_rank=*/0}};
+
+  EXPECT_EQ(amdgpu::cluster_lds_lane_addr(txn, 0, txn.targets[0].lds_base), 0x100000000ULL);
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_EQ(cu->lds().read32(0), kSentinel);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineDropsInvalidSignedOffsetAddress) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  cu->clear_lds();
+
+  constexpr uint32_t kLdsBase = 0x200;
+  constexpr uint32_t kValue = 0x12345678;
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = kLdsBase;
+  txn.bytes_per_lane = sizeof(kValue);
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = amdgpu::kInvalidLdsAddress;
+  txn.payload.resize(sizeof(kValue));
+  std::memcpy(txn.payload.data(), &kValue, sizeof(kValue));
+  txn.targets = {{cu, /*wg_id=*/0, kLdsBase, /*cluster_rank=*/0}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_EQ(cu->lds().read32(kLdsBase), 0u);
 }
 
 TEST(Gfx1250ExecutionTest, ClusterLdsPinPreventsAllocatorReuseUntilClusterCompletes) {
@@ -1083,6 +1218,182 @@ TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsWritesEachIssuingParticipant) {
     uint32_t expected_value = read_unaligned_input(lane * 4);
     EXPECT_EQ(value0, expected_value) << "lane " << lane;
     EXPECT_EQ(value1, expected_value) << "lane " << lane;
+  }
+}
+
+TEST(Gfx1250SimulationTest, GlobalLoadAsyncToLdsDropsNetNegativeDestination) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2600;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t kSentinel = 0xa5a5a5a5u;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr + 4), // s_mov_b32 s0, input_addr + 4
+      0xBE810080u,                                           // s_mov_b32 s1, 0
+      0x7E000280u,                                           // v_mov_b32_e32 v0, 0
+      0xEE180000u,    0x00000000u,
+      0xFFFFFC00u, // global_load_async_to_lds_b32 v0, v0, s[0:1] offset:-4
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.memory->write32(input_addr, 0x12345678u);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 32;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.group_segment_size = lds_bytes_per_wg;
+  pkt.kernel_object = kernel_object;
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->lds_size(), lds_bytes_per_wg);
+  sim.cu()->lds().write32(wf->lds_base(), kSentinel);
+  EXPECT_NO_THROW(sim.engine->run());
+  EXPECT_EQ(sim.cu()->lds().read32(wf->lds_base()), kSentinel);
+}
+
+TEST(Gfx1250SimulationTest, GlobalLoadAsyncToLdsDropsDestinationPastWorkgroupAllocation) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2800;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t kSentinel = 0xa5a5a5a5u;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr - lds_bytes_per_wg),
+      0xBE810080u, // s_mov_b32 s1, 0
+      0x7E000280u, // v_mov_b32_e32 v0, 0
+      0xEE180000u,    0x00000000u,
+      0x00010000u, // global_load_async_to_lds_b32 v0, v0, s[0:1] offset:256
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.memory->write32(input_addr, 0x12345678u);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 32;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.group_segment_size = lds_bytes_per_wg;
+  pkt.kernel_object = kernel_object;
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->lds_size(), lds_bytes_per_wg);
+  const uint32_t outside_allocation = wf->lds_base() + lds_bytes_per_wg;
+  sim.cu()->lds().write32(outside_allocation, kSentinel);
+  EXPECT_NO_THROW(sim.engine->run());
+  EXPECT_EQ(sim.cu()->lds().read32(outside_allocation), kSentinel);
+}
+
+TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsDropsNetNegativeDestination) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2700;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t kSentinel = 0xa5a5a5a5u;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr + 4), // s_mov_b32 s0, input_addr + 4
+      0xBE810080u,                                           // s_mov_b32 s1, 0
+      0xBEFD0083u,                                           // s_mov_b32 m0, 0x3
+      0x7E000280u,                                           // v_mov_b32_e32 v0, 0
+      0xEE1AC000u,    0x00000000u,
+      0xFFFFFC00u, // cluster_load_async_to_lds_b32 v0, v0, s[0:1] offset:-4
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.memory->write32(input_addr, 0x12345678u);
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*mcast_mask=*/0x3);
+  ASSERT_EQ(targets.size(), 2u);
+  for (const auto &target : targets)
+    target.cu->lds().write32(target.lds_base, kSentinel);
+  EXPECT_NO_THROW(sim.engine->run());
+  for (const auto &target : targets)
+    EXPECT_EQ(target.cu->lds().read32(target.lds_base), kSentinel);
+}
+
+TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsAppliesIoffsetToGlobalAndLds) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2800;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t instruction_offset = 4;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr), // s_mov_b32 s0, input_addr
+      0xBE810080u,                                       // s_mov_b32 s1, 0
+      0xBEFD0083u,                                       // s_mov_b32 m0, 0x3
+      0x30000082u,                                       // v_lshlrev_b32_e32 v0, 2, v0
+      0xEE1AC000u,    0x00000000u,
+      0x00000400u, // cluster_load_async_to_lds_b32 v0, v0, s[0:1] offset:4
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  for (uint32_t byte = 0; byte < 256; ++byte)
+    sim.memory->write8(input_addr + byte, static_cast<uint8_t>(0xc0u + byte));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*mcast_mask=*/0x3);
+  ASSERT_EQ(targets.size(), 2u);
+  ASSERT_NE(targets[0].cu, nullptr);
+  ASSERT_NE(targets[1].cu, nullptr);
+  EXPECT_NE(targets[0].cu, targets[1].cu);
+  sim.engine->run();
+
+  auto read_unaligned_input = [&](uint32_t byte_offset) {
+    uint32_t value = 0;
+    for (uint32_t byte = 0; byte < 4; ++byte)
+      value |= static_cast<uint32_t>(sim.memory->read8(input_addr + byte_offset + byte))
+               << (byte * 8);
+    return value;
+  };
+
+  for (uint32_t lane = 0; lane < 32; ++lane) {
+    const uint32_t lds_offset = lane * 4 + instruction_offset;
+    const uint32_t expected_value = read_unaligned_input(lds_offset);
+    EXPECT_EQ(targets[0].cu->lds().read32(targets[0].lds_base + lds_offset), expected_value)
+        << "lane " << lane;
+    EXPECT_EQ(targets[1].cu->lds().read32(targets[1].lds_base + lds_offset), expected_value)
+        << "lane " << lane;
   }
 }
 

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -19,6 +19,25 @@ namespace {
 using namespace rocjitsu;
 using namespace rocjitsu::test::cdna5;
 
+TEST(Gfx1250ExecutionTest, LdsAccessesRejectWrappedRanges) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto &lds = cu->lds();
+  constexpr uint32_t kWrappedAddress = UINT32_MAX - 3;
+  constexpr uint32_t kValue = 0x12345678u;
+
+  lds.write32(kWrappedAddress, kValue);
+  EXPECT_EQ(lds.read32(kWrappedAddress), 0u);
+
+  std::array<uint8_t, sizeof(kValue)> bytes{};
+  std::memcpy(bytes.data(), &kValue, sizeof(kValue));
+  lds.write(kWrappedAddress, bytes.data(), bytes.size());
+  bytes.fill(0xff);
+  const auto &const_lds = lds;
+  const_lds.read(kWrappedAddress, bytes.data(), bytes.size());
+  EXPECT_EQ(bytes, (std::array<uint8_t, sizeof(kValue)>{}));
+}
+
 TEST(Gfx1250SimulationTest, DispatchesEndpgmThroughConfig) {
   Gfx1250Sim sim;
   const uint32_t code[] = {S_ENDPGM_GFX12};

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -1131,6 +1131,7 @@ TEST(Gfx1250SimulationTest, AsyncToLdsUsesDstAndSrc0HighBanks) {
   const uint32_t vb = wf->vgpr_alloc().base;
   auto &cu = *sim.cu();
   wf->set_lds_base(cu.allocate_lds(256));
+  wf->set_lds_size(256);
   wf->set_vgpr_msb_mode((kDstBank << 6) | kSrc0Bank);
   cu.write_vgpr(vb + kSrc0Bank * kBankStride + kVaddr, 0, static_cast<uint32_t>(kGlobalAddr));
   cu.write_vgpr(vb + kSrc0Bank * kBankStride + kVaddr + 1, 0,

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -37,6 +37,7 @@
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/lds.h"
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
 #include "rocjitsu/vm/soc.h"
 #include "scoped_temp.h"
@@ -2847,6 +2848,53 @@ TEST(RaceDetectorPluginOutputTest, DispatchLineUsesReadableNameAndExactSymbol) {
   EXPECT_NE(sink.str().find("[rocjitsu] Kernel dispatch: \"racy_kernel\" "
                             "symbol=\"_Z11racy_kernelPKfPf\"\n"),
             std::string::npos);
+}
+
+TEST(RaceDetectorPluginTest, DroppedAsyncLdsLaneDoesNotCreateLowAddressRace) {
+  PluginFixture f(/*num_wf_slots=*/2, /*arch=*/"gfx1250", /*wavefront_size=*/32);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *cu = f.cu();
+  auto *writer = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+  auto *reader = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(writer, nullptr);
+  ASSERT_NE(reader, nullptr);
+  writer->set_exec(0x1u);
+  reader->set_exec(0x1u);
+  std::array<amdgpu::Wavefront *, 2> waves{writer, reader};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*physical_vgpr_count=*/512, /*sgpr_count=*/208,
+                                               waves);
+
+  auto dropped = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  dropped->elem_size = 4;
+  dropped->num_elems = 1;
+  dropped->is_load = true;
+  dropped->lds_dst = true;
+  dropped->lds_per_lane_addr = true;
+  dropped->wf_size = writer->wf_size();
+  dropped->lane_mask = 0x1u;
+  dropped->per_lane_lds_addr[0] = amdgpu::kInvalidLdsAddress;
+  TestMemoryInstruction dropped_inst(std::move(dropped));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(dropped_inst, *writer);
+
+  auto read = std::make_unique<VectorMemState>(LOCAL_MEM);
+  read->elem_size = 4;
+  read->num_elems = 1;
+  read->is_load = true;
+  read->wf_size = reader->wf_size();
+  read->lane_mask = 0x1u;
+  read->per_lane_addr[0] = 0;
+  read->dst_reg_base = reader->vgpr_alloc().base;
+  TestMemoryInstruction read_inst(std::move(read));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(read_inst, *reader);
+
+  EXPECT_EQ(sink.str().find("RACE "), std::string::npos);
 }
 
 TEST(ExecutionPluginGroupTest, OwnsConfiguredSinkForRetainedGroupLifetime) {


### PR DESCRIPTION
Apply the signed 24-bit IOFFSET to both the global and LDS addresses for ordinary and cluster async loads and async stores, matching CDNA5 section 10.8.1 and expressions 95-102 and 106-109.

Reject LDS destinations outside the issuing workgroup allocation, keep cluster remapping widened through validation, and filter invalid lanes from writeback and race detection.

Add generator, execution, multicast, and plugin coverage for signed offsets, allocation bounds, and wraparound addresses.

Fixes #8829