### PR TITLE
docs(rocprofiler-sdk): document experimental kernel replay for users and tool authors

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-kernel-replay.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-kernel-replay.rst
@@ -41,15 +41,15 @@ fit in one hardware pass, ``rocprofv3`` has three ways to collect them:
    * - Application replay (default for multiple ``--pmc`` groups)
      - Whole application, re-run once per group
      - None; each run is a fresh process
-     - ``O(N ×`` application runtime``)``
+     - ``O(N × application runtime)``
    * - **Kernel replay** (``--kernel-replay-beta-enabled``)
      - One dispatch, re-executed in place
      - Device memory snapshot and restore between passes
-     - ``O(N ×`` kernel time ``+ N ×`` snap/restore``)``
+     - ``O(N × kernel time + N × snap/restore)``
    * - Counter group rotation (``pmc_groups`` / ``pmc_group_interval``)
      - Amortized across successive dispatches
      - None; different dispatches sample different groups
-     - ``O(1 ×`` application runtime``)``, but not the same dispatch
+     - ``O(1 × application runtime)``, but not the same dispatch
 
 Kernel replay is **not** the same as :ref:`using-spm`. SPM streams counter samples over time from
 hardware ring buffers; kernel replay re-executes a dispatch so each pass can collect a different


### PR DESCRIPTION
## Motivation

The purpose of this PR is to provide documentation for the kernel replay feature as it stands in PR #8622, showing  both developer docs for rocprofiler-SDK and documentation for user tool consumers of the kernel replay service. 

## Details 
- Document experimental kernel replay for `rocprofv3` users (`--kernel-replay-beta-enabled`) and for SDK tool authors (callback tracing domain, not a dedicated counting service).
- Snapshot/restore is documented as a full in-memory copy. Dirty-page hashing is **not** in this design; host-side and/or device-side hashing is called out as expected later.
- Base is the #8622 feature branch (`users/mkuriche/kernel-replay-callback-api`), not `develop`.

## Test plan
- [ ] Confirm Sphinx/TOC links resolve for the new how-to, conceptual, and API-reference pages
- [ ] Confirm CLI docs list `--kernel-replay-beta-enabled` and that it requires `--pmc`
- [ ] Spot-check that docs do not describe the old counting-service prototype (`--kernel-replay-passes`, `Replay_Pass` CSV column, file-backed hashing)


Made with help of [Cursor](https://cursor.com)