### PR TITLE
[rocjitsu][util] Add result and diagnostic utilities

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/result.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/result.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "util/result.h"
+
+namespace rocjitsu {
+
+using util::FailureOr;
+using util::Result;
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/util/README.md
+++ b/emulation/rocjitsu/lib/util/README.md
@@ -41,6 +41,8 @@ INTERFACE library that contributes an include path and nothing to link.
 | File | Description |
 |------|-------------|
 | `log.h` | Compile-time and runtime configurable logging with named groups (VM, CP). Thread-safe, supports lazy evaluation via lambda forms. Use `Logger::print<GroupId>()` for group-filtered output. |
+| `result.h` | No-throw `Result` and `FailureOr<T>` return types for expected failures. |
+| `diagnostic.h` | Non-owning diagnostic sinks and stream-style error construction for result-returning APIs. |
 | `except.h` | Exception hierarchy: `Exception` (base), `InvalidInst`, `UnimplementedInst`, `ConfigError`. All derive from `std::exception`. |
 
 ### Miscellaneous

--- a/emulation/rocjitsu/lib/util/include/util/diagnostic.h
+++ b/emulation/rocjitsu/lib/util/include/util/diagnostic.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "util/result.h"
+
+#include <cassert>
+#include <concepts>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace util {
+
+/// A non-owning destination for one completed diagnostic message.
+///
+/// The referenced callable must outlive the sink and every diagnostic created
+/// from it. It must be a non-volatile object; wrap a free function in an object
+/// when needed. A default-constructed sink intentionally discards messages.
+/// Explicit emission propagates callback failures, while destructor-triggered
+/// emission suppresses them.
+class DiagnosticSink {
+public:
+  DiagnosticSink() = default;
+
+  template <typename Callable>
+    requires(!std::same_as<std::remove_cvref_t<Callable>, DiagnosticSink> &&
+             std::is_object_v<Callable> && !std::is_volatile_v<Callable> &&
+             std::invocable<Callable &, std::string_view>)
+  explicit DiagnosticSink(Callable &callable)
+      : context_(std::addressof(callable)),
+        callback_([](const void *context, std::string_view message) {
+          using Object = std::remove_const_t<Callable>;
+          if constexpr (std::is_const_v<Callable>)
+            std::invoke(*static_cast<const Object *>(context), message);
+          else
+            std::invoke(*const_cast<Object *>(static_cast<const Object *>(context)), message);
+        }) {}
+
+  void emit(std::string_view message) const {
+    if (callback_ != nullptr)
+      callback_(context_, message);
+  }
+
+  [[nodiscard]] bool ignores_messages() const { return callback_ == nullptr; }
+
+private:
+  using Callback = void (*)(const void *, std::string_view);
+
+  const void *context_ = nullptr;
+  Callback callback_ = nullptr;
+};
+
+/// A move-only error builder that commits its message at most once.
+/// Non-fatal diagnostics and structured severity are intentionally outside this API.
+class InFlightDiagnostic {
+public:
+  explicit InFlightDiagnostic(DiagnosticSink sink) : sink_(sink) {
+    if (!sink_.ignores_messages())
+      stream_.emplace();
+  }
+
+  InFlightDiagnostic(const InFlightDiagnostic &) = delete;
+  InFlightDiagnostic &operator=(const InFlightDiagnostic &) = delete;
+
+  InFlightDiagnostic(InFlightDiagnostic &&other) noexcept
+      : sink_(other.sink_), stream_(std::move(other.stream_)), active_(other.active_) {
+    other.active_ = false;
+  }
+
+  InFlightDiagnostic &operator=(InFlightDiagnostic &&other) noexcept {
+    if (this == &other)
+      return *this;
+    emit_from_destructor();
+    sink_ = other.sink_;
+    stream_ = std::move(other.stream_);
+    active_ = other.active_;
+    other.active_ = false;
+    return *this;
+  }
+
+  ~InFlightDiagnostic() { emit_from_destructor(); }
+
+  template <typename T> InFlightDiagnostic &operator<<(T &&fragment) {
+    assert(active_ && "cannot append to an emitted diagnostic");
+    if (stream_)
+      *stream_ << std::forward<T>(fragment);
+    return *this;
+  }
+
+  InFlightDiagnostic &operator<<(std::ostream &(*manipulator)(std::ostream &)) {
+    assert(active_ && "cannot append to an emitted diagnostic");
+    if (stream_)
+      *stream_ << manipulator;
+    return *this;
+  }
+
+  /// Commit the diagnostic and return failure for compact propagation.
+  Result emit() {
+    if (active_) {
+      active_ = false;
+      if (stream_)
+        sink_.emit(stream_->str());
+    }
+    return Result::failure();
+  }
+
+  operator Result() { return emit(); }
+
+  template <typename T> operator FailureOr<T>() {
+    (void)emit();
+    return Result::failure();
+  }
+
+private:
+  void emit_from_destructor() noexcept {
+    if (!active_)
+      return;
+    try {
+      (void)emit();
+    } catch (...) {
+      // A destructor cannot safely surface diagnostic delivery failures.
+      active_ = false;
+    }
+  }
+
+  DiagnosticSink sink_;
+  std::optional<std::ostringstream> stream_;
+  bool active_ = true;
+};
+
+/// A cheap, copyable producer for in-flight diagnostics.
+class DiagnosticEmitter {
+public:
+  DiagnosticEmitter() = default;
+  explicit DiagnosticEmitter(DiagnosticSink sink) : sink_(sink) {}
+
+  template <typename Callable>
+    requires(!std::same_as<std::remove_cvref_t<Callable>, DiagnosticEmitter> &&
+             std::is_object_v<Callable> && !std::is_volatile_v<Callable> &&
+             std::invocable<Callable &, std::string_view>)
+  explicit DiagnosticEmitter(Callable &callable) : sink_(callable) {}
+
+  [[nodiscard]] InFlightDiagnostic emit() const { return InFlightDiagnostic(sink_); }
+  [[nodiscard]] bool ignores_messages() const { return sink_.ignores_messages(); }
+
+private:
+  DiagnosticSink sink_;
+};
+
+/// Owns the latest diagnostic message and provides an emitter that writes it.
+/// This single-threaded helper is pinned because its emitters borrow it.
+class StringDiagnostic {
+public:
+  StringDiagnostic() = default;
+  StringDiagnostic(const StringDiagnostic &) = delete;
+  StringDiagnostic(StringDiagnostic &&) = delete;
+  StringDiagnostic &operator=(const StringDiagnostic &) = delete;
+  StringDiagnostic &operator=(StringDiagnostic &&) = delete;
+
+  void operator()(std::string_view message) { message_.assign(message); }
+
+  [[nodiscard]] DiagnosticEmitter emitter() & { return DiagnosticEmitter(*this); }
+  DiagnosticEmitter emitter() && = delete;
+  [[nodiscard]] const std::string &message() const { return message_; }
+
+private:
+  std::string message_;
+};
+
+} // namespace util

--- a/emulation/rocjitsu/lib/util/include/util/result.h
+++ b/emulation/rocjitsu/lib/util/include/util/result.h
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace util {
+
+/// A success/failure result for operations that do not return a value.
+class [[nodiscard]] Result {
+public:
+  constexpr Result() noexcept = default;
+
+  static constexpr Result success() noexcept {
+    Result result;
+    result.succeeded_ = true;
+    return result;
+  }
+  static constexpr Result failure() noexcept { return {}; }
+
+  [[nodiscard]] constexpr bool succeeded() const noexcept { return succeeded_; }
+  [[nodiscard]] constexpr bool failed() const noexcept { return !succeeded_; }
+
+private:
+  bool succeeded_ = false;
+};
+
+/// Customization point for value types with a reserved failure representation.
+/// Niche specializations provide failure_value() and is_failure(). The niche must
+/// be safe to copy, move, assign, and destroy as a T. Program-defined
+/// specializations must be declared with T and be visible before every use of
+/// FailureOr<T> so that all translation units select the same storage.
+template <typename T> struct failure_or_storage_traits {
+  static constexpr bool has_niche = false;
+};
+
+/// Null is the canonical pointer failure representation.
+template <typename T> struct failure_or_storage_traits<T *> {
+  static constexpr bool has_niche = true;
+
+  [[nodiscard]] static constexpr T *failure_value() noexcept { return nullptr; }
+
+  [[nodiscard]] static constexpr bool is_failure(T *value) noexcept { return value == nullptr; }
+};
+
+/// A unique pointer with raw-pointer storage can use the null niche while retaining value
+/// references. Fancy pointers use the generic optional-backed storage.
+template <typename T, typename Deleter>
+  requires(std::is_same_v<typename std::unique_ptr<T, Deleter>::pointer,
+                          typename std::unique_ptr<T, Deleter>::element_type *> &&
+           failure_or_storage_traits<typename std::unique_ptr<T, Deleter>::pointer>::has_niche &&
+           std::is_constructible_v<std::unique_ptr<T, Deleter>,
+                                   typename std::unique_ptr<T, Deleter>::pointer>)
+struct failure_or_storage_traits<std::unique_ptr<T, Deleter>> {
+  using Value = std::unique_ptr<T, Deleter>;
+  using Pointer = typename Value::pointer;
+
+  static constexpr bool has_niche = true;
+
+  [[nodiscard]] static constexpr Value failure_value() noexcept { return Value(Pointer{}); }
+
+  [[nodiscard]] static constexpr bool is_failure(const Value &value) noexcept {
+    return failure_or_storage_traits<Pointer>::is_failure(value.get());
+  }
+};
+
+/// Storage for FailureOr. Specialize failure_or_storage_traits to use a niche.
+template <typename T, bool HasNiche = failure_or_storage_traits<T>::has_niche>
+class FailureOrStorage {
+public:
+  constexpr FailureOrStorage() noexcept = default;
+
+  template <typename U>
+    requires std::is_constructible_v<T, U &&>
+  constexpr FailureOrStorage(U &&value) noexcept : value_(std::in_place, std::forward<U>(value)) {}
+
+  FailureOrStorage(const FailureOrStorage &) noexcept = default;
+  FailureOrStorage(FailureOrStorage &&) noexcept = default;
+  FailureOrStorage &operator=(const FailureOrStorage &) noexcept = default;
+  FailureOrStorage &operator=(FailureOrStorage &&) noexcept = default;
+  constexpr ~FailureOrStorage() noexcept = default;
+
+  [[nodiscard]] constexpr bool has_value() const noexcept { return value_.has_value(); }
+
+  [[nodiscard]] constexpr T &value() & noexcept { return *value_; }
+  [[nodiscard]] constexpr const T &value() const & noexcept { return *value_; }
+  [[nodiscard]] constexpr T &&value() && noexcept { return std::move(*value_); }
+
+private:
+  std::optional<T> value_;
+};
+
+/// Niche-backed storage that still contains a T and can therefore return references.
+template <typename T> class FailureOrStorage<T, true> {
+  using Traits = failure_or_storage_traits<T>;
+
+public:
+  constexpr FailureOrStorage() noexcept : value_(Traits::failure_value()) {}
+
+  template <typename U>
+    requires std::is_constructible_v<T, U &&>
+  constexpr FailureOrStorage(U &&value) noexcept : value_(std::forward<U>(value)) {
+    assert(!Traits::is_failure(value_) &&
+           "cannot construct a successful FailureOr from its failure representation");
+  }
+
+  FailureOrStorage(const FailureOrStorage &) noexcept = default;
+  FailureOrStorage(FailureOrStorage &&) noexcept = default;
+  FailureOrStorage &operator=(const FailureOrStorage &) noexcept = default;
+  FailureOrStorage &operator=(FailureOrStorage &&) noexcept = default;
+  constexpr ~FailureOrStorage() noexcept = default;
+
+  [[nodiscard]] constexpr bool has_value() const noexcept { return !Traits::is_failure(value_); }
+
+  [[nodiscard]] constexpr T &value() & noexcept { return value_; }
+  [[nodiscard]] constexpr const T &value() const & noexcept { return value_; }
+  [[nodiscard]] constexpr T &&value() && noexcept { return std::move(value_); }
+
+private:
+  T value_;
+};
+
+/// A result that contains either a value or failure. A niche's failure
+/// representation is not a valid success value. After a move, the source is
+/// valid but whether it contains a value is unspecified.
+/// Every operation is noexcept; an exception from a value operation terminates the process.
+template <typename T> class [[nodiscard]] FailureOr {
+public:
+  /// Construct a failure; the supplied Result must itself represent failure.
+  constexpr FailureOr([[maybe_unused]] Result result) noexcept {
+    assert(result.failed() && "cannot construct a FailureOr from a successful Result");
+  }
+
+  template <typename U = T>
+    requires(!std::is_same_v<std::remove_cvref_t<U>, FailureOr> &&
+             !std::is_same_v<std::remove_cvref_t<U>, Result> && std::is_constructible_v<T, U &&>)
+  constexpr FailureOr(U &&value) noexcept : storage_(std::forward<U>(value)) {}
+
+  FailureOr(const FailureOr &) noexcept = default;
+  FailureOr(FailureOr &&) noexcept = default;
+  FailureOr &operator=(const FailureOr &) noexcept = default;
+  FailureOr &operator=(FailureOr &&) noexcept = default;
+  constexpr ~FailureOr() noexcept = default;
+
+  [[nodiscard]] constexpr bool succeeded() const noexcept { return storage_.has_value(); }
+  [[nodiscard]] constexpr bool failed() const noexcept { return !storage_.has_value(); }
+
+  [[nodiscard]] constexpr T &value() & noexcept {
+    assert(succeeded() && "cannot access the value of a failed FailureOr");
+    return storage_.value();
+  }
+  [[nodiscard]] constexpr const T &value() const & noexcept {
+    assert(succeeded() && "cannot access the value of a failed FailureOr");
+    return storage_.value();
+  }
+  [[nodiscard]] constexpr T &&value() && noexcept {
+    assert(succeeded() && "cannot access the value of a failed FailureOr");
+    return std::move(storage_).value();
+  }
+
+private:
+  FailureOrStorage<T> storage_;
+};
+
+} // namespace util

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -457,6 +457,7 @@ add_executable(
     cdna3_predicate_mask_test.cpp
     scoped_temp_test.cpp
     decode_execute_benchmark.cpp
+    util_result_test.cpp
     util_unique_handle_test.cpp
     util_simd_test.cpp
     v_add_simd_benchmark.cpp

--- a/emulation/rocjitsu/tests/util_result_test.cpp
+++ b/emulation/rocjitsu/tests/util_result_test.cpp
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/result.h"
+#include "util/diagnostic.h"
+#include "util/result.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <iomanip>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+struct CustomNicheValue {
+  int value;
+};
+
+class FancyPointer {
+public:
+  using element_type = int;
+
+  constexpr FancyPointer() = default;
+  constexpr FancyPointer(std::nullptr_t) {}
+  explicit constexpr FancyPointer(int state) : state_(state) {}
+
+  explicit constexpr operator bool() const { return state_ != 0; }
+  friend constexpr bool operator==(FancyPointer, FancyPointer) = default;
+  friend constexpr bool operator==(FancyPointer pointer, std::nullptr_t) {
+    return pointer.state_ == 0;
+  }
+  [[nodiscard]] constexpr int state() const { return state_; }
+
+private:
+  int state_ = 0;
+};
+
+struct FancyPointerDeleter {
+  using pointer = FancyPointer;
+
+  void operator()(FancyPointer) const noexcept {}
+};
+
+template <> struct util::failure_or_storage_traits<CustomNicheValue> {
+  static constexpr bool has_niche = true;
+
+  [[nodiscard]] static constexpr CustomNicheValue failure_value() noexcept { return {-1}; }
+  [[nodiscard]] static constexpr bool is_failure(const CustomNicheValue &value) noexcept {
+    return value.value == -1;
+  }
+};
+
+template <> struct util::failure_or_storage_traits<FancyPointer> {
+  static constexpr bool has_niche = true;
+
+  [[nodiscard]] static constexpr FancyPointer failure_value() noexcept { return FancyPointer(1); }
+  [[nodiscard]] static constexpr bool is_failure(FancyPointer pointer) noexcept {
+    return pointer.state() == 1;
+  }
+};
+
+namespace {
+
+struct PotentiallyThrowingValue {
+  PotentiallyThrowingValue() = default;
+  PotentiallyThrowingValue(PotentiallyThrowingValue &&) noexcept(false) {}
+  PotentiallyThrowingValue &operator=(PotentiallyThrowingValue &&) noexcept(false) { return *this; }
+};
+
+struct CountingDeleter {
+  static inline int calls = 0;
+
+  void operator()(int *value) const noexcept {
+    ++calls;
+    delete value;
+  }
+};
+
+struct FormattingProbe {
+  bool &formatted;
+};
+
+struct ConstCollector {
+  std::vector<std::string> &messages;
+
+  void operator()(std::string_view message) const { messages.emplace_back(message); }
+};
+
+using DiagnosticFunction = void(std::string_view);
+
+template <typename T>
+concept HasRvalueEmitter = requires { std::declval<T &&>().emitter(); };
+
+std::ostream &operator<<(std::ostream &stream, const FormattingProbe &probe) {
+  probe.formatted = true;
+  return stream;
+}
+
+TEST(ResultTest, RepresentsSuccessAndFailure) {
+  constexpr util::Result default_failure;
+  constexpr auto success = util::Result::success();
+  constexpr util::Result failure = util::Result::failure();
+  static_assert(default_failure.failed());
+  static_assert(success.succeeded() && !success.failed());
+  static_assert(failure.failed() && !failure.succeeded());
+  static_assert(noexcept(success.succeeded()) && noexcept(failure.failed()));
+  static_assert(std::is_same_v<decltype(util::Result::failure()), util::Result>);
+  static_assert(std::is_same_v<rocjitsu::Result, util::Result>);
+}
+
+TEST(FailureOrTest, RepresentsValueOrFailureWithoutThrowing) {
+  using IntResult = util::FailureOr<int>;
+  constexpr IntResult value(42);
+  constexpr IntResult failure(util::Result::failure());
+  static_assert(value.succeeded() && value.value() == 42);
+  static_assert(failure.failed());
+  static_assert(std::is_nothrow_copy_constructible_v<IntResult>);
+  static_assert(std::is_nothrow_copy_assignable_v<IntResult>);
+  static_assert(std::is_nothrow_move_constructible_v<IntResult>);
+  static_assert(std::is_nothrow_move_assignable_v<IntResult>);
+  static_assert(std::is_nothrow_destructible_v<IntResult>);
+  static_assert(std::is_nothrow_constructible_v<IntResult, util::Result>);
+  static_assert(std::is_nothrow_move_constructible_v<util::FailureOr<std::unique_ptr<int>>>);
+  static_assert(sizeof(util::FailureOr<std::unique_ptr<int>>) == sizeof(std::unique_ptr<int>));
+  static_assert(sizeof(util::FailureOr<std::unique_ptr<int[]>>) == sizeof(std::unique_ptr<int[]>));
+  using TerminatingResult = util::FailureOr<PotentiallyThrowingValue>;
+  static_assert(std::is_nothrow_constructible_v<TerminatingResult, PotentiallyThrowingValue>);
+  static_assert(std::is_nothrow_move_constructible_v<TerminatingResult>);
+  static_assert(std::is_nothrow_move_assignable_v<TerminatingResult>);
+  static_assert(noexcept(value.succeeded()) && noexcept(failure.failed()) &&
+                noexcept(value.value()));
+  static_assert(std::is_same_v<rocjitsu::FailureOr<int>, IntResult>);
+}
+
+TEST(FailureOrTest, RejectsSuccessfulResult) {
+  EXPECT_DEBUG_DEATH(
+      { [[maybe_unused]] util::FailureOr<int> result(util::Result::success()); }, "");
+}
+
+TEST(FailureOrTest, UsesNullAsPointerFailure) {
+  constexpr util::FailureOr<int *> pointer_failure(util::Result::failure());
+  constexpr util::FailureOr<char *> byte_pointer_failure(util::Result::failure());
+  constexpr util::FailureOr<void *> void_pointer_failure(util::Result::failure());
+  constexpr util::FailureOr<void (*)()> function_pointer_failure(util::Result::failure());
+
+  static_assert(pointer_failure.failed());
+  static_assert(sizeof(util::FailureOr<char *>) == sizeof(char *));
+  static_assert(byte_pointer_failure.failed());
+  static_assert(void_pointer_failure.failed());
+  static_assert(function_pointer_failure.failed());
+}
+
+TEST(FailureOrTest, SupportsCustomNicheTraits) {
+  constexpr util::FailureOr<CustomNicheValue> value(CustomNicheValue{42});
+  constexpr util::FailureOr<CustomNicheValue> failure(util::Result::failure());
+
+  static_assert(value.succeeded() && value.value().value == 42);
+  static_assert(failure.failed());
+  static_assert(sizeof(util::FailureOr<CustomNicheValue>) == sizeof(CustomNicheValue));
+}
+
+TEST(FailureOrTest, UsesNullUniquePointerAsFailure) {
+  util::FailureOr<std::unique_ptr<int>> value(std::make_unique<int>(42));
+  util::FailureOr<std::unique_ptr<int>> failure(util::Result::failure());
+
+  ASSERT_TRUE(value.succeeded());
+  EXPECT_EQ(*value.value(), 42);
+  EXPECT_TRUE(failure.failed());
+}
+
+TEST(FailureOrTest, FallsBackToGenericStorageForFancyUniquePointer) {
+  using Pointer = std::unique_ptr<int, FancyPointerDeleter>;
+  static_assert(!util::failure_or_storage_traits<Pointer>::has_niche);
+
+  util::FailureOr<Pointer> failure(util::Result::failure());
+  util::FailureOr<Pointer> null_value(Pointer{});
+
+  EXPECT_TRUE(failure.failed());
+  EXPECT_TRUE(null_value.succeeded());
+  EXPECT_FALSE(static_cast<bool>(null_value.value()));
+}
+
+TEST(FailureOrTest, RejectsTheFailureRepresentationOnTheSuccessPath) {
+  EXPECT_DEBUG_DEATH(
+      { [[maybe_unused]] util::FailureOr<int *> result(static_cast<int *>(nullptr)); }, "");
+  EXPECT_DEBUG_DEATH(
+      { [[maybe_unused]] util::FailureOr<std::unique_ptr<int>> result(std::unique_ptr<int>{}); },
+      "");
+}
+
+TEST(FailureOrTest, DoesNotDeleteTheNullUniquePointerFailure) {
+  using Pointer = std::unique_ptr<int, CountingDeleter>;
+  using PointerResult = util::FailureOr<Pointer>;
+  static_assert(sizeof(PointerResult) == sizeof(Pointer));
+
+  CountingDeleter::calls = 0;
+  {
+    PointerResult result(util::Result::failure());
+    result = PointerResult(Pointer(new int(42)));
+    ASSERT_TRUE(result.succeeded());
+    EXPECT_EQ(*result.value(), 42);
+
+    result = PointerResult(util::Result::failure());
+    EXPECT_TRUE(result.failed());
+    EXPECT_EQ(CountingDeleter::calls, 1);
+  }
+  EXPECT_EQ(CountingDeleter::calls, 1);
+}
+
+TEST(InFlightDiagnosticTest, EmitsExactlyOnceAfterMove) {
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+  util::DiagnosticEmitter emitter(collect);
+
+  {
+    auto first = emitter.emit();
+    first << "invalid opcode 0x" << std::hex << 42 << std::endl;
+    auto second = std::move(first);
+    EXPECT_TRUE(second.emit().failed());
+  }
+
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "invalid opcode 0x2a\n");
+}
+
+TEST(DiagnosticSinkTest, SupportsConstCallableObjects) {
+  std::vector<std::string> messages;
+  const ConstCollector collect{messages};
+  util::DiagnosticEmitter emitter(collect);
+
+  EXPECT_TRUE((emitter.emit() << "const callable").emit().failed());
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "const callable");
+  static_assert(!std::is_constructible_v<util::DiagnosticEmitter, DiagnosticFunction &>);
+}
+
+TEST(InFlightDiagnosticTest, EmitsOnDestruction) {
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+  util::DiagnosticEmitter emitter(collect);
+
+  { emitter.emit() << "implicit emit"; }
+
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "implicit emit");
+}
+
+TEST(InFlightDiagnosticTest, RejectsFragmentsAfterEmission) {
+  auto diagnostic = util::DiagnosticEmitter{}.emit();
+  EXPECT_TRUE(diagnostic.emit().failed());
+  EXPECT_DEBUG_DEATH(diagnostic << "late fragment", "");
+}
+
+TEST(InFlightDiagnosticTest, MoveAssignmentEmitsTheOverwrittenMessage) {
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+  util::DiagnosticEmitter emitter(collect);
+
+  {
+    auto first = emitter.emit();
+    first << "first";
+    auto second = emitter.emit();
+    second << "second";
+    first = std::move(second);
+  }
+
+  ASSERT_EQ(messages.size(), 2u);
+  EXPECT_EQ(messages[0], "first");
+  EXPECT_EQ(messages[1], "second");
+}
+
+TEST(InFlightDiagnosticTest, ConvertsToFailedValueResult) {
+  std::vector<std::string> messages;
+  auto collect = [&](std::string_view message) { messages.emplace_back(message); };
+  util::DiagnosticEmitter emitter(collect);
+
+  auto fail = [&]() -> util::FailureOr<std::unique_ptr<int>> {
+    return emitter.emit() << "bad operand";
+  };
+
+  auto result = fail();
+  EXPECT_TRUE(result.failed());
+  ASSERT_EQ(messages.size(), 1u);
+  EXPECT_EQ(messages.front(), "bad operand");
+}
+
+TEST(InFlightDiagnosticTest, NoOpEmitterStillReturnsFailure) {
+  util::DiagnosticEmitter emitter;
+  bool formatted = false;
+
+  auto fail = [&]() -> util::Result { return emitter.emit() << FormattingProbe{formatted}; };
+
+  EXPECT_TRUE(fail().failed());
+  EXPECT_TRUE(emitter.ignores_messages());
+  EXPECT_FALSE(formatted);
+}
+
+TEST(StringDiagnosticTest, RetainsLatestMessage) {
+  static_assert(!std::is_copy_constructible_v<util::StringDiagnostic>);
+  static_assert(!std::is_move_constructible_v<util::StringDiagnostic>);
+  static_assert(!HasRvalueEmitter<util::StringDiagnostic>);
+
+  util::StringDiagnostic diagnostic;
+  auto emitter = diagnostic.emitter();
+
+  EXPECT_TRUE((emitter.emit() << "invalid operand " << 7).emit().failed());
+  EXPECT_EQ(diagnostic.message(), "invalid operand 7");
+}
+
+} // namespace


### PR DESCRIPTION
Add compact Result and FailureOr types for expected failures that should not propagate exceptions. Their operations establish an explicit termination boundary if a value operation throws.

Factor FailureOr storage behind a type traits-style customization point. We provide one for pointers -- `nullptr` is considered the failure state, which makes the representation more space efficient and avoids the usual confusion about double-nullable types.

Add non-owning diagnostic sinks and stream-style in-flight diagnostics -- this decouples diagnostics from error handling, as an alternative to strongly typed error code enums or custom error types.

Issue: https://github.com/ROCm/rocm-systems/issues/10239