### PR TITLE
fix(clr): create the cross-device graph stream on first use.

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1077,11 +1077,10 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
     return hipSuccess;
   }
 
-  // num_streams is already capped by Init() but guard here defensively. Create
-  // the full requested internal pool: cross-device launches do not have a
-  // launch stream on captureDeviceId_, so streams_[0] must be an internal
-  // capture-device stream.
-  uint32_t max_streams = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
+  // num_streams is already capped by Init() but guard here defensively. On the
+  // instantiation device the launch stream fills one slot, so create one fewer there.
+  uint32_t capped = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
+  uint32_t max_streams = (devId == captureDeviceId_ && capped > 0) ? capped - 1 : capped;
   if (max_streams == 0) {
     return hipSuccess;
   }
@@ -1107,24 +1106,63 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
       return hipErrorOutOfMemory;
     }
 
-    // Same-device launches supply stream slot 0 with the user launch stream, so
-    // keep the last capture-device stream as an unpinned reserve. It does not
-    // acquire a HW queue unless a cross-device launch needs the full internal
-    // pool. All other streams stay pinned for the graph lifetime.
-    const bool cross_device_reserve =
-        devId == captureDeviceId_ && (i + 1) == max_streams;
-    if (!cross_device_reserve) {
-      stream->vdev()->PinQueue();
-      // Acquire a queue that doesn't collide with previously created internal streams.
-      // On the first stream (used_qids empty) this is a normal acquisition.
-      if (!used_qids.empty()) {
-        stream->vdev()->ReacquireQueueExcluding(used_qids);
-      }
-      used_qids.insert(stream->getQueueID());
+    // Pin the queue so dynamic queue management won't release it between launches
+    stream->vdev()->PinQueue();
+    // Acquire a queue that doesn't collide with previously created internal streams.
+    // On the first stream (used_qids empty) this is a normal acquisition.
+    if (!used_qids.empty()) {
+      stream->vdev()->ReacquireQueueExcluding(used_qids);
     }
+    used_qids.insert(stream->getQueueID());
 
     parallel_streams_[devId].push_back(stream);
   }
+  return hipSuccess;
+}
+
+// ================================================================================================
+// Creates the capture-device stream that serves as stream slot 0 when the launch
+// stream is on another device. Deferred to first use: a stream is not free.
+hipError_t GraphExecBase::EnsureCrossDeviceStream() {
+  std::scoped_lock lock(graphExecStreamCreateLock_);
+
+  // Callers pre-test the pointer, so a steady-state launch never takes this lock.
+  if (cross_device_stream_ != nullptr) {
+    return hipSuccess;
+  }
+  if (captureDeviceId_ < 0 || captureDeviceId_ >= g_devices.size() ||
+      g_devices[captureDeviceId_] == nullptr) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph] Invalid capture device ID %d for cross-device stream creation",
+            captureDeviceId_);
+    return hipErrorInvalidDevice;
+  }
+
+  auto stream = new hip::Stream(g_devices[captureDeviceId_], hip::Stream::Priority::Normal,
+                                hipStreamNonBlocking);
+  if (!stream->Create()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph] Failed to create cross-device stream for device %d", captureDeviceId_);
+    hip::Stream::Destroy(stream);
+    return hipErrorOutOfMemory;
+  }
+
+  auto& parallel_streams = parallel_streams_[captureDeviceId_];
+  stream->vdev()->PinQueue();
+  // Avoid colliding with the queues already held by the capture-device pool.
+  std::unordered_set<uint64_t> used_qids;
+  for (auto* existing : parallel_streams) {
+    if (existing != nullptr) {
+      used_qids.insert(existing->getQueueID());
+    }
+  }
+  if (!used_qids.empty()) {
+    stream->vdev()->ReacquireQueueExcluding(used_qids);
+  }
+
+  // Owned by parallel_streams_, so ~GraphExecBase() tears it down with the rest.
+  parallel_streams.push_back(stream);
+  cross_device_stream_ = stream;
   return hipSuccess;
 }
 
@@ -1228,9 +1266,8 @@ hipError_t GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 // ================================================================================================
 void GraphExecSegmented::RoundRobinStreamAssignment() {
   // max_streams_dev_ holds the raw parallelism count per device as computed by
-  // FindStreamsReqPerDevForSegments() and capped in Init(). It represents the
-  // total stream pool size uniformly; UpdateStreams() substitutes the user
-  // launch stream for the capture-device reserve on same-device launches.
+  // FindStreamsReqPerDevForSegments() and capped in Init(). CreateStreams() applies
+  // the -1 for the instantiation device, so this is the total pool size everywhere.
   auto getPoolSize = [&](int dev_id) -> size_t {
     auto it = max_streams_dev_.find(dev_id);
     return (it != max_streams_dev_.end() && it->second > 0)
@@ -2818,9 +2855,9 @@ void GraphExecBase::UpdateStreams(hip::Stream* launch_stream) {
   hip::Stream* skipped_stream = nullptr;
   if (launch_stream != nullptr) {
     used_qids.insert(launch_stream->getQueueID());
-    // Same-device launches use the user launch stream as stream slot 0, so
-    // leave the unpinned reserve unused.
-    skipped_stream = parallel_streams.back();
+    // The launch stream fills slot 0 here, so a stream added for cross-device use
+    // stays idle.
+    skipped_stream = (devId == captureDeviceId_) ? cross_device_stream_ : nullptr;
   }
 
   for (auto* stream : parallel_streams) {
@@ -3120,18 +3157,13 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   const bool cross_device_launch = (captureDeviceId_ != launch_stream->DeviceId());
   launch_stream->vdev()->SetPreferredQueue();
   launch_stream->vdev()->AcquireQueueWithPreference();
-  if (cross_device_launch) {
-    // The last capture-device stream is kept unpinned and queue-less while the
-    // graph is used only on its capture device. Pin the full pool before a
-    // cross-device launch; UpdateStreams() will acquire a distinct queue for
-    // the reserve when it builds streams_.
-    auto it = parallel_streams_.find(captureDeviceId_);
-    if (it != parallel_streams_.end()) {
-      for (auto* stream : it->second) {
-        if (stream != nullptr) {
-          stream->vdev()->PinQueue();
-        }
-      }
+  // Slot 0 must be an internal capture-device stream when the launch stream lives on
+  // another device. Built on first use; later launches only test the pointer.
+  if (cross_device_launch && cross_device_stream_ == nullptr) {
+    status = EnsureCrossDeviceStream();
+    if (status != hipSuccess) {
+      this->release();
+      return status;
     }
   }
   UpdateStreams(cross_device_launch ? nullptr : launch_stream);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1078,7 +1078,7 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
   }
 
   // num_streams is already capped by Init() but guard here defensively. On the
-  // instantiation device the launch stream fills one slot, so create one fewer there.
+  // capture device the launch stream fills one slot, so create one fewer there.
   uint32_t capped = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
   uint32_t max_streams = (devId == captureDeviceId_ && capped > 0) ? capped - 1 : capped;
   if (max_streams == 0) {
@@ -1265,9 +1265,9 @@ hipError_t GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 
 // ================================================================================================
 void GraphExecSegmented::RoundRobinStreamAssignment() {
-  // max_streams_dev_ holds the raw parallelism count per device as computed by
-  // FindStreamsReqPerDevForSegments() and capped in Init(). CreateStreams() applies
-  // the -1 for the instantiation device, so this is the total pool size everywhere.
+  // max_streams_dev_ represents the total stream-slot count uniformly per device;
+  // CreateStreams() does not adjust it. The capture device's slot 0 instead comes
+  // from the launch stream (same-device) or EnsureCrossDeviceStream() (cross-device).
   auto getPoolSize = [&](int dev_id) -> size_t {
     auto it = max_streams_dev_.find(dev_id);
     return (it != max_streams_dev_.end() && it->second > 0)

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1080,13 +1080,14 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
   bool repeatLaunch_ = false;
   //! parallel streams per device
   std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
-  //! Capture-device stream used as slot 0 by cross-device launches.
-  //! Null until first such launch; owned by parallel_streams_.
+  //! Extra capture-device stream created on first cross-device launch, covering
+  //! the stream slot the user's launch stream fills on same-device launches.
+  //! Null until then; owned by parallel_streams_.
   hip::Stream* cross_device_stream_ = nullptr;
 
   //! Create parallel streams for a device
   hipError_t CreateStreams(uint32_t num_streams, int devId);
-  //! Create the capture-device stream used as slot 0 by cross-device launches
+  //! Create the extra capture-device stream needed on first cross-device launch
   hipError_t EnsureCrossDeviceStream();
   //! Compute per-device stream requirements from streams_dev_ids_ mappings
   void FindStreamsReqPerDev();

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1080,9 +1080,14 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
   bool repeatLaunch_ = false;
   //! parallel streams per device
   std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
+  //! Capture-device stream used as slot 0 by cross-device launches.
+  //! Null until first such launch; owned by parallel_streams_.
+  hip::Stream* cross_device_stream_ = nullptr;
 
   //! Create parallel streams for a device
   hipError_t CreateStreams(uint32_t num_streams, int devId);
+  //! Create the capture-device stream used as slot 0 by cross-device launches
+  hipError_t EnsureCrossDeviceStream();
   //! Compute per-device stream requirements from streams_dev_ids_ mappings
   void FindStreamsReqPerDev();
   //! Update streams_ for a launch and resolve HW queue collisions.

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1411,6 +1411,16 @@ graph:
     <<: *level_2
     tags: [exec]
     disabled: [amd_windows]
+  Unit_hipGraphStreamPool_InstantiateFootprint:
+    <<: *level_2
+    tags: [exec]
+    # (amd_windows) PAL backend does not charge device memory for the unpinned
+    # leaked stream this test measures, so the leak is unmeasurable there.
+    disabled: [amd_windows]
+  Unit_hipGraphStreamPool_CrossDeviceInterleaved:
+    <<: *level_2
+    tags: [exec]
+    disabled: [amd_windows]
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -132,6 +132,7 @@ set(TEST_SRC
   hipGraphExecDestroy.cc
   hipGraphUpload.cc
   hipGraphCrossDeviceLaunch.cc
+  hipGraphStreamPoolFootprint.cc
   hipGraphKernelNodeCopyAttributes.cc
   hipGraphCycle.cc
   hipGraphPerf.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphStreamPoolFootprint.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphStreamPoolFootprint.cc
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests the device-memory footprint of a graph exec's internal stream pool.
+ * Each hip::Stream a graph exec holds carries a VirtualGPU whose kernarg pool is
+ * device-local on large-BAR parts, so a stream created per instantiate but never
+ * used is charged against VRAM for the whole graph lifetime. Workloads that keep
+ * thousands of graphs resident amplify this into gigabytes.
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_checkers.hh>
+#include <hip_test_kernels.hh>
+#include <utils.hh>
+
+#include <vector>
+
+namespace {
+
+constexpr int kElems = 1024;
+
+__global__ void bumpKernel(int* out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] += 1;
+}
+
+// Independent chains of kernel nodes, so the scheduler requests more than one
+// internal stream rather than folding the graph onto a single one.
+void buildChainedGraph(hipGraph_t* graph, int* buf, int chains, int depth) {
+  HIP_CHECK(hipGraphCreate(graph, 0));
+  for (int c = 0; c < chains; ++c) {
+    hipGraphNode_t prev = nullptr;
+    for (int d = 0; d < depth; ++d) {
+      hipGraphNode_t node = nullptr;
+      int elems = kElems;
+      void* args[] = {&buf, &elems};
+      hipKernelNodeParams params = {};
+      params.func = reinterpret_cast<void*>(bumpKernel);
+      params.gridDim = dim3(1);
+      params.blockDim = dim3(64);
+      params.sharedMemBytes = 0;
+      params.kernelParams = args;
+      params.extra = nullptr;
+      HIP_CHECK(hipGraphAddKernelNode(&node, *graph, prev ? &prev : nullptr, prev ? 1 : 0,
+                                      &params));
+      prev = node;
+    }
+  }
+}
+
+size_t freeDeviceMemory() {
+  size_t free_bytes = 0, total_bytes = 0;
+  HIP_CHECK(hipMemGetInfo(&free_bytes, &total_bytes));
+  return free_bytes;
+}
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Instantiates many graphs and measures the device memory each one retains.
+ *    A graph exec must not hold internal streams that its launches never use, so
+ *    the steady-state cost per instantiate stays well below one stream's kernarg
+ *    pool (HSA_KERNARG_POOL_SIZE, 4 MiB by default).
+ * Test source
+ * ------------------------
+ *  - unit/graph/hipGraphStreamPoolFootprint.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+HIP_TEST_CASE(Unit_hipGraphStreamPool_InstantiateFootprint) {
+  constexpr int kGraphs = 64;
+  constexpr size_t kMaxBytesPerGraph = 2 * 1024 * 1024;
+
+  int* buf = nullptr;
+  HIP_CHECK(hipMalloc(&buf, kElems * sizeof(int)));
+
+  // Warm up so one-off runtime allocations are not attributed to the graphs.
+  for (int i = 0; i < 4; ++i) {
+    hipGraph_t warm_graph = nullptr;
+    hipGraphExec_t warm_exec = nullptr;
+    buildChainedGraph(&warm_graph, buf, 4, 2);
+    HIP_CHECK(hipGraphInstantiate(&warm_exec, warm_graph, nullptr, nullptr, 0));
+    HIP_CHECK(hipGraphExecDestroy(warm_exec));
+    HIP_CHECK(hipGraphDestroy(warm_graph));
+  }
+
+  const size_t free_before = freeDeviceMemory();
+
+  std::vector<hipGraph_t> graphs(kGraphs, nullptr);
+  std::vector<hipGraphExec_t> execs(kGraphs, nullptr);
+  for (int i = 0; i < kGraphs; ++i) {
+    buildChainedGraph(&graphs[i], buf, 4, 2);
+    HIP_CHECK(hipGraphInstantiate(&execs[i], graphs[i], nullptr, nullptr, 0));
+  }
+
+  const size_t free_after = freeDeviceMemory();
+  const size_t used = (free_before > free_after) ? (free_before - free_after) : 0;
+  const size_t per_graph = used / kGraphs;
+  INFO("device memory per instantiate: " << per_graph << " bytes over " << kGraphs << " graphs");
+  REQUIRE(per_graph <= kMaxBytesPerGraph);
+
+  for (int i = 0; i < kGraphs; ++i) {
+    HIP_CHECK(hipGraphExecDestroy(execs[i]));
+    HIP_CHECK(hipGraphDestroy(graphs[i]));
+  }
+
+  // Everything the graphs held must come back on destroy.
+  const size_t free_end = freeDeviceMemory();
+  const size_t retained = (free_before > free_end) ? (free_before - free_end) : 0;
+  INFO("device memory retained after destroy: " << retained << " bytes");
+  REQUIRE(retained <= kMaxBytesPerGraph);
+
+  HIP_CHECK(hipFree(buf));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Interleaves same-device and cross-device launches of one graph exec. A
+ *    cross-device launch needs an internal capture-device stream for slot 0,
+ *    while a same-device launch supplies slot 0 itself; both orderings must keep
+ *    working when that stream is created on demand rather than at instantiate.
+ * Test source
+ * ------------------------
+ *  - unit/graph/hipGraphStreamPoolFootprint.cc
+ * Test requirements
+ * ------------------------
+ *  - Multi device
+ *  - HIP_VERSION >= 6.0
+ */
+HIP_TEST_CASE(Unit_hipGraphStreamPool_CrossDeviceInterleaved) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  constexpr int kChains = 4;
+  constexpr int kDepth = 2;
+  constexpr int kLaunches = 4;
+
+  HIP_CHECK(hipSetDevice(0));
+  int* buf = nullptr;
+  HIP_CHECK(hipMalloc(&buf, kElems * sizeof(int)));
+  HIP_CHECK(hipMemset(buf, 0, kElems * sizeof(int)));
+
+  hipGraph_t graph = nullptr;
+  hipGraphExec_t exec = nullptr;
+  buildChainedGraph(&graph, buf, kChains, kDepth);
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  hipStream_t same_dev_stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&same_dev_stream));
+  hipStream_t cross_dev_stream = nullptr;
+  HIP_CHECK(hipSetDevice(1));
+  HIP_CHECK(hipStreamCreate(&cross_dev_stream));
+  HIP_CHECK(hipSetDevice(0));
+
+  // same-device first, so slot 0 comes from the user stream
+  HIP_CHECK(hipGraphLaunch(exec, same_dev_stream));
+  HIP_CHECK(hipStreamSynchronize(same_dev_stream));
+
+  // cross-device, which is where the internal slot-0 stream is needed
+  HIP_CHECK(hipSetDevice(1));
+  HIP_CHECK(hipGraphLaunch(exec, cross_dev_stream));
+  HIP_CHECK(hipStreamSynchronize(cross_dev_stream));
+  HIP_CHECK(hipSetDevice(0));
+
+  // back to same-device: the stream added above must be left idle
+  HIP_CHECK(hipGraphLaunch(exec, same_dev_stream));
+  HIP_CHECK(hipStreamSynchronize(same_dev_stream));
+
+  // cross-device again, reusing rather than recreating
+  HIP_CHECK(hipSetDevice(1));
+  HIP_CHECK(hipGraphLaunch(exec, cross_dev_stream));
+  HIP_CHECK(hipStreamSynchronize(cross_dev_stream));
+  HIP_CHECK(hipSetDevice(0));
+
+  // Every launch must have run every node exactly once, on either device.
+  int observed = 0;
+  HIP_CHECK(hipMemcpy(&observed, buf, sizeof(int), hipMemcpyDeviceToHost));
+  INFO("observed " << observed << " increments");
+  REQUIRE(observed == kChains * kDepth * kLaunches);
+
+  HIP_CHECK(hipStreamDestroy(same_dev_stream));
+  HIP_CHECK(hipSetDevice(1));
+  HIP_CHECK(hipStreamDestroy(cross_dev_stream));
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(buf));
+}


### PR DESCRIPTION
## Motivation
`GraphExecBase::CreateStreams()` allocates one `hip::Stream` per graph exec on the capture
device to act as stream slot 0 for cross-device launches. It is left unpinned so it holds no
HW queue, but `hip::Stream::Create()` still builds a `VirtualGPU`, whose kernarg pool
(`HSA_KERNARG_POOL_SIZE`, 4 MiB) is device-local on large-BAR parts. Same-device launches
never use the stream, so every instantiate holds 4 MiB of VRAM for the graph lifetime. A vLLM
llama-2-13b run instantiates 2142 graphs (8.37 GiB) and dies during CUDA graph capture on a
36 GiB MI355X CPX partition.

## Technical Details
Restore the `-1` on the instantiation device in `CreateStreams()`, and create the extra stream
in the new `GraphExecBase::EnsureCrossDeviceStream()` on the first cross-device launch. The
call site tests `cross_device_stream_` first, so same-device launches add no work and repeat
cross-device launches never take the (pre-existing) creation lock. `UpdateStreams()` now skips
that tracked stream rather than `parallel_streams.back()`, which is ambiguous once the pool may
not contain it. The stream is owned by `parallel_streams_`, so `~GraphExecBase()` reclaims it.
Cross-device replay, marker ordering, and hidden-heap handling are untouched.

## Issue Tracking
ROCM-29490. Regression introduced by #8611 (AIRUNTIME-572) and still present on develop.

## Test Plan
- vLLM llama-2-13b latency benchmark on MI355X, CPX compute / NPS2 memory, 36 GiB partition
- Full `unit/graph` suite (544 tests) run individually, stock vs patched, on 64 CPX partitions
- Same suite under `DEBUG_HIP_GRAPH_CLASSIC_PATH=1` to cover the classic path
- #8611's cross-device and multi-device tests, plus a graph needing 4 internal streams
- New `Unit_hipGraphStreamPool_InstantiateFootprint` and `Unit_hipGraphStreamPool_CrossDeviceInterleaved`

## Test Result
- vLLM: `hipErrorOutOfMemory` at capture 22/51 before; after, capture completes in 7 s taking
  3.76 GiB, avg latency 0.73 s
- Device memory per graph instantiate 6 MiB -> 2 MiB, matching the pre-regression build
- Graph suite: 0 differences between stock and patched on both the segmented and classic paths
- `InstantiateFootprint` fails on unfixed CLR (6291456 bytes/graph) and passes with the fix
- No leak: 0 bytes retained over 200 graph exec create/destroy cycles with cross-device launches

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
