### PR TITLE
feat(rocprofiler-sdk): reader<->hub glue + teardown + interposition bridge [7/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -44,6 +44,10 @@
 #include "lib/rocprofiler-sdk/hsa/signal_pool.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/tracing.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
 
@@ -461,6 +465,178 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     }
 }
 
+// The no-signal finalizer. Runs on a task-group worker, or on the thread
+// flushing the retry owner -- never on the reader thread or under a hub lock.
+//
+// There is deliberately no HSA fallback: a signal-less dispatch never had an SDK
+// signal and the app may already have destroyed its own, so a convert/sanity
+// failure emits no record but still retires the correlation id.
+void
+complete_signal_less_dispatch(kfd::signal_less_hub_t::proven&& proven)
+{
+    auto&       _payload    = proven.payload;
+    const auto* _rocp_agent = agent::get_agent(_payload.agent_id);
+    auto        _hsa_agent  = agent::get_hsa_agent(_rocp_agent);
+
+    auto _convert = [&_hsa_agent](uint64_t ticks, uint64_t* out) {
+        if(!_hsa_agent) return false;
+        const auto* _ext = get_amd_ext_table();
+        if(!_ext || !_ext->hsa_amd_profiling_convert_tick_to_system_domain_fn) return false;
+        return _ext->hsa_amd_profiling_convert_tick_to_system_domain_fn(*_hsa_agent, ticks, out) ==
+               HSA_STATUS_SUCCESS;
+    };
+
+    auto _emit = [&_payload](uint64_t start_ns, uint64_t end_ns) {
+        kernel_dispatch::emit_kernel_dispatch_record(_payload.tracing_data,
+                                                     _payload.callback_record,
+                                                     _payload.correlation_id,
+                                                     _payload.tid,
+                                                     start_ns,
+                                                     end_ns);
+    };
+
+    // Retires exactly once whatever the outcome, and even if a client callback
+    // throws (run_complete_signal_less_dispatch arms this from a scope destructor).
+    auto _retire = [&_payload]() {
+        auto* _corr_id = _payload.correlation_id;
+        if(!_corr_id) return;
+        ROCP_FATAL_IF(_corr_id->get_ref_count() == 0)
+            << "reference counter for correlation id " << _corr_id->internal
+            << " has no reference count";
+        _corr_id->sub_kern_count();
+        _corr_id->sub_ref_count();
+    };
+
+    const uint64_t _now = common::timestamp_ns();
+
+    auto       _detail  = kfd::finalize_detail{};
+    const auto _outcome = kfd::run_complete_signal_less_dispatch(proven.start_ticks,
+                                                                 proven.end_ticks,
+                                                                 _payload.enqueue_ts,
+                                                                 _now,
+                                                                 _convert,
+                                                                 _emit,
+                                                                 _retire,
+                                                                 &_detail);
+
+    if(_outcome == kfd::finalize_outcome::result_ready)
+    {
+        kfd::note_signal_less(kfd::signal_less_counter::finalizer_emitted);
+        return;
+    }
+
+    kfd::note_signal_less(kfd::signal_less_counter::finalizer_no_timing);
+
+    // Rate-limited: the first few are the diagnostic, a steady stream must not
+    // flood the log.
+    static auto _warned = std::atomic<int>{0};
+    if(_warned.fetch_add(1, std::memory_order_relaxed) < 10)
+    {
+        ROCP_INFO << fmt::format(
+            "KFD dispatch-log: no timing for dispatch (reason={}, gpu={} slot={} idx={})",
+            kfd::finalize_reason_name(_detail.reason),
+            proven.key.gpu_id,
+            proven.key.doorbell_off,
+            proven.key.dispatch_idx_low32);
+    }
+}
+
+bool
+submit_to_task_group(kfd::signal_less_hub_t::proven& proven)
+{
+    auto* _tg = get_async_signal_handler();
+    if(!_tg || registration::get_fini_status() != 0) return false;
+
+    // task_group_t::async takes a std::function, which must be copy-constructible;
+    // the payload is move-only, so it travels in a shared_ptr.
+    auto _held = std::make_shared<kfd::signal_less_hub_t::proven>(std::move(proven));
+    _tg->async([_held]() { complete_signal_less_dispatch(std::move(*_held)); });
+    return true;
+}
+
+bool
+is_dispatch_packet(const rocprofiler_packet& pkt)
+{
+    auto _type = bit_extract(pkt.kernel_dispatch.header,
+                             HSA_PACKET_HEADER_TYPE,
+                             HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
+    if(_type == HSA_PACKET_TYPE_KERNEL_DISPATCH) return true;
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+    if(_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC)
+        return pkt.ext_kernel_dispatch.amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH;
+#endif
+    return false;
+}
+
+// Per-BATCH signal-less eligibility, decided ONCE before any packet is touched.
+// It must be final up front: a batch that has skipped its completion signals
+// cannot be moved back onto the signal path, so even "will the hub accept these
+// keys" is answered here. If ANY packet fails, the WHOLE batch keeps the signal
+// path.
+//
+// keys_out is indexed BY PACKET INDEX, so registration uses the exact keys the
+// hub validated here rather than re-deriving them from a second doorbell lookup
+// that could observe a different generation.
+bool
+signal_less_batch_eligible(Queue*                                            queue,
+                           const rocprofiler_packet*                         packets,
+                           uint64_t                                          num_packets,
+                           uint64_t                                          base_pkt_index,
+                           std::vector<std::optional<kfd::correlation_key>>* keys_out,
+                           kfd::window_ptr*                                  window_out)
+{
+    keys_out->clear();
+    if(window_out) *window_out = {};
+
+    // Cheapest gate first: with the feature off this is one relaxed load.
+    if(kfd::signal_less_child_stale()) return false;
+    if(!kfd::signal_less_feature_enabled()) return false;
+
+    const auto _gpu_id = queue->get_agent().get_rocp_agent()->gpu_id;
+    if(!kfd::ensure_reader_session(static_cast<uint32_t>(_gpu_id))) return false;
+    const auto _gpu = static_cast<uint32_t>(_gpu_id);
+
+    // Resolve the window open for this queue: rlock only, no clock, no bind.
+    // No window (SDMA, poisoned/overlapped slot, disabled) -> signal path.
+    auto _w = kfd::doorbell_map().resolve(_gpu, queue->get_id());
+    if(!_w) return false;
+    const uint32_t _slot = (*_w)->slot;
+
+    keys_out->assign(num_packets, std::nullopt);
+    auto _flat = std::vector<kfd::correlation_key>{};
+    for(uint64_t i = 0; i < num_packets; ++i)
+    {
+        if(!is_dispatch_packet(packets[i])) continue;
+        auto _key = kfd::correlation_key{
+            _slot, static_cast<uint32_t>((base_pkt_index + i) & 0xFFFFFFFFULL), _gpu};
+        (*keys_out)[i] = _key;
+        _flat.emplace_back(_key);
+    }
+    if(_flat.empty())
+    {
+        keys_out->clear();
+        return false;
+    }
+
+    // The admission latch replaces the deleted is_closing() hub call: a
+    // plain bool read while this thread already holds gate_lock, via the
+    // doorbell_tls handoff process_doorbell_impl set before calling the interceptor.
+    auto*      _st       = get_doorbell_tls().state;
+    const bool _eligible = kfd::owner_registry().slot_uniquely_owned(_gpu, _slot) &&
+                           kfd::signal_less_hub().can_register_batch(_flat) &&
+                           !(_st != nullptr && _st->admission_closed);
+
+    if(_eligible)
+    {
+        if(window_out) *window_out = *_w;
+    }
+    else
+    {
+        keys_out->clear();
+    }
+    return _eligible;
+}
+
 // Local kernel-dispatch tracing path: swaps in pooled completion signals,
 // runs KERNEL_DISPATCH_ENQUEUE tracer hooks, and prepares a completion-signal
 // waiter for the async signal handler pool. Strict 1:1 packet forwarding; does
@@ -470,7 +646,8 @@ write_interceptor(Queue*                                queue,
                   const void*                           packets,
                   uint64_t                              pkt_count,
                   hsa_amd_queue_intercept_packet_writer writer,
-                  async_signal_task_vector_t*           deferred_async_tasks)
+                  async_signal_task_vector_t*           deferred_async_tasks,
+                  uint64_t                              base_pkt_index)
 {
     using callback_record_t = packet_data_t::callback_record_t;
     using packet_vector_t   = common::container::small_vector<rocprofiler_packet, 512>;
@@ -568,6 +745,7 @@ write_interceptor(Queue*                                queue,
     auto process_packet_batch = [&queue, &corr_id, tracing_data_v, deferred_async_tasks](
                                     const rocprofiler_packet* _packets,
                                     uint64_t                  _num_packets,
+                                    uint64_t                  _base_pkt_index,
                                     const packet_writer_fn_t& _writer) {
         static constexpr auto null_signal = hsa_signal_t{.handle = 0};
 
@@ -584,6 +762,18 @@ write_interceptor(Queue*                                queue,
                                                   .enqueue_ts     = common::timestamp_ns(),
                                                   .correlation_id = corr_id,
                                                   .packet_data    = packet_data_array_t{}};
+
+        // Decided once for the whole batch, before any packet is modified. All
+        // packets in a batch share one queue, hence one owner_window.
+        auto            _signal_less_keys   = std::vector<std::optional<kfd::correlation_key>>{};
+        kfd::window_ptr _signal_less_window = {};
+        const bool      _signal_less_batch  = signal_less_batch_eligible(queue,
+                                                                   _packets,
+                                                                   _num_packets,
+                                                                   _base_pkt_index,
+                                                                   &_signal_less_keys,
+                                                                   &_signal_less_window);
+        auto            _signal_less_regs   = std::vector<kfd::signal_less_hub_t::registration>{};
 
         // Searching across all the packets given during this write
         for(size_t i = 0; i < _num_packets; ++i)
@@ -679,6 +869,7 @@ write_interceptor(Queue*                                queue,
             _packet_data.kernel_packet = _packets[i];
             // create a reference for short hand access
             auto& kernel_packet = _packet_data.kernel_packet;
+
 #if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
             auto& completion_signal =
                 is_ext_kernel_dispatch
@@ -702,14 +893,17 @@ write_interceptor(Queue*                                queue,
                 return nullptr;
             };
 
-            // No barrier packet: borrow a pooled signal if needed, then bump value by 1.
-            if(!existing_completion_signal)
-                _packet_data.pooled_signal = create_signal(&completion_signal);
+            if(!_signal_less_batch)
+            {
+                // No barrier packet: borrow a pooled signal if needed, then bump value by 1.
+                if(!existing_completion_signal)
+                    _packet_data.pooled_signal = create_signal(&completion_signal);
 
-            get_core_table()->hsa_signal_add_scacq_screl_fn(completion_signal, 1);
+                get_core_table()->hsa_signal_add_scacq_screl_fn(completion_signal, 1);
 
-            // set the completion signal to the kernel packet
-            _packet_data.completion_signal = completion_signal;
+                // set the completion signal to the kernel packet
+                _packet_data.completion_signal = completion_signal;
+            }
 
             // computes the "size" based on the offset of reserved_padding field
             constexpr auto kernel_dispatch_info_rt_size =
@@ -755,6 +949,26 @@ write_interceptor(Queue*                                queue,
                 thr_id,
                 ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH);
 
+            if(_signal_less_batch && _signal_less_keys[i].has_value())
+            {
+                auto _reg           = kfd::signal_less_hub_t::registration{};
+                _reg.key            = *_signal_less_keys[i];
+                _reg.correlation_id = internal_corr_id;
+                _reg.window         = _signal_less_window;
+
+                auto& _pl           = _reg.payload;
+                _pl.callback_record = _packet_data.callback_record;
+                _pl.tracing_data    = _packet_data.tracing_data;
+                // The reference this payload inherits was taken by the
+                // add_ref_count()/add_kern_count() above; the finalizer releases it.
+                _pl.correlation_id = corr_id;
+                _pl.tid            = thr_id;
+                _pl.agent_id       = queue->get_agent().get_rocp_agent()->id;
+                _pl.enqueue_ts     = _info_session.enqueue_ts;
+
+                _signal_less_regs.emplace_back(std::move(_reg));
+            }
+
             // Stores the instrumentation pkt (i.e. AQL packets for counter collection)
             // along with an ID of the client we got the packet from (this will be returned via
             // completed_cb_t)
@@ -782,7 +996,36 @@ write_interceptor(Queue*                                queue,
         auto current_signal_value   = hsa_signal_value_t{0};
         auto _shared_info_session   = std::shared_ptr<queue_info_session_t>{};
 
-        if(!_info_session.packet_data.empty())
+        // Register the whole batch BEFORE the writer publishes any packet, so a
+        // firmware record can never arrive for a dispatch the hub has not seen.
+        const auto _signal_less_count = _signal_less_regs.size();
+        if(_signal_less_batch &&
+           !kfd::signal_less_hub().register_batch(std::move(_signal_less_regs)))
+        {
+            // Reachable only if another queue's collision quarantined this slot between
+            // eligibility and here. The packets already skipped their signals, so nothing
+            // else will retire these ids.
+            kfd::note_signal_less(kfd::signal_less_counter::register_refused, _signal_less_count);
+            // Safe to iterate after the std::move above: register_batch() validates the
+            // whole batch under its lock and returns false BEFORE moving any element, so
+            // on this refusal path _signal_less_regs is intact.
+            for(auto& _reg : _signal_less_regs)
+            {
+                auto* _corr_id = _reg.payload.correlation_id;
+                if(_corr_id == nullptr) continue;
+                _corr_id->sub_kern_count();
+                _corr_id->sub_ref_count();
+            }
+            ROCP_WARNING << "KFD dispatch-log: signal-less batch registration refused; these "
+                            "dispatches will not be timed";
+        }
+        else if(_signal_less_batch)
+        {
+            kfd::note_signal_less(kfd::signal_less_counter::entry_registered, _signal_less_count);
+        }
+
+        // A signal-less batch has no completion signal to wait on.
+        if(!_info_session.packet_data.empty() && !_signal_less_batch)
         {
             last_completion_signal = _info_session.packet_data.back().completion_signal;
 
@@ -822,11 +1065,54 @@ write_interceptor(Queue*                                queue,
     ROCP_TRACE_IF(pkt_count > 1) << fmt::format(
         "[{}] Batching packets. Number of packets = {}", __FUNCTION__, pkt_count);
 
-    process_packet_batch(packets_arr, pkt_count, [&writer](packet_vector_t&& _packets) {
-        writer(_packets.data(), _packets.size());
-    });
+    process_packet_batch(
+        packets_arr, pkt_count, base_pkt_index, [&writer](packet_vector_t&& _packets) {
+            writer(_packets.data(), _packets.size());
+        });
 }
 }  // namespace
+
+uint64_t
+close_admission_and_snapshot(const hsa_queue_t* queue)
+{
+    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
+    if(!state) return 0;
+    auto lk                 = std::lock_guard<std::mutex>{state->gate_lock};
+    state->admission_closed = true;  // SW-2: no later batch can register
+    return state->next_submit_pos;   // snapshot, ordered by this same lock
+}
+
+bool
+wait_queue_hw_drained(const hsa_queue_t* queue, uint64_t submit_pos, uint64_t deadline_ns)
+{
+    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
+    if(!state || !state->real_rdid) return true;
+
+    while(!hw_queue_drained(__atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE), submit_pos))
+    {
+        if(kfd::steady_now_ns() >= deadline_ns) return false;
+        std::this_thread::sleep_for(std::chrono::microseconds{200});
+    }
+    return true;
+}
+
+void
+fence_all_queue_gates()
+{
+    // Copy the states out from under the registry lock FIRST: taking a queue's
+    // gate_lock while holding it would invert the established order.
+    auto _states = std::vector<queue_state_ptr_t>{};
+    get_queue_registry().rlock([&_states](const auto& map) {
+        _states.reserve(map.size());
+        for(const auto& itr : map)
+            if(itr.second) _states.emplace_back(itr.second);
+    });
+
+    for(const auto& _state : _states)
+    {
+        auto lk = std::lock_guard<std::mutex>{_state->gate_lock};
+    }
+}
 
 void
 process_doorbell_impl(const queue_state_ptr_t& state,
@@ -933,7 +1219,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
                           source_snapshot,
                           pkt_count,
                           ring_buffer_writer,
-                          &deferred_async_tasks);
+                          &deferred_async_tasks,
+                          start_submit_pos);
     }
     else
     {
@@ -1253,6 +1540,12 @@ interposition_init(CoreApiTable* core_table, bool enabled)
 
     // mark that intercept has been activated
     s_intercept_active.store(enabled, std::memory_order_release);
+
+    // Inline intercept is the only path that produces a KFD correlation key, so
+    // probe dispatch-log here (not in generic queue_init()). Master opt-in gate:
+    // the KFD dispatch-log feature does nothing unless signal-less is enabled.
+    // Best-effort.
+    if(kfd::signal_less_feature_enabled()) kfd::init_kfd_profiler();
 }
 
 void
@@ -1274,4 +1567,34 @@ interposition_fini()
 }
 }  // namespace queue_interposition
 }  // namespace hsa
+
+// Bridge for the KFD layer (declared in kfd/signal_less.hpp). Defined here so
+// kfd never needs the HSA interposition headers, and called directly -- both
+// sides are in the same object library.
+namespace kfd
+{
+bool
+submit_complete_signal_less_dispatch(signal_less_hub_t::proven& p)
+{
+    return hsa::queue_interposition::submit_to_task_group(p);
+}
+
+void
+finalize_complete_signal_less_dispatch(signal_less_hub_t::proven&& p)
+{
+    hsa::queue_interposition::complete_signal_less_dispatch(std::move(p));
+}
+
+void
+drain_signal_less_interceptor()
+{
+    hsa::queue_interposition::fence_all_queue_gates();
+}
+
+void
+join_signal_less_tasks()
+{
+    hsa::queue_interposition::interposition_sync();
+}
+}  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -69,6 +69,12 @@ struct QueueState
     const hsa_queue_t* hsa_queue       = nullptr;  ///< HSA queue pointer for Queue* lookup
     hsa_signal_t       doorbell_signal = {0};      ///< The queue's doorbell signal
     std::mutex         gate_lock       = {};       ///< Lock for packet submission gating
+
+    /// Signal-less admission latch (§1.5.4). Plain bool, guarded by gate_lock: set
+    /// by the destroy path's close_admission_and_snapshot() so no later batch can
+    /// register against this queue's window, read in signal_less_batch_eligible()
+    /// which already holds gate_lock. Never an atomic -- one lock orders both.
+    bool admission_closed = false;
 };
 
 using queue_state_ptr_t = std::shared_ptr<QueueState>;
@@ -211,6 +217,37 @@ create_queue_state(const hsa_queue_t* queue, bool overwrite = false);
  */
 void
 destroy_queue_state(const hsa_queue_t* queue);
+
+// The fence across EVERY live queue: teardown step 2 and the (a) fence of a
+// hub-aware sync. The caller must hold no hub, registry or gate lock.
+void
+fence_all_queue_gates();
+
+/// The hardware queue has consumed every packet we submitted. The inline path's
+/// analogue of `_active_kernels == 0`, which only the legacy path maintains.
+inline bool
+hw_queue_drained(uint64_t real_rdid, uint64_t next_submit_pos)
+{
+    return real_rdid >= next_submit_pos;
+}
+
+// Close signal-less admission and snapshot the submit position in ONE gate_lock
+// section (§1.5.4, Path-4 step 0): set admission_closed (SW-2, no later batch can
+// register against this queue's window) AND read next_submit_pos, ordered by the
+// same lock that serialises every publishing critical section. Returns that
+// snapshot P. No separate fence and no atomic are needed.
+uint64_t
+close_admission_and_snapshot(const hsa_queue_t* queue);
+
+/// Wait, bounded by an absolute kfd::steady_now_ns() deadline, until this queue's
+/// hardware read index has caught up with the sampled submit position `P`, so
+/// every packet in that snapshot -- hence every registered START -- has been
+/// consumed by the CP before the caller decides anything was lost (§1.3 Path 4).
+///
+/// False on deadline; true immediately with no state or when P is already drained.
+/// Takes no lock: P was snapshotted under gate_lock by close_admission_and_snapshot.
+bool
+wait_queue_hw_drained(const hsa_queue_t* queue, uint64_t submit_pos, uint64_t deadline_ns);
 
 /**
  * @brief Check if queue interposition has been installed

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
@@ -1,7 +1,8 @@
 #
 #
-set(ROCPROFILER_LIB_KFD_EVENT_SOURCES abi.cpp dlog_abi.cpp kfd.cpp doorbell_map.cpp
-                                      kfd_correlation.cpp kfd_profiler.cpp kfd_reader.cpp)
+set(ROCPROFILER_LIB_KFD_EVENT_SOURCES
+    abi.cpp dlog_abi.cpp kfd.cpp doorbell_map.cpp kfd_correlation.cpp kfd_profiler.cpp
+    kfd_reader.cpp signal_less.cpp)
 set(ROCPROFILER_LIB_KFD_EVENT_HEADERS
     defines.hpp
     kfd.hpp
@@ -18,7 +19,9 @@ set(ROCPROFILER_LIB_KFD_EVENT_HEADERS
     kfd_reader.hpp
     dispatch_hub.hpp
     owner_registry.hpp
-    complete_signal_less_dispatch.hpp)
+    complete_signal_less_dispatch.hpp
+    signal_less.hpp
+    signal_less_gate.hpp)
 
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_KFD_EVENT_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -33,6 +33,7 @@
 #include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
 #include "lib/rocprofiler-sdk/kfd/poll_reader.hpp"
 #include "lib/rocprofiler-sdk/kfd/record_pipe.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less.hpp"
 #include "lib/rocprofiler-sdk/kfd/stream_geometry.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 
@@ -543,18 +544,51 @@ session_has_pending(const dlog_session& s)
     return false;
 }
 
-// STAGE 2, processor thread: pairs start/eop. The hub handoff and the watermark
-// eviction are wired in at the reader-hub-glue layer; here it only drains the
-// pairing state so the reader/processor plumbing is exercisable in isolation.
+// STAGE 2, processor thread: pairs start/eop and drives the hub's time-as-
+// generation resolution. All the lock-taking work lives here, off
+// the ring-reading path. It runs no client callback itself; hand_off_proven()
+// submits to the task group. Exactly one hub lock per record, no map, no clock.
 uint64_t
 process_batch(processor_state& proc, const record_batch& batch)
 {
-    auto& _pairing = proc.for_gpu(batch.gpu_id);
-    return pair_records(batch.records.data(),
-                        batch.records.size(),
-                        _pairing,
-                        batch.now_ns,
-                        [](const drained_record&) {});
+    const uint32_t _gpu     = batch.gpu_id;
+    auto&          _pairing = proc.for_gpu(_gpu);
+
+    // evict stale retained STARTs BEFORE pairing, watermarked by THIS
+    // batch's own copy time (never the wall clock), throttled per GPU.
+    // Ordering it ahead of pairing keeps a START the watermark has condemned from
+    // binding this batch's recycled EOP first; watermarking by batch.now_ns means a
+    // backlogged processor ages nothing. starts_evicted is an R1 source counter.
+    if(batch.now_ns - _pairing.last_evict_ns >= kProcessorEvictIntervalNs)
+    {
+        _pairing.starts_evicted += _pairing.evict_stale(batch.now_ns, kStartMaxAgeNs);
+        _pairing.last_evict_ns = batch.now_ns;
+    }
+
+    return pair_records(
+        batch.records.data(),
+        batch.records.size(),
+        _pairing,
+        batch.now_ns,
+        [_gpu](const drained_record& rec) {
+            // Torn records were dropped at the top of pair_records, so
+            // every record here is trusted; no drain_loss_free gate remains.
+            // gpu_id stamped from the ring this record came from: a record can only
+            // ever match a dispatch enqueued on the same GPU. No generation.
+            auto key =
+                correlation_key{doorbell_off_to_page_slot(rec.doorbell_off), rec.dispatch_id, _gpu};
+            auto _start = rec.start_known ? std::optional<uint64_t>{rec.start_ticks} : std::nullopt;
+
+            // Signal-less: this EOP IS the completion event. The hub selects the
+            // entry whose window contains the START tick.
+            if(auto _proven = signal_less_hub().record_kernel_end(key, _start, rec.end_ticks))
+            {
+                note_signal_less(signal_less_counter::eop_proven);
+                hand_off_proven(std::move(*_proven));
+                return;
+            }
+            note_signal_less(signal_less_counter::eop_unmatched);
+        });
 }
 
 // Two distinct conditions, reported separately so a growing processor backlog is
@@ -678,6 +712,8 @@ disable_reader_in_child()
     // the DoorbellMap lock a vanished thread may have been holding.
     disable_kfd_dispatch_log();
 
+    signal_less_abandon_in_child();
+
     auto& st = state();
     st.any_session_ready.store(false, std::memory_order_relaxed);
     // Latch unavailable: setup_mu may have been held by a thread that did not
@@ -715,10 +751,23 @@ processor_loop()
     auto& st   = state();
     auto  proc = processor_state{};
 
+    uint64_t last_gc_ns = common::timestamp_ns();
+
     while(true)
     {
-        // The periodic closed-window GC tick is wired in at the reader-hub-glue
-        // layer (it needs the hub); here the processor only drains the pipe.
+        // GC closed-window entries on the periodic tick, ABOVE the
+        // pipe-empty continue -- an idle GPU (a queue destroyed after its work
+        // finished, the dominant case) never delivers another batch, so a GC placed
+        // after process_batch would never run and the close_grace_ns bound would be
+        // vacuous. Leaked payloads are ledgered; dropping them here is off the lock.
+        const uint64_t _gc_now = common::timestamp_ns();
+        if(_gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
+        {
+            last_gc_ns = _gc_now;
+            auto _gc   = signal_less_hub().gc_closed_windows(steady_now_ns());
+            if(_gc.second.dispatches > 0) note_signal_less_losses();
+        }
+
         auto* _batch = st.pipe.peek();
         if(!_batch)
         {
@@ -1076,14 +1125,16 @@ reader_loop()
         _ring_untrusted += st.sessions[i].cursors.untrusted_records;
     }
 
-    ROCP_WARNING_IF(_ring_overruns > 0 || _ring_lost > 0 || _ring_untrusted > 0) << fmt::format(
-        "KFD dispatch-log ring: {} lap(s), {} record(s) lost to laps, {} record(s) "
-        "untrusted (dropped), processor backlog peaked at {} batch(es) -- a lost or "
-        "untrusted record is a lost START, which shows up as a start-unknown no-timing",
-        _ring_overruns,
-        _ring_lost,
-        _ring_untrusted,
-        st.overflow_peak.load(std::memory_order_relaxed));
+    ROCP_WARNING_IF(signal_less_feature_enabled() &&
+                    (_ring_overruns > 0 || _ring_lost > 0 || _ring_untrusted > 0))
+        << fmt::format(
+               "KFD dispatch-log ring: {} lap(s), {} record(s) lost to laps, {} record(s) "
+               "untrusted (dropped), processor backlog peaked at {} batch(es) -- a lost or "
+               "untrusted record is a lost START, which shows up as a start-unknown no-timing",
+               _ring_overruns,
+               _ring_lost,
+               _ring_untrusted,
+               st.overflow_peak.load(std::memory_order_relaxed));
 }
 }  // namespace
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -1,0 +1,459 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/kfd/signal_less.hpp"
+
+#include "lib/common/environment.hpp"
+#include "lib/common/logging.hpp"
+#include "lib/common/static_object.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+
+#include <fmt/core.h>
+
+#include <pthread.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// Process-lifetime singleton. The signal-less feature attaches once per process
+// (init_kfd_profiler runs from the single interposition_init) and tears down at
+// finalize; it is never re-attached. The hub's m_* fields are therefore not reset
+// between attaches -- there is no second attach -- and after teardown the
+// process-wide disable latch keeps the hub inert. If the SDK ever grows a
+// re-attach path, this singleton and the OwnerRegistry/disable-latch it partners
+// with would need an explicit reset; today that is deliberately unsupported.
+signal_less_hub_t&
+signal_less_hub()
+{
+    static auto*& _v = common::static_object<signal_less_hub_t>::construct();
+    return *_v;
+}
+
+bool
+signal_less_feature_enabled()
+{
+    // Read once: the answer must not change under a running process, and the
+    // enqueue path cannot afford an env lookup per batch.
+    static const bool _enabled = []() {
+        if(!common::get_env("ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS", false)) return false;
+        // register the fork-child abandon handler HERE, where the feature
+        // is decided -- every path that creates signal-less state passes this gate
+        // first, so "state exists => a handler is registered" is a property of the
+        // gate, not of the reader lifecycle (which may never start). If
+        // pthread_atfork fails, the feature stays OFF: no state can then exist
+        // without a handler to abandon it in a child.
+        if(int _rc = pthread_atfork(nullptr, nullptr, signal_less_abandon_in_child); _rc != 0)
+        {
+            ROCP_WARNING << "KFD dispatch-log: pthread_atfork failed (" << _rc
+                         << "), signal-less kernel-dispatch completion stays DISABLED";
+            return false;
+        }
+        ROCP_WARNING << "KFD dispatch-log: signal-less kernel-dispatch completion is ACTIVE "
+                        "(ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS). Eligible batches publish "
+                        "their packets untouched and complete from firmware records instead of "
+                        "completion signals; ineligible batches keep the signal path. Unset the "
+                        "variable to return to signal-based completion.";
+        return true;
+    }();
+    return _enabled;
+}
+
+namespace
+{
+// Free-standing counters (constant-initialized, so no lazy-init behind them).
+std::atomic<uint64_t> g_counters[static_cast<size_t>(signal_less_counter::kCount)] = {};
+
+// Constant-initialized (no guard variable, no dynamic initialization), so the
+// atfork child handler can store to it with no lazy-init machinery behind it.
+std::atomic<bool> g_child_stale{false};
+
+// Completions the task group would not take. Only reachable once finalization
+// has begun, so this is drained once, by the teardown thread, after the reader
+// and processor are joined -- which is what keeps a client callback off them.
+struct deferred_completions
+{
+    std::mutex                             mu   = {};
+    std::vector<signal_less_hub_t::proven> held = {};
+};
+
+deferred_completions&
+deferred()
+{
+    static auto*& _v = common::static_object<deferred_completions>::construct();
+    return *_v;
+}
+
+// Guards the loss-ledger lookup so the correlation-id finalize path costs one
+// atomic load, and never constructs the hub, until something is actually leaked.
+std::atomic<bool>&
+any_leaked()
+{
+    static auto _v = std::atomic<bool>{false};
+    return _v;
+}
+
+OwnerRegistry&
+registry_storage()
+{
+    static auto*& _v = common::static_object<OwnerRegistry>::construct();
+    return *_v;
+}
+
+// submission gate. hand_off_proven and flush_deferred_completions take it
+// SHARED over their whole body; the fence's abandon path takes it EXCLUSIVE to
+// latch g_abandoned. The exclusive acquire waits out every in-flight submitter, so
+// none can submit or append to deferred() after the abandoner flushed and joined
+// -- the check-then-append window a bare atomic cannot close (TaskGroup::async
+// increments its task count AFTER the check). Constant-initialised, so no lazy
+// init hides behind them. Not on the per-record path.
+std::shared_mutex g_submit_gate;
+std::atomic<bool> g_abandoned{false};
+
+}  // namespace
+
+void
+note_signal_less(signal_less_counter which, uint64_t n)
+{
+    // Nothing is counted unless the feature is actually active, so the default
+    // path never touches these atomics.
+    if(!signal_less_feature_enabled()) return;
+    g_counters[static_cast<size_t>(which)].fetch_add(n, std::memory_order_relaxed);
+}
+
+signal_less_counter_array
+signal_less_stats()
+{
+    auto _s = signal_less_counter_array{};
+    for(size_t i = 0; i < _s.size(); ++i)
+        _s[i] = g_counters[i].load(std::memory_order_relaxed);
+    return _s;
+}
+
+const char*
+signal_less_counter_name(signal_less_counter which)
+{
+    switch(which)
+    {
+        case signal_less_counter::entry_registered: return "registered";
+        case signal_less_counter::eop_proven: return "eop-proven";
+        case signal_less_counter::eop_unmatched: return "eop-unmatched";
+        case signal_less_counter::finalizer_emitted: return "emitted";
+        case signal_less_counter::finalizer_no_timing: return "no-timing";
+        case signal_less_counter::register_refused: return "register-refused";
+        case signal_less_counter::kCount: break;
+    }
+    return "?";
+}
+
+bool
+signal_less_child_stale()
+{
+    return g_child_stale.load(std::memory_order_acquire);
+}
+
+void
+signal_less_abandon_in_child()
+{
+    // Async-signal-safe by construction: every statement is an atomic scalar store
+    // or a load of an already-initialized static pointer. Nothing locks,
+    // allocates, logs, joins or frees.
+    //
+    // static_object<T>::get() returns the pointer WITHOUT constructing it, so an
+    // object this process never created stays uncreated. These accessors must
+    // live in this TU: static_object's context type is per-TU, so get() from
+    // elsewhere would observe a different (null) instantiation.
+    g_child_stale.store(true, std::memory_order_release);
+
+    if(auto* _hub = common::static_object<signal_less_hub_t>::get()) _hub->abandon_in_child();
+    if(auto* _reg = common::static_object<OwnerRegistry>::get()) _reg->abandon_in_child();
+}
+
+void
+hand_off_proven(signal_less_hub_t::proven&& p)
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+
+    // the g_abandoned check, the submit, and the failed-submit deferred
+    // append are all inside ONE shared acquisition, so the abandoner's exclusive
+    // acquire cannot interleave. One read of g_abandoned: the latch is written only
+    // under the exclusive gate, so it cannot transition while this shared region is
+    // held.
+    auto _gate = std::shared_lock<std::shared_mutex>{g_submit_gate};
+    if(g_abandoned.load(std::memory_order_acquire))
+    {
+        // Abandoned mid-handoff: this record is dropped (no emit). record_kernel_end
+        // already erased the entry, so drain_for_teardown cannot ledger it -- do it
+        // here, and mark losses so correlation_id_finalize skips it instead of
+        // force-retiring it as a dangling id. Lock order: g_submit_gate (shared) then
+        // the hub's m_mu, the only place they nest and never the reverse.
+        signal_less_hub().ledger_abandoned(p.correlation_id);
+        note_signal_less_losses();
+        return;
+    }
+
+    if(submit_complete_signal_less_dispatch(p)) return;
+
+    // Deliberately NOT finalized here: this is the processor thread, which must
+    // never run a client callback.
+    auto& _d = deferred();
+    auto  lk = std::lock_guard<std::mutex>{_d.mu};
+    _d.held.emplace_back(std::move(p));
+}
+
+size_t
+flush_deferred_completions()
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return 0;
+
+    // finalize_complete_signal_less_dispatch touches the metadata being
+    // invalidated, so the whole body is inside the same shared gate the abandoner
+    // waits out before latching.
+    auto _gate = std::shared_lock<std::shared_mutex>{g_submit_gate};
+
+    auto _taken = std::vector<signal_less_hub_t::proven>{};
+    {
+        auto& _d = deferred();
+        auto  lk = std::lock_guard<std::mutex>{_d.mu};
+        _taken.swap(_d.held);
+    }
+    // Outside the deferred() lock (still under the shared gate): the finalizer runs
+    // client callbacks.
+    for(auto& _p : _taken)
+        finalize_complete_signal_less_dispatch(std::move(_p));
+    return _taken.size();
+}
+
+OwnerRegistry&
+owner_registry()
+{
+    return registry_storage();
+}
+
+void
+poison_slot(uint32_t gpu_id, uint32_t doorbell_slot)
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+    // Leak + permanently quarantine in one hub critical section. The returned
+    // payloads are released here, off the hub lock; releasing one runs no client
+    // code, so this is safe on the destroying / creating thread.
+    auto _stranded = signal_less_hub().quarantine_slot(gpu_id, doorbell_slot);
+    if(_stranded.empty()) return;
+    note_signal_less_losses();
+    ROCP_WARNING << fmt::format(
+        "KFD dispatch-log: doorbell slot {} poisoned (structural ambiguity or truncated close); {} "
+        "in-flight signal-less dispatch(es) emit no record and are signal-path-only for the rest "
+        "of the process.",
+        doorbell_slot,
+        _stranded.size());
+}
+
+void
+add_live_queue(uint64_t queue_token, uint32_t gpu_id, std::optional<uint32_t> doorbell_slot)
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+    auto _result = owner_registry().add_queue(queue_token, gpu_id, doorbell_slot);
+    if(_result != OwnerRegistry::add_result::collision) return;
+
+    // A second live owner means a firmware record on this slot can no longer be
+    // attributed to one queue: the registry's collision verdict converges on the
+    // same poison as the window-overlap verdict.
+    poison_slot(gpu_id, *doorbell_slot);
+}
+
+// Per-close ceiling on the hardware drain and, reused, the closed-window GC grace.
+// The aggregate 2 s pool is deleted (TEARDOWN-LATENCY); this is the only
+// close-path knob.
+uint64_t
+close_drain_budget_ns()
+{
+    static const uint64_t _v = []() {
+        auto _ms = common::get_env("ROCPROFILER_KFD_DISPATCH_LOG_CLOSE_DRAIN_MS", 250);
+        _ms      = std::max(_ms, 0);
+        return static_cast<uint64_t>(_ms) * 1'000'000ull;
+    }();
+    return _v;
+}
+
+void
+signal_less_disable_permanently()
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+    // Part 1: sticky process-wide latch, so resolve()/open_window() refuse
+    // everywhere and register_batch() rejects under m_mu.
+    signal_less_disable_latch().store(true, std::memory_order_release);
+    // Part 2: drain the hub while it is still LIVE -- drain_for_teardown() sets
+    // m_mode=stopping and leaks+ledgers every existing entry in one m_mu section.
+    // Deliberately NOT m_abandoned (the fork-child latch, which would no-op the
+    // drain and force-retire live ids). Part 3 (the register_batch latch check)
+    // closes the register-vs-drain race by the mutex chain.
+    auto _loss = signal_less_hub().drain_for_teardown();
+    if(_loss.second.dispatches == 0) return;
+    note_signal_less_losses();
+    ROCP_WARNING << fmt::format(
+        "KFD dispatch-log: signal-less disabled process-wide (a doorbell owner this process never "
+        "windowed exists); {} in-flight dispatch(es) across {} correlation id(s) drained and "
+        "ledgered.",
+        _loss.second.dispatches,
+        _loss.second.correlation_ids);
+}
+
+void
+remove_live_queue(uint64_t queue_token)
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+    owner_registry().remove_queue(queue_token);
+}
+
+void
+note_signal_less_losses()
+{
+    any_leaked().store(true, std::memory_order_release);
+}
+
+bool
+signal_less_id_is_leaked(uint64_t correlation_id)
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return false;
+    if(!any_leaked().load(std::memory_order_acquire)) return false;
+    return signal_less_hub().is_ledgered(correlation_id);
+}
+
+void
+signal_less_teardown()
+{
+    // A forked child abandoned everything and owns none of it: running the
+    // teardown there would join threads that do not exist.
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+
+    // With the feature off there is no hub work, no retry-owner work and no
+    // reader->task handoff, so the ordering constraint does not apply and the
+    // existing finalize path is left byte-for-byte as it was.
+    if(!signal_less_feature_enabled()) return;
+
+    // Strict order. Each step is what makes the next final:
+    //   1. stopping  -> eligibility fails, so no new PENDING is reserved
+    //   2. quiesce   -> fences in-flight registration/publication
+    //   3. join      -> only the reader creates PENDING->EOP_PROVEN, so after this
+    //                   nothing can be added to the retry owner
+    //   4. flush     -> therefore final; leftovers finalize in place on THIS thread
+    //   5. leak      -> whatever never got an EOP is ledgered, so finalize skips it
+    //   6. join tasks-> safe only now: no producer can submit another task
+    signal_less_hub().set_mode(session_mode::stopping);
+    drain_signal_less_interceptor();
+    // Safe only here: steps 1-2 closed the set of records the reader still has to
+    // drain, so this two-stage wait (drain_epoch then pipe.empty) covers a finite
+    // amount of work rather than a moving target. Bounded, and a no-op when the
+    // reader never started. On timeout teardown still proceeds: stop_kfd_reader()
+    // below is stronger than the fence's abandon, and drain_for_teardown() ledgers
+    // whatever is left.
+    wait_for_reader_quiesce();
+    stop_kfd_reader();
+    const size_t _flushed = flush_deferred_completions();
+
+    auto         _loss   = signal_less_hub().drain_for_teardown();
+    const size_t _leaked = _loss.second.dispatches;
+    if(_leaked > 0)
+    {
+        note_signal_less_losses();
+        ROCP_WARNING << fmt::format(
+            "KFD dispatch-log: {} signal-less dispatch(es) across {} correlation id(s) were still "
+            "in flight at finalization; they emit no record and their correlation ids are not "
+            "retired.",
+            _loss.second.dispatches,
+            _loss.second.correlation_ids);
+    }
+
+    join_signal_less_tasks();
+
+    // The only signal-less summary: the reader does not print one too.
+    const auto _c     = signal_less_stats();
+    auto       _chain = std::string{};
+    for(size_t i = 0; i < _c.size(); ++i)
+        _chain += fmt::format("{}{}={}",
+                              i == 0 ? "" : " ",
+                              signal_less_counter_name(static_cast<signal_less_counter>(i)),
+                              _c[i]);
+
+    ROCP_WARNING << fmt::format(
+        "KFD dispatch-log signal-less summary: {}; teardown finalized {} deferred and stranded {}",
+        _chain,
+        _flushed,
+        _leaked);
+}
+
+void
+signal_less_fence_completions()
+{
+    if(g_child_stale.load(std::memory_order_acquire)) return;
+    if(!signal_less_feature_enabled()) return;
+    // (a) no registration/publication is mid-flight.
+    drain_signal_less_interceptor();
+    // (b) the two-stage wait: every record present in the ring at this call has
+    // been copied+published (Stage 1) and popped+processed (Stage 2), so every
+    // completion whose firmware record had reached the ring is emitted or deferred.
+    const bool _quiesced = wait_for_reader_quiesce();
+    if(!_quiesced)
+    {
+        // abandon-on-timeout: latch g_abandoned under the EXCLUSIVE gate, which
+        // waits out every in-flight submitter, so none can submit or defer after
+        // this. A proven already in flight is dropped AND ledgered by hand_off_proven.
+        {
+            auto _g = std::unique_lock<std::shared_mutex>{g_submit_gate};
+            g_abandoned.store(true, std::memory_order_release);
+        }
+        // Set the process-wide disable latch BEFORE draining, so a batch that passed
+        // eligibility cannot register into the emptied hub afterward: register_batch
+        // checks this latch under m_mu, so a registration completed before the latch
+        // is swept by the drain and one that acquires m_mu after it is refused. This
+        // also stops resolve()/open_window(), matching "abandoned process-wide". Not
+        // m_mode and not m_abandoned -- see signal_less_disable_permanently().
+        signal_less_disable_latch().store(true, std::memory_order_release);
+        auto _loss = signal_less_hub().drain_for_teardown();
+        if(_loss.second.dispatches > 0) note_signal_less_losses();
+        ROCP_WARNING << fmt::format(
+            "KFD dispatch-log fence: reader did not quiesce within the budget; signal-less "
+            "abandoned process-wide, {} outstanding dispatch(es) across {} correlation id(s) "
+            "ledgered.",
+            _loss.second.dispatches,
+            _loss.second.correlation_ids);
+    }
+    // (c) nothing is left deferred waiting to be finalized, and (d) every submitted
+    // completion has finished executing -- both before returning, because closing
+    // the gate stops further submissions but not already-queued ones.
+    flush_deferred_completions();
+    join_signal_less_tasks();
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.hpp
@@ -1,0 +1,140 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/kfd/complete_signal_less_dispatch.hpp"
+#include "lib/rocprofiler-sdk/kfd/dispatch_hub.hpp"
+#include "lib/rocprofiler-sdk/kfd/owner_registry.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
+#include "lib/rocprofiler-sdk/tracing/fwd.hpp"
+
+#include <rocprofiler-sdk/callback_tracing.h>
+#include <rocprofiler-sdk/fwd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+// The owned payload the hub carries for each pending dispatch, plus the
+// process-wide hub instance. Flag and eligibility live in signal_less_gate.hpp.
+
+namespace rocprofiler
+{
+namespace context
+{
+struct correlation_id;
+}  // namespace context
+
+namespace kfd
+{
+// Held BY VALUE, with no raw `Queue&`, HSA signal handle or code-object pointer:
+// the queue is a stable token and the agent a rocprofiler id, so the payload
+// survives the queue being destroyed mid-flight. `correlation_id`'s reference
+// was taken at enqueue; releasing it is the finalizer's job.
+struct pending_payload
+{
+    using callback_record_t = rocprofiler_callback_tracing_kernel_dispatch_data_t;
+
+    callback_record_t        callback_record = {};
+    tracing::tracing_data    tracing_data    = {};
+    context::correlation_id* correlation_id  = nullptr;
+    rocprofiler_thread_id_t  tid             = 0;
+    rocprofiler_agent_id_t   agent_id        = {};
+    uint64_t                 enqueue_ts      = 0;
+};
+
+using signal_less_hub_t = DispatchHub<pending_payload>;
+
+// Process-wide hub. Backed by common::static_object for ordered teardown.
+signal_less_hub_t&
+signal_less_hub();
+
+// LOCK ORDERING: the registry lock is never held while the hub lock is taken,
+// or vice versa -- callers take one, release it, then take the other.
+OwnerRegistry&
+owner_registry();
+
+// Registers ownership; on discovering a second live owner it quarantines the
+// slot in the hub (leaking that slot's pending entries) AFTER releasing the
+// registry lock.
+void
+add_live_queue(uint64_t queue_token, uint32_t gpu_id, std::optional<uint32_t> doorbell_slot);
+
+void
+remove_live_queue(uint64_t queue_token);
+
+// Poison a (gpu, slot): leak+ledger its pending entries and refuse every future
+// registration on it, permanently. One tail for the four structural poisons --
+// window overlap, registry collision, truncated close, clock failure.
+// Must be called with NO hub/registry lock held.
+void
+poison_slot(uint32_t gpu_id, uint32_t doorbell_slot);
+
+// The process has a doorbell owner it never windowed (capture failure, or an
+// attach registration), so first_owner can no longer be trusted anywhere.
+// Latches signal-less off process-wide: sets the sticky disable latch
+// so resolve()/open_window() refuse everywhere, then drains and ledgers every
+// entry the hub already holds while it is still live. Must hold NO lock.
+void
+signal_less_disable_permanently();
+
+// The per-close hardware-drain budget (ROCPROFILER_KFD_DISPATCH_LOG_CLOSE_DRAIN_MS,
+// 250 ms). Doubles as the closed-window GC grace. The only close knob.
+uint64_t
+close_drain_budget_ns();
+
+// Bridge to the HSA interposition layer, defined in queue_interposition.cpp.
+// Everything in this file is linked into the same object library, so these are
+// direct calls rather than installed function pointers.
+
+// Hand a proven completion to the async task group. Moves out of `p` ONLY on
+// true; false means the task group is gone, which only happens once
+// finalization has begun.
+bool
+submit_complete_signal_less_dispatch(signal_less_hub_t::proven& p);
+
+// Run the finalizer on the CALLING thread. Only the deferred flush uses this,
+// and only from the teardown thread -- never the reader or processor.
+void
+finalize_complete_signal_less_dispatch(signal_less_hub_t::proven&& p);
+
+// Take and release every live queue's gate_lock. Caller holds no other lock.
+void
+drain_signal_less_interceptor();
+
+// Wait for every already-submitted completion to finish executing.
+void
+join_signal_less_tasks();
+
+// Processor-side handoff for a proven completion. Submits to the task group;
+// if it is gone, defers the entry for the teardown thread. Never runs a client
+// callback on the caller's thread.
+void
+hand_off_proven(signal_less_hub_t::proven&& p);
+
+// Finalize every deferred completion on the CALLING thread. Returns how many.
+size_t
+flush_deferred_completions();
+
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
@@ -1,0 +1,123 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+
+// Signal-less kernel-dispatch completion: the feature flag and the per-batch
+// eligibility decision. Deliberately free of the SDK tracing/HSA headers so the
+// decision table stays unit-testable; the payload and hub live in signal_less.hpp.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS, read once and cached. Defaults OFF,
+// so a typo or unrelated value can never activate the feature.
+bool
+signal_less_feature_enabled();
+
+// True if the loss policy deliberately leaked this id, in which case
+// correlation_id_finalize() must NOT force-retire it: its kernel may still be
+// running and its references were intentionally not dropped.
+bool
+signal_less_id_is_leaked(uint64_t correlation_id);
+
+// Record that the loss ledger is now non-empty. Called by the loss paths only.
+void
+note_signal_less_losses();
+
+// Steps 1-6 of the teardown order, called BEFORE the existing
+// queue_controller_fini / kfd::finalize / correlation_id_finalize sequence.
+// No-op unless signal-less is active.
+void
+signal_less_teardown();
+
+// The two-stage completion fence: on return, every kernel-dispatch
+// completion whose firmware record had reached the ring before this call has been
+// emitted or accounted, and no completion task is still executing. Does not stop
+// the reader; on timeout it abandons signal-less process-wide. Must be
+// called holding NO lock -- in particular not a queue gate_lock, which it
+// acquires, and not the hub lock.
+void
+signal_less_fence_completions();
+
+// Every stage of eligible-batch -> registered -> EOP proven -> handed off ->
+// finalized bumps a counter, so a break in the chain is visible without a
+// rebuild. Skipped entirely unless signal-less is active.
+enum class signal_less_counter
+{
+    entry_registered = 0,  // pending entries the hub accepted
+    eop_proven,            // firmware EOP claimed a pending entry
+    eop_unmatched,         // firmware EOP found no pending entry (key mismatch?)
+    finalizer_emitted,     // RESULT_READY: record emitted with KFD timestamps
+    finalizer_no_timing,   // COMPLETED_NO_TIMING: retired, no record
+    register_refused,      // hub refused a batch eligibility had accepted; id retired here
+    kCount
+};
+
+void
+note_signal_less(signal_less_counter which, uint64_t n = 1);
+
+// Snapshot indexed by signal_less_counter, so a new counter needs no mirror
+// struct and no copy loop -- add an enumerator and a name and it prints.
+using signal_less_counter_array =
+    std::array<uint64_t, static_cast<size_t>(signal_less_counter::kCount)>;
+
+signal_less_counter_array
+signal_less_stats();
+
+const char*
+signal_less_counter_name(signal_less_counter which);
+
+// pthread_atfork CHILD handler. RESTRICTED CONTEXT: only the forking thread
+// survives, so this does atomic scalar stores ONLY -- no mutex, allocation, map
+// access, logging or join. It never constructs a shared object, only abandons
+// ones that already exist, because construction would allocate.
+void
+signal_less_abandon_in_child();
+
+// True in a process that inherited signal-less state across a fork.
+bool
+signal_less_child_stale();
+
+// Per-SKU gate. Signal-less window creation is allowed ONLY on a SKU whose GPU
+// clock domain has been validated. On an unvalidated SKU the firmware<->KFD clock
+// offset is bounded but unscreened, so a record could be silently mis-windowed (a
+// wrong-dispatch outcome, not just coverage loss); such an agent takes the signal
+// path instead. Adding a SKU requires validating its clock domain first -- a
+// matching gfx_target_version is not sufficient evidence on its own.
+inline bool
+tclk_validated_sku(uint32_t gfx_target_version)
+{
+    switch(gfx_target_version)
+    {
+        case 90500: return true;  // gfx950 (MI350) -- validated
+        default: return false;    // every other SKU: validate, then add it here
+    }
+}
+
+}  // namespace kfd
+}  // namespace rocprofiler


### PR DESCRIPTION
signal_less.{hpp,cpp,gate.hpp} (payload, hub instance, deferred completions,
add/close live-queue, teardown/quiesce), the reader hooks restored
(process_batch drives the hub + hand_off_proven; atfork abandons), and the
queue_interposition BRIDGE/FENCE callees (submit/finalize/drain/join +
fence_queue_gate/fence_all_queue_gates/wait_queue_hw_drained). Still inert:
nothing registers a batch yet (no interceptor, no init caller). Builds + 56
kfd-dlog tests pass in-container.


---

## This PR (7/9) — reader ↔ hub glue + interposition bridge

Wires the reader to the hub and adds the queue-interposition bridge/fence callees, but
still inert: nothing registers a batch yet (no interceptor, no init caller). Builds and all
56 kfd-dlog tests pass in-container.

```mermaid
flowchart TD
    subgraph SL["signal_less.hpp / .cpp / gate.hpp"]
      PAY["payload + hub instance"]
      DEF["deferred completions"]
      LQ["add / close live-queue"]
      TEAR["teardown / quiesce"]
    end
    READER["reader process_batch"] -->|"drives"| HUB["DispatchHub"]
    HUB --> HANDOFF["hand_off_proven"]
    ATFORK["atfork abandons"] -.-> HUB
    subgraph BRIDGE["queue_interposition bridge / fence callees"]
      SUB["submit / finalize / drain / join"]
      FENCE["fence_queue_gate,<br/>fence_all_queue_gates,<br/>wait_queue_hw_drained"]
    end
    HANDOFF --> SUB
    NOTE["still inert: nothing registers a batch yet"] -.-> READER
```



---

JIRA ID: AIPROFSDK-1012
