### PR TITLE
fix(rccl/ginsdma) 2 deadlock inducing contitions for SDMA GIN since sync 30.4

### DIFF
--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1718,14 +1718,8 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
     reqs->ginSignalCount = ginSignalTotal;
     reqs->ginCounterCount = ginCounterTotal;
     NCCLCHECK(ncclGinDevCommSetup(comm, reqs, outDevComm));
-#ifdef ENABLE_ROCSHMEM_GIN
-    if (ginSignalTotal > 0 && devr->winSortedCount > 0) {
-      struct ncclDevrWindow* win0 = devr->winSorted[0].win;
-      NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win0->userPtr, ginAnvilNetSignalsOffset,
-                                                          nGinContextsTotal, ginSignalTotal),
-                    ret, fail);
-    }
-#endif
+    // SDMA signal binding is deferred until the resource window is created
+    // (see ncclGinAnvilBindResourceWindowSignals call below).
   }
 
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
@@ -1801,6 +1795,17 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
   }
 
   CUDACHECKGOTO(cudaStreamSynchronize(stream), ret, fail_stream_mem_win);
+
+#ifdef ENABLE_ROCSHMEM_GIN
+  // Bind SDMA signal regions after the resource window is created and zeroed.
+  // Must use this devComm's own resource window (win->userPtr), not
+  // devr->winSorted[0] which may belong to a different devComm (e.g. symk).
+  if (devr->ginEnabled && ginSignalTotal > 0 && outDevComm->resourceWindow != nullptr) {
+    NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win->userPtr, ginAnvilNetSignalsOffset,
+                                                        nGinContextsTotal, ginSignalTotal),
+                  ret, fail_stream_mem_win);
+  }
+#endif
 
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail_stream_mem_win);
   CUDACHECKGOTO(cudaStreamDestroy(stream), ret, fail_stream_mem_win);

--- a/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
+++ b/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
@@ -68,7 +68,6 @@ struct GinAnvilPendingEntry {
 };
 
 static std::map<struct ncclComm*, GinAnvilPendingEntry*> g_pendingByComm;
-static std::map<struct ncclComm*, int> g_nextSignalSlot;
 
 static void ginAnvilPendingAdd(struct ncclComm* comm, ginAnvilGinCtx* ctx) {
   std::lock_guard<std::mutex> lock(pluginMutex);
@@ -97,7 +96,6 @@ static void ginAnvilPendingClear(struct ncclComm* comm) {
     e = next;
   }
   g_pendingByComm.erase(comm);
-  g_nextSignalSlot.erase(comm);
 }
 
 struct ginAnvilMemHandle {
@@ -130,7 +128,6 @@ void ncclGinAnvilPluginTestResetHostState(void) {
       e = next;
     }
     g_pendingByComm.erase(comm);
-    g_nextSignalSlot.erase(comm);
   }
   bufferRegRefcount.clear();
 }
@@ -464,10 +461,12 @@ ncclResult_t ncclGinAnvilBindResourceWindowSignals(struct ncclComm* comm, void* 
   if (!comm || !resourceUserPtr || nContexts < 1 || nSignalsPerContext < 1) return ncclInvalidArgument;
 
   ncclResult_t ret = ncclSuccess;
+  int slot = 0;
   for (GinAnvilPendingEntry* e = g_pendingByComm[comm]; e != nullptr; e = e->next) {
     ginAnvilGinCtx* ctx = e->ctx;
     if (ctx->nSignals <= 0) continue;
-    if (ctx->signalSlot < 0 || ctx->signalSlot >= nContexts) {
+    ctx->signalSlot = slot++;
+    if (ctx->signalSlot >= nContexts) {
       WARN("GIN anvil-sdma: signal slot %d out of range (nContexts=%d)", ctx->signalSlot, nContexts);
       ginAnvilPendingClear(comm);
       return ncclInvalidArgument;
@@ -502,10 +501,7 @@ static ncclResult_t ginAnvilCreateContext(void* collComm, ncclGinConfig_t* confi
   ctx->nSignals = config->nSignals;
   ctx->nCounters = config->nCounters;
   ctx->comm = cctx->comm;
-  {
-    std::lock_guard<std::mutex> lock(pluginMutex);
-    ctx->signalSlot = g_nextSignalSlot[cctx->comm]++;
-  }
+  ctx->signalSlot = -1;  // assigned during ncclGinAnvilBindResourceWindowSignals
   ctx->hasError = false;
   ctx->signalsBound = false;
   ctx->gpu_queue_handles = cctx->gpu_queue_handles;


### PR DESCRIPTION
from later work on 30.4 sync: signal regions are allocated later in the synced code, signal regions are tracked per ctx not globally.

## Motivation

The original SDMA code used a single global region for all signals. This assumption is not correct anymore past 30.4 resync. 


## Technical Details

Use per-ctx signal pools
No global increment for signal index

## Issue Tracking

JIRA ID: AICOMRCCL-1871 AICOMRCCL-1868


## Test Plan

GIN-SDMA Ran to completion on all2all post 916a218d 

## Test Result

alltoall pass/stable with PR, deadlock without

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
