### PR TITLE
fix(rccl): decouple rccl-UnitTestsGdr from librccl ABI

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -549,6 +549,8 @@ if(BUILD_TESTS)
   )
 
   add_executable(rccl-UnitTestsGdr ${TEST_GDR_SOURCE_FILES})
+  # Ensure hipify-staged headers (including debug.h) exist before compiling this target.
+  add_dependencies(rccl-UnitTestsGdr hipify_all)
   # rccl-UnitTestsAmdSmi: tests for the amdsmi_wrap layer.
   #
   # AmdSmiFabricTests.cpp covers the fabric predicates and struct layout pinned in

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -693,14 +693,12 @@ if(BUILD_TESTS)
         set_target_properties(${test_executable} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
       endif()
     endif()
-    # rccl-UnitTestsGinAnvilPlugin is a self-contained host unit test: it compiles
-    # the plugin sources directly and provides its own stubs (bootstrap/devr/debug/
-    # factory), so it must NOT link librccl.so. When RCCL is built with
-    # ENABLE_ROCSHMEM_GIN=ON but ENABLE_ROCSHMEM=OFF, librccl.so carries unresolved
-    # rocSHMEM symbols (e.g. rocshmem::envvar::log_flags) that would fail at load
-    # time for any executable linking it.
+    # These host-only tests compile code directly with local stubs and must not
+    # link librccl.so (avoids runtime ABI coupling and unresolved rocSHMEM in
+    # plugin-only builds).
     if(test_executable STREQUAL "rccl-UnitTestsGinAnvilPlugin" OR
-       test_executable STREQUAL "rccl-UnitTestsDevRuntime")
+       test_executable STREQUAL "rccl-UnitTestsDevRuntime" OR
+       test_executable STREQUAL "rccl-UnitTestsGdr")
       # Intentionally no rccl link; needed symbols come from the compiled-in
       # source(s) + stubs and RCCL_COMMON_LINK_LIBS (hip/hsa/gtest/dl).
     elseif(BUILD_SHARED_LIBS)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -744,6 +744,11 @@ if(BUILD_TESTS)
     rocm_install(TARGETS ${test_executable} COMPONENT tests)
   endforeach()
 
+  # gdr_peermem.h lives in src/include. Add late so hipify-staged headers
+  # (e.g. debug.h) from RCCL_COMMON_INCLUDE_DIRS take precedence.
+  target_include_directories(rccl-UnitTestsGdr PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/include)
+
   # Suite H: shadow rocSHMEM sdma headers with no-op test stubs (higher-priority include path).
   if(ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS))
     if(ROCSHMEM_SOURCE_DIR)

--- a/projects/rccl/test/GdrPeerMemTests.cpp
+++ b/projects/rccl/test/GdrPeerMemTests.cpp
@@ -15,12 +15,11 @@
 #include <system_error>
 #include <unistd.h>
 
-// Weak stub for ncclDebugLog, required because gdr_peermem.cc uses the debug.h
-// INFO() macro. Debug builds: ncclDebugLog is exported from librccl.so
-// (-fvisibility=default), so the strong shared-library definition wins at link
-// time and this stub is unused. Release builds: ncclDebugLog is hidden in
-// librccl.so (-fvisibility=hidden), so this stub provides the symbol and drops logs.
-// Mirrors the pattern in test/AltRsmiTests.cpp.
+// Weak stubs for debug globals/logging used by debug.h INFO() in gdr_peermem.cc.
+// They keep this test self-contained when it intentionally does not link librccl.so.
+// If linked with librccl.so, the strong shared-library definitions take precedence.
+int __attribute__((weak)) ncclDebugLevel = 0;
+uint64_t __attribute__((weak)) ncclDebugMask = 0;
 void __attribute__((weak)) ncclDebugLog(ncclDebugLogLevel, unsigned long, const char*, int, const char*, ...) {}
 
 namespace RcclUnitTesting {


### PR DESCRIPTION
## Motivation

`rccl-UnitTestsGdr` is intended to test `gdr_peermem.cc` in isolation, but it still linked `librccl.so` through the shared test-link path. That created runtime coupling to whichever RCCL library was resolved first (for example, older system-installed ROCm packages), causing symbol/runtime compatibility failures unrelated to the GDR test logic.

## Technical Details

- Updated `test/CMakeLists.txt`:
  - Excluded `rccl-UnitTestsGdr` from `librccl.so` linking, alongside other self-contained host-only test binaries.
- Updated `test/GdrPeerMemTests.cpp`:
  - Added weak stubs for debug symbols used by `debug.h`/`INFO()`:
    - `ncclDebugLevel`
    - `ncclDebugMask`
    - `ncclDebugLog`
  - This preserves standalone linking when `librccl.so` is intentionally not linked.

### Why this is safe

- Change is test-only (`test/` files), no production code path changes.
- `rccl-UnitTestsGdr` still compiles and runs the same GDR client detection tests.
- Weak symbols ensure compatibility if a stronger definition is present in another link mode.

## Issue Tracking

JIRA ID: AICOMRCCL-1940

## Test Plan

- Rebuilt GDR unit-test target in both configurations:
  - `cmake --build build/release --target rccl-UnitTestsGdr`
  - `cmake --build build/debug --target rccl-UnitTestsGdr`
- Verified runtime dependencies:
  - `ldd build/release/test/rccl-UnitTestsGdr`
  - `ldd build/debug/test/rccl-UnitTestsGdr`
  - Confirmed no `librccl.so` dependency.
- Ran tests:
  - `build/release/test/rccl-UnitTestsGdr --gtest_color=no`
  - `build/debug/test/rccl-UnitTestsGdr --gtest_color=no`

## Test Result

- `rccl-UnitTestsGdr`: **9/9 tests passed** in both `release` and `debug`.
- Binary no longer depends on `librccl.so`, removing external RCCL ABI/runtime coupling for this test target.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
