### PR TITLE
[rocjitsu] Resolve every PC-relative code address after scope placement

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1594,69 +1594,6 @@ materialization_diagnostic_kind(const KernelTextAppendResult &materialization) {
   return DiagnosticKind::KernelDescriptor;
 }
 
-/// @brief A code-address builder awaiting the final placement of the body it names.
-struct PendingCodeRelocation {
-  uint64_t target_getpc_offset = 0;
-  uint64_t target_literal_offset = 0;
-  uint64_t source_target_text_offset = 0;
-};
-
-/// @brief Point every deferred code-address builder at the placement its target received.
-///
-/// @details Runs after every scope is placed, which is the first moment a target's final offset
-/// is known. A source offset emitted more than once has no single answer -- a runtime-dereferenced
-/// code address cannot choose between clones -- so that fails closed rather than picking one,
-/// matching how relocate_relative_text_addends treats a conflicting relocation addend.
-///
-/// @returns false when the object must be left unchanged.
-[[nodiscard]] bool resolve_pending_code_relocations(
-    const std::vector<PendingCodeRelocation> &pending,
-    const std::vector<TextOffsetRelocation> &text_relocations,
-    const std::unordered_map<uint64_t, uint64_t> &canonical_placement,
-    const std::unordered_set<uint64_t> &canonical_placement_variant_conflict,
-    std::vector<PcRelativeTextRelocation> &code_relocations,
-    std::vector<TranslationDiagnostic> &diagnostics) {
-  if (pending.empty())
-    return true;
-
-  std::unordered_map<uint64_t, uint64_t> placement;
-  std::unordered_set<uint64_t> conflicting;
-  for (const TextOffsetRelocation &relocation : text_relocations) {
-    auto [it, inserted] = placement.try_emplace(relocation.source_offset, relocation.target_offset);
-    if (!inserted && it->second != relocation.target_offset)
-      conflicting.insert(relocation.source_offset);
-  }
-
-  for (const PendingCodeRelocation &entry : pending) {
-    // A canonical copy only answers for its clones when they are interchangeable. Offsets whose
-    // clones disagreed on kernel-scope variant are not, so they fall through to the placement map
-    // below and fail closed there rather than silently naming whichever clone was nominated first.
-    if (const auto canonical = canonical_placement.find(entry.source_target_text_offset);
-        canonical != canonical_placement.end() &&
-        !canonical_placement_variant_conflict.contains(entry.source_target_text_offset)) {
-      code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
-                                  .target_literal_offset = entry.target_literal_offset,
-                                  .target_text_offset = canonical->second});
-      continue;
-    }
-    const auto placed = placement.find(entry.source_target_text_offset);
-    if (placed == placement.end() || conflicting.contains(entry.source_target_text_offset)) {
-      append_error(diagnostics, DiagnosticKind::Legalization,
-                   conflicting.contains(entry.source_target_text_offset)
-                       ? "PC-relative code address names a body emitted at more than one "
-                         "placement; leaving code object unchanged"
-                       : "PC-relative code address names a body this translation did not emit; "
-                         "leaving code object unchanged",
-                   entry.source_target_text_offset);
-      return false;
-    }
-    code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
-                                .target_literal_offset = entry.target_literal_offset,
-                                .target_text_offset = placed->second});
-  }
-  return true;
-}
-
 /// @brief What one scope added to the three code-address containers, so a skipped scope can take
 /// it back.
 ///
@@ -1685,7 +1622,7 @@ struct ObjectRollbackState {
   std::vector<TextOffsetRelocation> &text_relocations;
   std::vector<PcRelativeDataRelocation> &data_relocations;
   std::vector<PcRelativeTextRelocation> &code_relocations;
-  std::vector<PendingCodeRelocation> &pending_code_relocations;
+  std::vector<internal::PendingCodeRelocation> &pending_code_relocations;
   std::unordered_map<uint64_t, uint64_t> &canonical_placement;
   std::unordered_map<uint64_t, bool> &canonical_placement_is_sidecar;
   std::unordered_set<uint64_t> &canonical_placement_variant_conflict;
@@ -1830,6 +1767,77 @@ bool scope_roots_are_entry_state(std::span<BasicBlock *const> blocks,
     if (hardware_entry_offsets.contains(block->start_offset()) || call_targets.contains(block))
       continue;
     return false;
+  }
+  return true;
+}
+
+bool resolve_pending_code_relocations(
+    const std::vector<PendingCodeRelocation> &pending,
+    const std::vector<TextOffsetRelocation> &text_relocations,
+    const std::unordered_map<uint64_t, uint64_t> &canonical_placement,
+    const std::unordered_set<uint64_t> &canonical_placement_variant_conflict,
+    std::vector<PcRelativeTextRelocation> &code_relocations,
+    std::vector<TranslationDiagnostic> &diagnostics) {
+  if (pending.empty())
+    return true;
+
+  std::unordered_map<uint64_t, uint64_t> placement;
+  std::unordered_set<uint64_t> conflicting;
+  for (const TextOffsetRelocation &relocation : text_relocations) {
+    auto [it, inserted] = placement.try_emplace(relocation.source_offset, relocation.target_offset);
+    if (!inserted && it->second != relocation.target_offset)
+      conflicting.insert(relocation.source_offset);
+  }
+
+  for (const PendingCodeRelocation &entry : pending) {
+    // Clones that disagreed on kernel-scope variant are lowered against different LDS models, so
+    // no one of them answers for the rest. This is checked before anything else and refuses the
+    // object: a computed address can be dereferenced from a scope other than the one that built
+    // it, so neither the canonical copy nor the builder's own clone is a safe answer. Reaching
+    // for the local copy here would pick a clone by which scope happened to compute the address,
+    // which is exactly the choice that is not available to make.
+    if (canonical_placement_variant_conflict.contains(entry.source_target_text_offset)) {
+      append_error(diagnostics, DiagnosticKind::Legalization,
+                   "PC-relative code address names a body whose copies were lowered against "
+                   "different LDS models; leaving code object unchanged",
+                   entry.source_target_text_offset);
+      return false;
+    }
+    // An adopted body has one canonical copy and every code address names it, whatever scope the
+    // builder lives in.
+    if (const auto canonical = canonical_placement.find(entry.source_target_text_offset);
+        canonical != canonical_placement.end()) {
+      code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
+                                  .target_literal_offset = entry.target_literal_offset,
+                                  .target_text_offset = canonical->second});
+      continue;
+    }
+    // Otherwise prefer the copy the computing scope emitted. A body reached by several kernels is
+    // cloned once per scope so each scope's branches resolve through its own placement map, and
+    // patch_recovered_builder_fixups already points a recovered builder at its scope's clone.
+    // Following the same convention keeps a computed address consistent with the code that
+    // computed it, and avoids inventing a conflict between clones distinguishable only by which
+    // scope emitted them.
+    if (entry.local_target_text_offset) {
+      code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
+                                  .target_literal_offset = entry.target_literal_offset,
+                                  .target_text_offset = *entry.local_target_text_offset});
+      continue;
+    }
+    const auto placed = placement.find(entry.source_target_text_offset);
+    if (placed == placement.end() || conflicting.contains(entry.source_target_text_offset)) {
+      append_error(diagnostics, DiagnosticKind::Legalization,
+                   conflicting.contains(entry.source_target_text_offset)
+                       ? "PC-relative code address names a body emitted at more than one "
+                         "placement; leaving code object unchanged"
+                       : "PC-relative code address names a body this translation did not emit; "
+                         "leaving code object unchanged",
+                   entry.source_target_text_offset);
+      return false;
+    }
+    code_relocations.push_back({.target_getpc_offset = entry.target_getpc_offset,
+                                .target_literal_offset = entry.target_literal_offset,
+                                .target_text_offset = placed->second});
   }
   return true;
 }
@@ -2542,7 +2550,7 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   // scope not yet emitted, and a body reached from several kernels is cloned once per scope, so the
   // final offset is only knowable once every placement is recorded. Hold the source-side answer and
   // resolve against the completed map below.
-  std::vector<PendingCodeRelocation> pending_code_relocations;
+  std::vector<internal::PendingCodeRelocation> pending_code_relocations;
   std::vector<PcRelativeTextRelocation> code_relocations;
   // Final offset of the one copy of each adopted body. Code addresses name this copy, so a body a
   // caller also clones still has exactly one address, and that address is stable no matter which
@@ -4139,40 +4147,25 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (owned_by_recovered_builder(builder.source_address_add_offset))
         continue;
       const uint64_t source_target = builder.target_vaddr - text_vaddr;
-      // An adopted body has one canonical copy; every code address names it, whatever scope the
-      // builder lives in. Resolving that here rather than after the loop keeps the address stable
-      // even when a caller also clones the body. Offsets whose clones disagreed on kernel-scope
-      // variant are excluded: those clones are lowered against different LDS models, so no single
-      // one of them can answer for the rest.
-      if (const auto canonical = canonical_placement.find(source_target);
-          canonical != canonical_placement.end() &&
-          !canonical_placement_variant_conflict.contains(source_target)) {
-        code_relocations.push_back(
-            {.target_getpc_offset = getpc->second + target_delta,
-             .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
-             .target_text_offset = canonical->second});
-        continue;
-      }
-      // Otherwise prefer this scope's own copy of the target. A body reached by several kernels is
-      // cloned once per scope so each scope's branches resolve through its own placement map, and
-      // patch_recovered_builder_fixups already points a recovered builder at its scope's clone.
-      // Following the same convention keeps a computed address consistent with the code that
-      // computed it, and avoids inventing a conflict between clones that are only distinguishable
-      // by which scope emitted them.
+      // Every code address is resolved after the loop, never here. Both inputs the decision needs
+      // are still being written while scopes are placed: a later scope can nominate a canonical
+      // placement, and a later scope is precisely what records a variant conflict, since the
+      // conflict is only discovered when a second clone disagrees with the first. Resolving in the
+      // loop answers against whatever half of that state exists so far, and the entry is never
+      // revisited once it is in code_relocations.
+      //
+      // The scope's own copy of the target travels with the entry so deferring costs nothing: the
+      // resolver can still prefer it, and now does so knowing whether the offset ended up
+      // conflicted.
+      std::optional<uint64_t> local_target;
       if (const auto local = target_offset_by_source_offset.find(source_target);
-          local != target_offset_by_source_offset.end()) {
-        code_relocations.push_back(
-            {.target_getpc_offset = getpc->second + target_delta,
-             .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
-             .target_text_offset = local->second + target_delta});
-        continue;
-      }
-      // Otherwise the target belongs to another scope -- an adopted body, say -- and can only be
-      // resolved once every placement is known.
+          local != target_offset_by_source_offset.end())
+        local_target = local->second + target_delta;
       pending_code_relocations.push_back(
           {.target_getpc_offset = getpc->second + target_delta,
            .target_literal_offset = add->second + target_delta + sizeof(uint32_t),
-           .source_target_text_offset = source_target});
+           .source_target_text_offset = source_target,
+           .local_target_text_offset = local_target});
     }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
@@ -4338,9 +4331,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return leave_unchanged();
   }
 
-  if (!resolve_pending_code_relocations(pending_code_relocations, text_relocations,
-                                        canonical_placement, canonical_placement_variant_conflict,
-                                        code_relocations, result.diagnostics))
+  if (!internal::resolve_pending_code_relocations(
+          pending_code_relocations, text_relocations, canonical_placement,
+          canonical_placement_variant_conflict, code_relocations, result.diagnostics))
     return leave_unchanged();
 
   if (continue_after_failure && has_error_diagnostic(result.diagnostics))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator_internal.h
@@ -12,9 +12,15 @@
 
 #pragma once
 
+#include "rocjitsu/code/dbt/translation_diagnostic.h"
+#include "rocjitsu/code/patch/code_object_patcher.h"
+
 #include <cstdint>
+#include <optional>
 #include <span>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace rocjitsu {
 
@@ -44,6 +50,51 @@ namespace internal {
 scope_roots_are_entry_state(std::span<BasicBlock *const> blocks,
                             const std::unordered_set<uint64_t> &hardware_entry_offsets,
                             const std::unordered_set<uint64_t> &table_callee_offsets);
+
+/// @brief A code-address builder awaiting the final placement of the body it names.
+///
+/// @details Every builder waits, including one whose target this scope emitted itself. The
+/// canonical placement and the variant-conflict set are both still being written while scopes are
+/// placed, so a decision taken in the loop is a decision taken against a partial answer. Carrying
+/// the emitting scope's own copy here keeps the deferred resolution able to prefer it without
+/// having to re-derive which scope asked.
+struct PendingCodeRelocation {
+  uint64_t target_getpc_offset = 0;
+  uint64_t target_literal_offset = 0;
+  uint64_t source_target_text_offset = 0;
+  /// @brief This scope's own placement of the target, when it emitted one.
+  std::optional<uint64_t> local_target_text_offset;
+};
+
+/// @brief Point every deferred code-address builder at the placement its target received.
+///
+/// @details Runs after every scope is placed, which is the first moment a target's final offset
+/// is known. A source offset emitted more than once has no single answer -- a runtime-dereferenced
+/// code address cannot choose between clones -- so that fails closed rather than picking one,
+/// matching how relocate_relative_text_addends treats a conflicting relocation addend.
+///
+/// Surfaced here because the two inputs that decide a refusal cannot be produced together by any
+/// buildable image: the variant-conflict set is populated only by virtual-LDS sidecar variants,
+/// which exist for the CDNA4-to-CDNA3 pair alone, while a PC-relative address builder is recovered
+/// only from a getpc plus `s_add_nc_u64`, an encoding CDNA4 does not have. A focused test is the
+/// only way to drive both refusal orderings.
+///
+/// @param pending Deferred builders in the order the scope walk queued them, so an entry queued
+///        before the conflict was discovered comes first.
+/// @param text_relocations Every scope's source-to-target block placement, used only for a target
+///        no scope nominated canonical.
+/// @param canonical_placement Final placement of each address-taken body, keyed by source offset.
+/// @param canonical_placement_variant_conflict Source offsets whose clones disagreed on variant.
+/// @param code_relocations Receives one entry per resolved builder.
+/// @param diagnostics Receives the refusal reason when this returns false.
+/// @returns false when the object must be left unchanged.
+[[nodiscard]] bool resolve_pending_code_relocations(
+    const std::vector<PendingCodeRelocation> &pending,
+    const std::vector<TextOffsetRelocation> &text_relocations,
+    const std::unordered_map<uint64_t, uint64_t> &canonical_placement,
+    const std::unordered_set<uint64_t> &canonical_placement_variant_conflict,
+    std::vector<PcRelativeTextRelocation> &code_relocations,
+    std::vector<TranslationDiagnostic> &diagnostics);
 
 } // namespace internal
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -14,6 +14,7 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/builders/instruction_builder.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/dbt/binary_translator_internal.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
 #include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/dbt/semantic_translator.h"
@@ -2351,6 +2352,103 @@ TEST(BinaryTranslatorE2E, VariantConflictedAddressTakenCloneRefusesInsteadOfNami
                                    "relocated .text could not be materialized safely"))
       << (result.diagnostics.empty() ? "" : result.diagnostics.front().message);
   EXPECT_EQ(result.elf_bytes, image) << "fail-closed must leave the object unchanged";
+}
+
+// The two tests above reach the variant-conflict guard through an R_AMDGPU_RELATIVE64 addend. A
+// getpc-plus-literal builder is the other way to hold a code address, and it is resolved by
+// internal::resolve_pending_code_relocations rather than by the addend path, so it needs its own
+// coverage.
+//
+// No image can carry both halves of that case. The conflict set is written only by virtual-LDS
+// sidecar variants, which exist for the CDNA4 -> CDNA3 pair alone, while a PC-relative address
+// builder is recovered only from a getpc followed by s_add_nc_u64 -- an encoding CDNA4 does not
+// have -- so the two never co-occur in anything the translator can be handed. These drive the
+// resolver directly instead.
+//
+// The orderings are the two ways the scope walk can queue a builder relative to the scope that
+// discovers the disagreement. A conflict is only found when a second clone disagrees with the
+// first, so a builder in the earlier scope is queued before the conflict exists and one in the
+// later scope after it. Resolution happens once, after every scope is placed, so both must refuse:
+// the earlier builder must not have been settled against the canonical clone, and the later one
+// must not fall through to the clone its own scope emitted.
+namespace {
+
+constexpr uint64_t kConflictedTargetOffset = 0x40;
+
+/// @brief The refusal every conflicted code address must produce.
+[[nodiscard]] bool
+refused_for_variant_conflict(const std::vector<internal::PendingCodeRelocation> &pending,
+                             const std::unordered_map<uint64_t, uint64_t> &canonical_placement,
+                             std::vector<PcRelativeTextRelocation> &code_relocations) {
+  std::vector<TranslationDiagnostic> diagnostics;
+  const bool resolved = internal::resolve_pending_code_relocations(
+      pending, /*text_relocations=*/{}, canonical_placement,
+      /*canonical_placement_variant_conflict=*/{kConflictedTargetOffset}, code_relocations,
+      diagnostics);
+  if (resolved || diagnostics.empty())
+    return false;
+  return diagnostics.front().message.find("lowered against different LDS models") !=
+         std::string::npos;
+}
+
+} // namespace
+
+// The builder's scope ran before the disagreement was discovered, so nothing had excluded the
+// target yet and a canonical placement for it exists. Settling the builder against that placement
+// at the time it was queued -- as resolving inside the scope walk would -- leaves a code address
+// naming one clone of a body whose clones are not interchangeable.
+TEST(BinaryTranslatorInternal, CodeAddressQueuedBeforeTheVariantConflictIsStillRefused) {
+  const std::vector<internal::PendingCodeRelocation> pending = {
+      {.target_getpc_offset = 0x10,
+       .target_literal_offset = 0x18,
+       .source_target_text_offset = kConflictedTargetOffset,
+       .local_target_text_offset = std::nullopt}};
+  const std::unordered_map<uint64_t, uint64_t> canonical_placement = {
+      {kConflictedTargetOffset, 0x200}};
+
+  std::vector<PcRelativeTextRelocation> code_relocations;
+  EXPECT_TRUE(refused_for_variant_conflict(pending, canonical_placement, code_relocations));
+  EXPECT_TRUE(code_relocations.empty())
+      << "a refused object must not leave a code address pointing at one clone";
+}
+
+// The builder's scope is the one that disagreed, so by the time it is resolved the target is
+// excluded from the canonical map. Preferring the clone this scope emitted would pick between the
+// two by which scope happened to compute the address -- but the address can be dereferenced from
+// either scope, so that choice is not available to make.
+TEST(BinaryTranslatorInternal, CodeAddressQueuedAfterTheVariantConflictDoesNotUseItsLocalClone) {
+  const std::vector<internal::PendingCodeRelocation> pending = {
+      {.target_getpc_offset = 0x10,
+       .target_literal_offset = 0x18,
+       .source_target_text_offset = kConflictedTargetOffset,
+       .local_target_text_offset = 0x300}};
+
+  std::vector<PcRelativeTextRelocation> code_relocations;
+  EXPECT_TRUE(refused_for_variant_conflict(pending, /*canonical_placement=*/{}, code_relocations));
+  EXPECT_TRUE(code_relocations.empty())
+      << "the emitting scope's own clone is not an answer for an address others dereference";
+}
+
+// The control for both: with no disagreement recorded, a builder whose target has a canonical
+// placement resolves to it. Without this the refusals above could be passing because the resolver
+// rejects every deferred code address.
+TEST(BinaryTranslatorInternal, UnconflictedCodeAddressResolvesToItsCanonicalPlacement) {
+  const std::vector<internal::PendingCodeRelocation> pending = {
+      {.target_getpc_offset = 0x10,
+       .target_literal_offset = 0x18,
+       .source_target_text_offset = kConflictedTargetOffset,
+       .local_target_text_offset = 0x300}};
+  const std::unordered_map<uint64_t, uint64_t> canonical_placement = {
+      {kConflictedTargetOffset, 0x200}};
+
+  std::vector<PcRelativeTextRelocation> code_relocations;
+  std::vector<TranslationDiagnostic> diagnostics;
+  EXPECT_TRUE(internal::resolve_pending_code_relocations(
+      pending, /*text_relocations=*/{}, canonical_placement,
+      /*canonical_placement_variant_conflict=*/{}, code_relocations, diagnostics));
+  ASSERT_EQ(code_relocations.size(), 1u);
+  EXPECT_EQ(code_relocations.front().target_text_offset, 0x200u)
+      << "the canonical copy answers for every scope, including the one that emitted a clone";
 }
 
 } // namespace


### PR DESCRIPTION
A getpc-plus-literal builder naming a body in .text was resolved inside the scope-placement loop, against a canonical-placement map and a variant-conflict set that later scopes were still writing. A builder settled before the disagreement was discovered kept an address naming one clone and was never revisited, and a builder in the disagreeing scope missed the canonical entry and fell through to the clone its own scope emitted. Either way the object could keep a pointer to one of two clones lowered against different LDS models, which a scope other than the one that computed the address can dereference.

Every builder is now deferred and resolved once, after all scopes are placed, carrying the emitting scope's own placement so that preference survives the wait. The resolver consults the completed conflict set first and refuses the object. The three tests drive the resolver directly because no buildable image can supply both halves: the conflict set is written only by virtual-LDS sidecar variants, which exist for the CDNA4-to-CDNA3 pair alone, while a PC-relative builder is recovered only from a getpc plus s_add_nc_u64, an encoding CDNA4 does not have.