### PR TITLE
fix(clr):  hipMemcpyPeer should sync with both src and dst devices

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -186,7 +186,8 @@ void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stre
       waitForStream(null_stream_);
     }
   } else {
-    activeQueues = blocking_stream->device().getActiveQueues();
+    // Wait on this device's active streams.
+    activeQueues = devices()[0]->getActiveQueues();
     for (const auto& queue : activeQueues) {
       auto* active_stream = static_cast<hip::Stream*>(queue);
       // Only wait on blocking (non-nonblocking) streams other than the current one

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -186,7 +186,10 @@ void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stre
       waitForStream(null_stream_);
     }
   } else {
-    // Wait on this device's active streams.
+    // Wait on the active streams of this device, not blocking_stream->device().
+    // blocking_stream is only where the barrier gets enqueued and it can be on a
+    // different device. (e.g. hipMemcpyPeer is the cross-device caller waiting on peer
+    // device while enqueuing the barrier on the current device's null stream).
     activeQueues = devices()[0]->getActiveQueues();
     for (const auto& queue : activeQueues) {
       auto* active_stream = static_cast<hip::Stream*>(queue);

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -619,8 +619,9 @@ namespace hip {
     hipError_t GetAndClearBlockingStreamsAsyncError();
     /// Returns true if any stream on this device is in capture mode
     bool StreamCaptureBlocking();
-    /// Wait all active streams on the blocking queue. The method enqueues a wait command and
-    /// doesn't stall the current thread.
+    /// Enqueue a barrier on blocking_stream that waits for all active blocking streams
+    /// (or just the null stream) of this device. This doesn't stall the current thread.
+    /// blocking_stream can be on the same or a different device.
     void WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stream = false);
 
     // Destroying a recorded IPC event must wait for the GPU barrier that decrements the

--- a/projects/clr/hipamd/src/hip_peer.cpp
+++ b/projects/clr/hipamd/src/hip_peer.cpp
@@ -173,6 +173,15 @@ hipError_t hipDeviceEnablePeerAccess(int peerDeviceId, unsigned int flags) {
   HIP_RETURN(hip::getCurrentDevice()->EnablePeerAccess(peerDeviceId));
 }
 
+// Serialize copyStream against all pending work on peer device's blocking streams.
+static void waitForPeerDevices(hip::Device* peerDevice, hip::Stream* copyStream) {
+  if (peerDevice == nullptr || peerDevice == copyStream->GetDevice()) {
+    // Same device as the copy stream, no need to wait on peer device's streams.
+    return;
+  }
+  peerDevice->WaitActiveStreams(copyStream);
+}
+
 hipError_t hipMemcpyPeer(void* dst, int dstDevice, const void* src, int srcDevice,
                          size_t sizeBytes) {
   HIP_INIT_API(hipMemcpyPeer, dst, dstDevice, src, srcDevice, sizeBytes);
@@ -182,8 +191,14 @@ hipError_t hipMemcpyPeer(void* dst, int dstDevice, const void* src, int srcDevic
     HIP_RETURN(hipErrorInvalidDevice);
   }
 
+  // Unlike hipMemcpyPeerAsync, hipMemcpyPeer is serialized with respect to all the pending
+  // work on the current device, srcDevice and dstDevice.
+  hip::Stream* copyStream = hip::getNullStream();
+  waitForPeerDevices(g_devices[srcDevice], copyStream);
+  waitForPeerDevices(g_devices[dstDevice], copyStream);
+
   HIP_RETURN(
-      ihipMemcpy(dst, src, sizeBytes, hipMemcpyDeviceToDevice, *hip::getNullStream(), true, false));
+      ihipMemcpy(dst, src, sizeBytes, hipMemcpyDeviceToDevice, *copyStream, true, false));
 }
 
 hipError_t hipMemcpyPeerAsync(void* dst, int dstDevice, const void* src, int srcDevice,

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1416,6 +1416,9 @@ memory:
     tags: [multigpu, transfer]
     # Disabling test tracked SWDEV-391555
     disabled: [amd_windows, amd_wsl]
+  Unit_hipMemcpyPeer_Positive_OrderingWithSrcBlockingStream:
+    <<: *level_2
+    tags: [multigpu, transfer]
   Unit_hipMemcpyPeer_Negative_Parameters:
     <<: *level_2
     tags: [multigpu, transfer]

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressHelpers.hh
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressHelpers.hh
@@ -128,7 +128,7 @@ bool validateCharDeviceArray(char *arr, int size, int refValue) {
  */
 __global__ void fillArray(int *arr, int size, int value) {
   for ( int i = 0; i < size; i++ ) {
-    arr[i] = value;
+    __hip_atomic_store(&arr[i], value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   }
 }
 

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressHelpers.hh
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressHelpers.hh
@@ -128,7 +128,7 @@ bool validateCharDeviceArray(char *arr, int size, int refValue) {
  */
 __global__ void fillArray(int *arr, int size, int value) {
   for ( int i = 0; i < size; i++ ) {
-    __hip_atomic_store(&arr[i], value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    arr[i] = value;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -6077,10 +6077,6 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
     HIP_CHECK(hipMalloc(&srcDevPtr, Nbytes));
     REQUIRE(srcDevPtr != nullptr);
     fillDeviceArray(srcDevPtr, N, value);
-    // srcDevPtr is being filled by a kernel on srcDevice's null stream but the below
-    // p2p copy is on peer device's null stream, the copy can start before the fill above happens
-    // and the test can fail. Synchronizing makes the copy operate on the right data.
-    HIP_CHECK(hipDeviceSynchronize());
 
     HIP_CHECK(hipSetDevice(peerDeviceId));
 

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -6077,6 +6077,10 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
     HIP_CHECK(hipMalloc(&srcDevPtr, Nbytes));
     REQUIRE(srcDevPtr != nullptr);
     fillDeviceArray(srcDevPtr, N, value);
+    // srcDevPtr is being filled by a kernel on srcDevice's null stream but the below
+    // p2p copy is on peer device's null stream, the copy can start before the fill above happens
+    // and the test can fail. Synchronizing makes the copy operate on the right data.
+    HIP_CHECK(hipDeviceSynchronize());
 
     HIP_CHECK(hipSetDevice(peerDeviceId));
 
@@ -6102,6 +6106,10 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
     HIP_CHECK(hipMalloc(&srcDevPtr, Nbytes));
     REQUIRE(srcDevPtr != nullptr);
     fillDeviceArray(srcDevPtr, N, value);
+    // srcDevPtr is being filled by a kernel on srcDevice's null stream but the below
+    // p2p copy is on peer device's null stream, the copy can start before the fill above happens
+    // and the test can fail. Synchronizing makes the copy operate on the right data.
+    HIP_CHECK(hipDeviceSynchronize());
 
     HIP_CHECK(hipSetDevice(peerDeviceId));
 

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -6102,9 +6102,10 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
     HIP_CHECK(hipMalloc(&srcDevPtr, Nbytes));
     REQUIRE(srcDevPtr != nullptr);
     fillDeviceArray(srcDevPtr, N, value);
-    // srcDevPtr is being filled by a kernel on srcDevice's null stream but the below
-    // p2p copy is on peer device's null stream, the copy can start before the fill above happens
-    // and the test can fail. Synchronizing makes the copy operate on the right data.
+    // srcDevPtr is filled by a kernel on srcDevice's null stream, but the copy below is
+    // on a user stream created on the peer device. hipMemcpyPeerAsync is not serialized
+    // against pending work on srcDevice, so the fill could still be running when the copy
+    // reads srcDevPtr. Synchronize the fill first.
     HIP_CHECK(hipDeviceSynchronize());
 
     HIP_CHECK(hipSetDevice(peerDeviceId));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
@@ -281,6 +281,78 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Negative_Parameters) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ *  - Checks cross-device ordering of hipMemcpyPeer.
+ *  - A producer kernel fills the source buffer on a user-created blocking stream and the peer
+ *    copy is issued immediately, with no host-side synchronization in between. hipMemcpyPeer
+ *    must serialize against all pending work on srcDevice, that waits on every active
+ *    blocking stream of the peer device. Without that serialization the copy races with the fill
+ *    and the destination is left with stale data.
+ * Test source
+ * ------------------------
+ *  - unit/memory/hipMemcpyPeer.cc
+ * Test requirements
+ * ------------------------
+ *  - Peer access supported
+ *  - Multi-device
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_OrderingWithSrcBlockingStream) {
+  const auto device_count = HipTest::getDeviceCount();
+  if (device_count < 2) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+  }
+
+  const int src_device = 0;
+  const int dst_device = 1;
+
+  int can_access_peer = 0;
+  HIP_CHECK(hipSetDevice(src_device));
+  HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
+  if (!can_access_peer) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+  }
+
+  // Allocate a large buffer to increase the likelihood of a race
+  constexpr size_t element_count = 4 * 1024 * 1024;
+  constexpr size_t allocation_size = element_count * sizeof(int);
+  constexpr int stale_value = 0;
+  constexpr int expected_value = 42;
+
+  HIP_CHECK(hipSetDevice(src_device));
+  LinearAllocGuard<int> src_alloc(LinearAllocs::hipMalloc, allocation_size);
+  HIP_CHECK(hipMemset(src_alloc.ptr(), stale_value, allocation_size));
+  HIP_CHECK(hipDeviceSynchronize());
+
+  // Producer runs on a user-created blocking stream on srcDevice.
+  hipStream_t src_stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&src_stream));
+
+  HIP_CHECK(hipSetDevice(dst_device));
+  LinearAllocGuard<int> dst_alloc(LinearAllocs::hipMalloc, allocation_size);
+  LinearAllocGuard<int> result(LinearAllocs::hipHostMalloc, allocation_size);
+
+  HIP_CHECK(hipSetDevice(src_device));
+  constexpr auto thread_count = 256;
+  const auto block_count = element_count / thread_count;
+
+  VectorSet<<<block_count, thread_count, 0, src_stream>>>(src_alloc.ptr(), expected_value,
+                                                          element_count);
+  HIP_CHECK(hipGetLastError());
+
+  HIP_CHECK(hipSetDevice(dst_device));
+  HIP_CHECK(
+      hipMemcpyPeer(dst_alloc.ptr(), dst_device, src_alloc.ptr(), src_device, allocation_size));
+
+  HIP_CHECK(
+      hipMemcpy(result.host_ptr(), dst_alloc.ptr(), allocation_size, hipMemcpyDeviceToHost));
+  ArrayFindIfNot(result.host_ptr(), expected_value, element_count);
+
+  HIP_CHECK(hipStreamDestroy(src_stream));
+}
+
+/**
  * End doxygen group PeerToPeerTest.
  * @}
  */


### PR DESCRIPTION
## Motivation

The hip catch test "Unit_hipGetProcAddress_MemoryApisPeerToPeer" fails on Navi48.

## Technical Details

The source ptr is on device 0 and the data is filled using a kernel. Later, device is set to 1 where peer copy happens from source ptr to dst ptr (on device 1). hipMemcpyPeer should sync with the prior work on both the src device as well as dst device before proceeding with the memcpy, else incorrect data gets copied causing corruption. 

## Issue Tracking

GitHub issue: https://github.com/ROCm/TheRock/issues/6471

## Test Plan

Verify the test on Navi48

## Test Result

Passes with this fix

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
