### PR TITLE
fix(rocprofiler-sdk) fix pc sampling microsecond interval being clamped

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -463,7 +463,11 @@ convert_ioctl_pcs_config_to_rocp(const rocprofiler_ioctl_pc_sampling_info_t& ioc
         // No one configured PC sampling on the corresponding device.
         // Read the values of min and max interval provided by the KFD
         rocp_pcs_config.min_interval = ioctl_pcs_config.interval_min;
-        rocp_pcs_config.max_interval = std::min(ioctl_pcs_config.interval_max, 1ul << 20);
+        rocp_pcs_config.max_interval = ioctl_pcs_config.interval_max;
+        if(rocp_pcs_config.unit == ROCPROFILER_PC_SAMPLING_UNIT_CYCLES)
+        {
+            rocp_pcs_config.max_interval = std::min(rocp_pcs_config.max_interval, 1ul << 20);
+        }
     }
 
     rocp_pcs_config.flags = ioctl_pcs_config.flags;


### PR DESCRIPTION
## Motivation

[PR8431](https://github.com/ROCm/rocm-systems/pull/8431) had the unintended effect of also limiting the maximum number of microseconds users could specify when using PC sampling.

## Technical Details

Gated clamp behind a check on interval type.

## JIRA ID
JIRA ID : AIPROFSDK-913

## Test Plan

ran `rocprofv3-avail info --pc-sampling` to check valid intervals

## Test Result

time-based interval was unbounded after fix

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
