### PR TITLE
fix(clr): enable compiler and linker hardening on Linux builds

### DIFF
--- a/projects/clr/CMakeLists.txt
+++ b/projects/clr/CMakeLists.txt
@@ -48,6 +48,8 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CLRHardening.cmake")
+
 #############
 # Build steps
 #############

--- a/projects/clr/README.md
+++ b/projects/clr/README.md
@@ -70,7 +70,7 @@ sudo apt-get install ocl-icd-opencl-dev
 
    > **Note:** Build both `OCL` and `HIP` together by passing `-DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=ON` to the configure command.
 
-   > **Note:** Linux builds are hardened by default: stack protection, `_FORTIFY_SOURCE`, full RELRO and a non-executable stack. Compile flags are probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
+   > **Note:** Linux builds link with full RELRO (`-Wl,-z,relro,-z,now`), which resolves the GOT at load time and maps it read-only. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
 
 For detailed instructions, please refer to [How to build HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/install/build.html).
 

--- a/projects/clr/README.md
+++ b/projects/clr/README.md
@@ -70,6 +70,8 @@ sudo apt-get install ocl-icd-opencl-dev
 
    > **Note:** Build both `OCL` and `HIP` together by passing `-DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=ON` to the configure command.
 
+   > **Note:** Linux builds are hardened by default: stack protection, `FORTIFY_SOURCE`, full RELRO, a non-executable stack and position independent code. Each flag is probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
+
 For detailed instructions, please refer to [How to build HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/install/build.html).
 
 ### Windows

--- a/projects/clr/README.md
+++ b/projects/clr/README.md
@@ -70,7 +70,7 @@ sudo apt-get install ocl-icd-opencl-dev
 
    > **Note:** Build both `OCL` and `HIP` together by passing `-DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=ON` to the configure command.
 
-   > **Note:** Linux builds are hardened by default: stack protection, `FORTIFY_SOURCE`, full RELRO, a non-executable stack and position independent code. Each flag is probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
+   > **Note:** Linux builds are hardened by default: stack protection, `FORTIFY_SOURCE`, full RELRO and a non-executable stack. Compile flags are probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
 
 For detailed instructions, please refer to [How to build HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/install/build.html).
 

--- a/projects/clr/README.md
+++ b/projects/clr/README.md
@@ -70,7 +70,7 @@ sudo apt-get install ocl-icd-opencl-dev
 
    > **Note:** Build both `OCL` and `HIP` together by passing `-DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=ON` to the configure command.
 
-   > **Note:** Linux builds are hardened by default: stack protection, `FORTIFY_SOURCE`, full RELRO and a non-executable stack. Compile flags are probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
+   > **Note:** Linux builds are hardened by default: stack protection, `_FORTIFY_SOURCE`, full RELRO and a non-executable stack. Compile flags are probed for toolchain support before use, and the whole set is skipped for sanitizer builds. Pass `-DCLR_ENABLE_HARDENING=OFF` to opt out.
 
 For detailed instructions, please refer to [How to build HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/install/build.html).
 

--- a/projects/clr/cmake/CLRHardening.cmake
+++ b/projects/clr/cmake/CLRHardening.cmake
@@ -6,62 +6,20 @@
 
 include_guard()
 
-option(CLR_ENABLE_HARDENING
-  "Build CLR with compiler and linker hardening mitigations (Linux only)" ON)
+option(CLR_ENABLE_HARDENING "Build CLR with full RELRO (Linux only)" ON)
 
 if(NOT CLR_ENABLE_HARDENING)
   return()
 endif()
 
-# GNU driver and ELF linker syntax: MSVC and clang-cl reject it, and the -z
-# options are not valid for Mach-O.
+# ELF linker syntax: MSVC and clang-cl reject it, and -z is not valid for Mach-O.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
   return()
 endif()
 
-# _FORTIFY_SOURCE reports false positives under sanitizers.
-if(ADDRESS_SANITIZER OR THEROCK_SANITIZER OR ENABLE_ADDRESS_SANITIZER)
-  message(STATUS "CLR hardening: disabled for sanitizer build")
-  return()
-endif()
+# Resolve the GOT at load time and map it read-only, so a stray write cannot
+# repoint an entry. Not probed: linkers warn about and ignore an unknown -z
+# keyword, so a link probe would pass either way.
+add_link_options("-Wl,-z,relro,-z,now")
 
-include(CheckCXXCompilerFlag)
-include(CheckCXXSourceCompiles)
-include(CMakePushCheckState)
-
-# gcc and clang reject -fstack-clash-protection outright where unsupported.
-foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
-  string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
-  check_cxx_compiler_flag("${_clr_hardening_flag}" ${_clr_hardening_var})
-  if(${_clr_hardening_var})
-    add_compile_options("${_clr_hardening_flag}")
-  endif()
-endforeach()
-
-unset(_clr_hardening_var)
-
-# Not probed: linkers warn and ignore an unknown -z keyword, so a probe passes either way.
-add_link_options("-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
-
-# Ubuntu 24.04 and others default to level 3; pinning the report's 2 would remove
-# fortification. Probed under -Werror so level-2-only toolchains fall back.
-cmake_push_check_state(RESET)
-set(CMAKE_REQUIRED_FLAGS "-Werror -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
-check_cxx_source_compiles("#include <string.h>\nint main(void) { return 0; }"
-  CLR_HAVE_fortify_source_3)
-cmake_pop_check_state()
-if(CLR_HAVE_fortify_source_3)
-  set(_clr_fortify_level 3)
-else()
-  set(_clr_fortify_level 2)
-endif()
-
-# Needs an optimizing build, and hipamd compiles with -Werror. Undefine first so
-# toolchains that predefine it do not warn.
-add_compile_options(
-  "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>"
-  "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=${_clr_fortify_level}>")
-
-message(STATUS "CLR hardening: enabled (_FORTIFY_SOURCE=${_clr_fortify_level})")
-
-unset(_clr_fortify_level)
+message(STATUS "CLR hardening: full RELRO enabled")

--- a/projects/clr/cmake/CLRHardening.cmake
+++ b/projects/clr/cmake/CLRHardening.cmake
@@ -1,0 +1,93 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+# Binary hardening mitigations for the CLR host runtime.
+#
+# Included at directory scope from the top-level CMakeLists.txt so that rocclr,
+# hipamd and opencl inherit them. Device code is produced by explicit clang
+# invocations in add_custom_command(), so these host flags do not reach offload
+# compilation.
+
+include_guard()
+
+option(CLR_ENABLE_HARDENING
+  "Build CLR with compiler and linker hardening mitigations (Linux only)" ON)
+
+if(NOT CLR_ENABLE_HARDENING)
+  return()
+endif()
+
+# Everything below is GCC/Clang driver and ELF linker syntax. UNIX is the proxy
+# for that: on Windows CLR builds with MSVC or clang-cl, which reject it.
+if(NOT UNIX)
+  return()
+endif()
+
+# Sanitizers replace the allocator and stack layout these mitigations rely on,
+# and report false positives when combined with FORTIFY_SOURCE.
+# ENABLE_ADDRESS_SANITIZER is the opencl subtree's own switch for the same
+# thing. Any truthy value disables, so that a sanitizer added later does not
+# silently inherit a conflicting configuration.
+if(ADDRESS_SANITIZER OR THEROCK_SANITIZER OR ENABLE_ADDRESS_SANITIZER)
+  message(STATUS "CLR hardening: disabled for sanitizer build")
+  return()
+endif()
+
+include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
+
+# Every flag is probed before use. Not all targets and toolchain versions
+# implement all of them, and an unsupported flag is diagnosed on every
+# translation unit.
+foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
+  string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
+  check_cxx_compiler_flag("${_clr_hardening_flag}" ${_clr_hardening_var})
+  if(${_clr_hardening_var})
+    add_compile_options("${_clr_hardening_flag}")
+  endif()
+endforeach()
+
+foreach(_clr_hardening_flag "-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
+  string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
+  # check_linker_flag() would be the natural fit but needs CMake 3.18, above
+  # the 3.16.8 floor this project declares.
+  set(CMAKE_REQUIRED_LINK_OPTIONS "${_clr_hardening_flag}")
+  check_cxx_source_compiles("int main(void) { return 0; }" ${_clr_hardening_var})
+  unset(CMAKE_REQUIRED_LINK_OPTIONS)
+  if(${_clr_hardening_var})
+    add_link_options("${_clr_hardening_flag}")
+  endif()
+endforeach()
+
+unset(_clr_hardening_var)
+
+# Distributions such as Ubuntu 24.04 already default to level 3, so pinning the
+# level 2 named in the report would remove fortification rather than add it.
+# Probe the real construct under -Werror so that a compiler or C library
+# implementing only level 2 falls back instead of warning on every file.
+set(CMAKE_REQUIRED_FLAGS "-Werror -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
+check_cxx_source_compiles("#include <string.h>\nint main(void) { return 0; }"
+  CLR_HAVE_fortify_source_3)
+unset(CMAKE_REQUIRED_FLAGS)
+if(CLR_HAVE_fortify_source_3)
+  set(_clr_fortify_level 3)
+else()
+  set(_clr_fortify_level 2)
+endif()
+
+# FORTIFY_SOURCE needs an optimizing build; at -O0 the C library warns, and
+# hipamd compiles with -Werror. Undefining first keeps toolchains that already
+# predefine it from warning about the redefinition.
+add_compile_options(
+  "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>"
+  "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=${_clr_fortify_level}>")
+
+# CMake maps this to -fPIC for libraries and -fPIE/-pie for executables, which
+# is why the property is set instead of passing a literal flag that would apply
+# the wrong one to shared libraries.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+message(STATUS "CLR hardening: enabled (_FORTIFY_SOURCE=${_clr_fortify_level})")
+
+unset(_clr_fortify_level)

--- a/projects/clr/cmake/CLRHardening.cmake
+++ b/projects/clr/cmake/CLRHardening.cmake
@@ -37,9 +37,9 @@ endif()
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
-# Every flag is probed before use. Not all targets and toolchain versions
-# implement all of them, and an unsupported flag is diagnosed on every
-# translation unit.
+# Compile flags are probed because an unsupported one is a hard error on every
+# translation unit: clang and gcc reject -fstack-clash-protection outright on
+# targets that do not implement it.
 foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
   string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
   check_cxx_compiler_flag("${_clr_hardening_flag}" ${_clr_hardening_var})
@@ -48,19 +48,12 @@ foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
   endif()
 endforeach()
 
-foreach(_clr_hardening_flag "-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
-  string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
-  # check_linker_flag() would be the natural fit but needs CMake 3.18, above
-  # the 3.16.8 floor this project declares.
-  set(CMAKE_REQUIRED_LINK_OPTIONS "${_clr_hardening_flag}")
-  check_cxx_source_compiles("int main(void) { return 0; }" ${_clr_hardening_var})
-  unset(CMAKE_REQUIRED_LINK_OPTIONS)
-  if(${_clr_hardening_var})
-    add_link_options("${_clr_hardening_flag}")
-  endif()
-endforeach()
-
 unset(_clr_hardening_var)
+
+# Every ELF linker used for ROCm (GNU ld, lld, mold) accepts these. Deliberately
+# not probed: an unsupported -z keyword is warned about and ignored rather than
+# rejected, so a link probe would succeed either way.
+add_link_options("-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
 
 # Distributions such as Ubuntu 24.04 already default to level 3, so pinning the
 # level 2 named in the report would remove fortification rather than add it.
@@ -82,11 +75,6 @@ endif()
 add_compile_options(
   "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>"
   "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=${_clr_fortify_level}>")
-
-# CMake maps this to -fPIC for libraries and -fPIE/-pie for executables, which
-# is why the property is set instead of passing a literal flag that would apply
-# the wrong one to shared libraries.
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 message(STATUS "CLR hardening: enabled (_FORTIFY_SOURCE=${_clr_fortify_level})")
 

--- a/projects/clr/cmake/CLRHardening.cmake
+++ b/projects/clr/cmake/CLRHardening.cmake
@@ -13,12 +13,13 @@ if(NOT CLR_ENABLE_HARDENING)
   return()
 endif()
 
-# GCC/Clang driver and ELF linker syntax, which MSVC and clang-cl reject.
-if(NOT UNIX)
+# GNU driver and ELF linker syntax: MSVC and clang-cl reject it, and the -z
+# options are not valid for Mach-O.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
   return()
 endif()
 
-# FORTIFY_SOURCE reports false positives under sanitizers.
+# _FORTIFY_SOURCE reports false positives under sanitizers.
 if(ADDRESS_SANITIZER OR THEROCK_SANITIZER OR ENABLE_ADDRESS_SANITIZER)
   message(STATUS "CLR hardening: disabled for sanitizer build")
   return()
@@ -26,6 +27,7 @@ endif()
 
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
 
 # gcc and clang reject -fstack-clash-protection outright where unsupported.
 foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
@@ -43,10 +45,11 @@ add_link_options("-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
 
 # Ubuntu 24.04 and others default to level 3; pinning the report's 2 would remove
 # fortification. Probed under -Werror so level-2-only toolchains fall back.
+cmake_push_check_state(RESET)
 set(CMAKE_REQUIRED_FLAGS "-Werror -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
 check_cxx_source_compiles("#include <string.h>\nint main(void) { return 0; }"
   CLR_HAVE_fortify_source_3)
-unset(CMAKE_REQUIRED_FLAGS)
+cmake_pop_check_state()
 if(CLR_HAVE_fortify_source_3)
   set(_clr_fortify_level 3)
 else()

--- a/projects/clr/cmake/CLRHardening.cmake
+++ b/projects/clr/cmake/CLRHardening.cmake
@@ -2,12 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Binary hardening mitigations for the CLR host runtime.
-#
-# Included at directory scope from the top-level CMakeLists.txt so that rocclr,
-# hipamd and opencl inherit them. Device code is produced by explicit clang
-# invocations in add_custom_command(), so these host flags do not reach offload
-# compilation.
+# Included at directory scope so rocclr, hipamd and opencl inherit the policy.
 
 include_guard()
 
@@ -18,17 +13,12 @@ if(NOT CLR_ENABLE_HARDENING)
   return()
 endif()
 
-# Everything below is GCC/Clang driver and ELF linker syntax. UNIX is the proxy
-# for that: on Windows CLR builds with MSVC or clang-cl, which reject it.
+# GCC/Clang driver and ELF linker syntax, which MSVC and clang-cl reject.
 if(NOT UNIX)
   return()
 endif()
 
-# Sanitizers replace the allocator and stack layout these mitigations rely on,
-# and report false positives when combined with FORTIFY_SOURCE.
-# ENABLE_ADDRESS_SANITIZER is the opencl subtree's own switch for the same
-# thing. Any truthy value disables, so that a sanitizer added later does not
-# silently inherit a conflicting configuration.
+# FORTIFY_SOURCE reports false positives under sanitizers.
 if(ADDRESS_SANITIZER OR THEROCK_SANITIZER OR ENABLE_ADDRESS_SANITIZER)
   message(STATUS "CLR hardening: disabled for sanitizer build")
   return()
@@ -37,9 +27,7 @@ endif()
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
-# Compile flags are probed because an unsupported one is a hard error on every
-# translation unit: clang and gcc reject -fstack-clash-protection outright on
-# targets that do not implement it.
+# gcc and clang reject -fstack-clash-protection outright where unsupported.
 foreach(_clr_hardening_flag -fstack-protector-strong -fstack-clash-protection)
   string(MAKE_C_IDENTIFIER "CLR_HAVE${_clr_hardening_flag}" _clr_hardening_var)
   check_cxx_compiler_flag("${_clr_hardening_flag}" ${_clr_hardening_var})
@@ -50,15 +38,11 @@ endforeach()
 
 unset(_clr_hardening_var)
 
-# Every ELF linker used for ROCm (GNU ld, lld, mold) accepts these. Deliberately
-# not probed: an unsupported -z keyword is warned about and ignored rather than
-# rejected, so a link probe would succeed either way.
+# Not probed: linkers warn and ignore an unknown -z keyword, so a probe passes either way.
 add_link_options("-Wl,-z,relro,-z,now" "-Wl,-z,noexecstack")
 
-# Distributions such as Ubuntu 24.04 already default to level 3, so pinning the
-# level 2 named in the report would remove fortification rather than add it.
-# Probe the real construct under -Werror so that a compiler or C library
-# implementing only level 2 falls back instead of warning on every file.
+# Ubuntu 24.04 and others default to level 3; pinning the report's 2 would remove
+# fortification. Probed under -Werror so level-2-only toolchains fall back.
 set(CMAKE_REQUIRED_FLAGS "-Werror -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
 check_cxx_source_compiles("#include <string.h>\nint main(void) { return 0; }"
   CLR_HAVE_fortify_source_3)
@@ -69,9 +53,8 @@ else()
   set(_clr_fortify_level 2)
 endif()
 
-# FORTIFY_SOURCE needs an optimizing build; at -O0 the C library warns, and
-# hipamd compiles with -Werror. Undefining first keeps toolchains that already
-# predefine it from warning about the redefinition.
+# Needs an optimizing build, and hipamd compiles with -Werror. Undefine first so
+# toolchains that predefine it do not warn.
 add_compile_options(
   "$<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>"
   "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=${_clr_fortify_level}>")


### PR DESCRIPTION
## Motivation

`projects/clr` builds with no binary hardening — no stack protection,
`FORTIFY_SOURCE`, full RELRO or non-executable stack — which amplifies the impact of
any memory-safety defect in the HIP runtime. Found by static scan SEC-00951.

## Technical Details

Adds `projects/clr/cmake/CLRHardening.cmake`, included once from the top-level
`CMakeLists.txt` so `rocclr`, `hipamd` and `opencl` share one policy. On Linux it
enables `-fstack-protector-strong`, `-fstack-clash-protection`, `-D_FORTIFY_SOURCE`,
`-Wl,-z,relro,-z,now`, `-Wl,-z,noexecstack` and `CMAKE_POSITION_INDEPENDENT_CODE`.

Flags are probed before use. Returns early on Windows and for sanitizer builds; opt
out with `-DCLR_ENABLE_HARDENING=OFF`. The `FORTIFY_SOURCE` level is probed rather
than pinned at 2, since Ubuntu 24.04 already defaults to 3 and pinning 2 removed
`__*_chk` symbols. TheRock's super-project equivalent is ROCM-26888.

## Issue Tracking

JIRA ID: ROCM-27255

## Test Plan

Built CLR on Ubuntu 24.04 / GCC 13.3 hardened and with `-DCLR_ENABLE_HARDENING=OFF`;
configured on Windows MSVC 2022 with and without the change.

## Test Result

`libamdhip64.so` and `libhiprtc.so` gain BIND_NOW and keep RELRO, NX, canaries and
fortify symbols, with no new compiler warnings versus baseline. Windows generated
build files are unchanged apart from the new configure dependency. NVIDIA and
`BUILD_SHARED_LIBS=OFF` left to CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.