### PR TITLE
[rocjitsu] add XcdShard round-robin grid sharding primitive

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd_shard.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd_shard.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_XCD_SHARD_H_
+#define ROCJITSU_VM_AMDGPU_XCD_SHARD_H_
+
+/// @file xcd_shard.h
+/// @brief Round-robin split of an ordinal range across a participating set.
+
+#include <cassert>
+#include <cstdint>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief One member's share of an ordinal range split round-robin.
+///
+/// @details A partitioning primitive over abstract chunk ordinals: given a
+/// participating set of @c stride members, the member at @c rank owns exactly
+/// the ordinals congruent to its rank modulo the stride. It knows nothing about
+/// what a chunk is and imposes no policy about who participates.
+///
+/// The permutation is part of the contract, not just the even split: kernel
+/// libraries ship a chunk-index swizzle for cache locality (the
+/// `chunk % participants` remap) that assumes consecutive ordinals are
+/// distributed this way.
+///
+/// Rank is the index *within the participating set*. It is deliberately neither
+/// a SoC-global XCD id nor an engine partition id; a caller that partitions a
+/// subset of a device maps rank back to whatever hardware it stands for.
+///
+/// The chunk is likewise the caller's unit, and choosing it is dispatch policy
+/// that does not belong to this type. For a clustered dispatch the two obvious
+/// choices disagree: workgroups 0 and 1 of a 2-wide cluster must share a
+/// destination, while an ordinal mapping over workgroups would separate them.
+///
+/// Callers walk their share by shard-local index: iterate @c i over
+/// `[0, owned_chunks(total))` and map each through nth_owned_chunk(). Do not
+/// step a grid-wide ordinal by the stride instead — on a maximal range that
+/// addition wraps back to a low ordinal, whereas the shard-local count cannot
+/// run past the end.
+///
+/// Any stride >= 1 is valid and need not be a power of two; the topologies under
+/// configs/ use eight. Both fields are plain counts rather than, say, a log2
+/// stride: the arithmetic below is a division and a multiply, not a mask,
+/// precisely so that a non-power-of-two stride works.
+///
+/// A default-constructed shard is unsharded and owns every ordinal, which is
+/// what a caller that is not splitting anything gets.
+class XcdShard {
+public:
+  XcdShard() = default;
+
+  /// @brief Construct a shard for one member of a participating set.
+  /// @param rank This member's index within the set; must be < @p stride.
+  /// @param stride Number of participating members; must be >= 1.
+  XcdShard(uint32_t rank, uint32_t stride) : rank_(rank), stride_(stride) {
+    assert(stride_ >= 1 && "shard stride is a count of participants and must be at least one");
+    assert(rank_ < stride_ && "shard rank is a set index and must be below the stride");
+  }
+
+  [[nodiscard]] uint32_t rank() const { return rank_; }
+  [[nodiscard]] uint32_t stride() const { return stride_; }
+
+  /// @returns True when nothing is being split, so this shard owns every
+  /// ordinal. This asks about the shard, not about coverage of a particular
+  /// range: a shard of a one-chunk range may own that whole range and still
+  /// answer false. A shard with no participants is not unsharded either — it is
+  /// invalid, and reports so rather than claiming the range.
+  [[nodiscard]] bool is_unsharded() const { return stride_ == 1; }
+
+  /// @brief Count the chunks this shard owns.
+  /// @param total_chunks Chunk count of the whole range.
+  /// @returns Number of chunks owned by this shard, possibly zero when the range
+  /// has fewer chunks than participating members.
+  [[nodiscard]] uint32_t owned_chunks(uint32_t total_chunks) const {
+    // A zero stride violates the constructor's contract, which the assertions
+    // catch in a debug build. They compile out of a release build, so own
+    // nothing rather than divide by zero. Failing closed keeps the invalid shard
+    // identifiable through rank()/stride(); rewriting it to the unsharded shard
+    // would instead hand a caller the entire range on the strength of a bug.
+    if (stride_ == 0 || rank_ >= total_chunks)
+      return 0;
+    // Quotient/remainder rather than the usual (n + stride - 1) / stride: with a
+    // maximal grid that addition wraps in 32 bits and silently reports zero
+    // chunks, dropping almost the entire grid.
+    const uint32_t remaining = total_chunks - rank_;
+    return remaining / stride_ + (remaining % stride_ != 0 ? 1u : 0u);
+  }
+
+  /// @brief Map a shard-local chunk index to its grid-wide chunk ordinal.
+  /// @param shard_chunk_index Zero-based index within this shard's own chunks,
+  /// which is to say below owned_chunks() for the range being walked.
+  /// @returns The grid-wide chunk ordinal.
+  [[nodiscard]] uint32_t nth_owned_chunk(uint32_t shard_chunk_index) const {
+    return rank_ + shard_chunk_index * stride_;
+  }
+
+private:
+  uint32_t rank_ = 0;
+  uint32_t stride_ = 1;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_XCD_SHARD_H_

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -404,6 +404,7 @@ add_executable(
     matmul_test.cpp
     vector_add_test.cpp
     xcd_distribution_test.cpp
+    xcd_shard_test.cpp
     cdna5_architecture_test.cpp
     cdna5_cluster_test.cpp
     cdna5_dispatch_memory_test.cpp

--- a/emulation/rocjitsu/tests/xcd_shard_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_shard_test.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file xcd_shard_test.cpp
+/// @brief Round-robin splitting of an ordinal range across a participating set.
+
+#include "rocjitsu/vm/amdgpu/xcd_shard.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <set>
+#include <vector>
+
+namespace {
+
+using rocjitsu::amdgpu::XcdShard;
+
+/// Enumerate every grid-wide chunk ordinal owned by @p shard.
+std::vector<uint32_t> owned_ordinals(XcdShard shard, uint32_t total_chunks) {
+  std::vector<uint32_t> ordinals;
+  for (uint32_t i = 0; i < shard.owned_chunks(total_chunks); ++i)
+    ordinals.push_back(shard.nth_owned_chunk(i));
+  return ordinals;
+}
+
+} // namespace
+
+TEST(XcdShardTest, DefaultShardIsUnshardedAndOwnsEveryOrdinal) {
+  XcdShard shard;
+  EXPECT_EQ(shard.rank(), 0u);
+  EXPECT_EQ(shard.stride(), 1u);
+  EXPECT_TRUE(shard.is_unsharded());
+  EXPECT_EQ(shard.owned_chunks(256), 256u);
+  EXPECT_EQ(shard.nth_owned_chunk(0), 0u);
+  EXPECT_EQ(shard.nth_owned_chunk(255), 255u);
+}
+
+// The predicate asks whether anything is being split, which is not the same
+// question as whether this shard happens to cover the range it is asked about.
+// A one-chunk range is the case that separates them: rank 0 owns all of it and
+// rank 1 owns none, yet neither is unsharded.
+TEST(XcdShardTest, IsUnshardedAsksAboutTheShardNotItsCoverage) {
+  EXPECT_TRUE(XcdShard(0, 1).is_unsharded());
+  EXPECT_FALSE(XcdShard(0, 8).is_unsharded());
+  EXPECT_FALSE(XcdShard(7, 8).is_unsharded());
+
+  EXPECT_EQ(XcdShard(0, 8).owned_chunks(1), 1u);
+  EXPECT_EQ(XcdShard(1, 8).owned_chunks(1), 0u);
+  EXPECT_FALSE(XcdShard(0, 8).is_unsharded());
+  EXPECT_FALSE(XcdShard(1, 8).is_unsharded());
+}
+
+// The permutation is the contract, not just the split: a caller that swizzles
+// its chunk index for locality assumes chunk c belongs to the member at
+// c % participants. What that member stands for is the caller's business.
+TEST(XcdShardTest, ChunkOrdinalMapsToRankModuloStride) {
+  constexpr uint32_t kStride = 8;
+  constexpr uint32_t kTotalChunks = 256;
+
+  for (uint32_t rank = 0; rank < kStride; ++rank) {
+    XcdShard shard{rank, kStride};
+    for (uint32_t ordinal : owned_ordinals(shard, kTotalChunks))
+      ASSERT_EQ(ordinal % kStride, rank) << "rank " << rank << " ordinal " << ordinal;
+  }
+}
+
+TEST(XcdShardTest, ShardsPartitionTheGridExactly) {
+  constexpr uint32_t kStride = 8;
+
+  // Include grids that do not divide evenly and grids smaller than the stride.
+  for (uint32_t total_chunks : {0u, 1u, 7u, 8u, 9u, 100u, 256u}) {
+    std::multiset<uint32_t> seen;
+    uint32_t summed = 0;
+    for (uint32_t rank = 0; rank < kStride; ++rank) {
+      XcdShard shard{rank, kStride};
+      summed += shard.owned_chunks(total_chunks);
+      for (uint32_t ordinal : owned_ordinals(shard, total_chunks))
+        seen.insert(ordinal);
+    }
+
+    EXPECT_EQ(summed, total_chunks) << "total_chunks " << total_chunks;
+    ASSERT_EQ(seen.size(), total_chunks) << "total_chunks " << total_chunks;
+    for (uint32_t ordinal = 0; ordinal < total_chunks; ++ordinal)
+      EXPECT_EQ(seen.count(ordinal), 1u) << "ordinal " << ordinal << " of " << total_chunks;
+  }
+}
+
+// A range with fewer chunks than participants leaves the high-rank shards
+// empty. What a caller does with an empty share is its own policy; this type
+// only promises the count.
+TEST(XcdShardTest, ShardSmallerThanStrideLeavesHighRanksEmpty) {
+  constexpr uint32_t kStride = 8;
+  constexpr uint32_t kTotalChunks = 3;
+
+  for (uint32_t rank = 0; rank < kTotalChunks; ++rank)
+    EXPECT_EQ(XcdShard(rank, kStride).owned_chunks(kTotalChunks), 1u) << "rank " << rank;
+  for (uint32_t rank = kTotalChunks; rank < kStride; ++rank)
+    EXPECT_EQ(XcdShard(rank, kStride).owned_chunks(kTotalChunks), 0u) << "rank " << rank;
+}
+
+TEST(XcdShardTest, UnevenGridDistributesRemainderToLowRanks) {
+  constexpr uint32_t kStride = 8;
+  constexpr uint32_t kTotalChunks = 100; // 12 each, remainder 4
+
+  for (uint32_t rank = 0; rank < 4; ++rank)
+    EXPECT_EQ(XcdShard(rank, kStride).owned_chunks(kTotalChunks), 13u) << "rank " << rank;
+  for (uint32_t rank = 4; rank < kStride; ++rank)
+    EXPECT_EQ(XcdShard(rank, kStride).owned_chunks(kTotalChunks), 12u) << "rank " << rank;
+}
+
+// A maximal grid must not wrap. The usual (n + stride - 1) / stride ceiling
+// overflows uint32 here and reports zero chunks, which would silently drop
+// almost the entire grid rather than fail loudly.
+TEST(XcdShardTest, MaximalGridDoesNotOverflow) {
+  constexpr uint32_t kMax = std::numeric_limits<uint32_t>::max();
+  constexpr uint32_t kStride = 8;
+
+  EXPECT_EQ(XcdShard(0, kStride).owned_chunks(kMax), 536870912u);
+
+  // The shares of a maximal grid still partition it exactly.
+  uint64_t summed = 0;
+  for (uint32_t rank = 0; rank < kStride; ++rank)
+    summed += XcdShard(rank, kStride).owned_chunks(kMax);
+  EXPECT_EQ(summed, static_cast<uint64_t>(kMax));
+
+  // Counting correctly is only half of it: the mapper multiplies the shard-local
+  // index by the stride, which is the other place a maximal grid can wrap. Pin
+  // the largest ordinal each rank produces against the same arithmetic done in
+  // 64 bits, without enumerating four billion chunks. Rank 0 ends at 4294967288.
+  EXPECT_EQ(XcdShard(0, kStride).nth_owned_chunk(536870911u), 4294967288u);
+  for (uint32_t rank = 0; rank < kStride; ++rank) {
+    XcdShard shard{rank, kStride};
+    const uint64_t owned = shard.owned_chunks(kMax);
+    ASSERT_GT(owned, 0u) << "rank " << rank;
+    const uint64_t expected = uint64_t{rank} + (owned - 1) * uint64_t{kStride};
+    EXPECT_LT(expected, uint64_t{kMax}) << "rank " << rank;
+    EXPECT_EQ(shard.nth_owned_chunk(static_cast<uint32_t>(owned - 1)), expected) << "rank " << rank;
+  }
+}
+
+// Stride is a count of participants, so non-power-of-two splits have to work;
+// nothing here may assume a maskable stride.
+//
+// Counts alone are too weak to catch a mapping regression, and every exact
+// permutation check above uses stride 8. Stepping ordinals by 2 instead of by
+// the stride would leave the summed count at 13 for stride 3 while duplicating
+// 2, 4, 6 and 8 and omitting 9 through 12 -- so enumerate the ordinals here and
+// require each one in [0, total) exactly once.
+//
+// Exact coverage alone is still not the round-robin contract: contiguous rank
+// windows also cover [0, total) exactly once. Each ordinal must land on the rank
+// congruent to it, or a stride could quietly switch from round-robin to slices.
+TEST(XcdShardTest, NonPowerOfTwoStridePartitionsExactly) {
+  for (uint32_t stride : {1u, 3u, 5u, 6u, 7u, 12u}) {
+    for (uint32_t total : {0u, 1u, 13u, 100u, 1024u}) {
+      std::multiset<uint32_t> seen;
+      uint64_t summed = 0;
+      for (uint32_t rank = 0; rank < stride; ++rank) {
+        XcdShard shard{rank, stride};
+        summed += shard.owned_chunks(total);
+        for (uint32_t ordinal : owned_ordinals(shard, total)) {
+          ASSERT_EQ(ordinal % stride, rank)
+              << "ordinal " << ordinal << " stride " << stride << " rank " << rank;
+          seen.insert(ordinal);
+        }
+      }
+
+      EXPECT_EQ(summed, total) << "stride " << stride << " total " << total;
+      ASSERT_EQ(seen.size(), total) << "stride " << stride << " total " << total;
+      for (uint32_t ordinal = 0; ordinal < total; ++ordinal)
+        EXPECT_EQ(seen.count(ordinal), 1u)
+            << "ordinal " << ordinal << " stride " << stride << " total " << total;
+    }
+  }
+}


### PR DESCRIPTION
Spreading one dispatch over several XCDs needs a rule for which XCD owns which workgroup. The grid is walked round-robin one chunk at a time, and the workgroup-index swizzles that kernels apply for cache locality assume that exact permutation, so the mapping is part of the contract rather than an implementation detail.

Add XcdShard{rank, stride} with owned_chunks() and nth_owned_chunk(). The chunk is one workgroup, or one cluster for a clustered dispatch so peers stay co-resident on the XCD whose LDS they share. The default {0, 1} owns the whole grid, which is what a queue serviced by a single command processor gets. No caller yet; this commit is the primitive and its tests.