### PR TITLE
feat(hipFile) Add system tests for zero-sized IO operations using the sync APIs

### DIFF
--- a/projects/hipfile/CHANGELOG.md
+++ b/projects/hipfile/CHANGELOG.md
@@ -17,13 +17,13 @@
 * A KFD-based alternative check for P2P DMA support was added to `ais-check`. This inspects the `capability` property under `/sys/class/kfd/kfd/topology/nodes/*/properties`.
 * Added support for Logical Volume Manager (LVM) volumes with a maximum of 16 extents
 * Added guides for setting up storage targets to the documentation
-* hipFileRead/hipFileWrite return -1 with errno set to EINVAL for negative offsets instead of returning -hipFileInternalError
 
 ### Changed
 
 * `ais-check` now lists the AIS-capable file system mounts detected on the system and fails if none are found.
 * Fastpath-only tests are now automatically skipped on systems that do not support the AIS fastpath instead of failing. Running ctest in verbose mode (`ctest -V`) will provide the reason why the test was skipped.
 * Updated INSTALL.md to point to official install docs
+* hipFileRead and hipFileWrite now return -1 with `errno` set to `EINVAL` for negative offsets instead of returning `-hipFileInternalError`
 
 ### Removed
 

--- a/projects/hipfile/CHANGELOG.md
+++ b/projects/hipfile/CHANGELOG.md
@@ -17,6 +17,7 @@
 * A KFD-based alternative check for P2P DMA support was added to `ais-check`. This inspects the `capability` property under `/sys/class/kfd/kfd/topology/nodes/*/properties`.
 * Added support for Logical Volume Manager (LVM) volumes with a maximum of 16 extents
 * Added guides for setting up storage targets to the documentation
+* hipFileRead/hipFileWrite return -1 with errno set to EINVAL for negative offsets instead of returning -hipFileInternalError
 
 ### Changed
 

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -60,8 +60,6 @@ using namespace std;
  *        header so hipGetProcAddress() is used to lookup each function's function
  *        pointer
  *      - returns
- *          - hipSuccess if size is zero
- *              - This check should be removed
  *          - hipErrorInvalidDevice if unable to lookup current device
  *          - hipErrorUnknown if rocr runtime does not return success
  *  - ROCR Runtime (userspace)
@@ -78,8 +76,6 @@ using namespace std;
  *      - hsa_amd_ais_file_read(...), hsa_amd_ais_file_write(...)
  *      - status and size_coppied untouched
  *      - returns
- *          - HSA_STATUS_ERROR_INVALID_ARGUMENT if size is zero
- *              - This check should be be removed
  *          - HSA_STATUS_ERROR_INVALID_ARGUMENT if devicePtr is NULL
  *              - This check should be be removed
  *          - HSA_STATUS_ERROR if hsaKmtAisReadWriteFile(...) does not return success

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -213,6 +213,10 @@ hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
 try {
     auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
 
+    if (file_offset < 0 || buffer_offset < 0) {
+        throw std::system_error(EINVAL, std::generic_category());
+    }
+
     std::shared_ptr<Backend> backend{selectBackend(backends, file, buffer, size, file_offset, buffer_offset)};
 
     return backend->io(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);

--- a/projects/hipfile/test/common/test-common.h
+++ b/projects/hipfile/test/common/test-common.h
@@ -103,7 +103,7 @@ struct Tmpfile {
 
 /// @brief Round value to the next multiple of align. Align _must_ be a power of 2.
 /// @param value The value to round up.
-/// @param align Value will be rounded up to a multiple of align
+/// @param align Value will be rounded up to a multiple of align.
 /// @return Value rounded up to a multiple of align.
 static inline size_t
 align_up(size_t value, size_t align)

--- a/projects/hipfile/test/common/test-common.h
+++ b/projects/hipfile/test/common/test-common.h
@@ -8,6 +8,7 @@
 #include "hipfile.h"
 #include "magic-word.h"
 
+#include <bit>
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
@@ -99,3 +100,16 @@ struct Tmpfile {
         close(fd);
     }
 };
+
+/// @brief Round value to the next multiple of align. Align _must_ be a power of 2.
+/// @param value The value to round up.
+/// @param align Value will be rounded up to a multiple of align
+/// @return Value rounded up to a multiple of align.
+static inline size_t
+align_up(size_t value, size_t align)
+{
+    if (std::popcount(align) != 1) {
+        throw std::invalid_argument("align must be a power of 2");
+    }
+    return (value + align - 1) & ~(align - 1);
+}

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -67,11 +67,11 @@ HIPFILE_WARN_NO_EXIT_DTOR_ON
 
 struct HipFileIo : public testing::TestWithParam<IoTestParam> {
 
-    Tmpfile         tmpfile;
-    size_t          tmpfile_size;
-    hipFileHandle_t tmpfile_handle;
-    void           *unregistered_device_buffer;
-    size_t          unregistered_device_buffer_size;
+    Tmpfile              tmpfile;
+    size_t               tmpfile_size;
+    hipFileHandle_t      tmpfile_handle;
+    void                *unregistered_device_buffer;
+    size_t               unregistered_device_buffer_size;
 
     HipFileIo()
         : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_handle{nullptr},

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -5,6 +5,7 @@
 
 #include "context.h"
 #include "configuration.h"
+#include "hipfile-literals.h"
 #include "hipfile-warnings.h"
 #include "hipfile.h"
 
@@ -19,6 +20,7 @@
 #include <string>
 #include <thread>
 #include <unistd.h>
+#include <vector>
 
 extern SystemTestOptions test_env;
 
@@ -72,10 +74,12 @@ struct HipFileIo : public testing::TestWithParam<IoTestParam> {
     hipFileHandle_t      tmpfile_handle;
     void                *unregistered_device_buffer;
     size_t               unregistered_device_buffer_size;
+    std::vector<uint8_t> host_buffer;
 
     HipFileIo()
-        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_handle{nullptr},
-          unregistered_device_buffer{nullptr}, unregistered_device_buffer_size{1024 * 1024}
+        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1_MiB}, tmpfile_handle{nullptr},
+          unregistered_device_buffer{nullptr}, unregistered_device_buffer_size{tmpfile_size},
+          host_buffer(tmpfile_size)
     {
     }
 
@@ -137,6 +141,46 @@ TEST_P(HipFileIo, ReadToUnregisteredBufferAtOffsetReturnsErrorIfOverflow)
 
     ASSERT_EQ(-hipFileInvalidValue,
               hipFileRead(tmpfile_handle, unregistered_device_buffer, io_size, 0, io_buffer_offset));
+}
+
+TEST_P(HipFileIo, readAtNegativeFileOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, pread(tmpfile.fd, host_buffer.data(), host_buffer.size(), -1));
+    ASSERT_EQ(EINVAL, errno);
+
+    errno = 0;
+    ASSERT_EQ(
+        -1, hipFileRead(tmpfile_handle, unregistered_device_buffer, unregistered_device_buffer_size, -1, 0));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, writeAtNegativeFileOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, pwrite(tmpfile.fd, host_buffer.data(), host_buffer.size(), -1));
+    ASSERT_EQ(EINVAL, errno);
+
+    errno = 0;
+    ASSERT_EQ(
+        -1, hipFileWrite(tmpfile_handle, unregistered_device_buffer, unregistered_device_buffer_size, -1, 0));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, readAtNegativeBufferOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(
+        -1, hipFileRead(tmpfile_handle, unregistered_device_buffer, unregistered_device_buffer_size, 0, -1));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, writeAtNegativeBufferOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(
+        -1, hipFileWrite(tmpfile_handle, unregistered_device_buffer, unregistered_device_buffer_size, 0, -1));
+    ASSERT_EQ(EINVAL, errno);
 }
 
 INSTANTIATE_TEST_SUITE_P(, HipFileIo, testing::ValuesIn(io_test_params),

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -14,9 +14,12 @@
 #include "test-options.h"
 
 #include <array>
+#include <bit>
 #include <cstdlib>
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
+#include <linux/stat.h>
 #include <string>
 #include <thread>
 #include <unistd.h>
@@ -71,16 +74,27 @@ struct HipFileIo : public testing::TestWithParam<IoTestParam> {
 
     Tmpfile              tmpfile;
     size_t               tmpfile_size;
+    uint32_t             tmpfile_dio_offset_align;
     hipFileHandle_t      tmpfile_handle;
     void                *unregistered_device_buffer;
     size_t               unregistered_device_buffer_size;
     std::vector<uint8_t> host_buffer;
 
     HipFileIo()
-        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1_MiB}, tmpfile_handle{nullptr},
-          unregistered_device_buffer{nullptr}, unregistered_device_buffer_size{tmpfile_size},
-          host_buffer(tmpfile_size)
+        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1_MiB}, tmpfile_dio_offset_align{4_KiB},
+          tmpfile_handle{nullptr}, unregistered_device_buffer{nullptr},
+          unregistered_device_buffer_size{tmpfile_size}, host_buffer(tmpfile_size)
     {
+#if defined(STATX_DIOALIGN)
+        struct statx stx {};
+        if (0 == statx(tmpfile.fd, "", AT_EMPTY_PATH, STATX_DIOALIGN, &stx) &&
+            stx.stx_mask & STATX_DIOALIGN) {
+            if (std::popcount(stx.stx_dio_offset_align) != 1) {
+                throw std::runtime_error("Invalid statx dio offset");
+            }
+            tmpfile_dio_offset_align = stx.stx_dio_offset_align;
+        }
+#endif
     }
 
     void SetUp() override
@@ -182,6 +196,55 @@ TEST_P(HipFileIo, writeAtNegativeBufferOffsetReturnsEINVAL)
         -1, hipFileWrite(tmpfile_handle, unregistered_device_buffer, unregistered_device_buffer_size, 0, -1));
     ASSERT_EQ(EINVAL, errno);
 }
+
+// Zero-sized IO tests require >= ROCm 7.14
+#if HIP_VERSION_MAJOR > 7 || (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR >= 14)
+TEST_P(HipFileIo, zeroSizedReadAtAlignedFileOffsetReturnsZero)
+{
+    for (hoff_t offset = 0; offset < static_cast<hoff_t>(tmpfile_size); offset += tmpfile_dio_offset_align) {
+        ASSERT_EQ(0, pread(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileRead(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedWriteAtAlignedFileOffsetReturnsZero)
+{
+    for (hoff_t offset = 0; offset < static_cast<hoff_t>(tmpfile_size); offset += tmpfile_dio_offset_align) {
+        ASSERT_EQ(0, pwrite(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedReadAtAlignedOffsetBeyondEndOfFileReturnsZero)
+{
+    size_t aligned_eof{align_up(tmpfile_size + 1, tmpfile_dio_offset_align)};
+    for (size_t i = 0; i < 10; i++) {
+        hoff_t offset{static_cast<hoff_t>(aligned_eof * i)};
+        ASSERT_EQ(0, pread(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileRead(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+
+        // ensure the file size has not increased
+        struct stat st {};
+        ASSERT_EQ(0, fstat(tmpfile.fd, &st));
+        ASSERT_EQ(tmpfile_size, static_cast<size_t>(st.st_size));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedWriteAtAlignedOffsetBeyondEndOfFileReturnsZero)
+{
+    size_t aligned_eof{align_up(tmpfile_size + 1, tmpfile_dio_offset_align)};
+    for (size_t i = 0; i < 10; i++) {
+        hoff_t offset{static_cast<hoff_t>(aligned_eof * i)};
+        ASSERT_EQ(0, pwrite(tmpfile.fd, host_buffer.data(), 0, static_cast<off_t>(offset)));
+        ASSERT_EQ(0, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+
+        // ensure the file size has not increased
+        struct stat st {};
+        ASSERT_EQ(0, fstat(tmpfile.fd, &st));
+        ASSERT_EQ(tmpfile_size, static_cast<size_t>(st.st_size));
+    }
+}
+#endif
 
 INSTANTIATE_TEST_SUITE_P(, HipFileIo, testing::ValuesIn(io_test_params),
                          [](const testing::TestParamInfo<HipFileIo::ParamType> &param_info) {


### PR DESCRIPTION
## Motivation

`hipFileRead`/`hipfileWrite` should support zero-sized IO operations. Ensures that zero-sized IO works end-to-end.

## Technical Details

Support for zero sized IO required changes to the HIP Runtime, ROCr Runtime, and amdgpu. The changes to the these layers are available in >= ROCm 7.14.

Related changes:
* https://github.com/ROCm/rocm-systems/pull/6639
* https://github.com/ROCm/rocm-systems/pull/6744

## JIRA ID

JIRA ID :  AIHIPFILE-110
JIRA ID : ROCM-1353

## Test Plan

This change adds system tests that run when the ROCm version >= 7.14.