### PR TITLE
feat(rocprofiler-sdk): doorbell identity (DoorbellMap, correlation_key, capture) [3/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
@@ -1,8 +1,18 @@
 #
 #
-set(ROCPROFILER_LIB_KFD_EVENT_SOURCES abi.cpp dlog_abi.cpp kfd.cpp)
-set(ROCPROFILER_LIB_KFD_EVENT_HEADERS defines.hpp kfd.hpp utils.hpp kfd_dlog_uapi.h
-                                      dlog_drain.hpp record_pipe.hpp stream_geometry.hpp)
+set(ROCPROFILER_LIB_KFD_EVENT_SOURCES abi.cpp dlog_abi.cpp kfd.cpp doorbell_map.cpp
+                                      kfd_correlation.cpp)
+set(ROCPROFILER_LIB_KFD_EVENT_HEADERS
+    defines.hpp
+    kfd.hpp
+    utils.hpp
+    kfd_dlog_uapi.h
+    dlog_drain.hpp
+    record_pipe.hpp
+    stream_geometry.hpp
+    correlation_types.hpp
+    doorbell_map.hpp
+    kfd_correlation.hpp)
 
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_KFD_EVENT_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
@@ -1,0 +1,108 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+// Identity types bridging an SDK dispatch to a firmware dispatch-log record.
+// Firmware identifies a dispatch as (doorbell_off, dispatch_idx_low32); the SDK
+// captures the same pair at enqueue.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// Absolute monotonic nanoseconds; all deadlines in the KFD path are values of
+// this. steady_clock (CLOCK_MONOTONIC) is deliberate: the close/GC deadlines are
+// elapsed-time budgets, so they must be immune to CLOCK_REALTIME jumps (NTP step,
+// settimeofday). It is never compared against a GPU tick or a system-domain
+// timestamp -- those live in their own domains and never cross into this one.
+inline uint64_t
+steady_now_ns()
+{
+    using namespace std::chrono;
+    return static_cast<uint64_t>(
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+// The identity a firmware record can reconstruct: (page-relative doorbell slot,
+// low-32 dispatch index, GPU). The owning owner_window is carried BESIDE the key
+// (on the registration and the hub entry), never in it, because a record cannot
+// reconstruct a window -- time-as-generation resolves the window from the START
+// tick. `generation` is deleted: recycled-doorbell collisions are
+// now representable (the hub's multimap) and resolved by window containment.
+struct correlation_key
+{
+    uint32_t doorbell_off       = 0;
+    uint32_t dispatch_idx_low32 = 0;
+    // Doorbell slots and dispatch indices are per-GPU and both restart from low
+    // values, so without this a record from one GPU can match a dispatch on
+    // another. No cross-agent tick comparison ever happens.
+    uint32_t gpu_id = 0;
+
+    bool operator==(const correlation_key& rhs) const
+    {
+        return doorbell_off == rhs.doorbell_off && dispatch_idx_low32 == rhs.dispatch_idx_low32 &&
+               gpu_id == rhs.gpu_id;
+    }
+
+    bool operator!=(const correlation_key& rhs) const { return !(*this == rhs); }
+};
+
+// How far past a CPU timestamp a converted firmware end may legitimately land, in
+// the CLOCK_MONOTONIC SYSTEM domain (common::timestamp_ns(), the domain
+// hsa_amd_profiling_convert_tick_to_system_domain targets) -- NOT the GPU tick
+// domain the owner windows compare in, which is raw-tick-only and immune to
+// resync. Tick-to-system-domain conversion re-syncs periodically, so a
+// just-completed dispatch's converted end can measure a few ms AFTER a `now`
+// sampled right behind it (low single-digit ms observed in practice); a hard
+// `end <= now` would discard every valid record. 100 ms keeps a wide margin over
+// that. This is NOT a correctness threshold: it only raises the after_now
+// diagnostic flag. Emission is gated by the finalizer's own postcondition, which
+// unconditionally shifts end down to `now`, so the exact value is not
+// safety-critical -- too small only over-flags, too large only under-flags. The
+// hard raw-terminal rejects are kMaxStaleNs/kMaxFutureNs (seconds).
+constexpr uint64_t kKfdFutureSlackNs = 100'000'000;  // 100 ms
+
+// kfd_time_is_sane is deleted: its role -- "is this interval usable" -- is
+// now the finalizer's own unconditional postcondition (result_ready requires
+// enqueue <= start < end <= now), at a tighter bound than this helper's slack.
+
+struct correlation_key_hash
+{
+    size_t operator()(const correlation_key& key) const
+    {
+        auto mix = [](size_t seed, uint32_t value) {
+            return seed ^ (std::hash<uint32_t>{}(value) + 0x9e3779b9UL + (seed << 6) + (seed >> 2));
+        };
+        size_t seed = std::hash<uint32_t>{}(key.doorbell_off);
+        seed        = mix(seed, key.dispatch_idx_low32);
+        seed        = mix(seed, key.gpu_id);
+        return seed;
+    }
+};
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/doorbell_map.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/doorbell_map.cpp
@@ -1,0 +1,120 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+open_result
+DoorbellMap::open_window(uint32_t               gpu_id,
+                         rocprofiler_queue_id_t queue_id,
+                         uint32_t               slot,
+                         uint64_t               tick_sample)
+{
+    // The process has an owner it never windowed; first_owner is untrustworthy,
+    // so open nothing anywhere for the rest of the process.
+    if(signal_less_disabled()) return open_result{};
+
+    return m_data.wlock([&](map_data& data) -> open_result {
+        auto&    live  = data.by_slot[{gpu_id, slot}];
+        uint64_t floor = 0;
+        if(!live.empty())
+        {
+            // A REFERENCE, no shared_ptr copy: a copy would hold use_count()==2
+            // across the prune and the predecessor would never be reclaimed.
+            owner_window& prev = *live.back();
+            if(prev.t_close.load(std::memory_order_acquire) == kWindowOpen)
+                return open_result{nullptr, true};  // two live owners: overlap, open nothing
+            floor = prev.t_close.load(std::memory_order_acquire);
+            prev.superseded.store(true, std::memory_order_release);
+        }
+
+        // live.empty() is exactly "this process never opened a window on this
+        // slot" and stays that way: pruning runs only after the push below.
+        const bool first_owner = live.empty();
+
+        auto w         = std::make_shared<owner_window>();
+        w->slot        = slot;
+        w->first_owner = first_owner;
+        // The max is load-bearing: both clock reads happen outside any
+        // shared lock, so a create sample can be observed after a later-real-time
+        // destroy sample. Flooring at prev.t_close makes disjointness a property
+        // of the data, not of the thread schedule.
+        w->t_open = std::max(tick_sample, floor);
+        // prev is not touched after this point; push_back may reallocate.
+        live.push_back(w);
+        data.by_queue[queue_id.handle] = w;
+
+        // Prune closed windows nobody but this list references (their entries have
+        // been GC'd). Bounded, O(list); never reaches the just-pushed live window.
+        for(auto it = live.begin(); it != live.end();)
+        {
+            if((*it)->t_close.load(std::memory_order_acquire) != kWindowOpen &&
+               it->use_count() == 1)
+                it = live.erase(it);
+            else
+                ++it;
+        }
+
+        return open_result{std::move(w), false};
+    });
+}
+
+std::optional<window_ptr>
+DoorbellMap::resolve(uint32_t /*gpu_id*/, rocprofiler_queue_id_t queue_id)
+{
+    // Pure read-lock lookup plus the process-wide latch check (one atomic load,
+    // no lock). The enqueue path never takes the write lock.
+    if(signal_less_disabled()) return std::nullopt;
+    return m_data.rlock([&](const map_data& data) -> std::optional<window_ptr> {
+        auto it = data.by_queue.find(queue_id.handle);
+        if(it == data.by_queue.end()) return std::nullopt;
+        return it->second;
+    });
+}
+
+window_ptr
+DoorbellMap::close_window(rocprofiler_queue_id_t queue_id,
+                          uint64_t               tick_sample,
+                          uint64_t               gc_deadline_ns)
+{
+    return m_data.wlock([&](map_data& data) -> window_ptr {
+        auto it = data.by_queue.find(queue_id.handle);
+        if(it == data.by_queue.end()) return nullptr;  // never opened a window
+        auto w = it->second;
+        data.by_queue.erase(it);
+        // t_close is stored LAST, with release, so any thread that observes a
+        // closed window also observes its deadline.
+        w->gc_deadline_ns = gc_deadline_ns;
+        w->t_close.store(tick_sample, std::memory_order_release);
+        return w;
+    });
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/doorbell_map.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/doorbell_map.hpp
@@ -1,0 +1,170 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/synchronized.hpp"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+// DoorbellMap: time-as-generation identity.
+//
+// A firmware record carries no queue id, no VMID, no generation -- only a doorbell
+// slot, a low-32 dispatch id, and a GPU timestamp. For each (gpu, doorbell_slot)
+// the SDK keeps a time-ordered, non-overlapping list of OWNER WINDOWS (t_open,
+// t_close). A dispatch is registered against the window open at its enqueue; a
+// record is attributed by the hub to the registration whose window strictly
+// contains the record's START tick. The clock is read exactly twice per queue
+// lifetime (create/destroy), from that queue's own agent, never per dispatch.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// Both the capture side (from a queue's doorbell pointer) and the reader side
+// (from a firmware record's doorbell_off) reduce the doorbell identity to a
+// PAGE-RELATIVE dword index. Correctness needs only that the two sides use the
+// SAME modulus, so it is defined once here and shared -- they cannot drift apart.
+// The value is the doorbell-page granularity (4 KiB / 1024 dwords), a fixed GPU
+// aperture-layout constant, NOT the OS page size sysconf(_SC_PAGESIZE) returns:
+// the mmap page size (used for the stream BO mapping in the reader) is a separate
+// concern and legitimately differs on a 64 KiB-page host. The reduction drops the
+// process's absolute doorbell base, which neither the pointer nor the record
+// encodes.
+constexpr uint32_t kDoorbellSlotsPerPage = 1024;
+constexpr uint64_t kDoorbellPageBytes    = static_cast<uint64_t>(kDoorbellSlotsPerPage) * 4;
+
+// Reader side: absolute record doorbell_off -> page-relative slot index.
+inline uint32_t
+doorbell_off_to_page_slot(uint32_t record_doorbell_off)
+{
+    return record_doorbell_off & (kDoorbellSlotsPerPage - 1);
+}
+
+// Capture side: a queue's hardware doorbell pointer -> page-relative slot index.
+// The pointer's offset within its 4 KiB page, in dwords (>>2): GFX12 dispatch-log
+// records store a dword index, and adjacent 8-byte doorbells are 2 dwords apart.
+inline uint32_t
+doorbell_ptr_to_page_slot(uint64_t hardware_doorbell_ptr)
+{
+    return static_cast<uint32_t>((hardware_doorbell_ptr & (kDoorbellPageBytes - 1)) >> 2);
+}
+
+// t_close sentinel: the window is still live.
+constexpr uint64_t kWindowOpen = UINT64_MAX;
+
+// One owner of a (gpu, slot) over a time interval. Immutable except for
+// two write-once atomics plus one plain field, each written by exactly one thread
+// at one point in the object's life: t_close and gc_deadline_ns by the destroying
+// thread, superseded by the next creating thread under the map write lock.
+struct owner_window
+{
+    uint32_t              slot        = 0;      // page-relative doorbell dword index
+    bool                  first_owner = false;  // this slot had no prior owner, ever
+    uint64_t              t_open      = 0;      // agent GPU tick, immutable after construction
+    std::atomic<uint64_t> t_close     = {kWindowOpen};  // written once, by the destroy path
+    std::atomic<bool>     superseded  = {false};        // a later window opened on this slot
+    // steady ns; 0 while open. Deliberately PLAIN: the destroy thread writes it
+    // BEFORE the release store of t_close, and the GC reads it only after an
+    // acquire load of t_close that observed a real value, so that pair already
+    // publishes it.
+    uint64_t gc_deadline_ns = 0;
+};
+using window_ptr = std::shared_ptr<owner_window>;
+
+struct open_result
+{
+    window_ptr w          = {};
+    bool       overlapped = false;  // two live owners on one slot
+};
+
+// The process-wide signal-less disable latch. Header-only inline
+// static so it is one instance across every TU with no link dependency. Set by
+// signal_less_disable_permanently() on a doorbell-capture failure or an attach
+// registration -- an owner this process never windowed exists, so first_owner can
+// no longer be trusted. resolve()/open_window() then return nothing everywhere.
+inline std::atomic<bool>&
+signal_less_disable_latch()
+{
+    static std::atomic<bool> _v{false};
+    return _v;
+}
+
+inline bool
+signal_less_disabled()
+{
+    return signal_less_disable_latch().load(std::memory_order_acquire);
+}
+
+class DoorbellMap
+{
+public:
+    DoorbellMap()  = default;
+    ~DoorbellMap() = default;
+
+    DoorbellMap(const DoorbellMap&)     = delete;
+    DoorbellMap(DoorbellMap&&) noexcept = delete;
+    DoorbellMap& operator=(const DoorbellMap&) = delete;
+    DoorbellMap& operator=(DoorbellMap&&) noexcept = delete;
+
+    // Queue create: open a window on (gpu, slot). `tick_sample` is read by the
+    // caller BEFORE this call, from that queue's agent. Under the write lock:
+    // supersede the previous window and floor t_open at its t_close (max),
+    // or report `overlapped` if the previous owner is still live.
+    open_result open_window(uint32_t               gpu_id,
+                            rocprofiler_queue_id_t queue_id,
+                            uint32_t               slot,
+                            uint64_t               tick_sample);
+
+    // Enqueue: a pure read-lock lookup of the window open for this queue, plus the
+    // process-wide disable-latch check (one atomic load, no lock). No clock, no
+    // bind -- the enqueue path never takes the write lock again.
+    std::optional<window_ptr> resolve(uint32_t gpu_id, rocprofiler_queue_id_t queue_id);
+
+    // Queue destroy: stamp t_close and the GC deadline (release), so any thread
+    // that observes the closed window also observes its deadline. Returns the
+    // window, or nullptr when the queue never opened one (SDMA, clock/capture
+    // failure, attach, overlap-poisoned slot).
+    window_ptr close_window(rocprofiler_queue_id_t queue_id,
+                            uint64_t               tick_sample,
+                            uint64_t               gc_deadline_ns);
+
+private:
+    struct map_data
+    {
+        std::unordered_map<uint64_t /*queue handle*/, window_ptr> by_queue;
+        // Keyed by (gpu_id, doorbell_slot); time-ordered, pruned in open_window.
+        std::map<std::pair<uint32_t, uint32_t>, std::vector<window_ptr>> by_slot;
+    };
+
+    common::Synchronized<map_data> m_data = {};
+};
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_correlation.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_correlation.cpp
@@ -1,0 +1,43 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+
+#include "lib/common/static_object.hpp"
+
+// Lazily constructs a single process-wide instance via common::static_object
+// (same idiom as kfd_profiler.cpp state()): placement-new into a static buffer
+// with ordered teardown, no heap leak, no unspecified static-destructor ordering
+// at library unload.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+DoorbellMap&
+doorbell_map()
+{
+    static auto*& _v = common::static_object<DoorbellMap>::construct();
+    return *_v;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_correlation.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_correlation.hpp
@@ -1,0 +1,35 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// One instance per process: the enqueue paths and the reader thread share it.
+DoorbellMap&
+doorbell_map();
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -65,3 +65,24 @@ rocprofiler_add_unit_test(
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_LIB_KFD_DLOG_TEST_SOURCES data_structures.cpp)
+
+add_executable(kfd-dlog-data-structures)
+
+target_sources(kfd-dlog-data-structures PRIVATE ${ROCPROFILER_LIB_KFD_DLOG_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-data-structures
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-data-structures
+    SOURCES ${ROCPROFILER_LIB_KFD_DLOG_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
@@ -1,0 +1,132 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/kfd/correlation_types.hpp"
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+using namespace rocprofiler::kfd;
+rocprofiler_queue_id_t
+qid(uint64_t h)
+{
+    return rocprofiler_queue_id_t{h};
+}
+}  // namespace
+
+TEST(correlation_key, equality_hash_and_per_gpu_scoping)
+{
+    // (doorbell_off, dispatch_idx_low32, gpu_id) -- `generation` is deleted; a
+    // recycled doorbell is now a distinct window carried beside the key, not a key
+    // field.
+    auto a = correlation_key{7, 100, 0};
+    EXPECT_EQ(a, (correlation_key{7, 100, 0}));
+    EXPECT_EQ(correlation_key_hash{}(a), correlation_key_hash{}(correlation_key{7, 100, 0}));
+    // GPU id scopes the key; two records with the same slot/index on two GPUs must
+    // never be equal (no cross-agent tick comparison).
+    auto on_gpu0 = correlation_key{7, 100, 0};
+    auto on_gpu1 = correlation_key{7, 100, 1};
+    EXPECT_NE(on_gpu0, on_gpu1) << "identical slot/index on two GPUs must not be equal";
+    EXPECT_NE(a, (correlation_key{8, 100, 0})) << "different slot";
+    EXPECT_NE(a, (correlation_key{7, 101, 0})) << "different dispatch index";
+}
+// Time-as-generation window bookkeeping: open/resolve/close, max, the overlap
+// verdict, first_owner, the disable latch, and the page-slot helpers.
+TEST(DoorbellMap, window_open_resolve_close_and_slot_helpers)
+{
+    signal_less_disable_latch().store(false);  // shared process latch; start clean
+
+    {  // max: open(100)/close(200)/open(50) -> W2.t_open == 200
+        auto m  = DoorbellMap{};
+        auto o1 = m.open_window(0, qid(1), 5, 100);
+        ASSERT_TRUE(o1.w);
+        EXPECT_FALSE(o1.overlapped);
+        EXPECT_EQ(o1.w->t_open, 100u);
+        EXPECT_TRUE(o1.w->first_owner) << "first ever owner of this slot";
+        m.close_window(qid(1), 200, 0);
+        auto o2 = m.open_window(0, qid(2), 5, 50);  // sample 50 < prev t_close 200
+        ASSERT_TRUE(o2.w);
+        EXPECT_EQ(o2.w->t_open, 200u) << "t_open = max(sample, prev.t_close)";
+        EXPECT_FALSE(o2.w->first_owner) << "slot had a prior owner";
+    }
+    {  // overlap: two live owners on one slot -> overlapped, no window opened
+        auto m  = DoorbellMap{};
+        auto o1 = m.open_window(0, qid(1), 5, 100);
+        ASSERT_TRUE(o1.w);
+        auto o2 = m.open_window(0, qid(2), 5, 150);  // q1 still live
+        EXPECT_TRUE(o2.overlapped);
+        EXPECT_FALSE(o2.w) << "overlap opens nothing";
+        EXPECT_FALSE(m.resolve(0, qid(2)).has_value()) << "no window for the overlapping queue";
+    }
+    {  // resolve returns the live window object; close removes it; unknown -> nullopt
+        auto m = DoorbellMap{};
+        EXPECT_FALSE(m.resolve(0, qid(9)).has_value());
+        auto o = m.open_window(0, qid(9), 4, 100);
+        auto r = m.resolve(0, qid(9));
+        ASSERT_TRUE(r.has_value());
+        EXPECT_EQ((*r)->slot, 4u);
+        EXPECT_EQ((*r).get(), o.w.get()) << "resolve returns the same window object";
+        auto w = m.close_window(qid(9), 200, 0);
+        ASSERT_TRUE(w);
+        EXPECT_EQ(w->t_close.load(), 200u);
+        EXPECT_FALSE(m.resolve(0, qid(9)).has_value()) << "closed -> no resolve";
+        EXPECT_FALSE(m.close_window(qid(9), 300, 0)) << "double close -> nullptr";
+        EXPECT_FALSE(m.close_window(qid(404), 1, 0)) << "never-opened -> nullptr";
+    }
+    {  // first_owner is live.empty(): after many reuses it is false; the
+       // predecessor is superseded before the successor opens
+        auto m = DoorbellMap{};
+        for(int i = 1; i <= 4; ++i)
+        {
+            auto o = m.open_window(0, qid(i), 5, static_cast<uint64_t>(i) * 100);
+            ASSERT_TRUE(o.w);
+            m.close_window(qid(i), static_cast<uint64_t>(i) * 100 + 50, 0);
+        }
+        auto o = m.open_window(0, qid(99), 5, 1000);
+        ASSERT_TRUE(o.w);
+        EXPECT_FALSE(o.w->first_owner) << "slot has had prior owners";
+    }
+    {  // page geometry: capture and reader agree on the fixed 4 KiB/1024 mask,
+       // now with no page_size parameter, on both 4 KiB and 64 KiB-page hosts
+        EXPECT_EQ(doorbell_off_to_page_slot(4100u), 4u);
+        EXPECT_EQ(doorbell_off_to_page_slot(4104u), 8u);
+        EXPECT_EQ(doorbell_ptr_to_page_slot(0x7f0000004010ull), 4u);
+        EXPECT_EQ(doorbell_ptr_to_page_slot(0x7f0000004020ull), 8u);
+        EXPECT_EQ(doorbell_off_to_page_slot(4100u), doorbell_ptr_to_page_slot(0x7f0000004010ull));
+        EXPECT_EQ(doorbell_ptr_to_page_slot(0x7f0000104010ull), 4u)
+            << "64 KiB-page offset still masks to the same 4 KiB slot";
+    }
+    {  // the process-wide disable latch makes resolve() and open_window()
+       // return nothing everywhere
+        auto m = DoorbellMap{};
+        m.open_window(0, qid(1), 5, 100);
+        ASSERT_TRUE(m.resolve(0, qid(1)).has_value());
+        signal_less_disable_latch().store(true);
+        EXPECT_FALSE(m.resolve(0, qid(1)).has_value()) << "disabled -> resolve refuses";
+        auto o = m.open_window(0, qid(2), 6, 100);
+        EXPECT_FALSE(o.w) << "disabled -> open_window opens nothing";
+        signal_less_disable_latch().store(false);  // reset for other tests
+    }
+}


### PR DESCRIPTION
Pure queue<->firmware-record identity: DoorbellMap + generation, correlation_key
(gpu-scoped) + hash + steady_now_ns, kfd_correlation singleton, and the
capture_doorbell_key free function (page-relative slot from the intercept
queue's doorbell signal). Unit-tested (data_structures, queue_controller); no
interceptor calls it yet.


---

## This PR (3/9) — doorbell identity

The queue-to-firmware-record identity used to correlate a KFD record back to the dispatch
that produced it. Pure data structures plus one free function; no interceptor calls it yet.

```mermaid
flowchart TD
    Q["intercept queue doorbell signal"] --> CAP["capture_doorbell_key:<br/>page-relative slot"]
    CAP --> KEY["correlation_key:<br/>gpu-scoped + hash + steady_now_ns"]
    KEY --> MAP["DoorbellMap + generation"]
    MAP --> SING["kfd_correlation singleton"]
    NOTE["unit-tested: data_structures, queue_controller<br/>(no interceptor calls it yet)"] -.-> CAP
```



---

JIRA ID: AIPROFSDK-1012
