### PR TITLE
feat(rocprofiler-sdk): enqueue-side signal-less interceptor + queue lifecycle [8/9]

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -27,12 +27,23 @@
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+#include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
 #include <hsa/amd_hsa_queue.h>
+#include <hsa/amd_hsa_signal.h>
+#include <hsa/hsa_ext_amd.h>
 
 #include <rocprofiler-sdk/fwd.h>
+#include <unistd.h>
 #include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
 
 namespace rocprofiler
 {
@@ -40,6 +51,40 @@ namespace hsa
 {
 namespace
 {
+// Read AGENT's own GPU-clock counter -- the same tick domain as fw_record::ts for
+// records emitted by AGENT. Called exactly twice per queue lifetime, never
+// per dispatch. Returns 0 on any failure or on an untrustworthy sentinel; the
+// caller then fails closed (poison / signal path). `core` is the saved core table
+// the controller already holds, so this needs no free-function table accessor.
+uint64_t
+gpu_tick_now(const CoreApiTable& core, hsa_agent_t agent)
+{
+// HSA_AMD_AGENT_INFO_CLOCK_COUNTERS / hsa_amd_clock_counters_t were added at HSA
+// AMD interface 1.11 (ROCm 7.0). Older installed headers (e.g. the 6.2/6.3/6.4
+// release-compatibility builds) don't declare them at all, so this whole path is
+// compiled out there; the caller's existing clock-failure handling (poison the
+// slot / take the signal path) is exactly the right degraded behavior when the
+// query itself can't be made.
+#if defined(HSA_AMD_INTERFACE_VERSION_MAJOR) &&                                                    \
+    (HSA_AMD_INTERFACE_VERSION_MAJOR > 1 ||                                                        \
+     (HSA_AMD_INTERFACE_VERSION_MAJOR == 1 && HSA_AMD_INTERFACE_VERSION_MINOR >= 11))
+    hsa_amd_clock_counters_t c{};
+    if(core.hsa_agent_get_info_fn == nullptr) return 0;
+    if(core.hsa_agent_get_info_fn(agent,
+                                  static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CLOCK_COUNTERS),
+                                  &c) != HSA_STATUS_SUCCESS)
+        return 0;
+    // Reject 0 and the kWindowOpen sentinel so no sentinel is ever stored as a
+    // real t_open/t_close and boundary reasoning never sees a wrapped tick.
+    if(c.gpu_clock_counter == 0 || c.gpu_clock_counter == kfd::kWindowOpen) return 0;
+    return c.gpu_clock_counter;
+#else
+    (void) core;
+    (void) agent;
+    return 0;
+#endif
+}
+
 // HSA Intercept Functions (create_queue/destroy_queue)
 hsa_status_t
 create_queue(hsa_agent_t        agent,
@@ -324,7 +369,11 @@ queue_controller_iterate_attach_queue(hsa_queue_t* queue, hsa_agent_t agent, voi
             qc->serializer(new_queue.get()).wlock([&](auto& serializer) {
                 serializer.add_queue(&queue, *new_queue);
             });
-            qc->add_queue(queue, std::move(new_queue));
+            // is_compute is an ASSUMPTION here (the attach callback carries no
+            // engine type); is_attach is a fact about this call site. Both
+            // written out. Attach opens no window and latches the process-wide
+            // disable, so its dispatches take the signal path.
+            qc->add_queue(queue, std::move(new_queue), /*is_compute=*/true, /*is_attach=*/true);
             registration_consumed = true;
             ROCP_INFO << "Adding queue from queue registration for HSA agent handle "
                       << agent.handle;
@@ -366,7 +415,8 @@ queue_controller_load_attach_queues()
 void
 QueueController::add_queue(hsa_queue_t*           id,
                            std::unique_ptr<Queue> queue,
-                           bool                   create_interposition_state)
+                           bool                   is_compute,
+                           bool                   is_attach)
 {
     CHECK(queue);
     const auto agent_id = queue->get_agent().get_rocp_agent()->id;
@@ -385,7 +435,73 @@ QueueController::add_queue(hsa_queue_t*           id,
         });
     });
 
-    if(create_interposition_state)
+    // signal-less live-queue bookkeeping and window open. Gated on
+    // is_compute -- only a compute queue's doorbell can source a CP dispatch-log
+    // record -- and on fork safety. Inert with the feature off. Every live
+    // compute queue registers ownership (a queue that predates the session or never
+    // dispatches still owns its slot); the clock is read once, before the map lock.
+    if(is_compute && kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
+    {
+        if(const auto* _q = get_queue(*id))
+        {
+            // T-CLK per-SKU gate (section 5.9): open owner windows only on a SKU whose
+            // clock domain passed the T-CLK Tier-1 screen. On any other SKU the
+            // firmware<->KFD clock offset is unscreened, so a record could be
+            // mis-windowed -- open no window (and do not register), so every dispatch
+            // there takes the signal path. Do NOT disable process-wide: another agent
+            // may be a validated SKU.
+            const auto* _rocp = _q->get_agent().get_rocp_agent();
+            if(kfd::tclk_validated_sku(_rocp->gfx_target_version))
+            {
+                const auto _gpu     = static_cast<uint32_t>(_rocp->gpu_id);
+                auto       _slot    = std::optional<uint32_t>{};
+                bool       _poison  = false;
+                bool       _disable = is_attach;  // an adopted queue's history is unseen
+                if(auto _db = capture_doorbell_key(_q->intercept_queue()))
+                {
+                    _slot = *_db;  // a live owner, always registered with its real slot
+                    if(!is_attach)
+                    {
+                        const uint64_t _tick =
+                            gpu_tick_now(get_core_table(), _q->get_agent().get_hsa_agent());
+                        if(_tick == 0)
+                            _poison = true;  // clock failure: slot-scoped poison
+                        else
+                            _poison = kfd::doorbell_map()
+                                          .open_window(_gpu, _q->get_id(), *_slot, _tick)
+                                          .overlapped;  // two live owners
+                    }
+                }
+                else
+                {
+                    _disable = true;  // capture failed: an unwindowed owner exists
+                }
+                kfd::add_live_queue(_q->get_id().handle, _gpu, _slot);
+                if(_poison && _slot) kfd::poison_slot(_gpu, *_slot);
+                if(_disable) kfd::signal_less_disable_permanently();
+            }
+            else
+            {
+                // Record the arch once per distinct SKU so an operator sees why
+                // signal-less is inactive on this GPU. Interposition still proceeds
+                // below, so signal-based tracing is unaffected.
+                static auto _warned_mu   = std::mutex{};
+                static auto _warned_arch = std::set<uint32_t>{};
+                auto        _lk          = std::lock_guard<std::mutex>{_warned_mu};
+                if(_warned_arch.insert(_rocp->gfx_target_version).second)
+                    ROCP_WARNING << fmt::format(
+                        "KFD dispatch-log: signal-less gated off on {} (gfx_target_version {}): "
+                        "not "
+                        "a T-CLK-validated SKU; its dispatches use the signal path (design 5.9).",
+                        _rocp->name != nullptr ? _rocp->name : "?",
+                        _rocp->gfx_target_version);
+            }
+        }
+    }
+
+    // Interposition-state creation wants the same answer as the signal-less gate:
+    // only a compute queue's AQL ring can be interposed.
+    if(is_compute)
     {
         queue_interposition::create_queue_state(id);
     }
@@ -400,6 +516,47 @@ QueueController::destroy_queue(hsa_queue_t* id)
 
     // return if queue does not exist
     if(!queue) return;
+
+    const auto _queue_token = queue->get_id().handle;
+
+    // close this queue's owner window. Inert with the feature off and
+    // gated for fork safety. Holds at most one of {gate, DoorbellMap, hub, registry}
+    // at any instant, so no lock cycle exists. Never blocks on the reader.
+    if(kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
+    {
+        // Step 0: latch admission AND snapshot next_submit_pos in ONE gate_lock
+        // section. The latch precedes the snapshot; both are ordered
+        // against every publishing critical section by that lock, so no separate
+        // fence is needed and every already-registered packet is <= P.
+        const uint64_t _P = queue_interposition::close_admission_and_snapshot(id);
+
+        // Step 0b: derive (gpu, slot) BEFORE step 6 destroys the mapping; skip the
+        // window work entirely when this queue never resolved a slot.
+        const auto _slot = kfd::owner_registry().slot_of(_queue_token);
+        const auto _gpu  = kfd::owner_registry().gpu_of(_queue_token);
+        if(_slot && _gpu)
+        {
+            // Step 2: HW drain against the snapshot P, unconditionally -- this
+            // queue's UNREGISTERED dispatches also produce firmware records that an
+            // unanchored t_close could misattribute. Bounded by the
+            // per-close budget; the aggregate pool is deleted.
+            const uint64_t _deadline = kfd::steady_now_ns() + kfd::close_drain_budget_ns();
+            const bool     _drained = queue_interposition::wait_queue_hw_drained(id, _P, _deadline);
+            // Step 3: read t_close AFTER the drain, before any lock, from this
+            // queue's agent.
+            const uint64_t _tick =
+                gpu_tick_now(get_core_table(), queue->get_agent().get_hsa_agent());
+            // Step 4: a truncated close or a clock failure leaves t_close unable to
+            // bound anything, so poison the slot.
+            if(!_drained || _tick == 0) kfd::poison_slot(*_gpu, *_slot);
+            // Step 5: stamp t_close and the GC deadline (nullptr if no window).
+            kfd::doorbell_map().close_window(
+                queue->get_id(), _tick, kfd::steady_now_ns() + kfd::close_drain_budget_ns());
+        }
+
+        // Step 6: drop ownership so a surviving co-owner becomes injective again.
+        kfd::remove_live_queue(_queue_token);
+    }
 
     queue_interposition::destroy_queue_state(id);
     queue->sync();
@@ -752,6 +909,33 @@ queue_controller_init(RocAttachDispatchTable* attach_table)
     *(get_attach_table()) = attach_table;
 
     if(enable_queue_intercept()) queue_init();
+}
+
+std::optional<uint32_t>
+capture_doorbell_key(const hsa_queue_t* intercept_queue)
+{
+    // Extract the queue's hardware doorbell pointer from its intercept queue's
+    // doorbell signal (HSA-internal amd_signal_t layout; same pattern as
+    // hsa/async_copy.cpp). nullopt if unavailable -> caller falls back to HSA.
+    uint64_t hwptr = 0;
+    if(intercept_queue != nullptr && intercept_queue->doorbell_signal.handle != 0)
+    {
+        // hsa_signal_t::handle IS the address of the amd_signal_t in the AMD HSA
+        // ABI, so the int-to-ptr conversion is the only way to reach it; same
+        // construct as queue_interposition.cpp's lookup_queue_state_by_doorbell.
+        const uint64_t _h = intercept_queue->doorbell_signal.handle;
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        const auto* sig = reinterpret_cast<const amd_signal_t*>(_h);
+        // hardware_doorbell_ptr aliases other union members for non-doorbell kinds.
+        if(sig->kind == AMD_SIGNAL_KIND_DOORBELL || sig->kind == AMD_SIGNAL_KIND_LEGACY_DOORBELL)
+            hwptr = reinterpret_cast<uint64_t>(sig->hardware_doorbell_ptr);
+    }
+    if(hwptr == 0) return std::nullopt;
+
+    // Page-relative doorbell slot; must match what the reader derives from each
+    // firmware record (kfd::doorbell_off_to_page_slot). The 4 KiB / 1024-dword
+    // mask is baked in -- no sysconf, no bind (open_window binds now).
+    return kfd::doorbell_ptr_to_page_slot(hwptr);
 }
 
 }  // namespace hsa

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -24,6 +24,7 @@
 
 #include "lib/rocprofiler-sdk/hsa/profile_serializer.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
 
 #include "lib/rocprofiler-sdk-attach/table.h"
 
@@ -60,11 +61,18 @@ public:
     // HSA has been inited.
     void init(CoreApiTable& core_table, AmdExtTable& ext_table);
 
-    // Called to add a queue that was created by the user program.
-    // When |create_interposition_state| is false, the queue is registered in the queue map and
-    // serializer but no inline QueueState is created.  Use this for non-compute queues (e.g. SDMA)
-    // whose packet format and queue-size semantics are incompatible with AQL interposition.
-    void add_queue(hsa_queue_t*, std::unique_ptr<Queue>, bool create_interposition_state = true);
+    // Called to add a queue that was created by the user program. |is_compute|
+    // gates BOTH inline QueueState creation and the signal-less ownership/window
+    // bookkeeping: only a compute queue's doorbell can source a CP dispatch-log
+    // record (§3.9), and a non-compute (e.g. SDMA) queue's packet format is
+    // incompatible with AQL interposition. |is_attach| marks a queue adopted
+    // mid-life via the attach API: its earlier slot history went unseen, so it
+    // opens no window and latches the process-wide signal-less disable (§0.4,
+    // §3.9). Every call site passes both explicitly.
+    void add_queue(hsa_queue_t*,
+                   std::unique_ptr<Queue>,
+                   bool is_compute = true,
+                   bool is_attach  = false);
     void destroy_queue(hsa_queue_t*);
 
     // Add callback to queues associated with the agent. Returns a client
@@ -149,5 +157,12 @@ queue_controller_init(RocAttachDispatchTable* table);
 
 void
 profiler_serializer_kernel_completion_signal(hsa_signal_t queue_block_signal);
+
+// Resolve a queue's page-relative doorbell slot from its intercept queue's
+// hardware doorbell pointer (§3.2, pure derivation -- no bind, no GPU/queue id).
+// Capture and the reader MUST compute the identical slot for correlation to work.
+// nullopt when the queue's doorbell signal is missing or is not a doorbell kind.
+std::optional<uint32_t>
+capture_doorbell_key(const hsa_queue_t* intercept_queue);
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
@@ -23,6 +23,7 @@
 #include "lib/rocprofiler-sdk/kfd/correlation_types.hpp"
 #include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
 #include <gtest/gtest.h>
 
@@ -129,4 +130,15 @@ TEST(DoorbellMap, window_open_resolve_close_and_slot_helpers)
         EXPECT_FALSE(o.w) << "disabled -> open_window opens nothing";
         signal_less_disable_latch().store(false);  // reset for other tests
     }
+}
+
+// The T-CLK per-SKU allowlist (section 5.9): gfx950 is discharged; every other SKU
+// is gated off until its own T-CLK Tier-1 screen passes. gfx12 is deliberately off.
+TEST(TclkGate, only_gfx950_is_validated)
+{
+    EXPECT_TRUE(tclk_validated_sku(90500)) << "gfx950 (MI350) discharged, section 5.9(e)";
+    EXPECT_FALSE(tclk_validated_sku(90400)) << "gfx942 not screened";
+    EXPECT_FALSE(tclk_validated_sku(120000)) << "gfx12.0.0 pending its own T-CLK run";
+    EXPECT_FALSE(tclk_validated_sku(120001)) << "gfx12.0.1 pending its own T-CLK run";
+    EXPECT_FALSE(tclk_validated_sku(0)) << "unknown SKU gated off";
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(rocprofiler_lib_sources
     hsa.cpp
     late_start.cpp
     naming.cpp
+    queue_controller.cpp
     queue_interposition.cpp
     timestamp.cpp
     version.cpp

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/queue_controller.cpp
@@ -1,0 +1,70 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include <gtest/gtest.h>
+#include <hsa/amd_hsa_signal.h>
+#include <hsa/hsa.h>
+#include <unistd.h>
+#include <cstdint>
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+namespace rocprofiler
+{
+namespace hsa
+{
+// DOORBELL kind decodes hardware_doorbell_ptr's page slot (§3.2, pure derivation --
+// no bind, no page_size); USER kind (.value aliases it), null signal, and no queue
+// all reject.
+TEST(queue_controller, capture_doorbell_key)
+{
+    volatile uint64_t doorbell   = 0;
+    auto              user_sig   = amd_signal_t{};
+    user_sig.kind                = AMD_SIGNAL_KIND_USER;
+    user_sig.value               = 0x7f0000004010;
+    auto db_sig                  = amd_signal_t{};
+    db_sig.kind                  = AMD_SIGNAL_KIND_DOORBELL;
+    db_sig.hardware_doorbell_ptr = &doorbell;
+    const uint32_t want_slot =
+        kfd::doorbell_ptr_to_page_slot(reinterpret_cast<uint64_t>(&doorbell));
+    // has_queue=false models "no intercept queue"; sig=nullptr models a null doorbell signal.
+    struct tc
+    {
+        const amd_signal_t* sig;
+        bool                has_queue;
+        bool                accept;
+        const char*         label;
+    };
+    const tc rows[] = {{&user_sig, true, false, "non-doorbell (USER) kind rejected"},
+                       {&db_sig, true, true, "doorbell kind accepted"},
+                       {nullptr, false, false, "no intercept queue"},
+                       {nullptr, true, false, "null doorbell signal"}};
+    for(const auto& tc : rows)
+    {
+        auto q            = hsa_queue_t{};
+        q.doorbell_signal = hsa_signal_t{.handle = reinterpret_cast<uint64_t>(tc.sig)};
+        auto e            = capture_doorbell_key(tc.has_queue ? &q : nullptr);
+        EXPECT_EQ(e.has_value(), tc.accept) << tc.label;
+        if(!tc.accept || !e.has_value()) continue;
+        EXPECT_EQ(*e, want_slot) << tc.label;
+    }
+}
+}  // namespace hsa
+}  // namespace rocprofiler


### PR DESCRIPTION
The only packet-touching layer: signal_less_batch_eligible/is_dispatch_packet,
write_interceptor batch decision (skip completion signal, register-before-
publish, refusal path), process_doorbell_impl base_pkt_index, and
QueueController add_queue/destroy_queue signal-less hooks gated on
signal_less_feature_enabled() (flag-off byte-identical). Orphans A
(async-grace) and B (lazy-profiling) are deliberately excluded -- parked on
branches above PR 9. Still inert until PR 9 wires init_kfd_profiler.


---

## This PR (8/9) — enqueue-side interceptor + queue lifecycle

The only packet-touching layer. Decides batch eligibility, skips the completion signal for
eligible signal-less batches (register-before-publish, with a refusal fallback), and gates
the queue-lifecycle hooks on the feature flag (flag-off byte-identical). Orphans A
(async-grace) and B (lazy-profiling) are deliberately excluded and parked above PR 9. Still
inert until PR 9 wires `init_kfd_profiler`.

```mermaid
flowchart TD
    PKT["HSA packets"] --> ELIG{"signal_less_batch_eligible<br/>+ is_dispatch_packet"}
    ELIG -->|"eligible"| DEC["write_interceptor batch decision:<br/>skip completion signal,<br/>register-before-publish"]
    ELIG -->|"not eligible"| SIG["normal signal path"]
    DEC -->|"refusal path"| SIG
    DEC --> DB["process_doorbell_impl:<br/>base_pkt_index"]
    subgraph LC["QueueController lifecycle (gated)"]
      ADD["add_queue"]
      DES["destroy_queue"]
    end
    GATE{{"signal_less_feature_enabled<br/>(flag-off byte-identical)"}} -.-> ADD
    GATE -.-> DES
    NOTE["orphans A/B excluded; inert until PR9"] -.-> DEC
```



---

JIRA ID: AIPROFSDK-1012
