### PR TITLE
feat(hipfile) SRIOV virtual function GPU checks for AIS CHECK

### DIFF
--- a/projects/hipfile/docs/how-to/checking-system-compatibility.rst
+++ b/projects/hipfile/docs/how-to/checking-system-compatibility.rst
@@ -58,8 +58,19 @@ present: kernel P2PDMA, a HIP runtime with AIS symbols, the amdgpu driver hook, 
            amdgpu                  : True
            hipFile-capable volume  : True
 
-| ``Kernel P2PDMA support``: Peer-to-peer DMA between the GPU and storage is available. 
+| ``Kernel P2PDMA support``: Peer-to-peer DMA between the GPU and storage is available.
 | ``HIP runtime``: A discovered HIP runtime library exports  ``hipAmdFileRead()`` and ``hipAmdFileWrite()``.
 | ``amdgpu``: The loaded amdgpu kernel driver exposes ``kfd_ais_rw_file`` in ``/proc/kallsyms``.
 | ``hipFile-capable volume``: At least one row in the mounted volumes table has ``HIPFILE`` set to ``yes``.
+
+SR-IOV virtual functions
+========================
+
+hipFile's fastpath is only supported on GPU physical functions (PFs). When a GPU
+is an SR-IOV virtual function (VF), the fastpath is disabled and I/O falls back to
+the slower compatibility path. ``ais-check`` uses ``amd-smi`` to detect VFs (a
+VF's device name ends in ``VF``, for example ``AMD Instinct MI300X VF``) and, if
+any are present, prints a ``WARNING`` to stderr. Because a VF is a performance
+caveat rather than a missing component, this warning does not change the exit
+code. If ``amd-smi`` is not installed the check is skipped.
 

--- a/projects/hipfile/docs/how-to/checking-system-compatibility.rst
+++ b/projects/hipfile/docs/how-to/checking-system-compatibility.rst
@@ -63,8 +63,6 @@ present: kernel P2PDMA, a HIP runtime with AIS symbols, the amdgpu driver hook, 
 | ``amdgpu``: The loaded amdgpu kernel driver exposes ``kfd_ais_rw_file`` in ``/proc/kallsyms``.
 | ``hipFile-capable volume``: At least one row in the mounted volumes table has ``HIPFILE`` set to ``yes``.
 
-SR-IOV virtual functions
-========================
 
 .. note::
 

--- a/projects/hipfile/docs/how-to/checking-system-compatibility.rst
+++ b/projects/hipfile/docs/how-to/checking-system-compatibility.rst
@@ -66,11 +66,13 @@ present: kernel P2PDMA, a HIP runtime with AIS symbols, the amdgpu driver hook, 
 SR-IOV virtual functions
 ========================
 
-hipFile's fastpath is only supported on GPU physical functions (PFs). When a GPU
-is an SR-IOV virtual function (VF), the fastpath is disabled and I/O falls back to
-the slower compatibility path. ``ais-check`` uses ``amd-smi`` to detect VFs (a
-VF's device name ends in ``VF``, for example ``AMD Instinct MI300X VF``) and, if
-any are present, prints a ``WARNING`` to stderr. Because a VF is a performance
-caveat rather than a missing component, this warning does not change the exit
-code. If ``amd-smi`` is not installed the check is skipped.
+.. note::
+
+   hipFile's fastpath is only supported on GPU physical functions (PFs). When a
+   GPU is an SR-IOV virtual function (VF), the fastpath is disabled and I/O falls
+   back to the compatibility path. ``ais-check`` uses ``amd-smi`` to detect VFs.
+   If ``amd-smi`` is not installed, the check is skipped. If a VF is present,
+   ``amd-smi`` will print a warning to stderr. This warning won't affect the exit
+   code. VFs can be identified by a device name that ends in ``VF``, such as
+   ``AMD Instinct MI300X VF``.
 

--- a/projects/hipfile/docs/troubleshooting/known-issues.rst
+++ b/projects/hipfile/docs/troubleshooting/known-issues.rst
@@ -40,6 +40,9 @@ Example:
 
 hipFile's fastpath is only supported on GPU physical functions (PFs).
 
+``ais-check`` also detects virtual functions via ``amd-smi`` and prints a warning
+when one is present, though it does not change its exit code in that case.
+
 High memory utilization with hipFile
 ====================================
 

--- a/projects/hipfile/docs/troubleshooting/known-issues.rst
+++ b/projects/hipfile/docs/troubleshooting/known-issues.rst
@@ -41,7 +41,7 @@ Example:
 hipFile's fastpath is only supported on GPU physical functions (PFs).
 
 ``ais-check`` also detects virtual functions via ``amd-smi`` and prints a warning
-when one is present, though it does not change its exit code in that case.
+when one is present. This warning won't change the exit code.
 
 High memory utilization with hipFile
 ====================================

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -36,6 +36,7 @@ import ctypes.util
 import errno
 import glob
 import gzip
+import json
 import os
 import subprocess
 import sys
@@ -79,6 +80,10 @@ KFD_CAPABILITY_AIS = 0x40
 
 # Per-GPU topology directory the kernel's KFD driver publishes.
 KFD_TOPOLOGY_NODES = "/sys/class/kfd/kfd/topology/nodes"
+
+# amd-smi reports a virtual function's market name with a "VF" suffix (e.g.
+# "AMD Instinct MI300X VF"); see docs/troubleshooting/known-issues.rst.
+AMD_SMI = "amd-smi"
 
 
 def amdgpu_dkms_version():
@@ -399,6 +404,77 @@ def amdgpu_supports_ais():
     return False
 
 
+def sriov_vf_gpus():
+    """
+    Return a list of (bdf, market_name) for AMD GPUs that are SR-IOV virtual
+    functions (VFs), as reported by amd-smi.
+
+    hipFile's fastpath is only supported on GPU physical functions; on a VF it
+    falls back to the slower compatibility path. amd-smi names a VF with a "VF"
+    suffix (e.g. "AMD Instinct MI300X VF"), which is the authoritative signal --
+    it works inside SR-IOV guests where the physical function isn't visible in
+    sysfs. See docs/troubleshooting/known-issues.rst.
+
+    Returns [] when amd-smi is missing, exits non-zero, or emits output that
+    can't be parsed; VF status is treated as "not detected" rather than an error,
+    matching the tool's other best-effort probes.
+    """
+    try:
+        result = subprocess.run(
+            [AMD_SMI, "static", "--asic", "--bus", "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    vfs = []
+    for entry in data.get("gpu_data", []):
+        if not isinstance(entry, dict):
+            continue
+        asic = entry.get("asic") or {}
+        market = (asic.get("market_name") or "").strip()
+        normalized = market.upper()
+        if normalized != "VF" and not normalized.endswith(" VF"):
+            continue
+        bus = entry.get("bus") or {}
+        bdf = bus.get("bdf") or f"gpu {entry.get('gpu', '?')}"
+        vfs.append((bdf, market))
+
+    return vfs
+
+
+def print_sriov_warning(vf_gpus):
+    """
+    Print a warning to stderr when any SR-IOV virtual function GPU is present.
+
+    Written to stderr (not stdout) so it remains visible in quiet mode. Does
+    nothing when vf_gpus is empty.
+    """
+    if not vf_gpus:
+        return
+
+    devices = ", ".join(f"{bdf} ({name})" for bdf, name in vf_gpus)
+    print(
+        f"WARNING: SR-IOV virtual function GPU(s) detected: {devices}.\n"
+        "         hipFile's fast path is not available on GPU virtual functions; "
+        "I/O will\n"
+        "         fall back to the slower compatibility path. The fast path "
+        "requires a\n"
+        "         GPU physical function (PF).",
+        file=sys.stderr,
+    )
+
+
 class Mount:  # pylint: disable=too-few-public-methods
     """A single parsed /proc/self/mountinfo entry."""
 
@@ -694,6 +770,7 @@ def main():
 
     hip_libraries = hip_runtime_supports_ais()
     volume_rows, volumes_ok = capable_volumes()
+    vf_gpus = sriov_vf_gpus()
 
     component_support = [
         ("Kernel P2PDMA support", kernel_supports_p2pdma()),
@@ -728,6 +805,10 @@ def main():
         print("AIS support in:")
         for name, supported in component_support:
             print(f"\t{name:<24}: {supported}")
+
+    # A VF is a performance caveat, not a missing component, so warn (always, even
+    # in quiet mode) without affecting the exit code.
+    print_sriov_warning(vf_gpus)
 
     return int(not all(supported for (_, supported) in component_support))
 

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -466,11 +466,9 @@ def print_sriov_warning(vf_gpus):
     devices = ", ".join(f"{bdf} ({name})" for bdf, name in vf_gpus)
     print(
         f"WARNING: SR-IOV virtual function GPU(s) detected: {devices}.\n"
-        "         hipFile's fast path is not available on GPU virtual functions; "
-        "I/O will\n"
-        "         fall back to the slower compatibility path. The fast path "
-        "requires a\n"
-        "         GPU physical function (PF).",
+        "hipFile's fast path is not available on GPU virtual functions; "
+        "I/O will fall back to the slower compatibility path. The fast path "
+        "requires a GPU physical function (PF).",
         file=sys.stderr,
     )
 

--- a/projects/hipfile/tools/ais-check/tests/test_sriov.py
+++ b/projects/hipfile/tools/ais-check/tests/test_sriov.py
@@ -1,0 +1,157 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for the SR-IOV virtual function detection / warning."""
+
+# Test functions are self-documenting by name; docstrings add noise.
+# pylint: disable=missing-function-docstring
+
+import json
+from collections import namedtuple
+
+_Completed = namedtuple("CompletedProcess", "returncode stdout")
+
+
+def _patch_amd_smi(monkeypatch, ais_check, *, stdout="", returncode=0, exc=None):
+    def fake_run(*_args, **_kwargs):
+        if exc is not None:
+            raise exc
+        return _Completed(returncode, stdout)
+
+    monkeypatch.setattr(ais_check.subprocess, "run", fake_run)
+
+
+def _gpu(index, market_name, bdf):
+    return {
+        "gpu": index,
+        "asic": {"market_name": market_name},
+        "bus": {"bdf": bdf},
+    }
+
+
+def _payload(*gpus):
+    return json.dumps({"gpu_data": list(gpus)})
+
+
+# ---------------------------------------------------------------------------
+# sriov_vf_gpus()
+# ---------------------------------------------------------------------------
+
+
+def test_single_vf_detected(monkeypatch, ais_check):
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=_payload(_gpu(0, "AMD Instinct MI300X VF", "0000:05:00.0")),
+    )
+
+    assert ais_check.sriov_vf_gpus() == [("0000:05:00.0", "AMD Instinct MI300X VF")]
+
+
+def test_physical_function_not_flagged(monkeypatch, ais_check):
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=_payload(_gpu(0, "AMD Radeon RX 6800 XT", "0000:23:00.0")),
+    )
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+def test_mixed_pf_and_vf(monkeypatch, ais_check):
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=_payload(
+            _gpu(0, "AMD Instinct MI300X", "0000:05:00.0"),
+            _gpu(1, "AMD Instinct MI300X VF", "0000:06:00.0"),
+            _gpu(2, "AMD Instinct MI300X VF", "0000:07:00.0"),
+        ),
+    )
+
+    assert ais_check.sriov_vf_gpus() == [
+        ("0000:06:00.0", "AMD Instinct MI300X VF"),
+        ("0000:07:00.0", "AMD Instinct MI300X VF"),
+    ]
+
+
+def test_vf_suffix_requires_word_boundary(monkeypatch, ais_check):
+    # A name that merely ends in the letters "VF" without a separating space is
+    # not treated as a virtual function.
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=_payload(_gpu(0, "AMD SomethingVF", "0000:05:00.0")),
+    )
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+def test_missing_bdf_falls_back_to_gpu_index(monkeypatch, ais_check):
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=json.dumps(
+            {
+                "gpu_data": [
+                    {"gpu": 3, "asic": {"market_name": "AMD Instinct MI300X VF"}}
+                ]
+            }
+        ),
+    )
+
+    assert ais_check.sriov_vf_gpus() == [("gpu 3", "AMD Instinct MI300X VF")]
+
+
+def test_amd_smi_missing(monkeypatch, ais_check):
+    _patch_amd_smi(monkeypatch, ais_check, exc=FileNotFoundError())
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+def test_non_zero_returncode(monkeypatch, ais_check):
+    _patch_amd_smi(
+        monkeypatch,
+        ais_check,
+        stdout=_payload(_gpu(0, "AMD Instinct MI300X VF", "0000:05:00.0")),
+        returncode=1,
+    )
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+def test_malformed_json(monkeypatch, ais_check):
+    _patch_amd_smi(monkeypatch, ais_check, stdout="not json at all")
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+def test_empty_gpu_data(monkeypatch, ais_check):
+    _patch_amd_smi(monkeypatch, ais_check, stdout=json.dumps({"gpu_data": []}))
+
+    assert ais_check.sriov_vf_gpus() == []
+
+
+# ---------------------------------------------------------------------------
+# print_sriov_warning()
+# ---------------------------------------------------------------------------
+
+
+def test_warning_printed_for_vf(capsys, ais_check):
+    ais_check.print_sriov_warning([("0000:05:00.0", "AMD Instinct MI300X VF")])
+
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "0000:05:00.0" in captured.err
+    assert "AMD Instinct MI300X VF" in captured.err
+    # The warning must go to stderr, not stdout.
+    assert captured.out == ""
+
+
+def test_no_warning_when_empty(capsys, ais_check):
+    ais_check.print_sriov_warning([])
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""


### PR DESCRIPTION
## Motivation

If GPU's are virtual function the fast path cannot run and ais-check should be printing a warning

## Technical Details

ais-check is using amd-smi to to check if the GPU's are a virtual function and prints a warning

## Issue Tracking

JIRA ID : AIHIPFILE-185

## Test Plan

CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
