### PR TITLE
test(rccl/proxy): add manual TSAN check for the free-list ordering fix

### DIFF
--- a/projects/rccl/tools/scripts/build_tsan_proxy_lib.sh
+++ b/projects/rccl/tools/scripts/build_tsan_proxy_lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Rebuild librccl.so with ThreadSanitizer instrumentation on src/proxy.cc only.
+#
+# The main-thread <-> proxy-thread free-list race lives entirely inside
+# proxy.cc, so instrumenting that single translation unit (it is already built
+# --offload-host-only, i.e. pure host code) is enough for TSAN to judge the real
+# RCCL code, without paying for a whole-library sanitizer build. The sanitizer
+# runtime itself is not linked in here - see the relink step below - the caller
+# preloads it into the process instead.
+#
+# Usage: build_tsan_proxy_lib.sh <build_dir> <out_dir> [source]
+# The optional source replaces the hipified proxy.cc for this compile, which is
+# how the caller feeds in a shimmed copy without touching the source tree.
+# Must run where the build's compiler and ROCm are available. Nothing is assumed
+# about their paths: the compiler is taken from the build directory itself.
+set -euo pipefail
+
+BD="${1:?usage: $0 <build_dir> <out_dir> [source]}"
+OUT="${2:?usage: $0 <build_dir> <out_dir> [source]}"
+D="$BD/src/CMakeFiles/rccl.dir"
+SRC="${3:-$BD/hipify/src/proxy.cc}"
+OBJ="$D/__/hipify/src/proxy.cc.o"
+
+[ -f "$D/flags.make" ] || { echo "missing $D/flags.make"; exit 1; }
+[ -f "$D/link.txt" ]   || { echo "missing $D/link.txt"; exit 1; }
+[ -f "$SRC" ]          || { echo "missing source to compile: $SRC"; exit 1; }
+
+CXX_DEFINES=$(sed -n 's/^CXX_DEFINES = //p'  "$D/flags.make")
+CXX_INCLUDES=$(sed -n 's/^CXX_INCLUDES = //p' "$D/flags.make")
+CXX_FLAGS=$(sed -n 's/^CXX_FLAGS = //p'      "$D/flags.make")
+
+# Use the compiler the build itself uses, so this keeps working under a different
+# ROCm prefix or a compiler wrapper instead of assuming one fixed path.
+CXX=$(sed -n 's/^CMAKE_CXX_COMPILER:[A-Z]*=//p' "$BD/CMakeCache.txt")
+[ -x "$CXX" ] || { echo "cannot run the build's C++ compiler (CMAKE_CXX_COMPILER='$CXX')"; exit 1; }
+
+# CONSUMER_FN is the function the caller attributes reports to. Inlining it would
+# leave the sanitizer naming its caller instead, which reads as "no race" on code
+# that is racy, so keep it out of line and check below that it stayed there.
+CONSUMER_FN="${CONSUMER_FN:-ncclLocalOpAppend}"
+
+echo "[tsan] recompiling $(basename "$SRC") with -fsanitize=thread ($CXX)"
+# shellcheck disable=SC2086
+"$CXX" $CXX_DEFINES $CXX_INCLUDES $CXX_FLAGS \
+  -fsanitize=thread -fno-omit-frame-pointer -fno-inline -g \
+  -o "$OBJ" -c "$SRC"
+
+# If the instrumentation silently did not happen the run would report no races
+# at all, which reads like a clean result, so check the object for it.
+OBJREFS=$(nm -u "$OBJ" | grep -c "__tsan_" || true)
+[ "$OBJREFS" -gt 0 ] || { echo "$OBJ has no __tsan_ references - not instrumented"; exit 1; }
+
+# Same reasoning for the frame the caller keys on: if it is gone, whether inlined
+# away or renamed upstream, reports would be attributed elsewhere and go uncounted.
+FRAMES=$(nm -C "$OBJ" | grep -c "$CONSUMER_FN" || true)
+[ "$FRAMES" -gt 0 ] || { echo "$OBJ has no '$CONSUMER_FN' symbol, so reports could not be attributed to it"; exit 1; }
+
+echo "[tsan] relinking librccl.so.1.0 with the instrumented proxy.cc"
+# The link command is used exactly as the build wrote it. -fsanitize=thread is
+# deliberately not injected: clang does not link the sanitizer runtime into a
+# shared library, it expects the process to bring it, which is why the runner
+# preloads it. Injecting the flag here would only look like it did something.
+# Read link.txt before the subshell: its own paths are relative to $BD/src.
+LINKCMD=$(cat "$D/link.txt")
+( cd "$BD/src" && eval "$LINKCMD" )
+
+mkdir -p "$OUT"
+# Plain cp: only the contents matter, and preserving attributes fails outright on
+# filesystems that do not support them.
+cp -f "$BD/librccl.so.1.0" "$OUT/"
+( cd "$OUT" && ln -sf librccl.so.1.0 librccl.so.1 && ln -sf librccl.so.1.0 librccl.so )
+# The check that actually matters: the library handed to the runner has to carry
+# the instrumentation. If a relink silently does nothing, the run reports no
+# races and that reads like a clean result.
+REFS=$(nm -u "$OUT/librccl.so.1.0" | grep -c "__tsan_" || true)
+[ "$REFS" -gt 0 ] || { echo "$OUT/librccl.so.1.0 carries no __tsan_ references - the relink did not pick up the instrumented object"; exit 1; }
+echo "[tsan] wrote $OUT/librccl.so.1.0 ($REFS __tsan_ references, runtime comes from LD_PRELOAD)"

--- a/projects/rccl/tools/scripts/proxy_tsan.supp
+++ b/projects/rccl/tools/scripts/proxy_tsan.supp
@@ -1,0 +1,23 @@
+# ThreadSanitizer suppressions for running RCCL under TSAN.
+#
+# Only src/proxy.cc is instrumented (see build_tsan_proxy_lib.sh), but the
+# sanitizer still intercepts pthread/malloc globally and therefore reports races
+# inside the uninstrumented ROCm/HIP runtime and the C++ runtime. Those are not
+# the subject of this test and would otherwise bury the RCCL findings, so they
+# are suppressed here by originating library.
+#
+# Nothing in RCCL itself is suppressed: a race in proxy.cc must still be
+# reported, which is what the test asserts.
+
+called_from_lib:libamdhip64.so
+called_from_lib:libhsa-runtime64.so
+called_from_lib:libamd_comgr.so
+called_from_lib:librocprofiler-register.so
+called_from_lib:libamdsmi.so
+called_from_lib:libmpi.so
+called_from_lib:libopen-pal.so
+called_from_lib:libopen-rte.so
+
+race:^libamdhip64
+race:^libhsa-runtime64
+race:^libstdc\+\+

--- a/projects/rccl/tools/scripts/proxy_tsan_shims.py
+++ b/projects/rccl/tools/scripts/proxy_tsan_shims.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Apply the test-only shims that let run_proxy_freelist_tsan_test.sh observe the
+proxy-op free-list handoff.
+
+No shim changes the publish/consume protocol under test; they change how the pool
+is mapped, how many ops it hands out, and whether the take path reports itself.
+Without them the test cannot observe anything at all, so it would pass no matter
+what the code does.
+
+single mapping
+    The pool is mapped separately by the proxy thread (proxyProgressInit) and by
+    every connection (ncclProxyConnect), so producer and consumer reach the same
+    physical memory through different virtual addresses. ThreadSanitizer keys its
+    shadow state on the virtual address and therefore cannot correlate the two
+    accesses. Reusing one mapping per shm object inside the process makes the
+    real protocol observable.
+
+execution proof
+    A run that never reaches the shared free list would report no race for the
+    trivial reason that it never looked. The take path says once that it ran, and
+    the test requires that line.
+
+short free chain
+    MAX_OPS_PER_PEER is in the thousands, so in a short run the main thread never
+    drains its private chain and never comes back to the shared free list - the
+    site under test simply does not execute. Handing each peer a few ops forces
+    the handoff to run while the proxy thread recycles into it.
+
+The input is normally the hipified proxy.cc inside the build directory, so the
+source tree is left untouched.
+
+Usage:
+  proxy_tsan_shims.py --in build/hipify/src/proxy.cc --out /tmp/proxy_tsan.cc
+"""
+import argparse
+import sys
+
+# Anything near MAX_OPS_PER_PEER defeats the shim, so the accepted range is kept
+# small on purpose; see the check in main().
+MAX_TEST_OPS_PER_PEER = 256
+
+POOL_INIT_OLD = """    for (int r = 0; r < proxyState->tpLocalnRanks; r++) {
+      pool->freeOps[r] = r * MAX_OPS_PER_PEER;
+      for (int i = 0; i < MAX_OPS_PER_PEER - 1; i++)
+        pool->ops[r * MAX_OPS_PER_PEER + i].next = r * MAX_OPS_PER_PEER + i + 1;
+      pool->ops[(r + 1) * MAX_OPS_PER_PEER - 1].next = -1;
+    }
+"""
+
+POOL_INIT_NEW = """    // TEST-ONLY (short free chain): see proxy_tsan_shims.py. Each peer starts with
+    // a few ops instead of MAX_OPS_PER_PEER so the main thread runs out and has to
+    // come back to the shared pool->freeOps list while the proxy thread recycles
+    // into it. Capacity only; the pool keeps its size and the handoff protocol is
+    // untouched.
+    for (int r = 0; r < proxyState->tpLocalnRanks; r++) {
+      const int testOpsPerPeer = %d;
+      // A chain longer than one peer's partition would link ops that belong to
+      // the next peer, so two peers could hand out the same op. The bound is
+      // checked here because only the compiler knows MAX_OPS_PER_PEER, which
+      // depends on the target.
+      static_assert(testOpsPerPeer <= MAX_OPS_PER_PEER,
+                    "test free chain does not fit in one peer's partition of pool->ops");
+      pool->freeOps[r] = r * MAX_OPS_PER_PEER;
+      for (int i = 0; i < testOpsPerPeer - 1; i++)
+        pool->ops[r * MAX_OPS_PER_PEER + i].next = r * MAX_OPS_PER_PEER + i + 1;
+      pool->ops[r * MAX_OPS_PER_PEER + testOpsPerPeer - 1].next = -1;
+    }
+"""
+
+SINGLE_MAPPING_REGISTRY = """
+// ---- TEST-ONLY (single shm mapping per pool) -------------------------------
+// See proxy_tsan_shims.py: the proxy-op pool is mapped separately by the proxy
+// thread and by each connection, so a sanitizer cannot correlate the producer
+// and consumer accesses (different virtual addresses, same physical memory).
+// Reusing one mapping per shm object inside the process makes the real free-list
+// protocol observable. Mapping only; no protocol change.
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <string>
+static std::mutex g_testShmMutex;
+static std::map<std::string, void*> g_testShmCache;
+// Producer and consumer spell the same object differently but both end in the
+// mkstemp suffix of /dev/shm/nccl-XXXXXX, which is what lets one key serve both.
+// That shape is checked rather than assumed: if it ever changes, the lookup would
+// quietly miss, the pool would be mapped twice again, and the test would observe
+// nothing and pass.
+static std::string testShmKey(const char* p) {
+  std::string s(p);
+  size_t at = s.rfind("nccl-");
+  if (at == std::string::npos || s.size() - (at + 5) != 6) {
+    fprintf(stderr, "[test] proxy-op shm path '%s' is not .../nccl-XXXXXX, "
+                    "so the single-mapping shim cannot key on it\\n", p);
+    abort();
+  }
+  return s.substr(at + 5);
+}
+static void testShmRegister(const char* p, void* addr) {
+  std::lock_guard<std::mutex> lk(g_testShmMutex);
+  g_testShmCache[testShmKey(p)] = addr;
+}
+static void* testShmLookup(const char* p) {
+  std::lock_guard<std::mutex> lk(g_testShmMutex);
+  auto it = g_testShmCache.find(testShmKey(p));
+  return it == g_testShmCache.end() ? nullptr : it->second;
+}
+// ---------------------------------------------------------------------------
+"""
+
+REGISTRY_ANCHOR = "#define NCCL_MAX_PROXY_CONNECTIONS"
+
+CONSUMER_OLD = """    if (proxyOps->pool == NULL) {
+      NCCLCHECK(ncclShmOpen(poolPath, sizeof(poolPath), sizeof(struct ncclProxyOpsPool), (void**)(&proxyOps->pool),
+                            NULL, -1, &proxyOps->handle));
+      proxyOps->nextOps = proxyOps->nextOpsEnd = proxyOps->freeOp = -1;
+    }
+"""
+
+CONSUMER_NEW = """    if (proxyOps->pool == NULL) {
+      void* shared = testShmLookup(poolPath);
+      if (shared != nullptr) {
+        proxyOps->pool = (struct ncclProxyOpsPool*)shared;
+      } else {
+        NCCLCHECK(ncclShmOpen(poolPath, sizeof(poolPath), sizeof(struct ncclProxyOpsPool), (void**)(&proxyOps->pool),
+                              NULL, -1, &proxyOps->handle));
+        testShmRegister(poolPath, proxyOps->pool);
+      }
+      proxyOps->nextOps = proxyOps->nextOpsEnd = proxyOps->freeOp = -1;
+    }
+"""
+
+PRODUCER_OLD = """    NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, (void**)&pool, NULL, proxyState->tpLocalnRanks,
+                          &state->handle));
+"""
+
+PRODUCER_NEW = """    NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, (void**)&pool, NULL, proxyState->tpLocalnRanks,
+                          &state->handle));
+    testShmRegister(shmPath, pool);
+"""
+
+TAKE_PROOF_OLD = """    opIndex = freeOp;
+"""
+
+TAKE_PROOF_NEW = """    opIndex = freeOp;
+    // TEST-ONLY (execution proof): see proxy_tsan_shims.py. A run that never
+    // reaches the shared free list reports no race for the trivial reason that it
+    // never looked, so say once that this path did run.
+    {
+      static unsigned long testSharedTakes = 0;
+      if (__atomic_fetch_add(&testSharedTakes, 1UL, __ATOMIC_RELAXED) == 0)
+        fprintf(stderr, "[test] main thread took the shared free list\\n");
+    }
+"""
+
+
+def replace_once(text, old, new, what):
+    n = text.count(old)
+    if n != 1:
+        sys.exit(f"[proxy_tsan_shims] expected exactly one occurrence of {what}, found {n}")
+    return text.replace(old, new)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="src", required=True)
+    ap.add_argument("--out", dest="dst", required=True)
+    ap.add_argument("--ops-per-peer", type=int, default=32,
+                    help="ops handed to each peer at pool init (default 32, keep it small)")
+    args = ap.parse_args()
+
+    # The value has to stay far below MAX_OPS_PER_PEER, and not merely inside it:
+    # a chain the main thread never drains means the handoff under test is never
+    # reached, and the run then comes back clean without having checked anything.
+    # The generated code also carries a static_assert against the real
+    # MAX_OPS_PER_PEER, which is the only place its value is known.
+    if not 1 <= args.ops_per_peer <= MAX_TEST_OPS_PER_PEER:
+        ap.error(f"--ops-per-peer must be between 1 and {MAX_TEST_OPS_PER_PEER}; the point of the shim is a"
+                 " chain short enough that the main thread runs out and takes the shared free list")
+
+    s = open(args.src).read()
+    s = replace_once(s, POOL_INIT_OLD, POOL_INIT_NEW % args.ops_per_peer, "the free-list pool init")
+    s = replace_once(s, REGISTRY_ANCHOR, SINGLE_MAPPING_REGISTRY + "\n" + REGISTRY_ANCHOR,
+                     "the registry anchor")
+    s = replace_once(s, CONSUMER_OLD, CONSUMER_NEW, "the connection-side shm open")
+    s = replace_once(s, TAKE_PROOF_OLD, TAKE_PROOF_NEW, "the shared free-list take")
+    s = replace_once(s, PRODUCER_OLD, PRODUCER_NEW, "the proxy-thread-side shm open")
+
+    open(args.dst, "w").write(s)
+    print(f"[proxy_tsan_shims] wrote {args.dst} (ops_per_peer={args.ops_per_peer})")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rccl/tools/scripts/run_proxy_freelist_tsan_test.sh
+++ b/projects/rccl/tools/scripts/run_proxy_freelist_tsan_test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Manual check that the proxy-op free-list handoff in src/proxy.cc is ordered.
+#
+# WHAT IT CHECKS
+#   The proxy-op free list is handed between the main thread and the proxy thread
+#   through shared memory: the proxy thread links returned ops and publishes the
+#   list head, the main thread takes it. Since NCCL 2.28.9 (RCCL 80adf7fc56,
+#   release note "Fixed operation ordering between main thread and proxy thread to
+#   prevent hangs at large scale") that handoff uses an acquire/release protocol;
+#   before it, plain stores and a plain read left producer and consumer
+#   unsynchronised.
+#
+#   The test builds the real librccl from the tree as it is, with proxy.cc
+#   instrumented, runs a real rccl-tests collective under ThreadSanitizer, and
+#   fails if the handoff is reported as racy.
+#
+#   Scope: a report means the synchronisation is missing. It does not mean a
+#   hang: on x86 the store ordering happens to work out regardless, so the hang
+#   the fix prevents needs weakly ordered hardware. Races reported elsewhere in
+#   proxy.cc are printed but do not fail the test.
+#
+# WHAT RE-RUNS IT
+#   Nothing, today: it is run by hand. Wiring it into CI is possible but is its own
+#   piece of work. The suites under tools/ci/lib are single-node sbatch scripts
+#   driven by .github/workflows/rccl-suite.yml, and this needs two nodes, so it
+#   would take a two-node sbatch of its own, a caller workflow gated on changes to
+#   src/proxy.cc, and a reservation that can hold both nodes for the length of a
+#   ROCm build plus two short runs.
+#
+# CHECKING THAT THE TEST CAN FAIL
+#   Restore the pre-2.28.9 handoff by hand and re-run: in ncclLocalOpAppend
+#   replace the acquire COMPILER_ATOMIC_EXCHANGE on pool->freeOps with a plain
+#   read plus __sync_val_compare_and_swap, and in ncclProxyGetPostedOps replace
+#   the release COMPILER_ATOMIC_COMPARE_EXCHANGE loop with the plain store of
+#   pool->freeOps[i]. Both hunks are the reverse of the diff in 80adf7fc56. The
+#   run then reports the race, in the order of ten to twenty times.
+#
+# WHY THE TEST-ONLY SHIMS ARE NEEDED
+#   Two of them are there because otherwise the test cannot observe the handoff at
+#   all and would pass no matter what the code does: the pool is mapped twice per
+#   process so a sanitizer cannot correlate producer and consumer, and
+#   MAX_OPS_PER_PEER is large enough that a short run never reaches the shared
+#   list. The third makes the take path say once that it ran, which is what lets
+#   this test tell "no race" apart from "never looked"; a run without that line
+#   fails, and the answer is usually a lower OPS_PER_PEER. All three are applied to
+#   a copy of the hipified proxy.cc inside the build directory, so the source tree
+#   is never modified. See proxy_tsan_shims.py.
+#
+# REQUIREMENTS
+#   Two hosts that expose GPUs, ROCm with the ThreadSanitizer runtime, Open MPI,
+#   and an rccl-tests all_reduce_perf built against this RCCL. Slurm is used for
+#   host discovery and for the build when available, but is not required.
+#
+# ENVIRONMENT (everything is auto-detected; set to override)
+#   TEST_HOSTS      comma-separated hosts to use, e.g. "nodeA,nodeB".
+#                   Default: two idle Slurm nodes that expose enough GPUs.
+#   TEST_BIN        path to rccl-tests all_reduce_perf.
+#                   Default: first match under ../rccl-tests/build*/.
+#   TEST_IFACE      NIC for MPI and RCCL out-of-band traffic.
+#                   Default: the interface the launch host routes to its peer
+#                   over. If that cannot be determined, MPI and RCCL are left to
+#                   choose, which may be slower or pick an unusable link.
+#   GPUS_PER_PROC   GPUs per rank (default 4); hosts with fewer are skipped.
+#   OPS_PER_PEER    ops each peer starts with (default 32, 1..256); see the shims.
+#   NODE_DOMAIN     domain appended when a bare host name does not resolve.
+#                   Default: the domain of this host's own FQDN.
+#   TSANRT          path to libclang_rt.tsan-x86_64.so on the hosts.
+#                   Default: asked from the compiler.
+#   ROCM_PATH       ROCm prefix on the hosts (default /opt/rocm).
+#   OUT             where the instrumented library and logs are written.
+#   BUILD_CPUS, BUILD_MINUTES  srun sizing for the build.
+#   REMOTE_TIMEOUT  seconds allowed for each remote command (default 900).
+#
+# Exit status: 0 clean, 1 racy or the run did not complete, 3 no usable hosts.
+#
+# Usage: run_proxy_freelist_tsan_test.sh [build_dir]
+set -uo pipefail
+
+BD="${1:-build_proxy_tsan}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RCCL="$(cd "$HERE/../.." && pwd)"
+PROJECTS="$(cd "$RCCL/.." && pwd)"
+OUT="${OUT:-$HOME/.proxy_freelist_tsan}"
+SUPP="$HERE/proxy_tsan.supp"
+ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+GPUS_PER_PROC="${GPUS_PER_PROC:-4}"
+OPS_PER_PEER="${OPS_PER_PEER:-32}"
+BUILD_CPUS="${BUILD_CPUS:-64}"
+BUILD_MINUTES="${BUILD_MINUTES:-45}"
+NODE_DOMAIN="${NODE_DOMAIN:-$(hostname -f 2>/dev/null | sed -n 's/^[^.]*\.//p')}"
+LOG="$OUT/run.log"
+# The consumer side of the handoff, used twice: reports are attributed to it, and
+# the build keeps it out of line and refuses to go on if the symbol is missing.
+# Without that guard an inlined or renamed function would leave reports
+# unattributed, and racy code would read as clean.
+CONSUMER_FN="${CONSUMER_FN:-ncclLocalOpAppend}"
+rc=0
+
+cd "$RCCL" || exit 1
+[ -f "$BD/src/CMakeFiles/rccl.dir/flags.make" ] || { echo "[FAIL] no usable build dir: $BD"; exit 1; }
+
+if [ -z "${TEST_BIN:-}" ]; then
+  # Several rccl-tests build directories are common. Take the most recent one
+  # instead of whatever the glob lists first, and say so when there is a choice,
+  # because only the caller knows which build goes with this RCCL.
+  found=0
+  for cand in "$PROJECTS"/rccl-tests/build*/all_reduce_perf; do
+    [ -x "$cand" ] || continue
+    found=$((found + 1))
+    if [ -z "${TEST_BIN:-}" ] || [ "$cand" -nt "$TEST_BIN" ]; then TEST_BIN="$cand"; fi
+  done
+  [ "$found" -gt 1 ] && echo "== note: $found rccl-tests builds found, using the newest; set TEST_BIN to pin one"
+fi
+[ -x "${TEST_BIN:-}" ] || { echo "[FAIL] no rccl-tests all_reduce_perf found under $PROJECTS/rccl-tests; set TEST_BIN"; exit 1; }
+echo "== rccl-tests binary: $TEST_BIN"
+mkdir -p "$OUT"
+
+# --- helpers ---------------------------------------------------------------
+# Bare node names are not always resolvable, so fall back to the FQDN form.
+resolve_host() {
+  local h="$1"
+  getent hosts "$h" >/dev/null 2>&1 && { echo "$h"; return 0; }
+  [ -n "$NODE_DOMAIN" ] && getent hosts "$h.$NODE_DOMAIN" >/dev/null 2>&1 && { echo "$h.$NODE_DOMAIN"; return 0; }
+  return 1
+}
+
+# Run where ROCm and the GPUs are. Only the local host needs no ssh.
+remote() {
+  local host="$1"; shift
+  case "$host" in
+    "$(hostname)"|"$(hostname -f 2>/dev/null)"|localhost) bash -c "$*" ;;
+    *) timeout "${REMOTE_TIMEOUT:-900}" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=8 "$host" "$*" ;;
+  esac
+}
+
+# The build needs a machine with ROCm; use Slurm for it when present.
+build_somewhere() {
+  if command -v srun >/dev/null 2>&1; then
+    srun -N1 -n1 -c"$BUILD_CPUS" -t"$BUILD_MINUTES" bash -c "$1"
+  else
+    bash -c "$1"
+  fi
+}
+
+# --- pick two hosts that really expose GPUs --------------------------------
+if [ -n "${TEST_HOSTS:-}" ]; then
+  IFS=, read -r -a CAND <<< "$TEST_HOSTS"
+elif command -v sinfo >/dev/null 2>&1; then
+  mapfile -t CAND < <(sinfo -t idle -h -o "%n")
+else
+  echo "[FAIL] no Slurm for host discovery; set TEST_HOSTS=hostA,hostB"; exit 1
+fi
+
+NODES=()
+for n in "${CAND[@]}"; do
+  [ "${#NODES[@]}" -ge 2 ] && break
+  [ -n "$n" ] || continue
+  addr=$(resolve_host "$n") || { echo "  [preflight] skip $n (does not resolve)"; continue; }
+  gpus=$(remote "$addr" "'$ROCM_PATH/bin/rocminfo' 2>/dev/null | grep -c 'Device Type:.*GPU'" 2>/dev/null | tr -d '[:space:]')
+  if [ "${gpus:-0}" -ge "$GPUS_PER_PROC" ] 2>/dev/null; then
+    NODES+=("$addr")
+  else
+    echo "  [preflight] skip $n (GPUs=${gpus:-unreachable}, need $GPUS_PER_PROC)"
+  fi
+done
+[ "${#NODES[@]}" -ge 2 ] || { echo "[skip] need 2 reachable hosts with >= $GPUS_PER_PROC GPUs, found ${#NODES[@]}"; exit 3; }
+HOSTS="${NODES[0]}:1,${NODES[1]}:1"
+LAUNCH="${NODES[0]}"
+echo "== hosts: $HOSTS"
+
+# The library carries the instrumentation but not the sanitizer runtime (clang
+# does not link it into a shared object), so the runtime is preloaded into the
+# process. Ask the compiler where it lives instead of assuming a ROCm layout.
+if [ -z "${TSANRT:-}" ]; then
+  TSANRT=$(remote "$LAUNCH" "for c in '$ROCM_PATH/bin/amdclang++' amdclang++ clang++; do
+      p=\$(\$c -print-file-name=libclang_rt.tsan-x86_64.so 2>/dev/null); [ -f \"\$p\" ] && { echo \"\$p\"; break; }; done" \
+      2>/dev/null | tr -d '[:space:]')
+fi
+[ -n "$TSANRT" ] || { echo "[FAIL] could not locate libclang_rt.tsan-x86_64.so on $LAUNCH (set TSANRT)"; exit 1; }
+# A runtime that does not preload would produce a silent, meaningless clean run,
+# so prove here that it loads.
+remote "$LAUNCH" "LD_PRELOAD='$TSANRT' /bin/true" >/dev/null 2>&1 \
+  || { echo "[FAIL] TSAN runtime does not preload on $LAUNCH: $TSANRT"; exit 1; }
+echo "== tsan runtime: $TSANRT"
+
+# MPI and RCCL both need to agree on the out-of-band link. Whatever the launch
+# host uses to reach its peer is the safe answer, and it keeps the run off any
+# interface that cannot carry it.
+if [ -z "${TEST_IFACE:-}" ]; then
+  TEST_IFACE=$(remote "$LAUNCH" "ip=\$(getent hosts '${NODES[1]}' | awk '{print \$1; exit}')
+      [ -n \"\$ip\" ] && ip -o route get \"\$ip\" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if(\$i==\"dev\"){print \$(i+1); exit}}'" \
+      2>/dev/null | tr -d '[:space:]')
+fi
+IFACE_FLAGS=""
+if [ -n "$TEST_IFACE" ]; then
+  IFACE_FLAGS="--mca oob_tcp_if_include $TEST_IFACE --mca btl_tcp_if_include $TEST_IFACE -x NCCL_SOCKET_IFNAME=$TEST_IFACE"
+  echo "== interface: $TEST_IFACE"
+else
+  echo "== interface: not detected, leaving the choice to MPI and RCCL"
+fi
+
+# --- build the instrumented library ----------------------------------------
+echo
+echo "== building librccl with TSAN on proxy.cc =="
+# The shims are applied to the hipified copy, so it has to be a faithful copy of
+# the current source. hipify only regenerates it on a newer timestamp, so drop it
+# and let the build write it again; that also clears a shimmed copy left behind by
+# an earlier run. Only the build directory is affected.
+rm -f "$BD/hipify/src/proxy.cc"
+build_somewhere "cd '$RCCL' && cmake --build '$BD' -j $BUILD_CPUS" > "$OUT/build.log" 2>&1 \
+  || { echo "[FAIL] build failed, see $OUT/build.log"; exit 1; }
+grep -q "TEST-ONLY" "$BD/hipify/src/proxy.cc" \
+  && { echo "[FAIL] $BD/hipify/src/proxy.cc still carries test shims from an earlier run; rebuild $BD"; exit 1; }
+python3 "$HERE/proxy_tsan_shims.py" --in "$BD/hipify/src/proxy.cc" --out "$OUT/proxy_shimmed.cc" \
+        --ops-per-peer "$OPS_PER_PEER" || { echo "[FAIL] could not apply the test shims"; exit 1; }
+build_somewhere "CONSUMER_FN='$CONSUMER_FN' '$HERE/build_tsan_proxy_lib.sh' '$BD' '$OUT/lib' '$OUT/proxy_shimmed.cc'" >> "$OUT/build.log" 2>&1 \
+  || { echo "[FAIL] instrumented build failed, see $OUT/build.log"; exit 1; }
+grep -E "^\[tsan\]" "$OUT/build.log" | sed 's/^/   /'
+
+# --- run --------------------------------------------------------------------
+# PMIX_MCA_gds=hash keeps PMIx off its shared-memory component, which collides
+# with the address space TSAN reserves.
+echo
+echo "== running the collective under TSAN =="
+remote "$LAUNCH" "
+  cd '$PROJECTS'
+  export PMIX_MCA_gds=hash
+  mpirun --mca plm rsh --mca plm_rsh_agent 'ssh -o StrictHostKeyChecking=no' \
+    $IFACE_FLAGS -H $HOSTS -np 2 \
+    -x PMIX_MCA_gds -x LD_LIBRARY_PATH=$OUT/lib -x LD_PRELOAD=$TSANRT \
+    -x TSAN_OPTIONS='halt_on_error=0 history_size=7 suppressions=$SUPP' \
+    -x NCCL_MIN_NCHANNELS=8 \
+    bash -c 'unset HIP_VISIBLE_DEVICES ROCR_VISIBLE_DEVICES; cd $PROJECTS; exec setarch \$(uname -m) -R $TEST_BIN -b 8 -e 1K -f 2 -g $GPUS_PER_PROC -n 50 -w 5'
+" > "$LOG" 2>&1
+RUN_RC=$?
+
+# Reports are attributed to the consumer by the '#0' frames only, since matching
+# the name anywhere in the log would also pick up unrelated reports that merely
+# pass through the proxy thread. Keying on the pool's address instead is not an
+# option: the same shm object also carries the unrelated pool->nextOps reports.
+# The build guarantees the frame exists, so a rename or an inlining decision cannot
+# turn this into a silent zero.
+freelist_races() {
+  awk -v fn="$CONSUMER_FN" '
+    /WARNING: ThreadSanitizer: data race/ { inblk = 1; hit = 0 }
+    inblk && /^ +#0 / && index($0, fn) { hit = 1 }
+    inblk && /^SUMMARY: ThreadSanitizer/ { n += hit; inblk = 0 }
+    END { print n + 0 }
+  ' "$LOG" 2>/dev/null || echo 0
+}
+
+RACES=$(freelist_races)
+TOTAL=$(grep -c "WARNING: ThreadSanitizer: data race" "$LOG" 2>/dev/null || true)
+DONE=$(grep -c "Collective test concluded" "$LOG" 2>/dev/null || true)
+TOOK=$(grep -c "main thread took the shared free list" "$LOG" 2>/dev/null || true)
+echo "   collective completed: $DONE   shared-list takes seen: $TOOK   free-list races: $RACES"
+echo "   exit status: $RUN_RC   (data-race reports in total: $TOTAL)"
+
+echo
+# A run that died early would report no races either, so it cannot count as clean.
+if [ "${DONE:-0}" -gt 0 ]; then
+  echo "[ok] the collective ran to completion"
+else
+  echo "[FAIL] the collective did not complete - see $LOG"
+  rc=1
+fi
+# 66 is ThreadSanitizer's own exit code for "reported something", which is expected
+# here because proxy.cc carries unrelated findings. Anything else non-zero means the
+# run itself went wrong, and then a clean verdict would be meaningless.
+if [ "${RUN_RC:-1}" -eq 0 ] || [ "${RUN_RC:-1}" -eq 66 ]; then
+  echo "[ok] the run exited as expected ($RUN_RC)"
+else
+  echo "[FAIL] the run exited with $RUN_RC, which is neither success nor TSAN's 66 - see $LOG"
+  rc=1
+fi
+# Without this the test cannot tell "no race" from "never looked".
+if [ "${TOOK:-0}" -gt 0 ]; then
+  echo "[ok] the shared free-list handoff was exercised"
+else
+  echo "[FAIL] the shared free-list handoff never ran, so nothing was checked - lower OPS_PER_PEER"
+  rc=1
+fi
+if [ "${RACES:-0}" -eq 0 ]; then
+  echo "[ok] the free-list handoff is race free"
+else
+  echo "[FAIL] the free-list handoff is reported as racy $RACES time(s) - see $LOG"
+  rc=1
+fi
+
+echo
+echo "note: $BD now holds the instrumented, shimmed proxy.cc object; rebuild it before using it for anything else"
+[ "$rc" = 0 ] && echo "RESULT: PASS (logs in $OUT)" || echo "RESULT: FAIL (logs in $OUT)"
+exit "$rc"


### PR DESCRIPTION
## Motivation

NCCL 2.28.9 made the proxy-op free-list handoff between the main thread and the proxy thread use an acquire/release protocol ("Fixed operation ordering between main thread and proxy thread to prevent hangs at large scale", ported in 80adf7fc56). Before it, the head was published with plain stores and taken with a plain read. Nothing in the tree verifies this, and the failure it prevents cannot occur on x86 at all, so review has been the only thing holding the protocol in place.

## Technical Details

- Builds the real `librccl` from the tree as it is with `proxy.cc` under ThreadSanitizer, runs a real `all_reduce_perf` across two hosts, and fails if the handoff is reported as racy. A report means the synchronisation is missing, not that a hang occurs - the hang needs weakly ordered hardware.
- Does not rewrite the code under test and does not write to the source tree. Two shims - one shm mapping per pool, and a short free chain - go into the hipified copy in the build directory; without them the handoff is either unobservable by a sanitizer or never executed.
- Will not report a clean result by accident: the object and the library must carry `__tsan_` references, the consumer function must survive as a symbol so reports can be attributed to it, the runtime must preload, the collective must complete, the exit status must be 0 or ThreadSanitizer's 66, and the handoff must announce that it ran.
- Manual: nothing re-runs it. CI would need a two-node sbatch of its own, since the existing suites are single-node, plus a caller gated on `src/proxy.cc`; left as a follow-up and stated in the script header. Confirming the check can fail is likewise manual, and that procedure is in the header too.
- Nothing cluster-specific is assumed; every discovery has an override, listed in the script header.

## Issue Tracking

JIRA ID: AICOMRCCL-1885

## Test Plan

- Build `librccl` for gfx942 and run `tools/scripts/run_proxy_freelist_tsan_test.sh <build_dir>` on two MI300X nodes.
- Revert the two free-list hunks of 80adf7fc56 by hand and re-run; the check must fail.
- Run with no environment overrides set, and confirm `git status` is clean afterwards.

## Test Result

- Current tree: PASS. The handoff is confirmed to have executed, no race is reported, and the run exits 66, which is ThreadSanitizer's code for the unrelated findings `proxy.cc` already carries.
- Hand-reverted: FAIL, 10 races on the handoff. Across runs 10, 13 and 18 were seen, which is why the assertion is "none" rather than a fixed count.
- No modified tracked files after either run, and the auto-detected interface matches the one that used to be hard-coded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
