### PR TITLE
test(rocprofiler-compute): register roctx recordfn gtest in the root CMakeLists

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -891,6 +891,21 @@ add_test(
 if(ENABLE_TESTS)
     add_subdirectory(src/lib/roctx_recordfn)
 endif()
+
+if(TARGET test-roctx-recordfn)
+    if(TEST_FROM_INSTALL)
+        set(_rcfn_test_cmd tests/test-roctx-recordfn)
+    else()
+        set(_rcfn_test_cmd $<TARGET_FILE:test-roctx-recordfn>)
+    endif()
+    add_test(NAME test-roctx-recordfn COMMAND ${_rcfn_test_cmd})
+    get_target_property(_rcfn_ld_path test-roctx-recordfn ROCPROF_TEST_LD_LIBRARY_PATH)
+    set(_rcfn_test_env "LD_LIBRARY_PATH=${_rcfn_ld_path}:$ENV{LD_LIBRARY_PATH}")
+    sanitizer_runtime_env(_san_env OFF)
+    list(APPEND _rcfn_test_env ${_san_env})
+    set_tests_properties(test-roctx-recordfn PROPERTIES ENVIRONMENT "${_rcfn_test_env}")
+endif()
+
 # -----------------------------------
 # Torch trace tests
 # -----------------------------------

--- a/projects/rocprofiler-compute/src/lib/roctx_recordfn/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/roctx_recordfn/tests/CMakeLists.txt
@@ -89,17 +89,11 @@ if(_rcfn_openblas_dir)
 endif()
 list(JOIN _rcfn_test_ld_paths ":" _rcfn_test_ld_path)
 
-if(TEST_FROM_INSTALL)
-    set(_rcfn_test_cmd tests/${target})
-else()
-    set(_rcfn_test_cmd $<TARGET_FILE:${target}>)
-endif()
-add_test(NAME ${target} COMMAND ${_rcfn_test_cmd})
-set_tests_properties(
+# The root CMakeLists.txt registers this test alongside the other native
+# gtests; publish the search path torch needs to resolve its own dependencies.
+set_target_properties(
     ${target}
-    PROPERTIES
-        LABELS "profile"
-        ENVIRONMENT "LD_LIBRARY_PATH=${_rcfn_test_ld_path}:$ENV{LD_LIBRARY_PATH}"
+    PROPERTIES ROCPROF_TEST_LD_LIBRARY_PATH "${_rcfn_test_ld_path}"
 )
 
 if(INSTALL_TESTS)


### PR DESCRIPTION
## Motivation

Three of the four native gtests are registered in the root `CMakeLists.txt`; the roctx recordfn one registers itself in its own subdirectory, with a different shape and no sanitizer environment.

## Technical Details

- Move `add_test` for `test-roctx-recordfn` to the root, matching the `TEST_FROM_INSTALL` branch and `sanitizer_runtime_env` the other three use.
- The subdirectory publishes its torch `LD_LIBRARY_PATH` as a target property for the root to read. It stays because torch's own dependencies are resolved via torch's runpath, which no rpath on the test binary can reach.
- Drop `LABELS "profile"`, which no other native gtest carries.

## JIRA ID

N/A

## Test Plan

Configure with `ENABLE_TESTS=ON` and confirm `ctest -N` lists `test-roctx-recordfn`, and that `CTestTestfile.cmake` shows the test registered from the root with its `LD_LIBRARY_PATH` intact.

## Test Result

Both confirmed locally on x86_64. The test is registered from the root `CMakeLists.txt` with the torch search path preserved and no label. Not run; this changes registration only.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)