### PR TITLE
fix(rocprofiler-sdk): serialize code_object::finalize() with the destroy mutex

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
@@ -1439,6 +1439,11 @@ get_kernel_id(uint64_t kernel_object)
 void
 finalize()
 {
+    // Same mutex executable_destroy_internal() holds across shutdown(), so a runtime-thread
+    // destroy cannot run the unload callbacks concurrently with finalization. is_shutdown is
+    // both tested and set under the lock, so a destroy arriving afterwards observes it.
+    auto _lk = std::unique_lock{get_destroy_mutex()};
+
     if(is_shutdown.load(std::memory_order_acquire) || !get_executables() || !get_code_objects())
         return;
 


### PR DESCRIPTION
executable_destroy_internal() has held get_destroy_mutex() across shutdown()
since ed42157c31, but finalize() called the same shutdown() without it, so the
finalize-vs-destroy pair was never serialized and is_shutdown was tested and
set outside the lock. A destroy could therefore pass the is_shutdown check and
enter shutdown() while registration::finalize() ran ahead into
correlation_id_finalize() and the client finalizers, leaving shutdown() to walk
contexts and callback tracers that had already been destroyed.

Taking the same mutex in finalize() closes this: an in-flight destroy completes
before finalization starts, and one arriving afterwards blocks, observes
is_shutdown, and returns without touching anything.

Observed on gfx1201 with four concurrent json-tool processes, where the KFD
dispatch-log adds a 100 ms drain-barrier wait inside shutdown() that widens the
window enough to make the pre-existing race dominant. Crashing runs fault in
shutdown() on the HSA AsyncEventsLoop thread while the main thread is in
tool_fini/write_json; record accounting stays exact, so the failure is purely
teardown ordering. 24/48 defect workers aborted before the change and 0/208
after, across 12- and 40-iteration batches, with control arms clean and the
kfd-dlog (55) and code-object (17) ctest sets passing.

The residual drain-barrier timeout warning is a separate defect and is left
alone here: wait_for_reader_drain_barrier() checks reader liveness only on
entry, so a reader stopped by signal_less_teardown() mid-wait freezes
drain_epoch and guarantees the full timeout.

JIRA ID: AIPROFSDK-1028


---

## This PR (10) — serialize code_object finalize vs destroy

`executable_destroy_internal()` already holds `get_destroy_mutex()` across `shutdown()`, but
`finalize()` called the same `shutdown()` without it, so `is_shutdown` was tested/set outside
the lock. This PR takes the same mutex in `finalize()` so the finalize-vs-destroy pair is
serialized. Surfaced by the KFD dispatch-log drain barrier widening the window on gfx1201.

```mermaid
flowchart TD
    subgraph BEFORE["Before: unserialized (race)"]
      F1["registration::finalize()"] --> S1["code_object::finalize()<br/>calls shutdown() with NO lock"]
      D1["executable_destroy_internal()<br/>holds get_destroy_mutex(), calls shutdown()"]
      S1 -.->|"is_shutdown tested/set outside lock"| RACE["both enter shutdown();<br/>destroy walks already-freed<br/>contexts / tracers -> crash"]
      D1 -.-> RACE
    end
    subgraph AFTER["After: serialized (this PR)"]
      F2["code_object::finalize()"] --> L["take get_destroy_mutex()"]
      L --> CHK{"is_shutdown ?"}
      CHK -->|"in-flight destroy finished first"| SAFE["shutdown() once, safely"]
      CHK -->|"destroy arrives after"| NOOP["observes is_shutdown,<br/>returns without touching state"]
    end
```
