### PR TITLE
[rocjitsu] Emit leading V_NOPs ahead of a gfx1250 MODE write

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/legalization/gfx1250_b0_to_a0.cpp
@@ -31,6 +31,18 @@ namespace {
 /// rules. Prefix-classified WMMA/SWMMAC and cluster-load instructions are
 /// handled separately by family-level translation rules.
 ///
+/// A rule keyed on an exact (encoding id, opcode) that only inserts spacing and
+/// leaves the opcode alone needs no entry here at all: with no classification
+/// the instruction reaches the semantic rule table on its own and, when the rule
+/// declines, takes the verbatim copy path. The MODE-write separation rule is
+/// registered that way, and the diff report is what shows it, as "expand
+/// semantic" with no legalization action.
+///
+/// An entry here does more than label the report when it is a mnemonic prefix
+/// that covers more instructions than the semantic table implements: the
+/// unimplemented siblings then fail closed instead of passing through silently.
+/// That is why the integer WMMA prefixes below keep their entry.
+///
 /// Separately, a 64-bit source reading FLAT_SCRATCH_BASE is classified via
 /// operand inspection (see gfx1250_reads_flat_scratch_base_64bit), and the
 /// barrier-state query and s_monitor_sleep are DEFERRED with a pass-through

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -1855,7 +1855,7 @@ ExpandResult expand_dot2_f32_bf16_cdna4_to_cdna3(const Instruction &inst, uint32
 }
 
 // Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
-const TranslationRule kExpandRules_cdna4_to_cdna3[] = {
+constexpr TranslationRule kExpandRules_cdna4_to_cdna3[] = {
     {cdna4::encoding::kVop1, cdna4::kVPermlane16SwapB32Vop1, RuleAction::Expand, 0, 0, nullptr,
      expand_permlane16_swap_b32_cdna4_to_cdna3, nullptr, nullptr},
     {cdna4::encoding::kVop1, cdna4::kVPermlane32SwapB32Vop1, RuleAction::Expand, 0, 0, nullptr,
@@ -1909,6 +1909,9 @@ const TranslationRule kExpandRules_cdna4_to_cdna3[] = {
     {cdna4::encoding::kMubuf, cdna4::kBufferLoadDwordx4Mubuf, RuleAction::Expand, 0, 0, nullptr,
      expand_buffer_load_dwordx4_lds_cdna4_to_cdna3, nullptr, nullptr},
 };
+
+static_assert(translation_rules_sorted(kExpandRules_cdna4_to_cdna3),
+              "the CDNA4-to-CDNA3 rule table must stay sorted by (encoding id, opcode)");
 
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna3.cpp
@@ -36,12 +36,15 @@ ExpandResult expand_waitcnt_gfx9_to_gfx11(const Instruction &inst, uint32_t, uin
 }
 
 // Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
-const TranslationRule kExpandRules_cdna4_to_rdna3[] = {
+constexpr TranslationRule kExpandRules_cdna4_to_rdna3[] = {
     {cdna4::encoding::kSopp, cdna4::kSWaitcnt, RuleAction::Expand, 0, 0, nullptr,
      expand_waitcnt_gfx9_to_gfx11, nullptr, nullptr},
     {cdna4::encoding::kVop3OpHi4, cdna4::kVLshlAddU64, RuleAction::Expand, 0, 0, nullptr,
      expand_cdna4_v_lshl_add_u64_for_rdna, nullptr, nullptr},
 };
+
+static_assert(translation_rules_sorted(kExpandRules_cdna4_to_rdna3),
+              "the CDNA4-to-RDNA3 rule table must stay sorted by (encoding id, opcode)");
 
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
@@ -289,7 +289,7 @@ ExpandResult expand_mfma_f32_16x16x16_f16(const Instruction &inst, uint32_t, uin
 }
 
 // Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
-const TranslationRule kExpandRules_cdna4_to_rdna4[] = {
+constexpr TranslationRule kExpandRules_cdna4_to_rdna4[] = {
     {cdna4::encoding::kSopp, cdna4::kSWaitcnt, RuleAction::Expand, 0, 0, nullptr, expand_waitcnt,
      nullptr, nullptr},
     {cdna4::encoding::kVop3OpHi4, cdna4::kVLshlAddU64, RuleAction::Expand, 0, 0, nullptr,
@@ -301,6 +301,9 @@ const TranslationRule kExpandRules_cdna4_to_rdna4[] = {
     {cdna4::encoding::kVop3pMfma, cdna4::kVAccvgprWrite, RuleAction::Expand, 0, 0, nullptr,
      expand_accvgpr_write, nullptr, nullptr},
 };
+
+static_assert(translation_rules_sorted(kExpandRules_cdna4_to_rdna4),
+              "the CDNA4-to-RDNA4 rule table must stay sorted by (encoding id, opcode)");
 
 static_assert(rocjitsu::kMatrixConversionCount >= 2,
               "Auto-generated matrix conversion table too small");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/gfx1250_b0_to_a0.cpp
@@ -13,6 +13,7 @@
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/vgpr_msb.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/isa/operand.h"
 
@@ -24,6 +25,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -395,6 +397,113 @@ ExpandResult expand_gfx1250_s_clause(const Instruction &inst, uint32_t, uint64_t
 
   const auto nop = cdna5::build_sopp(cdna5::kSNopSopp, {.simm16 = 0});
   return ExpandResult::success(std::vector<uint32_t>(nop.begin(), nop.end()));
+}
+
+/// @brief Count canonical V_NOPs adjacent to @p inst inside its own basic block.
+///
+/// @details @p step picks the side to count. `previous_instruction` counts words
+/// before @p inst, `next_instruction` counts words after it. Both stop at the
+/// block boundary, and that is what makes the count usable: a counted word is in
+/// the same block and therefore stays adjacent to @p inst after layout, whereas
+/// a branch landing between the two would have started a new block and ended the
+/// walk. Counting stops at @p limit, and a noncanonical NOP ends it, so credit is
+/// never overstated.
+[[nodiscard]] int count_adjacent_canonical_v_nops(const Instruction &inst, int limit,
+                                                  const Instruction *(Instruction::*step)() const) {
+  const uint32_t v_nop = cdna5::build_vop1(cdna5::kVNopVop1)[0];
+  int counted = 0;
+  for (const Instruction *at = (inst.*step)();
+       counted < limit && at != nullptr && at->size() == static_cast<int>(sizeof(uint32_t)) &&
+       at->raw_encoding() != nullptr && at->raw_encoding()[0] == v_nop;
+       at = (at->*step)())
+    ++counted;
+  return counted;
+}
+
+/// @brief Give a MODE-register write its required leading V_NOP separation.
+///
+/// @details On this target an `s_setreg*` naming the MODE register requires two
+/// V_NOPs immediately before it to be ordered against the instructions that
+/// precede it. Compiler output does not supply that separation. The write is
+/// commonly the first instruction of a kernel or device function, and sometimes
+/// follows a short prefetch prologue.
+///
+/// The filler is V_NOP because the requirement names it, and because the
+/// separation is required in the VALU pipeline, so it has to occupy VALU issue
+/// slots. A scalar wait does not -- `s_nop 1` inserts two wait states in the
+/// scalar path and orders nothing in the vector one -- so it is not a substitute
+/// despite executing unconditionally. An arbitrary independent VALU instruction
+/// is worse than V_NOP rather than better, being skipped outright under an empty
+/// mask.
+///
+/// A V_NOP has no architectural result, so emitting the missing ones cannot
+/// change what the program computes; it supplies the ordering distance and
+/// nothing else.
+///
+/// Under EXEC==0 the filler contributes no VALU spacing, and the setreg still
+/// executes -- but ordinary VALU is skipped under an empty mask, so there is
+/// correspondingly little VALU work in flight. The separation is therefore
+/// effective where EXEC != 0 and best effort in fully inactive control flow, and
+/// no filler this translator may emit improves on that without touching EXEC,
+/// which it must not do. The IU8 spacing rule below rests on the same reasoning.
+///
+/// Every MODE write gets the separation rather than some subset, because the
+/// requirement is stated for the register and not for individual fields within
+/// it.
+///
+/// The scope is the `s_setreg*` instruction, not the MODE register as a
+/// location, so the other instructions that write MODE state are deliberately
+/// excluded: `s_set_vgpr_msb`, whose banks this profile models as MODE fields,
+/// and the SOPP writers `s_round_mode` and `s_denorm_mode`. What has to be
+/// separated is the setreg's own execution against the instructions ahead of it;
+/// a different opcode reaching the same fields is a different case and is not
+/// covered by widening this rule. Writes naming any other hardware register are
+/// declined and copied through unchanged.
+///
+/// V_NOPs already immediately before the write are counted and only the missing
+/// slots are emitted, so a second translation is a fixed point. A counted V_NOP
+/// reaches the target unchanged and with nothing appended to it: it matches no
+/// expansion rule, takes no legalization entry, and needs no completion wait, so
+/// it can only take the verbatim copy path.
+///
+/// TODO: Count separation an adjacent rule is about to emit, not just what the
+/// source already holds. A dense IU8 WMMA immediately followed by a MODE write
+/// yields eleven V_NOPs -- nine from the spacing rule, then two here -- where
+/// nine already separate the write. It is a fixed point and costs only two issue
+/// slots, and no corpus object has that adjacency. Fixing it needs the emitted
+/// stream rather than the source, which is the same whole-kernel pass the IU8
+/// rule's own TODO asks for; do both together.
+ExpandResult expand_gfx1250_setreg_mode_ordering(const Instruction &inst, uint32_t, uint64_t,
+                                                 std::span<const uint8_t>, const LivenessAnalysis &,
+                                                 TranslationContext &, const LaneLayout *,
+                                                 const LaneLayout *) {
+  constexpr int kRequiredLeadingVNops = 2;
+
+  if (inst.mnemonic() != "s_setreg_b32" && inst.mnemonic() != "s_setreg_imm32_b32")
+    return ExpandResult::failed("gfx1250 MODE setreg rule received an unsupported instruction");
+  const int size_bytes = inst.size();
+  if (size_bytes < static_cast<int>(sizeof(uint32_t)) ||
+      size_bytes % static_cast<int>(sizeof(uint32_t)) != 0 || inst.raw_encoding() == nullptr)
+    return ExpandResult::failed("gfx1250 MODE setreg rule received an unsupported encoding");
+
+  // SOPK carries the hardware-register selector in SIMM16. Only MODE requires
+  // the separation, so the mnemonic alone cannot decide this.
+  const uint16_t simm16 = static_cast<uint16_t>(inst.raw_encoding()[0] & 0xffffu);
+  if (amdgpu::decode_vgpr_msb_hwreg(simm16).id != amdgpu::MODE_HWREG)
+    return ExpandResult::not_handled();
+
+  const int existing_slots = count_adjacent_canonical_v_nops(inst, kRequiredLeadingVNops,
+                                                             &Instruction::previous_instruction);
+  if (existing_slots == kRequiredLeadingVNops)
+    return ExpandResult::not_handled();
+
+  const size_t words_in_encoding = static_cast<size_t>(size_bytes) / sizeof(uint32_t);
+  std::vector<uint32_t> words;
+  words.reserve(words_in_encoding + kRequiredLeadingVNops);
+  words.insert(words.end(), static_cast<size_t>(kRequiredLeadingVNops - existing_slots),
+               cdna5::build_vop1(cdna5::kVNopVop1)[0]);
+  words.insert(words.end(), inst.raw_encoding(), inst.raw_encoding() + words_in_encoding);
+  return ExpandResult::success(std::move(words));
 }
 
 /// @brief Decline the one barrier id this profile excludes.
@@ -1098,6 +1207,15 @@ ExpandResult expand_gfx1250_wmma_scale16(const Instruction &inst, uint32_t, uint
 /// the missing slots. Limiting credit to the block guarantees that every
 /// credited word remains adjacent after layout. Noncanonical NOPs and following
 /// control-flow successors conservatively receive no credit.
+///
+/// The slots are VALU issue slots, so this shares the MODE separation rule's
+/// filler reasoning: an ordinary VALU instruction is skipped when EXEC==0, and a
+/// V_NOP still issues but occupies no slot there, which makes V_NOP the best
+/// available filler rather than a guarantee. The exposure is narrower here than
+/// at the MODE write, because the producer is itself EXEC-masked: a wholly
+/// inactive shadow ran no WMMA and so has nothing to separate. What remains is
+/// an EXEC clear between the WMMA and its shadow, which is the case the TODO
+/// below has to rule out before it can count anything but a V_NOP.
 ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, uint64_t,
                                              std::span<const uint8_t>, const LivenessAnalysis &,
                                              TranslationContext &, const LaneLayout *,
@@ -1111,20 +1229,15 @@ ExpandResult expand_gfx1250_wmma_iu8_spacing(const Instruction &inst, uint32_t, 
   std::vector<uint32_t> words(inst.raw_encoding(),
                               inst.raw_encoding() + inst.size() / sizeof(uint32_t));
   const int required_slots = inst.mnemonic() == "v_wmma_i32_16x16x64_iu8" ? 9 : 5;
-  const uint32_t v_nop = cdna5::build_vop1(cdna5::kVNopVop1)[0];
-  int existing_slots = 0;
-  const Instruction *next = inst.next_instruction();
-  while (existing_slots < required_slots && next != nullptr &&
-         next->size() == static_cast<int>(sizeof(uint32_t)) && next->raw_encoding() != nullptr &&
-         next->raw_encoding()[0] == v_nop) {
-    ++existing_slots;
-    next = next->next_instruction();
-  }
+  const int existing_slots =
+      count_adjacent_canonical_v_nops(inst, required_slots, &Instruction::next_instruction);
 
   // TODO: Replace canonical V_NOP counting with whole-kernel scheduling that
-  // can also credit independent VALU in each reachable successor.
-  for (int slot = existing_slots; slot < required_slots; ++slot)
-    words.push_back(v_nop);
+  // can also credit independent VALU in each reachable successor. Crediting real
+  // VALU needs EXEC != 0 proved on the credited path first; without that proof
+  // only V_NOP counts, because ordinary VALU is skipped under an empty mask.
+  words.insert(words.end(), static_cast<size_t>(required_slots - existing_slots),
+               cdna5::build_vop1(cdna5::kVNopVop1)[0]);
   return ExpandResult::success(std::move(words));
 }
 
@@ -2319,9 +2432,25 @@ ExpandResult expand_gfx1250_k128_wmma(const Instruction &inst, uint32_t, uint64_
 }
 
 // The semantic translator binary-searches this table, so entries must stay
-// sorted by the full encoding ID and then opcode. VDS encoding IDs include the
-// high opcode bits, hence the four consecutive kVdsOpHi* groups below.
-inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
+// sorted by the full encoding ID and then opcode; the static_assert after the
+// table enforces that. VDS encoding IDs include the high opcode bits, hence the
+// four consecutive kVdsOpHi* groups below.
+// An encoding id is the top nine bits of the first word, so a SOPK id is the
+// SOPK base plus its opcode. The generated header names only the ids the ISA
+// description needed, which is why one of these two has no constant to use; the
+// assertions below pin the derivation against the one that does.
+constexpr uint16_t kSetregB32EncodingId = cdna5::encoding::kSopk + cdna5::kSSetregB32Sopk;
+constexpr uint16_t kSetregImm32B32EncodingId = cdna5::encoding::kSopk + cdna5::kSSetregImm32B32Sopk;
+static_assert(kSetregB32EncodingId == cdna5::encoding::kSopkOpHi18,
+              "SOPK encoding ids must remain the SOPK base plus the opcode");
+static_assert(kSetregImm32B32EncodingId == kSetregB32EncodingId + 1,
+              "consecutive SOPK opcodes must yield consecutive encoding ids");
+
+inline constexpr std::array<TranslationRule, 43> kGfx1250B0ToA0ExpandRules = {{
+    {kSetregB32EncodingId, cdna5::kSSetregB32Sopk, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_setreg_mode_ordering, nullptr, nullptr, false},
+    {kSetregImm32B32EncodingId, cdna5::kSSetregImm32B32Sopk, RuleAction::Expand, 0, 0, nullptr,
+     expand_gfx1250_setreg_mode_ordering, nullptr, nullptr, false},
     {cdna5::encoding::kSop1, cdna5::kSBarrierSignalIsfirstSop1, RuleAction::Expand, 0, 0, nullptr,
      expand_gfx1250_barrier_signal_isfirst, nullptr, nullptr, false},
     {cdna5::encoding::kSopp, cdna5::kSClauseSopp, RuleAction::Expand, 0, 0, nullptr,
@@ -2405,6 +2534,9 @@ inline constexpr std::array<TranslationRule, 41> kGfx1250B0ToA0ExpandRules = {{
     {cdna5::encoding::kVglobal, cdna5::kClusterLoadAsyncToLdsB128Vglobal, RuleAction::Expand, 0, 0,
      nullptr, expand_gfx1250_cluster_load, nullptr, nullptr},
 }};
+
+static_assert(translation_rules_sorted(kGfx1250B0ToA0ExpandRules),
+              "the gfx1250 B0-to-A0 rule table must stay sorted by (encoding id, opcode)");
 
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
@@ -10,6 +10,8 @@
 #include "rocjitsu/isa/instruction.h"
 
 #include <algorithm>
+#include <cassert>
+#include <functional>
 
 namespace rocjitsu {
 
@@ -49,6 +51,13 @@ SemanticTranslator::SemanticTranslator(rj_code_arch_t guest, rj_code_arch_t host
     expand_rule_keys_.push_back(packed_rule_key(rule.src_encoding_id, rule.src_opcode));
     max_encoding_id = std::max(max_encoding_id, rule.src_encoding_id);
   }
+  // Every table in the tree static_asserts translation_rules_sorted(), so this
+  // is the catch-all for one added later without it. Strict ordering, matching
+  // that predicate: a duplicated key would leave the second rule unreachable
+  // behind the first.
+  assert(std::adjacent_find(expand_rule_keys_.begin(), expand_rule_keys_.end(),
+                            std::greater_equal<>{}) == expand_rule_keys_.end() &&
+         "semantic rule tables must stay strictly sorted by (encoding id, opcode)");
   if (!expand_rules_.empty()) {
     // Candidate collection scans every decoded instruction in large kernels.
     // Most encodings have no handwritten semantic rules, so this tiny bitset

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -24,8 +24,11 @@
 
 #include "util/bit.h"
 
+#include <algorithm>
+#include <array>
 #include <compare>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <span>
@@ -435,6 +438,46 @@ struct TranslationRule {
     return src_encoding_id == rhs.src_encoding_id && src_opcode == rhs.src_opcode;
   }
 };
+
+/// @brief Whether a semantic rule table is strictly ordered for binary search.
+///
+/// @details SemanticTranslator::find_expand_rule() binary-searches these tables,
+/// so an entry in the wrong place misses its own rule rather than failing.
+/// Encoding ids are derived rather than written down -- a SOPK id, for instance,
+/// is the SOPK base plus the opcode -- which makes a misplaced entry easy to
+/// introduce and silent to observe. Every table static_asserts this.
+///
+/// Strict rather than merely nondecreasing: the search takes the first match, so
+/// a duplicated (encoding id, opcode) leaves the second rule permanently
+/// unreachable -- the same silent miss, arrived at from the other direction.
+/// Catching that case depends on the comparison below ordering rules by their
+/// key alone, which is what makes two entries that share a key but differ in
+/// action or handler compare greater-equal here. Defaulting those operators
+/// would keep the out-of-order half working and silently drop the duplicate
+/// half.
+[[nodiscard]] constexpr bool translation_rules_sorted(std::span<const TranslationRule> rules) {
+  return std::ranges::adjacent_find(rules, std::ranges::greater_equal{}) == rules.end();
+}
+
+namespace translation_rule_detail {
+
+/// @brief Two rules sharing a key but differing in everything else.
+///
+/// @details The duplicate half of translation_rules_sorted() works only while
+/// the comparison ignores these trailing fields. Defaulting the operators would
+/// order this pair by them instead, so the pair would compare ascending, every
+/// table in the tree would still satisfy its own assertion, and the duplicate
+/// check would be silently gone. Pinning it here fails at the definition rather
+/// than at some future table that happens to duplicate a key.
+inline constexpr std::array<TranslationRule, 2> kSameKeyDifferentTail = {{
+    {1, 2, RuleAction::Identity, 0, 0, nullptr, nullptr, nullptr, nullptr, true},
+    {1, 2, RuleAction::Expand, 3, 0, nullptr, nullptr, nullptr, nullptr, false},
+}};
+static_assert(!translation_rules_sorted(kSameKeyDifferentTail),
+              "TranslationRule must order by (encoding id, opcode) alone, or "
+              "translation_rules_sorted() stops rejecting duplicate keys");
+
+} // namespace translation_rule_detail
 
 // ---------------------------------------------------------------------------
 // Tier 3: Lane Layout Descriptor

--- a/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/dbt/gfx1250_b0_a0_expected_rewrites.json
@@ -1,7 +1,7 @@
 {
   "expected_rewrites": {
     "00023c9f3fc277f35d928cca3a2e5614bba26b581e71abd3bbcff3fe3a417405": {
-      "instructions_requiring_rewrite": 9
+      "instructions_requiring_rewrite": 10
     }
   },
   "input_revision": "b0",

--- a/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_b0_a0_semantic_rewrites.json
@@ -2,49 +2,49 @@
   "schema": 1,
   "tests": {
     "barrier_signal_isfirst_test": {
-      "instructions_requiring_rewrite": 0
-    },
-    "cluster_load_test": {
-      "instructions_requiring_rewrite": 14
-    },
-    "ds_2addr_test": {
-      "instructions_requiring_rewrite": 9
-    },
-    "ds_addtid_test": {
-      "instructions_requiring_rewrite": 3
-    },
-    "ds_storexchg_2addr_test": {
-      "instructions_requiring_rewrite": 6
-    },
-    "fp8_e5m3_unpack_test": {
-      "instructions_requiring_rewrite": 5
-    },
-    "integer_wmma_hazard_test": {
-      "instructions_requiring_rewrite": 3
-    },
-    "s_clause_test": {
       "instructions_requiring_rewrite": 1
     },
-    "tensor_load_to_lds_test": {
+    "cluster_load_test": {
+      "instructions_requiring_rewrite": 15
+    },
+    "ds_2addr_test": {
+      "instructions_requiring_rewrite": 10
+    },
+    "ds_addtid_test": {
       "instructions_requiring_rewrite": 4
     },
-    "wmma_scale16_m16_test": {
-      "instructions_requiring_rewrite": 5
-    },
-    "wmma_scale16_m32_test": {
-      "instructions_requiring_rewrite": 8
-    },
-    "wmma_scale_regular_test": {
-      "instructions_requiring_rewrite": 11
-    },
-    "wmma_split_f16_test": {
-      "instructions_requiring_rewrite": 6
-    },
-    "wmma_split_f32_test": {
+    "ds_storexchg_2addr_test": {
       "instructions_requiring_rewrite": 7
     },
-    "wmma_split_fp4_test": {
+    "fp8_e5m3_unpack_test": {
+      "instructions_requiring_rewrite": 6
+    },
+    "integer_wmma_hazard_test": {
+      "instructions_requiring_rewrite": 4
+    },
+    "s_clause_test": {
+      "instructions_requiring_rewrite": 2
+    },
+    "tensor_load_to_lds_test": {
+      "instructions_requiring_rewrite": 6
+    },
+    "wmma_scale16_m16_test": {
+      "instructions_requiring_rewrite": 6
+    },
+    "wmma_scale16_m32_test": {
+      "instructions_requiring_rewrite": 9
+    },
+    "wmma_scale_regular_test": {
+      "instructions_requiring_rewrite": 12
+    },
+    "wmma_split_f16_test": {
+      "instructions_requiring_rewrite": 7
+    },
+    "wmma_split_f32_test": {
       "instructions_requiring_rewrite": 8
+    },
+    "wmma_split_fp4_test": {
+      "instructions_requiring_rewrite": 9
     }
   }
 }

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -8351,6 +8351,12 @@ TEST(SemanticTranslator, Gfx1250ClassifiesLivenessFreeExpandRules) {
   }
 
   const std::vector<uint32_t> expected = {
+      // A SOPK encoding id is the SOPK base plus the opcode, so the MODE-write
+      // separation rules sort ahead of everything else in the table.
+      (static_cast<uint32_t>(cdna5::encoding::kSopk + cdna5::kSSetregB32Sopk) << 16) |
+          cdna5::kSSetregB32Sopk,
+      (static_cast<uint32_t>(cdna5::encoding::kSopk + cdna5::kSSetregImm32B32Sopk) << 16) |
+          cdna5::kSSetregImm32B32Sopk,
       (static_cast<uint32_t>(cdna5::encoding::kSop1) << 16) | cdna5::kSBarrierSignalIsfirstSop1,
       (static_cast<uint32_t>(cdna5::encoding::kSopp) << 16) | cdna5::kSClauseSopp,
       (static_cast<uint32_t>(cdna5::encoding::kVop3p) << 16) | cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
@@ -8416,7 +8422,7 @@ TEST(BinaryTranslatorE2E, Gfx1250UsesNeutralScaledK128Fp8Bf8Wmma) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
 
-  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 41u);
+  EXPECT_EQ(rocjitsu::semantic_expand_rules_gfx1250_b0_to_a0().size(), 43u);
   for (const WmmaCase &test_case : cases) {
     SCOPED_TRACE(test_case.name);
     auto source_wmma = cdna5::build_vop3p(test_case.source_opcode, fields);
@@ -10401,15 +10407,19 @@ TEST(BinaryTranslatorE2E, Gfx1250GeneratedVgprMsbTransitionsCarryPreviousState) 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_GE(decoded.size(), 5u);
-  EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
+  // The guest MODE write opens the block, so its separation rule puts two V_NOPs
+  // ahead of it before anything this test is about.
+  ASSERT_GE(decoded.size(), 7u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[2]->mnemonic(), "s_setreg_imm32_b32");
   // The dependency barrier also separates the guest MODE write from the
   // generated transition. The transition retains its dedicated memory drain.
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_wait_idle");
-  EXPECT_EQ(decoded[2]->mnemonic(), "s_wait_xcnt");
-  EXPECT_EQ(decoded[3]->mnemonic(), "s_set_vgpr_msb");
-  ASSERT_NE(decoded[3]->raw_encoding(), nullptr);
-  EXPECT_EQ(decoded[3]->raw_encoding()[0] & 0xffffu, 0x0100u);
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_wait_idle");
+  EXPECT_EQ(decoded[4]->mnemonic(), "s_wait_xcnt");
+  EXPECT_EQ(decoded[5]->mnemonic(), "s_set_vgpr_msb");
+  ASSERT_NE(decoded[5]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[5]->raw_encoding()[0] & 0xffffu, 0x0100u);
 
   // Every generated s_set_vgpr_msb must be immediately preceded by an s_wait_xcnt.
   std::vector<uint16_t> generated_modes;
@@ -12771,6 +12781,137 @@ TEST(BinaryTranslatorE2E, Gfx1250TerminatesFallthroughIntoZeroPadding) {
                                                      /*guest_offset=*/4));
 }
 
+// On this target an s_setreg* naming MODE requires two V_NOPs immediately ahead of it to be ordered
+// against the instructions that precede it, and the compiler emits none. The requirement is
+// specific to MODE, so a write naming any other hardware register must stay untouched. Both
+// spellings carry the selector the same way, so both are covered: the immediate form (opcode 19,
+// which carries a literal) and the register-source form (opcode 18, which does not).
+TEST(BinaryTranslatorE2E, Gfx1250SeparatesModeWriteWithLeadingVNops) {
+  // s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 0, 32), 0 -- register id 1.
+  constexpr uint32_t kSetregWaveMode = 0xb980f801u;
+  // The same write naming HW_REG_WAVE_STATUS -- register id 2.
+  constexpr uint32_t kSetregWaveStatus = 0xb980f802u;
+  // s_setreg_b32 hwreg(HW_REG_WAVE_MODE, 0, 32), s0 -- register id 1, no literal.
+  constexpr uint32_t kSetregB32WaveMode = 0xb900f801u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {kSetregWaveMode, 0u, kSetregWaveStatus, 0u, kSetregB32WaveMode, kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+
+  ASSERT_EQ(decoded.size(), 8u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
+  ASSERT_NE(decoded[2]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[2]->raw_encoding()[0], kSetregWaveMode)
+      << "the MODE write itself must be preserved, only separated";
+  // The status write follows the MODE write with no V_NOPs of its own, which is what proves the
+  // rule discriminates on the hardware-register selector rather than the mnemonic.
+  ASSERT_NE(decoded[3]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[3]->raw_encoding()[0], kSetregWaveStatus);
+  // The register-source form is separated on the same terms. Its predecessor is the status write
+  // rather than a V_NOP, so it receives a fresh pair rather than counting anything.
+  EXPECT_EQ(decoded[4]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[5]->mnemonic(), "v_nop_e32");
+  ASSERT_NE(decoded[6]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[6]->mnemonic(), "s_setreg_b32");
+  EXPECT_EQ(decoded[6]->raw_encoding()[0], kSetregB32WaveMode);
+  EXPECT_EQ(decoded[7]->mnemonic(), "s_endpgm");
+
+  // Separation already present must be counted, or a repeated translation would keep prepending.
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
+// Counting V_NOPs that are already present is only sound inside one basic block: a V_NOP that a
+// branch can jump past does not run before the write on every path that reaches it. The write here
+// is a branch target, so its textual predecessors are in another block and must not be counted,
+// even though they are canonical V_NOPs sitting immediately in front of it.
+TEST(BinaryTranslatorE2E, Gfx1250IgnoresLeadingVNopsAcrossABlockBoundary) {
+  constexpr uint32_t kSetregWaveMode = 0xb980f801u;
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  const uint32_t v_nop = cdna5::build_vop1(cdna5::kVNopVop1)[0];
+
+  // s_cbranch_scc0 +2 lands on the MODE write, so the two V_NOPs it skips open no path to it.
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = 2})[0], v_nop, v_nop, kSetregWaveMode,
+       0u, kGfx1250SEndpgm});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_FALSE(translated.text_sections().empty());
+  const auto decoded =
+      decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
+
+  ASSERT_EQ(decoded.size(), 7u)
+      << "the write must receive a fresh pair, not count the skipped ones";
+  EXPECT_EQ(decoded[0]->mnemonic(), "s_cbranch_scc0");
+  for (size_t i = 1; i < 5; ++i)
+    EXPECT_EQ(decoded[i]->mnemonic(), "v_nop_e32") << "at index " << i;
+  ASSERT_NE(decoded[5]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[5]->raw_encoding()[0], kSetregWaveMode);
+  EXPECT_EQ(decoded[6]->mnemonic(), "s_endpgm");
+
+  // The branch must land on the separation rather than on the bare write, or the path through it
+  // would reach the write with no V_NOPs in front at all -- the case this rule exists to prevent.
+  ASSERT_NE(decoded[0]->raw_encoding(), nullptr);
+  const size_t landing_word =
+      1 + static_cast<size_t>(static_cast<int16_t>(decoded[0]->raw_encoding()[0] & 0xffffu));
+  size_t word = 0;
+  size_t landing_index = 0;
+  while (landing_index < decoded.size() && word < landing_word) {
+    word += static_cast<size_t>(decoded[landing_index]->size()) / sizeof(uint32_t);
+    ++landing_index;
+  }
+  ASSERT_EQ(word, landing_word) << "the branch must land on an instruction boundary";
+  ASSERT_LT(landing_index + 2, decoded.size());
+  EXPECT_EQ(decoded[landing_index]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[landing_index + 1]->mnemonic(), "v_nop_e32");
+  ASSERT_NE(decoded[landing_index + 2]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[landing_index + 2]->raw_encoding()[0], kSetregWaveMode)
+      << "exactly two V_NOPs must separate the branch target from the write";
+
+  // Retargeting moved the write, so this is the case where a second pass could disagree with the
+  // first about which V_NOPs belong to the write's own block.
+  rocjitsu::BinaryTranslator verifier(
+      ROCJITSU_CODE_ARCH_GFX1250, ROCJITSU_CODE_ARCH_GFX1250, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  auto second = verifier.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(second.elf_bytes, result.elf_bytes);
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250TerminatesSetupFallthroughIntoZeroPadding) {
   // clang emits this one-instruction body for rocPRIM target-specialized
   // trampolines whose source ends in __builtin_unreachable(). The following
@@ -12794,18 +12935,21 @@ TEST(BinaryTranslatorE2E, Gfx1250TerminatesSetupFallthroughIntoZeroPadding) {
   ASSERT_FALSE(translated.text_sections().empty());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_EQ(decoded.size(), 2u)
+  // The MODE write opens its block, so its separation rule contributes both V_NOPs here.
+  ASSERT_EQ(decoded.size(), 4u)
       << "the synthesized endpgm must be the only instruction after the stub body";
-  ASSERT_NE(decoded[0]->raw_encoding(), nullptr);
-  EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
-  EXPECT_EQ(decoded[0]->raw_encoding()[0], kSetReplayMode);
-  EXPECT_EQ(decoded[0]->raw_encoding()[1], kLiteralOne);
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_endpgm");
+  EXPECT_EQ(decoded[0]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
+  ASSERT_NE(decoded[2]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[2]->mnemonic(), "s_setreg_imm32_b32");
+  EXPECT_EQ(decoded[2]->raw_encoding()[0], kSetReplayMode);
+  EXPECT_EQ(decoded[2]->raw_encoding()[1], kLiteralOne);
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_endpgm");
 
   const auto kernel_symbol =
       rocjitsu::test_support::find_elf_symbol_for_test(result.elf_bytes, "kernel");
   ASSERT_TRUE(kernel_symbol.has_value());
-  EXPECT_EQ(kernel_symbol->st_size, 3 * sizeof(uint32_t))
+  EXPECT_EQ(kernel_symbol->st_size, 5 * sizeof(uint32_t))
       << "the translated function extent must include its synthesized terminator";
 }
 
@@ -12833,15 +12977,18 @@ TEST(BinaryTranslatorE2E, Gfx1250TerminatesPrefetchSetupFallthroughIntoZeroPaddi
   ASSERT_FALSE(translated.text_sections().empty());
   const auto decoded =
       decode_text_instructions(*translated.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_EQ(decoded.size(), 4u)
+  // The prologue's own V_NOP counts toward the MODE write's separation, so it needs
+  // only one more rather than a fresh pair.
+  ASSERT_EQ(decoded.size(), 5u)
       << "the synthesized endpgm must be the only instruction after the stub body";
   EXPECT_EQ(decoded[0]->mnemonic(), "global_prefetch_b8");
   EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
-  EXPECT_EQ(decoded[2]->mnemonic(), "s_setreg_imm32_b32");
-  ASSERT_NE(decoded[2]->raw_encoding(), nullptr);
-  EXPECT_EQ(decoded[2]->raw_encoding()[0], kSetReplayMode[0]);
-  EXPECT_EQ(decoded[2]->raw_encoding()[1], kSetReplayMode[1]);
-  EXPECT_EQ(decoded[3]->mnemonic(), "s_endpgm");
+  EXPECT_EQ(decoded[2]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_setreg_imm32_b32");
+  ASSERT_NE(decoded[3]->raw_encoding(), nullptr);
+  EXPECT_EQ(decoded[3]->raw_encoding()[0], kSetReplayMode[0]);
+  EXPECT_EQ(decoded[3]->raw_encoding()[1], kSetReplayMode[1]);
+  EXPECT_EQ(decoded[4]->mnemonic(), "s_endpgm");
 }
 
 // A stub whose last instruction ends exactly at the end of `.text` has no padding after it, but it
@@ -12865,9 +13012,11 @@ TEST(BinaryTranslatorE2E, Gfx1250MaterializesSectionFinalClangUnreachableKernelS
   rocjitsu::AmdGpuCodeObject first_output(first.elf_bytes.data(), first.elf_bytes.size());
   const auto decoded =
       decode_text_instructions(*first_output.text_sections()[0], ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_EQ(decoded.size(), 2u);
-  EXPECT_EQ(decoded[0]->mnemonic(), "s_setreg_imm32_b32");
-  EXPECT_EQ(decoded[1]->mnemonic(), "s_endpgm");
+  ASSERT_EQ(decoded.size(), 4u);
+  EXPECT_EQ(decoded[0]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[1]->mnemonic(), "v_nop_e32");
+  EXPECT_EQ(decoded[2]->mnemonic(), "s_setreg_imm32_b32");
+  EXPECT_EQ(decoded[3]->mnemonic(), "s_endpgm");
   // Section end is the same inferred boundary as padding, so it must be reported the same way.
   EXPECT_TRUE(rocjitsu::test_support::has_warning_at(first, rocjitsu::DiagnosticKind::Legalization,
                                                      "synthesized s_endpgm boundary",

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <span>
 #include <sstream>
 #include <string>
@@ -278,6 +279,28 @@ std::string read_text_file(const std::filesystem::path &path) {
 
 bool contains(std::string_view haystack, std::string_view needle) {
   return haystack.find(needle) != std::string_view::npos;
+}
+
+/// @brief Read one `name=<count>` field out of the summary line.
+///
+/// @details The counters are space-separated, so a substring search for
+/// "expand=1" also matches "expand=10". Anchoring on the leading space and
+/// reading to the next delimiter makes the comparison numeric, so a count that
+/// drifts fails instead of still matching a prefix.
+std::optional<long long> summary_counter(std::string_view text, std::string_view name) {
+  const std::string key = " " + std::string(name) + "=";
+  const size_t at = text.find(key);
+  if (at == std::string_view::npos)
+    return std::nullopt;
+  const size_t first = at + key.size();
+  const size_t last = text.find_first_not_of("0123456789", first);
+  if (last == first)
+    return std::nullopt;
+  long long value = 0;
+  const auto digits = text.substr(first, last - first);
+  for (const char digit : digits)
+    value = value * 10 + (digit - '0');
+  return value;
 }
 
 bool command_succeeded(int status) {
@@ -722,6 +745,50 @@ TEST(RjDbtTranslate, VerifiesGfx1250ClusterLoadIdempotence) {
   EXPECT_TRUE(stderr_text.empty()) << stderr_text;
   EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
   EXPECT_TRUE(contains(stdout_text, "idempotence_diagnostics: 0")) << stdout_text;
+}
+
+// A rule registered in the semantic table with no legalization entry reports through a label and a
+// counter branch that no other fixture reaches: the existing ones all translate through a
+// legalization-classified rule. The MODE separation rule is the only one shaped this way, so
+// without this the label and the partition can drift while the suite stays green.
+TEST(RjDbtTranslate, ReportsUnclassifiedSemanticExpansionInTheDiff) {
+  const rocjitsu::test::ScopedTempDirectory temp_dir("rj_dbt_translate_unclassified_semantic_");
+  const std::filesystem::path temp_path(temp_dir.path());
+  const std::filesystem::path input = temp_path / "mode_setreg_gfx1250.co";
+  const std::filesystem::path output = temp_path / "stdout.txt";
+  const std::filesystem::path error = temp_path / "stderr.txt";
+
+  // s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 0, 32), 0 -- the one write the rule separates.
+  constexpr std::array<uint32_t, 3> text_words = {0xb980f801u, 0x00000001u, 0xbfb00000u};
+  {
+    const std::vector<uint8_t> image = make_gfx1250_smoke_code_object(text_words);
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command = shell_quote(g_translate_tool.string()) + " " +
+                              shell_quote(input.string()) +
+                              " --input-target gfx1250 --input-revision b0 --output-target gfx1250 "
+                              "--output-revision a0 --verify-idempotence --output-mode diff > " +
+                              shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  ASSERT_TRUE(command_succeeded(status)) << "stderr:\n"
+                                         << stderr_text << "\nstdout:\n"
+                                         << stdout_text;
+  EXPECT_TRUE(stderr_text.empty()) << stderr_text;
+
+  // The label must name the rule that rewrote the instruction rather than a re-encode.
+  EXPECT_TRUE(contains(stdout_text, "expand semantic")) << stdout_text;
+  // The counters must still partition the total: the expansion belongs to expand, not encode.
+  EXPECT_EQ(summary_counter(stdout_text, "expand"), 1) << stdout_text;
+  EXPECT_EQ(summary_counter(stdout_text, "encode"), 0) << stdout_text;
+  EXPECT_EQ(summary_counter(stdout_text, "semantic"), 1) << stdout_text;
+  EXPECT_TRUE(contains(stdout_text, "idempotence: verified")) << stdout_text;
 }
 
 int main(int argc, char **argv) {

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -63,6 +63,24 @@ struct InstructionTranslationReport {
   uint64_t target_offset = 0;
   std::vector<uint32_t> target_words;
   std::vector<std::string> target_instructions;
+
+  /// @brief What actually happened to this instruction, as one value.
+  ///
+  /// @details The label and the action counters must agree, and reconstructing
+  /// the rules for that at each consumer is how they drift apart. The one case
+  /// that is not simply `action` is a semantic rule carrying an instruction with
+  /// no legalization entry naming it: that is an expansion, and reporting it as
+  /// a re-encode would hide the rule that rewrote the instruction.
+  ///
+  /// @returns The effective legalization action, or nullopt when the instruction
+  ///          was copied verbatim or re-encoded without a rule.
+  [[nodiscard]] std::optional<Action> effective_action() const {
+    if (copied_original)
+      return std::nullopt;
+    if (!has_legalization)
+      return semantic_lowering ? std::optional<Action>(Action::Expand) : std::nullopt;
+    return action;
+  }
 };
 
 struct TranslateOptions {

--- a/emulation/rocjitsu/tools/dbt_translate_cli.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_cli.cpp
@@ -386,10 +386,15 @@ void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic,
 [[nodiscard]] std::string translation_action_text(const InstructionTranslationReport &translation) {
   if (translation.copied_original)
     return "copy_original";
-  if (!translation.has_legalization)
+
+  // An unclassified semantic lowering deliberately reads the same as a
+  // classified expansion: whether a legalization entry also named the opcode is
+  // internal to the profile, and the action the reader sees is the same one.
+  const auto action = translation.effective_action();
+  if (!action)
     return "encode";
 
-  std::string text = legalization_action_name(translation.action);
+  std::string text = legalization_action_name(*action);
   if (translation.semantic_lowering)
     text += " semantic";
   return text;
@@ -404,23 +409,19 @@ void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic,
 
 [[nodiscard]] size_t count_action(const std::vector<InstructionTranslationReport> &translations,
                                   Action action) {
-  size_t count = 0;
-  for (const auto &translation : translations) {
-    if (!translation.copied_original && translation.has_legalization &&
-        translation.action == action)
-      ++count;
-  }
-  return count;
+  return static_cast<size_t>(std::ranges::count_if(
+      translations, [action](const InstructionTranslationReport &translation) {
+        return translation.effective_action() == action;
+      }));
 }
 
+/// @brief Instructions re-encoded with no rule: not copied, and no action.
 [[nodiscard]] size_t
 count_runtime_encode(const std::vector<InstructionTranslationReport> &translations) {
-  size_t count = 0;
-  for (const auto &translation : translations) {
-    if (!translation.copied_original && !translation.has_legalization)
-      ++count;
-  }
-  return count;
+  return static_cast<size_t>(
+      std::ranges::count_if(translations, [](const InstructionTranslationReport &translation) {
+        return !translation.copied_original && !translation.effective_action();
+      }));
 }
 
 [[nodiscard]] size_t


### PR DESCRIPTION
On this target an s_setreg* naming the MODE register requires two V_NOPs immediately ahead of it to be ordered against the instructions that precede it, and compiler output does not supply them: a gfx1250 kernel entry reaches its MODE write through one V_NOP and a SALU. Classify such a write during b0-to-a0 legalization -- the hardware-register selector in SIMM16, not the mnemonic, is what distinguishes it -- and expand it to the missing V_NOPs followed by the original instruction.

V_NOPs already immediately ahead of the write are counted so only the missing slots are emitted, which keeps the pass a fixed point under repeated translation. Writes naming any other hardware register stay on the copy path.