### PR TITLE
feat(rocprofiler-sdk): poll scheduling helpers (pure) [4/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
@@ -12,7 +12,8 @@ set(ROCPROFILER_LIB_KFD_EVENT_HEADERS
     stream_geometry.hpp
     correlation_types.hpp
     doorbell_map.hpp
-    kfd_correlation.hpp)
+    kfd_correlation.hpp
+    poll_reader.hpp)
 
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_KFD_EVENT_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/poll_reader.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/poll_reader.hpp
@@ -1,0 +1,173 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+// Pure poll-scheduling logic, factored out of kfd_reader.cpp so it can be
+// unit-tested without a GPU, an mmap, the reader thread, or its singletons.
+// These are the decisions the reader makes around poll(): the timeout to use,
+// whether a session belongs in the active poll set, and the consecutive
+// zero-copy backstop that turns a sticky-EPOLLIN spin into a timeout-only wait.
+//
+// Readiness is the kernel's level-triggered .poll predicate alone: a stream fd
+// stays readable while wptr != rptr, so poll() re-triggers on its own. The SDK
+// keeps no second readiness authority.
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include <poll.h>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// poll() timeout when ROCPROFILER_KFD_DISPATCH_LOG_POLL_TIMEOUT_MS is unset. The
+// sparse-tail / lost-interrupt watchdog: on timeout the reader does a full scan.
+constexpr int kPollTimeoutMsDefault = 10;
+
+// Upper bound on drain passes per wake. Reaching it returns the reader to
+// poll(); the kernel's level trigger fires it again at once if wptr != rptr, so
+// a continuously advancing producer cannot livelock the reader in one wake.
+constexpr int kMaxDrainPassesPerWake = 8;
+
+// Consecutive wakes that reported readiness (poll returned before the timeout)
+// yet copied nothing, before the reader falls back to a timeout-only wait. This
+// is the spin backstop: if the kernel reports level EPOLLIN while the drain
+// copies nothing (an incoherent or reset-mismatched rptr the drain reconcile did
+// not resolve), the reader would otherwise free-run at 100% CPU. Past this count
+// it warns once and stops trusting the level trigger until a copy makes progress.
+constexpr int kMaxConsecutiveEmptyWakes = 64;
+
+// Parse the poll-timeout env value. Domain is [1, INT_MAX] ms; anything else
+// (empty, zero, negative, non-numeric, overflow) returns 0 to mean "use the
+// default" -- 0 would busy-poll and a negative would block poll() forever, so
+// both are rejected rather than passed to poll(). Bounded per digit so it can
+// never wrap.
+inline int
+poll_timeout_ms_from_str(std::string_view v)
+{
+    if(v.empty()) return 0;
+    uint64_t ms = 0;
+    for(char c : v)
+    {
+        if(c < '0' || c > '9') return 0;
+        ms = ms * 10 + static_cast<uint64_t>(c - '0');
+        if(ms > static_cast<uint64_t>(INT_MAX)) return 0;
+    }
+    if(ms == 0) return 0;
+    return static_cast<int>(ms);
+}
+
+// Whether a session belongs in the active poll set: it must be published (ready),
+// mapped, and not quarantined. A terminal (POLLHUP) stream is quarantined after
+// its final drain so a sticky HUP cannot spin poll().
+inline bool
+session_is_pollable(bool ready, bool quarantined, bool mapped)
+{
+    return ready && mapped && !quarantined;
+}
+
+// The poll-set attributes of one session, as build_pollfds() sees them. `has_fd`
+// is `stream_fd >= 0`; a session with no fd is skipped before the pollable check.
+struct poll_session_view
+{
+    bool has_fd      = false;
+    bool ready       = false;
+    bool quarantined = false;
+    bool mapped      = false;
+};
+
+// Fill `slot_of` with the session indices that belong in the active poll set, in
+// order. The caller places the control eventfd at pollfd[0] and one entry per
+// returned index at pollfd[k+1], so slot_of[k] maps pollfd k+1 back to its
+// session. This is the exact membership build_pollfds() uses; factored out so the
+// production decision (fd skip, then the pollable predicate) is unit-testable.
+template <typename SessionView, typename SlotOut>
+void
+build_poll_slots(const SessionView* sessions, size_t count, SlotOut& slot_of)
+{
+    for(size_t i = 0; i < count; ++i)
+    {
+        const auto& s = sessions[i];
+        if(!s.has_fd) continue;
+        if(!session_is_pollable(s.ready, s.quarantined, s.mapped)) continue;
+        slot_of.push_back(i);
+    }
+}
+
+// How the terminal handler must treat a stream's poll revents.
+enum class terminal_action
+{
+    none,       // no terminal/error bit set
+    keep_live,  // POLLERR only: a recoverable reset; log but keep the stream live
+    quarantine  // POLLHUP/POLLNVAL: terminal; drain, then quarantine when level-dry
+};
+
+// Classify a stream's revents for the terminal handler. POLLHUP/POLLNVAL are
+// terminal; POLLERR alone is a recoverable reset (the stream node survives). The
+// reader still defers an actual quarantine until the terminal stream is level-dry.
+inline terminal_action
+classify_terminal_revents(short revents)
+{
+    if((revents & (POLLHUP | POLLNVAL)) != 0) return terminal_action::quarantine;
+    if((revents & POLLERR) != 0) return terminal_action::keep_live;
+    return terminal_action::none;
+}
+
+// The control/wake eventfd occupies poll slot 0; the stream fds follow at 1..N.
+// build_pollfds() (the producer) and any_stream_pollin() / the terminal-revents
+// scan (the consumers) all depend on this layout, so the index lives here as the
+// single source of truth -- a caller that builds the array differently must change
+// this, not silently diverge from a comment.
+constexpr size_t kControlPollSlot     = 0;
+constexpr size_t kFirstStreamPollSlot = kControlPollSlot + 1;
+
+// Whether any STREAM pollfd reported POLLIN. Slot kControlPollSlot is the
+// control/wake eventfd; only a stream readable state should feed the empty-wake
+// backstop, since a control nudge that copies nothing is not a spin symptom.
+inline bool
+any_stream_pollin(const pollfd* fds, size_t count)
+{
+    for(size_t k = kFirstStreamPollSlot; k < count; ++k)
+        if((fds[k].revents & POLLIN) != 0) return true;
+    return false;
+}
+
+// Spin backstop for a sticky level trigger. `empty_wakes` is how many consecutive
+// pre-timeout wakes have copied nothing. Once it passes kMaxConsecutiveEmptyWakes
+// the reader must stop trusting the level trigger and wait on the timeout only,
+// so an incoherent rptr the drain reconcile could not resolve degrades to a
+// diagnosable warning rather than an un-killable 100% CPU hang.
+//
+// UNVALIDATED-pending-hardware: the drain reconcile (copy_pipes forcing rptr:=wptr
+// on a regression) should keep wptr and rptr coherent, but until that is validated
+// on hardware this backstop is what bounds a mismatch.
+inline bool
+empty_wake_backstop_tripped(int empty_wakes)
+{
+    return empty_wakes > kMaxConsecutiveEmptyWakes;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -86,3 +86,25 @@ rocprofiler_add_unit_test(
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+set(ROCPROFILER_LIB_KFD_POLL_READER_TEST_SOURCES poll_reader_test.cpp)
+
+add_executable(kfd-dlog-poll-reader)
+
+target_sources(kfd-dlog-poll-reader
+               PRIVATE ${ROCPROFILER_LIB_KFD_POLL_READER_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-poll-reader
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-poll-reader
+    SOURCES ${ROCPROFILER_LIB_KFD_POLL_READER_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/poll_reader_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/poll_reader_test.cpp
@@ -1,0 +1,181 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Unit tests for the dispatch-log reader poll-scheduling helpers: poll timeout,
+// poll-set membership, terminal-revents classification, and spin backstop.
+#include "lib/rocprofiler-sdk/kfd/poll_reader.hpp"
+
+#include <gtest/gtest.h>
+#include <poll.h>
+#include <climits>
+#include <string>
+#include <vector>
+
+namespace
+{
+using namespace rocprofiler::kfd;
+// A fully-ready, mapped, non-quarantined session with an fd.
+poll_session_view
+ready_view()
+{
+    return poll_session_view{true, true, false, true};
+}
+std::vector<size_t>
+poll_slots(const std::vector<poll_session_view>& s)
+{
+    std::vector<size_t> slots;
+    build_poll_slots(s.data(), s.size(), slots);
+    return slots;
+}
+}  // namespace
+
+// Only a plain decimal in [1, INT_MAX] parses; everything else returns 0.
+TEST(poll_timeout, parse)
+{
+    struct tc
+    {
+        const char* in;
+        int         want;
+        const char* label;
+    };
+    const tc rows[] = {{"1", 1, "one"},
+                       {"10", 10, "ten"},
+                       {"100", 100, "hundred"},
+                       {"2147483647", INT_MAX, "INT_MAX digits"},
+                       {"", 0, "empty"},
+                       {"0", 0, "zero"},
+                       {"00", 0, "00"},
+                       {"-1", 0, "neg 1"},
+                       {"-10", 0, "neg 10"},
+                       {"abc", 0, "non-numeric"},
+                       {" 10", 0, "leading space"},
+                       {"10 ", 0, "trailing space"},
+                       {"10ms", 0, "trailing junk"},
+                       {"+10", 0, "plus sign"},
+                       {"0x10", 0, "hex"},
+                       {"2147483648", 0, "INT_MAX+1"},
+                       {"4294967296", 0, "UINT32_MAX+1"},
+                       {"18446744073709551615", 0, "UINT64_MAX"},
+                       {"18446744073709551616", 0, "UINT64_MAX+1"}};
+    for(const auto& tc : rows)
+        EXPECT_EQ(poll_timeout_ms_from_str(tc.in), tc.want) << tc.label;
+    EXPECT_EQ(poll_timeout_ms_from_str(std::to_string(INT_MAX)), INT_MAX) << "INT_MAX to_string";
+    EXPECT_EQ(poll_timeout_ms_from_str(std::string(64, '9')), 0) << "64 nines";
+}
+// One entry per live, mapped, non-quarantined session with an fd; keeps orig index.
+TEST(poll_set, membership)
+{
+    auto not_ready = ready_view(), not_mapped = ready_view(), no_fd = ready_view();
+    not_ready.ready = false, not_mapped.mapped = false, no_fd.has_fd = false;
+    struct tc
+    {
+        std::vector<poll_session_view> sessions;
+        std::vector<size_t>            want;
+        const char*                    label;
+    };
+    const tc rows[] = {
+        {{}, {}, "zero sessions"},
+        {{ready_view()}, {0u}, "one ready"},
+        {{ready_view(), ready_view(), ready_view()}, {0u, 1u, 2u}, "multiple in order"},
+        {{not_ready, ready_view(), not_mapped, no_fd}, {1u}, "unready/unmapped/fdless excluded"}};
+    for(const auto& tc : rows)
+        EXPECT_EQ(poll_slots(tc.sessions), tc.want) << tc.label;
+}
+// A quarantined terminal (post-final-drain) drops out; survivor keeps its index.
+TEST(poll_set, quarantined_terminal_is_excluded)
+{
+    std::vector<poll_session_view> sessions = {ready_view(), ready_view()};
+    EXPECT_EQ(poll_slots(sessions).size(), 2u);
+
+    sessions[0].quarantined = true;
+    auto slots              = poll_slots(sessions);
+    ASSERT_EQ(slots.size(), 1u);
+    EXPECT_EQ(slots[0], 1u);
+}
+// HUP/NVAL terminal; ERR alone recoverable; POLLIN/0 neither; HUP wins over ERR.
+TEST(terminal_revents, classify)
+{
+    struct tc
+    {
+        short           revents;
+        terminal_action want;
+        const char*     label;
+    };
+    const tc rows[] = {
+        {POLLIN, terminal_action::none, "plain readable"},
+        {0, terminal_action::none, "no events"},
+        {POLLHUP, terminal_action::quarantine, "hup"},
+        {POLLNVAL, terminal_action::quarantine, "nval"},
+        {static_cast<short>(POLLIN | POLLHUP), terminal_action::quarantine, "in|hup final drain"},
+        {POLLERR, terminal_action::keep_live, "err alone"},
+        {static_cast<short>(POLLIN | POLLERR), terminal_action::keep_live, "in|err"},
+        {static_cast<short>(POLLERR | POLLHUP), terminal_action::quarantine, "hup wins over err"}};
+    for(const auto& tc : rows)
+        EXPECT_EQ(classify_terminal_revents(tc.revents), tc.want) << tc.label;
+}
+// The backstop trips only strictly past kMaxConsecutiveEmptyWakes.
+TEST(spin_backstop, threshold)
+{
+    struct tc
+    {
+        int         wakes;
+        bool        want;
+        const char* label;
+    };
+    const tc rows[] = {{0, false, "zero"},
+                       {1, false, "one"},
+                       {kMaxConsecutiveEmptyWakes, false, "at threshold"},
+                       {kMaxConsecutiveEmptyWakes + 1, true, "one past"},
+                       {kMaxConsecutiveEmptyWakes + 1000, true, "far past"}};
+    for(const auto& tc : rows)
+        EXPECT_EQ(empty_wake_backstop_tripped(tc.wakes), tc.want) << tc.label;
+}
+// Only a STREAM pollfd (slot >= 1) reporting POLLIN counts; the control fd at slot
+// 0 is ignored, so a bare control-eventfd nudge does not feed the spin backstop.
+TEST(stream_pollin, control_fd_ignored)
+{
+    // Control fd alone readable: not a stream readable state.
+    pollfd ctrl_only[] = {{.fd = 0, .events = POLLIN, .revents = POLLIN}};
+    EXPECT_FALSE(any_stream_pollin(ctrl_only, 1)) << "control fd only";
+
+    // Control readable, one stream not readable.
+    pollfd ctrl_and_idle[] = {{.fd = 0, .events = POLLIN, .revents = POLLIN},
+                              {.fd = 1, .events = POLLIN, .revents = 0}};
+    EXPECT_FALSE(any_stream_pollin(ctrl_and_idle, 2)) << "control readable, stream idle";
+
+    // One stream readable.
+    pollfd one_stream[] = {{.fd = 0, .events = POLLIN, .revents = 0},
+                           {.fd = 1, .events = POLLIN, .revents = POLLIN}};
+    EXPECT_TRUE(any_stream_pollin(one_stream, 2)) << "one stream readable";
+
+    // A later stream readable while an earlier one is idle.
+    pollfd second_stream[] = {{.fd = 0, .events = POLLIN, .revents = 0},
+                              {.fd = 1, .events = POLLIN, .revents = 0},
+                              {.fd = 2, .events = POLLIN, .revents = POLLIN}};
+    EXPECT_TRUE(any_stream_pollin(second_stream, 3)) << "second stream readable";
+
+    // Backstop-tripped shape: only the control fd is polled (count == 1), so even a
+    // stale stream revents cannot be seen.
+    pollfd backstop[] = {{.fd = 0, .events = POLLIN, .revents = POLLIN},
+                         {.fd = 1, .events = POLLIN, .revents = POLLIN}};
+    EXPECT_FALSE(any_stream_pollin(backstop, 1)) << "backstop polls control only";
+}


### PR DESCRIPTION
poll_reader.hpp decision logic (timeout parse, poll-set membership, terminal
revents, spin backstop) with the fix so only stream POLLIN wakes feed the
backstop (control-eventfd nudges do not) and a timeout scan resets it.
Unit-tested; no reader thread yet.


---

## This PR (4/9) — poll scheduling helpers

Pure decision logic for the reader's poll loop. Key correctness fix: only **stream POLLIN**
wakes feed the spin backstop; control-eventfd nudges do not, and a timeout scan resets it.
No reader thread yet.

```mermaid
flowchart TD
    subgraph PR["poll_reader.hpp (pure decision logic)"]
      SPIN["spin backstop"]
    end
    POLLIN["stream POLLIN wake"] -->|"feeds"| SPIN
    CTRL["control-eventfd nudge"] -.->|"does NOT feed"| SPIN
    TOUT["timeout scan"] -->|"resets"| SPIN
    HELP["timeout parse, poll-set membership,<br/>terminal revents"] -.-> SPIN
    NOTE["unit-tested; no reader thread yet"] -.-> SPIN
```



---

JIRA ID: AIPROFSDK-1012
