### PR TITLE
feat(rccl): cover grouped suspend/resume for single-process multi-GPU

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -36,6 +36,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Added Pythonic API bindings under `bindings/nccl4py/` (RCCL fork of NVIDIA `nccl4py` v0.2.0). Provides Python access to RCCL collectives via Cython bindings, an on-disk `cuda.core` HIP shim for ROCm hosts without `cuda-bindings` / `cuda-core`, and RCCL-only collective wrappers (`ncclAllReduceWithBias`, `ncclAllToAllv`).
 * Added RCCL examples to the repository.
 * Added `RCCL host API` pull-in from NCCL 2.30.
+* Added communicator suspend and resume (`ncclCommSuspend`, `ncclCommResume`, `ncclCommMemStats`), which releases the dynamic GPU memory of an idle communicator and reacquires it later without destroying the communicator.
 
 ### Changed
 * Enabled WarpSpeed auto mode for grow communicators.

--- a/projects/rccl/docs/how-to/rccl-usage-tips.rst
+++ b/projects/rccl/docs/how-to/rccl-usage-tips.rst
@@ -537,3 +537,19 @@ To suspend or resume several communicators together, wrap the calls in
    NCCLCHECK(ncclCommSuspend(commB, NCCL_SUSPEND_MEM));
    NCCLCHECK(ncclGroupEnd());
 
+   // ... later, the matching resume ...
+
+   NCCLCHECK(ncclGroupStart());
+   NCCLCHECK(ncclCommResume(commA));
+   NCCLCHECK(ncclCommResume(commB));
+   NCCLCHECK(ncclGroupEnd());
+
+.. note::
+
+   The grouped form is required when a single process owns one communicator per
+   GPU, as created by ``ncclCommInitAll``. Every ``ncclCommSuspend`` and
+   ``ncclCommResume`` call is collective over all ranks of its communicator, and
+   here those ranks are the other communicators owned by the same thread, so an
+   ungrouped call blocks waiting for ranks that the thread only reaches after
+   that call returns.
+

--- a/projects/rccl/docs/how-to/rccl-usage-tips.rst
+++ b/projects/rccl/docs/how-to/rccl-usage-tips.rst
@@ -546,10 +546,7 @@ To suspend or resume several communicators together, wrap the calls in
 
 .. note::
 
-   The grouped form is required when a single process owns one communicator per
-   GPU, as created by ``ncclCommInitAll``. Every ``ncclCommSuspend`` and
-   ``ncclCommResume`` call is collective over all ranks of its communicator, and
-   here those ranks are the other communicators owned by the same thread, so an
-   ungrouped call blocks waiting for ranks that the thread only reaches after
-   that call returns.
+   When a single process owns one communicator per device through
+   ``ncclCommInitAll``, ``ncclCommSuspend`` and ``ncclCommResume`` need to be
+   wrapped around a group API.
 

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -318,20 +318,6 @@ ncclResult_t ncclCommGroupRegisterSymmetric(struct ncclAsyncJob* job_) {
     free(task);
   }
 
-  while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
-    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->suspendTaskQueue);
-    struct ncclComm* taskComm = task->comm;
-    free(task);
-    NCCLCHECKGOTO(ncclCommMemSuspend(taskComm), ret, fail);
-  }
-
-  while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
-    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->resumeTaskQueue);
-    struct ncclComm* taskComm = task->comm;
-    free(task);
-    NCCLCHECKGOTO(ncclCommMemResume(taskComm), ret, fail);
-  }
-
   while (!ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* task = ncclIntruQueueDequeue(&comm->rmaCeInitTaskQueue);
     NCCLCHECKGOTO(ncclRmaCeInit(task->comm), ret, fail);

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -1026,6 +1026,7 @@ ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
   }
 
   ncclResult_t ret = ncclSuccess;
+  ncclResult_t groupRet = ncclSuccess;
   int saveDev;
   CUDACHECK(cudaGetDevice(&saveDev));
   NCCLCHECK(ncclGroupStartInternal());
@@ -1059,10 +1060,15 @@ ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
   }
 
 exit:
+  // RCCL: the current device was switched to comm->cudaDev above and is switched
+  // back at the end of this block. Do not return in between: a rejected call comes
+  // back out of ncclGroupEndInternal and would skip the switch back.
   ncclGroupErrCheck(ret);
-  NCCLCHECK(ncclGroupEndInternal());
-  if (comm && !comm->config.blocking) {
-    NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
+  groupRet = ncclGroupEndInternal();
+  if (ret == ncclSuccess) ret = groupRet;
+  if (ret == ncclSuccess && comm && !comm->config.blocking) {
+    const ncclResult_t asyncRet = ncclCommGetAsyncError(comm, &ret);
+    if (asyncRet != ncclSuccess) ret = asyncRet;
   }
   CUDACHECK(cudaSetDevice(saveDev));
   return ret;
@@ -1077,6 +1083,7 @@ ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   ncclResult_t ret = ncclSuccess;
+  ncclResult_t groupRet = ncclSuccess;
   int saveDev;
   CUDACHECK(cudaGetDevice(&saveDev));
   NCCLCHECK(ncclGroupStartInternal());
@@ -1108,10 +1115,15 @@ ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
   ncclGroupCommJoin(comm, ncclGroupTaskTypeSymRegister); // Reuse to avoid creating a new task type
 
 exit:
+  // RCCL: the current device was switched to comm->cudaDev above and is switched
+  // back at the end of this block. Do not return in between: a rejected call comes
+  // back out of ncclGroupEndInternal and would skip the switch back.
   ncclGroupErrCheck(ret);
-  NCCLCHECK(ncclGroupEndInternal());
-  if (comm && !comm->config.blocking) {
-    NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
+  groupRet = ncclGroupEndInternal();
+  if (ret == ncclSuccess) ret = groupRet;
+  if (ret == ncclSuccess && comm && !comm->config.blocking) {
+    const ncclResult_t asyncRet = ncclCommGetAsyncError(comm, &ret);
+    if (asyncRet != ncclSuccess) ret = asyncRet;
   }
   CUDACHECK(cudaSetDevice(saveDev));
   return ret;

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -1027,6 +1027,7 @@ ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
 
   ncclResult_t ret = ncclSuccess;
   ncclResult_t groupRet = ncclSuccess;
+  cudaError_t restoreErr = cudaSuccess;
   int saveDev;
   CUDACHECK(cudaGetDevice(&saveDev));
   NCCLCHECK(ncclGroupStartInternal());
@@ -1070,7 +1071,11 @@ exit:
     const ncclResult_t asyncRet = ncclCommGetAsyncError(comm, &ret);
     if (asyncRet != ncclSuccess) ret = asyncRet;
   }
-  CUDACHECK(cudaSetDevice(saveDev));
+  restoreErr = cudaSetDevice(saveDev);
+  if (restoreErr != cudaSuccess) {
+    const ncclResult_t restoreRet = rcclCudaErrorHandler(restoreErr);
+    if (ret == ncclSuccess) ret = restoreRet;
+  }
   return ret;
 fail:
   goto exit;
@@ -1084,6 +1089,7 @@ ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
 
   ncclResult_t ret = ncclSuccess;
   ncclResult_t groupRet = ncclSuccess;
+  cudaError_t restoreErr = cudaSuccess;
   int saveDev;
   CUDACHECK(cudaGetDevice(&saveDev));
   NCCLCHECK(ncclGroupStartInternal());
@@ -1125,7 +1131,11 @@ exit:
     const ncclResult_t asyncRet = ncclCommGetAsyncError(comm, &ret);
     if (asyncRet != ncclSuccess) ret = asyncRet;
   }
-  CUDACHECK(cudaSetDevice(saveDev));
+  restoreErr = cudaSetDevice(saveDev);
+  if (restoreErr != cudaSuccess) {
+    const ncclResult_t restoreRet = rcclCudaErrorHandler(restoreErr);
+    if (ret == ncclSuccess) ret = restoreRet;
+  }
   return ret;
 fail:
   goto exit;

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -1951,12 +1951,8 @@ TEST_F(SuspendResumeGroup, CollectiveAfterSuspendInSameGroup)
 // ----------------------------------------------------------------------------
 // 6. Single-process multi-GPU
 //
-// One process drives every visible GPU through ncclCommInitAll, so the peer
-// ranks of each communicator are the other communicators owned by this thread.
-// ncclCommMemSuspend/Resume barrier across all ranks of a comm and asyncJobLaunch
-// runs a lone job inline, so the whole set has to be wrapped in one group for any
-// of them to make progress. That is the configuration these tests cover, and it
-// is also the only one that reaches the intra-process peer-import path in p2pMap.
+// One process drives every visible GPU. Communicators are created through
+// ncclCommInitAll.
 //
 // The suite needs the binary launched as a single rank; validateTestPrerequisites
 // skips it otherwise.

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -2180,10 +2180,13 @@ protected:
     // the fixture helper always uses the default one.
     ncclResult_t createCommWithConfig(ncclConfig_t* config, ncclComm_t* comm)
     {
-        ncclResult_t idResult = ncclSuccess;
+        // The status travels ahead of the id: a failure known only to rank 0 would leave
+        // the other ranks blocked in ncclCommInitRankConfig for a rank that never joins.
+        int idResult = ncclSuccess;
         if (MPIEnvironment::world_rank == 0) idResult = ncclGetUniqueId(&nccl_id_);
+        MPI_Bcast(&idResult, 1, MPI_INT, 0, MPI_COMM_WORLD);
+        if (idResult != ncclSuccess) return static_cast<ncclResult_t>(idResult);
         MPI_Bcast(&nccl_id_, sizeof(ncclUniqueId), MPI_BYTE, 0, MPI_COMM_WORLD);
-        if (idResult != ncclSuccess) return idResult;
         return ncclCommInitRankConfig(comm, MPIEnvironment::world_size, nccl_id_,
                                       MPIEnvironment::world_rank, config);
     }

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -45,6 +45,10 @@
  *   - SuspendResumeBasic / MemStats / CollectiveIntegrity / Lifecycle / Group
  *     / ArgValidation / MemStatsValidation - public API tests for
  *     ncclCommSuspend / ncclCommResume / ncclCommMemStats. Need np >= 2.
+ *   - SuspendResumeSingleProcMultiGpu - one rank owning several GPUs through
+ *     ncclCommInitAll. Needs exactly 1 rank and >= 2 GPUs, and drives at most
+ *     kMaxGpusForSingleProcess of them. Every rank reaches the same skip
+ *     decision, so launching it with more ranks is safe.
  *
  * Run (a single mpirun -np 2 invocation runs the entire file):
  *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManager*:SuspendResume*'
@@ -53,6 +57,7 @@
  *   mpirun -np 1 ./rccl-UnitTestsMPI --gtest_filter='MemManagerAnyRanks.*'
  *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManagerTwoRank.*'
  *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='SuspendResume*'
+ *   mpirun -np 1 ./rccl-UnitTestsMPI --gtest_filter='SuspendResumeSingleProcMultiGpu.*'
  */
 
 #include "DeviceBufferHelpers.hpp"
@@ -63,6 +68,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -1943,14 +1949,245 @@ TEST_F(SuspendResumeGroup, CollectiveAfterSuspendInSameGroup)
 }
 
 // ----------------------------------------------------------------------------
-// 6. Argument validation / corner cases
+// 6. Single-process multi-GPU
+//
+// One process drives every visible GPU through ncclCommInitAll, so the peer
+// ranks of each communicator are the other communicators owned by this thread.
+// ncclCommMemSuspend/Resume barrier across all ranks of a comm and asyncJobLaunch
+// runs a lone job inline, so the whole set has to be wrapped in one group for any
+// of them to make progress. That is the configuration these tests cover, and it
+// is also the only one that reaches the intra-process peer-import path in p2pMap.
+//
+// The suite needs the binary launched as a single rank; validateTestPrerequisites
+// skips it otherwise.
+// ----------------------------------------------------------------------------
+
+namespace
+{
+constexpr int kMinGpusForSingleProcess = 2;
+// Grouping is already covered by a handful of communicators, and ncclCommInitAll
+// costs minutes once every GPU of the node joins in.
+constexpr int kMaxGpusForSingleProcess = 4;
+}
+
+class SuspendResumeSingleProcMultiGpu : public SuspendResumePublicAPITestBase
+{
+protected:
+    // Number of GPUs this process will drive, or 0 when the environment cannot
+    // host the suite (launched with more than one rank, or fewer than two
+    // devices). Capped, see kMaxGpusForSingleProcess.
+    int usableDeviceCount()
+    {
+        if (!validateTestPrerequisites(1, /*max_processes=*/1)) return 0;
+        int count = 0;
+        if (hipGetDeviceCount(&count) != hipSuccess) return 0;
+        if (count < kMinGpusForSingleProcess) return 0;
+        return std::min(count, kMaxGpusForSingleProcess);
+    }
+
+    ncclResult_t suspendAll(const std::vector<ncclComm_t>& comms)
+    {
+        ncclResult_t ret = ncclGroupStart();
+        if (ret != ncclSuccess) return ret;
+        for (ncclComm_t comm : comms)
+        {
+            ret = ncclCommSuspend(comm, NCCL_SUSPEND_MEM);
+            if (ret != ncclSuccess) break;
+        }
+        ncclResult_t endRet = ncclGroupEnd();
+        return ret != ncclSuccess ? ret : endRet;
+    }
+
+    ncclResult_t resumeAll(const std::vector<ncclComm_t>& comms)
+    {
+        ncclResult_t ret = ncclGroupStart();
+        if (ret != ncclSuccess) return ret;
+        for (ncclComm_t comm : comms)
+        {
+            ret = ncclCommResume(comm);
+            if (ret != ncclSuccess) break;
+        }
+        ncclResult_t endRet = ncclGroupEnd();
+        return ret != ncclSuccess ? ret : endRet;
+    }
+};
+
+TEST_F(SuspendResumeSingleProcMultiGpu, GroupSuspendResumeAllComms)
+{
+    const int deviceCount = usableDeviceCount();
+    if (deviceCount == 0) GTEST_SKIP() << "Needs exactly 1 rank and >= 2 GPUs";
+
+    std::vector<ncclComm_t> comms(deviceCount, nullptr);
+    ASSERT_EQ(ncclSuccess, ncclCommInitAll(comms.data(), deviceCount, nullptr));
+    std::vector<NcclCommAutoGuard> commGuards;
+    commGuards.reserve(deviceCount);
+    for (ncclComm_t comm : comms) commGuards.emplace_back(comm);
+
+    for (int dev = 0; dev < deviceCount; ++dev)
+        EXPECT_EQ(0u, readStat(comms[dev], ncclStatGpuMemSuspended))
+            << "comm on device " << dev << " starts active";
+
+    ASSERT_EQ(ncclSuccess, suspendAll(comms));
+    for (int dev = 0; dev < deviceCount; ++dev)
+        EXPECT_EQ(1u, readStat(comms[dev], ncclStatGpuMemSuspended))
+            << "comm on device " << dev << " must be suspended once the group closes";
+
+    ASSERT_EQ(ncclSuccess, resumeAll(comms));
+    for (int dev = 0; dev < deviceCount; ++dev)
+        EXPECT_EQ(0u, readStat(comms[dev], ncclStatGpuMemSuspended))
+            << "comm on device " << dev << " must be active again";
+}
+
+TEST_F(SuspendResumeSingleProcMultiGpu, CallerDeviceRestored)
+{
+    const int deviceCount = usableDeviceCount();
+    if (deviceCount == 0) GTEST_SKIP() << "Needs exactly 1 rank and >= 2 GPUs";
+
+    std::vector<ncclComm_t> comms(deviceCount, nullptr);
+    ASSERT_EQ(ncclSuccess, ncclCommInitAll(comms.data(), deviceCount, nullptr));
+    std::vector<NcclCommAutoGuard> commGuards;
+    commGuards.reserve(deviceCount);
+    for (ncclComm_t comm : comms) commGuards.emplace_back(comm);
+
+    // The communicators switch to devices 0..deviceCount-1 in turn, so a caller
+    // sitting on device 0 sees a missing restore as a current device left at
+    // deviceCount - 1. Picking the last device instead would hide the bug.
+    const int callerDevice = 0;
+    ASSERT_EQ(hipSuccess, hipSetDevice(callerDevice));
+
+    ASSERT_EQ(ncclSuccess, suspendAll(comms));
+    int deviceAfterSuspend = -1;
+    ASSERT_EQ(hipSuccess, hipGetDevice(&deviceAfterSuspend));
+    EXPECT_EQ(callerDevice, deviceAfterSuspend)
+        << "ncclCommSuspend must leave the caller's current device untouched";
+
+    ASSERT_EQ(ncclSuccess, resumeAll(comms));
+    int deviceAfterResume = -1;
+    ASSERT_EQ(hipSuccess, hipGetDevice(&deviceAfterResume));
+    EXPECT_EQ(callerDevice, deviceAfterResume)
+        << "ncclCommResume must leave the caller's current device untouched";
+}
+
+// Suspend releases the peer imports that p2pMap created for the other devices of
+// this process, and Resume rebuilds them at the same addresses. Read from the
+// manager's entries: a collective here would deadlock, because the symmetric
+// init it triggers is itself collective over each comm in turn.
+TEST_F(SuspendResumeSingleProcMultiGpu, IntraProcessPeerImportsSurviveCycle)
+{
+    const int deviceCount = usableDeviceCount();
+    if (deviceCount == 0) GTEST_SKIP() << "Needs exactly 1 rank and >= 2 GPUs";
+
+    std::vector<ncclComm_t> comms(deviceCount, nullptr);
+    ASSERT_EQ(ncclSuccess, ncclCommInitAll(comms.data(), deviceCount, nullptr));
+    std::vector<NcclCommAutoGuard> commGuards;
+    commGuards.reserve(deviceCount);
+    for (ncclComm_t comm : comms) commGuards.emplace_back(comm);
+
+    // ncclCuMemEnable only reports the effective setting once RCCL has initialized.
+    if (!ncclCuMemEnable())
+        GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - p2pMap does not track intra-process imports";
+
+    struct PeerImport
+    {
+        void* ptr        = nullptr;
+        void* ownerPtr   = nullptr;
+        bool  active     = false;
+        bool  ownsHandle = false;
+    };
+    auto importsOf = [](ncclComm_t comm) {
+        std::vector<PeerImport> imports;
+        std::lock_guard<std::mutex> lk(comm->memManager->lock);
+        for (auto* e = comm->memManager->entries; e != nullptr; e = e->next)
+        {
+            if (!e->isImportedFromPeer) continue;
+            imports.push_back({e->ptr, e->desc.imported.ownerPtr,
+                               e->state == ncclDynMemStateActive, e->handle != 0});
+        }
+        std::sort(imports.begin(), imports.end(),
+                  [](const PeerImport& l, const PeerImport& r) { return l.ptr < r.ptr; });
+        return imports;
+    };
+    auto addressesOf = [](const std::vector<PeerImport>& imports) {
+        std::vector<std::pair<void*, void*>> addresses;
+        for (const PeerImport& import : imports) addresses.emplace_back(import.ptr, import.ownerPtr);
+        return addresses;
+    };
+    auto countActive = [](const std::vector<PeerImport>& imports) {
+        return static_cast<int>(std::count_if(imports.begin(), imports.end(),
+                                              [](const PeerImport& import) { return import.active; }));
+    };
+    auto countOwningHandle = [](const std::vector<PeerImport>& imports) {
+        return static_cast<int>(std::count_if(imports.begin(), imports.end(),
+                                              [](const PeerImport& import) { return import.ownsHandle; }));
+    };
+
+    std::vector<std::vector<PeerImport>> before(deviceCount);
+    int                                  handlelessBefore = 0;
+    for (int dev = 0; dev < deviceCount; ++dev)
+    {
+        ASSERT_NE(nullptr, comms[dev]->memManager);
+        before[dev]     = importsOf(comms[dev]);
+        const int total = static_cast<int>(before[dev].size());
+        EXPECT_EQ(total, countActive(before[dev]))
+            << "every peer import of the comm on device " << dev << " starts active";
+        handlelessBefore += total - countOwningHandle(before[dev]);
+    }
+    // p2pMap releases the handle right after mapping the peer memory, so the
+    // imports it tracks own none. Without them the test says nothing about the
+    // intra-process branch.
+    ASSERT_GT(handlelessBefore, 0) << "ncclCommInitAll must leave handle-less peer imports behind";
+
+    ASSERT_EQ(ncclSuccess, suspendAll(comms));
+    for (int dev = 0; dev < deviceCount; ++dev)
+    {
+        const std::vector<PeerImport> suspended = importsOf(comms[dev]);
+        EXPECT_EQ(before[dev].size(), suspended.size())
+            << "Suspend must keep the entries of the comm on device " << dev << ", only release them";
+        EXPECT_EQ(0, countActive(suspended))
+            << "Suspend must release every peer import of the comm on device " << dev;
+    }
+
+    ASSERT_EQ(ncclSuccess, resumeAll(comms));
+    for (int dev = 0; dev < deviceCount; ++dev)
+    {
+        const std::vector<PeerImport> resumed = importsOf(comms[dev]);
+        const int                     total   = static_cast<int>(resumed.size());
+        EXPECT_EQ(addressesOf(before[dev]), addressesOf(resumed))
+            << "Resume must rebuild the peer imports of the comm on device " << dev
+            << " at their original addresses";
+        EXPECT_EQ(total, countActive(resumed))
+            << "Resume must leave every peer import of the comm on device " << dev << " active";
+        // Resume re-imports through cuMemImportFromShareableHandle, so unlike
+        // p2pMap it hands the entry a handle it owns and the next Suspend has to
+        // release. An entry left handle-less here would leak the peer's memory.
+        EXPECT_EQ(total, countOwningHandle(resumed))
+            << "a re-imported entry must own the handle it was imported with";
+    }
+}
+
+// ----------------------------------------------------------------------------
+// 7. Argument validation / corner cases
 //
 // Each of these returns from inside ncclCommSuspend/Resume/MemStats BEFORE the
 // bootstrapBarrier is reached, so individual ranks failing the call do not
 // leave their peers blocked on a barrier.
 // ----------------------------------------------------------------------------
 
-class SuspendResumeArgValidation : public SuspendResumePublicAPITestBase {};
+class SuspendResumeArgValidation : public SuspendResumePublicAPITestBase
+{
+protected:
+    // Same bootstrap as createTestCommunicator, but with a caller-supplied config;
+    // the fixture helper always uses the default one.
+    ncclResult_t createCommWithConfig(ncclConfig_t* config, ncclComm_t* comm)
+    {
+        ncclResult_t idResult = ncclSuccess;
+        if (MPIEnvironment::world_rank == 0) idResult = ncclGetUniqueId(&nccl_id_);
+        MPI_Bcast(&nccl_id_, sizeof(ncclUniqueId), MPI_BYTE, 0, MPI_COMM_WORLD);
+        if (idResult != ncclSuccess) return idResult;
+        return ncclCommInitRankConfig(comm, MPIEnvironment::world_size, nccl_id_,
+                                      MPIEnvironment::world_rank, config);
+    }
+};
 
 TEST_F(SuspendResumeArgValidation, ZeroFlags)
 {
@@ -2058,6 +2295,133 @@ TEST_F(SuspendResumeArgValidation, CollectiveWhileSuspended)
     ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
     EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
         << "a rejected collective must leave the comm usable";
+}
+
+// A non-blocking communicator takes the ncclCommGetAsyncError branch on the way
+// out of Suspend and Resume, so both may report ncclInProgress and have to be
+// polled to completion like any other non-blocking call.
+TEST_F(SuspendResumeArgValidation, NonBlockingCommCycle)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.blocking     = 0;
+
+    ncclComm_t   comm = nullptr;
+    ncclResult_t ret  = createCommWithConfig(&config, &comm);
+    ASSERT_MPI_TRUE(ret == ncclSuccess || ret == ncclInProgress);
+    ASSERT_MPI_TRUE(comm != nullptr);
+    auto commGuard = makeCommAutoGuard(comm);
+
+    // Give up rather than hang the whole mpirun; healthy calls take milliseconds.
+    auto waitForCompletion = [&](ncclResult_t callResult) {
+        const auto   deadline    = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        ncclResult_t asyncResult = callResult;
+        while (asyncResult == ncclInProgress)
+        {
+            if (ncclCommGetAsyncError(comm, &asyncResult) != ncclSuccess) return ncclSystemError;
+            if (std::chrono::steady_clock::now() > deadline) return ncclInProgress;
+        }
+        return asyncResult;
+    };
+
+    ASSERT_MPI_EQ(ncclSuccess, waitForCompletion(ret));
+
+    ASSERT_MPI_EQ(ncclSuccess, waitForCompletion(ncclCommSuspend(comm, NCCL_SUSPEND_MEM)));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended));
+
+    ASSERT_MPI_EQ(ncclSuccess, waitForCompletion(ncclCommResume(comm)));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+// splitShare is read from the parent's own config when the child is created, so
+// the flag has to be set at ncclCommInitRankConfig time rather than passed to
+// ncclCommSplit. The child then shares the parent's memory manager and neither
+// side owns the allocations alone, so both must refuse to suspend.
+TEST_F(SuspendResumeArgValidation, SplitShareCommRejected)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.splitShare   = 1;
+
+    ncclComm_t parent = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, createCommWithConfig(&config, &parent));
+    ASSERT_MPI_TRUE(parent != nullptr);
+    auto parentGuard = makeCommAutoGuard(parent);
+
+    ncclComm_t child = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSplit(parent, /*color=*/0, MPIEnvironment::world_rank,
+                                             &child, /*config=*/nullptr));
+    ASSERT_MPI_TRUE(child != nullptr);
+    auto childGuard = makeCommAutoGuard(child);
+
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(child, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(parent, NCCL_SUSPEND_MEM));
+}
+
+// A rejected Suspend or Resume must still hand the caller back the device it was
+// called on. Both rejections used here are raised after the internal switch to
+// comm->cudaDev; the argument checks reject before it and never touch the device.
+TEST_F(SuspendResumeArgValidation, RejectedCallRestoresCallerDevice)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+
+    int localDevices = 0;
+    ASSERT_EQ(hipSuccess, hipGetDeviceCount(&localDevices));
+    // Suspend and Resume below are collective, so the skip has to be unanimous.
+    int deviceCount = 0;
+    ASSERT_MPI_SUCCESS(MPI_Allreduce(&localDevices, &deviceCount, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+    if (deviceCount < 2) GTEST_SKIP() << "Needs >= 2 visible GPUs to tell a missing restore apart";
+
+    const int callerDevice  = (comm->cudaDev + 1) % deviceCount;
+    auto      currentDevice = [] {
+        int device = -1;
+        EXPECT_EQ(hipSuccess, hipGetDevice(&device));
+        return device;
+    };
+
+    ASSERT_EQ(hipSuccess, hipSetDevice(callerDevice));
+    EXPECT_EQ(ncclInvalidUsage, ncclCommResume(comm)) << "comm is active, Resume must be rejected";
+    EXPECT_EQ(callerDevice, currentDevice())
+        << "a rejected ncclCommResume must not leave the caller on the comm's device";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    ASSERT_EQ(hipSuccess, hipSetDevice(callerDevice));
+    EXPECT_EQ(ncclInvalidUsage, ncclCommSuspend(comm, NCCL_SUSPEND_MEM))
+        << "comm is already suspended, the second Suspend must be rejected";
+    EXPECT_EQ(callerDevice, currentDevice())
+        << "a rejected ncclCommSuspend must not leave the caller on the comm's device";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    ASSERT_EQ(hipSuccess, hipSetDevice(comm->cudaDev));
+}
+
+// NCCL_DISABLE_MEM_MANAGER is read through NCCL_PARAM, which caches on first use,
+// so this only reproduces in a process started with the variable already set.
+TEST_F(SuspendResumeArgValidation, MemManagerDisabledRejected)
+{
+    const char* memManagerDisabled = std::getenv("NCCL_DISABLE_MEM_MANAGER");
+    const int   disabledHere = (memManagerDisabled != nullptr && std::string(memManagerDisabled) == "1") ? 1 : 0;
+
+    // A launcher may forward the variable to only some ranks, and the collective
+    // below would then wait for the ranks that skipped.
+    int disabledEverywhere = 0;
+    ASSERT_MPI_SUCCESS(
+        MPI_Allreduce(&disabledHere, &disabledEverywhere, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+    if (!disabledEverywhere)
+        GTEST_SKIP() << "Needs NCCL_DISABLE_MEM_MANAGER=1 set on every rank before process start";
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
 }
 
 // ----- ncclCommMemStats validation --------------------------------------

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -2133,9 +2133,11 @@ TEST_F(SuspendResumeSingleProcMultiGpu, IntraProcessPeerImportsSurviveCycle)
         handlelessBefore += total - countOwningHandle(before[dev]);
     }
     // p2pMap releases the handle right after mapping the peer memory, so the
-    // imports it tracks own none. Without them the test says nothing about the
-    // intra-process branch.
-    ASSERT_GT(handlelessBefore, 0) << "ncclCommInitAll must leave handle-less peer imports behind";
+    // imports it tracks own none. They exist only when the P2P transport was
+    // selected: without peer access the comms fall back to SHM or NET, which
+    // register no imports and leave the intra-process branch unreachable.
+    if (handlelessBefore == 0)
+        GTEST_SKIP() << "no handle-less peer imports, these devices are not connected over P2P";
 
     ASSERT_EQ(ncclSuccess, suspendAll(comms));
     for (int dev = 0; dev < deviceCount; ++dev)
@@ -2332,6 +2334,13 @@ TEST_F(SuspendResumeArgValidation, NonBlockingCommCycle)
 
     ASSERT_MPI_EQ(ncclSuccess, waitForCompletion(ncclCommSuspend(comm, NCCL_SUSPEND_MEM)));
     EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended));
+
+    // A rejection is raised before the comm joins the group, so it never reaches
+    // the async state: the return code is the only place a caller can see it.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ncclResult_t asyncError = ncclSystemError;
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommGetAsyncError(comm, &asyncError));
+    ASSERT_MPI_EQ(ncclSuccess, asyncError);
 
     ASSERT_MPI_EQ(ncclSuccess, waitForCompletion(ncclCommResume(comm)));
     EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2309,6 +2309,40 @@
       ]
     },
 
+    "suspend_resume_single_proc_multi_gpu_cumem1": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "",
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        { "name": "SuspendResume_SingleProcMultiGpu_CuMem1",   "description": "One rank owning several GPUs via ncclCommInitAll: grouped Suspend/Resume, caller-device preservation, intra-process peer-import round trip (NCCL_CUMEM_ENABLE=1)", "test_filter": "SuspendResumeSingleProcMultiGpu.*" }
+      ]
+    },
+
+    "suspend_resume_mem_manager_disabled": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "",
+        "NCCL_DISABLE_MEM_MANAGER": "1"
+      },
+      "tests": [
+        { "name": "SuspendResume_MemManagerDisabled",          "description": "Suspend/Resume rejected when the memory manager is disabled; NCCL_DISABLE_MEM_MANAGER must be set before process start because NCCL_PARAM caches it", "test_filter": "SuspendResumeArgValidation.MemManagerDisabledRejected" }
+      ]
+    },
+
     "ce_base": {
       "extends": "default",
       "is_gtest": true,
@@ -4170,6 +4204,18 @@
       "name": "Suspend/Resume - Public API (CUMEM=1)",
       "description": "Public ncclCommSuspend/Resume/MemStats end-to-end, NCCL_CUMEM_ENABLE=1 (exercises CUMEM path where supported)",
       "config": "suspend_resume_public_api_cumem1",
+      "enabled": true
+    },
+    {
+      "name": "Suspend/Resume - Single-process multi-GPU (CUMEM=1)",
+      "description": "One rank owning several GPUs via ncclCommInitAll, NCCL_CUMEM_ENABLE=1 (exercises the intra-process peer-import path in p2pMap)",
+      "config": "suspend_resume_single_proc_multi_gpu_cumem1",
+      "enabled": true
+    },
+    {
+      "name": "Suspend/Resume - Memory manager disabled",
+      "description": "Suspend/Resume rejected when NCCL_DISABLE_MEM_MANAGER=1 is set before process start",
+      "config": "suspend_resume_mem_manager_disabled",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

Validation of the NCCL 2.30.3 change "dynamic memory offload with group support, single-process multi-GPU" in RCCL.

A process that owns one communicator per GPU through `ncclCommInitAll` has to wrap `ncclCommSuspend` and `ncclCommResume` in a group: every call is collective over the ranks of its communicator, and those ranks are the other communicators of the same thread. Nothing exercised this path, and testing it surfaced two defects.

## Technical Details

A rejected `ncclCommSuspend` or `ncclCommResume` left the caller on the communicator's device. Both switch to `comm->cudaDev` and restore the caller's device only after the `exit` label, but a rejection travels back out of `ncclGroupEndInternal`, and the `NCCLCHECK` around it returned before the restore.

`ncclCommGroupRegisterSymmetric` drained the suspend and resume queues twice. The first copy sat between `ceInit` and `rmaCeInit`, so a group holding both a suspend and an RMA CE init suspended the communicator before that init ran, and it left the second copy with nothing to do. Only the copy after `rmaCeInit` is kept, which is also the order upstream 2.30.3 uses.

Seven tests are added. The new `SuspendResumeSingleProcMultiGpu` suite drives several GPUs from one rank and checks the group cycle, the caller's device, and the peer imports that `p2pMap` creates between devices of the same process. `SuspendResumeArgValidation` gains a non-blocking cycle, a `split_share` rejection, a rejection with the memory manager disabled, and the device-restore regression above. Two test runner configurations cover the suites that need their own process environment. The docs gain the matching grouped resume example and a note that the group is required in this case, plus a CHANGELOG entry for the feature.

## Issue Tracking

JIRA ID : AICOMRCCL-1831

## Test Plan

1. MI350X (gfx950), ROCm 7.14, 1 and 2 ranks
2. CI tests

## Test Result

1. Debug build on MI350X (gfx950), ROCm 7.13, run against the rebased tip of this branch:

   | Run | Result |
   |---|---|
   | `SuspendResumeSingleProcMultiGpu.*`, 1 rank, `NCCL_CUMEM_ENABLE=1` | 3 passed |
   | `SuspendResume*`, 2 ranks, `NCCL_CUMEM_ENABLE=1` | 26 passed, 4 skipped |
   | `SuspendResumeArgValidation.MemManagerDisabledRejected`, 2 ranks, `NCCL_DISABLE_MEM_MANAGER=1` | 1 passed |
   | `SuspendResume*`, 2 ranks, `NCCL_CUMEM_ENABLE=0` | 20 passed, 10 skipped |
   | `MemManagerAnyRanks.*` and `MemManagerTwoRank.*`, 2 ranks, `NCCL_CUMEM_ENABLE=1` | 17 passed |

   Nothing failed. Every skip is a test whose fixture requires a different rank count or a different process environment.
2. Passed

```
================================================================================
Test: SuspendResume_ArgValidation_CuMem0
================================================================================
  Description: Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=0)
  Filter:  SuspendResumeArgValidation.*
  Ranks:   2
  Nodes:   1
  GPUs/node: 2
  Timeout: 300
  Environment variables (4):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_DEBUG=
    NCCL_CUMEM_ENABLE=0
[==========] Running 10 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 10 tests from SuspendResumeArgValidation
[ RUN      ] SuspendResumeArgValidation.ZeroFlags
[       OK ] SuspendResumeArgValidation.ZeroFlags (4196 ms)
[ RUN      ] SuspendResumeArgValidation.UnknownFlagsRejected
[       OK ] SuspendResumeArgValidation.UnknownFlagsRejected (739 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleSuspend
[       OK ] SuspendResumeArgValidation.DoubleSuspend (769 ms)
[ RUN      ] SuspendResumeArgValidation.ResumeWhenActive
[       OK ] SuspendResumeArgValidation.ResumeWhenActive (729 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleResume
[       OK ] SuspendResumeArgValidation.DoubleResume (752 ms)
[ RUN      ] SuspendResumeArgValidation.CollectiveWhileSuspended
/projects/math-ci/slurm-batch-submitter-1/workspace/batch-codecoverage_rccl_PR-10222@2/run4/rccl/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp:2272: Skipped
NCCL_CUMEM_ENABLE=0     nothing is tracked, so Suspend releases no memory and there is nothing to guard
[  SKIPPED ] SuspendResumeArgValidation.CollectiveWhileSuspended (0 ms)
[ RUN      ] SuspendResumeArgValidation.NonBlockingCommCycle
[       OK ] SuspendResumeArgValidation.NonBlockingCommCycle (755 ms)
[ RUN      ] SuspendResumeArgValidation.SplitShareCommRejected
[       OK ] SuspendResumeArgValidation.SplitShareCommRejected (782 ms)
[ RUN      ] SuspendResumeArgValidation.RejectedCallRestoresCallerDevice
[       OK ] SuspendResumeArgValidation.RejectedCallRestoresCallerDevice (752 ms)
[ RUN      ] SuspendResumeArgValidation.MemManagerDisabledRejected
/projects/math-ci/slurm-batch-submitter-1/workspace/batch-codecoverage_rccl_PR-10222@2/run4/rccl/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp:2425: Skipped
Needs NCCL_DISABLE_MEM_MANAGER=1 set on every rank before process start
[  SKIPPED ] SuspendResumeArgValidation.MemManagerDisabledRejected (0 ms)
[----------] 10 tests from SuspendResumeArgValidation (9478 ms total)
[----------] Global test environment tear-down
[==========] 10 tests from 1 test suite ran. (9787 ms total)
[  PASSED  ] 8 tests.
[  SKIPPED ] 2 tests, listed below:
[  SKIPPED ] SuspendResumeArgValidation.CollectiveWhileSuspended
[  SKIPPED ] SuspendResumeArgValidation.MemManagerDisabledRejected
  Result: PASSED (11.853 seconds)

================================================================================
Test: SuspendResume_ArgValidation_CuMem1
================================================================================
  Description: Argument validation: zero/unknown flags, double-Suspend/Resume (NCCL_CUMEM_ENABLE=1)
  Filter:  SuspendResumeArgValidation.*
  Ranks:   2
  Nodes:   1
  GPUs/node: 2
  Timeout: 300
  Environment variables (4):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_DEBUG=
    NCCL_CUMEM_ENABLE=1
[==========] Running 10 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 10 tests from SuspendResumeArgValidation
[ RUN      ] SuspendResumeArgValidation.ZeroFlags
[       OK ] SuspendResumeArgValidation.ZeroFlags (4805 ms)
[ RUN      ] SuspendResumeArgValidation.UnknownFlagsRejected
[       OK ] SuspendResumeArgValidation.UnknownFlagsRejected (1333 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleSuspend
[       OK ] SuspendResumeArgValidation.DoubleSuspend (1355 ms)
[ RUN      ] SuspendResumeArgValidation.ResumeWhenActive
[       OK ] SuspendResumeArgValidation.ResumeWhenActive (1061 ms)
[ RUN      ] SuspendResumeArgValidation.DoubleResume
[       OK ] SuspendResumeArgValidation.DoubleResume (1331 ms)
[ RUN      ] SuspendResumeArgValidation.CollectiveWhileSuspended
[       OK ] SuspendResumeArgValidation.CollectiveWhileSuspended (1343 ms)
[ RUN      ] SuspendResumeArgValidation.NonBlockingCommCycle
[       OK ] SuspendResumeArgValidation.NonBlockingCommCycle (1307 ms)
[ RUN      ] SuspendResumeArgValidation.SplitShareCommRejected
[       OK ] SuspendResumeArgValidation.SplitShareCommRejected (1313 ms)
[ RUN      ] SuspendResumeArgValidation.RejectedCallRestoresCallerDevice
[       OK ] SuspendResumeArgValidation.RejectedCallRestoresCallerDevice (1334 ms)
[ RUN      ] SuspendResumeArgValidation.MemManagerDisabledRejected
/projects/math-ci/slurm-batch-submitter-1/workspace/batch-codecoverage_rccl_PR-10222@2/run4/rccl/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp:2425: Skipped
Needs NCCL_DISABLE_MEM_MANAGER=1 set on every rank before process start
[  SKIPPED ] SuspendResumeArgValidation.MemManagerDisabledRejected (0 ms)
[----------] 10 tests from SuspendResumeArgValidation (15188 ms total)
[----------] Global test environment tear-down
[==========] 10 tests from 1 test suite ran. (20879 ms total)
[  PASSED  ] 9 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] SuspendResumeArgValidation.MemManagerDisabledRejected
  Result: PASSED (22.696 seconds)

================================================================================
Test: SuspendResume_SingleProcMultiGpu_CuMem1
================================================================================
  Description: One rank owning several GPUs via ncclCommInitAll: grouped Suspend/Resume, caller-device preservation, intra-process peer-import round trip (NCCL_CUMEM_ENABLE=1)
  Filter:  SuspendResumeSingleProcMultiGpu.*
  Ranks:   1
  Nodes:   1
  GPUs/node: 2
  Timeout: 300
  Environment variables (4):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_DEBUG=
    NCCL_CUMEM_ENABLE=1
Note: Google Test filter = SuspendResumeSingleProcMultiGpu.*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from SuspendResumeSingleProcMultiGpu
[ RUN      ] SuspendResumeSingleProcMultiGpu.GroupSuspendResumeAllComms
[       OK ] SuspendResumeSingleProcMultiGpu.GroupSuspendResumeAllComms (11393 ms)
[ RUN      ] SuspendResumeSingleProcMultiGpu.CallerDeviceRestored
[       OK ] SuspendResumeSingleProcMultiGpu.CallerDeviceRestored (5319 ms)
[ RUN      ] SuspendResumeSingleProcMultiGpu.IntraProcessPeerImportsSurviveCycle
[       OK ] SuspendResumeSingleProcMultiGpu.IntraProcessPeerImportsSurviveCycle (5401 ms)
[----------] 3 tests from SuspendResumeSingleProcMultiGpu (22114 ms total)
[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (22332 ms total)
[  PASSED  ] 3 tests.
  Result: PASSED (23.874 seconds)

================================================================================
Test: SuspendResume_MemManagerDisabled
================================================================================
  Description: Suspend/Resume rejected when the memory manager is disabled; NCCL_DISABLE_MEM_MANAGER must be set before process start because NCCL_PARAM caches it
  Filter:  SuspendResumeArgValidation.MemManagerDisabledRejected
  Ranks:   2
  Nodes:   1
  GPUs/node: 2
  Timeout: 300
  Environment variables (4):
    HSA_NO_SCRATCH_RECLAIM=1
    NCCL_SOCKET_IFNAME=eth0,eth1
    NCCL_DEBUG=
    NCCL_DISABLE_MEM_MANAGER=1
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SuspendResumeArgValidation
[ RUN      ] SuspendResumeArgValidation.MemManagerDisabledRejected
[       OK ] SuspendResumeArgValidation.MemManagerDisabledRejected (4089 ms)
[----------] 1 test from SuspendResumeArgValidation (4090 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4418 ms total)
[  PASSED  ] 1 test.
  Result: PASSED (11.395 seconds)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

