### PR TITLE
[rocjitsu][CI] Exercise simulator corpus under sanitizers

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -82,10 +82,15 @@ jobs:
             enable_tsan: 0
             enable_expensive_checks: 0
             sanitizer_runtime: STATIC
+            run_simulator_corpus: true
+            corpus_soft_timeout: 15
+            corpus_hard_timeout: 30
+            corpus_rerun_timeout: 600
+            corpus_sanitizer: none
           - name: asan-ubsan
             allow_failure: true
-            # Keep the first corpus gate on the fastest lane. Focused second-pass
-            # paths remain covered by the sanitizer test suite.
+            # Sanitized simulator cases need extra interpreter headroom.
+            # A failed-test rerun preserves extra diagnostics.
             verify_dbt_idempotence: 0
             dbt_timeout: 180
             dbt_memory_limit_mib: 4096
@@ -97,6 +102,11 @@ jobs:
             enable_tsan: 0
             enable_expensive_checks: 1
             sanitizer_runtime: SHARED
+            run_simulator_corpus: true
+            corpus_soft_timeout: 240
+            corpus_hard_timeout: 480
+            corpus_rerun_timeout: 1200
+            corpus_sanitizer: clang-asan
           - name: tsan
             allow_failure: false
             verify_dbt_idempotence: 0
@@ -111,6 +121,11 @@ jobs:
             enable_tsan: 1
             enable_expensive_checks: 0
             sanitizer_runtime: SHARED
+            run_simulator_corpus: false
+            corpus_soft_timeout: 0
+            corpus_hard_timeout: 0
+            corpus_rerun_timeout: 0
+            corpus_sanitizer: none
           - name: asan-ubsan-gcc
             allow_failure: true
             verify_dbt_idempotence: 0
@@ -128,6 +143,11 @@ jobs:
             sanitizer_runtime: SHARED
             c_compiler: gcc
             cxx_compiler: g++
+            run_simulator_corpus: true
+            corpus_soft_timeout: 240
+            corpus_hard_timeout: 480
+            corpus_rerun_timeout: 1200
+            corpus_sanitizer: gcc-asan
 
     steps:
       - name: Install base dependencies
@@ -153,7 +173,7 @@ jobs:
             shared/machine-readable-isa/isa
 
       - name: Checkout corpus
-        if: matrix.enable_tsan == 0
+        if: matrix.run_simulator_corpus
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
@@ -194,9 +214,12 @@ jobs:
           ROCMINFO=RocminfoTest
           RCCL_DAEMON=RcclDaemonTest
           EXCLUDED_TESTS="${ROCMINFO}|${RCCL_DAEMON}"
-          ASAN_UBSAN_EXCLUDED_TESTS=(
+          SANITIZER_EXCLUDED_TESTS=(
             "HsaTest\.InitSucceeded"
             "HsaTest\.GpuAgentFound"
+            # The hardware-backed tools-hook test cannot initialize ROCR when
+            # the launcher and hook use a sanitizer-instrumented process image.
+            "HsaHooksTest\.TranslateGfx950Mfma16x16ThroughToolsLib"
             "Cdna4ToCdna3SimulatedDispatchTest\..*"
             "Cdna4ToCdna3DbtGuestTest\..*"
             "HipMemcpyTest\.RoundTripFloat"
@@ -215,7 +238,11 @@ jobs:
             "RaceTest\..*"
           )
           TSAN_EXCLUDED_TESTS=(
-            "${ASAN_UBSAN_EXCLUDED_TESTS[@]}"
+            "${SANITIZER_EXCLUDED_TESTS[@]}"
+            # Hardware dispatch reports a TSan race while ROCr tears down its
+            # async-event bookkeeping, outside rocjitsu-owned code.
+            "HsaTranslateTest\.TranslateAndDispatchVectorAdd"
+            "HsaTranslateTest\.TranslateAndDispatchMfma16x16"
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"
@@ -224,7 +251,7 @@ jobs:
           TEST_REGEX="${{ matrix.test_regex }}"
           CMAKE_CONFIG_FLAGS=()
           if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
-            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
+            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${SANITIZER_EXCLUDED_TESTS[*]}")"
             CMAKE_CONFIG_FLAGS+=(
               -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
@@ -297,7 +324,7 @@ jobs:
             --output-on-failure
 
       - name: Install corpus test dependencies
-        if: matrix.name == 'release'
+        if: matrix.run_simulator_corpus
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         shell: bash
         run: |
@@ -321,7 +348,10 @@ jobs:
           python -m pytest lib/python/amdisa/tests
 
       - name: Run corpus tests
-        if: matrix.name == 'release'
+        if: matrix.run_simulator_corpus
+        # Clean runs on this change completed in 4-13 minutes. The sanitizer
+        # rerun budget is capped at 20 minutes within this step-level failsafe.
+        timeout-minutes: 60
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         shell: bash
         env:
@@ -340,14 +370,26 @@ jobs:
             WORKERS=16
           fi
           corpus_test_flags=(
-            --workers "${WORKERS}" \
-            --soft-timeout 15 \
-            --hard-timeout 30 \
-            --rerun-failed \
-            --warn-perf \
+            --workers "${WORKERS}"
+            --soft-timeout ${{ matrix.corpus_soft_timeout }}
+            --hard-timeout ${{ matrix.corpus_hard_timeout }}
+            --rerun-timeout ${{ matrix.corpus_rerun_timeout }}
+            --sanitizer ${{ matrix.corpus_sanitizer }}
+            --rerun-failed
+            --warn-perf
           )
           bash "${ROCJITSU_SOURCE_DIR}/tests/corpus/run-corpus-tests.sh" "${corpus_test_flags[@]}" || corpus_test_status=$?
           exit "${corpus_test_status}"
+
+      - name: Upload simulator corpus diagnostics
+        if: ${{ always() && matrix.run_simulator_corpus }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rocjitsu-corpus-diagnostics-${{ matrix.name }}
+          path: ${{ env.ROCJITSU_CORPUS_DIR }}/.pytest-artifacts
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Compare plain and translated gfx1250 simulator runs
         if: ${{ !cancelled() && matrix.name == 'release' && steps.build_rocjitsu.outcome == 'success' }}
@@ -407,7 +449,7 @@ jobs:
 
       - name: Extract pinned gfx1250 packaged HSACOs
         id: extract_dbt
-        if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.build_rocjitsu.outcome == 'success' }}
+        if: ${{ !cancelled() && matrix.run_simulator_corpus && steps.build_rocjitsu.outcome == 'success' }}
         timeout-minutes: 10
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         shell: bash
@@ -432,7 +474,7 @@ jobs:
 
       - name: Run gfx1250 DBT corpus tests
         id: run_dbt
-        if: ${{ !cancelled() && matrix.enable_tsan == 0 && steps.extract_dbt.outcome == 'success' }}
+        if: ${{ !cancelled() && matrix.run_simulator_corpus && steps.extract_dbt.outcome == 'success' }}
         timeout-minutes: ${{ matrix.dbt_job_timeout }}
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         shell: bash
@@ -549,7 +591,7 @@ jobs:
       # Debugging aid only. The pinned extraction is reproducible, so retain
       # translator logs but never upload the extracted HSACOs.
       - name: Upload gfx1250 DBT diagnostic logs
-        if: always() && matrix.enable_tsan == 0
+        if: always() && matrix.run_simulator_corpus
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gfx1250-dbt-logs-${{ matrix.name }}

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -290,6 +290,8 @@ public:
     size_t host_backed_bytes = 0;
     /// GPU-page offset that corresponds to host_ptr.
     size_t gpu_page_offset = 0;
+
+    bool operator==(const HostExtent &) const = default;
   };
 
   /// @brief One inline host extent, spilling to dynamic storage only for split pages.
@@ -313,6 +315,7 @@ public:
         move_from(std::move(other));
       return *this;
     }
+    bool operator==(const HostExtentList &) const = default;
 
     [[nodiscard]] size_t size() const {
       if (std::holds_alternative<std::monostate>(storage_))
@@ -447,6 +450,8 @@ public:
 
     amdgpu::Mtype mtype = amdgpu::Mtype::RW;
     HostExtentList host_extents;
+
+    bool operator==(const PageTableEntry &) const = default;
   };
 
   /// @brief Per-process GPU page table (GPU VA page number → PTE).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <format>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -353,7 +354,9 @@ public:
   /// @brief Find the contiguous host range containing a VMID-scoped GPU VA.
   /// @details KFD dispatches use per-process page tables. Kernel-symbol
   /// resolution needs a daemon-accessible host pointer range so it can scan
-  /// backward from the kernel descriptor to the loaded ELF header.
+  /// backward from the kernel descriptor to the loaded ELF header. Sanitized
+  /// builds release the VMID and page-table locks around allocator queries,
+  /// then revalidate the registry generation and every contributing PTE.
   std::pair<uint64_t, uint64_t> find_host_range(uint64_t addr, uint32_t vmid) const {
     if (vmid == 0) {
       auto *host = translate(addr, vmid, 1);
@@ -364,61 +367,113 @@ public:
       return {reinterpret_cast<uint64_t>(range), size};
     }
 
-    std::shared_lock vmid_lock(vmid_mutex_);
-    auto vmid_entry = vmid_table_.find(vmid);
-    if (vmid_entry == vmid_table_.end())
-      return {0, 0};
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    size_t metadata_retries = 0;
+#endif
+    while (true) {
+      std::shared_lock vmid_lock(vmid_mutex_);
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+      const uint64_t registry_generation = vmid_registry_generation_;
+#endif
+      auto vmid_entry = vmid_table_.find(vmid);
+      if (vmid_entry == vmid_table_.end())
+        return {0, 0};
 
-    auto &entry = vmid_entry->second;
-    std::shared_lock page_table_lock(*entry.mutex);
-    const uint64_t page = addr >> PAGE_SHIFT;
-    auto page_entry = entry.page_table->find(page);
-    if (page_entry == entry.page_table->end())
-      return {0, 0};
+      auto &entry = vmid_entry->second;
+      auto *page_table = entry.page_table;
+      auto *page_table_mutex = entry.mutex;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+      const uint64_t *generation_ptr = entry.generation;
+#endif
+      std::shared_lock page_table_lock(*page_table_mutex);
+      const uint64_t page = addr >> PAGE_SHIFT;
+      auto page_entry = page_table->find(page);
+      if (page_entry == page_table->end())
+        return {0, 0};
 
-    const size_t page_offset = addr & PAGE_MASK;
-    const auto *current_extent = host_extent_at(page_entry->second, page_offset);
-    if (!current_extent)
-      return {0, 0};
+      const size_t page_offset = addr & PAGE_MASK;
+      const auto *current_extent = host_extent_at(page_entry->second, page_offset);
+      if (!current_extent)
+        return {0, 0};
 
-    uint64_t first_page = page;
-    const auto *first_extent = current_extent;
-    uint8_t *first_host_byte = first_extent->host_ptr;
-    while (first_page > 0 && first_extent->gpu_page_offset == 0) {
-      auto previous_page_entry = entry.page_table->find(first_page - 1);
-      if (previous_page_entry == entry.page_table->end())
-        break;
-      const auto *previous_extent = host_extent_ending_at_page(previous_page_entry->second);
-      if (!previous_extent ||
-          previous_extent->host_ptr + previous_extent->host_backed_bytes != first_host_byte)
-        break;
-      --first_page;
-      first_extent = previous_extent;
-      first_host_byte = first_extent->host_ptr;
+      uint64_t first_page = page;
+      const auto *first_extent = current_extent;
+      uint8_t *first_host_byte = first_extent->host_ptr;
+      while (first_page > 0 && first_extent->gpu_page_offset == 0) {
+        auto previous_page_entry = page_table->find(first_page - 1);
+        if (previous_page_entry == page_table->end())
+          break;
+        const auto *previous_extent = host_extent_ending_at_page(previous_page_entry->second);
+        if (!previous_extent ||
+            previous_extent->host_ptr + previous_extent->host_backed_bytes != first_host_byte)
+          break;
+        --first_page;
+        first_extent = previous_extent;
+        first_host_byte = first_extent->host_ptr;
+      }
+
+      uint64_t last_page = page;
+      const auto *last_extent = current_extent;
+      while (last_extent->gpu_page_offset + last_extent->host_backed_bytes == PAGE_SIZE) {
+        auto next_page_entry = page_table->find(last_page + 1);
+        if (next_page_entry == page_table->end())
+          break;
+        const auto *next_extent = host_extent_starting_at_page(next_page_entry->second);
+        if (!next_extent ||
+            next_extent->host_ptr != last_extent->host_ptr + last_extent->host_backed_bytes)
+          break;
+        ++last_page;
+        last_extent = next_extent;
+      }
+
+      const uintptr_t first_host_address = reinterpret_cast<uintptr_t>(first_host_byte);
+      const uintptr_t last_host_address = reinterpret_cast<uintptr_t>(last_extent->host_ptr);
+      const uint64_t declared_range_size =
+          last_host_address - first_host_address + last_extent->host_backed_bytes;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+      auto *host_byte = current_extent->host_ptr + (page_offset - current_extent->gpu_page_offset);
+      std::vector<std::pair<uint64_t, KfdProcess::PageTableEntry>> pte_snapshot;
+      pte_snapshot.reserve(last_page - first_page + 1);
+      for (uint64_t snapshot_page = first_page;; ++snapshot_page) {
+        pte_snapshot.emplace_back(snapshot_page, page_table->at(snapshot_page));
+        if (snapshot_page == last_page)
+          break;
+      }
+
+      page_table_lock.unlock();
+      vmid_lock.unlock();
+      run_asan_page_table_unlocked_hook();
+      auto [range, range_size] =
+          addressable_range_containing(first_host_byte, declared_range_size, host_byte);
+
+      vmid_lock.lock();
+      auto current_vmid_entry = vmid_table_.find(vmid);
+      bool snapshot_valid = vmid_registry_generation_ == registry_generation &&
+                            current_vmid_entry != vmid_table_.end() &&
+                            current_vmid_entry->second.page_table == page_table &&
+                            current_vmid_entry->second.mutex == page_table_mutex &&
+                            current_vmid_entry->second.generation == generation_ptr;
+      if (snapshot_valid) {
+        page_table_lock.lock();
+        for (const auto &[snapshot_page, snapshot_pte] : pte_snapshot) {
+          auto current_pte = page_table->find(snapshot_page);
+          if (current_pte == page_table->end() || current_pte->second != snapshot_pte) {
+            snapshot_valid = false;
+            break;
+          }
+        }
+      }
+      if (snapshot_valid)
+        return {reinterpret_cast<uint64_t>(range), range_size};
+      if (++metadata_retries >= kMaxMetadataRetries)
+        return {0, 0};
+#else
+      auto [range, range_size] = addressable_range_containing(
+          first_host_byte, declared_range_size,
+          current_extent->host_ptr + (page_offset - current_extent->gpu_page_offset));
+      return {reinterpret_cast<uint64_t>(range), range_size};
+#endif
     }
-
-    uint64_t last_page = page;
-    const auto *last_extent = current_extent;
-    while (last_extent->gpu_page_offset + last_extent->host_backed_bytes == PAGE_SIZE) {
-      auto next_page_entry = entry.page_table->find(last_page + 1);
-      if (next_page_entry == entry.page_table->end())
-        break;
-      const auto *next_extent = host_extent_starting_at_page(next_page_entry->second);
-      if (!next_extent ||
-          next_extent->host_ptr != last_extent->host_ptr + last_extent->host_backed_bytes)
-        break;
-      ++last_page;
-      last_extent = next_extent;
-    }
-
-    const uintptr_t first_host_address = reinterpret_cast<uintptr_t>(first_host_byte);
-    const uintptr_t last_host_address = reinterpret_cast<uintptr_t>(last_extent->host_ptr);
-    const uint64_t declared_range_size =
-        last_host_address - first_host_address + last_extent->host_backed_bytes;
-    auto *host_byte = current_extent->host_ptr + (page_offset - current_extent->gpu_page_offset);
-    auto [range, range_size] =
-        addressable_range_containing(first_host_byte, declared_range_size, host_byte);
-    return {reinterpret_cast<uint64_t>(range), range_size};
   }
 
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
@@ -522,6 +577,8 @@ private:
   static constexpr unsigned kBackingAtomicHashFoldShift2 = 31;
   // Bound mutex storage while keeping collisions low for common GPU workloads.
   static constexpr size_t kBackingAtomicLockStripes = 4096;
+  // Bound repeated allocator queries when one page is continuously remapped.
+  static constexpr size_t kMaxMetadataRetries = 8;
   // The 64-bit golden-ratio hash constant scatters adjacent client PIDs.
   static constexpr uintptr_t kClientPidHashSalt = static_cast<uintptr_t>(0x9e3779b97f4a7c15ULL);
   static_assert((kBackingAtomicLockStripes & (kBackingAtomicLockStripes - 1)) == 0,
@@ -770,6 +827,11 @@ private:
 
   static size_t heap_allocation_bounded_length([[maybe_unused]] uint8_t *base, size_t len) {
 #if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    // A fully addressable range cannot cross an ASan heap allocation boundary:
+    // heap redzones are poisoned. Clean shadow also covers memory owned by
+    // external allocators, where the declared mapping is the available bound.
+    if (__asan_region_is_poisoned(base, len) == nullptr)
+      return len;
     std::array<char, 1> name{};
     void *region_address = nullptr;
     size_t region_size = 0;
@@ -810,6 +872,11 @@ private:
     std::shared_mutex *mutex = nullptr;
     const uint64_t *generation_ptr = nullptr;
   };
+
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+  /// @brief Test-only callback invoked while page-table and VMID locks are released.
+  using AsanPageTableUnlockedHook = std::function<void()>;
+#endif
 
   static const KfdProcess::HostExtent *host_extent_at(const KfdProcess::PageTableEntry &pte,
                                                       size_t page_offset) {
@@ -866,58 +933,164 @@ private:
   }
 
   /// @brief Walk a VMID page table with a generation-keyed thread-local cache.
-  /// @details The callback runs while both VMID registration and the selected
-  /// page table are shared-locked. This keeps a cached host pointer alive for
-  /// the whole copy and makes translate() and pte_mtype() share one invalidation
-  /// protocol.
+  /// @details A mapped-PTE callback runs while both VMID registration and the
+  /// selected page table are shared-locked. Miss callbacks and ASan allocator
+  /// queries run without either lock. After an unlocked query, the VMID binding
+  /// and exact PTE contents are revalidated before the bounded copy is published.
+  /// Addressability checks in the mapped-span helpers remain the final guard
+  /// against host-allocation reuse that preserves identical PTE contents.
   template <typename F>
   auto cached_walk(uint64_t addr, uint32_t vmid, PteCache &cache,
                    F &&fn) const -> std::invoke_result_t<F, const KfdProcess::PageTableEntry *> {
     const uint64_t page_key = addr >> PAGE_SHIFT;
-    std::shared_lock vmid_lock(vmid_mutex_);
-    const uint64_t registry_generation = vmid_registry_generation_;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+    size_t metadata_retries = 0;
+#endif
+    bool allow_cache_hit = true;
+    while (true) {
+      std::shared_lock vmid_lock(vmid_mutex_);
+      const uint64_t registry_generation = vmid_registry_generation_;
+      const bool cached_table =
+          cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
+          cache.registry_generation == registry_generation && cache.page_table && cache.mutex;
+      KfdProcess::PageTable *page_table = cache.page_table;
+      std::shared_mutex *page_table_mutex = cache.mutex;
+      const uint64_t *generation_ptr = cache.generation_ptr;
+      if (!cached_table) {
+        auto vmid_entry = vmid_table_.find(vmid);
+        if (vmid_entry == vmid_table_.end()) {
+          cache = {};
+          vmid_lock.unlock();
+          return fn(nullptr);
+        }
+        page_table = vmid_entry->second.page_table;
+        page_table_mutex = vmid_entry->second.mutex;
+        generation_ptr = vmid_entry->second.generation;
+      }
 
-    const bool cached_table =
-        cache.memory == this && cache.memory_instance == instance_id_ && cache.vmid == vmid &&
-        cache.registry_generation == registry_generation && cache.page_table && cache.mutex;
-    if (!cached_table) {
-      auto it = vmid_table_.find(vmid);
-      if (it == vmid_table_.end()) {
-        cache = {};
+      std::shared_lock page_table_lock(*page_table_mutex);
+      uint64_t generation = generation_ptr ? *generation_ptr : 0;
+      auto publish_cache = [&](bool found, KfdProcess::PageTableEntry pte) {
+        cache = {
+            .memory = this,
+            .memory_instance = instance_id_,
+            .vmid = vmid,
+            .registry_generation = registry_generation,
+            .page_key = page_key,
+            .generation = generation,
+            .found = found,
+            .pte = std::move(pte),
+            .page_table = page_table,
+            .mutex = page_table_mutex,
+            .generation_ptr = generation_ptr,
+        };
+      };
+      const bool cached_page = allow_cache_hit && cached_table && generation_ptr &&
+                               cache.generation == generation && cache.page_key == page_key;
+      if (cached_page) {
+        if (cache.found)
+          return fn(&cache.pte);
+        page_table_lock.unlock();
+        vmid_lock.unlock();
         return fn(nullptr);
       }
-      cache.memory = this;
-      cache.memory_instance = instance_id_;
-      cache.vmid = vmid;
-      cache.registry_generation = registry_generation;
-      cache.page_table = it->second.page_table;
-      cache.mutex = it->second.mutex;
-      cache.generation_ptr = it->second.generation;
-      cache.found = false;
-    }
+      allow_cache_hit = false;
 
-    std::shared_lock page_table_lock(*cache.mutex);
-    const uint64_t generation = cache.generation_ptr ? *cache.generation_ptr : 0;
-    const bool cached_page = cached_table && cache.generation_ptr &&
-                             cache.generation == generation && cache.page_key == page_key;
-    if (!cached_page) {
-      auto it = cache.page_table->find(page_key);
-      cache.page_key = page_key;
-      cache.generation = generation;
-      cache.found = it != cache.page_table->end();
-      if (cache.found)
-        cache.pte = it->second;
-#if defined(RJ_GPU_MEMORY_WITH_ASAN)
-      if (cache.found) {
-        for (auto &extent : cache.pte.host_extents)
-          extent.host_backed_bytes =
-              heap_allocation_bounded_length(extent.host_ptr, extent.host_backed_bytes);
+      auto it = page_table->find(page_key);
+      if (it == page_table->end()) {
+        publish_cache(false, {});
+        // A miss exposes no page-table storage. Release this lock before a
+        // passthrough callback performs any ASan allocator query.
+        page_table_lock.unlock();
+        vmid_lock.unlock();
+        return fn(nullptr);
       }
-#endif
-    }
+      const auto &[candidate_mtype, candidate_host_extents] = it->second;
+      KfdProcess::PageTableEntry candidate;
+      candidate.mtype = candidate_mtype;
+      candidate.host_extents = candidate_host_extents;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+      const KfdProcess::PageTableEntry raw_pte = candidate;
+      // AMD's ASan address lookup may consult ROCr for device allocations.
+      // Drop the page-table lock around that external query, then validate the
+      // copied PTE before exposing its host pointers to the callback.
+      page_table_lock.unlock();
+      vmid_lock.unlock();
+      run_asan_page_table_unlocked_hook();
+      for (auto &extent : candidate.host_extents)
+        extent.host_backed_bytes =
+            heap_allocation_bounded_length(extent.host_ptr, extent.host_backed_bytes);
 
-    return fn(cache.found ? &cache.pte : nullptr);
+      vmid_lock.lock();
+      if (vmid_registry_generation_ != registry_generation) {
+        cache = {};
+        if (++metadata_retries < kMaxMetadataRetries)
+          continue;
+
+        // Unrelated VMID churn consumes the same bounded retry budget as a
+        // target remap. Re-resolve the target registration under its locks so
+        // this access remains fail-closed without turning a live mapping into
+        // a passthrough miss.
+        auto current_vmid_entry = vmid_table_.find(vmid);
+        if (current_vmid_entry == vmid_table_.end()) {
+          vmid_lock.unlock();
+          return fn(nullptr);
+        }
+        auto *current_page_table = current_vmid_entry->second.page_table;
+        std::shared_lock current_page_table_lock(*current_vmid_entry->second.mutex);
+        auto current_pte = current_page_table->find(page_key);
+        if (current_pte == current_page_table->end()) {
+          current_page_table_lock.unlock();
+          vmid_lock.unlock();
+          return fn(nullptr);
+        }
+        candidate = current_pte->second;
+        for (auto &extent : candidate.host_extents)
+          extent.host_backed_bytes = 0;
+        return fn(&candidate);
+      }
+      page_table_lock.lock();
+      const bool generation_unchanged = generation_ptr && *generation_ptr == generation;
+      bool mapping_changed = !generation_unchanged;
+      if (mapping_changed) {
+        it = page_table->find(page_key);
+        mapping_changed = it == page_table->end() || it->second != raw_pte;
+      }
+      if (mapping_changed) {
+        if (++metadata_retries < kMaxMetadataRetries)
+          continue;
+
+        // Preserve mapped-page identity while preventing access through bounds
+        // that could not be validated under continuous remapping.
+        if (it == page_table->end()) {
+          publish_cache(false, {});
+          page_table_lock.unlock();
+          vmid_lock.unlock();
+          return fn(nullptr);
+        }
+        candidate = it->second;
+        for (auto &extent : candidate.host_extents)
+          extent.host_backed_bytes = 0;
+        // Use the fail-closed bounds for this access only. Publishing this
+        // synthetic PTE would make later accesses reuse zero-length extents
+        // after remapping has stopped.
+        cache = {};
+        return fn(&candidate);
+      }
+      if (generation_ptr)
+        generation = *generation_ptr;
+#endif
+      publish_cache(true, std::move(candidate));
+      return fn(&cache.pte);
+    }
   }
+
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+  void run_asan_page_table_unlocked_hook() const {
+    if (auto *hook = asan_page_table_unlocked_hook_.load(std::memory_order_acquire))
+      (*hook)();
+  }
+#endif
 
   template <typename F> bool with_page_mapping(uint64_t addr, uint32_t vmid, F &&fn) const {
     if (vmid == 0) {
@@ -1145,6 +1318,11 @@ private:
   std::unordered_map<uint32_t, VmidEntry> vmid_table_;
   // Version of VMID-to-page-table bindings, accessed only under vmid_mutex_.
   uint64_t vmid_registry_generation_ = 1;
+#if defined(RJ_GPU_MEMORY_WITH_ASAN)
+  /// @brief Private unit-test seam for deterministic unlocked-query coverage.
+  /// @details The pointed-to callback must outlive every concurrent invocation.
+  mutable std::atomic<AsanPageTableUnlockedHook *> asan_page_table_unlocked_hook_{nullptr};
+#endif
   mutable std::atomic<uint64_t> clipped_mapped_accesses_{0};
   bool passthrough_ = false;
 };

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -39,6 +39,7 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <new>
@@ -70,6 +71,14 @@ public:
   static std::mutex *backing_atomic_mutex_for(const void *address) {
     return &GpuMemory::backing_atomic_mutex(reinterpret_cast<uintptr_t>(address));
   }
+
+#if defined(RJ_AMDGPU_VM_TEST_WITH_ASAN)
+  static void set_page_table_unlocked_hook(GpuMemory &memory, std::function<void()> *hook) {
+    memory.asan_page_table_unlocked_hook_.store(hook, std::memory_order_release);
+  }
+
+  static constexpr size_t metadata_retry_limit() { return GpuMemory::kMaxMetadataRetries; }
+#endif
 };
 
 } // namespace rocjitsu::amdgpu
@@ -984,6 +993,318 @@ TEST(GpuMemoryTest, SanitizedMappedExtentTracksCurrentShadowState) {
   memory.write32(kBaseVa + kLaterLiveOffset, 0x55555555, kPid);
   EXPECT_EQ(memory.read32(kBaseVa + kLaterLiveOffset, kPid), 0x55555555u);
   __asan_unpoison_memory_region(allocation.get() + kInteriorPoisonOffset, kInteriorPoisonBytes);
+}
+
+TEST(GpuMemoryTest, SanitizedUnlockedQueryPreservesOuterWalkAcrossReentry) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kOuterVa = 0x40000000;
+  constexpr uint64_t kNestedVa = 0x50000000;
+
+  KfdProcess process(kPid);
+  auto outer_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto nested_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  outer_page[0] = 0x11;
+  nested_page[0] = 0x22;
+  process.map_pages(kOuterVa, outer_page.get(), KfdProcess::kPageSize);
+  process.map_pages(kNestedVa, nested_page.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  std::function<void()> query_hook = [&] {
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    memory.unregister_process(kPid);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            process.page_table_generation());
+    EXPECT_EQ(memory.read8(kNestedVa, kPid), 0x22);
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  EXPECT_EQ(memory.read8(kOuterVa, kPid), 0x11);
+}
+
+TEST(GpuMemoryTest, SanitizedUnlockedQueryRetriesAfterRemap) {
+  for (const bool use_generation : {false, true}) {
+    SCOPED_TRACE(use_generation ? "generation" : "legacy-exact-pte");
+    amdgpu::GpuMemory memory("memory");
+    constexpr uint32_t kPid = 7;
+    constexpr uint64_t kBaseVa = 0x40000000;
+
+    KfdProcess process(kPid);
+    auto old_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+    auto new_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+    old_page[0] = 0x11;
+    new_page[0] = 0x22;
+    process.map_pages(kBaseVa, old_page.get(), KfdProcess::kPageSize);
+    memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                            use_generation ? process.page_table_generation() : nullptr);
+
+    uint8_t *current_page = old_page.get();
+    size_t hook_calls = 0;
+    std::function<void()> query_hook = [&] {
+      ++hook_calls;
+      if (hook_calls == 4) {
+        amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+        return;
+      }
+      auto *next_page = current_page == old_page.get() ? new_page.get() : old_page.get();
+      process.remap_page_host_ptrs(kBaseVa, current_page, next_page, KfdProcess::kPageSize);
+      current_page = next_page;
+    };
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+    EXPECT_EQ(memory.read8(kBaseVa, kPid), 0x22);
+    EXPECT_EQ(hook_calls, 4u);
+  }
+}
+
+TEST(GpuMemoryTest, SanitizedRetryLimitKeepsMappedAccessOutOfFallback) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kLiveOffset = 128;
+
+  KfdProcess process(kPid);
+  auto first_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto second_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  std::fill_n(first_page.get(), KfdProcess::kPageSize, 0x5a);
+  std::fill_n(second_page.get(), KfdProcess::kPageSize, 0x5a);
+  process.map_pages(kBaseVa, first_page.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  uint8_t *current_page = first_page.get();
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    auto *next_page = current_page == first_page.get() ? second_page.get() : first_page.get();
+    process.remap_page_host_ptrs(kBaseVa, current_page, next_page, KfdProcess::kPageSize);
+    current_page = next_page;
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  memory.write8(kBaseVa + kLiveOffset, 0xa5, kPid);
+  EXPECT_EQ(hook_calls, amdgpu::GpuMemoryTestAccess::metadata_retry_limit());
+  EXPECT_EQ(first_page[kLiveOffset], 0x5a);
+  EXPECT_EQ(second_page[kLiveOffset], 0x5a);
+
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+  memory.write8(kBaseVa + kLiveOffset, 0xa5, kPid);
+  EXPECT_EQ(current_page[kLiveOffset], 0xa5);
+  memory.write8(kBaseVa + kLiveOffset, 0x3c, kPid);
+  EXPECT_EQ(current_page[kLiveOffset], 0x3c);
+  EXPECT_EQ(memory.read8(kBaseVa + kLiveOffset, kPid), 0x3c);
+  EXPECT_EQ(memory.read8(kBaseVa + kLiveOffset, kPid), 0x3c);
+  process.unmap_pages(kBaseVa, KfdProcess::kPageSize);
+  EXPECT_EQ(memory.read8(kBaseVa + kLiveOffset, kPid), 0u);
+}
+
+TEST(GpuMemoryTest, SanitizedRegistryRetryLimitKeepsMappedAccessOutOfFallback) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint32_t kChurnPid = 8;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kLiveOffset = 128;
+
+  KfdProcess process(kPid);
+  KfdProcess churn_process(kChurnPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  std::fill_n(allocation.get(), KfdProcess::kPageSize, 0x5a);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  bool churn_registered = false;
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    if (churn_registered)
+      memory.unregister_process(kChurnPid);
+    else
+      memory.register_process(kChurnPid, &churn_process.page_table_,
+                              &churn_process.page_table_mutex_,
+                              churn_process.page_table_generation());
+    churn_registered = !churn_registered;
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  memory.write8(kBaseVa + kLiveOffset, 0xa5, kPid);
+  EXPECT_EQ(hook_calls, amdgpu::GpuMemoryTestAccess::metadata_retry_limit());
+  EXPECT_EQ(allocation[kLiveOffset], 0x5a);
+
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+  if (churn_registered)
+    memory.unregister_process(kChurnPid);
+  memory.write8(kBaseVa + kLiveOffset, 0xa5, kPid);
+  EXPECT_EQ(allocation[kLiveOffset], 0xa5);
+  EXPECT_EQ(memory.read8(kBaseVa + kLiveOffset, kPid), 0xa5);
+}
+
+TEST(GpuMemoryTest, SanitizedFindHostRangeQueriesWithoutPageTableLocks) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kOtherVa = 0x50000000;
+  constexpr size_t kOffset = 128;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto other_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    process.map_pages(kOtherVa, other_page.get(), KfdProcess::kPageSize);
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  const auto [range, size] = memory.find_host_range(kBaseVa + kOffset, kPid);
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(range, reinterpret_cast<uint64_t>(allocation.get()));
+  EXPECT_EQ(size, KfdProcess::kPageSize);
+}
+
+TEST(GpuMemoryTest, SanitizedFindHostRangeRetriesTargetRemap) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kOffset = 128;
+
+  KfdProcess process(kPid);
+  auto old_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto new_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  process.map_pages(kBaseVa, old_page.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    process.remap_page_host_ptrs(kBaseVa, old_page.get(), new_page.get(), KfdProcess::kPageSize);
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  const auto [range, size] = memory.find_host_range(kBaseVa + kOffset, kPid);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(range, reinterpret_cast<uint64_t>(new_page.get()));
+  EXPECT_EQ(size, KfdProcess::kPageSize);
+}
+
+TEST(GpuMemoryTest, SanitizedFindHostRangeRejectsTargetUnmap) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kOffset = 128;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    process.unmap_pages(kBaseVa, KfdProcess::kPageSize);
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  const auto [range, size] = memory.find_host_range(kBaseVa + kOffset, kPid);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(range, 0u);
+  EXPECT_EQ(size, 0u);
+}
+
+TEST(GpuMemoryTest, SanitizedFindHostRangeRetriesVmidReplacement) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr size_t kOffset = 128;
+
+  KfdProcess old_process(kPid);
+  KfdProcess new_process(kPid);
+  auto old_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto new_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  old_process.map_pages(kBaseVa, old_page.get(), KfdProcess::kPageSize);
+  new_process.map_pages(kBaseVa, new_page.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &old_process.page_table_, &old_process.page_table_mutex_,
+                          old_process.page_table_generation());
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    ++hook_calls;
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    memory.unregister_process(kPid);
+    memory.register_process(kPid, &new_process.page_table_, &new_process.page_table_mutex_,
+                            new_process.page_table_generation());
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  const auto [range, size] = memory.find_host_range(kBaseVa + kOffset, kPid);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(range, reinterpret_cast<uint64_t>(new_page.get()));
+  EXPECT_EQ(size, KfdProcess::kPageSize);
+}
+
+TEST(GpuMemoryTest, SanitizedUnrelatedMappingChurnDoesNotLoseStableWrites) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint64_t kChurnVa = 0x50000000;
+  constexpr size_t kOffset = 128;
+  constexpr size_t kIterations = 64;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  auto churn_page = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation());
+
+  std::atomic<size_t> requested{0};
+  std::atomic<size_t> completed{0};
+  std::atomic<bool> stop{false};
+  std::jthread writer([&] {
+    size_t handled = 0;
+    bool mapped = false;
+    while (true) {
+      requested.wait(handled, std::memory_order_acquire);
+      if (stop.load(std::memory_order_acquire))
+        return;
+      const size_t target = requested.load(std::memory_order_acquire);
+      while (handled < target) {
+        if (mapped)
+          process.unmap_pages(kChurnVa, KfdProcess::kPageSize);
+        else
+          process.map_pages(kChurnVa, churn_page.get(), KfdProcess::kPageSize);
+        mapped = !mapped;
+        completed.store(++handled, std::memory_order_release);
+        completed.notify_all();
+      }
+    }
+  });
+  auto churn_once = [&] {
+    const size_t token = requested.fetch_add(1, std::memory_order_acq_rel) + 1;
+    requested.notify_one();
+    size_t observed = completed.load(std::memory_order_acquire);
+    while (observed < token) {
+      completed.wait(observed, std::memory_order_acquire);
+      observed = completed.load(std::memory_order_acquire);
+    }
+  };
+  std::function<void()> query_hook = churn_once;
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+
+  for (size_t i = 0; i < kIterations; ++i) {
+    churn_once();
+    const auto value = static_cast<uint8_t>(i + 1);
+    memory.write8(kBaseVa + kOffset, value, kPid);
+    EXPECT_EQ(allocation[kOffset], value);
+    EXPECT_EQ(memory.read8(kBaseVa + kOffset, kPid), value);
+  }
+
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+  stop.store(true, std::memory_order_release);
+  requested.fetch_add(1, std::memory_order_release);
+  requested.notify_one();
 }
 
 TEST(GpuMemoryTest, SanitizedCacheLinePreservesLiveBytesAfterInteriorGap) {

--- a/emulation/rocjitsu/tests/corpus/README.md
+++ b/emulation/rocjitsu/tests/corpus/README.md
@@ -60,3 +60,35 @@ exclusion, which prevents partial runs from becoming a develop baseline.
 
 With `--warn-perf`, `run-corpus-tests.sh` warns about passing tests whose
 runtime approaches the pytest timeout.
+
+## gfx1201 simulator exclusions
+
+`fpsan_global_load_tr_gfx12_w64_test` is excluded because its wave64
+`global_load_tr` path currently attempts to write a lane outside the gfx1201
+simulator wavefront. This is a simulator modeling gap, not a change introduced
+by the corpus SDK nightly.
+
+## Sanitizer simulator coverage
+
+The Clang and GCC ASan+UBSan lanes run the same target-qualified corpus as the
+release lane against a sanitizer-instrumented RocJITsu build. They use longer
+per-test timeouts to accommodate the instrumented simulator.
+
+Each case runs through `env` → `setpriv` → the process supervisor → `timeout` →
+`rocjitsu` → the optional HIP preload helper → the corpus executable. The
+run-wrapper `timeout` owns the per-test deadline and retains command output;
+pytest gets 15 seconds of cleanup headroom as a failsafe. Each target's
+failed-test rerun also has a 20-minute budget in CI, within the 60-minute
+workflow step.
+
+Clang sanitizer runs load HIP at child startup through the corpus-only helper.
+This keeps the shared Clang ASan runtime, simulator interposer, and HIP runtime
+in loader order without adding corpus-specific policy to the `rocjitsu`
+command-line interface. The GCC lane uses its executable-linked ASan runtime
+and leaves HIP loading to the corpus executable.
+
+Leak detection is disabled for the sanitizer corpus subprocesses because each
+target group mixes HIP-backed and pure simulator cases, while LeakSanitizer's
+stop-the-world scan stalls on HIP's multi-gigabyte mappings. The current corpus
+wrapper cannot vary that setting per individual case; ASan and UBSan remain
+enabled throughout.

--- a/emulation/rocjitsu/tests/corpus/corpus-hip-preload.sh
+++ b/emulation/rocjitsu/tests/corpus/corpus-hip-preload.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Add HIP to the child environment prepared by the Clang ASan launcher, then
+# replace this helper with the corpus command.
+
+set -euo pipefail
+
+if (( $# < 2 )); then
+  echo "Usage: $0 HIP_RUNTIME COMMAND [ARGUMENT ...]" >&2
+  exit 2
+fi
+
+hip_runtime="$1"
+shift
+
+if [[ "${hip_runtime}" != /* || ! -f "${hip_runtime}" || "${hip_runtime}" == *:* ]]; then
+  echo "Invalid HIP runtime path: ${hip_runtime}" >&2
+  exit 2
+fi
+
+preload="${LD_PRELOAD-}"
+IFS=: read -r -a libraries <<< "${preload}"
+if (( ${#libraries[@]} != 2 )); then
+  echo "Expected Clang ASan and the rocjitsu interposer in LD_PRELOAD" >&2
+  exit 2
+fi
+if [[ "${libraries[0]##*/}" != libclang_rt.asan*.so ||
+      "${libraries[1]##*/}" != librocjitsu.so ]]; then
+  echo "Unexpected Clang ASan corpus preload order: ${preload}" >&2
+  exit 2
+fi
+
+export LD_PRELOAD="${preload}:${hip_runtime}"
+exec -- "$@"

--- a/emulation/rocjitsu/tests/corpus/corpus-process-supervisor.sh
+++ b/emulation/rocjitsu/tests/corpus/corpus-process-supervisor.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Run a command below a pinned session leader and ensure no process-group
+# members survive the command or this supervisor.
+
+set -uo pipefail
+set +m
+
+if (( $# == 0 )); then
+  echo "Usage: $0 COMMAND [ARGUMENT ...]" >&2
+  exit 2
+fi
+
+# Re-exec this script as the session and process-group leader. Keep parent death
+# catchable by the real supervisor so its TERM trap can drain the process group.
+# If a caller with job control made the first shell a process-group leader, let
+# setsid fork and wait so the caller still observes the supervisor's exit status.
+if [[ "${ROCJITSU_CORPUS_SUPERVISOR_SESSION-}" != 1 ]]; then
+  current_pgid="$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')"
+  if [[ "${current_pgid}" == "$$" ]]; then
+    exec setsid --fork --wait setpriv --pdeathsig TERM -- \
+      env ROCJITSU_CORPUS_SUPERVISOR_SESSION=1 "$0" "$@"
+  fi
+  exec setsid setpriv --pdeathsig TERM -- \
+    env ROCJITSU_CORPUS_SUPERVISOR_SESSION=1 "$0" "$@"
+fi
+
+session_pgid="$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')"
+if [[ ! "${session_pgid}" =~ ^[1-9][0-9]*$ || "${session_pgid}" != "$$" ]]; then
+  echo "Corpus process supervisor did not become its process-group leader" >&2
+  exit 2
+fi
+
+group_member_pids=()
+collect_group_members() {
+  group_member_pids=()
+  local stat_path stat_record stat_suffix pid state process_pgid
+  for stat_path in /proc/[1-9]*/stat; do
+    IFS= read -r stat_record < "${stat_path}" 2>/dev/null || continue
+    pid="${stat_record%% *}"
+    stat_suffix="${stat_record##*) }"
+    read -r state _ process_pgid _ <<< "${stat_suffix}"
+    if [[ "${process_pgid}" == "${session_pgid}" && "${pid}" != "$$" &&
+          "${state}" != Z ]]; then
+      group_member_pids+=("${pid}")
+    fi
+  done
+}
+
+stop_child_group() {
+  # The supervisor pins the PGID, so it cannot be recycled during cleanup.
+  # Ignore our own TERM while delivering it to every other group member.
+  trap '' HUP INT TERM
+  kill -TERM -- "-${session_pgid}" 2>/dev/null || true
+  for _ in {1..50}; do
+    collect_group_members
+    if (( ${#group_member_pids[@]} == 0 )); then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  collect_group_members
+  if (( ${#group_member_pids[@]} != 0 )); then
+    kill -KILL -- "${group_member_pids[@]}" 2>/dev/null || true
+  fi
+  for _ in {1..50}; do
+    collect_group_members
+    if (( ${#group_member_pids[@]} == 0 )); then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "Corpus process cleanup left live process-group members: ${group_member_pids[*]}" >&2
+  return 1
+}
+
+# shellcheck disable=SC2317 # Invoked indirectly by the signal traps below.
+handle_signal() {
+  local exit_status="$1"
+  stop_child_group || true
+  exit "${exit_status}"
+}
+
+trap 'handle_signal 129' HUP
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
+
+# Apply the death signal inside the new session. If the supervisor is killed,
+# the immediate command is killed as well instead of becoming an orphan.
+setpriv --pdeathsig KILL -- "$@" &
+child_pid=$!
+wait "${child_pid}"
+exit_status=$?
+cleanup_status=0
+stop_child_group || cleanup_status=$?
+if (( exit_status != 0 )); then
+  exit "${exit_status}"
+fi
+exit "${cleanup_status}"

--- a/emulation/rocjitsu/tests/corpus/gfx1201_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1201_skip_tests.json
@@ -12,6 +12,7 @@
     "cts.gfx1201.fpsan.fpsan_xlane_gfx12_w64_test",
     "cts.gfx1201.fpsan.fpsan_classify_gfx12_w64_test",
     "cts.gfx1201.fpsan.fpsan_wave_gfx12_w64_test",
+    "cts.gfx1201.fpsan.fpsan_global_load_tr_gfx12_w64_test",
     "cts.gfx1201.fpsan.fpsan_amdgcn_math_extra_test",
     "cts.gfx1201.fpsan.fpsan_amdgcn_math_dot4_test",
     "cts.gfx1201.fpsan.fpsan_wmma_gfx12_acc16_w64_test",

--- a/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
+++ b/emulation/rocjitsu/tests/corpus/run-corpus-tests.sh
@@ -13,6 +13,8 @@
 #   --workers N          Number of pytest-xdist workers (default: 8)
 #   --soft-timeout N     Per-test timeout for the first run (default: 30)
 #   --hard-timeout N     Per-test timeout for failed-test reruns (default: 60)
+#   --rerun-timeout N    Overall failed-test rerun budget (default: 1200)
+#   --sanitizer MODE     Launcher instrumentation: none, clang-asan, or gcc-asan
 #   --rerun-failed       Rerun only tests that failed the soft-timeout pass
 #   --warn-perf          Warn about passing tests close to the soft timeout
 #
@@ -33,11 +35,14 @@ set -euo pipefail
 worker_count=8
 soft_timeout_seconds=30
 hard_timeout_seconds=60
+rerun_timeout_seconds=1200
 rerun_failed=false
 warn_perf=false
+sanitizer_mode=none
 
 usage() {
-  echo "Usage: $0 [--workers N] [--soft-timeout N] [--hard-timeout N] [--rerun-failed] [--warn-perf]" >&2
+  echo "Usage: $0 [--workers N] [--soft-timeout N] [--hard-timeout N] [--rerun-timeout N]" \
+    "[--sanitizer none|clang-asan|gcc-asan] [--rerun-failed] [--warn-perf]" >&2
 }
 
 targets=(
@@ -51,15 +56,55 @@ targets=(
 while (( $# )); do
   case "$1" in
     --workers)
+      if (( $# < 2 )); then
+        echo "--workers requires a value" >&2
+        usage
+        exit 1
+      fi
       worker_count="$2"
       shift 2
       ;;
     --soft-timeout)
+      if (( $# < 2 )); then
+        echo "--soft-timeout requires a value" >&2
+        usage
+        exit 1
+      fi
       soft_timeout_seconds="$2"
       shift 2
       ;;
     --hard-timeout)
+      if (( $# < 2 )); then
+        echo "--hard-timeout requires a value" >&2
+        usage
+        exit 1
+      fi
       hard_timeout_seconds="$2"
+      shift 2
+      ;;
+    --rerun-timeout)
+      if (( $# < 2 )); then
+        echo "--rerun-timeout requires a value" >&2
+        usage
+        exit 1
+      fi
+      rerun_timeout_seconds="$2"
+      shift 2
+      ;;
+    --sanitizer)
+      if (( $# < 2 )); then
+        echo "--sanitizer requires a mode" >&2
+        usage
+        exit 1
+      fi
+      sanitizer_mode="$2"
+      case "${sanitizer_mode}" in
+        none|clang-asan|gcc-asan) ;;
+        *)
+          echo "Unknown sanitizer mode: ${sanitizer_mode}" >&2
+          exit 1
+          ;;
+      esac
       shift 2
       ;;
     --rerun-failed)
@@ -77,6 +122,22 @@ while (( $# )); do
   esac
 done
 
+numeric_options=(
+  "worker_count:--workers"
+  "soft_timeout_seconds:--soft-timeout"
+  "hard_timeout_seconds:--hard-timeout"
+  "rerun_timeout_seconds:--rerun-timeout"
+)
+for numeric_option in "${numeric_options[@]}"; do
+  numeric_name="${numeric_option%%:*}"
+  numeric_flag="${numeric_option#*:}"
+  numeric_value="${!numeric_name}"
+  if [[ ! "${numeric_value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${numeric_flag} requires a positive integer" >&2
+    exit 1
+  fi
+done
+
 corpus_test_status=0
 corpus_work_dir="$(pwd -P)"
 junit_dir="${corpus_work_dir}/.pytest-artifacts/junit"
@@ -84,6 +145,117 @@ junit_xml_paths=()
 
 # A report left by an earlier run would otherwise be reported as this run's.
 rm -rf "${junit_dir}"
+
+# Direct simulator tests must bypass ROCr's built-in translation so every lane,
+# including release, executes the requested architecture semantics unchanged.
+run_wrapper_prefix=(
+  env
+  -u LD_PRELOAD
+  -u HSA_HOTSWAP_ENABLE
+  "HSA_HOTSWAP_DISABLE=1"
+)
+
+if ! rocjitsu_launcher="$(command -v rocjitsu)"; then
+  echo "Could not resolve rocjitsu on PATH for corpus tests" >&2
+  exit 1
+fi
+corpus_process_supervisor="${ROCJITSU_SOURCE_DIR}/tests/corpus/corpus-process-supervisor.sh"
+if ! command -v setpriv >/dev/null || ! command -v setsid >/dev/null ||
+   ! command -v timeout >/dev/null ||
+   [[ ! -x "${corpus_process_supervisor}" ]]; then
+  echo "Could not resolve the corpus process cleanup tools" >&2
+  exit 1
+fi
+
+if [[ "${sanitizer_mode}" != none ]]; then
+  asan_symbolizer="${ROCM_PATH}/lib/llvm/bin/llvm-symbolizer"
+  if [[ ! -x "${asan_symbolizer}" ]]; then
+    echo "Could not resolve the ASan symbolizer for corpus tests" >&2
+    exit 1
+  fi
+  # The corpus target groups mix HIP-backed and pure simulator programs, so the
+  # wrapper cannot vary this setting per case. LeakSanitizer's stop-the-world
+  # scan stalls on the multi-gigabyte HIP mappings; ASan and UBSan remain active.
+  corpus_asan_options="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}detect_leaks=0"
+  run_wrapper_prefix+=(
+    "ASAN_OPTIONS=${corpus_asan_options}"
+    "ASAN_SYMBOLIZER_PATH=${asan_symbolizer}"
+  )
+fi
+
+# Keep HIP startup ordering local to the corpus harness. The helper runs inside
+# rocjitsu's launched subtree, appends HIP after ASan and the interposer, and
+# replaces itself with the suite command.
+child_command_prefix=()
+if [[ "${sanitizer_mode}" == clang-asan ]]; then
+  hip_runtime="${ROCM_PATH}/lib/libamdhip64.so"
+  if [[ ! -f "${hip_runtime}" ]]; then
+    echo "Could not resolve HIP runtime for Clang ASan corpus preload" >&2
+    exit 1
+  fi
+  corpus_hip_preload="${ROCJITSU_SOURCE_DIR}/tests/corpus/corpus-hip-preload.sh"
+  if [[ ! -f "${corpus_hip_preload}" ]]; then
+    echo "Could not resolve the corpus HIP preload helper" >&2
+    exit 1
+  fi
+  child_command_prefix=(bash "${corpus_hip_preload}" "${hip_runtime}")
+
+  # Fail once before the target loop if this launcher is not an ASan build or
+  # does not construct the expected shared-runtime/interposer preload order.
+  preflight_config="${ROCJITSU_SOURCE_DIR}/configs/gfx942_cdna3.json"
+  "${run_wrapper_prefix[@]}" \
+    "${rocjitsu_launcher}" --config "${preflight_config}" -- \
+    "${child_command_prefix[@]}" true
+fi
+
+run_pytest() {
+  local timeout_seconds="$1"
+  local overall_timeout_seconds="$2"
+  local target_name="$3"
+  local config_path="$4"
+  local skip_config_path="$5"
+  local target_artifact_dir="$6"
+  local target_cache_dir="$7"
+  shift 7
+  # The run-wrapper timeout owns the per-test deadline and preserves the
+  # command's captured diagnostics. Foreground mode keeps timeout and its child
+  # in the supervisor-owned process group. Pytest gets cleanup headroom as a failsafe.
+  local pytest_timeout_seconds=$((timeout_seconds + 15))
+  local run_wrapper=(
+    "${run_wrapper_prefix[@]}"
+    setpriv --pdeathsig TERM
+    "${corpus_process_supervisor}"
+    timeout --foreground --signal=TERM --kill-after=5s "${timeout_seconds}s"
+    "${rocjitsu_launcher}"
+    --config "${config_path}"
+    --
+    "${child_command_prefix[@]}"
+  )
+  local run_wrapper_command
+  printf -v run_wrapper_command '%q ' "${run_wrapper[@]}"
+
+  local pytest_cmd=(
+    pytest tests/test_corpus.py
+    --target "${target_name}"
+    --suite "iree,kernels,cts"
+    --run-wrapper "${run_wrapper_command% }"
+    --skip-tests-config "${skip_config_path}"
+    --artifact-directory "${target_artifact_dir}"
+    --durations=0
+    -vv
+    -o "cache_dir=${target_cache_dir}"
+    --tb=short
+    -n "${worker_count}"
+    -o "timeout_func_only=true"
+    -o "junit_duration_report=call"
+  )
+  if (( overall_timeout_seconds > 0 )); then
+    timeout --signal=TERM --kill-after=10s "${overall_timeout_seconds}s" \
+      "${pytest_cmd[@]}" --timeout "${pytest_timeout_seconds}" "$@"
+    return
+  fi
+  "${pytest_cmd[@]}" --timeout "${pytest_timeout_seconds}" "$@"
+}
 
 for target in "${targets[@]}"; do
   read -r name rocjitsu_config skip_tests_config <<< "${target}"
@@ -95,24 +267,10 @@ for target in "${targets[@]}"; do
   cache_dir="${corpus_work_dir}/.pytest-cache/${name}"
   junit_xml="${junit_dir}/${name}.xml"
 
-  pytest_cmd=(
-    rocjitsu --config "${rocjitsu_config_path}" -- pytest tests/test_corpus.py
-    --target "${name}"
-    --suite iree,kernels,cts
-    --skip-tests-config "${skip_tests_config_path}"
-    --artifact-directory "${artifact_dir}"
-    --durations=0
-    -vv
-    -o "cache_dir=${cache_dir}"
-    --tb=short
-    -n "${worker_count}"
-    -o "timeout_func_only=true"
-    -o "junit_duration_report=call"
-  )
-
   # Only the soft-timeout run is configured to output a JUnit XML report.
   first_run_status=0
-  "${pytest_cmd[@]}" --timeout "${soft_timeout_seconds}" \
+  run_pytest "${soft_timeout_seconds}" 0 "${name}" "${rocjitsu_config_path}" \
+    "${skip_tests_config_path}" "${artifact_dir}" "${cache_dir}" \
     --junitxml "${junit_xml}" || first_run_status=$?
   if [[ -f "${junit_xml}" ]]; then
     junit_xml_paths+=("${junit_xml}")
@@ -137,7 +295,9 @@ for target in "${targets[@]}"; do
 
   # Retry success does not turn CI green.
   echo "::group::(${name}) pytest rerun failed tests"
-  if "${pytest_cmd[@]}" --last-failed --last-failed-no-failures=none --timeout "${hard_timeout_seconds}"; then
+  if run_pytest "${hard_timeout_seconds}" "${rerun_timeout_seconds}" "${name}" \
+       "${rocjitsu_config_path}" "${skip_tests_config_path}" "${artifact_dir}" \
+       "${cache_dir}" --last-failed --last-failed-no-failures=none; then
     echo "::endgroup::"
     echo "::warning::Retried (${name}) tests passed."
     continue


### PR DESCRIPTION
Run the same target-qualified IREE, kernel, and CTS corpus as release across all five simulator targets in the Clang and GCC ASan+UBSan CI lanes, using longer per-test timeouts while retaining the existing 16-way parallelism.

Load HIP only inside Clang-sanitized corpus children through a harness-local wrapper, supervise timed-out process groups, preserve per-lane diagnostics, and report passing cases that approach their timeout.

Avoid an ASan and ROCr page-table lock inversion by performing heap metadata queries outside the shared page-table lock and revalidating mappings before caching host pointers. Add deterministic coverage for re-entry, remapping, and bounded retry behavior.

Qualify existing target limitations and exclude hardware-backed sanitizer cases whose failures occur during ROCr initialization or asynchronous teardown.
