### PR TITLE
[rocjitsu] Drain XCNT before restoring M0 around a cluster load

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -413,6 +413,94 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
   dst.insert(dst.end(), src.begin(), src.end());
 }
 
+/// @brief First condition that stops this object from being translated, if any.
+///
+/// @details Every result leaves the object unchanged, but not every result is a failure: an
+/// object with no executable text and a matching target is a successful no-op, so the caller
+/// must preserve the returned severity rather than assuming an error.
+///
+/// Check order is observable, because only the first match is reported. Existing checks must not
+/// be permuted, and a new one should be appended unless it is deliberately more specific than a
+/// check already present.
+///
+/// @pre @p obj holds at least an ELF header. The empty-text branch reads one without a bound of
+/// its own; the caller rejects short images before reaching here, and that caller is now far
+/// enough away that the assert below is the only executable record of the requirement.
+///
+/// The image-size and decoder checks stay with the caller: they gate constructing the patcher
+/// and the decoder, which the rest of translation needs, so they cannot be hoisted here without
+/// either duplicating the construction or returning it.
+[[nodiscard]] std::optional<TranslationDiagnostic>
+translation_refusal(const AmdGpuCodeObject &obj, const CodeObjectPatcher &patcher,
+                    std::span<const uint8_t> text, rj_code_arch_t guest_arch,
+                    rj_code_arch_t host_arch, uint32_t target_mach,
+                    const BinaryTranslatorOptions &options) {
+  assert(obj.image_size() >= sizeof(Elf64_Ehdr) &&
+         "caller must reject short images before translation_refusal");
+  const auto error = [](DiagnosticKind kind, std::string message) {
+    return TranslationDiagnostic{.severity = DiagnosticSeverity::Error,
+                                 .kind = kind,
+                                 .guest_offset = std::nullopt,
+                                 .mnemonic = {},
+                                 .message = std::move(message),
+                                 .required_work = {}};
+  };
+
+  // A same-architecture gfx1250 translation is direction-specific: A0 and B0 share an ELF machine
+  // ID, so both revisions must be given. Enforce this here as well as in the C API.
+  if (guest_arch == ROCJITSU_CODE_ARCH_GFX1250 && host_arch == ROCJITSU_CODE_ARCH_GFX1250) {
+    if (options.input_revision == ProcessorRevision::Unspecified ||
+        options.output_revision == ProcessorRevision::Unspecified) {
+      return error(DiagnosticKind::Legalization,
+                   "gfx1250 same-target translation requires both input and output silicon "
+                   "revisions");
+    }
+    // Only the B0-to-A0 direction is implemented.
+    if (options.input_revision == ProcessorRevision::Gfx1250A0 &&
+        options.output_revision == ProcessorRevision::Gfx1250B0)
+      return error(DiagnosticKind::Legalization, "gfx1250 A0-to-B0 translation is not supported");
+  }
+
+  if (text.empty()) {
+    Elf64_Ehdr header{};
+    std::memcpy(&header, obj.image_data(), sizeof(header));
+    const uint32_t source_mach = header.e_flags & EF_AMDGPU_MACH;
+    if (guest_arch == host_arch && source_mach == (target_mach & EF_AMDGPU_MACH)) {
+      return TranslationDiagnostic{
+          .severity = DiagnosticSeverity::Warning,
+          .kind = DiagnosticKind::DataOnly,
+          .guest_offset = std::nullopt,
+          .mnemonic = {},
+          .message = "code object has no executable sections, segments, or callable symbols; "
+                     "leaving unchanged",
+          .required_work = {}};
+    }
+    return error(DiagnosticKind::ResourceLimit,
+                 "code object does not expose a non-empty .text section for translation");
+  }
+
+  // DBT relocates instructions within .text (compaction, expansion, per-kernel block placement)
+  // but does not rewrite relocation places that land inside .text. An in-.text relocation would
+  // therefore be applied to the wrong translated bytes. Fail closed rather than silently
+  // miscompile.
+  if (patcher.has_relocations_within_text()) {
+    return error(DiagnosticKind::Legalization,
+                 "code object has a relocation place inside .text; relocating instructions would "
+                 "apply it to the wrong bytes and is not supported");
+  }
+
+  // The patcher can retarget ordinary zero-addend symbol references and symbol-less RELATIVE64
+  // addends through the final source-to-target offset map. Keep less explicit forms fail-closed
+  // until their relocation-specific addend semantics are modeled.
+  if (patcher.has_unsupported_relocation_to_text()) {
+    return error(DiagnosticKind::Legalization,
+                 "code object has an unsupported relocation referencing .text; section symbols, "
+                 "implicit addends, and named-symbol addends cannot be remapped safely");
+  }
+
+  return std::nullopt;
+}
+
 /// @brief Return a human-readable kernel label for diagnostics.
 ///
 /// @details Some code objects carry empty kernel symbol names. Falling back to
@@ -1453,6 +1541,151 @@ adopted_root_return_offsets(const BlockOffsetIndex &block_index,
   return std::move(patcher).emit();
 }
 
+/// @brief One instruction's source and translated form, held until its target offset is known.
+///
+/// @details Traces cannot be emitted during lowering because a body's final placement is only
+/// fixed after relocation, so each is queued with its source-relative offset and rebased later.
+struct PendingTrace {
+  uint64_t source_offset = 0;
+  uint32_t source_size = 0;
+  std::vector<uint32_t> source_words;
+  const InstructionLegalization *legalization = nullptr;
+  bool copied_original = false;
+  bool semantic_lowering = false;
+  bool changed = false;
+  uint64_t target_offset = 0;
+  std::vector<uint32_t> target_words;
+};
+
+/// @brief A per-kernel lowering failure, before it is turned into a diagnostic.
+///
+/// @details Carried rather than reported immediately because skip_failed_kernels decides whether
+/// it becomes an object-level error or the prose of a KernelSkipped warning.
+struct KernelFailure {
+  DiagnosticKind kind = DiagnosticKind::Legalization;
+  std::string message;
+  std::optional<uint64_t> guest_offset;
+  std::string mnemonic;
+  std::vector<std::string> required_work;
+};
+
+/// @brief Build a per-kernel failure record.
+[[nodiscard]] KernelFailure make_kernel_failure(DiagnosticKind kind, std::string message,
+                                                std::optional<uint64_t> guest_offset = std::nullopt,
+                                                std::string mnemonic = {},
+                                                std::vector<std::string> required_work = {}) {
+  return KernelFailure{kind, std::move(message), guest_offset, std::move(mnemonic),
+                       std::move(required_work)};
+}
+
+/// @brief Map a control-flow relocation failure onto the diagnostic kind that reports it.
+[[nodiscard]] DiagnosticKind relocation_diagnostic_kind(const TextRelocationResult &relocation) {
+  if (relocation.failure == TextLayoutFailureCategory::ResourceLimit)
+    return DiagnosticKind::ResourceLimit;
+  return DiagnosticKind::Legalization;
+}
+
+/// @brief Map a body-materialization failure onto the diagnostic kind that reports it.
+[[nodiscard]] DiagnosticKind
+materialization_diagnostic_kind(const KernelTextAppendResult &materialization) {
+  if (materialization.failure == TextLayoutFailureCategory::ResourceLimit)
+    return DiagnosticKind::ResourceLimit;
+  return DiagnosticKind::KernelDescriptor;
+}
+
+/// @brief A code-address builder awaiting the final placement of the body it names.
+struct PendingCodeRelocation {
+  uint64_t target_getpc_offset = 0;
+  uint64_t target_literal_offset = 0;
+  uint64_t source_target_text_offset = 0;
+};
+
+/// @brief Point every deferred code-address builder at the placement its target received.
+///
+/// @details Runs after every scope is placed, which is the first moment a target's final offset
+/// is known. A source offset emitted more than once has no single answer -- a runtime-dereferenced
+/// code address cannot choose between clones -- so that fails closed rather than picking one,
+/// matching how relocate_relative_text_addends treats a conflicting relocation addend.
+///
+/// @returns false when the object must be left unchanged.
+[[nodiscard]] bool
+resolve_pending_code_relocations(const std::vector<PendingCodeRelocation> &pending,
+                                 const std::vector<TextOffsetRelocation> &text_relocations,
+                                 const std::unordered_map<uint64_t, uint64_t> &canonical_placement,
+                                 std::vector<PcRelativeTextRelocation> &code_relocations,
+                                 std::vector<TranslationDiagnostic> &diagnostics) {
+  if (pending.empty())
+    return true;
+
+  std::unordered_map<uint64_t, uint64_t> placement;
+  std::unordered_set<uint64_t> conflicting;
+  for (const TextOffsetRelocation &relocation : text_relocations) {
+    auto [it, inserted] = placement.try_emplace(relocation.source_offset, relocation.target_offset);
+    if (!inserted && it->second != relocation.target_offset)
+      conflicting.insert(relocation.source_offset);
+  }
+
+  for (const PendingCodeRelocation &entry : pending) {
+    if (const auto canonical = canonical_placement.find(entry.source_target_text_offset);
+        canonical != canonical_placement.end()) {
+      code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
+                                  .target_literal_offset = entry.target_literal_offset,
+                                  .target_text_offset = canonical->second});
+      continue;
+    }
+    const auto placed = placement.find(entry.source_target_text_offset);
+    if (placed == placement.end() || conflicting.contains(entry.source_target_text_offset)) {
+      append_error(diagnostics, DiagnosticKind::Legalization,
+                   conflicting.contains(entry.source_target_text_offset)
+                       ? "PC-relative code address names a body emitted at more than one "
+                         "placement; leaving code object unchanged"
+                       : "PC-relative code address names a body this translation did not emit; "
+                         "leaving code object unchanged",
+                   entry.source_target_text_offset);
+      return false;
+    }
+    code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
+                                .target_literal_offset = entry.target_literal_offset,
+                                .target_text_offset = placed->second});
+  }
+  return true;
+}
+
+/// @brief What one scope added to the three code-address containers, so a skipped scope can take
+/// it back.
+///
+/// @details The two vectors only ever grow within a scope, so a length restores them;
+/// canonical_placement is keyed by source offset and needs the inserted keys named.
+struct ScopeRelocationCheckpoint {
+  size_t code_relocations_begin = 0;
+  size_t pending_code_relocations_begin = 0;
+  std::vector<uint64_t> canonical_placements_added;
+  // Variant conflicts this scope raised. A skipped scope's text is discarded, so the clone it
+  // disagreed about no longer exists; leaving the conflict behind would withhold a canonical
+  // placement whose surviving clones actually agree and refuse the object over a scope that
+  // contributes nothing. The companion is_sidecar entry is restored with it so a later scope
+  // compares against the variant that really nominated the canonical copy.
+  std::vector<uint64_t> canonical_variant_conflicts_added;
+  // The resource verdict is set before descriptor recomputation, which can still skip the scope.
+  // Rolling the placements back without also restoring this would leave a skipped host's verdict
+  // standing and refuse the object over a scope that no longer contributes anything.
+  bool canonical_host_outgrew_its_descriptor = false;
+};
+
+/// @brief Everything one scope must be able to give back if it fails.
+///
+/// @details Bundling the rollback state keeps a new participant from being added here but
+/// forgotten at one of the failure sites. This is not a RAII guard: rollback is conditional on
+/// skip_failed_kernels, and a failing scope still contributes a stub body, so unwinding is an
+/// explicit call rather than a destructor.
+struct ScopeTransaction {
+  size_t output_begin = 0;
+  size_t text_relocations_begin = 0;
+  size_t data_relocations_begin = 0;
+  std::vector<DescriptorVariantCheckpoint> descriptors;
+  ScopeRelocationCheckpoint relocations;
+};
+
 } // namespace
 
 namespace internal {
@@ -1590,67 +1823,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   CodeObjectPatcher patcher(obj);
-
-  // A same-architecture gfx1250 translation is direction-specific: A0 and B0
-  // share an ELF machine ID, so both revisions must be given. Enforce this here
-  // as well as in the C API.
-  if (guest_arch_ == ROCJITSU_CODE_ARCH_GFX1250 && host_arch_ == ROCJITSU_CODE_ARCH_GFX1250) {
-    if (options_.input_revision == ProcessorRevision::Unspecified ||
-        options_.output_revision == ProcessorRevision::Unspecified) {
-      append_error(result.diagnostics, DiagnosticKind::Legalization,
-                   "gfx1250 same-target translation requires both input and output silicon "
-                   "revisions");
-      return leave_unchanged();
-    }
-    // Only the B0-to-A0 direction is implemented.
-    if (options_.input_revision == ProcessorRevision::Gfx1250A0 &&
-        options_.output_revision == ProcessorRevision::Gfx1250B0) {
-      append_error(result.diagnostics, DiagnosticKind::Legalization,
-                   "gfx1250 A0-to-B0 translation is not supported");
-      return leave_unchanged();
-    }
-  }
-
   auto text = patcher.text_bytes();
-  if (text.empty()) {
-    Elf64_Ehdr header{};
-    std::memcpy(&header, obj.image_data(), sizeof(header));
-    const uint32_t source_mach = header.e_flags & EF_AMDGPU_MACH;
-    if (guest_arch_ == host_arch_ && source_mach == (target_mach_ & EF_AMDGPU_MACH)) {
-      append_warning(result.diagnostics, DiagnosticKind::DataOnly,
-                     "code object has no executable sections, segments, or callable symbols; "
-                     "leaving unchanged");
-      return leave_unchanged();
-    }
-    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
-                 "code object does not expose a non-empty .text section for translation");
+  if (auto refusal = translation_refusal(obj, patcher, text, guest_arch_, host_arch_, target_mach_,
+                                         options_)) {
+    result.diagnostics.push_back(std::move(*refusal));
     return leave_unchanged();
   }
+
   std::unordered_set<uint64_t> generated_island_pool_candidates;
   if (guest_arch_ == host_arch_)
     generated_island_pool_candidates = generated_branch_island_pool_offsets(text, guest_arch_);
-
-  // DBT relocates instructions within .text (compaction, expansion, per-kernel
-  // block placement) but does not rewrite relocation places that land inside
-  // .text. An in-.text relocation would therefore be applied to the wrong
-  // translated bytes. Fail closed rather than silently miscompile.
-  if (patcher.has_relocations_within_text()) {
-    append_error(result.diagnostics, DiagnosticKind::Legalization,
-                 "code object has a relocation place inside .text; relocating instructions would "
-                 "apply it to the wrong bytes and is not supported");
-    return leave_unchanged();
-  }
-
-  // The patcher can retarget ordinary zero-addend symbol references and
-  // symbol-less RELATIVE64 addends through the final source-to-target offset
-  // map. Keep less explicit forms fail-closed until their relocation-specific
-  // addend semantics are modeled.
-  if (patcher.has_unsupported_relocation_to_text()) {
-    append_error(result.diagnostics, DiagnosticKind::Legalization,
-                 "code object has an unsupported relocation referencing .text; section symbols, "
-                 "implicit addends, and named-symbol addends cannot be remapped safely");
-    return leave_unchanged();
-  }
 
   // Per-kernel text relocation strategy:
   // 1. Translate descriptors first so their source entries and ABI state define
@@ -2163,18 +2345,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   translated_text.reserve(text.size());
   const bool continue_after_failure = options_.debug_continue_after_failure;
 
-  struct PendingTrace {
-    uint64_t source_offset = 0;
-    uint32_t source_size = 0;
-    std::vector<uint32_t> source_words;
-    const InstructionLegalization *legalization = nullptr;
-    bool copied_original = false;
-    bool semantic_lowering = false;
-    bool changed = false;
-    uint64_t target_offset = 0;
-    std::vector<uint32_t> target_words;
-  };
-
   auto queue_trace = [&](std::vector<PendingTrace> &pending, const Instruction &inst,
                          uint64_t offset, const InstructionLegalization *leg, bool copied_original,
                          bool semantic_lowering, bool changed, uint64_t target_offset,
@@ -2231,34 +2401,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       return false;
     copy_original_instruction(inst, offset, kernel_text, pending_traces);
     return true;
-  };
-
-  auto relocation_diagnostic_kind = [&](const TextRelocationResult &relocation) {
-    if (relocation.failure == TextLayoutFailureCategory::ResourceLimit)
-      return DiagnosticKind::ResourceLimit;
-    return DiagnosticKind::Legalization;
-  };
-
-  auto materialization_diagnostic_kind = [&](const KernelTextAppendResult &materialization) {
-    if (materialization.failure == TextLayoutFailureCategory::ResourceLimit)
-      return DiagnosticKind::ResourceLimit;
-    return DiagnosticKind::KernelDescriptor;
-  };
-
-  struct KernelFailure {
-    DiagnosticKind kind = DiagnosticKind::Legalization;
-    std::string message;
-    std::optional<uint64_t> guest_offset;
-    std::string mnemonic;
-    std::vector<std::string> required_work;
-  };
-
-  auto make_kernel_failure = [](DiagnosticKind kind, std::string message,
-                                std::optional<uint64_t> guest_offset = std::nullopt,
-                                std::string mnemonic = {},
-                                std::vector<std::string> required_work = {}) {
-    return KernelFailure{kind, std::move(message), guest_offset, std::move(mnemonic),
-                         std::move(required_work)};
   };
 
   auto emit_skipped_kernel = [&](const KernelTranslationScope &scope,
@@ -2332,11 +2474,6 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // scope not yet emitted, and a body reached from several kernels is cloned once per scope, so the
   // final offset is only knowable once every placement is recorded. Hold the source-side answer and
   // resolve against the completed map below.
-  struct PendingCodeRelocation {
-    uint64_t target_getpc_offset = 0;
-    uint64_t target_literal_offset = 0;
-    uint64_t source_target_text_offset = 0;
-  };
   std::vector<PendingCodeRelocation> pending_code_relocations;
   std::vector<PcRelativeTextRelocation> code_relocations;
   // Final offset of the one copy of each adopted body. Code addresses name this copy, so a body a
@@ -2357,30 +2494,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // value -- hence the tightening handed to replace_text() below.
   bool relied_on_relocated_by_construction = false;
 
-  // What one scope added to the three code-address containers, so a skipped scope can take it back.
-  // The two vectors only ever grow within a scope, so a length restores them; canonical_placement
-  // is keyed by source offset and needs the inserted keys named.
-  struct ScopeRelocationCheckpoint {
-    size_t code_relocations_begin = 0;
-    size_t pending_code_relocations_begin = 0;
-    std::vector<uint64_t> canonical_placements_added;
-    // Variant conflicts this scope raised. A skipped scope's text is discarded, so the clone it
-    // disagreed about no longer exists; leaving the conflict behind would withhold a canonical
-    // placement whose surviving clones actually agree and refuse the object over a scope that
-    // contributes nothing. The companion is_sidecar entry is restored with it so a later scope
-    // compares against the variant that really nominated the canonical copy.
-    std::vector<uint64_t> canonical_variant_conflicts_added;
-    // The resource verdict is set before descriptor recomputation, which can still skip the scope.
-    // Rolling the placements back without also restoring this would leave a skipped host's verdict
-    // standing and refuse the object over a scope that no longer contributes anything.
-    bool canonical_host_outgrew_its_descriptor = false;
-  };
-
-  auto fail_or_skip_kernel =
-      [&](const KernelTranslationScope &scope, KernelFailure failure, size_t output_begin,
-          const std::vector<DescriptorVariantCheckpoint> &descriptor_snapshot,
-          size_t text_relocations_begin, size_t data_relocations_begin,
-          const ScopeRelocationCheckpoint &relocation_snapshot) -> bool {
+  // Reports the failure, or rolls the scope back and emits a stub in its place, depending on
+  // skip_failed_kernels. Returns true when the caller should continue with the next scope.
+  auto fail_or_skip_kernel = [&](const KernelTranslationScope &scope, KernelFailure failure,
+                                 const ScopeTransaction &transaction) -> bool {
     if (!skip_failed_kernels) {
       append_error(result.diagnostics, failure.kind, std::move(failure.message),
                    failure.guest_offset, std::move(failure.mnemonic),
@@ -2389,24 +2506,24 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
 
     const uint64_t source_entry = scope.translation->entry_text_offset;
-    translated_text.resize(output_begin);
+    translated_text.resize(transaction.output_begin);
     // Discard any relocation records this scope committed before failing.
-    text_relocations.resize(text_relocations_begin);
-    data_relocations.resize(data_relocations_begin);
+    text_relocations.resize(transaction.text_relocations_begin);
+    data_relocations.resize(transaction.data_relocations_begin);
     // The code-address records and the canonical placements name offsets inside the text this
     // rollback just discarded. A later scope reuses those offsets for its own body, so keeping the
     // records would write a 64-bit literal into instructions that never asked for one.
-    code_relocations.resize(relocation_snapshot.code_relocations_begin);
-    pending_code_relocations.resize(relocation_snapshot.pending_code_relocations_begin);
-    for (const uint64_t placed : relocation_snapshot.canonical_placements_added) {
+    code_relocations.resize(transaction.relocations.code_relocations_begin);
+    pending_code_relocations.resize(transaction.relocations.pending_code_relocations_begin);
+    for (const uint64_t placed : transaction.relocations.canonical_placements_added) {
       canonical_placement.erase(placed);
       canonical_placement_is_sidecar.erase(placed);
     }
-    for (const uint64_t conflicted : relocation_snapshot.canonical_variant_conflicts_added)
+    for (const uint64_t conflicted : transaction.relocations.canonical_variant_conflicts_added)
       canonical_placement_variant_conflict.erase(conflicted);
     canonical_host_outgrew_its_descriptor =
-        relocation_snapshot.canonical_host_outgrew_its_descriptor;
-    for (const DescriptorVariantCheckpoint &saved : descriptor_snapshot) {
+        transaction.relocations.canonical_host_outgrew_its_descriptor;
+    for (const DescriptorVariantCheckpoint &saved : transaction.descriptors) {
       if (saved.index >= descriptor_translations.size()) {
         append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
                      "descriptor checkpoint index changed during skip rollback", source_entry);
@@ -2447,17 +2564,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     if (scope.translation->skipped)
       continue;
 
-    const size_t output_begin = translated_text.size();
-    const size_t text_relocations_begin = text_relocations.size();
-    const size_t data_relocations_begin = data_relocations.size();
-    ScopeRelocationCheckpoint relocation_snapshot{
-        .code_relocations_begin = code_relocations.size(),
-        .pending_code_relocations_begin = pending_code_relocations.size(),
-        .canonical_placements_added = {},
-        .canonical_variant_conflicts_added = {},
-        .canonical_host_outgrew_its_descriptor = canonical_host_outgrew_its_descriptor};
-    const auto descriptor_snapshot =
-        checkpoint_scope_descriptors(descriptor_translations, *scope.translation);
+    ScopeTransaction transaction{
+        .output_begin = translated_text.size(),
+        .text_relocations_begin = text_relocations.size(),
+        .data_relocations_begin = data_relocations.size(),
+        .descriptors = checkpoint_scope_descriptors(descriptor_translations, *scope.translation),
+        .relocations = {.code_relocations_begin = code_relocations.size(),
+                        .pending_code_relocations_begin = pending_code_relocations.size(),
+                        .canonical_placements_added = {},
+                        .canonical_variant_conflicts_added = {},
+                        .canonical_host_outgrew_its_descriptor =
+                            canonical_host_outgrew_its_descriptor}};
     bool skip_scope = false;
 
     if (!scope.translation->supported) {
@@ -2474,8 +2591,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         failure.required_work = diagnostic.required_work;
         break;
       }
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
+      if (fail_or_skip_kernel(scope, std::move(failure), transaction))
         continue;
       return leave_unchanged();
     }
@@ -2500,9 +2616,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         auto failure = make_kernel_failure(
             DiagnosticKind::ResourceLimit,
             "virtual LDS lowering cannot reserve a backing-buffer SGPR pair", layout.source_entry);
-        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin,
-                                relocation_snapshot))
+        if (fail_or_skip_kernel(scope, std::move(failure), transaction))
           continue;
         return leave_unchanged();
       }
@@ -2524,9 +2638,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               DiagnosticKind::ResourceLimit,
               "virtual LDS backing-pointer spill offset overflows the 32-bit private segment",
               layout.source_entry);
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot))
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction))
             continue;
           return leave_unchanged();
         }
@@ -2540,9 +2652,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             DiagnosticKind::KernelDescriptor,
             "virtual LDS lowering cannot materialize backing-buffer pointer entry prologue",
             layout.source_entry);
-        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin,
-                                relocation_snapshot))
+        if (fail_or_skip_kernel(scope, std::move(failure), transaction))
           continue;
         return leave_unchanged();
       }
@@ -2560,8 +2670,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           "kernel descriptor prologue does not fit in the 256-byte kernarg preload compatibility "
           "window",
           layout.source_entry);
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
+      if (fail_or_skip_kernel(scope, std::move(failure), transaction))
         continue;
       return leave_unchanged();
     }
@@ -2856,9 +2965,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               make_kernel_failure(DiagnosticKind::Legalization,
                                   "recovered indirect branch has inconsistent consumer metadata",
                                   source_call_offset, "indirect branch");
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -2886,9 +2993,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             "recovered indirect branch has an unconstrained predecessor path that cannot be "
             "relocated",
             source_call_offset, "indirect branch");
-        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin,
-                                relocation_snapshot)) {
+        if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
           skip_scope = true;
           break;
         }
@@ -3118,9 +3223,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                   DiagnosticKind::Legalization,
                   "generated direct branch island pool contains malformed live slot",
                   source_branch_offset);
-              if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                      text_relocations_begin, data_relocations_begin,
-                                      relocation_snapshot)) {
+              if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
                 skip_scope = true;
                 break;
               }
@@ -3134,9 +3237,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                   DiagnosticKind::Legalization,
                   "generated direct branch island pool targets outside source .text",
                   source_branch_offset);
-              if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                      text_relocations_begin, data_relocations_begin,
-                                      relocation_snapshot)) {
+              if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
                 skip_scope = true;
                 break;
               }
@@ -3273,9 +3374,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               continue;
             }
           }
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -3305,9 +3404,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                 continue;
               }
             }
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -3319,9 +3416,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             auto failure = make_kernel_failure(DiagnosticKind::Legalization,
                                                "direct branch is missing raw encoding", offset,
                                                std::string(inst.mnemonic()));
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -3414,9 +3509,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                 continue;
               }
             }
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -3451,9 +3544,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                 continue;
               }
             }
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -3486,9 +3577,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                 continue;
               }
             }
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -3515,9 +3604,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               continue;
             }
           }
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -3568,9 +3655,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               continue;
             }
           }
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -3686,9 +3771,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
             DiagnosticKind::Legalization,
             "recovered indirect branch builder is not fully present in the relocated body",
             fixup.source_call_offset, "indirect branch");
-        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin,
-                                relocation_snapshot)) {
+        if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
           skip_scope = true;
           break;
         }
@@ -3857,8 +3940,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       auto failure =
           make_kernel_failure(relocation_diagnostic_kind(patched_control_flow),
                               patched_control_flow.message, patched_control_flow.source_offset);
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
+      if (fail_or_skip_kernel(scope, std::move(failure), transaction))
         continue;
       return leave_unchanged();
     }
@@ -3867,8 +3949,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         !patched.ok) {
       auto failure = make_kernel_failure(relocation_diagnostic_kind(patched), patched.message,
                                          patched.source_offset, "indirect branch");
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
+      if (fail_or_skip_kernel(scope, std::move(failure), transaction))
         continue;
       return leave_unchanged();
     } else {
@@ -3889,8 +3970,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     if (!materialized.ok) {
       auto failure = make_kernel_failure(materialization_diagnostic_kind(materialized),
                                          materialized.message, materialized.source_offset);
-      if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                              text_relocations_begin, data_relocations_begin, relocation_snapshot))
+      if (fail_or_skip_kernel(scope, std::move(failure), transaction))
         continue;
       return leave_unchanged();
     }
@@ -3904,7 +3984,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (placed == target_offset_by_source_offset.end())
         continue;
       if (canonical_placement.try_emplace(taken, placed->second + target_delta).second) {
-        relocation_snapshot.canonical_placements_added.push_back(taken);
+        transaction.relocations.canonical_placements_added.push_back(taken);
         canonical_placement_is_sidecar[taken] = scope_is_sidecar;
         continue;
       }
@@ -3916,7 +3996,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       const auto variant = canonical_placement_is_sidecar.find(taken);
       if (variant != canonical_placement_is_sidecar.end() && variant->second != scope_is_sidecar &&
           canonical_placement_variant_conflict.insert(taken).second) {
-        relocation_snapshot.canonical_variant_conflicts_added.push_back(taken);
+        transaction.relocations.canonical_variant_conflicts_added.push_back(taken);
       }
     }
     for (const auto &[source_offset, target_offset] : target_offset_by_source_offset) {
@@ -4060,7 +4140,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     // GFX10+ the wavefront SGPR count is a reserved field, so the decoded 8 is the granule-0
     // artifact rather than a budget, and a long-branch thunk needing an SGPR pair above it raises
     // nothing and starves nobody. VGPR and private are encoded on every target and still count.
-    if (!relocation_snapshot.canonical_placements_added.empty() &&
+    if (!transaction.relocations.canonical_placements_added.empty() &&
         (kernel_context.required_vgpr_count > kernel_context.num_vgprs ||
          (arch_descriptor_encodes_sgpr_allocation(host_arch_) &&
           kernel_context.required_sgpr_count > kernel_context.num_sgprs) ||
@@ -4102,9 +4182,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           auto failure =
               make_kernel_failure(DiagnosticKind::KernelDescriptor,
                                   "kernel descriptor translation could not be recomputed");
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -4122,9 +4200,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           auto failure = make_kernel_failure(
               DiagnosticKind::KernelDescriptor,
               "virtual LDS lowering cannot materialize backing-buffer pointer entry prologue");
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -4146,9 +4222,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
               failure.required_work = diagnostic.required_work;
               break;
             }
-            if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                    text_relocations_begin, data_relocations_begin,
-                                    relocation_snapshot)) {
+            if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
               skip_scope = true;
               break;
             }
@@ -4165,9 +4239,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           auto failure = make_kernel_failure(
               DiagnosticKind::KernelDescriptor,
               "kernel descriptor prologue changed after relocated text was emitted");
-          if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                  text_relocations_begin, data_relocations_begin,
-                                  relocation_snapshot)) {
+          if (fail_or_skip_kernel(scope, std::move(failure), transaction)) {
             skip_scope = true;
             break;
           }
@@ -4185,9 +4257,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (!recomputed_descriptor) {
         auto failure = make_kernel_failure(DiagnosticKind::KernelDescriptor,
                                            "kernel descriptor translation could not be recomputed");
-        if (fail_or_skip_kernel(scope, std::move(failure), output_begin, descriptor_snapshot,
-                                text_relocations_begin, data_relocations_begin,
-                                relocation_snapshot))
+        if (fail_or_skip_kernel(scope, std::move(failure), transaction))
           continue;
         return leave_unchanged();
       }
@@ -4214,43 +4284,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return leave_unchanged();
   }
 
-  // Every scope has been placed, so a code-target builder can finally be told where its target
-  // landed. A source offset emitted more than once has no single answer -- a runtime-dereferenced
-  // code address cannot choose between clones -- so that fails closed rather than picking one,
-  // matching how relocate_relative_text_addends treats a conflicting relocation addend.
-  if (!pending_code_relocations.empty()) {
-    std::unordered_map<uint64_t, uint64_t> placement;
-    std::unordered_set<uint64_t> conflicting;
-    for (const TextOffsetRelocation &relocation : text_relocations) {
-      auto [it, inserted] =
-          placement.try_emplace(relocation.source_offset, relocation.target_offset);
-      if (!inserted && it->second != relocation.target_offset)
-        conflicting.insert(relocation.source_offset);
-    }
-    for (const PendingCodeRelocation &pending : pending_code_relocations) {
-      if (const auto canonical = canonical_placement.find(pending.source_target_text_offset);
-          canonical != canonical_placement.end()) {
-        code_relocations.push_back({.target_getpc_offset = pending.target_getpc_offset,
-                                    .target_literal_offset = pending.target_literal_offset,
-                                    .target_text_offset = canonical->second});
-        continue;
-      }
-      const auto placed = placement.find(pending.source_target_text_offset);
-      if (placed == placement.end() || conflicting.contains(pending.source_target_text_offset)) {
-        append_error(result.diagnostics, DiagnosticKind::Legalization,
-                     conflicting.contains(pending.source_target_text_offset)
-                         ? "PC-relative code address names a body emitted at more than one "
-                           "placement; leaving code object unchanged"
-                         : "PC-relative code address names a body this translation did not emit; "
-                           "leaving code object unchanged",
-                     pending.source_target_text_offset);
-        return leave_unchanged();
-      }
-      code_relocations.push_back({.target_getpc_offset = pending.target_getpc_offset,
-                                  .target_literal_offset = pending.target_literal_offset,
-                                  .target_text_offset = placed->second});
-    }
-  }
+  if (!resolve_pending_code_relocations(pending_code_relocations, text_relocations,
+                                        canonical_placement, code_relocations, result.diagnostics))
+    return leave_unchanged();
 
   if (continue_after_failure && has_error_diagnostic(result.diagnostics))
     return leave_unchanged();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -1155,8 +1155,9 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
 ///
 /// @details Every cluster-load form (both SADDR and off/NULL-saddr, all widths)
 /// is left as a cluster load and wrapped so it executes with M0 forced to zero:
-/// save M0 to a scratch SGPR, set M0 = 0, run the load, then restore M0. The opcode
-/// is not changed.
+/// save M0 to a scratch SGPR, set M0 = 0, run the load, drain XCNT, then restore M0. The opcode
+/// is not changed. The drain is what keeps the restore from racing an XNACK replay of the load;
+/// see the comment at the emission site.
 ///
 /// Under full SGPR pressure, EXEC-independent lane-zero operations carry one
 /// live SGPR through a dead low-bank VGPR. This keeps the guest cluster load
@@ -1203,7 +1204,7 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
   // MUST use kGfx1250M0 (125): on gfx1250 M0 encodes as 125 and NULL as 124 (the
   // inverse of CDNA), so a write to 124 would be a discarded NULL write.
   std::vector<uint32_t> words;
-  words.reserve(18);
+  words.reserve(19);
   append_gfx1250_scratch_dependency_barrier(words);
   uint8_t current_mode = 0;
   std::optional<uint8_t> original_mode;
@@ -1223,6 +1224,17 @@ ExpandResult expand_gfx1250_cluster_load(const Instruction &inst, uint32_t, uint
                                {.ssrc0 = kGfx1250M0, .sdst = static_cast<uint8_t>(scratch->base)}));
   words.push_back(build_cluster_m0_clear());
   words.insert(words.end(), inst.raw_encoding(), inst.raw_encoding() + 3);
+  // Drain XCNT before giving M0 its guest value back. The hardware latches M0 at issue, so the
+  // transfer itself is safe, but an XNACK replay re-issues the VMEM instruction and re-reads its
+  // scalar operands. A restore that has already landed would hand the replayed load the original
+  // cluster mask and silently reinstate the multicast this rewrite exists to suppress. Once XCNT
+  // reaches zero the load is acknowledged and unreplayable, and replay skips non-VMEM ops, so a
+  // restore placed after the wait can never execute mid-replay.
+  //
+  // Unconditional rather than gated on MODE.REPLAY_MODE: the compiler sets that bit in every
+  // gfx1250 entry prologue, and a translator cannot prove it is clear on every path into this
+  // block.
+  append_words(words, cdna5::build_sopp(cdna5::kSWaitXcntSopp, {.simm16 = 0}));
   append_words(
       words, cdna5::build_sop1(cdna5::kSMovB32Sop1,
                                {.ssrc0 = static_cast<uint8_t>(scratch->base), .sdst = kGfx1250M0}));

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -9158,6 +9158,56 @@ TEST(BinaryTranslatorE2E, Gfx1250F16K128WmmaLoweringMatchesUnloweredExecution) {
     wf->halt();
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDrainsXcntBeforeRestoringM0) {
+  // The M0 restore must not be reachable while the load is still replayable. Hardware latches M0
+  // at issue, so the transfer itself is safe, but an XNACK replay re-issues the VMEM instruction
+  // and re-reads its scalar operands; a restore that already ran would hand the replayed load the
+  // guest's original cluster mask and undo the multicast suppression this rewrite exists for.
+  // Assert the ordering rather than a fixed index so the guarantee survives changes in scratch
+  // allocation, which vary the surrounding instructions.
+  constexpr auto cluster =
+      cdna5::build_vglobal(cdna5::kClusterLoadB32Vglobal, {.saddr = 4, .vdst = 8, .vaddr = 12});
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+
+  constexpr uint16_t kGfx1250M0Operand = 125;
+  std::optional<size_t> load_index;
+  std::optional<size_t> drain_index;
+  std::optional<size_t> restore_index;
+  for (size_t i = 0; i < decoded.size(); ++i) {
+    const auto &inst = *decoded[i];
+    if (inst.opcode() == cdna5::kClusterLoadB32Vglobal && !load_index)
+      load_index = i;
+    if (inst.mnemonic() == "s_wait_xcnt" && load_index && !drain_index)
+      drain_index = i;
+    if (inst.mnemonic() == "s_mov_b32" && inst.raw_encoding() != nullptr && load_index &&
+        !restore_index && ((inst.raw_encoding()[0] >> 16) & 0x7fu) == kGfx1250M0Operand)
+      restore_index = i;
+  }
+
+  ASSERT_TRUE(load_index.has_value()) << "the cluster load must survive translation";
+  ASSERT_TRUE(drain_index.has_value()) << "no XCNT drain follows the cluster load";
+  ASSERT_TRUE(restore_index.has_value()) << "M0 is never restored after the cluster load";
+  EXPECT_LT(*load_index, *drain_index) << "the drain must follow the load it acknowledges";
+  EXPECT_LT(*drain_index, *restore_index)
+      << "M0 is restored while the load is still replayable, which reinstates the cluster mask";
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250MasksM0AroundOffFormClusterLoadForA0) {
   // An off-form (NULL-saddr) cluster load is NOT demoted to a global load. Like
   // every cluster-load form, it stays a cluster load and is wrapped so it runs
@@ -9305,17 +9355,20 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadsUseVgprCarrierUnderSgprPressure) {
     EXPECT_EQ(
         std::ranges::count_if(decoded, [&](const auto &inst) { return inst->opcode() == opcode; }),
         1);
-    ASSERT_GE(decoded.size(), 8u);
+    ASSERT_GE(decoded.size(), 9u);
     ASSERT_EQ(decoded[0]->mnemonic(), "s_wait_idle");
     ASSERT_EQ(decoded[1]->mnemonic(), "v_writelane_b32");
-    ASSERT_EQ(decoded[6]->mnemonic(), "v_readlane_b32");
+    // The XCNT drain separates the load from the M0 restore even when the borrowed SGPR is
+    // carried through a VGPR, so the carrier restore sits one instruction later than the drain.
+    ASSERT_EQ(decoded[5]->mnemonic(), "s_wait_xcnt");
+    ASSERT_EQ(decoded[7]->mnemonic(), "v_readlane_b32");
 
     ASSERT_NE(decoded[1]->raw_encoding(), nullptr);
-    ASSERT_NE(decoded[6]->raw_encoding(), nullptr);
+    ASSERT_NE(decoded[7]->raw_encoding(), nullptr);
     cdna5::Vop3MachineInst save{};
     cdna5::Vop3MachineInst restore{};
     std::memcpy(&save, decoded[1]->raw_encoding(), sizeof(save));
-    std::memcpy(&restore, decoded[6]->raw_encoding(), sizeof(restore));
+    std::memcpy(&restore, decoded[7]->raw_encoding(), sizeof(restore));
     EXPECT_EQ(save.src0, restore.vdst) << "the carrier must restore the borrowed SGPR";
     EXPECT_EQ(static_cast<uint16_t>(256u + save.vdst), restore.src0)
         << "the carrier save and restore must use the same VGPR";
@@ -9399,6 +9452,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
   constexpr auto generated_restore =
       cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 0, .sdst = 125});
   constexpr auto dependency_barrier = cdna5::build_sopp(cdna5::kSWaitIdleSopp);
+  constexpr auto wait_xcnt = cdna5::build_sopp(cdna5::kSWaitXcntSopp, {.simm16 = 0});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {nonzero_m0[0], cluster[0], cluster[1], cluster[2], kGfx1250SEndpgm});
@@ -9414,7 +9468,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 10 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   EXPECT_EQ(target_words[0], nonzero_m0[0]);
@@ -9424,8 +9478,11 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseNonzeroM0Write) {
   EXPECT_EQ(target_words[4], cluster[0]);
   EXPECT_EQ(target_words[5], cluster[1]);
   EXPECT_EQ(target_words[6], cluster[2]);
-  EXPECT_EQ(target_words[7], generated_restore[0]);
-  EXPECT_EQ(target_words[8], kGfx1250SEndpgm);
+  // The XCNT drain must sit between the load and the restore, or an XNACK replay of the load
+  // re-reads a restored M0 and the cluster mask comes back.
+  EXPECT_EQ(target_words[7], wait_xcnt[0]);
+  EXPECT_EQ(target_words[8], generated_restore[0]);
+  EXPECT_EQ(target_words[9], kGfx1250SEndpgm);
 
   rocjitsu::BinaryTranslator verifier(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
@@ -9459,7 +9516,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseZeroWriteToOtherSgpr) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 9 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 10 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   EXPECT_EQ(target_words[0], clear_s7[0]);
@@ -9481,6 +9538,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
   constexpr auto source_restore =
       cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 12, .sdst = 125});
   constexpr auto dependency_barrier = cdna5::build_sopp(cdna5::kSWaitIdleSopp);
+  constexpr auto wait_xcnt = cdna5::build_sopp(cdna5::kSWaitXcntSopp, {.simm16 = 0});
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
       {branch_to_cluster[0], source_save[0], clear_m0[0], cluster[0], cluster[1], cluster[2],
@@ -9497,7 +9555,7 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_FALSE(translated.text_sections().empty());
-  ASSERT_EQ(translated.text_sections()[0]->size(), 12 * sizeof(uint32_t));
+  ASSERT_EQ(translated.text_sections()[0]->size(), 13 * sizeof(uint32_t));
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
   constexpr auto generated_save = cdna5::build_sop1(cdna5::kSMovB32Sop1, {.ssrc0 = 125, .sdst = 0});
@@ -9512,9 +9570,10 @@ TEST(BinaryTranslatorE2E, Gfx1250ClusterLoadDoesNotReuseM0ClearBypassedByBranch)
   EXPECT_EQ(target_words[6], cluster[0]);
   EXPECT_EQ(target_words[7], cluster[1]);
   EXPECT_EQ(target_words[8], cluster[2]);
-  EXPECT_EQ(target_words[9], generated_restore[0]);
-  EXPECT_EQ(target_words[10], source_restore[0]);
-  EXPECT_EQ(target_words[11], kGfx1250SEndpgm);
+  EXPECT_EQ(target_words[9], wait_xcnt[0]);
+  EXPECT_EQ(target_words[10], generated_restore[0]);
+  EXPECT_EQ(target_words[11], source_restore[0]);
+  EXPECT_EQ(target_words[12], kGfx1250SEndpgm);
 
   rocjitsu::BinaryTranslator verifier(
       ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,


### PR DESCRIPTION
The B0-to-A0 cluster-load rewrite runs the load with M0 forced to zero so no multicast fan-out is generated, then hands M0 its guest value back on the next instruction. Hardware latches M0 at issue, so the transfer itself never sees the restored value and the rewrite looked complete. XNACK replay breaks that reasoning: a replayed VMEM instruction re-issues and re-reads its scalar operands, so a restore that has already executed gives the replayed load the guest's original cluster mask and silently reinstates exactly the multicast the rewrite exists to suppress.

Emit S_WAIT_XCNT 0 between the load and the restore. Once XCNT reaches zero the load is acknowledged and can no longer be replayed, and replay skips non-VMEM instructions, so a restore placed after the drain cannot execute mid-replay. This is unconditional rather than gated on MODE.REPLAY_MODE: the compiler sets that bit in every gfx1250 entry prologue, and a translator cannot prove it is clear on every path reaching this block. The file already applies the same discipline to VGPR bank switches, whose drain exists for the same replay hazard.

Tensor loads stay exempt and must remain so. Replay skips the DMA and the engine replays from its own descriptor copy, so the hazard does not arise; worse, a tensor XACK only returns once every copy has completed, so draining there would serialize the transfer rather than protect it.

The four existing cluster tests pinned exact word or instruction indices and move by one. The new ordering test asserts load < drain < restore rather than fixed positions, so it still holds when scratch allocation changes the surrounding instructions; removing the drain makes it fail. No object in the 905-object gfx1250 corpus contains a cluster load, so translated output is unchanged there and the corpus cannot exercise this path -- the unit tests are the coverage, and confirming the hardware behavior needs a kernel issuing cluster loads under XNACK pressure.