### PR TITLE
rccl(ainic): Add QP sharing support for AINIC in net-ib-cast plugin

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+    src/transport/net_ib_cast/qp_sharing.h
     src/transport/net_ib_cast/common.cc
     src/transport/net_ib_cast/connect.cc
     src/transport/net_ib_cast/gdr.cc
@@ -23,6 +24,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/reg.cc
     src/transport/net_ib_cast/scheduler.cc
     src/transport/net_ib_cast/gin.cc
+    src/transport/net_ib_cast/qp_sharing.cc
 )
 
 # The cast headers (common_cast.h, p2p_cast.h, etc.) live in this directory.

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,6 +23,9 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
+extern int ncclParamIbCastResiliencyPortFailover();
+extern int64_t rcclParamIbCastCommNGroups();
+
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -84,6 +87,17 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
+#if 0
+  if (rcclParamIbCastCommNGroups() > 0) {
+    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
+    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
+    // which is correct for a shared RQ.
+    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
+    }
+    recvComm->prepostReceiveWorkRequests = true;
+  }
+#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -7,6 +7,7 @@
 
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
+#include "qp_sharing.h"
 
 char IbCastIfName[MAX_IF_NAME_SIZE + 1];
 union ncclSocketAddress IbCastIfAddr;
@@ -24,7 +25,6 @@ NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS",
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
 extern int ncclParamIbCastResiliencyPortFailover();
-extern int64_t rcclParamIbCastCommNGroups();
 
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
@@ -87,17 +87,6 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
-#if 0
-  if (rcclParamIbCastCommNGroups() > 0) {
-    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
-    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
-    // which is correct for a shared RQ.
-    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
-    }
-    recvComm->prepostReceiveWorkRequests = true;
-  }
-#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -149,10 +149,17 @@ extern struct ncclIbDev IbCastDevs[MAX_IB_DEVS];
 extern int IbCastRelaxedOrderingEnabled;
 extern bool IbCastUseInline;
 
+#define WR_ID_RX_COMM_ID_MASK  0xffff
+#define WR_ID_RX_COMM_ID_SHIFT 48
 #define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000
 #define WR_IMM_SIZE_MASK 0x007fffff
+// QP sharing BY_ID imm_data layout: reqId in bits[7:0], receiver commId in bits[23:8].
+// reqId fits in 8 bits (NET_IB_MAX_REQUESTS <= 256); commId fits in 16 bits.
+#define WR_IMM_BYID_REQ_ID_MASK   0xff
+#define WR_IMM_BYID_COMM_ID_SHIFT 8
+#define WR_IMM_BYID_COMM_ID_MASK  0xffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool IbCastAinicCtsInlineData;
@@ -525,6 +532,13 @@ struct alignas(32) ncclIbNetCommBase {
   bool faultQpError[NCCL_IB_MAX_QPS];
 #endif
   struct ncclIbResiliency* resiliency;
+
+  // QP Sharing fields
+  uint16_t commId;              // 0 = not shared
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;      // -1 = not shared
+  int      remIbDevIdx;
+  int      sharedPrimaryNqps;
 };
 
 struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -625,6 +639,7 @@ struct ncclIbSendComm {
   // Resolved slot for telChId on this comm's first device (NULL if untracked).
   // Same reasoning as ncclIbQp::telQpStats: avoid re-resolving per completion.
   RcclChannelStats* telChStats;
+  uint16_t remCommId;           // receiver's commId for imm_data encoding (QP sharing)
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -80,7 +80,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
     return BY_ORDER;
   }
 
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     return BY_ID;
   }
 
@@ -814,7 +814,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -908,11 +908,11 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     comm->remCommId = remMeta->commId;
 
     // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
-    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+    if (IbCastCommIsSecondary(&comm->base)) {
       // Just assign remDevIdx from remote metadata
       uint nqps = comm->base.nqps;
       for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -988,6 +988,175 @@ int IbCastGetTrafficClass(void* ctx) {
 void IbCastSetTrafficClass(void* ctx, int trafficClass) {
   ncclNetCommConfig_t* config = (ncclNetCommConfig_t*)ctx;
   if (config) config->trafficClass = trafficClass;
+}
+
+// Determine QP sharing role for sender and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastSenderQpsCreate
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingSenderSetup(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    struct ncclIbConnectionMetadata* meta,
+    const ncclNetVDeviceProps_t* remoteVProps,
+    int depthMult,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || handle->isRMA) {
+    return ncclSuccess;
+  }
+
+  int ngroups = rcclParamIbCastCommNGroups();
+
+  // Allocate commId for this comm
+  comm->base.commId = IbCastAllocCommId(comm, true);
+  if (comm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  IbCastSharedQpKey probeKey;
+  memset(&probeKey, 0, sizeof(probeKey));
+  memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&probeKey.peerAddr);
+
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  //        handle for Fusion/Cast where remoteVProps->ndevs > 1
+  int probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+  int probeRemIbDevIdx = remoteVProps->devs[0];
+
+  // Count existing refs to determine groupIdx
+  int totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+  int groupIdx = totalRefs % ngroups;
+  comm->base.sharedGroupIdx = groupIdx;
+  comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+  probeKey.ibDevN = probeIbDevN;
+  probeKey.remIbDevIdx = probeRemIbDevIdx;
+  probeKey.isSend = true;
+  probeKey.groupIdx = groupIdx;
+  probeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* existingSlot = IbCastFindSharedQp(&probeKey);
+
+  if (existingSlot != NULL) {
+    // SECONDARY: reuse existing QPs from pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+         __func__, comm->base.commId, groupIdx, totalRefs);
+
+    comm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+    comm->base.sharedPrimaryNqps = primaryNqps;
+
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+    key.isSend = true;
+    key.groupIdx = groupIdx;
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQP = q % primaryNqps;
+      key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps->devs[mappedQP % remoteVProps->ndevs];
+      key.qpIdx = mappedQP;
+
+      struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+      if (slot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+        // Fallback: free commId and go non-sharing
+        IbCastFreeCommId(comm->base.commId);
+        comm->base.commId = 0;
+        comm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      // Copy QP info from shared pool to this comm
+      comm->base.qps[q].qp = slot->qp;
+      comm->base.qps[q].devIndex = slot->devIndex;
+      comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+      comm->base.activeQps[q] = &comm->base.qps[q];
+
+      // Populate metadata with shared QP info
+      meta->qpInfo[q].qpn = slot->qp->qp_num;
+      meta->qpInfo[q].devIndex = slot->devIndex;
+
+      slot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+      comm->devs[i].base.cq = existingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = comm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    existingSlot->cqRefcount++;
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY: create QPs with scaled depth, then register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+         __func__, comm->base.commId, groupIdx, depthMult);
+    comm->base.isSharedQpPrimary = true;
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary sender's QPs in the shared pool.
+// Called after IbCastSenderQpsCreate when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingSenderRegisterPrimary(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    const ncclNetVDeviceProps_t* remoteVProps) {
+
+  union ncclSocketAddress peerAddr;
+  memcpy(&peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&peerAddr);
+
+  int nqps = comm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    key.peerAddr = peerAddr;
+    key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+    key.remIbDevIdx = remoteVProps->devs[q % remoteVProps->ndevs];
+    key.groupIdx = comm->base.sharedGroupIdx;
+    key.isSend = true;
+    key.qpIdx = q;
+
+    int devIdx = q % comm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+        comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+        comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+    entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+  }
+
+  return ncclSuccess;
 }
 
 ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** sendComm,
@@ -1102,21 +1271,15 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
-  // Initialize QP sharing fields
-  comm->base.commId = 0;
-  comm->base.isSharedQpPrimary = false;
-  comm->base.sharedGroupIdx = -1;
-  comm->base.remIbDevIdx = -1;
-  comm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&comm->base);
   comm->remCommId = 0;
 
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
 
-  // Compute depth multiplier for QP sharing
   int depthMult;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  depthMult = IbCastQpSharingDepthMultiplier();
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1156,194 +1319,48 @@ ib_recv_dev_list:
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
   meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
-  // QP Sharing: sender-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
-    int ngroups = rcclParamIbCastCommNGroups();
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingSenderSetup(comm, handle, &meta, &remoteVProps, depthMult, &sharingRole), ret, fail);
 
-    // Allocate commId for this comm
-    comm->base.commId = IbCastAllocCommId(comm, true);
-    if (comm->base.commId == 0) {
-      // Fallback to non-sharing if pool exhausted
-      goto qp_sharing_skip_sender;
-    }
+  // Set sharedGroupIdx before IbCastSenderQpsCreate which needs it
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-    // Check if primary exists for this group
-    IbCastSharedQpKey probeKey;
-    memset(&probeKey, 0, sizeof(probeKey));
-    // Build probe key from peer address
-    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-    IbCastStripPort(&probeKey.peerAddr);
-
-    // Use first device's ibDevN for the probe
-    int probeIbDevN;
-    int probeRemIbDevIdx;
-    // TODO - QP sharing
-    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
-    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
-    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
-    probeRemIbDevIdx = remoteVProps.devs[0];
-
-    // Count existing refs to determine groupIdx
-    int totalRefs;
-    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
-    int groupIdx;
-    groupIdx = totalRefs % ngroups;
-    comm->base.sharedGroupIdx = groupIdx;
-    comm->base.remIbDevIdx = probeRemIbDevIdx;
-
-    probeKey.ibDevN = probeIbDevN;
-    probeKey.remIbDevIdx = probeRemIbDevIdx;
-    probeKey.isSend = true;
-    probeKey.groupIdx = groupIdx;
-    probeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* existingSlot;
-    existingSlot = IbCastFindSharedQp(&probeKey);
-
-    if (existingSlot != NULL) {
-      // SECONDARY: reuse existing QPs from pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
-           __func__, comm->base.commId, groupIdx, totalRefs);
-
-      comm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
-      comm->base.sharedPrimaryNqps = primaryNqps;
-
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
-      key.isSend = true;
-      key.groupIdx = groupIdx;
-
-      int nqps = comm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-        int mappedQP = q % primaryNqps;
-        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
-        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
-        key.qpIdx = mappedQP;
-
-        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
-        if (slot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
-          // Fallback: free commId and go non-sharing
-          IbCastFreeCommId(comm->base.commId);
-          comm->base.commId = 0;
-          comm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_sender;
-        }
-
-        // Copy QP info from shared pool to this comm
-        comm->base.qps[q].qp = slot->qp;
-        comm->base.qps[q].devIndex = slot->devIndex;
-        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
-        comm->base.activeQps[q] = &comm->base.qps[q];
-
-        // Populate metadata with shared QP info
-        meta.qpInfo[q].qpn = slot->qp->qp_num;
-        meta.qpInfo[q].devIndex = slot->devIndex;
-
-        slot->refcount++;
-      }
-
-      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
+    comm->telChId = channelId;
+    comm->telChStats = NULL;
+  
+    // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
+    // the untracked value the hooks expect.
+    if (rcclTelemetryOn()) {
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
-        comm->devs[i].base.cq = existingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = comm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        int ibDevN = comm->base.vProps.devs[i];
+        int numQpsForDev = 0;
+        for (int q = 0; q < comm->base.nqps; q++)
+          if (comm->base.qps[q].devIndex == i) numQpsForDev++;
+        int numSlots = 0;
+        int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
+        if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
+        int slotOffset = 0;
+        for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
+          if (comm->base.qps[q].devIndex != i) continue;
+          // QPs past the granted slots keep telQpStats == NULL (untracked).
+          int telSlot = startSlot + slotOffset++;
+          rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
+          comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
         }
       }
-      existingSlot->cqRefcount++;
-
-      // Skip QP creation; metadata is already populated
-      goto qp_sharing_done_sender;
-    } else {
-      // PRIMARY: create QPs with scaled depth, then register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
-           __func__, comm->base.commId, groupIdx, depthMult);
-
-      comm->base.isSharedQpPrimary = true;
+      // Request completions are charged to the comm's first device.
+      comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
     }
-  }
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-qp_sharing_skip_sender:
-  // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
-
-  comm->telChId = channelId;
-  comm->telChStats = NULL;
-
-  // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
-  // the untracked value the hooks expect.
-  if (rcclTelemetryOn()) {
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      int ibDevN = comm->base.vProps.devs[i];
-      int numQpsForDev = 0;
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].devIndex == i) numQpsForDev++;
-      int numSlots = 0;
-      int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
-      if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
-      int slotOffset = 0;
-      for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
-        if (comm->base.qps[q].devIndex != i) continue;
-        // QPs past the granted slots keep telQpStats == NULL (untracked).
-        int telSlot = startSlot + slotOffset++;
-        rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
-        comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
-      }
-    }
-    // Request completions are charged to the comm's first device.
-    comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
-  }
-
-  // If primary, register QPs in shared pool
-  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
-    union ncclSocketAddress peerAddr;
-    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
-    IbCastStripPort(&peerAddr);
-
-    int nqps = comm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-      IbCastStripPort(&key.peerAddr);
-      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
-      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
-      key.groupIdx = comm->base.sharedGroupIdx;
-      key.isSend = true;
-      key.qpIdx = q;
-
-      int devIdx = q % comm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
-          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingSenderRegisterPrimary(comm, handle, &remoteVProps), ret, fail);
     }
   }
 
-qp_sharing_done_sender:
-  // Populate QP sharing metadata
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  // Populate remaining QP sharing metadata
   meta.commId = comm->base.commId;
   // TODO - QP sharing
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
@@ -1599,7 +1616,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
 
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -1744,10 +1761,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
-      // QP sharing is disabled for flush QP
-      qpCreateAttrs.isQpSharingEnabled = false;
-      qpCreateAttrs.qpSharingGroupIdx = -1;
-      qpCreateAttrs.cqDepthMultiplier = 1;
+      IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1815,6 +1829,221 @@ ncclResult_t IbCastReceiverPrePostReceiveWorkRequests(struct ncclIbRecvComm* rec
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, &recvComm->base.qps[i]));
   }
+  return ncclSuccess;
+}
+
+// Determine QP sharing role for receiver and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastReceiverQpsCreateToRts
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingReceiverSetup(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta,
+    struct ncclIbConnectionMetadata* meta,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || remMeta->isRMA || remMeta->sharedGroupIdx < 0) {
+    return ncclSuccess;
+  }
+
+  int recvGroupIdx = remMeta->sharedGroupIdx;
+
+  // Allocate commId for this comm
+  rComm->base.commId = IbCastAllocCommId(rComm, false);
+  if (rComm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  rComm->base.sharedGroupIdx = recvGroupIdx;
+  rComm->base.remIbDevIdx = remMeta->senderIbDevIdx;
+  int recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+  IbCastSharedQpKey recvProbeKey;
+  memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+  recvProbeKey.ibDevN = recvProbeIbDevN;
+  recvProbeKey.peerAddr = recvPeerAddr;
+  recvProbeKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvProbeKey.isSend = false;
+  recvProbeKey.groupIdx = recvGroupIdx;
+  recvProbeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+  if (recvExistingSlot != NULL) {
+    // SECONDARY receiver: reuse existing QPs
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+
+    rComm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta->senderIbDevIdx, false, remMeta->sharedGroupIdx);
+    rComm->base.sharedPrimaryNqps = primaryNqps;
+    rComm->useCtsOffload = false;
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.isSend = false;
+    recvKey.groupIdx = recvGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQ = q % primaryNqps;
+      int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+      recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+      recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      recvKey.qpIdx = mappedQ;
+
+      struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+      if (recvSlot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+        IbCastFreeCommId(rComm->base.commId);
+        rComm->base.commId = 0;
+        rComm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      rComm->base.qps[q].qp = recvSlot->qp;
+      rComm->base.qps[q].devIndex = recvSlot->devIndex;
+      rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+      // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+      // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+      rComm->base.qps[q].remDevIdx = remMeta->qpInfo[q].devIndex;
+      rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+      meta->qpInfo[q].qpn = recvSlot->qp->qp_num;
+      meta->qpInfo[q].devIndex = recvSlot->devIndex;
+
+      recvSlot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+      rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = rComm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    recvExistingSlot->cqRefcount++;
+
+    // Share flush QPs from primary
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = recvGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+        if (flushSlot) {
+          rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+          flushSlot->refcount++;
+          INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+               __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+        } else {
+          WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+               __func__, i, recvGroupIdx, rComm->base.commId);
+        }
+      }
+    }
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY receiver: create QPs with scaled depth, register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+    rComm->base.isSharedQpPrimary = true;
+    rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary receiver's QPs (and flush QPs) in the shared pool.
+// Called after IbCastReceiverQpsCreateToRts when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingReceiverRegisterPrimary(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta) {
+
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  IbCastSharedQpKey recvKey;
+  memset(&recvKey, 0, sizeof(recvKey));
+  recvKey.peerAddr = recvPeerAddr;
+  recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvKey.isSend = false;
+  recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+  int nqps = rComm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+    recvKey.qpIdx = q;
+
+    int devIdx = q % rComm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+        rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+        rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+  }
+
+  // Register flush QPs in shared pool (primary only)
+  if (rComm->flushEnabled) {
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      IbCastSharedQpKey flushKey;
+      memset(&flushKey, 0, sizeof(flushKey));
+      flushKey.ibDevN = rComm->base.vProps.devs[i];
+      flushKey.peerAddr = recvPeerAddr;
+      flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      flushKey.isSend = false;
+      flushKey.groupIdx = rComm->base.sharedGroupIdx;
+      flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+      struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+          rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+      if (flushEntry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+             "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+             __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+        continue;
+      }
+      INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+           __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+           rComm->base.sharedGroupIdx, rComm->base.commId);
+    }
+  }
+
   return ncclSuccess;
 }
 
@@ -1953,15 +2182,9 @@ ib_recv:
     }
   }
 
-  // Initialize QP sharing fields on receiver
-  rComm->base.commId = 0;
-  rComm->base.isSharedQpPrimary = false;
-  rComm->base.sharedGroupIdx = -1;
-  rComm->base.remIbDevIdx = -1;
-  rComm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&rComm->base);
 
   // IB setup
-  // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
   int ibDevN;
   struct ncclIbRecvCommDev* rCommDev;
@@ -1977,9 +2200,8 @@ ib_recv:
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
 
-  // Compute depth multiplier for receiver QP sharing
   int recvDepthMult;
-  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  recvDepthMult = IbCastQpSharingDepthMultiplier();
 
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
@@ -2056,202 +2278,17 @@ ib_recv:
                           1 :
                           0;
 
-  // QP Sharing: receiver-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
-    int recvGroupIdx = remMeta.sharedGroupIdx;
-    int recvProbeIbDevN;
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingReceiverSetup(rComm, &remMeta, &meta, &sharingRole), ret, fail);
 
-    rComm->base.commId = IbCastAllocCommId(rComm, false);
-    if (rComm->base.commId == 0) {
-      goto qp_sharing_skip_recv;
-    }
-    // Build probe key from peer address
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    rComm->base.sharedGroupIdx = recvGroupIdx;
-	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
-
-    IbCastSharedQpKey recvProbeKey;
-    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
-    recvProbeKey.ibDevN = recvProbeIbDevN;
-    recvProbeKey.peerAddr = recvPeerAddr;
-    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeKey.isSend = false;
-    recvProbeKey.groupIdx = recvGroupIdx;
-    recvProbeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* recvExistingSlot;
-    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
-
-    if (recvExistingSlot != NULL) {
-      // SECONDARY receiver: reuse existing QPs
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
-           __func__, rComm->base.commId, recvGroupIdx);
-
-      rComm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
-
-      rComm->base.sharedPrimaryNqps = primaryNqps;
-      rComm->useCtsOffload = false;
-
-      IbCastSharedQpKey recvKey;
-      memset(&recvKey, 0, sizeof(recvKey));
-      recvKey.peerAddr = recvPeerAddr;
-      recvKey.isSend = false;
-      recvKey.groupIdx = recvGroupIdx;
-
-      int nqps = rComm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-		int mappedQ = q % primaryNqps;
-		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
-		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
-        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        recvKey.qpIdx = mappedQ;
-
-        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
-        if (recvSlot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
-          IbCastFreeCommId(rComm->base.commId);
-          rComm->base.commId = 0;
-          rComm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_recv;
-        }
-
-        rComm->base.qps[q].qp = recvSlot->qp;
-        rComm->base.qps[q].devIndex = recvSlot->devIndex;
-        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
-        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
-        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
-        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
-        rComm->base.activeQps[q] = &rComm->base.qps[q];
-
-        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
-        meta.qpInfo[q].devIndex = recvSlot->devIndex;
-
-        recvSlot->refcount++;
-      }
-
-      // Redirect CQs
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
-        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = rComm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
-        }
-      }
-      recvExistingSlot->cqRefcount++;
-
-      // Share flush QPs from primary
-      if (rComm->flushEnabled) {
-        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-          IbCastSharedQpKey flushKey;
-          memset(&flushKey, 0, sizeof(flushKey));
-          flushKey.ibDevN = rComm->base.vProps.devs[i];
-          flushKey.peerAddr = recvPeerAddr;
-          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-          flushKey.isSend = false;
-          flushKey.groupIdx = recvGroupIdx;
-          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
-          if (flushSlot) {
-            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
-            flushSlot->refcount++;
-            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
-                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
-          } else {
-            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
-                 __func__, i, recvGroupIdx, rComm->base.commId);
-          }
-        }
-      }
-
-      goto qp_sharing_done_recv;
-    } else {
-      // PRIMARY receiver: create QPs with scaled depth, register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
-           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
-      rComm->base.isSharedQpPrimary = true;
-      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingReceiverRegisterPrimary(rComm, &remMeta), ret, fail);
     }
   }
 
-qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
-
-  // If primary receiver, register QPs in shared pool
-  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    IbCastSharedQpKey recvKey;
-    memset(&recvKey, 0, sizeof(recvKey));
-    recvKey.peerAddr = recvPeerAddr;
-    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvKey.isSend = false;
-    recvKey.groupIdx = rComm->base.sharedGroupIdx;
-
-    int nqps = rComm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
-      recvKey.qpIdx = q;
-
-      int devIdx = q % rComm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
-          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-    }
-
-    // Register flush QPs in shared pool (primary only)
-    if (rComm->flushEnabled) {
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        IbCastSharedQpKey flushKey;
-        memset(&flushKey, 0, sizeof(flushKey));
-        flushKey.ibDevN = rComm->base.vProps.devs[i];
-        flushKey.peerAddr = recvPeerAddr;
-        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        flushKey.isSend = false;
-        flushKey.groupIdx = rComm->base.sharedGroupIdx;
-        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
-        if (flushEntry == NULL) {
-          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
-               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
-               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
-          continue;
-        }
-        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
-             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
-             rComm->base.sharedGroupIdx, rComm->base.commId);
-      }
-    }
-  }
-
-qp_sharing_done_recv:
   // Populate QP sharing metadata in response
   meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
   meta.commId = rComm->base.commId;
@@ -2419,20 +2456,37 @@ fail:
   goto exit;
 }
 
+// Per-device MR cleanup for sender comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseSendCommDevResources(struct ncclIbSendComm* comm, int devIndex) {
+  struct ncclIbSendCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (commDev->putSignalScratchpadMr != NULL)
+    NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseSend(void* sendComm) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, true);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2443,53 +2497,33 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
+
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(IbCastCloseSendCommDevResources(comm, i));
+      if (!isSharing) {
+        NCCLCHECK(IbCastDestroyBase(&comm->devs[i].base));
       }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    }
 
-      // Deregister per-comm MRs (not shared)
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
-      }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them, or ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them, or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
       }
     }
 
@@ -2502,20 +2536,48 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   return ncclSuccess;
 }
 
+// Per-device flush memory cleanup (common between shared/non-shared paths).
+// Releases GPU memory, MRs, and dma-buf FDs. Does NOT destroy the flush QP.
+static ncclResult_t IbCastCloseRecvFlushMem(struct ncclIbRecvCommDev* commDev) {
+  if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+    CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+    commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+    if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+    commDev->gpuFlush.gpuMr = nullptr;
+    if (commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd); }
+  }
+  return ncclSuccess;
+}
+
+// Per-device MR cleanup for receiver comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseRecvCommDevResources(struct ncclIbRecvComm* comm, int devIndex) {
+  struct ncclIbRecvCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseRecv(void* recvComm) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // Data QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, false);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2526,27 +2588,28 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
 
-      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          // Per-comm flush memory cleanup (always done)
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          // Shared flush QP teardown (refcount-based)
-          if (commDev->gpuFlush.qp.qp != NULL) {
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup: flush QP/memory and MR teardown
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      struct ncclIbRecvCommDev* commDev = comm->devs + i;
+      if (comm->flushEnabled) {
+        // Flush memory is always per-comm
+        NCCLCHECK(IbCastCloseRecvFlushMem(commDev));
+        // Flush QP teardown: refcount-based for shared, direct destroy for non-shared
+        if (commDev->gpuFlush.qp.qp != NULL) {
+          if (isSharing) {
             struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
                 commDev->gpuFlush.qp.qp->qp_num, false);
             if (flushSlot) {
@@ -2556,65 +2619,34 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
+                IbCastUnregisterSharedQpLocked(flushSlot);
               }
             } else {
-              // Not in pool -- e.g. registration hit the pool-exhaustion
-              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
-              // flush QP was never pool-tracked, so just destroy it directly.
+              // Not in pool (pool-exhaustion fallback) — destroy directly
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
-            commDev->gpuFlush.qp.qp = NULL;
+          } else {
+            NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
           }
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+          commDev->gpuFlush.qp.qp = NULL;
         }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them (data QPs above, this comm's own flush QP just above), or
-      // ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
-        }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
+      NCCLCHECK(IbCastCloseRecvCommDevResources(comm, i));
+      if (!isSharing) {
         NCCLCHECK(IbCastDestroyBase(&commDev->base));
       }
     }
+
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them (data QPs and flush QPs above), or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
+      }
+    }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2100,6 +2100,31 @@ ib_recv:
       }
       recvExistingSlot->cqRefcount++;
 
+      // Share flush QPs from primary
+      if (rComm->flushEnabled) {
+        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+          IbCastSharedQpKey flushKey;
+          memset(&flushKey, 0, sizeof(flushKey));
+          flushKey.ibDevN = rComm->base.vProps.devs[i];
+          flushKey.peerAddr = recvPeerAddr;
+          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+          flushKey.isSend = false;
+          flushKey.groupIdx = recvGroupIdx;
+          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+          if (flushSlot) {
+            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+            flushSlot->refcount++;
+            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+          } else {
+            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+                 __func__, i, recvGroupIdx, rComm->base.commId);
+          }
+        }
+      }
+
       goto qp_sharing_done_recv;
     } else {
       // PRIMARY receiver: create QPs with scaled depth, register in pool
@@ -2140,6 +2165,26 @@ qp_sharing_skip_recv:
         if (q == 0) {
           entry->cqRefcount = 1;
         }
+      }
+    }
+
+    // Register flush QPs in shared pool (primary only)
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = rComm->base.sharedGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+             rComm->base.sharedGroupIdx, rComm->base.commId);
       }
     }
   }
@@ -2429,10 +2474,11 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
-      // GPU flush cleanup remains per-comm
+      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
+          // Per-comm flush memory cleanup (always done)
           if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
             CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
             commDev->gpuFlush.gpuFlushGpuMem = nullptr;
@@ -2440,7 +2486,25 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             commDev->gpuFlush.gpuMr = nullptr;
             if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
           }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          // Shared flush QP teardown (refcount-based)
+          if (commDev->gpuFlush.qp.qp != NULL) {
+            struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
+                commDev->gpuFlush.qp.qp->qp_num, false);
+            if (flushSlot) {
+              flushSlot->refcount--;
+              if (flushSlot->refcount <= 0 && flushSlot->qp) {
+                INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared flush QP qpn=%u group=%d",
+                     flushSlot->qp->qp_num, flushSlot->key.groupIdx);
+                wrap_ibv_destroy_qp(flushSlot->qp);
+                flushSlot->qp = NULL;
+                flushSlot->used = false;
+              }
+            } else {
+              // Not in pool (shouldn't happen), destroy directly
+              NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+            }
+            commDev->gpuFlush.qp.qp = NULL;
+          }
           if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
         }
         if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -95,7 +95,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int64_t cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -107,12 +107,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
   }
 
   if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
-    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+    WARN("NET/IB: %s: requested CQ size %ld exceeds device %s max_cqe %d, clamping",
          __func__, cqSize, ibDev->devName, ibDev->maxCqe);
     cqSize = ibDev->maxCqe;
   }
 
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, (int)cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -1132,7 +1132,7 @@ ib_recv_dev_list:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, ((int64_t)cqSize * depthMult)), ret, fail);
     if (depthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what depthMult asked for, shrink depthMult to match so QP WR depth
@@ -1995,7 +1995,7 @@ ib_recv:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, ((int64_t)cqSize * recvDepthMult)), ret, fail);
     if (recvDepthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
@@ -2236,8 +2236,14 @@ qp_sharing_skip_recv:
         flushKey.groupIdx = rComm->base.sharedGroupIdx;
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
-        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
             rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+        if (flushEntry == NULL) {
+          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+          continue;
+        }
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -106,6 +106,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
+  if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
+    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+         __func__, cqSize, ibDev->devName, ibDev->maxCqe);
+    cqSize = ibDev->maxCqe;
+  }
+
   NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
@@ -795,9 +801,13 @@ fail:
 // is updated accordingly. The meta data structure is then expected to be
 // delivered to the remote side (receiver) as part of the connection
 // establishment process.
-static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
+static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId,
+                                          int depthMult) {
   uint nqps = comm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -806,7 +816,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1124,6 +1133,13 @@ ib_recv_dev_list:
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    if (depthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what depthMult asked for, shrink depthMult to match so QP WR depth
+      // and this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = comm->devs[i].base.cq->cqe / cqSize;
+      if (achievedMult < depthMult) depthMult = std::max(1, achievedMult);
+    }
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1261,7 +1277,7 @@ ib_recv_dev_list:
 
 qp_sharing_skip_sender:
   // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
 
   comm->telChId = channelId;
   comm->telChStats = NULL;
@@ -1564,10 +1580,14 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
-                                                 struct ncclIbConnectionMetadata* meta, int channelId) {
+                                                 struct ncclIbConnectionMetadata* meta, int channelId,
+                                                 int depthMult) {
   uint nqps = rComm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1581,7 +1601,6 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
 
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1977,6 +1996,13 @@ ib_recv:
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    if (recvDepthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
+      // this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = rCommDev->base.cq->cqe / cqSize;
+      if (achievedMult < recvDepthMult) recvDepthMult = std::max(1, achievedMult);
+    }
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -2162,7 +2188,7 @@ ib_recv:
   }
 
 qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
 
   // If primary receiver, register QPs in shared pool
   if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1300,7 +1300,7 @@ qp_sharing_skip_sender:
       int devIdx = q % comm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -2159,7 +2159,7 @@ qp_sharing_skip_recv:
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
       if (entry) {
         entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
         if (q == 0) {
@@ -2181,7 +2181,7 @@ qp_sharing_skip_recv:
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
         IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2382,12 +2382,6 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           }
         }
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
 
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
@@ -2405,6 +2399,15 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them, or ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown
@@ -2466,12 +2469,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // GPU flush cleanup — flush QP is shared, memory resources are per-comm
@@ -2513,6 +2510,16 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           IbCastResiliencyDevDestroy(comm->base.resiliency, i);
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them (data QPs above, this comm's own flush QP just above), or
+      // ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -10,6 +10,7 @@
 #include "p2p_cast.h"
 #include "p2p_resiliency_cast.h"
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbCastRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
@@ -77,6 +78,10 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
 
   if (useCtsOffload) {
     return BY_ORDER;
+  }
+
+  if (rcclParamIbCastCommNGroups() > 0) {
+    return BY_ID;
   }
 
   if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
@@ -405,6 +410,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   return ncclSuccess;
 }
 
+
 static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs, struct ncclIbQp* qp) {
   struct ibv_qp_init_attr qpInitAttr;
   enum ncclIbChannelType channel_type = (createQpAttrs->isDataQp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
@@ -413,8 +419,14 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
   qpInitAttr.qp_type = createQpAttrs->type;
-  qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
-  qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  // Scale WR depths for QP sharing
+  if (createQpAttrs->isQpSharingEnabled) {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest * createQpAttrs->cqDepthMultiplier;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest * createQpAttrs->cqDepthMultiplier;
+  } else {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  }
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
   if (createQpAttrs->isCtsEnabled) {
@@ -439,17 +451,23 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
 
-  if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
-    bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
-    nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
-      !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
-  }
-  if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+  if (createQpAttrs->isQpSharingEnabled && (createQpAttrs->qpSharingGroupIdx >= 0)) {
+    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
+    uint8_t mask = (createQpAttrs->qpSharingGroupIdx % 2 == 0) ? IONIC_UDMA_MASK_LOW : IONIC_UDMA_MASK_HIGH;
+    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, mask);
   } else {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
+      bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
+      nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
+        !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
+    }
+    if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+    } else {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    }
   }
 
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, createQpAttrs->pd, &qpInitAttr));
@@ -779,12 +797,17 @@ fail:
 // establishment process.
 static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = comm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -876,6 +899,25 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    comm->remCommId = remMeta->commId;
+
+    // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
+    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+      // Just assign remDevIdx from remote metadata
+      uint nqps = comm->base.nqps;
+      for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+        ncclIbQp* localQp = &comm->base.qps[qpIndex];
+        ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
+        localQp->remDevIdx = remQpInfo->devIndex;
+      }
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
+      }
+      return ncclSuccess;
+    }
+  }
+
   uint nqps = comm->base.nqps;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
@@ -904,6 +946,7 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
 
     struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    remDevInfo->mtu = rtrAttr->mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
     rtrAttr->sl = remMeta->sl;
@@ -1050,9 +1093,21 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
+  // Initialize QP sharing fields
+  comm->base.commId = 0;
+  comm->base.isSharedQpPrimary = false;
+  comm->base.sharedGroupIdx = -1;
+  comm->base.remIbDevIdx = -1;
+  comm->base.sharedPrimaryNqps = 0;
+  comm->remCommId = 0;
+
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
+
+  // Compute depth multiplier for QP sharing
+  int depthMult;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1068,7 +1123,7 @@ ib_recv_dev_list:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1079,7 +1134,121 @@ ib_recv_dev_list:
   meta.ndevs = comm->base.vProps.ndevs;
   meta.isP2p = isP2p;
   meta.isRMA = handle->isRMA;
+  meta.sharedGroupIdx = -1;
+  meta.commId = 0;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
+  // QP Sharing: sender-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
+    int ngroups = rcclParamIbCastCommNGroups();
+
+    // Allocate commId for this comm
+    comm->base.commId = IbCastAllocCommId(comm, true);
+    if (comm->base.commId == 0) {
+      // Fallback to non-sharing if pool exhausted
+      goto qp_sharing_skip_sender;
+    }
+
+    // Check if primary exists for this group
+    IbCastSharedQpKey probeKey;
+    memset(&probeKey, 0, sizeof(probeKey));
+    // Build probe key from peer address
+    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+    IbCastStripPort(&probeKey.peerAddr);
+
+    // Use first device's ibDevN for the probe
+    int probeIbDevN;
+    int probeRemIbDevIdx;
+    // TODO - QP sharing
+    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
+    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+    probeRemIbDevIdx = remoteVProps.devs[0];
+
+    // Count existing refs to determine groupIdx
+    int totalRefs;
+    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+    int groupIdx;
+    groupIdx = totalRefs % ngroups;
+    comm->base.sharedGroupIdx = groupIdx;
+    comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+    probeKey.ibDevN = probeIbDevN;
+    probeKey.remIbDevIdx = probeRemIbDevIdx;
+    probeKey.isSend = true;
+    probeKey.groupIdx = groupIdx;
+    probeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* existingSlot;
+    existingSlot = IbCastFindSharedQp(&probeKey);
+
+    if (existingSlot != NULL) {
+      // SECONDARY: reuse existing QPs from pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+           __func__, comm->base.commId, groupIdx, totalRefs);
+
+      comm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+      comm->base.sharedPrimaryNqps = primaryNqps;
+
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+      key.isSend = true;
+      key.groupIdx = groupIdx;
+
+      int nqps = comm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+        int mappedQP = q % primaryNqps;
+        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
+        key.qpIdx = mappedQP;
+
+        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+        if (slot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+          // Fallback: free commId and go non-sharing
+          IbCastFreeCommId(comm->base.commId);
+          comm->base.commId = 0;
+          comm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_sender;
+        }
+
+        // Copy QP info from shared pool to this comm
+        comm->base.qps[q].qp = slot->qp;
+        comm->base.qps[q].devIndex = slot->devIndex;
+        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+        comm->base.activeQps[q] = &comm->base.qps[q];
+
+        // Populate metadata with shared QP info
+        meta.qpInfo[q].qpn = slot->qp->qp_num;
+        meta.qpInfo[q].devIndex = slot->devIndex;
+
+        slot->refcount++;
+      }
+
+      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+        comm->devs[i].base.cq = existingSlot->primaryCq;
+      }
+      existingSlot->cqRefcount++;
+
+      // Skip QP creation; metadata is already populated
+      goto qp_sharing_done_sender;
+    } else {
+      // PRIMARY: create QPs with scaled depth, then register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+           __func__, comm->base.commId, groupIdx, depthMult);
+
+      comm->base.isSharedQpPrimary = true;
+    }
+  }
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+
+qp_sharing_skip_sender:
   // Create QPs on the sender side
   NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
 
@@ -1109,6 +1278,45 @@ ib_recv_dev_list:
     // Request completions are charged to the comm's first device.
     comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
   }
+
+  // If primary, register QPs in shared pool
+  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
+    union ncclSocketAddress peerAddr;
+    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
+    IbCastStripPort(&peerAddr);
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+      IbCastStripPort(&key.peerAddr);
+      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
+      key.groupIdx = comm->base.sharedGroupIdx;
+      key.isSend = true;
+      key.qpIdx = q;
+
+      int devIdx = q % comm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+      if (entry && q == 0) {
+        entry->cqRefcount = 1;
+      }
+      if (entry) {
+        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+      }
+    }
+  }
+
+qp_sharing_done_sender:
+  // Populate QP sharing metadata
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  meta.commId = comm->base.commId;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
@@ -1344,6 +1552,7 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
                                                  struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = rComm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1354,6 +1563,11 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // When resiliency is enabled, the number of send work requests is as the
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
+
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1408,6 +1622,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
         return ncclInternalError;
       }
     }
+
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
@@ -1495,6 +1710,10 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
+      // QP sharing is disabled for flush QP
+      qpCreateAttrs.isQpSharingEnabled = false;
+      qpCreateAttrs.qpSharingGroupIdx = -1;
+      qpCreateAttrs.cqDepthMultiplier = 1;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1700,6 +1919,13 @@ ib_recv:
     }
   }
 
+  // Initialize QP sharing fields on receiver
+  rComm->base.commId = 0;
+  rComm->base.isSharedQpPrimary = false;
+  rComm->base.sharedGroupIdx = -1;
+  rComm->base.remIbDevIdx = -1;
+  rComm->base.sharedPrimaryNqps = 0;
+
   // IB setup
   // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
@@ -1716,6 +1942,11 @@ ib_recv:
   // Metadata to send back to requestor (sender)
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
+
+  // Compute depth multiplier for receiver QP sharing
+  int recvDepthMult;
+  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
@@ -1730,7 +1961,7 @@ ib_recv:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1784,7 +2015,140 @@ ib_recv:
                           1 :
                           0;
 
+  // QP Sharing: receiver-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
+    int recvGroupIdx = remMeta.sharedGroupIdx;
+    int recvProbeIbDevN;
+
+    rComm->base.commId = IbCastAllocCommId(rComm, false);
+    if (rComm->base.commId == 0) {
+      goto qp_sharing_skip_recv;
+    }
+    // Build probe key from peer address
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    rComm->base.sharedGroupIdx = recvGroupIdx;
+	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+    IbCastSharedQpKey recvProbeKey;
+    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+    recvProbeKey.ibDevN = recvProbeIbDevN;
+    recvProbeKey.peerAddr = recvPeerAddr;
+    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeKey.isSend = false;
+    recvProbeKey.groupIdx = recvGroupIdx;
+    recvProbeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* recvExistingSlot;
+    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+    if (recvExistingSlot != NULL) {
+      // SECONDARY receiver: reuse existing QPs
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+           __func__, rComm->base.commId, recvGroupIdx);
+
+      rComm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
+
+      rComm->base.sharedPrimaryNqps = primaryNqps;
+      rComm->useCtsOffload = false;
+
+      IbCastSharedQpKey recvKey;
+      memset(&recvKey, 0, sizeof(recvKey));
+      recvKey.peerAddr = recvPeerAddr;
+      recvKey.isSend = false;
+      recvKey.groupIdx = recvGroupIdx;
+
+      int nqps = rComm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+		int mappedQ = q % primaryNqps;
+		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        recvKey.qpIdx = mappedQ;
+
+        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+        if (recvSlot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+          IbCastFreeCommId(rComm->base.commId);
+          rComm->base.commId = 0;
+          rComm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_recv;
+        }
+
+        rComm->base.qps[q].qp = recvSlot->qp;
+        rComm->base.qps[q].devIndex = recvSlot->devIndex;
+        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
+        rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
+        meta.qpInfo[q].devIndex = recvSlot->devIndex;
+
+        recvSlot->refcount++;
+      }
+
+      // Redirect CQs
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+      }
+      recvExistingSlot->cqRefcount++;
+
+      goto qp_sharing_done_recv;
+    } else {
+      // PRIMARY receiver: create QPs with scaled depth, register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
+           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
+      rComm->base.isSharedQpPrimary = true;
+      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    }
+  }
+
+qp_sharing_skip_recv:
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+
+  // If primary receiver, register QPs in shared pool
+  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvKey.isSend = false;
+    recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+      recvKey.qpIdx = q;
+
+      int devIdx = q % rComm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+      if (entry) {
+        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+        if (q == 0) {
+          entry->cqRefcount = 1;
+        }
+      }
+    }
+  }
+
+qp_sharing_done_recv:
+  // Populate QP sharing metadata in response
+  meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
+  meta.commId = rComm->base.commId;
+
   if (rComm->prepostReceiveWorkRequests) {
     NCCLCHECKGOTO(IbCastReceiverPrePostReceiveWorkRequests(rComm), ret, fail);
   }
@@ -1955,23 +2319,70 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbSendCommDev* commDev = comm->devs + i;
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared send QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
+          }
+        }
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // Deregister per-comm MRs (not shared)
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }
@@ -1988,34 +2399,86 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbRecvCommDev* commDev = comm->devs + i;
-      if (comm->flushEnabled) {
-        if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-          commDev->gpuFlush.gpuMr = nullptr;
-          if (commDev->gpuFlush.dmabufFd > 0) {
-            close(commDev->gpuFlush.dmabufFd);
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared recv QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
           }
         }
-        if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+
       if (comm->base.resiliency) {
-        IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // GPU flush cleanup remains per-comm
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1312,12 +1312,16 @@ qp_sharing_skip_sender:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
           comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry && q == 0) {
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      if (q == 0) {
         entry->cqRefcount = 1;
       }
-      if (entry) {
-        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
-      }
+      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
     }
   }
 
@@ -2182,11 +2186,15 @@ qp_sharing_skip_recv:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
           rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry) {
-        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-        if (q == 0) {
-          entry->cqRefcount = 1;
-        }
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+      if (q == 0) {
+        entry->cqRefcount = 1;
       }
     }
 
@@ -2516,10 +2524,12 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                flushSlot->used = false;
+                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
               }
             } else {
-              // Not in pool (shouldn't happen), destroy directly
+              // Not in pool -- e.g. registration hit the pool-exhaustion
+              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
+              // flush QP was never pool-tracked, so just destroy it directly.
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
             commDev->gpuFlush.qp.qp = NULL;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1233,6 +1233,17 @@ ib_recv_dev_list:
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
         comm->devs[i].base.cq = existingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = comm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       existingSlot->cqRefcount++;
 
@@ -2097,6 +2108,17 @@ ib_recv:
       for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
         rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = rComm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       recvExistingSlot->cqRefcount++;
 

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -115,6 +115,13 @@ struct ncclIbConnectionMetadata {
   int      senderIbDevIdx;      // sender's IB device index
 };
 
+// Initialize QP sharing fields to defaults (sharing disabled)
+static inline void IbCastQpCreateAttrInitSharing(struct ncclIbQpCreateAttr* attr) {
+  attr->isQpSharingEnabled = false;
+  attr->qpSharingGroupIdx = -1;
+  attr->cqDepthMultiplier = 1;
+}
+
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -57,6 +57,9 @@ struct ncclIbQpCreateAttr {
   int channelId;
   int ibDevN;
   bool useIonic;
+  bool isQpSharingEnabled;
+  int  cqDepthMultiplier;
+  int  qpSharingGroupIdx;
 };
 
 // Per-QP connection metatdata
@@ -105,6 +108,11 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
+
+  // QP Sharing metadata
+  int      sharedGroupIdx;      // QP sharing group index (-1 = not shared)
+  uint16_t commId;              // QP sharing comm ID (0 = not shared)
+  int      senderIbDevIdx;      // sender's IB device index
 };
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -8,6 +8,7 @@
 #include "common_cast.h"
 #include "p2p_resiliency_recovery_cast.h"
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 extern int64_t ncclParamIbCastQpsPerConn();
 RCCL_PARAM(IbCastQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -633,6 +634,12 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // flag IbCastAinicCtsInlineData is used specifically to identify UseInline for Ainic
       IbCastAinicCtsInlineData = IbCastUseInline;
 
+      // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
+      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+        INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
+        IbCastOffloadEnabled = false;
+      }
+
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: %s; GDR Flush: %s",
@@ -646,6 +653,10 @@ exit:
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
                                "(load balancer integration with resiliency is pending)");
+    castGlobalQpSchedParms.enable = false;
+  }
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -360,6 +360,10 @@ ncclResult_t IbCastFinalizeDevices(void) {
   // No telemetry flush here: netRefCount reaching 0 is not process exit, and
   // the flush is one-shot. atexit(rcclTelemetryFlush) covers the process.
   --netRefCount;
+  if (netRefCount == 0) {
+    // debug validation
+    IbCastValidateSharedQpPool();
+  }
   return ncclSuccess;
 }
 
@@ -635,7 +639,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       IbCastAinicCtsInlineData = IbCastUseInline;
 
       // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
-      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+      if (IbCastOffloadEnabled && IbCastQpSharingEnabled()) {
         INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
         IbCastOffloadEnabled = false;
       }
@@ -655,7 +659,7 @@ exit:
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
   }
-  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && IbCastQpSharingEnabled()) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -13,6 +13,7 @@
 #include "net_ib_ops_fault.h"
 #endif
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
@@ -68,14 +69,14 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   switch (wr->opcode) {
   case IBV_WR_RDMA_WRITE:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
     break;
   case IBV_WR_RDMA_WRITE_WITH_IMM:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
@@ -115,7 +116,12 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : ctsFifoAddr(slots, r);
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    wr->wr_id = wr_id;
+    // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    } else {
+      wr->wr_id = wr_id;
+    }
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif
@@ -132,6 +138,9 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   }
 
   // For ID-based matching scheme, immData carries the request ID.
+  //   If QP sharing is enabled, immData also carries the receiver's commId:
+  //       reqId in bits[7:0],
+  //       remCommId in bits[23:8].
   // For index-based matching scheme, immData layout (BY_INDEX):
   //   bits [31:24] - rxReqIndex: receiver's request slot index (from CTS fifo)
   //   bit  [23]    - WR_IMM_SPLIT_DATA_FLAG: set when sending across >1 QPs
@@ -143,6 +152,10 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
+      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
+                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
       immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
@@ -166,7 +179,14 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     lastWr->imm_data = htobe32(immData);
   }
-  lastWr->wr_id = wr_id;
+  // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
+  // route the send completion to the right comm on a shared QP. The scheduler
+  // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
+  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  } else {
+    lastWr->wr_id = wr_id;
+  }
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
@@ -178,7 +198,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
     TRACE(NCCL_NET,
-          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx) on QP (qp_num=%u, "
           "devIndex=%d, qpIndex=%d)",
           __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
@@ -335,8 +355,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       reqs[r]->send.sentData[qpIndex] = true;
 
       TRACE(NCCL_VERBS,
-            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
-            "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            "Posted send wr_id=0x%lx, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
+            "imm_data=0x%x, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
             comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
             comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid, comm->wrs[r].opcode,
             comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
@@ -345,7 +365,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx)", __func__,
         reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
   if (nowNs) {
     if (comm->base.nextQpTxSchedUpdateNs == 0)
@@ -576,11 +596,15 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
+    // QP Sharing: encode commId in upper bits of CTS wr_id
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -590,7 +614,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   rcclTelemetryQpCtsSent(ctsQp->telQpStats, (wr.send_flags & IBV_SEND_SIGNALED) ? 1 : 0);
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -751,6 +775,9 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
     wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
@@ -759,7 +786,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
@@ -768,7 +795,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
   }
 
@@ -788,6 +815,7 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
+// QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id
 static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
                                                                ncclIbRequest** req) {
   assert(req != NULL);
@@ -797,24 +825,38 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=0x%lx, opcode=%s, imm_data=0x%x, byte_len=%d)",
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+      *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
+    } else {
+      *req = recvComm->recvReqs[immDataHost % NET_IB_MAX_REQUESTS];
+    }
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
-    *req = &base->reqs[((be32toh(wc->imm_data) >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK)];
+    // BY_INDEX (non-sharing CAST default): rxReqIndex is echoed in imm_data[31:24].
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
+    *req = &base->reqs[reqIdx];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
-    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
+    // wr_id[63:48] may carry a commId for completion routing (zero if sharing is
+    // disabled). Strip it to recover the original request index.
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (IbCastStripCommId(wc->wr_id) - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
+    // Non-wr-imm recv (e.g. signalled CTS completion). base is the polling comm.
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[wc->wr_id];
+    *req = recvComm->recvReqs[wc->wr_id & 0xFFFF];
   } else {
+    // Sender completion. targetBase was routed by IbCastTest via commId in wr_id[63:48];
+    // the low byte is the request slot. (BY_ID / BY_ORDER: no scheduler remap.)
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
-      // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
+      // BY_INDEX: wr_id was remapped by the CAST scheduler for RTT timing.
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
@@ -822,13 +864,12 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
-      // BY_ID / other: wr_id is raw slot-encoded value (no remap)
       *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
   TRACE(NCCL_NET,
-        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
-        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, wc.opcode=%s, "
+        "wc.imm_data=0x%x, wc.byte_len=%d, wc.qp_num=%u)",
         __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type],
         wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
@@ -934,21 +975,23 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
     WARN("NET/IB: %s: recvMatchingScheme not supported", __func__);
     return ncclInternalError;
   }
+
   if (commBase->isSend) {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    req = &(commBase->reqs[wc->wr_id & 0xff]);
   }
 
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -959,7 +1002,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -967,7 +1010,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
@@ -997,7 +1040,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1024,8 +1067,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
       req->events[devIndex]--;
       return ncclSuccess;
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1050,7 +1093,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(IbCastRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -1059,7 +1102,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 #ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN + 1];
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -1067,18 +1110,19 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
-    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
+    // QP Sharing: use the target comm from the routed request, not the polling comm
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)req->base;
     struct ncclIbRequest* sendReq = NULL;
     int slot = req->id % NET_IB_MAX_REQUESTS;
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
-      if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
+      if (!req->base->resiliency && (sendReq->events[devIndex] <= 0)) {
         WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
@@ -1100,13 +1144,13 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
-             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=0x%lx, wc.imm_data=0x%x, wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
              ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1132,9 +1176,15 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
+#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
+        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
+        uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
+        commBase->rxPosts[rawWrId]--;
+#else
         commBase->rxPosts[wc->wr_id]--;
+#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
@@ -1166,14 +1216,14 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
-             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             "id=%ld, wc.wr_id=0x%lx, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
              __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
              be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1241,7 +1291,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           // errors happen, so gating this on !resiliency left the counter at 0.
           rcclTelemetryCqError(r->devBases[i]->ibDevN);
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=0x%lx, qp_num=%d)", __func__,
                  i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             IbCastLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
@@ -1249,13 +1299,24 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          TRACE(NCCL_NET,
-                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
-                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
-          if (r->base->recvMatchingScheme != BY_ORDER) {
-            NCCLCHECK(IbCastCompletionEventProcess(r->base, wc, i));
+          struct ncclIbNetCommBase* targetBase = (struct ncclIbNetCommBase*)r->base;
+          // RECV_RDMA_WITH_IMM (data receive) carries commId in imm_data and is
+          // routed in IbCastRequestRetrieveFromCompletion. All other completions
+          // (send, CTS/RDMA_WRITE, flush/RDMA_READ) carry commId in wr_id[63:48]
+          // and are routed here.
+          if (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromWrId(wc->wr_id);
+            if (routed) targetBase = routed;
           } else {
-            NCCLCHECK(IbCastCompletionEventByOrder(r->base, wc, i));
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromImmData((struct ncclIbNetCommBase*)r->base, be32toh(wc->imm_data));
+            if (routed && !routed->isSend && (routed->recvMatchingScheme == BY_ID)) targetBase = routed;
+          }
+
+          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)", __func__, i, targetBase, targetBase->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          if (targetBase->recvMatchingScheme != BY_ORDER) {
+            NCCLCHECK(IbCastCompletionEventProcess(targetBase, wc, i));
+          } else {
+            NCCLCHECK(IbCastCompletionEventByOrder(targetBase, wc, i));
           }
         }
       }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -770,6 +770,10 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
   req->sock = &comm->base.sock;
   struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[last];
 
+  INFO(NCCL_NET, "NET/IB: %s: flush commId=%u group=%d isPrimary=%d ndevs=%d",
+       __func__, comm->base.commId, comm->base.sharedGroupIdx,
+       comm->base.isSharedQpPrimary, comm->base.vProps.ndevs);
+
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     struct ibv_send_wr wr;
@@ -790,6 +794,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
+    INFO(NCCL_NET, "NET/IB: %s: posting flush dev=%d qpn=%u wr_id=0x%lx",
+         __func__, i, comm->devs[i].gpuFlush.qp.qp->qp_num, wr.wr_id);
     NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
     TIME_STOP(4);
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -117,8 +117,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
     } else {
       wr->wr_id = wr_id;
     }
@@ -152,9 +152,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
-      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
-                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      if (IbCastCommIsSharing(&comm->base) && comm->remCommId != 0) {
+        immData = IbCastEncodeCommIdImmData((uint32_t)reqs[0]->id, comm->remCommId);
       }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
@@ -182,8 +181,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
   // route the send completion to the right comm on a shared QP. The scheduler
   // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
-  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  if (IbCastCommIsSharing(&comm->base)) {
+    lastWr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
   } else {
     lastWr->wr_id = wr_id;
   }
@@ -597,8 +596,8 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
     // QP Sharing: encode commId in upper bits of CTS wr_id
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
@@ -779,8 +778,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
@@ -838,7 +837,7 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     uint32_t immDataHost = be32toh(wc->imm_data);
-    if (rcclParamIbCastCommNGroups() > 0) {
+    if (IbCastQpSharingEnabled()) {
       uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
       *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
     } else {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -17,6 +17,7 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
+extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -275,7 +276,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   bool inFlushRange =
     (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+    WARN("NET/IB: %s: Invalid wr_id (0x%lx). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
          wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
@@ -286,7 +287,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=0x%lx, wc.status=%s(%d)).", __func__,
          resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
@@ -352,7 +353,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
 
   if (request == NULL) {
     WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
-         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         "wc.wr_id=0x%lx, wc.status=%s(%d), wc.opcode=%s(%d)).",
          __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
          ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
@@ -361,7 +362,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = IbCastResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, "
          "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
          __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id,
          ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
@@ -540,7 +541,7 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
 static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
                                                                struct ibv_wc* probeWc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=0x%lx, wc->qp_num=%u)",
        __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
@@ -598,9 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
-         baseComm->isSend ? "send" : "recv", baseComm);
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+    // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
+    // when QP sharing is enabled.
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm,
+         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -810,6 +814,9 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -899,6 +906,9 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"
@@ -1049,7 +1059,7 @@ ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bo
 
 ncclResult_t IbCastResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=0x%lx, "
        "wc->qp_num=%u, wc->byte_len=%d)",
        __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
        wc->qp_num, wc->byte_len);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -9,6 +9,7 @@
 #include "p2p_cast.h" // For replay (IbCastMultiSend() and IbCastPostFifo())
 #include "connect_cast.h" // For IbCastQpCreate()
 #include "p2p_resiliency_recovery_cast.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastResiliencyPortFailover, "IB_RESILIENCY_PORT_FAILOVER", 0);
 NCCL_PARAM(IbCastResiliencyPortFailoverMaxAttempts, "IB_RESILIENCY_PORT_FAILOVER_MAX_ATTEMPTS", 1);
@@ -17,7 +18,6 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
-extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -599,12 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || IbCastQpSharingEnabled()) {
     // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
     // when QP sharing is enabled.
     INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
          baseComm->isSend ? "send" : "recv", baseComm,
-         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
+         IbCastQpSharingEnabled() ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -814,9 +814,7 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -906,9 +904,7 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,9 +313,7 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -387,9 +385,7 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,6 +313,9 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -384,6 +387,9 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -50,9 +50,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     //        as of now QP sharing disabled during recovery restore.
     //        to analyze and set sharing accordingly for this QP during recovery restore.
     //        identify if it is primary or secondary comm and set sharing attributes accordingly.
-    createAttr.isQpSharingEnabled = false;
-    createAttr.qpSharingGroupIdx = -1;
-    createAttr.cqDepthMultiplier = 1;
+    IbCastQpCreateAttrInitSharing(&createAttr);
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
     localQp->telQpStats = telQpStats;
 
@@ -87,9 +85,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.isDataQp = flushQp->isDataQp;
         // TODO - QP sharing:
         //        disabled for flush QP
-        flushCreateAttr.isQpSharingEnabled = false;
-        flushCreateAttr.qpSharingGroupIdx = -1;
-        flushCreateAttr.cqDepthMultiplier = 1;
+        IbCastQpCreateAttrInitSharing(&flushCreateAttr);
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -46,6 +46,13 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     createAttr.isDataQp = localQp->isDataQp;
     // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
     // CTS offload is disabled when resiliency features are enabled (init.cc).
+    // TODO - QP sharing:
+    //        as of now QP sharing disabled during recovery restore.
+    //        to analyze and set sharing accordingly for this QP during recovery restore.
+    //        identify if it is primary or secondary comm and set sharing attributes accordingly.
+    createAttr.isQpSharingEnabled = false;
+    createAttr.qpSharingGroupIdx = -1;
+    createAttr.cqDepthMultiplier = 1;
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
     localQp->telQpStats = telQpStats;
 
@@ -78,6 +85,11 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
+        // TODO - QP sharing:
+        //        disabled for flush QP
+        flushCreateAttr.isQpSharingEnabled = false;
+        flushCreateAttr.qpSharingGroupIdx = -1;
+        flushCreateAttr.cqDepthMultiplier = 1;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -16,6 +16,8 @@ struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+int                         g_IbCastCommIdFreeTop = 0;
 std::mutex                  g_IbCastSharedQpMutex;
 
 void IbCastStripPort(union ncclSocketAddress* addr) {
@@ -109,11 +111,17 @@ int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peer
 
 uint16_t IbCastAllocCommId(void* comm, bool isSend) {
     std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+    uint16_t id;
+    if (g_IbCastCommIdFreeTop > 0) {
+        // Reuse a previously freed commId — O(1)
+        id = g_IbCastCommIdFreeStack[--g_IbCastCommIdFreeTop];
+    } else if (g_IbCastNextCommId < IBCAST_MAX_COMMS) {
+        // Allocate a fresh commId — O(1)
+        id = g_IbCastNextCommId++;
+    } else {
         WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
         return 0;
     }
-    uint16_t id = g_IbCastNextCommId++;
     g_IbCastCommTable[id].comm = comm;
     g_IbCastCommTable[id].isSend = isSend;
     g_IbCastCommTable[id].used = true;
@@ -126,6 +134,7 @@ void IbCastFreeCommIdLocked(uint16_t commId) {
     if (commId > 0 && commId < IBCAST_MAX_COMMS) {
         g_IbCastCommTable[commId].used = false;
         g_IbCastCommTable[commId].comm = NULL;
+        g_IbCastCommIdFreeStack[g_IbCastCommIdFreeTop++] = commId;
     }
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -60,7 +60,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
 
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+    int primaryIbDevN, int devIndex, int initialRefcount) {
 
     if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
@@ -70,7 +70,7 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
-    entry->primaryDevBase = primaryDevBase;
+    entry->primaryIbDevN = primaryIbDevN;
     entry->devIndex = devIndex;
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
@@ -197,8 +197,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
                      g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
             }
             destroyedCqs[nDestroyed++] = cq;
-            if (g_IbCastSharedQpPool[i].primaryDevBase) {
-                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+            {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryIbDevN;
                 std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
                 INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
                      ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "qp_sharing.h"
+#include <cassert>
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -163,7 +164,7 @@ struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
 }
 
 struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
     //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
     if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
@@ -190,6 +191,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
 
     for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
         if (!g_IbCastSharedQpPool[i].used) continue;
+        // Skip flush QP slots — they are torn down separately before CQ cleanup
+        if (g_IbCastSharedQpPool[i].key.qpIdx == IBCAST_FLUSH_QP_IDX) continue;
         if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
         if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
         if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
@@ -226,5 +229,42 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
         }
         g_IbCastSharedQpPool[i].used = false;
         g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
+    }
+}
+
+void IbCastValidateSharedQpPool(void) {
+    if (!IbCastQpSharingEnabled()) return;
+
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int leakedSlots = 0;
+    int leakedCommIds = 0;
+
+    // Check QP pool for leaked entries
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        struct IbCastSharedQp* slot = &g_IbCastSharedQpPool[i];
+        if (slot->used) {
+            WARN("IB CAST POOL LEAK: slot=%d qpIdx=%d group=%d isSend=%d refcount=%d cqRefcount=%d qp=%p",
+                 i, slot->key.qpIdx, slot->key.groupIdx, slot->key.isSend,
+                 slot->refcount, slot->cqRefcount, (void*)slot->qp);
+            leakedSlots++;
+        }
+    }
+
+    // Check comm table for leaked commIds
+    for (int i = 1; i < IBCAST_MAX_COMMS; i++) {
+        if (g_IbCastCommTable[i].used) {
+            WARN("IB CAST POOL LEAK: commId=%d isSend=%d comm=%p still in use",
+                 i, g_IbCastCommTable[i].isSend, g_IbCastCommTable[i].comm);
+            leakedCommIds++;
+        }
+    }
+
+    if (leakedSlots == 0 && leakedCommIds == 0) {
+        INFO(NCCL_NET, "IB CAST POOL VALIDATE: clean shutdown — pool=%d/%d slots used, freeStack=%d, nextCommId=%u",
+             0, g_IbCastSharedQpPoolCount, g_IbCastCommIdFreeTop, g_IbCastNextCommId);
+    } else {
+        WARN("IB CAST POOL VALIDATE: UNCLEAN shutdown — %d leaked QP slots, %d leaked commIds", leakedSlots, leakedCommIds);
+        assert(leakedSlots == 0 && "QP sharing pool has leaked QP slots at shutdown");
+        assert(leakedCommIds == 0 && "QP sharing pool has leaked commIds at shutdown");
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -14,6 +14,8 @@ RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
+int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpFreeTop = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
 uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -62,11 +64,18 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount) {
 
-    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int idx;
+    if (g_IbCastSharedQpFreeTop > 0) {
+        // Reuse a slot freed by IbCastCleanupGroupCqs -- O(1)
+        idx = g_IbCastSharedQpFreeStack[--g_IbCastSharedQpFreeTop];
+    } else if (g_IbCastSharedQpPoolCount < IBCAST_MAX_SHARED_QPS) {
+        idx = g_IbCastSharedQpPoolCount++;
+    } else {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
         return NULL;
     }
-    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[idx];
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
@@ -77,6 +86,13 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->used = true;
     entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
+}
+
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry) {
+    if (entry == NULL) return;
+    int idx = (int)(entry - g_IbCastSharedQpPool);
+    entry->used = false;
+    g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = idx;
 }
 
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
@@ -209,5 +225,6 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
             }
         }
         g_IbCastSharedQpPool[i].used = false;
+        g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -1,0 +1,204 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing pool management implementation for IB CAST transport layer.
+ ************************************************************************/
+
+#include "qp_sharing.h"
+
+// QP sharing configuration parameters
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+
+// Pool and comm table globals
+struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpPoolCount = 0;
+struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+std::mutex                  g_IbCastSharedQpMutex;
+
+void IbCastStripPort(union ncclSocketAddress* addr) {
+    if (addr->sa.sa_family == AF_INET) {
+        addr->sin.sin_port = 0;
+    } else if (addr->sa.sa_family == AF_INET6) {
+        addr->sin6.sin6_port = 0;
+    }
+}
+
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b) {
+    if (a->ibDevN != b->ibDevN) return false;
+    if (a->isSend != b->isSend) return false;
+    if (a->groupIdx != b->groupIdx) return false;
+    if (a->qpIdx != b->qpIdx) return false;
+    if (a->remIbDevIdx != b->remIbDevIdx) return false;
+    if (memcmp(&a->peerAddr, &b->peerAddr, sizeof(union ncclSocketAddress)) != 0) return false;
+    return true;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && IbCastSharedQpKeyMatch(&g_IbCastSharedQpPool[i].key, key)) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && g_IbCastSharedQpPool[i].qp &&
+            g_IbCastSharedQpPool[i].key.isSend == isSend &&
+            g_IbCastSharedQpPool[i].qp->qp_num == qpn) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+
+    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+        WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
+        return NULL;
+    }
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    entry->key = *key;
+    entry->qp = qp;
+    entry->primaryCq = primaryCq;
+    entry->primaryDevBase = primaryDevBase;
+    entry->devIndex = devIndex;
+    entry->refcount = initialRefcount;
+    entry->cqRefcount = 0;
+    entry->used = true;
+    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
+    return entry;
+}
+
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx) {
+    int count = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend) {
+    int total = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.qpIdx != 0) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            total += g_IbCastSharedQpPool[i].refcount;
+        }
+    }
+    return total;
+}
+
+uint16_t IbCastAllocCommId(void* comm, bool isSend) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+        WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
+        return 0;
+    }
+    uint16_t id = g_IbCastNextCommId++;
+    g_IbCastCommTable[id].comm = comm;
+    g_IbCastCommTable[id].isSend = isSend;
+    g_IbCastCommTable[id].used = true;
+    return id;
+}
+
+// Caller MUST hold g_IbCastSharedQpMutex. Used by the teardown paths, which take
+// the mutex across the whole shared-QP cleanup block.
+void IbCastFreeCommIdLocked(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        g_IbCastCommTable[commId].used = false;
+        g_IbCastCommTable[commId].comm = NULL;
+    }
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
+  uint16_t commId = (wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
+  if (commId == 0 || commId >= IBCAST_MAX_COMMS || !g_IbCastCommTable[commId].used) return NULL;
+  return g_IbCastCommTable[commId].isSend
+    ? &((struct ncclIbSendComm*)g_IbCastCommTable[commId].comm)->base
+    : &((struct ncclIbRecvComm*)g_IbCastCommTable[commId].comm)->base;
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
+    //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+    if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+      return g_IbCastCommTable[immCommId].isSend
+        ? &((struct ncclIbSendComm*)g_IbCastCommTable[immCommId].comm)->base
+        : &((struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm)->base;
+    }
+  }
+  return NULL;
+}
+
+// Self-locking variant for callers that do NOT already hold the mutex
+// (e.g. the connect/accept non-sharing fallback paths).
+void IbCastFreeCommId(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        IbCastFreeCommIdLocked(commId);
+    }
+}
+
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
+    struct ibv_cq* destroyedCqs[NCCL_IB_MAX_DEVS_PER_NIC];
+    int nDestroyed = 0;
+
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, &slot0Entry->key.peerAddr,
+                   sizeof(union ncclSocketAddress)) != 0) continue;
+
+        struct ibv_cq* cq = g_IbCastSharedQpPool[i].primaryCq;
+        bool alreadyDestroyed = false;
+        for (int j = 0; j < nDestroyed; j++) {
+            if (destroyedCqs[j] == cq) { alreadyDestroyed = true; break; }
+        }
+        if (!alreadyDestroyed && cq != NULL) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying CQ %p group=%d ibDevN=%d isSend=%d remIbDev=%d qpIdx=%d refcount=%d",
+                 (void*)cq, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                 g_IbCastSharedQpPool[i].key.isSend, g_IbCastSharedQpPool[i].key.remIbDevIdx,
+                 g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            ncclResult_t cqRet = wrap_ibv_destroy_cq(cq);
+            if (cqRet != ncclSuccess) {
+                WARN("IB CAST TEARDOWN: ibv_destroy_cq FAILED cq=%p errno=%d group=%d ibDevN=%d qpIdx=%d refcount=%d",
+                     (void*)cq, errno, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                     g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            }
+            destroyedCqs[nDestroyed++] = cq;
+            if (g_IbCastSharedQpPool[i].primaryDevBase) {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+                std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
+                INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
+                     ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,
+                     (IbCastDevs[ibDevN2].pdRefs == 1) ? "DEALLOC" : "");
+                if (0 == --IbCastDevs[ibDevN2].pdRefs) {
+                    wrap_ibv_dealloc_pd(IbCastDevs[ibDevN2].pd);
+                }
+            }
+        }
+        g_IbCastSharedQpPool[i].used = false;
+    }
+}

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -42,7 +42,10 @@ struct IbCastSharedQp {
     IbCastSharedQpKey key;
     struct ibv_qp*    qp;                  // the physical QP
     struct ibv_cq*    primaryCq;           // CQ for this device in this group
-    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      primaryIbDevN;                // local IB device index of the primary comm's device,
+                                            // captured by value: the primary comm (and its inline
+                                            // devs[]) may be freed while secondaries or this pool
+                                            // entry still reference the group
     int      devIndex;                     // local device index within comm->devs[]
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
@@ -81,7 +84,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 // Register a new shared QP in the pool
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+    int primaryIbDevN, int devIndex, int initialRefcount);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -62,6 +62,8 @@ extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
+extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+extern int                         g_IbCastCommIdFreeTop;
 extern std::mutex                  g_IbCastSharedQpMutex;
 
 // Strip port from socket address for peer matching

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -22,6 +22,51 @@ extern int64_t rcclParamIbCastCommNGroups();
 // CQ/WR depth scaling for primary QPs
 extern int64_t rcclParamIbCastQpDepthMultiplier();
 
+// QP sharing role for a comm during connection setup.
+// Returned by IbCastQpSharing{Sender,Receiver}Setup() to tell the caller
+// whether to create QPs, register them, or skip both.
+enum IbCastQpSharingRole {
+  QP_SHARING_NONE,       // sharing disabled or fallback — normal QP creation
+  QP_SHARING_PRIMARY,    // primary — create QPs with scaled depth, then register
+  QP_SHARING_SECONDARY,  // secondary — QPs already assigned, skip creation
+};
+
+// Returns true when QP sharing is enabled (NCCL_IB_COMM_NGROUPS > 0)
+static inline bool IbCastQpSharingEnabled(void) {
+  return rcclParamIbCastCommNGroups() > 0;
+}
+
+// Returns true when this comm is actively sharing QPs (sharing enabled AND
+// commId was successfully allocated; commId==0 means fallback to non-sharing).
+static inline bool IbCastCommIsSharing(const struct ncclIbNetCommBase* base) {
+  return IbCastQpSharingEnabled() && base->commId != 0;
+}
+
+// Returns true when this comm is the primary (owner) of shared QPs in its group.
+static inline bool IbCastCommIsPrimary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && base->isSharedQpPrimary;
+}
+
+// Returns true when this comm is a secondary (reuses QPs owned by a primary).
+static inline bool IbCastCommIsSecondary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && !base->isSharedQpPrimary;
+}
+
+// Initialize QP sharing fields on a comm base to defaults (sharing disabled).
+static inline void IbCastCommInitSharingFields(struct ncclIbNetCommBase* base) {
+  base->commId = 0;
+  base->isSharedQpPrimary = false;
+  base->sharedGroupIdx = -1;
+  base->remIbDevIdx = -1;
+  base->sharedPrimaryNqps = 0;
+}
+
+// Compute CQ/WR depth multiplier for shared QPs.
+// Returns 1 when sharing is disabled.
+static inline int IbCastQpSharingDepthMultiplier(void) {
+  return IbCastQpSharingEnabled() ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+}
+
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
@@ -111,6 +156,23 @@ void IbCastFreeCommIdLocked(uint16_t commId);
 
 // Destroy all CQs for a group when cqRefcount reaches 0
 void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Validate that all shared QP pool entries and commIds are cleaned up.
+// Logs leaked entries and asserts on non-zero counts. Call at finalize time.
+void IbCastValidateSharedQpPool(void);
+
+// Encode commId into wr_id[63:48]. When commId==0 (sharing disabled or
+// fallback) this is a no-op (OR with zero).
+static inline uint64_t IbCastEncodeCommId(uint64_t wr_id, uint16_t commId) {
+  return wr_id | ((uint64_t)commId << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Encode receiver commId into immData for BY_ID matching scheme:
+//   bits[7:0]  = reqId,  bits[23:8] = remCommId.
+static inline uint32_t IbCastEncodeCommIdImmData(uint32_t reqId, uint16_t remCommId) {
+  return (reqId & WR_IMM_BYID_REQ_ID_MASK) |
+         (((uint32_t)remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+}
 
 // Strip the commId from wr_id[63:48], recovering the original index. Safe when
 // sharing is disabled (commId==0, so the mask is a no-op).

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -63,6 +63,8 @@ struct IbCastCommTableEntry {
 // Pool and comm table globals (defined in qp_sharing.cc)
 extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
+extern int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpFreeTop;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
 extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -85,6 +87,10 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount);
+
+// Undo a registration for a slot whose last user is closing outside of
+// IbCastCleanupGroupCqs (the flush-QP path).
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -25,6 +25,7 @@ extern int64_t rcclParamIbCastQpDepthMultiplier();
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+#define IBCAST_FLUSH_QP_IDX  -1   // sentinel qpIdx for flush QPs in the shared pool
 
 // Pool key -- uniquely identifies a shared QP
 struct IbCastSharedQpKey {

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -1,0 +1,119 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing infrastructure for IB CAST transport layer.
+ * Allows multiple RCCL communicator channels to share physical IB QPs,
+ * reducing QP count and improving scalability.
+ * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ ************************************************************************/
+
+#ifndef NET_IB_CAST_QP_SHARING_H_
+#define NET_IB_CAST_QP_SHARING_H_
+
+#include "common_cast.h"
+#include "param.h"
+#include <mutex>
+
+// QP sharing configuration parameters
+// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
+// 0 = disabled, >0 = enable QP sharing with N groups
+extern int64_t rcclParamIbCastCommNGroups();
+// CQ/WR depth scaling for primary QPs
+extern int64_t rcclParamIbCastQpDepthMultiplier();
+
+#define IBCAST_MAX_SHARED_QPS 1024
+#define IBCAST_MAX_COMMS      4096
+#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+
+// Pool key -- uniquely identifies a shared QP
+struct IbCastSharedQpKey {
+    int             ibDevN;              // local IB device index
+    union ncclSocketAddress peerAddr;    // remote peer address (port stripped)
+    int             remIbDevIdx;         // remote IB device index for disambiguation
+    bool            isSend;              // send vs recv direction
+    int             groupIdx;            // sharing group (0..m-1)
+    int             qpIdx;              // QP slot within the group (0..nqps-1)
+};
+
+// Pool entry -- one per physical shared QP
+struct IbCastSharedQp {
+    IbCastSharedQpKey key;
+    struct ibv_qp*    qp;                  // the physical QP
+    struct ibv_cq*    primaryCq;           // CQ for this device in this group
+    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      devIndex;                     // local device index within comm->devs[]
+    int      refcount;                     // number of comms using this QP
+    int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
+    bool     used;                         // slot in use
+    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+};
+
+// Global comm table for completion routing (commId -> comm pointer)
+struct IbCastCommTableEntry {
+    void*    comm;          // ncclIbSendComm* or ncclIbRecvComm*
+    bool     isSend;
+    bool     used;
+};
+
+// Pool and comm table globals (defined in qp_sharing.cc)
+extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpPoolCount;
+extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+extern uint16_t                    g_IbCastNextCommId;
+extern std::mutex                  g_IbCastSharedQpMutex;
+
+// Strip port from socket address for peer matching
+void IbCastStripPort(union ncclSocketAddress* addr);
+
+// Compare two pool keys
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b);
+
+// Find a shared QP by key
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key);
+
+// Find a shared QP by QP number and direction (for teardown)
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
+
+// Register a new shared QP in the pool
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+
+// Count QP slots registered by the primary for a given group
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx);
+
+// Count total comms connected to a peer (for channelSeq computation)
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend);
+
+// Allocate a commId and register in the global comm table (mutex-protected)
+uint16_t IbCastAllocCommId(void* comm, bool isSend);
+
+// Free a commId (self-locking; for callers NOT holding g_IbCastSharedQpMutex)
+void IbCastFreeCommId(uint16_t commId);
+
+// Free a commId; caller MUST already hold g_IbCastSharedQpMutex (teardown paths)
+void IbCastFreeCommIdLocked(uint16_t commId);
+
+// Destroy all CQs for a group when cqRefcount reaches 0
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Strip the commId from wr_id[63:48], recovering the original index. Safe when
+// sharing is disabled (commId==0, so the mask is a no-op).
+static inline uint64_t IbCastStripCommId(uint64_t wr_id) {
+  return wr_id & ~((uint64_t)WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Look up the target comm from the commId encoded in wr_id[63:48]. Returns NULL
+// if sharing is disabled or the commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id);
+
+// Look up the target comm from the commId encoded in immData.
+// Returns target base based on commId in immData if sharing is enabled or
+// returns NULL if sharing is disabled or commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(
+    struct ncclIbNetCommBase* base, uint32_t immDataHost);
+
+#endif // NET_IB_CAST_QP_SHARING_H_


### PR DESCRIPTION
## Motivation

* At scale, each RCCL communicator channel creates its own set of IB Queue Pairs (QPs), leading to high QP count per node
* High QP count increases memory consumption, HCA resource pressure, and can hit firmware/hardware limits on AINIC/Ionic NICs
* QP sharing allows multiple communicator channels to multiplex onto a smaller set of physical QPs, improving scalability and reducing resource usage
* This feature was previously implemented against the legacy monolithic net_ib_rocm.cc; this PR ports it to the refactored modular net_ib_cast/ architecture

## Technical Details
* New files: qp_sharing.h / qp_sharing.cc — global shared QP pool (IbCastSharedQpPool[1024]), comm routing table (IbCastCommTable[4096]), and pool management functions (find, register, cleanup, commId allocation, refcount lifecycle)
* Runtime control: NCCL_IB_COMM_NGROUPS (0=disabled, >0=number of sharing groups) and NCCL_IB_QP_DEPTH_MULTIPLIER (CQ/WR depth scaling for shared QPs)
* Primary/Secondary pattern: First comm to a peer/group creates QPs (primary), subsequent comms reuse them (secondary) with refcount tracking
* CQ depth scaling: Primary QP CQ and WR depths scaled by depthMultiplier to handle completions from multiple comms
Completion routing: commId encoded in wr_id upper 16 bits (bits 48-63) for send-side routing; imm_data carries (rxReqIdx << 24) | commId for recv-side routing via g_IbCastCommTable lookup
* Completion dispatch: commId extraction and targetBase resolution done in IbCastTest() before dispatching to IbCastCompletionEventProcess() / IbCastCompletionEventByOrder()
* Ionic UDMA mask: Shared QPs use groupIdx-based UDMA mask selection (even=LOW, odd=HIGH) instead of channel-based alternation
* CTS offload: Mutually exclusive with QP sharing; auto-disabled at init when NCCL_IB_COMM_NGROUPS > 0
QP sharing attrs: isQpSharingEnabled, cqDepthMultiplier, qpSharingGroupIdx added to ncclIbQpCreateAttr struct; resiliency/recovery/flush QPs explicitly set isQpSharingEnabled=false
* Refcount teardown: QPs destroyed only when last comm's refcount reaches 0; CQs cleaned up when cqRefcount reaches 0 via IbCastCleanupGroupCqs()
* Backward compatible: Default NCCL_IB_COMM_NGROUPS=0 takes the original non-sharing code path with zero overhead

## Issue Tracking
JIRA ID: AICOMNET-375

## Test Plan

* Build RCCL with QP sharing changes — verify clean compilation
* Functional Tests - Add new functional tests for QP sharing and verify
* Run with NCCL_IB_COMM_NGROUPS=0 (default) — verify identical behavior to baseline (no regression)
* Run with NCCL_IB_COMM_NGROUPS=2 — verify QP sharing active (check NCCL_DEBUG=INFO for primary/secondary logs)
* Multi-node all_reduce correctness with sharing enabled (2+ nodes)
* Verify clean teardown — no leaked QPs/CQs (check teardown logs with NCCL_DEBUG=INFO)
* Verify NCCL_IB_QP_DEPTH_MULTIPLIER scales CQ/WR depths correctly
* Stress test: multiple communicators connecting/disconnecting to exercise refcount logic


## Test Result
- [x] Build & Verified: Clean compilation verified on gfx942 (ROCm 7.14)
- [x] Verify functional tests pass
- [x] Verify no regression in performance with RCCL benchmark tests with QP sharing disabled
- [x] Run tuning for optimal RCCL benchmark performance with QP sharing enabled
- [x] Verify RCCL benchmark performance with QP sharing enabled is on-par (or better) than QP sharing disabled
- [x] Collect data on QP usage statistics across QP sharing disabled & enabled for RCCL benchmark tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
