### PR TITLE
ci(rocprofiler-systems): Update clang-tidy workflow

### DIFF
--- a/.github/workflows/rocprofiler-systems-clang-tidy.yml
+++ b/.github/workflows/rocprofiler-systems-clang-tidy.yml
@@ -65,6 +65,6 @@ jobs:
         run: |
           python3 scripts/clang-tidy-check.py \
             --base "origin/${{ github.base_ref }}" \
-            --build-path build/debug \
+            --build-path build/mpi-debug \
             -j $(nproc) \
             --timeout 120

--- a/.github/workflows/rocprofiler-systems-clang-tidy.yml
+++ b/.github/workflows/rocprofiler-systems-clang-tidy.yml
@@ -50,15 +50,15 @@ jobs:
 
       - name: Install clang-tidy
         run: |
-          apt-get update
-          apt-get install -y clang-tidy-18
+          python3 -m pip install --break-system-packages clang-tidy==22.1.8
+          clang-tidy --version
 
       - name: CMake configure
         working-directory: projects/rocprofiler-systems
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$PWD"
-          cmake --preset debug
+          cmake --preset debug-mpi
 
       - name: Run clang-tidy-check
         working-directory: projects/rocprofiler-systems
@@ -67,5 +67,4 @@ jobs:
             --base "origin/${{ github.base_ref }}" \
             --build-path build/debug \
             -j $(nproc) \
-            --timeout 120 \
-            --clang-tidy-binary clang-tidy-18
+            --timeout 120

--- a/.github/workflows/rocprofiler-systems-clang-tidy.yml
+++ b/.github/workflows/rocprofiler-systems-clang-tidy.yml
@@ -65,6 +65,6 @@ jobs:
         run: |
           python3 scripts/clang-tidy-check.py \
             --base "origin/${{ github.base_ref }}" \
-            --build-path build/mpi-debug \
+            --build-path build/debug-mpi \
             -j $(nproc) \
             --timeout 120

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -78,7 +78,7 @@
             "description": "Debug build with MPI support",
             "displayName": "Debug build with MPI",
             "inherits": "debug",
-            "name": "mpi-debug"
+            "name": "debug-mpi"
         },
         {
             "binaryDir": "${sourceDir}/build/mpi-release",
@@ -88,7 +88,7 @@
             "description": "Release build with MPI support",
             "displayName": "Release build with MPI",
             "inherits": "release",
-            "name": "mpi-release"
+            "name": "release-mpi"
         },
         {
             "binaryDir": "${sourceDir}/build/coverage",

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -71,6 +71,26 @@
             "name": "release"
         },
         {
+            "binaryDir": "${sourceDir}/build/mpi-debug",
+            "cacheVariables": {
+                "ROCPROFSYS_USE_MPI": "ON"
+            },
+            "description": "Debug build with MPI support",
+            "displayName": "Debug build with MPI",
+            "inherits": "debug",
+            "name": "mpi-debug"
+        },
+        {
+            "binaryDir": "${sourceDir}/build/mpi-release",
+            "cacheVariables": {
+                "ROCPROFSYS_USE_MPI": "ON"
+            },
+            "description": "Release build with MPI support",
+            "displayName": "Release build with MPI",
+            "inherits": "release",
+            "name": "mpi-release"
+        },
+        {
             "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -71,7 +71,7 @@
             "name": "release"
         },
         {
-            "binaryDir": "${sourceDir}/build/mpi-debug",
+            "binaryDir": "${sourceDir}/build/debug-mpi",
             "cacheVariables": {
                 "ROCPROFSYS_USE_MPI": "ON"
             },
@@ -81,7 +81,7 @@
             "name": "debug-mpi"
         },
         {
-            "binaryDir": "${sourceDir}/build/mpi-release",
+            "binaryDir": "${sourceDir}/build/release-mpi",
             "cacheVariables": {
                 "ROCPROFSYS_USE_MPI": "ON"
             },


### PR DESCRIPTION
## Motivation

Update version of `clang-tidy` used in workflow. Configure project with `ROCPROFSYS_USE_MPI` to improve coverage.

## Technical Details

- Install `clang-tidy==22.1.8`.
- Using `pip install` because it's easier to select a specific version.
- Add `release-mpi` and `debug-mpi` presets to `CMakePresets.json`

## Issue Tracking

JIRA ID: AIPROFSYST-496

## Test Plan

Run new workflows (locally and on runners)

## Test Result

Workflows pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
