### PR TITLE
feat(rocdbgapi): introduce clusters of workgroups (alternative)

### DIFF
--- a/projects/rocdbgapi/CHANGELOG.md
+++ b/projects/rocdbgapi/CHANGELOG.md
@@ -3,7 +3,23 @@
 Full documentation for AMD Debugger API is available at
 [rocm.docs.amd.com/rocdbgapi](https://rocm.docs.amd.com/projects/ROCdbgapi/en/latest/index.html).
 
-## rocm-dbgapi-0.80 for ROCm-X
+## rocm-dbgapi-0.81 for ROCm-X
+### Added
+- `amd_dbgapi_cluster_get_info` to query various information about a given
+  cluster.
+
+- A new error code, `AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID`
+  that is returned when the cluster id passed to an API function is invalid.
+
+- `amd_dbgapi_workgroup_get_info` adds a new query named
+  `AMD_DBGAPI_WORKGROUP_INFO_CLUSTER` to get the cluster a workgroup belongs to.
+
+- `amd_dbgapi_wave_get_info` adds a query named
+  `AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD` to get the cluster coordinates
+  of a wave, and a query named `AMD_DBGAPI_WAVE_INFO_CLUSTER` to get the
+  cluster a wave's workgroup belongs to.
+
+## rocm-dbgapi-0.80
 ### Added
 - amd_dbgapi_process_get_info() adds a new query to get a mask spanning
   over all the bits used by all the address spaces.  The query is called

--- a/projects/rocdbgapi/CHANGELOG.md
+++ b/projects/rocdbgapi/CHANGELOG.md
@@ -12,12 +12,16 @@ Full documentation for AMD Debugger API is available at
   that is returned when the cluster id passed to an API function is invalid.
 
 - `amd_dbgapi_workgroup_get_info` adds a new query named
-  `AMD_DBGAPI_WORKGROUP_INFO_CLUSTER` to get the cluster a workgroup belongs to.
+  `AMD_DBGAPI_WORKGROUP_INFO_CLUSTER` to get the cluster a workgroup belongs
+  to and a query named `AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD_IN_CLUSTER`
+  to get the workgroup's coordinates within its cluster.
 
 - `amd_dbgapi_wave_get_info` adds a query named
   `AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD` to get the cluster coordinates
-  of a wave, and a query named `AMD_DBGAPI_WAVE_INFO_CLUSTER` to get the
-  cluster a wave's workgroup belongs to.
+  of a wave, `AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD_IN_CLUSTER` to get the
+  wave's workgroup's coordinates within its cluster, and a query named
+  `AMD_DBGAPI_WAVE_INFO_CLUSTER` to get the cluster a wave's workgroup belongs
+  to.
 
 - `amd_dbgapi_dispatch_get_info` adds a query named
   `AMD_DBGAPI_DISPATCH_INFO_CLUSTER_SIZES` to get the cluster sizes in

--- a/projects/rocdbgapi/CHANGELOG.md
+++ b/projects/rocdbgapi/CHANGELOG.md
@@ -19,6 +19,10 @@ Full documentation for AMD Debugger API is available at
   of a wave, and a query named `AMD_DBGAPI_WAVE_INFO_CLUSTER` to get the
   cluster a wave's workgroup belongs to.
 
+- `amd_dbgapi_dispatch_get_info` adds a query named
+  `AMD_DBGAPI_DISPATCH_INFO_CLUSTER_SIZES` to get the cluster sizes in
+  work-items.
+
 ## rocm-dbgapi-0.80
 ### Added
 - amd_dbgapi_process_get_info() adds a new query to get a mask spanning

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(amd-dbgapi
   src/agent.cpp
   src/architecture.cpp
   src/callbacks.cpp
+  src/cluster.cpp
   src/code_object.cpp
   src/debug.cpp
   src/dispatch.cpp

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -3421,6 +3421,31 @@ amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_dispatch_list (
 
 /** @} */
 
+/** \defgroup cluster_group Workgroup Clusters
+ *
+ * Operations related to AMD GPU Workgroup Clusters.
+ *
+ * @{
+ */
+
+/**
+ * Opaque cluster handle.
+ *
+ * AMD GPU may execute code as workgroups organized into clusters.
+ *
+ * Globally unique for a single library instance.
+ */
+typedef struct
+{
+  uint64_t handle;
+} amd_dbgapi_cluster_id_t;
+
+/**
+ * The NULL cluster handle.
+ */
+#define AMD_DBGAPI_CLUSTER_NONE                                                  \
+    AMD_DBGAPI_HANDLE_LITERAL (amd_dbgapi_cluster_id_t, 0)
+
 /** \defgroup workgroup_group Workgroup
  *
  * Operations related to AMD GPU workgroups.

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -333,7 +333,7 @@
  * 6. By default, for some architectures, the AMD GPU device driver for Linux
  *    causes all wavefronts created when the library is not attached to the
  *    process by ::amd_dbgapi_process_attach to be unable to query the
- *    wavesfront's ::AMD_DBGAPI_WAVE_INFO_DISPATCH,
+ *    wavefront's ::AMD_DBGAPI_WAVE_INFO_DISPATCH,
  *    ::AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD, or
  *    ::AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP, or workgroup's
  *    ::AMD_DBGAPI_WORKGROUP_INFO_DISPATCH, or

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -3287,7 +3287,17 @@ typedef enum
    * not define a completion event, then ::amd_dbgapi_dispatch_get_info will
    * return ::AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED.
    */
-  AMD_DBGAPI_DISPATCH_INFO_KERNEL_COMPLETION_ADDRESS = 17
+  AMD_DBGAPI_DISPATCH_INFO_KERNEL_COMPLETION_ADDRESS = 17,
+  /**
+   * Return the dispatch cluster size (work-items) in the X, Y, and Z
+   * dimensions.  The type of this attribute is \p uint32_t[3].  If
+   * the architecture does not support clusters, then
+   * ::amd_dbgapi_dispatch_get_info returns
+   * ::AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED.  If the dispatch is not
+   * in cluster mode, then ::amd_dbgapi_dispatch_get_info
+   * returns ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.
+   */
+  AMD_DBGAPI_DISPATCH_INFO_CLUSTER_SIZES = 18,
 } amd_dbgapi_dispatch_info_t;
 
 /**
@@ -3333,7 +3343,7 @@ typedef enum
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_dispatch_get_info (
     amd_dbgapi_dispatch_id_t dispatch_id, amd_dbgapi_dispatch_info_t query,
-    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_54;
+    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_81;
 
 /**
  * Dispatch barrier.

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -665,6 +665,12 @@ typedef unsigned long amd_dbgapi_DWORD;
  */
 #define AMD_DBGAPI_VERSION_0_80
 
+/**
+ * The function was introduced in version 0.81 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.81"``.
+ */
+#define AMD_DBGAPI_VERSION_0_81
+
 /** @} */
 
 /** \ingroup callbacks_group
@@ -1090,6 +1096,10 @@ typedef enum
    * The requested memory location is valid but currently unreachable.
    */
   AMD_DBGAPI_STATUS_ERROR_MEMORY_UNAVAILABLE = -50,
+  /**
+   * The cluster handle is invalid.
+   */
+  AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID = -51,
 } amd_dbgapi_status_t;
 
 /**
@@ -3446,6 +3456,96 @@ typedef struct
 #define AMD_DBGAPI_CLUSTER_NONE                                                  \
     AMD_DBGAPI_HANDLE_LITERAL (amd_dbgapi_cluster_id_t, 0)
 
+/**
+ * Cluster queries that are supported by ::amd_dbgapi_cluster_get_info.
+ *
+ * Each query specifies the type of data returned in the \p value argument to
+ * ::amd_dbgapi_cluster_get_info.
+ */
+typedef enum
+{
+  /**
+   * Return the dispatch to which this cluster belongs.  The type of this
+   * attribute is ::amd_dbgapi_dispatch_id_t.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_DISPATCH = 1,
+  /**
+   * Return the queue to which this cluster belongs.  The type of this
+   * attribute is ::amd_dbgapi_queue_id_t.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_QUEUE = 2,
+  /**
+   * Return the agent to which this cluster belongs.  The type of this
+   * attribute is ::amd_dbgapi_agent_id_t.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_AGENT = 3,
+  /**
+   * Return the process to which this cluster belongs.  The type of this
+   * attribute is ::amd_dbgapi_process_id_t.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_PROCESS = 4,
+  /**
+   * Return the architecture of this cluster.  The type of this attribute is
+   * ::amd_dbgapi_architecture_id_t.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_ARCHITECTURE = 5,
+  /**
+   * The cluster coordinate in the dispatch grid dimensions.  The type
+   * of this attribute is \p uint32_t[3] with elements 1, 2, and 3
+   * corresponding to the X, Y, and Z coordinates respectively.
+   *
+   * If the dispatch associated with a workgroup is not available then
+   * ::amd_dbgapi_cluster_get_info returns
+   * ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.  See the \ref known_limitations
+   * section.
+   */
+  AMD_DBGAPI_CLUSTER_INFO_CLUSTER_COORD = 6,
+} amd_dbgapi_cluster_info_t;
+
+/**
+ * Query information about a cluster.
+ *
+ * ::amd_dbgapi_cluster_info_t specifies the queries supported and the type
+ * returned using the \p value argument.
+ *
+ * \param[in] cluster_id The handle of the cluster being queried.
+ *
+ * \param[in] query The query being requested.
+ *
+ * \param[in] value_size Size of the memory pointed to by \p value.  Must be
+ * equal to the byte size of the query result.
+ *
+ * \param[out] value Pointer to memory where the query result is stored.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_SUCCESS The function has been executed
+ * successfully and the result is stored in \p value.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_FATAL A fatal error occurred.  The library is
+ * left uninitialized and \p value is unaltered.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED The library is not
+ * initialized.  The library is left uninitialized and \p value is unaltered.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID \p cluster_id is
+ * invalid. \p value is unaltered.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT \p value is NULL or \p
+ * query is invalid.  \p value is unaltered.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY \p
+ * value_size does not match the size of the \p query result.  \p value is
+ * unaltered.
+ *
+ * \retval ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE \p The requested information
+ * is not available.  See ::amd_dbgapi_cluster_info_t for queries that can
+ * produce this error.  \p value is unaltered.
+ */
+amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_cluster_get_info (
+    amd_dbgapi_cluster_id_t cluster_id, amd_dbgapi_cluster_info_t query,
+    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_81;
+
+/** @} */
+
 /** \defgroup workgroup_group Workgroup
  *
  * Operations related to AMD GPU workgroups.
@@ -3519,7 +3619,12 @@ typedef enum
    * ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.  See the \ref known_limitations
    * section.
    */
-  AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD = 6
+  AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD = 6,
+  /**
+   * Return the cluster this workgroup belongs to.  The type of this attribute is
+   * ::amd_dbgapi_cluster_id_t.
+   */
+  AMD_DBGAPI_WORKGROUP_INFO_CLUSTER = 7,
 } amd_dbgapi_workgroup_info_t;
 
 /**
@@ -3566,7 +3671,7 @@ typedef enum
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_workgroup_get_info (
     amd_dbgapi_workgroup_id_t workgroup_id, amd_dbgapi_workgroup_info_t query,
-    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_64;
+    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_81;
 
 /**
  * Return the list of existing workgroups.
@@ -3763,7 +3868,24 @@ typedef enum
    * The number of lanes supported by the wave.  The type of this attribute is
    * \p size_t.
    */
-  AMD_DBGAPI_WAVE_INFO_LANE_COUNT = 14
+  AMD_DBGAPI_WAVE_INFO_LANE_COUNT = 14,
+  /**
+   * Return the cluster this wave's workgroup belongs to.  The type of
+   * this attribute is ::amd_dbgapi_cluster_id_t.
+   */
+  AMD_DBGAPI_WAVE_INFO_CLUSTER = 15,
+  /**
+   * The wave's workgroup's cluster coordinate in the dispatch grid
+   * dimensions.  The type of this attribute is \p uint32_t[3] with
+   * elements 1, 2, and 3 corresponding to the X, Y, and Z coordinates
+   * respectively.
+   *
+   * If the dispatch associated with a wave is not available then
+   * ::amd_dbgapi_wave_get_info returns
+   * ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.  See the \ref known_limitations
+   * section.
+   */
+  AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD = 16,
 } amd_dbgapi_wave_info_t;
 
 /**
@@ -3814,7 +3936,7 @@ typedef enum
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_wave_get_info (
     amd_dbgapi_wave_id_t wave_id, amd_dbgapi_wave_info_t query,
-    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_64;
+    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_81;
 
 /**
  * The execution state of a wave.

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -3635,6 +3635,17 @@ typedef enum
    * ::amd_dbgapi_cluster_id_t.
    */
   AMD_DBGAPI_WORKGROUP_INFO_CLUSTER = 7,
+  /**
+   * The workgroup coordinate within the cluster of the workgroup.  The
+   * type of this attribute is \p uint32_t[3] with elements 1, 2, and 3
+   * corresponding to the X, Y, and Z coordinates respectively.
+   *
+   * If the dispatch associated with a workgroup is not available then
+   * ::amd_dbgapi_workgroup_get_info returns
+   * ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.  See the \ref known_limitations
+   * section.
+   */
+  AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD_IN_CLUSTER = 8,
 } amd_dbgapi_workgroup_info_t;
 
 /**
@@ -3896,6 +3907,18 @@ typedef enum
    * section.
    */
   AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD = 16,
+  /**
+   * The wave's workgroup's coordinate within the cluster of the
+   * workgroup.  The type of this attribute is \p uint32_t[3] with
+   * elements 1, 2, and 3 corresponding to the X, Y, and Z coordinates
+   * respectively.
+   *
+   * If the dispatch associated with a wave is not available then
+   * ::amd_dbgapi_wave_get_info returns
+   * ::AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE.  See the \ref known_limitations
+   * section.
+   */
+  AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD_IN_CLUSTER = 17,
 } amd_dbgapi_wave_info_t;
 
 /**

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -7855,6 +7855,8 @@ public:
   get_apertures (const os_agent_info_t &info) const override;
   const void *register_read_only_mask (amdgpu_regnum_t regnum) const override;
 
+  bool supports_clusters () const override { return true; }
+
 private:
   register_class_t &get_register_class (const char *class_name);
 };

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -76,6 +76,24 @@ architecture_t::cwsr_record_t::architecture () const
   return queue ().architecture ();
 }
 
+std::optional<std::array<uint32_t, 3>>
+architecture_t::cwsr_record_t::cluster_ids () const
+{
+  /* By default, even when the dispatch is not in cluster mode, we
+     think of a workgroup being in a single-workgroup cluster.  In
+     that case, the cluster is positioned at the same location with
+     the workgroup it contains.  */
+  return group_ids ();
+}
+
+std::array<uint32_t, 3>
+architecture_t::cwsr_record_t::nwg_in_cluster () const
+{
+  /* By default, there is a single workgroup.  See the comment in
+     cluster_ids above.  */
+  return {1, 1, 1};
+}
+
 /* Base class for all AMDGCN architectures.  */
 
 class amdgcn_architecture_t : public architecture_t
@@ -2523,9 +2541,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const
   {
     dbgapi_assert (compute_relaunch_state.size () == 1);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
@@ -3365,7 +3386,7 @@ gfx9_architecture_t::control_stack_iterate (
       else
         {
           auto cwsr_record = make_cwsr_record (queue, xcc_id, relaunch, state,
-                                               last_wave_area - 64);
+                                               last_wave_area - 64, false);
 
           last_wave_area
             = cwsr_record->register_address (amdgpu_regnum_t::v0_64).value ();
@@ -3541,7 +3562,8 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    bool in_cluster) const override
     = 0;
 
   mi_architecture_t (elf_amdgpu_machine_t e_machine,
@@ -3690,9 +3712,12 @@ class gfx908_t final : public mi_architecture_t
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 1);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
@@ -3754,9 +3779,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 1);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
@@ -3874,9 +3902,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 1);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
@@ -4298,9 +4329,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 1);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
@@ -4408,9 +4442,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 2);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       compute_relaunch_state[1], context_save_address);
@@ -5321,6 +5358,7 @@ gfx10_architecture_t::control_stack_iterate (
 {
   size_t wave_count = 0;
   std::vector<uint32_t> state{ 0, 0 };
+  bool in_cluster_so_far = false;
 
   agent_address_t last_wave_area = wave_area_address;
 
@@ -5342,8 +5380,16 @@ gfx10_architecture_t::control_stack_iterate (
         }
       else
         {
+          /* cwsr_record_t ctor marks the CWSR record to be in cluster mode
+             if the record is the first wave of a cluster, even if
+             in_cluster_so_far is false.  */
           auto cwsr_record = make_cwsr_record (queue, xcc_id, relaunch, state,
-                                               last_wave_area);
+                                               last_wave_area,
+                                               in_cluster_so_far);
+
+          in_cluster_so_far
+            = ((in_cluster_so_far || cwsr_record->is_first_of_cluster ())
+               && !cwsr_record->is_last_of_cluster ());
 
           last_wave_area = cwsr_record->begin ();
           wave_callback (std::move (cwsr_record));
@@ -5508,9 +5554,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 2);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       compute_relaunch_state[1], context_save_address);
@@ -6359,9 +6408,12 @@ protected:
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    [[maybe_unused]] bool in_cluster) const override
   {
     dbgapi_assert (compute_relaunch_state.size () == 2);
+    dbgapi_assert (!in_cluster);
+
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       compute_relaunch_state[1], context_save_address);
@@ -7654,16 +7706,30 @@ protected:
       return utils::bit_extract (relaunch_wave, 13, 13);
     }
 
+    static constexpr uint32_t
+    compute_relaunch_wave_payload_first_of_cluster (uint32_t relaunch_wave)
+    {
+      return utils::bit_extract (relaunch_wave, 27, 27);
+    }
+
+    static constexpr uint32_t
+    compute_relaunch_wave_payload_last_of_cluster (uint32_t relaunch_wave)
+    {
+      return utils::bit_extract (relaunch_wave, 28, 28);
+    }
+
   public:
     cwsr_record_t (compute_queue_t &queue, uint32_t xcc_id,
                    uint32_t compute_relaunch_wave,
                    uint32_t compute_relaunch_state,
                    uint32_t compute_relaunch2_state,
-                   agent_address_t context_save_address)
+                   agent_address_t context_save_address,
+                   bool in_cluster)
       : gfx12_architecture_t::cwsr_record_t (
           queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
           compute_relaunch2_state, context_save_address)
     {
+      m_in_cluster = in_cluster || is_first_of_cluster ();
     }
 
     /* There's no "shared_vgpr" in gfx 125x anymore.  */
@@ -7672,20 +7738,29 @@ protected:
     size_t hwreg_count () const override;
     size_t lds_size () const override;
     bool is_last_wave () const override;
+    bool is_first_of_cluster () const override;
+    bool is_last_of_cluster () const override;
+    std::optional<std::array<uint32_t, 3>> cluster_ids () const override;
+    std::array<uint32_t, 3> nwg_in_cluster () const override;
+    std::optional<std::array<uint32_t, 3>> group_ids () const override;
 
     std::optional<agent_address_t>
     register_address (amdgpu_regnum_t regnum) const override;
+
+  protected:
+    bool m_in_cluster;
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
   make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
                     uint32_t compute_relaunch_wave,
                     const std::vector<uint32_t> &compute_relaunch_state,
-                    agent_address_t context_save_address) const override
+                    agent_address_t context_save_address,
+                    bool in_cluster) const override
   {
     return std::make_unique<cwsr_record_t> (
       queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
-      compute_relaunch_state[1], context_save_address);
+      compute_relaunch_state[1], context_save_address, in_cluster);
   }
 
   /* A note regarding all the register methods in this class:
@@ -8048,6 +8123,81 @@ bool
 gfx12_5_architecture_t::cwsr_record_t::is_last_wave () const
 {
   return compute_relaunch_wave_payload_last_wave (m_compute_relaunch_wave);
+}
+
+bool
+gfx12_5_architecture_t::cwsr_record_t::is_first_of_cluster () const
+{
+  return compute_relaunch_wave_payload_first_of_cluster (m_compute_relaunch_wave);
+}
+
+bool
+gfx12_5_architecture_t::cwsr_record_t::is_last_of_cluster () const
+{
+  return compute_relaunch_wave_payload_last_of_cluster (m_compute_relaunch_wave);
+}
+
+std::optional<std::array<uint32_t, 3>>
+gfx12_5_architecture_t::cwsr_record_t::cluster_ids () const
+{
+  /* If we are not in cluster mode, pretend there is a
+     single-workgroup cluster.  That imaginary cluster would be positioned in
+     the same place as the workgroup.  */
+  if (!m_in_cluster)
+    return group_ids ();
+
+  /* If we are in cluster mode, the coordinates are fetched from the
+     registers the same way group ids are fetched in gfx12.  */
+  return gfx12_architecture_t::cwsr_record_t::group_ids ();
+}
+
+std::array<uint32_t, 3>
+gfx12_5_architecture_t::cwsr_record_t::nwg_in_cluster () const
+{
+  if (!m_in_cluster)
+    return {1, 1, 1};
+
+  uint32_t ttmp6;
+  const agent_address_t ttmp6_address
+    = register_address (amdgpu_regnum_t::ttmp6).value ();
+  agent ().read_agent_memory (ttmp6_address, &ttmp6);
+
+  std::array<uint32_t, 3> nwg;
+  nwg[0] = utils::bit_extract (ttmp6, 12, 15);
+  nwg[1] = utils::bit_extract (ttmp6, 16, 19);
+  nwg[2] = utils::bit_extract (ttmp6, 20, 23);
+
+  return nwg;
+}
+
+std::optional<std::array<uint32_t, 3>>
+gfx12_5_architecture_t::cwsr_record_t::group_ids () const
+{
+  if (!m_in_cluster)
+    return gfx12_architecture_t::cwsr_record_t::group_ids ();
+
+  auto cids = cluster_ids ();
+  dbgapi_assert (cids.has_value ());
+  std::array<uint32_t, 3> cluster_in_grid = cids.value ();
+
+  std::array<uint32_t, 3> nwg = nwg_in_cluster ();
+
+  uint32_t ttmp6;
+  const agent_address_t ttmp6_address
+    = register_address (amdgpu_regnum_t::ttmp6).value ();
+  agent ().read_agent_memory (ttmp6_address, &ttmp6);
+
+  std::array<uint32_t, 3> wg_in_cluster;
+  wg_in_cluster[0] = utils::bit_extract (ttmp6, 0, 3);
+  wg_in_cluster[1] = utils::bit_extract (ttmp6, 4, 7);
+  wg_in_cluster[2] = utils::bit_extract (ttmp6, 8, 11);
+
+  std::array<uint32_t, 3> wg_in_grid;
+  wg_in_grid[0] = cluster_in_grid[0] * nwg[0] + wg_in_cluster[0];
+  wg_in_grid[1] = cluster_in_grid[1] * nwg[1] + wg_in_cluster[1];
+  wg_in_grid[2] = cluster_in_grid[2] * nwg[2] + wg_in_cluster[2];
+
+  return wg_in_grid;
 }
 
 std::optional<agent_address_t>

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -201,7 +201,16 @@ public:
     virtual bool spi_ttmps_setup_enabled () const = 0;
     /* Return the globally unique wave identifier.  */
     virtual amd_dbgapi_wave_id_t id () const = 0;
-    /* The 3-dimensional workgroup coordinates.  */
+    /* The 3-dimensional cluster coordinates within the grid.  If a
+       dispatch could not be associated, this is nullopt.  */
+    virtual std::optional<std::array<uint32_t, 3>> cluster_ids () const;
+    /* The number of workgroups in each of 3-dimensions in the cluster
+       that this wave belongs to.  Even when the dispatch is not in
+       cluster mode, we imagine that each workgroup belongs to a
+       cluster, which is (1, 1, 1) in size.  */
+    virtual std::array<uint32_t, 3> nwg_in_cluster () const;
+    /* The 3-dimensional workgroup coordinates within the grid.  If a
+       dispatch could not be associated, this is nullopt.  */
     virtual std::optional<std::array<uint32_t, 3>> group_ids () const = 0;
     /* Return the record's position in the workgroup.  */
     virtual std::optional<uint32_t> position_in_group () const = 0;
@@ -212,6 +221,10 @@ public:
     virtual bool is_last_wave () const = 0;
     /* First wave of threadgroup.  */
     virtual bool is_first_wave () const = 0;
+    /* Last wave of cluster.  */
+    virtual bool is_last_of_cluster () const { return false; }
+    /* First wave of cluster  */
+    virtual bool is_first_of_cluster () const { return false; }
 
     /* Size of the local data share.  */
     virtual size_t lds_size () const = 0;

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -469,6 +469,8 @@ public:
   void get_info (amd_dbgapi_architecture_info_t query, size_t value_size,
                  void *value) const;
 
+  virtual bool supports_clusters () const { return false; }
+
   template <typename Object, typename... Args> auto &create (Args &&...args)
   {
     return get_base_type_element<Object> (m_handle_object_sets)

--- a/projects/rocdbgapi/src/cluster.cpp
+++ b/projects/rocdbgapi/src/cluster.cpp
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE. */
+
+#include "cluster.h"
+#include "agent.h"
+#include "dispatch.h"
+#include "process.h"
+#include "queue.h"
+
+namespace amd::dbgapi
+{
+
+queue_t &
+cluster_t::queue () const
+{
+  return dispatch ().queue ();
+}
+
+const agent_t &
+cluster_t::agent () const
+{
+  return queue ().agent ();
+}
+
+process_t &
+cluster_t::process () const
+{
+  return agent ().process ();
+}
+
+const architecture_t &
+cluster_t::architecture () const
+{
+  return queue ().architecture ();
+}
+
+} /* namespace amd::dbgapi */

--- a/projects/rocdbgapi/src/cluster.cpp
+++ b/projects/rocdbgapi/src/cluster.cpp
@@ -51,4 +51,72 @@ cluster_t::architecture () const
   return queue ().architecture ();
 }
 
+void
+cluster_t::get_info (amd_dbgapi_cluster_info_t query, size_t value_size,
+                     void *value) const
+{
+  switch (query)
+    {
+    case AMD_DBGAPI_CLUSTER_INFO_DISPATCH:
+      utils::get_info (value_size, value, dispatch ().id ());
+      return;
+
+    case AMD_DBGAPI_CLUSTER_INFO_QUEUE:
+      utils::get_info (value_size, value, queue ().id ());
+      return;
+
+    case AMD_DBGAPI_CLUSTER_INFO_AGENT:
+      utils::get_info (value_size, value, agent ().id ());
+      return;
+
+    case AMD_DBGAPI_CLUSTER_INFO_PROCESS:
+      utils::get_info (value_size, value, process ().id ());
+      return;
+
+    case AMD_DBGAPI_CLUSTER_INFO_ARCHITECTURE:
+      utils::get_info (value_size, value, architecture ().id ());
+      return;
+
+    case AMD_DBGAPI_CLUSTER_INFO_CLUSTER_COORD:
+      {
+        auto ids = cluster_ids ();
+        if (!ids.has_value ())
+          THROW (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
+    }
+
+  throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
+}
+
 } /* namespace amd::dbgapi */
+
+using namespace amd::dbgapi;
+
+amd_dbgapi_status_t AMD_DBGAPI
+amd_dbgapi_cluster_get_info (amd_dbgapi_cluster_id_t cluster_id,
+                             amd_dbgapi_cluster_info_t query,
+                             size_t value_size, void *value)
+{
+  TRACE_BEGIN (param_in (cluster_id), param_in (query),
+               param_in (value_size), param_in (value));
+  TRY
+  {
+    if (!detail::is_initialized)
+      THROW (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED);
+
+    cluster_t *cluster = find (cluster_id);
+
+    if (cluster == nullptr)
+      THROW (AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID);
+
+    cluster->get_info (query, value_size, value);
+  }
+  CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT,
+         AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY,
+         AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+  TRACE_END (make_query_ref (query, param_out (value)));
+}

--- a/projects/rocdbgapi/src/cluster.h
+++ b/projects/rocdbgapi/src/cluster.h
@@ -1,0 +1,79 @@
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE. */
+
+#ifndef AMD_DBGAPI_CLUSTER_H
+#define AMD_DBGAPI_CLUSTER_H 1
+
+#include "amd-dbgapi.h"
+#include "handle_object.h"
+
+#include <array>
+#include <optional>
+
+namespace amd::dbgapi
+{
+
+class dispatch_t;
+class queue_t;
+class agent_t;
+class architecture_t;
+class process_t;
+
+/* AMD Debugger API Cluster.  */
+
+class cluster_t : public detail::handle_object<amd_dbgapi_cluster_id_t>
+{
+private:
+  /* The cluster ids are the coordinates within the grid.  */
+  std::optional<const std::array<uint32_t, 3>> m_cluster_ids;
+
+  /* Number of workgroups this cluster contains in the X, Y, Z dimensions.  */
+  const std::array<uint32_t, 3> m_num_wgs;
+
+  epoch_t m_mark{ 0 };
+
+  const dispatch_t &m_dispatch;
+
+public:
+  cluster_t (amd_dbgapi_cluster_id_t cluster_id,
+             const dispatch_t &dispatch,
+             std::optional<const std::array<uint32_t, 3>> cluster_ids,
+             const std::array<uint32_t, 3> num_wgs)
+    : handle_object (cluster_id), m_cluster_ids (cluster_ids),
+      m_num_wgs (num_wgs), m_dispatch (dispatch)
+  {
+  }
+
+  const auto &cluster_ids () const { return m_cluster_ids; }
+  const auto &num_wgs () const { return m_num_wgs; }
+
+  epoch_t mark () const { return m_mark; }
+  void set_mark (epoch_t mark) { m_mark = mark; }
+
+  const dispatch_t &dispatch () const { return m_dispatch; }
+  queue_t &queue () const;
+  const agent_t &agent () const;
+  process_t &process () const;
+  const architecture_t &architecture () const;
+};
+
+} /* namespace amd::dbgapi */
+
+#endif /* AMD_DBGAPI_CLUSTER_H */

--- a/projects/rocdbgapi/src/cluster.h
+++ b/projects/rocdbgapi/src/cluster.h
@@ -67,6 +67,9 @@ public:
   epoch_t mark () const { return m_mark; }
   void set_mark (epoch_t mark) { m_mark = mark; }
 
+  void get_info (amd_dbgapi_cluster_info_t query, size_t value_size,
+                 void *value) const;
+
   const dispatch_t &dispatch () const { return m_dispatch; }
   queue_t &queue () const;
   const agent_t &agent () const;

--- a/projects/rocdbgapi/src/dispatch.cpp
+++ b/projects/rocdbgapi/src/dispatch.cpp
@@ -77,6 +77,8 @@ amd_dbgapi_dispatch_get_info (amd_dbgapi_dispatch_id_t dispatch_id,
     dispatch->get_info (query, value_size, value);
   }
   CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,
+         AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE,
+         AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED,
          AMD_DBGAPI_STATUS_ERROR_INVALID_DISPATCH_ID,
          AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT,
          AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY,

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -9,7 +9,6 @@ global: amd_dbgapi_address_is_in_address_class;
         amd_dbgapi_breakpoint_get_info;
         amd_dbgapi_code_object_get_info;
         amd_dbgapi_disassemble_instruction;
-        amd_dbgapi_dispatch_get_info;
         amd_dbgapi_displaced_stepping_get_info;
         amd_dbgapi_dwarf_address_class_to_address_class;
         amd_dbgapi_dwarf_address_space_to_address_space;
@@ -106,6 +105,7 @@ global: amd_dbgapi_process_get_info;
 
 @AMD_DBGAPI_NAME@_0.81 {
 global: amd_dbgapi_cluster_get_info;
+        amd_dbgapi_dispatch_get_info;
         amd_dbgapi_wave_get_info;
         amd_dbgapi_workgroup_get_info;
 } @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -57,8 +57,6 @@ global: amd_dbgapi_address_class_get_info;
 
 @AMD_DBGAPI_NAME@_0.64 {
 global: amd_dbgapi_process_workgroup_list;
-        amd_dbgapi_wave_get_info;
-        amd_dbgapi_workgroup_get_info;
 } @AMD_DBGAPI_NAME@_0.62;
 
 @AMD_DBGAPI_NAME@_0.67 {
@@ -105,3 +103,9 @@ global:	amd_dbgapi_address_dependency;
 @AMD_DBGAPI_NAME@_0.80 {
 global: amd_dbgapi_process_get_info;
 } @AMD_DBGAPI_NAME@_0.79;
+
+@AMD_DBGAPI_NAME@_0.81 {
+global: amd_dbgapi_cluster_get_info;
+        amd_dbgapi_wave_get_info;
+        amd_dbgapi_workgroup_get_info;
+} @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -367,6 +367,7 @@ to_string (amd_dbgapi_status_t status)
       CASE (STATUS_ERROR_PROCESS_ALREADY_FROZEN);
       CASE (STATUS_ERROR_PROCESS_NOT_FROZEN);
       CASE (STATUS_ERROR_MEMORY_UNAVAILABLE);
+      CASE (STATUS_ERROR_INVALID_CLUSTER_ID);
     }
   return to_string (make_hex (status));
 }
@@ -1087,6 +1088,8 @@ to_string (amd_dbgapi_wave_info_t wave_info)
       CASE (WAVE_INFO_WORKGROUP_COORD);
       CASE (WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP);
       CASE (WAVE_INFO_LANE_COUNT);
+      CASE (WAVE_INFO_CLUSTER);
+      CASE (WAVE_INFO_CLUSTER_COORD);
     }
   return to_string (make_hex (wave_info));
 }
@@ -1143,6 +1146,11 @@ to_string (detail::query_ref<amd_dbgapi_wave_info_t> ref)
       return to_string (make_ref (static_cast<const uint32_t *> (value)));
     case AMD_DBGAPI_WAVE_INFO_LANE_COUNT:
       return to_string (make_ref (static_cast<const size_t *> (value)));
+    case AMD_DBGAPI_WAVE_INFO_CLUSTER:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_cluster_id_t *> (value)));
+    case AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD:
+      return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
     }
   fatal_error ("unhandled amd_dbgapi_wave_info_t query (%s)",
                to_cstring (query));
@@ -1647,6 +1655,7 @@ to_string (amd_dbgapi_workgroup_info_t workgroup_info)
       CASE (WORKGROUP_INFO_PROCESS);
       CASE (WORKGROUP_INFO_ARCHITECTURE);
       CASE (WORKGROUP_INFO_WORKGROUP_COORD);
+      CASE (WORKGROUP_INFO_CLUSTER);
     }
   return to_string (make_hex (workgroup_info));
 }
@@ -1675,8 +1684,56 @@ to_string (detail::query_ref<amd_dbgapi_workgroup_info_t> ref)
         make_ref (static_cast<const amd_dbgapi_architecture_id_t *> (value)));
     case AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD:
       return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
+    case AMD_DBGAPI_WORKGROUP_INFO_CLUSTER:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_cluster_id_t *> (value)));
     }
   fatal_error ("unhandled amd_dbgapi_workgroup_info_t query (%s)",
+               to_cstring (query));
+}
+
+template <>
+std::string
+to_string (amd_dbgapi_cluster_info_t cluster_info)
+{
+  switch (cluster_info)
+    {
+      CASE (CLUSTER_INFO_DISPATCH);
+      CASE (CLUSTER_INFO_QUEUE);
+      CASE (CLUSTER_INFO_AGENT);
+      CASE (CLUSTER_INFO_PROCESS);
+      CASE (CLUSTER_INFO_ARCHITECTURE);
+      CASE (CLUSTER_INFO_CLUSTER_COORD);
+    }
+  return to_string (make_hex (cluster_info));
+}
+
+template <>
+std::string
+to_string (detail::query_ref<amd_dbgapi_cluster_info_t> ref)
+{
+  auto [query, value] = ref;
+  switch (query)
+    {
+    case AMD_DBGAPI_CLUSTER_INFO_DISPATCH:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_dispatch_id_t *> (value)));
+    case AMD_DBGAPI_CLUSTER_INFO_QUEUE:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_queue_id_t *> (value)));
+    case AMD_DBGAPI_CLUSTER_INFO_AGENT:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_agent_id_t *> (value)));
+    case AMD_DBGAPI_CLUSTER_INFO_PROCESS:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_process_id_t *> (value)));
+    case AMD_DBGAPI_CLUSTER_INFO_ARCHITECTURE:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_architecture_id_t *> (value)));
+    case AMD_DBGAPI_CLUSTER_INFO_CLUSTER_COORD:
+      return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
+    }
+  fatal_error ("unhandled amd_dbgapi_cluster_info_t query (%s)",
                to_cstring (query));
 }
 

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -989,6 +989,7 @@ to_string (amd_dbgapi_dispatch_info_t dispatch_info)
       CASE (DISPATCH_INFO_KERNEL_DESCRIPTOR_ADDRESS);
       CASE (DISPATCH_INFO_KERNEL_CODE_ENTRY_ADDRESS);
       CASE (DISPATCH_INFO_KERNEL_COMPLETION_ADDRESS);
+      CASE (DISPATCH_INFO_CLUSTER_SIZES);
     }
   return to_string (make_hex (dispatch_info));
 }
@@ -1027,6 +1028,7 @@ to_string (detail::query_ref<amd_dbgapi_dispatch_info_t> ref)
     case AMD_DBGAPI_DISPATCH_INFO_WORKGROUP_SIZES:
       return to_string (make_ref (static_cast<const uint16_t *> (value), 3));
     case AMD_DBGAPI_DISPATCH_INFO_GRID_SIZES:
+    case AMD_DBGAPI_DISPATCH_INFO_CLUSTER_SIZES:
       return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
     case AMD_DBGAPI_DISPATCH_INFO_PRIVATE_SEGMENT_SIZE:
     case AMD_DBGAPI_DISPATCH_INFO_GROUP_SEGMENT_SIZE:

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -149,6 +149,16 @@ to_string (amd_dbgapi_workgroup_id_t workgroup_id)
 
 template <>
 std::string
+to_string (amd_dbgapi_cluster_id_t cluster_id)
+{
+  if (cluster_id == AMD_DBGAPI_CLUSTER_NONE)
+    return "CLUSTER_NONE";
+
+  return string_printf ("cluster_%" PRId64, cluster_id.handle);
+}
+
+template <>
+std::string
 to_string (amd_dbgapi_dispatch_id_t dispatch_id)
 {
   if (dispatch_id == AMD_DBGAPI_DISPATCH_NONE)

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -1092,6 +1092,7 @@ to_string (amd_dbgapi_wave_info_t wave_info)
       CASE (WAVE_INFO_LANE_COUNT);
       CASE (WAVE_INFO_CLUSTER);
       CASE (WAVE_INFO_CLUSTER_COORD);
+      CASE (WAVE_INFO_WORKGROUP_COORD_IN_CLUSTER);
     }
   return to_string (make_hex (wave_info));
 }
@@ -1152,6 +1153,8 @@ to_string (detail::query_ref<amd_dbgapi_wave_info_t> ref)
       return to_string (
         make_ref (static_cast<const amd_dbgapi_cluster_id_t *> (value)));
     case AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD:
+      return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
+    case AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD_IN_CLUSTER:
       return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
     }
   fatal_error ("unhandled amd_dbgapi_wave_info_t query (%s)",
@@ -1658,6 +1661,7 @@ to_string (amd_dbgapi_workgroup_info_t workgroup_info)
       CASE (WORKGROUP_INFO_ARCHITECTURE);
       CASE (WORKGROUP_INFO_WORKGROUP_COORD);
       CASE (WORKGROUP_INFO_CLUSTER);
+      CASE (WORKGROUP_INFO_WORKGROUP_COORD_IN_CLUSTER);
     }
   return to_string (make_hex (workgroup_info));
 }
@@ -1689,6 +1693,8 @@ to_string (detail::query_ref<amd_dbgapi_workgroup_info_t> ref)
     case AMD_DBGAPI_WORKGROUP_INFO_CLUSTER:
       return to_string (
         make_ref (static_cast<const amd_dbgapi_cluster_id_t *> (value)));
+    case AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD_IN_CLUSTER:
+      return to_string (make_ref (static_cast<const uint32_t *> (value), 3));
     }
   fatal_error ("unhandled amd_dbgapi_workgroup_info_t query (%s)",
                to_cstring (query));

--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -509,6 +509,7 @@ to_string (detail::parameter_t<detail::query_ref<T>, name, kind> param)
   F (amd_dbgapi_breakpoint_info_t)                                            \
   F (amd_dbgapi_changed_t)                                                    \
   F (amd_dbgapi_client_process_info_t)                                        \
+  F (amd_dbgapi_cluster_id_t)                                                 \
   F (amd_dbgapi_code_object_id_t)                                             \
   F (amd_dbgapi_code_object_info_t)                                           \
   F (amd_dbgapi_core_state_data_t)                                            \

--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -564,6 +564,7 @@ to_string (detail::parameter_t<detail::query_ref<T>, name, kind> param)
   F (detail::query_ref<amd_dbgapi_architecture_info_t>)                       \
   F (detail::query_ref<amd_dbgapi_breakpoint_info_t>)                         \
   F (detail::query_ref<amd_dbgapi_client_process_info_t>)                     \
+  F (detail::query_ref<amd_dbgapi_cluster_info_t>)                            \
   F (detail::query_ref<amd_dbgapi_code_object_info_t>)                        \
   F (detail::query_ref<amd_dbgapi_dispatch_info_t>)                           \
   F (detail::query_ref<amd_dbgapi_displaced_stepping_info_t>)                 \

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -272,6 +272,7 @@ process_t::detach ()
   dbgapi_assert (count<displaced_stepping_t> () == 0
                  && "all displaced steppings should have completed");
   std::get<handle_object_set_t<workgroup_t>> (m_handle_object_sets).clear ();
+  std::get<handle_object_set_t<cluster_t>> (m_handle_object_sets).clear ();
   std::get<handle_object_set_t<dispatch_t>> (m_handle_object_sets).clear ();
   std::get<handle_object_set_t<queue_t>> (m_handle_object_sets).clear ();
   std::get<handle_object_set_t<agent_t>> (m_handle_object_sets).clear ();

--- a/projects/rocdbgapi/src/process.h
+++ b/projects/rocdbgapi/src/process.h
@@ -24,6 +24,7 @@
 #include "amd-dbgapi.h"
 #include "callbacks.h"
 #include "code_object.h"
+#include "cluster.h"
 #include "debug.h"
 #include "dispatch.h"
 #include "displaced_stepping.h"
@@ -129,7 +130,8 @@ private:
     handle_object_set_t<code_object_t>, handle_object_set_t<dispatch_t>,
     handle_object_set_t<displaced_stepping_t>, handle_object_set_t<event_t>,
     handle_object_set_t<queue_t>, handle_object_set_t<watchpoint_t>,
-    handle_object_set_t<wave_t>, handle_object_set_t<workgroup_t>>
+    handle_object_set_t<wave_t>, handle_object_set_t<workgroup_t>,
+    handle_object_set_t<cluster_t>>
     m_handle_object_sets{};
 
   const agent_t m_dummy_agent;

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -380,8 +380,7 @@ compute_queue_t::update_waves ()
       group_leader = nullptr;
 
     wave->set_mark (wave_mark);
-    if (is_first_wave)
-      wave->workgroup ().set_mark (wave_mark);
+    wave->workgroup ().set_mark (wave_mark);
   };
 
   process_t &process = this->process ();

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -20,6 +20,7 @@
 
 #include "queue.h"
 #include "architecture.h"
+#include "cluster.h"
 #include "debug.h"
 #include "dispatch.h"
 #include "exception.h"
@@ -276,6 +277,7 @@ compute_queue_t::update_waves ()
 
     if (!wave)
       {
+        cluster_t *cluster = nullptr;
         workgroup_t *workgroup = nullptr;
 
         if (group_leader)
@@ -283,14 +285,17 @@ compute_queue_t::update_waves ()
             /* We already have identified the workgroup_t this wave belongs to,
                it is the same workgroup_t as the thread group leader's.  */
             workgroup = &group_leader->workgroup ();
+            cluster = &workgroup->cluster ();
 
-            if (workgroup->group_ids () != cwsr_record->group_ids ())
+            if (workgroup->group_ids () != cwsr_record->group_ids ()
+                || cluster->cluster_ids () != cwsr_record->cluster_ids ())
               fatal_error ("not in the same workgroup as the group_leader");
           }
         else
           {
             const auto packet_id = get_os_queue_packet_id (*cwsr_record);
             const auto group_ids = cwsr_record->group_ids ();
+            const auto cluster_ids = cwsr_record->cluster_ids ();
 
             /* Find the dispatch this wave belongs to using the packet_id.  The
                packet_id is only unique for a given queue.  */
@@ -302,11 +307,28 @@ compute_queue_t::update_waves ()
 
             if (dispatch)
               {
+                /* Find the workgroup this wave belongs to.
+                   Conceptually this is the dispatch -> cluster ->
+                   workgroup path.  */
                 workgroup = process.find_if (
-                  [dispatch, group_ids] (const workgroup_t &w) {
+                  [dispatch, &group_ids, &cluster_ids] (const workgroup_t &w) {
                     return w.dispatch () == *dispatch
+                           && w.cluster ().cluster_ids () == cluster_ids
                            && w.group_ids () == group_ids;
                   });
+
+                if (workgroup)
+                  cluster = &workgroup->cluster ();
+                else
+                  {
+                    /* Find the cluster this wave belongs to.
+                       Conceptually this is the dispatch -> cluster path.  */
+                    cluster = process.find_if (
+                      [dispatch, &cluster_ids] (const cluster_t &c) {
+                        return c.dispatch () == *dispatch
+                               && c.cluster_ids () == cluster_ids;
+                      });
+                  }
               }
             else if (packet_id)
               {
@@ -321,9 +343,13 @@ compute_queue_t::update_waves ()
                 dispatch = &m_dummy_dispatch;
               }
 
+            if (!cluster)
+              cluster = &process.create<cluster_t>
+                (*dispatch, cluster_ids, cwsr_record->nwg_in_cluster ());
+
             if (!workgroup)
               workgroup = &process.create<workgroup_t> (
-                *dispatch, group_ids, cwsr_record->lds_size ());
+                *cluster, group_ids, cwsr_record->lds_size ());
           }
 
         dbgapi_assert (workgroup != nullptr);
@@ -381,6 +407,7 @@ compute_queue_t::update_waves ()
 
     wave->set_mark (wave_mark);
     wave->workgroup ().set_mark (wave_mark);
+    wave->workgroup ().cluster ().set_mark (wave_mark);
   };
 
   process_t &process = this->process ();
@@ -462,6 +489,13 @@ compute_queue_t::update_waves ()
 
   auto &&workgroup_range = process.range<workgroup_t> ();
   for (auto it = workgroup_range.begin (); it != workgroup_range.end ();)
+    if (it->queue () == *this && it->mark () < wave_mark)
+      it = process.destroy (it);
+    else
+      ++it;
+
+  auto &&cluster_range = process.range<cluster_t> ();
+  for (auto it = cluster_range.begin (); it != cluster_range.end ();)
     if (it->queue () == *this && it->mark () < wave_mark)
       it = process.destroy (it);
     else
@@ -900,6 +934,10 @@ aql_queue_t::~aql_queue_t ()
 
   auto &&workgroup_range = process.range<workgroup_t> ();
   for (auto it = workgroup_range.begin (); it != workgroup_range.end ();)
+    it = (it->queue () == *this) ? process.destroy (it) : ++it;
+
+  auto &&cluster_range = process.range<cluster_t> ();
+  for (auto it = cluster_range.begin (); it != cluster_range.end ();)
     it = (it->queue () == *this) ? process.destroy (it) : ++it;
 
   auto &&dispatch_range = process.range<dispatch_t> ();

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -645,6 +645,7 @@ private:
 
     uint32_t grid_dimensions () const;
     std::array<uint32_t, 3> grid_sizes () const;
+    std::optional<std::array<uint32_t, 3>> cluster_sizes () const;
     std::array<uint16_t, 3> workgroup_sizes () const;
 
     void get_info (amd_dbgapi_dispatch_info_t query, size_t value_size,
@@ -776,6 +777,34 @@ aql_queue_t::aql_dispatch_t::grid_sizes () const
     m_packet);
 }
 
+std::optional<std::array<uint32_t, 3>>
+aql_queue_t::aql_dispatch_t::cluster_sizes () const
+{
+  return std::visit (
+    [] (auto &&p) -> std::optional<std::array<uint32_t, 3>>
+    {
+      using T = std::decay_t<decltype (p)>;
+      if constexpr (std::is_same_v<hsa_kernel_dispatch_packet_t, T>)
+        return std::nullopt;
+      else
+        {
+          /* If not in cluster mode, cluster size is 1,1,1.  */
+          if (p.cluster_size_x == 1 && p.cluster_size_y == 1
+              && p.cluster_size_z == 1)
+            return std::nullopt;
+
+          return std::array<uint32_t, 3>
+                 { static_cast<uint32_t> (p.cluster_size_x
+                                          * p.workgroup_size_x),
+                   static_cast<uint32_t> (p.cluster_size_y
+                                          * p.workgroup_size_y),
+                   static_cast<uint32_t> (p.cluster_size_z
+                                          * p.workgroup_size_z) };
+        }
+    },
+    m_packet);
+}
+
 std::array<uint16_t, 3>
 aql_queue_t::aql_dispatch_t::workgroup_sizes () const
 {
@@ -901,6 +930,18 @@ aql_queue_t::aql_dispatch_t::get_info (amd_dbgapi_dispatch_info_t query,
         value_size, value,
         std::visit ([] (auto &&p) { return p.completion_signal; }, m_packet));
       return;
+    case AMD_DBGAPI_DISPATCH_INFO_CLUSTER_SIZES:
+      {
+        if (!architecture ().supports_clusters ())
+          THROW (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+
+        auto sizes = cluster_sizes ();
+        if (!sizes.has_value ())
+          THROW (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+
+        utils::get_info (value_size, value, *sizes);
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/utils.cpp
+++ b/projects/rocdbgapi/src/utils.cpp
@@ -196,6 +196,11 @@ template std::pair<amd_dbgapi_dispatch_id_t * /* objects */,
 get_handle_list<dispatch_t> (const std::vector<process_t *> &processes,
                              amd_dbgapi_changed_t *changed);
 
+template std::pair<amd_dbgapi_cluster_id_t * /* objects */,
+                   size_t /* count */>
+get_handle_list<cluster_t> (const std::vector<process_t *> &processes,
+                            amd_dbgapi_changed_t *changed);
+
 template std::pair<amd_dbgapi_workgroup_id_t * /* objects */,
                    size_t /* count */>
 get_handle_list<workgroup_t> (const std::vector<process_t *> &processes,

--- a/projects/rocdbgapi/src/versioning.cpp
+++ b/projects/rocdbgapi/src/versioning.cpp
@@ -228,6 +228,9 @@ amd_dbgapi_get_status_string (amd_dbgapi_status_t status,
         string
           = "The memory at the specified address is currently unavailable";
         break;
+      case AMD_DBGAPI_STATUS_ERROR_INVALID_CLUSTER_ID:
+        string = "The cluster handle is invalid";
+        break;
         /* Don't add a default here, so that we can catch at compile time when
            an enum value is missing.  */
       }

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -993,10 +993,13 @@ wave_t::get_info (amd_dbgapi_wave_info_t query, size_t value_size,
       return;
 
     case AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD:
-      if (!workgroup ().group_ids ())
-        throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
-      utils::get_info (value_size, value, *workgroup ().group_ids ());
-      return;
+      {
+        auto ids = workgroup ().group_ids ();
+        if (!ids.has_value ())
+          throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
 
     case AMD_DBGAPI_WAVE_INFO_WAVE_NUMBER_IN_WORKGROUP:
       if (!m_wave_in_group)

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -69,10 +69,16 @@ wave_t::~wave_t ()
     raise_event (AMD_DBGAPI_EVENT_KIND_WAVE_COMMAND_TERMINATED);
 }
 
+cluster_t &
+wave_t::cluster () const
+{
+  return workgroup ().cluster ();
+}
+
 const dispatch_t &
 wave_t::dispatch () const
 {
-  return m_workgroup.dispatch ();
+  return cluster ().dispatch ();
 }
 
 queue_t &

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -1044,6 +1044,19 @@ wave_t::get_info (amd_dbgapi_wave_info_t query, size_t value_size,
     case AMD_DBGAPI_WAVE_INFO_LANE_COUNT:
       utils::get_info (value_size, value, lane_count ());
       return;
+
+    case AMD_DBGAPI_WAVE_INFO_CLUSTER:
+      utils::get_info (value_size, value, cluster ().id ());
+      return;
+
+    case AMD_DBGAPI_WAVE_INFO_CLUSTER_COORD:
+      {
+        auto ids = cluster ().cluster_ids ();
+        if (!ids.has_value ())
+          throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -1057,6 +1057,15 @@ wave_t::get_info (amd_dbgapi_wave_info_t query, size_t value_size,
         utils::get_info (value_size, value, *ids);
         return;
       }
+
+    case AMD_DBGAPI_WAVE_INFO_WORKGROUP_COORD_IN_CLUSTER:
+      {
+        auto ids = workgroup ().group_ids_in_cluster ();
+        if (!ids.has_value ())
+          throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/wave.h
+++ b/projects/rocdbgapi/src/wave.h
@@ -48,6 +48,7 @@ class event_t;
 class displaced_stepping_t;
 class process_t;
 class workgroup_t;
+class cluster_t;
 
 /* AMD Debugger API Wave.  */
 
@@ -243,6 +244,7 @@ public:
                  void *value) const;
 
   workgroup_t &workgroup () const { return m_workgroup; }
+  cluster_t &cluster () const;
   const dispatch_t &dispatch () const;
   queue_t &queue () const;
   const agent_t &agent () const;

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -146,10 +146,13 @@ workgroup_t::get_info (amd_dbgapi_workgroup_info_t query, size_t value_size,
       return;
 
     case AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD:
-      if (!group_ids ())
-        throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
-      utils::get_info (value_size, value, *group_ids ());
-      return;
+      {
+        auto ids = group_ids ();
+        if (!ids.has_value ())
+          throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -20,6 +20,7 @@
 
 #include "workgroup.h"
 #include "agent.h"
+#include "cluster.h"
 #include "dispatch.h"
 #include "memory.h"
 #include "process.h"
@@ -27,6 +28,12 @@
 
 namespace amd::dbgapi
 {
+
+const dispatch_t &
+workgroup_t::dispatch () const
+{
+  return cluster ().dispatch ();
+}
 
 queue_t &
 workgroup_t::queue () const

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -59,6 +59,23 @@ workgroup_t::architecture () const
   return queue ().architecture ();
 }
 
+std::optional<const std::array<uint32_t, 3>>
+workgroup_t::group_ids_in_cluster () const
+{
+  if (!m_group_ids.has_value ())
+    return std::nullopt;
+
+  const auto nwgs = cluster ().num_wgs ();
+  const auto &gids = m_group_ids.value ();
+
+  std::array<uint32_t, 3> ids
+    { gids[0] % nwgs[0],
+      gids[1] % nwgs[1],
+      gids[2] % nwgs[2] };
+
+  return ids;
+}
+
 void
 workgroup_t::update (agent_address_t local_memory_base_address)
 {
@@ -164,6 +181,15 @@ workgroup_t::get_info (amd_dbgapi_workgroup_info_t query, size_t value_size,
     case AMD_DBGAPI_WORKGROUP_INFO_CLUSTER:
       utils::get_info (value_size, value, cluster ().id ());
       return;
+
+    case AMD_DBGAPI_WORKGROUP_INFO_WORKGROUP_COORD_IN_CLUSTER:
+      {
+        auto ids = group_ids_in_cluster ();
+        if (!ids.has_value ())
+          throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_AVAILABLE);
+        utils::get_info (value_size, value, *ids);
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -160,6 +160,10 @@ workgroup_t::get_info (amd_dbgapi_workgroup_info_t query, size_t value_size,
         utils::get_info (value_size, value, *ids);
         return;
       }
+
+    case AMD_DBGAPI_WORKGROUP_INFO_CLUSTER:
+      utils::get_info (value_size, value, cluster ().id ());
+      return;
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -68,6 +68,12 @@ workgroup_t::group_ids_in_cluster () const
   const auto nwgs = cluster ().num_wgs ();
   const auto &gids = m_group_ids.value ();
 
+  log_level = AMD_DBGAPI_LOG_LEVEL_VERBOSE;
+  log_info ("nwgs:{%u,%u,%u}, gids:{%u,%u,%u}\n",
+            nwgs[0],nwgs[1],nwgs[2],
+            gids[0],gids[1],gids[2]);
+  log_level = AMD_DBGAPI_LOG_LEVEL_NONE;
+
   std::array<uint32_t, 3> ids
     { gids[0] % nwgs[0],
       gids[1] % nwgs[1],

--- a/projects/rocdbgapi/src/workgroup.h
+++ b/projects/rocdbgapi/src/workgroup.h
@@ -36,19 +36,21 @@ class architecture_t;
 class queue_t;
 class dispatch_t;
 class process_t;
+class cluster_t;
 
 /* AMD Debugger API Workgroup.  */
 
 class workgroup_t : public detail::handle_object<amd_dbgapi_workgroup_id_t>
 {
 private:
+  /* Coordinates of this workgroup within the grid.  */
   std::optional<const std::array<uint32_t, 3>> m_group_ids;
   epoch_t m_mark{ 0 };
 
   std::optional<agent_address_t> m_local_memory_base_address;
   amd_dbgapi_size_t const m_local_memory_size;
 
-  const dispatch_t &m_dispatch;
+  cluster_t &m_cluster;
 
   [[nodiscard]] size_t
   xfer_local_memory (const address_space_t &address_space,
@@ -57,11 +59,11 @@ private:
 
 public:
   workgroup_t (amd_dbgapi_workgroup_id_t workgroup_id,
-               const dispatch_t &dispatch,
+               cluster_t &cluster,
                std::optional<const std::array<uint32_t, 3>> group_ids,
                amd_dbgapi_size_t local_memory_size)
     : handle_object (workgroup_id), m_group_ids (group_ids),
-      m_local_memory_size (local_memory_size), m_dispatch (dispatch)
+      m_local_memory_size (local_memory_size), m_cluster (cluster)
   {
   }
 
@@ -80,7 +82,8 @@ public:
   void get_info (amd_dbgapi_workgroup_info_t query, size_t value_size,
                  void *value) const;
 
-  const dispatch_t &dispatch () const { return m_dispatch; }
+  cluster_t &cluster () const { return m_cluster; }
+  const dispatch_t &dispatch () const;
   queue_t &queue () const;
   const agent_t &agent () const;
   process_t &process () const;

--- a/projects/rocdbgapi/src/workgroup.h
+++ b/projects/rocdbgapi/src/workgroup.h
@@ -69,6 +69,8 @@ public:
 
   const auto &group_ids () const { return m_group_ids; }
 
+  std::optional<const std::array<uint32_t, 3>> group_ids_in_cluster () const;
+
   epoch_t mark () const { return m_mark; }
   void set_mark (epoch_t mark) { m_mark = mark; }
 


### PR DESCRIPTION
This is the same as PR #7992, except that it implements the "there is always a cluster" model.