### PR TITLE
fix(rccl): avoid comm destroy hang when proxy stop message is missed

### DIFF
--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -388,6 +388,9 @@ struct ncclProxyState {
   struct ncclSocket* listenSock;
   struct ncclIpcSocket ipcSock;
   int stop;
+#ifdef ENABLE_FAULT_INJECTION
+  int testServiceLoopEntered;
+#endif
   ncclResult_t asyncResult;
 
   // Used by main thread
@@ -520,5 +523,16 @@ ncclResult_t ncclProxyClientBatchQueryFdBlocking(struct ncclComm* comm, struct n
 ncclResult_t ncclProxyStop(struct ncclComm* comm);
 ncclResult_t ncclProxyShmUnlink(struct ncclComm* comm);
 ncclResult_t ncclProxyDestroy(struct ncclComm* comm);
+
+#ifdef ENABLE_FAULT_INJECTION
+enum ncclProxyStopFault {
+  ncclProxyStopFaultNone = 0,
+  ncclProxyStopFaultSocketInit,
+  ncclProxyStopFaultSocketConnect,
+  ncclProxyStopFaultSocketSend
+};
+
+void ncclProxyTestArmStopFault(enum ncclProxyStopFault fault);
+#endif
 
 #endif

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -388,9 +388,6 @@ struct ncclProxyState {
   struct ncclSocket* listenSock;
   struct ncclIpcSocket ipcSock;
   int stop;
-#ifdef ENABLE_FAULT_INJECTION
-  int testServiceLoopEntered;
-#endif
   ncclResult_t asyncResult;
 
   // Used by main thread
@@ -426,6 +423,12 @@ struct ncclProxyState {
   // [RCCL] Host mirrors of device side NCCL_LL128_LINEELEMS / NCCL_LL128_DATAELEMS
   int ll128LineElems;
   int ll128DataElems;
+
+#ifdef ENABLE_FAULT_INJECTION
+  // Test-only field: signals that ncclProxyService reached its main loop.
+  // Placed at end of struct to avoid ABI mismatch with non-test builds.
+  int testServiceLoopEntered;
+#endif
 };
 
 enum proxyConnectState {

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <algorithm>
+#include <atomic>
 #include <mutex>
 #include <cstring>
 #include <chrono>
@@ -1799,6 +1800,19 @@ enum {
   PROXY_ABORT = 2
 };
 
+#ifdef ENABLE_FAULT_INJECTION
+static std::atomic<enum ncclProxyStopFault> proxyStopFault{ncclProxyStopFaultNone};
+
+void ncclProxyTestArmStopFault(enum ncclProxyStopFault fault) {
+  proxyStopFault.store(fault, std::memory_order_release);
+}
+
+static bool ncclProxyTestConsumeStopFault(enum ncclProxyStopFault fault) {
+  enum ncclProxyStopFault expected = fault;
+  return proxyStopFault.compare_exchange_strong(expected, ncclProxyStopFaultNone, std::memory_order_acq_rel);
+}
+#endif
+
 void* ncclProxyService(void* _args) {
   struct ncclProxyState* proxyState = (struct ncclProxyState*)_args;
   // set the thread affinity before setting the cuda context
@@ -1856,6 +1870,10 @@ void* ncclProxyService(void* _args) {
     char line[SOCKET_NAME_MAXLEN + 1];
     INFO(NCCL_INIT, "proxy listening socket at %s", ncclSocketToString(&proxyState->listenSock->addr, line));
   }
+
+#ifdef ENABLE_FAULT_INJECTION
+  COMPILER_ATOMIC_STORE(&proxyState->testServiceLoopEntered, 1, std::memory_order_release);
+#endif
 
   while (stop == PROXY_RUNNING || npeers > 0) {
     /* Even if local comm aborts, we cannot let proxy thread exit if we still have peer
@@ -2225,11 +2243,34 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
         // We need to send a ncclProxyMsgStop message to our own proxy
         struct ncclSocket sock;
         int type = ncclProxyMsgStop;
-        NCCLCHECK(ncclSocketInit(&sock, sharedProxyState->peerAddresses + comm->topParentRanks[comm->rank],
-                                 comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag));
-        ncclResult_t stopRes = ncclSocketConnect(&sock);
+        ncclResult_t stopRes;
+#ifdef ENABLE_FAULT_INJECTION
+        if (ncclProxyTestConsumeStopFault(ncclProxyStopFaultSocketInit)) {
+          stopRes = ncclSystemError;
+        } else
+#endif
+        {
+          stopRes = ncclSocketInit(&sock, sharedProxyState->peerAddresses + comm->topParentRanks[comm->rank],
+                                   comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag);
+        }
+        NCCLCHECK(stopRes);
+#ifdef ENABLE_FAULT_INJECTION
+        if (ncclProxyTestConsumeStopFault(ncclProxyStopFaultSocketConnect)) {
+          stopRes = ncclSystemError;
+        } else
+#endif
+        {
+          stopRes = ncclSocketConnect(&sock);
+        }
         if (stopRes == ncclSuccess) {
-          stopRes = ncclSocketSend(&sock, &type, sizeof(int));
+#ifdef ENABLE_FAULT_INJECTION
+          if (ncclProxyTestConsumeStopFault(ncclProxyStopFaultSocketSend)) {
+            stopRes = ncclSystemError;
+          } else
+#endif
+          {
+            stopRes = ncclSocketSend(&sock, &type, sizeof(int));
+          }
           if (stopRes != ncclSuccess) {
             WARN("ncclProxyStop: failed to send stop msg comm %p rank %d res %d", comm, comm->rank, stopRes);
           }

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1861,7 +1861,13 @@ void* ncclProxyService(void* _args) {
     /* Even if local comm aborts, we cannot let proxy thread exit if we still have peer
      * connections. Need to wait until all other related comms call abort and safely exit
      * together, or we could face segmentation fault. */
+    /* Fallback stop path: if loopback stop message is missed, honor atomic stop flag. */
+    if (COMPILER_ATOMIC_LOAD(&proxyState->stop, std::memory_order_acquire)) {
+      stop = PROXY_STOP;
+    }
+
     if (COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_acquire) != 0) stop = PROXY_ABORT;
+
     /* never let proxy service thread blocks in poll, or it cannot receive abortFlag. */
     int ret = 0;
     const int timeout = asyncOpCount ? 0 : 500;
@@ -2213,8 +2219,14 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
         int type = ncclProxyMsgStop;
         NCCLCHECK(ncclSocketInit(&sock, sharedProxyState->peerAddresses + comm->topParentRanks[comm->rank],
                                  comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag));
-        if (ncclSocketConnect(&sock) == ncclSuccess) {
-          (void)ncclSocketSend(&sock, &type, sizeof(int));
+        ncclResult_t stopRes = ncclSocketConnect(&sock);
+        if (stopRes == ncclSuccess) {
+          stopRes = ncclSocketSend(&sock, &type, sizeof(int));
+          if (stopRes != ncclSuccess) {
+            WARN("ncclProxyStop: failed to send stop msg comm %p rank %d res %d", comm, comm->rank, stopRes);
+          }
+        } else {
+          WARN("ncclProxyStop: failed to connect stop socket comm %p rank %d res %d", comm, comm->rank, stopRes);
         }
         (void)ncclSocketClose(&sock);
       }

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -2213,6 +2213,14 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
     struct ncclProxyState* sharedProxyState = comm->proxyState;
 
     if ((comm->proxyRefCountOld = ncclAtomicRefCountDecrement(&sharedProxyState->refCount)) == 0) {
+      // Cleanup below can return early. Always publish the stop request before leaving this scope.
+      struct ProxyStopSignal {
+        struct ncclProxyState* state;
+        ~ProxyStopSignal() {
+          COMPILER_ATOMIC_STORE(&state->stop, 1, std::memory_order_release);
+        }
+      } stopSignal{sharedProxyState};
+
       if (*comm->abortFlag == 0 && sharedProxyState->peerAddresses) {
         // We need to send a ncclProxyMsgStop message to our own proxy
         struct ncclSocket sock;
@@ -2251,8 +2259,6 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
           }
         }
       }
-      // Now we notify proxy service and UDS thread to exit.
-      COMPILER_ATOMIC_STORE(&comm->proxyState->stop, 1, std::memory_order_release);
     }
   }
 

--- a/projects/rccl/test/ProxyTests.cpp
+++ b/projects/rccl/test/ProxyTests.cpp
@@ -746,82 +746,126 @@ TEST(ProxyTests, ProxyProgressDestroyJoinsAndFreesPools)
     TEST_INFO("[ProxyTests] ProxyProgressDestroyJoinsAndFreesPools PASSED");
 }
 
-/**
- * Validates the atomic stop fallback path in ncclProxyService.
- *
- * Scenario: ncclProxyStop() sends ncclProxyMsgStop over a loopback socket,
- * but if that socket send fails, the proxy service thread would hang forever.
- * The fix adds a fallback check of proxyState->stop (atomic flag) so the
- * service thread exits even if the socket message is missed.
- *
- * This test:
- * 1. Starts ncclProxyService with a minimal proxyState (no socket message sent)
- * 2. Sets proxyState->stop = 1 atomically (simulating fallback path)
- * 3. Verifies the service thread exits promptly instead of hanging
- */
-TEST(ProxyTests, ProxyServiceHonorsAtomicStopWithoutStopMessage)
+#ifdef ENABLE_FAULT_INJECTION
+static bool waitForProxyServiceLoop(ncclProxyState* proxyState, std::chrono::milliseconds timeout)
 {
-    RUN_ISOLATED_TEST(
-        "ProxyServiceHonorsAtomicStopWithoutStopMessage",
-        []()
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while(!COMPILER_ATOMIC_LOAD(&proxyState->testServiceLoopEntered, std::memory_order_acquire))
+    {
+        if(std::chrono::steady_clock::now() >= deadline)
         {
-            TEST_INFO("[ProxyTests] ProxyServiceHonorsAtomicStopWithoutStopMessage Start");
-
-            auto* proxyState = new ncclProxyState{};
-            ASSERT_NE(proxyState, nullptr);
-
-            auto* listenSock = (ncclSocket*)calloc(1, sizeof(ncclSocket));
-            ASSERT_NE(listenSock, nullptr);
-
-            uint32_t abortFlag = 0;
-
-            proxyState->abortFlag = &abortFlag;
-            proxyState->listenSock = listenSock;
-            proxyState->tpRank = 0;
-            proxyState->tpnRanks = 1;
-            proxyState->tpLocalnRanks = 1;
-            proxyState->cudaDev = 0;
-            proxyState->stop = 0;
-            proxyState->directMode = false;
-            proxyState->proxyOps = nullptr;
-            proxyState->peerSocks = nullptr;
-            proxyState->sharedDevMems = nullptr;
-            proxyState->peerAddresses = nullptr;
-            proxyState->peerAddressesUDS = nullptr;
-
-            union ncclSocketAddress listenAddr;
-            memset(&listenAddr, 0, sizeof(listenAddr));
-            listenAddr.sin.sin_family = AF_INET;
-            listenAddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-            listenAddr.sin.sin_port = 0;
-
-            ASSERT_EQ(
-                ncclSocketInit(
-                    listenSock,
-                    &listenAddr,
-                    NCCL_SOCKET_MAGIC,
-                    ncclSocketTypeProxy,
-                    &abortFlag),
-                ncclSuccess);
-            ASSERT_EQ(ncclSocketListen(listenSock), ncclSuccess);
-
-            std::thread svc([proxyState]() { (void)ncclProxyService(proxyState); });
-
-            // Let proxy thread enter poll loop. 600ms accommodates slow CI.
-            std::this_thread::sleep_for(std::chrono::milliseconds(600));
-
-            // Simulate ncclProxyStop() fallback: set atomic stop without socket message.
-            COMPILER_ATOMIC_STORE(&proxyState->stop, 1, std::memory_order_release);
-
-            // Before fix: hangs indefinitely. After fix: exits within ~500ms poll cycle.
-            svc.join();
-
-            proxyState->listenSock = nullptr;
-            delete proxyState;
-
-            TEST_INFO("[ProxyTests] ProxyServiceHonorsAtomicStopWithoutStopMessage PASSED");
+            return false;
         }
-    );
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
 }
+
+static void runProxyStopFailureCase(ncclProxyStopFault fault, ncclResult_t expectedStopResult)
+{
+    ncclComm            comm{};
+    ncclSharedResources sharedRes{};
+    uint32_t            abortFlag       = 0;
+    int                 topParentRanks[] = {0};
+    ncclSocketAddress   peerAddresses[1]{};
+
+    auto* proxyState = new ncclProxyState{};
+    ASSERT_NE(proxyState, nullptr);
+
+    auto* listenSock = (ncclSocket*)calloc(1, sizeof(ncclSocket));
+    ASSERT_NE(listenSock, nullptr);
+
+    ncclSocketAddress listenAddr{};
+    listenAddr.sin.sin_family      = AF_INET;
+    listenAddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listenAddr.sin.sin_port        = 0;
+
+    ASSERT_EQ(
+        ncclSocketInit(
+            listenSock,
+            &listenAddr,
+            NCCL_SOCKET_MAGIC,
+            ncclSocketTypeProxy,
+            &abortFlag),
+        ncclSuccess);
+    ASSERT_EQ(ncclSocketListen(listenSock), ncclSuccess);
+
+    peerAddresses[0] = listenSock->addr;
+
+    sharedRes.magic      = NCCL_SOCKET_MAGIC;
+    sharedRes.proxyState = proxyState;
+
+    comm.rank           = 0;
+    comm.sharedRes      = &sharedRes;
+    comm.proxyState     = proxyState;
+    comm.abortFlag      = &abortFlag;
+    comm.topParentRanks = topParentRanks;
+
+    proxyState->refCount      = 1;
+    proxyState->abortFlag     = &abortFlag;
+    proxyState->listenSock    = listenSock;
+    proxyState->peerAddresses = peerAddresses;
+    proxyState->tpRank        = 0;
+    proxyState->tpnRanks      = 1;
+    proxyState->tpLocalnRanks = 1;
+    proxyState->cudaDev       = 0;
+
+    proxyState->thread = std::thread(ncclProxyService, proxyState);
+
+    if(!waitForProxyServiceLoop(proxyState, std::chrono::seconds(2)))
+    {
+        COMPILER_ATOMIC_STORE(&proxyState->stop, 1, std::memory_order_release);
+        proxyState->thread.join();
+        delete proxyState;
+        FAIL() << "proxy service did not reach its polling loop";
+        return;
+    }
+
+    ncclProxyTestArmStopFault(fault);
+
+    const auto start      = std::chrono::steady_clock::now();
+    const auto stopResult = ncclProxyStop(&comm);
+    proxyState->thread.join();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(stopResult, expectedStopResult);
+    EXPECT_EQ(proxyState->refCount, 0);
+    EXPECT_EQ(comm.proxyRefCountOld, 0);
+    EXPECT_LT(elapsed, std::chrono::milliseconds(1500));
+
+    delete proxyState;
+}
+
+TEST(ProxyTests, ProxyStopFailuresStillStopService)
+{
+    using Config = ProcessIsolatedTestRunner::TestConfig;
+
+    RUN_ISOLATED_TESTS(
+        Config(
+            "ProxyStopConnectFailure",
+            []()
+            {
+                runProxyStopFailureCase(ncclProxyStopFaultSocketConnect, ncclSuccess);
+            })
+            .withTimeout(std::chrono::seconds(5))
+            .withNumGpus(1),
+        Config(
+            "ProxyStopSendFailure",
+            []()
+            {
+                runProxyStopFailureCase(ncclProxyStopFaultSocketSend, ncclSuccess);
+            })
+            .withTimeout(std::chrono::seconds(5))
+            .withNumGpus(1),
+        Config(
+            "ProxyStopInitFailure",
+            []()
+            {
+                runProxyStopFailureCase(ncclProxyStopFaultSocketInit, ncclSystemError);
+            })
+            .withTimeout(std::chrono::seconds(5))
+            .withNumGpus(1));
+}
+#endif
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/ProxyTests.cpp
+++ b/projects/rccl/test/ProxyTests.cpp
@@ -68,6 +68,9 @@ void ncclDumpProxyState(int signal);
 // Defined in proxy.cc, not exported through proxy.h.
 ncclResult_t ncclProxyPost(struct ncclProxyOpsPool* pool, int nextOps, int nextOpsEnd);
 ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState);
+void* ncclProxyService(void* _args);
+
+#include <netinet/in.h>
 
 #define PROXYARGS_ALLOCATE_SIZE NCCL_MAX_OPS
 
@@ -741,6 +744,84 @@ TEST(ProxyTests, ProxyProgressDestroyJoinsAndFreesPools)
     EXPECT_EQ(ps.pools, nullptr) << "destroy must free the entire pools chain";
 
     TEST_INFO("[ProxyTests] ProxyProgressDestroyJoinsAndFreesPools PASSED");
+}
+
+/**
+ * Validates the atomic stop fallback path in ncclProxyService.
+ *
+ * Scenario: ncclProxyStop() sends ncclProxyMsgStop over a loopback socket,
+ * but if that socket send fails, the proxy service thread would hang forever.
+ * The fix adds a fallback check of proxyState->stop (atomic flag) so the
+ * service thread exits even if the socket message is missed.
+ *
+ * This test:
+ * 1. Starts ncclProxyService with a minimal proxyState (no socket message sent)
+ * 2. Sets proxyState->stop = 1 atomically (simulating fallback path)
+ * 3. Verifies the service thread exits promptly instead of hanging
+ */
+TEST(ProxyTests, ProxyServiceHonorsAtomicStopWithoutStopMessage)
+{
+    RUN_ISOLATED_TEST(
+        "ProxyServiceHonorsAtomicStopWithoutStopMessage",
+        []()
+        {
+            TEST_INFO("[ProxyTests] ProxyServiceHonorsAtomicStopWithoutStopMessage Start");
+
+            auto* proxyState = new ncclProxyState{};
+            ASSERT_NE(proxyState, nullptr);
+
+            auto* listenSock = (ncclSocket*)calloc(1, sizeof(ncclSocket));
+            ASSERT_NE(listenSock, nullptr);
+
+            uint32_t abortFlag = 0;
+
+            proxyState->abortFlag = &abortFlag;
+            proxyState->listenSock = listenSock;
+            proxyState->tpRank = 0;
+            proxyState->tpnRanks = 1;
+            proxyState->tpLocalnRanks = 1;
+            proxyState->cudaDev = 0;
+            proxyState->stop = 0;
+            proxyState->directMode = false;
+            proxyState->proxyOps = nullptr;
+            proxyState->peerSocks = nullptr;
+            proxyState->sharedDevMems = nullptr;
+            proxyState->peerAddresses = nullptr;
+            proxyState->peerAddressesUDS = nullptr;
+
+            union ncclSocketAddress listenAddr;
+            memset(&listenAddr, 0, sizeof(listenAddr));
+            listenAddr.sin.sin_family = AF_INET;
+            listenAddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            listenAddr.sin.sin_port = 0;
+
+            ASSERT_EQ(
+                ncclSocketInit(
+                    listenSock,
+                    &listenAddr,
+                    NCCL_SOCKET_MAGIC,
+                    ncclSocketTypeProxy,
+                    &abortFlag),
+                ncclSuccess);
+            ASSERT_EQ(ncclSocketListen(listenSock), ncclSuccess);
+
+            std::thread svc([proxyState]() { (void)ncclProxyService(proxyState); });
+
+            // Let proxy thread enter poll loop. 600ms accommodates slow CI.
+            std::this_thread::sleep_for(std::chrono::milliseconds(600));
+
+            // Simulate ncclProxyStop() fallback: set atomic stop without socket message.
+            COMPILER_ATOMIC_STORE(&proxyState->stop, 1, std::memory_order_release);
+
+            // Before fix: hangs indefinitely. After fix: exits within ~500ms poll cycle.
+            svc.join();
+
+            proxyState->listenSock = nullptr;
+            delete proxyState;
+
+            TEST_INFO("[ProxyTests] ProxyServiceHonorsAtomicStopWithoutStopMessage PASSED");
+        }
+    );
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/ProxyTests.cpp
+++ b/projects/rccl/test/ProxyTests.cpp
@@ -13,6 +13,7 @@
 #include "socket.h"
 #define ENABLE_TIMER 0
 #include <assert.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <sched.h>
 #include <sys/mman.h>
@@ -69,8 +70,6 @@ void ncclDumpProxyState(int signal);
 ncclResult_t ncclProxyPost(struct ncclProxyOpsPool* pool, int nextOps, int nextOpsEnd);
 ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState);
 void* ncclProxyService(void* _args);
-
-#include <netinet/in.h>
 
 #define PROXYARGS_ALLOCATE_SIZE NCCL_MAX_OPS
 
@@ -746,6 +745,65 @@ TEST(ProxyTests, ProxyProgressDestroyJoinsAndFreesPools)
     TEST_INFO("[ProxyTests] ProxyProgressDestroyJoinsAndFreesPools PASSED");
 }
 
+// Validates the atomic stop fallback path in ncclProxyService deterministically.
+// Pre-sets proxyState->stop=1 BEFORE starting the service thread so the first
+// loop iteration takes the atomic fallback path — no timing dependencies.
+TEST(ProxyTests, ProxyServiceHonorsPresetAtomicStop)
+{
+    using Config = ProcessIsolatedTestRunner::TestConfig;
+
+    RUN_ISOLATED_TESTS(
+        Config(
+            "ProxyServiceHonorsPresetAtomicStop",
+            []()
+            {
+                auto* proxyState = new ncclProxyState{};
+                ASSERT_NE(proxyState, nullptr);
+
+                auto* listenSock = (ncclSocket*)calloc(1, sizeof(ncclSocket));
+                ASSERT_NE(listenSock, nullptr);
+
+                uint32_t abortFlag = 0;
+
+                proxyState->abortFlag     = &abortFlag;
+                proxyState->listenSock    = listenSock;
+                proxyState->tpRank        = 0;
+                proxyState->tpnRanks      = 1;
+                proxyState->tpLocalnRanks = 1;
+                proxyState->cudaDev       = 0;
+
+                ncclSocketAddress listenAddr{};
+                listenAddr.sin.sin_family      = AF_INET;
+                listenAddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+                listenAddr.sin.sin_port        = 0;
+
+                ASSERT_EQ(
+                    ncclSocketInit(
+                        listenSock,
+                        &listenAddr,
+                        NCCL_SOCKET_MAGIC,
+                        ncclSocketTypeProxy,
+                        &abortFlag),
+                    ncclSuccess);
+                ASSERT_EQ(ncclSocketListen(listenSock), ncclSuccess);
+
+                // Pre-set the flag so the first service-loop iteration takes the
+                // atomic fallback deterministically, without sleeps or fault injection.
+                COMPILER_ATOMIC_STORE(&proxyState->stop, 1, std::memory_order_release);
+
+                proxyState->thread = std::thread(ncclProxyService, proxyState);
+
+                // A regression hangs here; the isolated-test deadline terminates
+                // the child and reports a failure.
+                proxyState->thread.join();
+
+                // ncclProxyService frees listenSock internally on exit.
+                delete proxyState;
+            })
+            .withTimeout(std::chrono::seconds(5))
+            .withNumGpus(1));
+}
+
 #ifdef ENABLE_FAULT_INJECTION
 static bool waitForProxyServiceLoop(ncclProxyState* proxyState, std::chrono::milliseconds timeout)
 {
@@ -816,6 +874,10 @@ static void runProxyStopFailureCase(ncclProxyStopFault fault, ncclResult_t expec
     {
         COMPILER_ATOMIC_STORE(&proxyState->stop, 1, std::memory_order_release);
         proxyState->thread.join();
+        // Service took goto-fail path before reaching main loop, so listenSock
+        // was not freed internally. Clean it up here to avoid leak.
+        (void)ncclSocketClose(proxyState->listenSock);
+        free(proxyState->listenSock);
         delete proxyState;
         FAIL() << "proxy service did not reach its polling loop";
         return;


### PR DESCRIPTION
## Motivation

`ncclProxyStop()` sends an `ncclProxyMsgStop` message over a loopback socket to signal the proxy service thread to exit. If `ncclSocketConnect()` or `ncclSocketSend()` fails, the message is silently ignored, and the proxy service thread spins indefinitely in its `poll()` loop, hanging communicator destruction.

## Technical Details

1. **Atomic fallback in service loop** (`src/proxy.cc`): The proxy service thread now checks `proxyState->stop` on each iteration. If the socket message is missed, the atomic flag provides a reliable out-of-band stop signal.

2. **RAII stop guarantee** (`src/proxy.cc`): A `ProxyStopSignal` struct ensures the atomic stop flag is always set when `ncclProxyStop()` exits, even if `NCCLCHECK` triggers an early return.

3. **Diagnostic logging**: Added `WARN` when socket connect/send fails to aid debugging.

4. **Fault injection harness** (`src/include/proxy.h`, `src/proxy.cc`): Under `ENABLE_FAULT_INJECTION`, allows tests to simulate socket init/connect/send failures.

## Issue Tracking

JIRA ID: AICOMRCCL-1939

## Test Plan

- `ProxyServiceHonorsPresetAtomicStop`: Deterministic test that pre-sets the stop flag before starting the service thread and verifies the atomic fallback path without timing dependencies.
- `ProxyStopFailuresStillStopService` (under `ENABLE_FAULT_INJECTION`): Injects socket init/connect/send failures and verifies the proxy service still exits promptly.

## Test Result

- All new tests pass locally
- Existing `ProxyTests` suite unaffected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md