### PR TITLE
feat(ci): bump TheRock hash to `fb14a70` 2026-08-17

### DIFF
--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 56d538e3e6371499576bcdbe5fc5f84fddfd59d4 # 2026-08-12
+          ref: fb14a700643db761b8d0d675dddb5ffb27772cee # 2026-08-17
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
feat(ci): bump TheRock hash to `fb14a70` 2026-08-17

Picks up ROCm/TheRock#7425, which fixes the non-relocatable `rocm_sysdeps`
zlib.pc that broke the rocprofiler-compute native tool build on the Aug 17
nightly (ROCm/TheRock#7424).