### PR TITLE
[rocjitsu] Define standalone decoder ownership

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -57,6 +57,13 @@ typedef enum rj_code_arch_e {
 typedef uint32_t rj_code_binary_inst_t;
 
 /// @brief Instruction object.
+///
+/// @details A mutable pointer returned by rj_code_decoder_decode is an
+/// independent caller-owned object. Const pointers returned by basic-block
+/// accessors are borrowed from their owning list. Passing a borrowed pointer
+/// to the standalone instruction destruction API after casting away const is
+/// invalid. These are the two instruction ownership modes currently exposed
+/// by this API.
 typedef struct rj_code_inst_t rj_code_inst_t;
 
 /// @brief Opaque handle to a decoder object.
@@ -64,18 +71,22 @@ typedef struct rj_code_decoder_t rj_code_decoder_t;
 
 /// @brief Create a decoder for the architecture specified by @p arch.
 /// @param[in] arch Architecture to create a decoder for.
-/// @param[out] decoder Newly created decoder handle (refcount = 0).
+/// @param[out] decoder Newly created decoder handle (refcount = 0). Set to NULL
+/// on any failure when @p decoder itself is non-NULL.
 /// @retval ROCJITSU_STATUS_SUCCESS Decoder was created successfully.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT if @p arch is invalid or @p decoder is NULL.
+/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Allocation failed.
 /// @retval ROCJITSU_STATUS_ERROR if this component did not bind @p arch.
 RJ_API_EXPORT rj_status_t rj_code_decoder_create(rj_code_arch_t arch, rj_code_decoder_t **decoder);
 
 /// @brief Create a decoder by canonical target ID or alias.
 /// @param[in] target_id Null-terminated target identity selected in this
 /// component's statically composed registry.
-/// @param[out] decoder Newly created decoder handle (refcount = 0).
+/// @param[out] decoder Newly created decoder handle (refcount = 0). Set to NULL
+/// on any failure when @p decoder itself is non-NULL.
 /// @retval ROCJITSU_STATUS_SUCCESS Decoder was created successfully.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT if an argument is NULL or empty.
+/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Allocation failed.
 /// @retval ROCJITSU_STATUS_ERROR if this component did not include @p target_id.
 RJ_API_EXPORT rj_status_t rj_code_decoder_create_for_target(const char *target_id,
                                                             rj_code_decoder_t **decoder);
@@ -99,15 +110,30 @@ RJ_API_EXPORT void rj_code_decoder_release(rj_code_decoder_t *decoder);
 RJ_API_EXPORT void rj_code_decoder_destroy(rj_code_decoder_t *decoder);
 
 /// @brief Decode an instruction from raw binary bits.
+///
+/// @details On success, @p inst receives an independent caller-owned
+/// instruction that remains valid after @p decoder is destroyed. Release it
+/// with rj_code_inst_destroy. On any failure, @p inst is set to NULL.
 /// @param[in] decoder The decoder object to use for decoding.
 /// @param[in] binary_inst Pointer to raw instruction bits in the instruction stream.
 /// @param[out] inst Pointer to the newly decoded instruction object.
 /// @retval ROCJITSU_STATUS_SUCCESS Instruction was decoded successfully.
 /// @retval ROCJITSU_STATUS_INVALID_ARGUMENT A required argument is NULL.
+/// @retval ROCJITSU_STATUS_OUT_OF_RESOURCES Allocation failed.
 /// @retval ROCJITSU_STATUS_ERROR Decoding failed.
 RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
                                                  const rj_code_binary_inst_t *binary_inst,
                                                  rj_code_inst_t **inst);
+
+/// @brief Destroy a caller-owned standalone decoded instruction.
+///
+/// @details This instruction type is not reference counted; destruction frees
+/// the object immediately. Only mutable instructions returned by
+/// rj_code_decoder_decode may be passed to this function. Const instructions
+/// returned by basic-block accessors are borrowed and remain owned by their
+/// list.
+/// @param[in] inst Caller-owned instruction to destroy (may be NULL).
+RJ_API_EXPORT void rj_code_inst_destroy(rj_code_inst_t *inst);
 
 /// @brief GPU target identifiers.
 typedef enum rj_code_target_id_t {
@@ -368,7 +394,8 @@ rj_code_basic_block_first_inst(const rj_code_basic_block_t *block);
 
 /// @brief Get the next instruction in the same basic block.
 /// @param[in] inst Current instruction.
-/// @returns Pointer to the next instruction, or NULL if at the end of the block.
+/// @returns Pointer to the next instruction, or NULL if at the end of the block
+/// or if @p inst is a standalone instruction returned by rj_code_decoder_decode.
 RJ_API_EXPORT const rj_code_inst_t *rj_code_inst_next(const rj_code_inst_t *inst);
 
 /// @}

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -124,6 +124,7 @@ rj_status_t rj_code_inst_list_create(rj_code_object_t *obj, rj_code_target_id_t 
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
   try {
+    Instruction::ScopedHeapAllocation heap_allocation;
     auto owned = std::make_unique<rj_code_inst_list_t>();
 
     // DBT local caves are emitted into .text, so instruction-list callers only
@@ -158,15 +159,19 @@ void rj_code_inst_list_retain(rj_code_inst_list_t *inst_list) {
 void rj_code_inst_list_release(rj_code_inst_list_t *inst_list) {
   if (!inst_list)
     return;
-  if (inst_list->release())
+  if (inst_list->release()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete inst_list;
+  }
 }
 
 void rj_code_inst_list_destroy(rj_code_inst_list_t *inst_list) {
   if (!inst_list)
     return;
-  if (inst_list->destroy())
+  if (inst_list->destroy()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete inst_list;
+  }
 }
 
 rj_status_t rj_code_basic_block_list_create(rj_code_object_t *obj, rj_code_target_id_t target_id,
@@ -184,6 +189,7 @@ rj_status_t rj_code_basic_block_list_create(rj_code_object_t *obj, rj_code_targe
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
   try {
+    Instruction::ScopedHeapAllocation heap_allocation;
     auto owned = std::make_unique<rj_code_basic_block_list_t>();
     owned->blocks = BasicBlock::build(*obj->co, *decoder, arch);
     *list = owned.release();
@@ -201,15 +207,19 @@ void rj_code_basic_block_list_retain(rj_code_basic_block_list_t *list) {
 void rj_code_basic_block_list_release(rj_code_basic_block_list_t *list) {
   if (!list)
     return;
-  if (list->release())
+  if (list->release()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete list;
+  }
 }
 
 void rj_code_basic_block_list_destroy(rj_code_basic_block_list_t *list) {
   if (!list)
     return;
-  if (list->destroy())
+  if (list->destroy()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete list;
+  }
 }
 
 uint32_t rj_code_basic_block_list_size(const rj_code_basic_block_list_t *list) {
@@ -239,15 +249,19 @@ void rj_code_basic_block_retain(rj_code_basic_block_t *block) {
 void rj_code_basic_block_release(rj_code_basic_block_t *block) {
   if (!block)
     return;
-  if (block->release())
+  if (block->release()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete block;
+  }
 }
 
 void rj_code_basic_block_destroy(rj_code_basic_block_t *block) {
   if (!block)
     return;
-  if (block->destroy())
+  if (block->destroy()) {
+    Instruction::ScopedHeapAllocation heap_allocation;
     delete block;
+  }
 }
 
 uint64_t rj_code_basic_block_start_offset(const rj_code_basic_block_t *block) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
@@ -20,12 +20,12 @@ std::unique_ptr<Decoder> Decoder::create(const IsaTargetRegistry &registry, rj_c
 }
 
 Decoder::~Decoder() {
-  // If this decoder's pool is still the active one, deactivate it so
-  // surviving instructions (held by callers in unique_ptr/vectors) fall
-  // back to ::operator delete instead of following a dangling pool pointer.
-  if (Instruction::alloc_pool_ == &pool_)
-    deactivate_pool();
+  // Clear direct and temporarily suppressed references to this pool so no
+  // later allocation scope can restore a pointer into a destroyed decoder.
+  Instruction::invalidate_allocator_pool(&pool_);
 }
+
+void Decoder::disable_pool() { Instruction::invalidate_allocator_pool(&pool_); }
 
 void Decoder::validate_instruction_operands(const Instruction &inst) {
   for (int index = 0; index < inst.num_src_operands(); ++index) {
@@ -49,12 +49,6 @@ void Decoder::activate_pool(AllocFn alloc, DeallocFn dealloc, void *pool) {
   Instruction::alloc_fn_ = alloc;
   Instruction::dealloc_fn_ = dealloc;
   Instruction::alloc_pool_ = pool;
-}
-
-void Decoder::deactivate_pool() {
-  Instruction::alloc_fn_ = nullptr;
-  Instruction::dealloc_fn_ = nullptr;
-  Instruction::alloc_pool_ = nullptr;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.h
@@ -31,6 +31,8 @@ struct IsaExecutionBackend;
 /// (e.g., the ComputeUnit simulation loop).
 class Decoder {
 public:
+  using Pool = util::ArenaAlloc<512, 128>;
+
   virtual ~Decoder();
 
   /// @brief Decode a binary instruction.
@@ -71,15 +73,13 @@ public:
   }
 
   /// @brief Disable pool allocation; future allocations use the heap.
-  void disable_pool() { deactivate_pool(); }
+  void disable_pool();
 
 protected:
-  using Pool = util::ArenaAlloc<512, 128>;
   using AllocFn = void *(*)(void *, size_t);
   using DeallocFn = void (*)(void *, void *);
 
   static void activate_pool(AllocFn alloc, DeallocFn dealloc, void *pool);
-  static void deactivate_pool();
   static void validate_instruction_operands(const Instruction &inst);
 
   Pool pool_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
@@ -109,6 +109,63 @@ public:
   static thread_local inline DeallocFn dealloc_fn_;
   static thread_local inline void *alloc_pool_;
 
+  /// @brief Temporarily force instruction allocations onto the heap.
+  ///
+  /// @details C ABI entry points use this guard when instructions can outlive
+  /// the decoder that produced them. It preserves the ambient allocator hooks
+  /// and restores them on scope exit. Decoder destruction invalidates matching
+  /// saved hooks so a scope never restores a pointer to a dead pool.
+  class ScopedHeapAllocation {
+  public:
+    ScopedHeapAllocation()
+        : saved_alloc_fn_(alloc_fn_), saved_dealloc_fn_(dealloc_fn_),
+          saved_alloc_pool_(alloc_pool_), previous_scope_(active_scope_) {
+      active_scope_ = this;
+      alloc_fn_ = nullptr;
+      dealloc_fn_ = nullptr;
+      alloc_pool_ = nullptr;
+    }
+
+    ~ScopedHeapAllocation() {
+      assert(active_scope_ == this && "allocation guards must be destroyed in stack order");
+      alloc_fn_ = saved_alloc_fn_;
+      dealloc_fn_ = saved_dealloc_fn_;
+      alloc_pool_ = saved_alloc_pool_;
+      active_scope_ = previous_scope_;
+    }
+
+    ScopedHeapAllocation(const ScopedHeapAllocation &) = delete;
+    ScopedHeapAllocation &operator=(const ScopedHeapAllocation &) = delete;
+    ScopedHeapAllocation(ScopedHeapAllocation &&) = delete;
+    ScopedHeapAllocation &operator=(ScopedHeapAllocation &&) = delete;
+
+  private:
+    friend class Instruction;
+
+    static thread_local inline ScopedHeapAllocation *active_scope_;
+    AllocFn saved_alloc_fn_;
+    DeallocFn saved_dealloc_fn_;
+    void *saved_alloc_pool_;
+    ScopedHeapAllocation *previous_scope_;
+  };
+
+  /// @brief Remove every active or saved reference to an allocator pool.
+  /// @param[in] pool Pool that is being disabled or destroyed.
+  static void invalidate_allocator_pool(void *pool) {
+    if (alloc_pool_ == pool) {
+      alloc_fn_ = nullptr;
+      dealloc_fn_ = nullptr;
+      alloc_pool_ = nullptr;
+    }
+    for (auto *scope = ScopedHeapAllocation::active_scope_; scope; scope = scope->previous_scope_) {
+      if (scope->saved_alloc_pool_ != pool)
+        continue;
+      scope->saved_alloc_fn_ = nullptr;
+      scope->saved_dealloc_fn_ = nullptr;
+      scope->saved_alloc_pool_ = nullptr;
+    }
+  }
+
   static void *operator new(size_t size) {
     if (alloc_fn_)
       return alloc_fn_(alloc_pool_, size);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/rj_decode.cpp
@@ -7,9 +7,9 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/target_registry.h"
 #include "rocjitsu/refcount.h"
-#include "util/except.h"
 
 #include <memory>
+#include <new>
 
 using namespace rocjitsu;
 
@@ -17,31 +17,47 @@ struct rj_code_decoder_t : RefCounted {
   std::unique_ptr<Decoder> decoder;
 };
 
+namespace {
+
+template <typename Factory>
+rj_status_t create_decoder_handle(Factory &&factory, rj_code_decoder_t **decoder) {
+  try {
+    auto implementation = factory();
+    if (!implementation)
+      return ROCJITSU_STATUS_ERROR;
+
+    auto handle = std::make_unique<rj_code_decoder_t>();
+    handle->decoder = std::move(implementation);
+    *decoder = handle.release();
+    return ROCJITSU_STATUS_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (...) {
+    return ROCJITSU_STATUS_ERROR;
+  }
+}
+
+} // namespace
+
 rj_status_t rj_code_decoder_create(rj_code_arch_t arch, rj_code_decoder_t **decoder) {
-  if (!decoder || arch < ROCJITSU_CODE_ARCH_CDNA1 || arch >= ROCJITSU_CODE_ARCH_NUM_ARCHS)
+  if (!decoder)
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  *decoder = nullptr;
+  if (arch < ROCJITSU_CODE_ARCH_CDNA1 || arch >= ROCJITSU_CODE_ARCH_NUM_ARCHS)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  auto d = Decoder::create(arch);
-  if (!d)
-    return ROCJITSU_STATUS_ERROR;
-
-  *decoder = new rj_code_decoder_t{};
-  (*decoder)->decoder = std::move(d);
-  return ROCJITSU_STATUS_SUCCESS;
+  return create_decoder_handle([arch] { return Decoder::create(arch); }, decoder);
 }
 
 rj_status_t rj_code_decoder_create_for_target(const char *target_id, rj_code_decoder_t **decoder) {
-  if (target_id == nullptr || target_id[0] == '\0' || decoder == nullptr)
+  if (decoder == nullptr)
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  *decoder = nullptr;
+  if (target_id == nullptr || target_id[0] == '\0')
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  std::unique_ptr<Decoder> target_decoder =
-      Decoder::create(default_isa_target_registry(), target_id);
-  if (!target_decoder)
-    return ROCJITSU_STATUS_ERROR;
-
-  *decoder = new rj_code_decoder_t{};
-  (*decoder)->decoder = std::move(target_decoder);
-  return ROCJITSU_STATUS_SUCCESS;
+  return create_decoder_handle(
+      [target_id] { return Decoder::create(default_isa_target_registry(), target_id); }, decoder);
 }
 
 void rj_code_decoder_retain(rj_code_decoder_t *decoder) {
@@ -66,19 +82,28 @@ void rj_code_decoder_destroy(rj_code_decoder_t *decoder) {
 rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
                                    const rj_code_binary_inst_t *binary_inst,
                                    rj_code_inst_t **inst) {
-  if (!decoder || !decoder->decoder || !binary_inst || !inst)
+  if (!inst)
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  *inst = nullptr;
+  if (!decoder || !decoder->decoder || !binary_inst)
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
 
-  *inst = nullptr;
-  Instruction *decoded = nullptr;
   try {
-    decoded = decoder->decoder->decode(binary_inst);
-  } catch (const util::InvalidInst &) {
+    Instruction::ScopedHeapAllocation heap_allocation;
+    std::unique_ptr<Instruction> decoded(decoder->decoder->decode(binary_inst));
+    if (!decoded)
+      return ROCJITSU_STATUS_ERROR;
+
+    *inst = reinterpret_cast<rj_code_inst_t *>(decoded.release());
+    return ROCJITSU_STATUS_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    return ROCJITSU_STATUS_OUT_OF_RESOURCES;
+  } catch (...) {
     return ROCJITSU_STATUS_ERROR;
   }
-  if (!decoded)
-    return ROCJITSU_STATUS_ERROR;
+}
 
-  *inst = reinterpret_cast<rj_code_inst_t *>(decoded);
-  return ROCJITSU_STATUS_SUCCESS;
+void rj_code_inst_destroy(rj_code_inst_t *inst) {
+  Instruction::ScopedHeapAllocation heap_allocation;
+  delete reinterpret_cast<Instruction *>(inst);
 }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -415,6 +415,7 @@ add_executable(
     partitioning_test.cpp
     simulated_kfd_test.cpp
     decode_smoke_test.cpp
+    decoder_c_api_test.cpp
     buffer_operand_test.cpp
     smem_sbase_operand_test.cpp
     shared_infra_test.cpp

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -19,6 +19,7 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
 #include "scoped_temp.h"
 
 #include <gtest/gtest.h>
@@ -149,10 +150,23 @@ void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target)
   // The returned code-object handle must keep its executable storage alive.
   rj_code_executable_destroy(exec);
 
+  auto pooled_decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(pooled_decoder, nullptr);
+  pooled_decoder->enable_pool();
+
+  rj_code_inst_list_t *instructions = nullptr;
+  ASSERT_EQ(rj_code_inst_list_create(obj, target, &instructions), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(instructions, nullptr);
+
   rj_code_basic_block_list_t *blocks = nullptr;
   EXPECT_EQ(rj_code_basic_block_list_create(obj, target, &blocks), ROCJITSU_STATUS_SUCCESS)
       << "rj_code_basic_block_list_create must succeed for a target whose decoder is wired in";
   ASSERT_NE(blocks, nullptr);
+
+  // Both C API list types own their decoded instructions independently of an
+  // unrelated decoder pool that was active while they were constructed.
+  rj_code_inst_list_destroy(instructions);
+  pooled_decoder.reset();
 
   rj_code_basic_block_t *block = nullptr;
   ASSERT_EQ(rj_code_basic_block_list_get(blocks, 0, &block), ROCJITSU_STATUS_SUCCESS);

--- a/emulation/rocjitsu/tests/decoder_c_api_test.cpp
+++ b/emulation/rocjitsu/tests/decoder_c_api_test.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+
+namespace {
+
+// s_endpgm in the GFX9/CDNA SOPP encoding, which gfx1250 rejects.
+constexpr rj_code_binary_inst_t kCdnaSEndpgm = 0xBF810000u;
+
+static_assert(std::is_same_v<decltype(&rj_code_inst_destroy), void (*)(rj_code_inst_t *)>,
+              "standalone destruction must not accept borrowed const instructions");
+static_assert(
+    std::is_same_v<decltype(rj_code_basic_block_first_inst(nullptr)), const rj_code_inst_t *>,
+    "borrowed instructions must remain const-qualified");
+static_assert(std::is_same_v<decltype(rj_code_inst_next(nullptr)), const rj_code_inst_t *>,
+              "instruction traversal must preserve the borrowed const qualification");
+
+TEST(DecoderCApiTest, InvalidInstructionReturnsErrorAndClearsOutput) {
+  rj_code_decoder_t *decoder = nullptr;
+  ASSERT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_GFX1250, &decoder), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *instruction = reinterpret_cast<rj_code_inst_t *>(static_cast<uintptr_t>(1));
+  EXPECT_EQ(rj_code_decoder_decode(decoder, &kCdnaSEndpgm, &instruction), ROCJITSU_STATUS_ERROR);
+  EXPECT_EQ(instruction, nullptr);
+
+  rj_code_decoder_destroy(decoder);
+}
+
+TEST(DecoderCApiTest, InvalidArgumentsClearWritableOutputs) {
+  auto *instruction = reinterpret_cast<rj_code_inst_t *>(static_cast<uintptr_t>(1));
+  EXPECT_EQ(rj_code_decoder_decode(nullptr, &kCdnaSEndpgm, &instruction),
+            ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(instruction, nullptr);
+
+  auto *decoder = reinterpret_cast<rj_code_decoder_t *>(static_cast<uintptr_t>(1));
+  EXPECT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_INVALID, &decoder),
+            ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(decoder, nullptr);
+
+  decoder = reinterpret_cast<rj_code_decoder_t *>(static_cast<uintptr_t>(1));
+  EXPECT_EQ(rj_code_decoder_create_for_target(nullptr, &decoder), ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(decoder, nullptr);
+
+  decoder = reinterpret_cast<rj_code_decoder_t *>(static_cast<uintptr_t>(1));
+  EXPECT_EQ(rj_code_decoder_create_for_target("", &decoder), ROCJITSU_STATUS_INVALID_ARGUMENT);
+  EXPECT_EQ(decoder, nullptr);
+}
+
+TEST(DecoderCApiTest, StandaloneInstructionsAreCallerOwned) {
+  rj_code_decoder_t *decoder = nullptr;
+  ASSERT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_CDNA3, &decoder), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(decoder, nullptr);
+
+  rj_code_inst_t *instruction = nullptr;
+  ASSERT_EQ(rj_code_decoder_decode(decoder, &kCdnaSEndpgm, &instruction), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(instruction, nullptr);
+  EXPECT_STREQ(rj_code_inst_mnemonic(instruction), "s_endpgm");
+  rj_code_inst_destroy(instruction);
+
+  rj_code_inst_t *survivor = nullptr;
+  ASSERT_EQ(rj_code_decoder_decode(decoder, &kCdnaSEndpgm, &survivor), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(survivor, nullptr);
+  rj_code_decoder_destroy(decoder);
+
+  EXPECT_STREQ(rj_code_inst_mnemonic(survivor), "s_endpgm");
+  EXPECT_GT(rj_code_inst_size(survivor), 0u);
+  char disassembly[64]{};
+  EXPECT_EQ(rj_code_inst_disassemble(survivor, disassembly, sizeof(disassembly)),
+            ROCJITSU_STATUS_SUCCESS);
+  EXPECT_NE(std::strstr(disassembly, "s_endpgm"), nullptr);
+  EXPECT_EQ(rj_code_inst_next(survivor), nullptr);
+
+  rj_code_inst_destroy(survivor);
+  rj_code_inst_destroy(nullptr);
+}
+
+TEST(DecoderCApiTest, StandaloneInstructionIgnoresAmbientDecoderPool) {
+  auto pooled_decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(pooled_decoder, nullptr);
+  pooled_decoder->enable_pool();
+  const auto *active_pool =
+      static_cast<const rocjitsu::Decoder::Pool *>(rocjitsu::Instruction::alloc_pool_);
+  ASSERT_NE(active_pool, nullptr);
+
+  rj_code_decoder_t *decoder = nullptr;
+  ASSERT_EQ(rj_code_decoder_create(ROCJITSU_CODE_ARCH_CDNA3, &decoder), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(decoder, nullptr);
+
+  rj_code_inst_t *instruction = nullptr;
+  ASSERT_EQ(rj_code_decoder_decode(decoder, &kCdnaSEndpgm, &instruction), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(instruction, nullptr);
+  EXPECT_FALSE(active_pool->owns(instruction));
+  EXPECT_EQ(rocjitsu::Instruction::alloc_pool_, active_pool);
+  rj_code_inst_destroy(instruction);
+  EXPECT_EQ(rocjitsu::Instruction::alloc_pool_, active_pool);
+
+  instruction = nullptr;
+  ASSERT_EQ(rj_code_decoder_decode(decoder, &kCdnaSEndpgm, &instruction), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(instruction, nullptr);
+  EXPECT_FALSE(active_pool->owns(instruction));
+
+  rj_code_decoder_destroy(decoder);
+  pooled_decoder.reset();
+  EXPECT_EQ(rocjitsu::Instruction::alloc_pool_, nullptr);
+
+  EXPECT_STREQ(rj_code_inst_mnemonic(instruction), "s_endpgm");
+  rj_code_inst_destroy(instruction);
+}
+
+TEST(DecoderCApiTest, HeapAllocationScopeForgetsDestroyedPool) {
+  auto pooled_decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(pooled_decoder, nullptr);
+  pooled_decoder->enable_pool();
+  ASSERT_NE(rocjitsu::Instruction::alloc_pool_, nullptr);
+
+  {
+    rocjitsu::Instruction::ScopedHeapAllocation heap_allocation;
+    pooled_decoder.reset();
+  }
+  EXPECT_EQ(rocjitsu::Instruction::alloc_pool_, nullptr);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<rocjitsu::Instruction> instruction(decoder->decode(&kCdnaSEndpgm));
+  ASSERT_NE(instruction, nullptr);
+  EXPECT_EQ(instruction->mnemonic(), "s_endpgm");
+}
+
+} // namespace


### PR DESCRIPTION
Contain decoder failures inside the C API and clear writable outputs on every failure path.

Document successful standalone decode results as caller-owned, provide a matching destroy API, and cover invalid encodings plus leak-free lifetime behavior.

Fixes #8810

Fixes #8814