### PR TITLE
fix(rccl): free ipcInfos when IPC registration never completes (AICOMRCCL-1933)

### DIFF
--- a/projects/rccl/src/register/register.cc
+++ b/projects/rccl/src/register/register.cc
@@ -126,21 +126,23 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
            reg->collnetProxyconn->rank);
     }
   }
-  if (reg->state & IPC_REG_COMPLETE) {
-    if (reg->ipcInfos) {
-      for (int i = 0; i < reg->ipcInfosSize; ++i)
-        if (reg->ipcInfos[i]) {
-          if (ncclIpcDeregBuffer(comm, reg->ipcInfos[i]) != ncclSuccess) {
-            WARN("rank %d deregister IPC buffer %p peerRank %d failed", comm->rank, reg->ipcInfos[i]->baseAddr,
-                 reg->ipcInfos[i]->peerRank);
-          }
-          free(reg->ipcInfos[i]);
+
+  // RCCL: do not gate this on IPC_REG_COMPLETE. ipcInfos is allocated before the first peer
+  // registration is attempted, so a record that never reaches the flag still owns the array.
+  // Entries are non-NULL only for peers that completed.
+  if (reg->ipcInfos) {
+    for (int i = 0; i < reg->ipcInfosSize; ++i)
+      if (reg->ipcInfos[i]) {
+        if (ncclIpcDeregBuffer(comm, reg->ipcInfos[i]) != ncclSuccess) {
+          WARN("rank %d deregister IPC buffer %p peerRank %d failed", comm->rank, reg->ipcInfos[i]->baseAddr,
+               reg->ipcInfos[i]->peerRank);
         }
-      free(reg->ipcInfos);
-    }
-    if (reg->regIpcAddrs.hostPeerRmtAddrs) free(reg->regIpcAddrs.hostPeerRmtAddrs);
-    if (reg->regIpcAddrs.devPeerRmtAddrs) NCCLCHECK(ncclCudaFree(reg->regIpcAddrs.devPeerRmtAddrs, comm->memManager));
+        free(reg->ipcInfos[i]);
+      }
+    free(reg->ipcInfos);
   }
+  if (reg->regIpcAddrs.hostPeerRmtAddrs) free(reg->regIpcAddrs.hostPeerRmtAddrs);
+  if (reg->regIpcAddrs.devPeerRmtAddrs) NCCLCHECK(ncclCudaFree(reg->regIpcAddrs.devPeerRmtAddrs, comm->memManager));
   return ncclSuccess;
 }
 


### PR DESCRIPTION
## Motivation

`regCleanup()` leaks the `ipcInfos` array whenever an IPC buffer registration ends before reaching `IPC_REG_COMPLETE`. The array is allocated up front, so a record that never sets the flag has nothing left to free it.

## Technical Details

`reg->ipcInfos` is allocated in `ncclIpcRegisterBuffer()` (`src/transport/p2p.cc:1130`) before the first peer registration is attempted, while `IPC_REG_COMPLETE` is set only at `p2p.cc:1262`. The cleanup in `src/register/register.cc` gated the entire teardown on that flag, so every registration returning in between leaked. Removing the gate is the whole fix: the per-entry NULL checks already restrict `ncclIpcDeregBuffer()` to peers that completed, so deregistration behaviour does not change.

`regIpcAddrs.hostPeerRmtAddrs` and `.devPeerRmtAddrs` move out of the gate as well. They are allocated only after the flag is set (`p2p.cc:1272` and `:1296`), so their existing NULL checks keep them safe and the ordering assumption disappears.

## Issue Tracking

JIRA ID: AICOMRCCL-1933

## Test Plan

`rccl-UnitTestsMPI` on 8 ranks of one MI350X (gfx950) node, AddressSanitizer `--debug-fast` build, filter `P2pMPITest.*Registration*:P2pMPITest.IpcGraphRegisterBufferTest` (13 tests). Run A/B against `develop` with `register.cc` as the only difference and an incremental rebuild in between, so the two LeakSanitizer reports are directly comparable.

## Test Result

11 passed / 2 skipped in both runs, 52.3 s vs 52.2 s. LeakSanitizer per rank: 836197 B in 13214 allocations before, 835557 B in 13204 after. That 640 B / 10 allocation delta is entirely `ncclReallocDebug<ncclIpcRegInfo*>` reports, which fall from 6 ranks to zero; nothing else changes.

**(AI Asist)**

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
