### PR TITLE
[rocjitsu] walk the dispatch grid through the entry's shard

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1349,9 +1349,6 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
   };
 
   while (entry.dispatched_wgs < entry.total_wgs) {
-    uint32_t local_wg_id = entry.dispatched_wgs;
-    uint32_t global_wg_id = local_wg_id + entry.workgroup_id_offset;
-
     if (entry.has_workgroup_clusters()) {
       assert(!entry.wgp_mode && "workgroup clusters are gfx1250-only and use CU mode");
       // The SPI interface chooses one WG at a time and cannot reserve all peers
@@ -1362,8 +1359,10 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
              "clustered dispatch advances by whole clusters");
       assert(entry.total_wgs - entry.dispatched_wgs >= cluster_size &&
              "validate_cluster_shape guarantees a complete trailing cluster");
-      uint32_t cluster_ordinal = entry.dispatched_wgs / cluster_size;
-      local_wg_id = entry.cluster_base_local_wg_id_for_ordinal(cluster_ordinal);
+      // dispatched_wgs counts workgroups; the chunk here is a whole cluster, so
+      // convert to a cluster index before asking the shard for its ordinal.
+      uint32_t cluster_ordinal = entry.chunk_ordinal_for(entry.dispatched_wgs / cluster_size);
+      uint32_t local_wg_id = entry.cluster_base_local_wg_id_for_ordinal(cluster_ordinal);
       std::vector<PlannedWorkgroup> plan;
       size_t planned_next_cu = next_cu_;
       if (!plan_cluster_workgroups(entry, local_wg_id, next_cu_, cus_, plan, planned_next_cu)) {
@@ -1404,6 +1403,12 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       }
       continue;
     }
+
+    // Unclustered: the chunk is a single workgroup, so dispatched_wgs indexes
+    // the shard's chunks directly and the shard maps that to a grid-wide id.
+    // An unsharded entry maps the ordinal to itself.
+    uint32_t local_wg_id = entry.chunk_ordinal_for(entry.dispatched_wgs);
+    uint32_t global_wg_id = local_wg_id + entry.workgroup_id_offset;
 
     // SPI selects the CU or sibling-CU WGP based on descriptor mode and
     // resource availability.
@@ -1479,7 +1484,7 @@ void CommandProcessor::on_cu_idle() {
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
-  // Retire any non-kernel entries (barriers with total_wgs==0) that are now at
+  // Retire any non-kernel entries (barrier-kind packets) that are now at
   // the head, then drain again so a dependent kernel behind them can proceed.
   for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
     if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
@@ -1630,6 +1635,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.aql_packet_id = static_cast<uint32_t>(aql_packet_id);
   dp.kernel_entry_pc = entry_pc;
   dp.total_wgs = total_wgs;
+  dp.kind = DispatchPacketKind::Kernel;
   dp.dispatched_wgs = 0;
   dp.completed_wgs = 0;
   dp.wfs_per_workgroup = wfs_per_wg;
@@ -2031,6 +2037,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
           .queue_id = queue.queue_id,
           .process_id = queue.process_id,
           .completion_signal = sig,
+          .kind = DispatchPacketKind::NonKernel,
           .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
       };
 
@@ -2086,6 +2093,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = barrier.completion_signal.handle,
+            .kind = DispatchPacketKind::NonKernel,
             .barrier_bit = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
@@ -2146,6 +2154,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = sig,
+            .kind = DispatchPacketKind::NonKernel,
             .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
@@ -2307,7 +2316,7 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
   // immediately so host signal waits see completed barriers before returning.
   for (size_t i = 0; i < hw_queues_.size(); ++i)
     fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
-  // Process any new non-kernel entries (barriers with total_wgs==0).
+  // Process any new non-kernel entries (barrier-kind packets).
   for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
     if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
       continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -12,6 +12,8 @@
 /// independently. Completion signals fire when all WGs of a dispatch finish,
 /// in per-queue submission order.
 
+#include "rocjitsu/vm/amdgpu/xcd_shard.h"
+
 #include <cassert>
 #include <cstdint>
 #include <deque>
@@ -38,6 +40,20 @@ struct ClusterDispatchShape {
   uint32_t size_x = 1;
   uint32_t size_y = 1;
   uint32_t size_z = 1;
+};
+
+/// @brief What a queue entry carries, which decides how it retires.
+enum class DispatchPacketKind : uint8_t {
+  /// @brief Never a valid kind for an entry that has been queued.
+  ///
+  /// @details The default exists so that forgetting to set the kind trips the
+  /// assertion in @ref DispatchEntry::is_non_kernel rather than silently
+  /// retiring a kernel as though it were a barrier.
+  Unset = 0,
+  /// @brief An AQL kernel dispatch, even when this entry's share of it is empty.
+  Kernel,
+  /// @brief A packet that runs no shader: barrier, barrier-value, PM4 IB.
+  NonKernel,
 };
 
 /// @brief Per-dispatch tracking entry created by the AQL Packet Processor.
@@ -97,6 +113,12 @@ struct DispatchEntry {
   uint32_t private_segment_fixed_size = 0;
   uint32_t group_segment_fixed_size = 0;
 
+  /// This entry's share of the grid. The default owns all of it.
+  XcdShard shard{};
+
+  /// Workgroups this entry is responsible for: the whole grid for an unsharded
+  /// entry, otherwise this shard's share. dispatched_wgs and completed_wgs count
+  /// against it, so an entry retires when its own share is done.
   uint32_t total_wgs = 0;
   uint32_t dispatched_wgs = 0;
   uint32_t completed_wgs = 0;
@@ -110,16 +132,27 @@ struct DispatchEntry {
   /// timestamp on every kernel dispatch because non-profiled signals ignore the
   /// fields, and this keeps HIP/MIOpen event timing consistent for guest queues.
   uint64_t profiling_start_timestamp = 0;
+  /// What this entry carries. Every site that queues an entry must set it.
+  DispatchPacketKind kind = DispatchPacketKind::Unset;
   bool host_signal = false;
   bool barrier_bit = false;
   bool execution_begun = false;
 
   bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }
   bool fully_completed() const { return completed_wgs >= total_wgs; }
-  bool is_non_kernel() const { return total_wgs == 0; }
+  /// @returns True for packets that run no shader at all (barrier, barrier-value,
+  /// PM4 IB). Deliberately a stored kind rather than `total_wgs == 0`: a kernel
+  /// dispatch split across XCDs can legitimately leave one XCD an empty share,
+  /// and inferring the kind from the count would retire that kernel as though it
+  /// were a barrier and fire its completion signal early.
+  bool is_non_kernel() const {
+    assert(kind != DispatchPacketKind::Unset && "queued entry never had its packet kind set");
+    return kind != DispatchPacketKind::Kernel;
+  }
 
   uint32_t cluster_size() const { return cluster_size_x * cluster_size_y * cluster_size_z; }
   bool has_workgroup_clusters() const { return cluster_size() > 1; }
+
   bool cluster_grid_is_complete() const {
     return static_cast<uint64_t>(cluster_count_x) * cluster_size_x == grid_wgs_x &&
            static_cast<uint64_t>(cluster_count_y) * cluster_size_y == grid_wgs_y &&
@@ -188,6 +221,58 @@ struct DispatchEntry {
     base.y = cluster_coord.y * cluster_size_y;
     base.z = cluster_coord.z * cluster_size_z;
     return flatten_local_wg_coord(base);
+  }
+
+  /// @brief Chunk the grid walk advances by: a cluster, else a single workgroup.
+  uint32_t dispatch_chunk_wgs() const { return has_workgroup_clusters() ? cluster_size() : 1u; }
+
+  /// @brief Grid-wide chunk ordinal for this entry's @p shard_chunk_index -th chunk.
+  ///
+  /// @details The input is shard-local -- an index into this entry's own share,
+  /// counted from zero on every XCD -- and the result is grid-wide. The shard
+  /// cannot check the bound itself, since it knows the stride but not this
+  /// entry's share size, so an off-by-one or a workgroup-versus-cluster unit
+  /// mix-up would otherwise return an ordinal outside the grid and place a
+  /// workgroup that does not exist. Bound it here, where the share size is known.
+  /// @param shard_chunk_index Zero-based chunk index within this entry's share.
+  /// @returns The chunk's ordinal in the whole grid.
+  uint32_t chunk_ordinal_for(uint32_t shard_chunk_index) const {
+    assert(static_cast<uint64_t>(shard_chunk_index) * dispatch_chunk_wgs() < total_wgs &&
+           "chunk index is shard-local and must lie within this entry's share");
+    return shard.nth_owned_chunk(shard_chunk_index);
+  }
+
+  /// @brief Narrow this entry to one XCD's share of the grid it currently holds.
+  ///
+  /// @details Reads the grid size from this entry's own total_wgs and rewrites it
+  /// to the share @p xcd_shard owns, so the existing dispatch and retirement
+  /// bookkeeping operates on the share. The grid size is not passed in: a caller
+  /// supplying a mismatched value would silently desynchronize total_wgs from the
+  /// coordinate extents.
+  ///
+  /// Retirement contract: once a packet is split, per-entry retirement is NOT
+  /// packet retirement. An entry retiring means only that one XCD finished its
+  /// share, so the code that splits a packet is responsible for aggregating the
+  /// shares and for leaving completion_signal on exactly one entry -- otherwise
+  /// the signal fires once per share, and fires when the first XCD finishes.
+  /// The dispatch-level callbacks are the same problem in a second place: every
+  /// share reaches drain_completions() and would emit its own execution-end,
+  /// while a share with no workgroups never emits a matching begin. One matched
+  /// begin/end pair is owed per packet, not per share.
+  /// Nothing in this commit splits a packet; the fan-out change adds both.
+  ///
+  /// @param xcd_shard The shard to apply. Applying twice is rejected: the second
+  /// call would re-shard an already narrowed entry.
+  void apply_shard(XcdShard xcd_shard) {
+    assert(dispatched_wgs == 0 && "shard must be applied before dispatching");
+    assert(shard.is_unsharded() && "entry has already been sharded");
+    const uint32_t grid_wgs = total_wgs;
+    const uint32_t chunk = dispatch_chunk_wgs();
+    assert(chunk == 1 || (cluster_grid_is_complete() && grid_wgs % chunk == 0 &&
+                          "a clustered grid must tile exactly, or the truncated tail is dropped "
+                          "from every shard and the grid can never retire"));
+    shard = xcd_shard;
+    total_wgs = xcd_shard.owned_chunks(grid_wgs / chunk) * chunk;
   }
 
   uint32_t cluster_peer_local_wg_id(uint32_t local_wg_id, uint32_t rank) const {

--- a/emulation/rocjitsu/tests/xcd_shard_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_shard_test.cpp
@@ -4,6 +4,7 @@
 /// @file xcd_shard_test.cpp
 /// @brief Round-robin splitting of an ordinal range across a participating set.
 
+#include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/xcd_shard.h"
 
 #include <gtest/gtest.h>
@@ -15,6 +16,7 @@
 
 namespace {
 
+using rocjitsu::amdgpu::DispatchEntry;
 using rocjitsu::amdgpu::XcdShard;
 
 /// Enumerate every grid-wide chunk ordinal owned by @p shard.
@@ -174,4 +176,93 @@ TEST(XcdShardTest, NonPowerOfTwoStridePartitionsExactly) {
             << "ordinal " << ordinal << " stride " << stride << " total " << total;
     }
   }
+}
+
+// A dispatch entry walks its own share: dispatched_wgs indexes into the shard,
+// and chunk_ordinal_for maps that back to a grid-wide ordinal.
+TEST(XcdShardTest, EntryWalksItsOwnShareOfTheGrid) {
+  constexpr uint32_t kStride = 8;
+  constexpr uint32_t kGridWgs = 256;
+
+  std::multiset<uint32_t> seen;
+  for (uint32_t rank = 0; rank < kStride; ++rank) {
+    DispatchEntry entry;
+    entry.grid_wgs_x = kGridWgs;
+    entry.total_wgs = kGridWgs;
+    entry.apply_shard(XcdShard(rank, kStride));
+    EXPECT_EQ(entry.total_wgs, kGridWgs / kStride) << "rank " << rank;
+
+    for (uint32_t i = 0; i < entry.total_wgs; ++i) {
+      uint32_t wg = entry.chunk_ordinal_for(i);
+      ASSERT_EQ(wg % kStride, rank) << "rank " << rank << " wg " << wg;
+      seen.insert(wg);
+    }
+  }
+  // Size alone would still pass if some ordinals were duplicated and others
+  // missing, since the insert count is fixed at kStride * share. Require every
+  // ordinal of the grid exactly once.
+  ASSERT_EQ(seen.size(), kGridWgs);
+  for (uint32_t wg = 0; wg < kGridWgs; ++wg)
+    EXPECT_EQ(seen.count(wg), 1u) << "workgroup " << wg << " not covered exactly once";
+}
+
+// A clustered dispatch shards by whole clusters so cluster peers stay
+// co-resident on the XCD whose LDS they share.
+TEST(XcdShardTest, ClusteredEntryShardsByWholeClusters) {
+  constexpr uint32_t kStride = 8;
+  constexpr uint32_t kClusterSize = 4;
+  constexpr uint32_t kGridWgs = 256;
+
+  DispatchEntry entry;
+  entry.grid_wgs_x = kGridWgs;
+  entry.cluster_size_x = kClusterSize;
+  entry.cluster_count_x = kGridWgs / kClusterSize;
+  // grid_wgs_y and grid_wgs_z default to 1, so their cluster counts must be 1
+  // as well. Leaving them zero makes cluster_grid_is_complete() false and trips
+  // the assertion in apply_shard() under any assertion-enabled build.
+  entry.cluster_count_y = 1;
+  entry.cluster_count_z = 1;
+  entry.total_wgs = kGridWgs;
+  ASSERT_TRUE(entry.cluster_grid_is_complete());
+  ASSERT_EQ(entry.dispatch_chunk_wgs(), kClusterSize);
+
+  entry.apply_shard(XcdShard(3, kStride));
+  EXPECT_EQ(entry.total_wgs, kGridWgs / kStride);
+
+  // Every owned cluster ordinal belongs to this rank, and the workgroups of a
+  // cluster are never split across ranks.
+  for (uint32_t i = 0; i < entry.total_wgs / kClusterSize; ++i)
+    EXPECT_EQ(entry.chunk_ordinal_for(i) % kStride, 3u);
+}
+
+// An unsharded entry must walk the grid exactly as it did before sharding
+// existed: chunk index i is workgroup i.
+TEST(XcdShardTest, UnshardedEntryWalksTheGridUnchanged) {
+  DispatchEntry entry;
+  entry.grid_wgs_x = 100;
+  entry.total_wgs = 100;
+  for (uint32_t i = 0; i < entry.total_wgs; ++i)
+    EXPECT_EQ(entry.chunk_ordinal_for(i), i);
+}
+
+// The reason the packet kind is stored rather than inferred. A grid smaller
+// than the participating set leaves high ranks with nothing to run, and an
+// empty share is exactly what `total_wgs == 0` used to mean for a barrier. The
+// kind has to survive that, or the command processor retires the kernel early
+// and fires a completion signal the grid has not earned.
+TEST(XcdShardTest, EmptyKernelShareIsStillAKernel) {
+  DispatchEntry entry;
+  entry.kind = rocjitsu::amdgpu::DispatchPacketKind::Kernel;
+  entry.grid_wgs_x = 3;
+  entry.total_wgs = 3;
+
+  entry.apply_shard(XcdShard(7, 8));
+  ASSERT_EQ(entry.total_wgs, 0u) << "rank 7 of a 3-chunk grid owns nothing";
+  EXPECT_FALSE(entry.is_non_kernel());
+  EXPECT_TRUE(entry.fully_dispatched());
+  EXPECT_TRUE(entry.fully_completed());
+
+  DispatchEntry barrier;
+  barrier.kind = rocjitsu::amdgpu::DispatchPacketKind::NonKernel;
+  EXPECT_TRUE(barrier.is_non_kernel());
 }


### PR DESCRIPTION
dispatch_workgroups() derived the workgroup id straight from dispatched_wgs, so an entry could only ever mean "the whole grid". Spreading one dispatch over several XCDs needs each participating command processor to walk the same grid but place only its own share.

Give DispatchEntry an XcdShard and take the chunk ordinal from it, for both the workgroup walk and the cluster-ordinal walk. apply_shard() rewrites total_wgs to the share, so the existing dispatch and retirement bookkeeping counts against the share without further change. The default shard owns the whole grid and maps chunk i to i, so every current caller is unaffected; nothing applies a non-default shard yet.