### PR TITLE
[rocjitsu] Handle SMEM SGPR-offset (IMM=0) form on GFX9/CDNA

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -11421,7 +11421,9 @@ class CodeGenerator:
                             '  if (enc->imm)\n'
                             '    return Operand(32, OperandType::OPR_SIMM32, '
                             'static_cast<int>(enc->offset));\n'
-                            '  return Operand(32, OperandType::OPR_SIMM32, 0);\n'
+                            # IMM=0, SOFFSET_EN=0: OFFSET[6:0] is the offset SGPR.
+                            '  return Operand(32, OperandType::OPR_SMEM_OFFSET, '
+                            'static_cast<int>(enc->offset & 0x7F));\n'
                             '}\n'
                             '} // namespace'
                         )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.cpp
@@ -5,46 +5,17 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h"
-#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
-#include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
-#include "util/log.h"
 
 #include <cassert>
 #include <cstdint>
-#include <format>
 
 namespace rocjitsu {
 namespace cdna4 {
 
-namespace {
-bool is_scratch_op(uint32_t op) { return (op >= 5 && op <= 7) || (op >= 21 && op <= 23); }
-} // namespace
-
 uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
-  if (!is_scratch_op(inst.op))
-    return amdgpu::addr_calc::smem_calculate_address(inst, wf);
-
-  // S_SCRATCH_LOAD / S_SCRATCH_STORE per CDNA4 ISA spec (section 8.2.1.1):
-  // ADDR = SGPR[base] + inst_offset + { M0 or SGPR[soffset] or zero } * 64
-  const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
-  int64_t inst_offset = 0;
-  if (inst.imm)
-    inst_offset = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  uint64_t sgpr_off = 0;
-  if (inst.soffset_en)
-    sgpr_off = amdgpu::read_scalar_selector(wf, inst.soffset);
-  uint64_t addr = base + inst_offset + sgpr_off * 64;
-  util::Logger::cp([&](auto &os) {
-    static thread_local uint64_t scratch_smem_count = 0;
-    if (++scratch_smem_count <= 32)
-      os << std::format("S_SCRATCH_SMEM wf{} op={} sbase_idx={} base={:#x} inst_off={} "
-                        "sgpr_off={} addr={:#x} pc={:#x}",
-                        wf.wf_id(), inst.op, inst.sbase, base, inst_offset, sgpr_off, addr, wf.pc);
-  });
-  return addr;
+  return amdgpu::addr_calc::smem_calculate_address(inst, wf);
 }
 
 void flat_calculate_addresses(const FlatMachineInst &inst, amdgpu::Wavefront &wf,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/smem.cpp
@@ -23,7 +23,7 @@ Operand make_smem_offset(const Smem::OpEncoding *enc) {
     return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->soffset));
   if (enc->imm)
     return Operand(32, OperandType::OPR_SIMM32, static_cast<int>(enc->offset));
-  return Operand(32, OperandType::OPR_SIMM32, 0);
+  return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->offset & 0x7F));
 }
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/smem.cpp
@@ -23,7 +23,7 @@ Operand make_smem_offset(const Smem::OpEncoding *enc) {
     return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->soffset));
   if (enc->imm)
     return Operand(32, OperandType::OPR_SIMM32, static_cast<int>(enc->offset));
-  return Operand(32, OperandType::OPR_SIMM32, 0);
+  return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->offset & 0x7F));
 }
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/smem.cpp
@@ -24,7 +24,7 @@ Operand make_smem_offset(const Smem::OpEncoding *enc) {
     return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->soffset));
   if (enc->imm)
     return Operand(32, OperandType::OPR_SIMM32, static_cast<int>(enc->offset));
-  return Operand(32, OperandType::OPR_SIMM32, 0);
+  return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->offset & 0x7F));
 }
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/smem.cpp
@@ -24,7 +24,7 @@ Operand make_smem_offset(const Smem::OpEncoding *enc) {
     return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->soffset));
   if (enc->imm)
     return Operand(32, OperandType::OPR_SIMM32, static_cast<int>(enc->offset));
-  return Operand(32, OperandType::OPR_SIMM32, 0);
+  return Operand(32, OperandType::OPR_SMEM_OFFSET, static_cast<int>(enc->offset & 0x7F));
 }
 } // namespace
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
@@ -26,6 +26,11 @@ namespace rocjitsu {
 namespace amdgpu {
 namespace addr_calc {
 
+/// @brief GFX9 SMEM s_scratch_{load,store}_dword{,x2,x4} opcodes.
+constexpr bool smem_is_scratch_op(uint32_t op) {
+  return (op >= 5 && op <= 7) || (op >= 21 && op <= 23);
+}
+
 /// @brief Compute scalar address for SMEM encoding.
 ///
 /// Requires: inst.sbase, inst.soffset_en, inst.soffset, inst.imm, inst.offset.
@@ -36,8 +41,10 @@ uint64_t smem_calculate_address(const SmemInst &inst, amdgpu::Wavefront &wf) {
   uint64_t off = 0;
   if (inst.soffset_en)
     off += amdgpu::read_scalar_selector(wf, inst.soffset);
-  else if (!inst.imm) // IMM=0, SOE=0: OFFSET[6:0] is the offset SGPR
-    off += amdgpu::read_scalar_selector(wf, inst.offset & 0x7F);
+  else if (!inst.imm && !smem_is_scratch_op(inst.op)) { // IMM=0, SOE=0: SGPR[OFFSET[6:0]] or M0
+    const uint32_t sel = inst.offset & 0x7F;
+    off += (sel == 124 ? wf.m0() : amdgpu::read_scalar_selector(wf, sel)) & ~3u; // 2 LSBs ignored
+  }
   if (inst.imm)
     off += static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
   uint64_t addr = base + off;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
@@ -13,6 +13,7 @@
 /// with any ISA family whose encoding struct exposes the required field names.
 
 #include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_read.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
@@ -33,27 +34,34 @@ constexpr bool smem_is_scratch_op(uint32_t op) {
 
 /// @brief Compute scalar address for SMEM encoding.
 ///
-/// Requires: inst.sbase, inst.soffset_en, inst.soffset, inst.imm, inst.offset.
+/// @details GFX9 scalar memory addressing:
+/// ADDR = SGPR[base] + inst_offset + {SGPR[offset] or M0 or 0}, with the register
+/// component scaled by 64 for s_scratch_*. The two LSBs of each byte component are
+/// ignored. SBASE, OFFSET[6:0] (IMM=0) and SOFFSET (SOE=1) are scalar-source selectors.
+///
+/// Requires: inst.op, inst.sbase, inst.soffset_en, inst.soffset, inst.imm, inst.offset.
 template <typename SmemInst>
 uint64_t smem_calculate_address(const SmemInst &inst, amdgpu::Wavefront &wf) {
-  const uint32_t sbase_sel = inst.sbase * 2;
-  uint64_t base = amdgpu::read_scalar_selector64(wf, sbase_sel);
-  uint64_t off = 0;
-  if (inst.soffset_en)
-    off += amdgpu::read_scalar_selector(wf, inst.soffset);
-  else if (!inst.imm && !smem_is_scratch_op(inst.op)) { // IMM=0, SOE=0: SGPR[OFFSET[6:0]] or M0
-    const uint32_t sel = inst.offset & 0x7F;
-    off += (sel == 124 ? wf.m0() : amdgpu::read_scalar_selector(wf, sel)) & ~3u; // 2 LSBs ignored
-  }
+  constexpr uint64_t kDwordMask = ~0x3ULL;
+  constexpr int kM0Selector = 124;
+  const uint64_t base = amdgpu::resolve_src_scalar64(wf, inst.sbase * 2, kM0Selector) & kDwordMask;
+  int64_t inst_offset = 0;
   if (inst.imm)
-    off += static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
-  uint64_t addr = base + off;
+    inst_offset = static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11) & ~0x3LL;
+  uint64_t reg_offset = 0;
+  if (inst.soffset_en)
+    reg_offset = amdgpu::resolve_src_scalar(wf, inst.soffset, kM0Selector);
+  else if (!inst.imm)
+    reg_offset = amdgpu::resolve_src_scalar(wf, inst.offset & 0x7F, kM0Selector);
+  reg_offset = smem_is_scratch_op(inst.op) ? reg_offset * 64 : reg_offset & kDwordMask;
+  const uint64_t addr = base + inst_offset + reg_offset;
   util::Logger::vm([&](auto &os) {
     static thread_local uint64_t smem_count = 0;
     if (++smem_count <= 12 || (smem_count % 240) == 0)
-      os << std::format("SMEM #{} base={:#x} off={} imm={} soff_en={} addr={:#x} raw_off={}",
-                        smem_count, base, static_cast<int64_t>(off), inst.imm, inst.soffset_en,
-                        addr, inst.offset);
+      os << std::format("SMEM #{} op={} base={:#x} inst_off={:#x} reg_off={:#x} imm={} soff_en={} "
+                        "addr={:#x} raw_off={}",
+                        smem_count, inst.op, base, inst_offset, reg_offset, inst.imm,
+                        inst.soffset_en, addr, inst.offset);
   });
   return addr;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
@@ -36,6 +36,8 @@ uint64_t smem_calculate_address(const SmemInst &inst, amdgpu::Wavefront &wf) {
   uint64_t off = 0;
   if (inst.soffset_en)
     off += amdgpu::read_scalar_selector(wf, inst.soffset);
+  else if (!inst.imm) // IMM=0, SOE=0: OFFSET[6:0] is the offset SGPR
+    off += amdgpu::read_scalar_selector(wf, inst.offset & 0x7F);
   if (inst.imm)
     off += static_cast<int64_t>(static_cast<int32_t>(inst.offset << 11) >> 11);
   uint64_t addr = base + off;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2897,6 +2897,19 @@ constexpr uint32_t mubuf_hi(uint32_t vdata, uint32_t vaddr, uint32_t srsrc,
   return (soffset << 24) | (srsrc << 16) | (vdata << 8) | vaddr;
 }
 
+// SMEM (64-bit): CDNA layout.
+// dword0: sbase[5:0] (SGPR pair index), sdata[12:6], soffset_en[14], nv[15],
+//         glc[16], imm[17], op[25:18], encoding[31:26]=0x30
+// dword1: offset[20:0], soffset[31:25]
+constexpr uint32_t smem_lo(uint32_t op, uint32_t sdata, uint32_t sbase_sgpr, bool imm,
+                           bool soffset_en = false) {
+  return (0x30u << 26) | (op << 18) | (static_cast<uint32_t>(imm) << 17) |
+         (static_cast<uint32_t>(soffset_en) << 14) | (sdata << 6) | (sbase_sgpr / 2);
+}
+constexpr uint32_t smem_hi(uint32_t offset, uint32_t soffset = 0) {
+  return (soffset << 25) | (offset & 0x1FFFFFu);
+}
+
 constexpr uint32_t S_WAITCNT_0 = sopp(12, 0);
 constexpr uint32_t S_ENDPGM = sopp(1, 0);
 
@@ -3352,6 +3365,53 @@ TEST_P(IsaTest, BranchLoop) {
 
   EXPECT_EQ(fx.read_sgpr(3), 0u);
   EXPECT_TRUE(fx.halted());
+}
+
+// SMEM offset forms: IMM=0 (SGPR), IMM=1, IMM=1+SOE, SOE=1.
+TEST_P(IsaTest, SLoad_OffsetForms) {
+  ExecFixture fx(arch());
+  constexpr uint64_t kBufferAddr = 0x2000;
+  for (uint32_t i = 0; i < 64; ++i)
+    fx.f.mem()->write32(kBufferAddr + i * 4, 0x1000 + i);
+
+  using namespace enc;
+  constexpr uint32_t S_LOAD_DWORD = 0;
+  constexpr uint32_t S_LOAD_DWORDX2 = 1;
+  constexpr uint32_t S_BUFFER_LOAD_DWORD = 8;
+  const std::vector<uint32_t> code = {
+      s_mov_b32(SGPR(4), 255), // s[4:5] = kBufferAddr
+      static_cast<uint32_t>(kBufferAddr),
+      s_mov_b32(SGPR(5), INLINE_CONST(0)),
+      s_mov_b32(SGPR(6), INLINE_CONST(64)),
+      s_mov_b32(SGPR(12), SGPR(4)), // V# s[12:15]: base, stride 0, 256 records
+      s_mov_b32(SGPR(13), INLINE_CONST(0)),
+      s_mov_b32(SGPR(14), 255),
+      256u,
+      s_mov_b32(SGPR(15), INLINE_CONST(0)),
+      smem_lo(S_LOAD_DWORD, 7, 4, /*imm=*/false), // s7 = [s[4:5] + s6]
+      smem_hi(6),
+      smem_lo(S_LOAD_DWORDX2, 8, 4, /*imm=*/false), // s[8:9] = [s[4:5] + s6]
+      smem_hi(6),
+      smem_lo(S_BUFFER_LOAD_DWORD, 10, 12, /*imm=*/false), // s10 = [V# + s6]
+      smem_hi(6),
+      smem_lo(S_LOAD_DWORD, 16, 4, /*imm=*/true), // s16 = [s[4:5] + 8]
+      smem_hi(0x8),
+      smem_lo(S_LOAD_DWORD, 17, 4, /*imm=*/true, /*soffset_en=*/true), // s17 = [s[4:5] + 8 + s6]
+      smem_hi(0x8, 6),
+      smem_lo(S_LOAD_DWORD, 18, 4, /*imm=*/false, /*soffset_en=*/true), // s18 = [s[4:5] + s6]
+      smem_hi(0, 6),
+      S_WAITCNT_0,
+      S_ENDPGM,
+  };
+  fx.load_program(code);
+
+  EXPECT_EQ(fx.read_sgpr(7), 0x1010u) << "IMM=0 s_load_dword";
+  EXPECT_EQ(fx.read_sgpr(8), 0x1010u) << "IMM=0 s_load_dwordx2";
+  EXPECT_EQ(fx.read_sgpr(9), 0x1011u) << "IMM=0 s_load_dwordx2";
+  EXPECT_EQ(fx.read_sgpr(10), 0x1010u) << "IMM=0 s_buffer_load_dword";
+  EXPECT_EQ(fx.read_sgpr(16), 0x1002u) << "IMM=1";
+  EXPECT_EQ(fx.read_sgpr(17), 0x1012u) << "IMM=1 SOE=1";
+  EXPECT_EQ(fx.read_sgpr(18), 0x1010u) << "SOE=1";
 }
 
 INSTANTIATE_TEST_SUITE_P(Cdna, IsaTest, ::testing::Values("cdna3", "cdna4"),

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2806,6 +2806,7 @@ constexpr uint32_t sop1(uint32_t op, uint32_t sdst, uint32_t ssrc0) {
   return (0x17Du << 23) | (sdst << 16) | (op << 8) | ssrc0;
 }
 constexpr uint32_t s_mov_b32(uint32_t sdst, uint32_t ssrc0) { return sop1(0, sdst, ssrc0); }
+constexpr uint32_t s_mov_b64(uint32_t sdst, uint32_t ssrc0) { return sop1(1, sdst, ssrc0); }
 
 // SOP2: encoding[31:30]=0x2, op[29:23], sdst[22:16], ssrc1[15:8], ssrc0[7:0]
 constexpr uint32_t sop2(uint32_t op, uint32_t sdst, uint32_t ssrc0, uint32_t ssrc1) {
@@ -2898,13 +2899,12 @@ constexpr uint32_t mubuf_hi(uint32_t vdata, uint32_t vaddr, uint32_t srsrc,
 }
 
 // SMEM (64-bit): CDNA layout.
-// dword0: sbase[5:0] (SGPR pair index), sdata[12:6], soffset_en[14], nv[15],
-//         glc[16], imm[17], op[25:18], encoding[31:26]=0x30
+// dword0: sbase[5:0], sdata[12:6], soffset_en[14], nv[15], glc[16], imm[17],
+//         op[25:18], encoding[31:26]=0x30
 // dword1: offset[20:0], soffset[31:25]
-constexpr uint32_t smem_lo(uint32_t op, uint32_t sdata, uint32_t sbase_sgpr, bool imm,
-                           bool soffset_en = false) {
-  return (0x30u << 26) | (op << 18) | (static_cast<uint32_t>(imm) << 17) |
-         (static_cast<uint32_t>(soffset_en) << 14) | (sdata << 6) | (sbase_sgpr / 2);
+constexpr uint32_t smem_lo(uint32_t op, uint32_t sdata, uint32_t sbase, uint32_t imm = 0,
+                           uint32_t soffset_en = 0) {
+  return (0x30u << 26) | (op << 18) | (imm << 17) | (soffset_en << 14) | (sdata << 6) | sbase;
 }
 constexpr uint32_t smem_hi(uint32_t offset, uint32_t soffset = 0) {
   return (soffset << 25) | (offset & 0x1FFFFFu);
@@ -3367,7 +3367,8 @@ TEST_P(IsaTest, BranchLoop) {
   EXPECT_TRUE(fx.halted());
 }
 
-// SMEM offset forms: IMM=0 (SGPR, M0, unaligned SGPR), IMM=1, IMM=1+SOE, SOE=1.
+// SMEM offset forms: IMM=0 (SGPR, M0, unaligned SGPR, s_scratch x64), IMM=1 (aligned,
+// unaligned), IMM=1+SOE, SOE=1 (SGPR, M0, VCC_LO, unaligned SGPR), SBASE = VCC.
 TEST_P(IsaTest, SLoad_OffsetForms) {
   ExecFixture fx(arch());
   constexpr uint64_t kBufferAddr = 0x2000;
@@ -3375,37 +3376,50 @@ TEST_P(IsaTest, SLoad_OffsetForms) {
     fx.f.mem()->write32(kBufferAddr + i * 4, 0x1000 + i);
 
   using namespace enc;
-  constexpr uint32_t S_LOAD_DWORD = 0;
-  constexpr uint32_t S_LOAD_DWORDX2 = 1;
-  constexpr uint32_t S_BUFFER_LOAD_DWORD = 8;
+  constexpr uint32_t kM0 = 124, kVccLo = 106;
   const std::vector<uint32_t> code = {
       s_mov_b32(SGPR(4), 255), // s[4:5] = kBufferAddr
       static_cast<uint32_t>(kBufferAddr),
       s_mov_b32(SGPR(5), INLINE_CONST(0)),
       s_mov_b32(SGPR(6), INLINE_CONST(64)),
-      s_mov_b32(124, INLINE_CONST(32)), // m0
+      s_mov_b32(kM0, INLINE_CONST(32)),
+      s_mov_b32(kVccLo, INLINE_CONST(48)),
+      s_mov_b32(SGPR(2), INLINE_CONST(2)),
       s_mov_b32(SGPR(11), INLINE_CONST(63)),
       s_mov_b32(SGPR(12), SGPR(4)), // V# s[12:15]: base, stride 0, 256 records
       s_mov_b32(SGPR(13), INLINE_CONST(0)),
       s_mov_b32(SGPR(14), 255),
       256u,
       s_mov_b32(SGPR(15), INLINE_CONST(0)),
-      smem_lo(S_LOAD_DWORD, 7, 4, /*imm=*/false), // s7 = [s[4:5] + s6]
-      smem_hi(6),
-      smem_lo(S_LOAD_DWORDX2, 8, 4, /*imm=*/false), // s[8:9] = [s[4:5] + s6]
-      smem_hi(6),
-      smem_lo(S_BUFFER_LOAD_DWORD, 10, 12, /*imm=*/false), // s10 = [V# + s6]
-      smem_hi(6),
-      smem_lo(S_LOAD_DWORD, 16, 4, /*imm=*/true), // s16 = [s[4:5] + 8]
-      smem_hi(0x8),
-      smem_lo(S_LOAD_DWORD, 17, 4, /*imm=*/true, /*soffset_en=*/true), // s17 = [s[4:5] + 8 + s6]
-      smem_hi(0x8, 6),
-      smem_lo(S_LOAD_DWORD, 18, 4, /*imm=*/false, /*soffset_en=*/true), // s18 = [s[4:5] + s6]
-      smem_hi(0, 6),
-      smem_lo(S_LOAD_DWORD, 19, 4, /*imm=*/false), // s19 = [s[4:5] + m0]
-      smem_hi(124),
-      smem_lo(S_LOAD_DWORD, 20, 4, /*imm=*/false), // s20 = [s[4:5] + (s11 & ~3)]
-      smem_hi(11),
+      smem_lo(cdna4::kSLoadDwordSmem, 7, SGPR(4) / 2),
+      smem_hi(6), // s7 = [s[4:5] + s6]
+      smem_lo(cdna4::kSLoadDwordx2Smem, 8, SGPR(4) / 2),
+      smem_hi(6), // s[8:9] = [s[4:5] + s6]
+      smem_lo(cdna4::kSBufferLoadDwordSmem, 10, SGPR(12) / 2),
+      smem_hi(6), // s10 = [V# + s6]
+      smem_lo(cdna4::kSLoadDwordSmem, 16, SGPR(4) / 2, /*imm=*/1),
+      smem_hi(0x8), // s16 = [s[4:5] + 8]
+      smem_lo(cdna4::kSLoadDwordSmem, 17, SGPR(4) / 2, /*imm=*/1, /*soffset_en=*/1),
+      smem_hi(0x8, 6), // s17 = [s[4:5] + 8 + s6]
+      smem_lo(cdna4::kSLoadDwordSmem, 18, SGPR(4) / 2, /*imm=*/0, /*soffset_en=*/1),
+      smem_hi(0, 6), // s18 = [s[4:5] + s6]
+      smem_lo(cdna4::kSLoadDwordSmem, 19, SGPR(4) / 2),
+      smem_hi(kM0), // s19 = [s[4:5] + m0]
+      smem_lo(cdna4::kSLoadDwordSmem, 20, SGPR(4) / 2),
+      smem_hi(11), // s20 = [s[4:5] + (s11 & ~3)]
+      smem_lo(cdna4::kSLoadDwordSmem, 21, SGPR(4) / 2, /*imm=*/0, /*soffset_en=*/1),
+      smem_hi(0, kM0), // s21 = [s[4:5] + m0]
+      smem_lo(cdna4::kSLoadDwordSmem, 22, SGPR(4) / 2, /*imm=*/0, /*soffset_en=*/1),
+      smem_hi(0, kVccLo), // s22 = [s[4:5] + vcc_lo]
+      smem_lo(cdna4::kSLoadDwordSmem, 23, SGPR(4) / 2, /*imm=*/0, /*soffset_en=*/1),
+      smem_hi(0, 11), // s23 = [s[4:5] + (s11 & ~3)]
+      smem_lo(cdna4::kSLoadDwordSmem, 24, SGPR(4) / 2, /*imm=*/1),
+      smem_hi(0x9), // s24 = [s[4:5] + (9 & ~3)]
+      smem_lo(cdna4::kSScratchLoadDwordSmem, 25, SGPR(4) / 2),
+      smem_hi(2),                 // s25 = [s[4:5] + s2 * 64]
+      s_mov_b64(kVccLo, SGPR(4)), // vcc = s[4:5]
+      smem_lo(cdna4::kSLoadDwordSmem, 26, kVccLo / 2),
+      smem_hi(6), // s26 = [vcc + s6]
       S_WAITCNT_0,
       S_ENDPGM,
   };
@@ -3420,6 +3434,13 @@ TEST_P(IsaTest, SLoad_OffsetForms) {
   EXPECT_EQ(fx.read_sgpr(18), 0x1010u) << "SOE=1";
   EXPECT_EQ(fx.read_sgpr(19), 0x1008u) << "IMM=0 M0";
   EXPECT_EQ(fx.read_sgpr(20), 0x100fu) << "IMM=0 unaligned";
+  EXPECT_EQ(fx.read_sgpr(21), 0x1008u) << "SOE=1 M0";
+  EXPECT_EQ(fx.read_sgpr(22), 0x100cu) << "SOE=1 VCC_LO";
+  EXPECT_EQ(fx.read_sgpr(23), 0x100fu) << "SOE=1 unaligned";
+  EXPECT_EQ(fx.read_sgpr(24), 0x1002u) << "IMM=1 unaligned";
+  EXPECT_EQ(fx.read_sgpr(25), 0x1020u) << "IMM=0 s_scratch_load_dword";
+  EXPECT_EQ(fx.read_sgpr(26), 0x1010u) << "SBASE=VCC";
+  EXPECT_TRUE(fx.halted());
 }
 
 INSTANTIATE_TEST_SUITE_P(Cdna, IsaTest, ::testing::Values("cdna3", "cdna4"),

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -3367,7 +3367,7 @@ TEST_P(IsaTest, BranchLoop) {
   EXPECT_TRUE(fx.halted());
 }
 
-// SMEM offset forms: IMM=0 (SGPR), IMM=1, IMM=1+SOE, SOE=1.
+// SMEM offset forms: IMM=0 (SGPR, M0, unaligned SGPR), IMM=1, IMM=1+SOE, SOE=1.
 TEST_P(IsaTest, SLoad_OffsetForms) {
   ExecFixture fx(arch());
   constexpr uint64_t kBufferAddr = 0x2000;
@@ -3383,6 +3383,8 @@ TEST_P(IsaTest, SLoad_OffsetForms) {
       static_cast<uint32_t>(kBufferAddr),
       s_mov_b32(SGPR(5), INLINE_CONST(0)),
       s_mov_b32(SGPR(6), INLINE_CONST(64)),
+      s_mov_b32(124, INLINE_CONST(32)), // m0
+      s_mov_b32(SGPR(11), INLINE_CONST(63)),
       s_mov_b32(SGPR(12), SGPR(4)), // V# s[12:15]: base, stride 0, 256 records
       s_mov_b32(SGPR(13), INLINE_CONST(0)),
       s_mov_b32(SGPR(14), 255),
@@ -3400,6 +3402,10 @@ TEST_P(IsaTest, SLoad_OffsetForms) {
       smem_hi(0x8, 6),
       smem_lo(S_LOAD_DWORD, 18, 4, /*imm=*/false, /*soffset_en=*/true), // s18 = [s[4:5] + s6]
       smem_hi(0, 6),
+      smem_lo(S_LOAD_DWORD, 19, 4, /*imm=*/false), // s19 = [s[4:5] + m0]
+      smem_hi(124),
+      smem_lo(S_LOAD_DWORD, 20, 4, /*imm=*/false), // s20 = [s[4:5] + (s11 & ~3)]
+      smem_hi(11),
       S_WAITCNT_0,
       S_ENDPGM,
   };
@@ -3412,6 +3418,8 @@ TEST_P(IsaTest, SLoad_OffsetForms) {
   EXPECT_EQ(fx.read_sgpr(16), 0x1002u) << "IMM=1";
   EXPECT_EQ(fx.read_sgpr(17), 0x1012u) << "IMM=1 SOE=1";
   EXPECT_EQ(fx.read_sgpr(18), 0x1010u) << "SOE=1";
+  EXPECT_EQ(fx.read_sgpr(19), 0x1008u) << "IMM=0 M0";
+  EXPECT_EQ(fx.read_sgpr(20), 0x100fu) << "IMM=0 unaligned";
 }
 
 INSTANTIATE_TEST_SUITE_P(Cdna, IsaTest, ::testing::Values("cdna3", "cdna4"),

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -1473,17 +1473,25 @@ INSTANTIATE_TEST_SUITE_P(
 
 // SMEM IMM=0, SOE=0: OFFSET[6:0] is an SGPR and must decode as a register operand.
 TEST(CdnaSmemDecodeTest, SgprOffsetFormExposesOffsetRegister) {
-  const uint32_t words[] = {0xC0000101u, 0x00000005u}; // s_load_dword s4, s[2:3], s5
+  const struct {
+    uint32_t words[2];
+    const char *text;
+  } cases[] = {
+      {{0xC0000101u, 0x00000005u}, "s_load_dword s4, s[2:3], s5"},
+      {{0xC0140101u, 0x00000005u}, "s_scratch_load_dword s4, s[2:3], s5"},
+  };
   for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA1, ROCJITSU_CODE_ARCH_CDNA2,
                               ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
     auto decoder = Decoder::create(arch);
     ASSERT_NE(decoder, nullptr) << arch;
-    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
-    ASSERT_NE(inst, nullptr) << arch;
-    EXPECT_EQ(inst->disassemble(), "s_load_dword s4, s[2:3], s5") << arch;
+    for (const auto &tc : cases) {
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, tc.words));
+      ASSERT_NE(inst, nullptr) << arch;
+      EXPECT_EQ(inst->disassemble(), tc.text) << arch;
 
-    InstDefUse def_use(*inst);
-    EXPECT_TRUE(def_use.uses.contains({RegClass::SGPR, 5, 1})) << arch;
+      InstDefUse def_use(*inst);
+      EXPECT_TRUE(def_use.uses.contains({RegClass::SGPR, 5, 1})) << arch << " " << tc.text;
+    }
   }
 }
 

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -1471,6 +1471,22 @@ INSTANTIATE_TEST_SUITE_P(
       return name;
     });
 
+// SMEM IMM=0, SOE=0: OFFSET[6:0] is an SGPR and must decode as a register operand.
+TEST(CdnaSmemDecodeTest, SgprOffsetFormExposesOffsetRegister) {
+  const uint32_t words[] = {0xC0000101u, 0x00000005u}; // s_load_dword s4, s[2:3], s5
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA1, ROCJITSU_CODE_ARCH_CDNA2,
+                              ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    auto decoder = Decoder::create(arch);
+    ASSERT_NE(decoder, nullptr) << arch;
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
+    ASSERT_NE(inst, nullptr) << arch;
+    EXPECT_EQ(inst->disassemble(), "s_load_dword s4, s[2:3], s5") << arch;
+
+    InstDefUse def_use(*inst);
+    EXPECT_TRUE(def_use.uses.contains({RegClass::SGPR, 5, 1})) << arch;
+  }
+}
+
 TEST(Cdna3DecodeTest, DsRead2st64AccDestinationUsesAccumulatorRegisterClass) {
   const uint32_t words[] = {
       0xDA704746u,

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -4495,7 +4495,7 @@ rocjitsu::amdgpu::Wavefront *fault_a_wave_on_a_scalar_load(rocjitsu::SoC *soc,
   if (memory == nullptr)
     return nullptr;
   const uint32_t pid = driver->local_process_id();
-  memory->write32(kernel_pc, 0xC0000000u, pid);     // s_load_dword s0, s[0:1], 0x0
+  memory->write32(kernel_pc, 0xC0020000u, pid);     // s_load_dword s0, s[0:1], 0x0
   memory->write32(kernel_pc + 4, 0u, pid);          // ... its immediate offset
   memory->write32(kernel_pc + 8, 0xBF800000u, pid); // s_nop 0
 

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -7,7 +7,9 @@
 #include "decode_test_util.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna1/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna2/isa.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna5/isa.h"
@@ -5717,6 +5719,76 @@ TEST(RdnaScratchExecutionTest, Rdna3B128StoreFeedsB32LoadsWithVectorOffsets) {
   EXPECT_EQ(cu->read_vgpr(vbase + 1, 2), 0x1202u);
   EXPECT_EQ(cu->read_vgpr(vbase + 1, 3), 0x1303u);
   EXPECT_EQ(cu->read_vgpr(vbase + 1, 4), 0u);
+}
+
+// SMEM SBASE, SOFFSET (SOE=1) and OFFSET[6:0] (IMM=0) name FLAT_SCRATCH / VCC / M0 through the
+// scalar-source selector space, never the raw SGPR slice; byte components drop their two LSBs;
+// s_scratch_* scales the register offset by 64.
+TEST(CdnaAddrCalcTest, SmemOffsetSelectorsAlignmentAndScratchScale) {
+  for (rj_code_arch_t arch : {ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    amdgpu::GpuMemory mem("cdna_smem_addr_mem");
+    amdgpu::L2Cache l2("cdna_smem_addr_l2");
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = 128;
+    cfg.vgprs_per_wf = 16;
+    cfg.lds_size_kb = 64;
+    auto cu = amdgpu::ComputeUnitCore::create("cdna_smem_addr_cu", cfg, &mem, &l2);
+    ASSERT_NE(cu, nullptr);
+    auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+    ASSERT_NE(wf, nullptr);
+
+    constexpr uint64_t kBase = 0x10'0001'0000ULL;
+    constexpr uint64_t kVcc = 0x20'0000'1234ULL;
+    constexpr uint64_t kScratchBase = 0x30'0003'0000ULL;
+    const uint32_t sbase = wf->sgpr_alloc().base;
+    cu->write_sgpr(sbase, static_cast<uint32_t>(kBase));
+    cu->write_sgpr(sbase + 1, static_cast<uint32_t>(kBase >> 32));
+    cu->write_sgpr(sbase + 8, 63);
+    for (uint32_t sel :
+         {cdna3::OPR_SMEM_OFFSET_FLAT_SCRATCH_LO, cdna3::OPR_SMEM_OFFSET_FLAT_SCRATCH_HI,
+          cdna3::OPR_SMEM_OFFSET_VCC_LO, cdna3::OPR_SMEM_OFFSET_VCC_HI,
+          cdna3::OPR_SMEM_OFFSET_M0}) // decoys in the aliasing SGPR slots
+      cu->write_sgpr(sbase + sel, 0x777);
+    wf->set_m0(0x40);
+    wf->set_vcc_raw(kVcc);
+    wf->set_scratch_base(kScratchBase);
+
+    amdgpu::SmemMachineInst inst{}; // sbase = s[0:1]
+    inst.op = cdna3::kSLoadDwordSmem;
+    auto smem_addr = [&] {
+      return arch == ROCJITSU_CODE_ARCH_CDNA3 ? cdna3::smem_calculate_address(inst, *wf)
+                                              : cdna4::smem_calculate_address(inst, *wf);
+    };
+    inst.offset = cdna3::OPR_SMEM_OFFSET_M0; // IMM=0
+    EXPECT_EQ(smem_addr(), kBase + 0x40) << arch;
+    inst.soffset_en = 1;
+    inst.offset = 0;
+    inst.soffset = cdna3::OPR_SMEM_OFFSET_M0; // SOE=1
+    EXPECT_EQ(smem_addr(), kBase + 0x40) << arch;
+    inst.soffset = cdna3::OPR_SMEM_OFFSET_VCC_LO;
+    EXPECT_EQ(smem_addr(), kBase + 0x1234) << arch;
+    inst.soffset = 8; // SOE=1: 63 -> 60
+    EXPECT_EQ(smem_addr(), kBase + 60) << arch;
+    inst.imm = 1;
+    inst.offset = 0x9; // IMM=1 SOE=1: 9 -> 8
+    EXPECT_EQ(smem_addr(), kBase + 8 + 60) << arch;
+    inst.sbase = cdna3::OPR_SMEM_OFFSET_VCC_LO / 2; // VCC pair, not s[106:107]
+    EXPECT_EQ(smem_addr(), kVcc + 8 + 60) << arch;
+
+    inst = {};
+    inst.op = cdna3::kSScratchLoadDwordSmem;
+    inst.offset = 8; // IMM=0: s8 * 64
+    EXPECT_EQ(smem_addr(), kBase + 63 * 64) << arch;
+    inst.soffset_en = 1;
+    inst.soffset = 8;
+    inst.imm = 1;
+    inst.offset = 0x10; // IMM=1 SOE=1: 0x10 + s8 * 64
+    EXPECT_EQ(smem_addr(), kBase + 0x10 + 63 * 64) << arch;
+    inst.sbase = cdna3::OPR_SMEM_OFFSET_FLAT_SCRATCH_LO / 2; // FLAT_SCRATCH pair, not s[102:103]
+    EXPECT_EQ(smem_addr(), kScratchBase + 0x10 + 63 * 64) << arch;
+  }
 }
 
 TEST(RdnaAddrCalcTest, Rdna3SmemSoffsetHandlesNullM0AndSgprSelectors) {

--- a/emulation/rocjitsu/tests/wave_debug_test.cpp
+++ b/emulation/rocjitsu/tests/wave_debug_test.cpp
@@ -263,7 +263,7 @@ TEST(WaveDebugTest, UnmappedScalarLoadReportsMemoryViolationAfterInstruction) {
                                                               amdgpu::Mtype::RW};
   fx.gpu_mem.register_process(kProcessId, &page_table, &page_table_mutex);
 
-  fx.gpu_mem.write32(kKernelAddr, 0xC0000000u, kProcessId);     // s_load_dword s0, s[0:1]
+  fx.gpu_mem.write32(kKernelAddr, 0xC0020000u, kProcessId);     // s_load_dword s0, s[0:1]
   fx.gpu_mem.write32(kKernelAddr + 4, 0, kProcessId);           // immediate offset 0
   fx.gpu_mem.write32(kKernelAddr + 8, 0xBF800000u, kProcessId); // s_nop 0
   auto *wave = fx.dispatch(kKernelAddr);

--- a/emulation/rocjitsu/tests/wave_debug_test.cpp
+++ b/emulation/rocjitsu/tests/wave_debug_test.cpp
@@ -701,7 +701,7 @@ TEST(WaveDebugTest, DeclinedMemoryViolationStillIssuesTheAccess) {
                                                               amdgpu::Mtype::RW};
   fx.gpu_mem.register_process(kProcessId, &page_table, &page_table_mutex);
 
-  fx.gpu_mem.write32(kKernelAddr, 0xC0000000u, kProcessId);     // s_load_dword s0, s[0:1]
+  fx.gpu_mem.write32(kKernelAddr, 0xC0020000u, kProcessId);     // s_load_dword s0, s[0:1]
   fx.gpu_mem.write32(kKernelAddr + 4, 0, kProcessId);           // immediate offset 0
   fx.gpu_mem.write32(kKernelAddr + 8, 0xBF800000u, kProcessId); // s_nop 0
   auto *wave = fx.dispatch(kKernelAddr);
@@ -758,7 +758,7 @@ TEST(WaveDebugTest, ScalarLoadStraddlingIntoUnmappedPageReportsMemoryViolation) 
   page_table[kDataAddr >> amdgpu::GpuMemory::PAGE_SHIFT] = {data_page.data(), amdgpu::Mtype::RW};
   fx.gpu_mem.register_process(kProcessId, &page_table, &page_table_mutex);
 
-  fx.gpu_mem.write32(kKernelAddr, 0xC0040000u, kProcessId);     // s_load_dwordx2 s[0:1], s[0:1]
+  fx.gpu_mem.write32(kKernelAddr, 0xC0060000u, kProcessId);     // s_load_dwordx2 s[0:1], s[0:1]
   fx.gpu_mem.write32(kKernelAddr + 4, 0, kProcessId);           // immediate offset 0
   fx.gpu_mem.write32(kKernelAddr + 8, 0xBF800000u, kProcessId); // s_nop 0
   auto *wave = fx.dispatch(kKernelAddr);


### PR DESCRIPTION
## Motivation

GFX9/CDNA SMEM selects its offset with the `IMM` and `SOE` bits (MI300 ISA 8.2.1.1):

| IMM | SOE | Address |
|---|---|---|
| 0 | 0 | `SGPR[base] + (SGPR[offset] or M0)` |
| 0 | 1 | `SGPR[base] + (SGPR[soffset] or M0)` |
| 1 | 0 | `SGPR[base] + inst_offset` |
| 1 | 1 | `SGPR[base] + inst_offset + (SGPR[soffset] or M0)` |

LLVM assembles `s_load_dword s4, s[2:3], s5` to the first row (`llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx942 -show-encoding`: `[0x01,0x01,0x00,0xc0,0x05,0x00,0x00,0x00]`, i.e. IMM=0, SOE=0, OFFSET=5). The CDNA1-4 simulator did not handle that form: the address was computed with offset 0 and the operand disassembled as `0x0` (also hiding the offset SGPR from def-use), so kernels that index pointer tables through an SGPR offset read element 0 for every index.

## Technical Details

- `shared/addr_calc_scalar.h`: `smem_calculate_address()` implements the 8.2.1.1 formula for all four IMM/SOE rows — `ADDR = SGPR[base] + inst_offset + {SGPR[offset] or M0 or 0}`, with the register component `* 64` for `s_scratch_*` and the two LSBs of each byte component ignored. `SBASE`, `OFFSET[6:0]` (IMM=0) and `SOFFSET` (SOE=1) go through the existing `resolve_src_scalar{,64}()` (124 → M0, 106/107 → VCC, 102/103 → FLAT_SCRATCH, 108–123 → TTMP, otherwise the SGPR slice). Only the CDNA1-4 wrappers instantiate this template; RDNA and gfx1250 are unchanged.
- `cdna4/addr_calc.cpp`: the CDNA4-only `s_scratch_*` branch is removed; CDNA4 delegates to the shared path like CDNA1-3.
- `_generator.py` + regenerated `generated/cdna{1,2,3,4}/smem.cpp`: `make_smem_offset()` returns an `OPR_SMEM_OFFSET` register operand for IMM=0/SOE=0 (one line per file).
- Tests:
  - `Cdna/IsaTest.SLoad_OffsetForms/{cdna3,cdna4}`: SGPR / M0 / VCC_LO offsets via IMM=0 and SOE=1, unaligned register and immediate, IMM=1, IMM=1+SOE, `s_scratch_load_dword`, `SBASE = vcc`.
  - `CdnaAddrCalcTest.SmemOffsetSelectorsAlignmentAndScratchScale`: direct address probe on cdna3/cdna4 with decoy values in the SGPR slots that alias M0/VCC/FLAT_SCRATCH.
  - `CdnaSmemDecodeTest.SgprOffsetFormExposesOffsetRegister`: disassembly + def-use for `s_load_dword` / `s_scratch_load_dword` on cdna1-4.
- `tests/wave_debug_test.cpp` / `tests/kfd_ioctl_test.cpp`: four hand-encoded `s_load_dword`/`s_load_dwordx2` words meant as an immediate offset of 0 were IMM=0 (offset register `s0`); re-encoded with IMM=1.

## Issue Tracking

Addresses item 7 of #9933.

## Test Plan

- `rocjitsu_tests --gtest_filter='Cdna/IsaTest.SLoad_OffsetForms/*:CdnaAddrCalcTest.*:CdnaSmemDecodeTest.*:WaveDebugTest.*:KfdIoctl*'` before and after the change.
- Full `ctest` versus `develop`.
- `python -m pytest lib/python/amdisa/tests`.

## Test Result

- `SLoad_OffsetForms` on `develop`: register-offset loads return element 0 (e.g. `s_load_dword` 0x1000 vs 0x1010), SOE=1 with `m0`/`vcc_lo` and `SBASE = vcc` read the SGPR slice, unaligned cases are off by the low bits, scratch is unscaled — all pass after.
- `CdnaAddrCalcTest` on `develop` returns the decoy / unmasked / unscaled values for the same cases — passes after.
- `CdnaSmemDecodeTest` on `develop`: `s_load_dword s4, s[2:3], 0x0` / `s_scratch_load_dword s4, s[2:3], 0x0` and `s5` missing from def-use — passes after.
- Cross-checked on gfx950 hardware (ROCm 7.2.0) with equivalent inline-asm `s_load_dword`/`s_load_dwordx4` kernels: hardware returns the offset element; the simulator matches only with this change.
- Full `ctest`: no status changes versus `develop` other than the four added tests.
- `lib/python/amdisa/tests`: 1852 passed, 46 skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
