### PR TITLE
fix(rocprofiler-compute): Disable ROCm sysdeps pkg-config preference

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -187,7 +187,10 @@ jobs:
         shell: bash
         run: |
           apt-get update
-          apt install -y pkg-config
+          # libdw-dev/zlib1g-dev are temporary: the sysdeps block in
+          # src/lib/CMakeLists.txt is disabled until ROCm/TheRock#7424 is
+          # fixed. Drop them when that block is restored.
+          apt install -y libdw-dev zlib1g-dev pkg-config
           echo "✅ ROCm Dependencies Installed!"
 
       - name: Install Latest Nightly ROCm

--- a/.github/workflows/rocprofiler-compute-sanitizers.yml
+++ b/.github/workflows/rocprofiler-compute-sanitizers.yml
@@ -111,7 +111,10 @@ jobs:
         shell: bash
         run: |
           apt-get update
-          apt-get install -y pkg-config
+          # libdw-dev/zlib1g-dev are temporary: the sysdeps block in
+          # src/lib/CMakeLists.txt is disabled until ROCm/TheRock#7424 is
+          # fixed. Drop them when that block is restored.
+          apt-get install -y libdw-dev zlib1g-dev pkg-config
           echo "✅ Dependencies Installed!"
 
       - name: Install latest nightly ROCm

--- a/projects/rocprofiler-compute/src/lib/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/CMakeLists.txt
@@ -16,7 +16,8 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} "/opt/rocm/")
 #
 # Temporarily disabled: TheRock's bundled zlib.pc is not relocatable (its
 # prefix= is a CI build path), so pkg-config yields a non-existent include dir
-# and CMake fails to generate. Restore once TheRock ships a fixed zlib.pc.
+# and CMake fails to generate. Restore once ROCm/TheRock#7424 is fixed, and drop
+# the libdw-dev/zlib1g-dev installs the CI and sanitizer workflows added for it.
 # foreach(rocm_root IN LISTS CMAKE_PREFIX_PATH)
 #     if(IS_DIRECTORY "${rocm_root}/lib/rocm_sysdeps/lib")
 #         list(PREPEND CMAKE_LIBRARY_PATH "${rocm_root}/lib/rocm_sysdeps/lib")

--- a/projects/rocprofiler-compute/src/lib/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/CMakeLists.txt
@@ -13,15 +13,19 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} "/opt/rocm/")
 
 # TheRock ROCm bundles elfutils and zlib under lib/rocm_sysdeps; prefer them
 # when present, otherwise fall through to the distro packages.
-foreach(rocm_root IN LISTS CMAKE_PREFIX_PATH)
-    if(IS_DIRECTORY "${rocm_root}/lib/rocm_sysdeps/lib")
-        list(PREPEND CMAKE_LIBRARY_PATH "${rocm_root}/lib/rocm_sysdeps/lib")
-        set(ENV{PKG_CONFIG_PATH}
-            "${rocm_root}/lib/rocm_sysdeps/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"
-        )
-        break()
-    endif()
-endforeach()
+#
+# Temporarily disabled: TheRock's bundled zlib.pc is not relocatable (its
+# prefix= is a CI build path), so pkg-config yields a non-existent include dir
+# and CMake fails to generate. Restore once TheRock ships a fixed zlib.pc.
+# foreach(rocm_root IN LISTS CMAKE_PREFIX_PATH)
+#     if(IS_DIRECTORY "${rocm_root}/lib/rocm_sysdeps/lib")
+#         list(PREPEND CMAKE_LIBRARY_PATH "${rocm_root}/lib/rocm_sysdeps/lib")
+#         set(ENV{PKG_CONFIG_PATH}
+#             "${rocm_root}/lib/rocm_sysdeps/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"
+#         )
+#         break()
+#     endif()
+# endforeach()
 
 # libdw has no upstream CMake config and the SDK's bundled Findlibdw.cmake is
 # brittle across pkg-config / multiarch layouts. Define libdw::libdw via


### PR DESCRIPTION
## Motivation

Unblocks the native tool build against current TheRock nightlies. Their bundled
`lib/rocm_sysdeps/lib/pkgconfig/zlib.pc` is non-relocatable in some builds, so
`pkg_check_modules(zlib)` resolves an include dir that does not exist and CMake
refuses to generate.

Reported upstream as ROCm/TheRock#7424, with the fix in ROCm/TheRock#7425.

## Technical Details

- Comment out the `lib/rocm_sysdeps` preference block in `src/lib/CMakeLists.txt`
  rather than deleting it, with a note to restore it once TheRock ships a fixed
  `zlib.pc`
- `libdw`, `libelf`, and `zlib` fall back to the distro packages while the block
  is disabled
- Add `libdw-dev` and `zlib1g-dev` to the continuous-integration and sanitizer
  workflows, which installed only `pkg-config` and relied on the sysdeps block.
  The rhel, tarball, and ubuntu-jammy workflows already have them.
- Comments in all three changed files reference ROCm/TheRock#7424 so the packages
  and the block get reverted together

## Issue Tracking

JIRA ID : AIPROFCOMP-816

## Test Plan

- Configure and build from scratch against a TheRock wheel ROCm install that has
  the broken `zlib.pc`
- Inspect the resulting `librocprofiler-compute-tool.so` linkage

## Test Result

- Works locally on x86_64 against the `10.1.0a20260817` nightly wheel. Configure,
  generate, build, and install all succeed; before this change generate failed with
  `Imported target "PkgConfig::zlib" includes non-existent path`
- The tool links `libdw.so.1` and `libz.so.1` from the distro rather than
  `librocm_sysdeps_dw.so.1`, which is the expected consequence of disabling the
  block and the reason it is commented out rather than removed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
