### PR TITLE
[rocjitsu] spread one dispatch across every XCD of the SoC

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -2128,7 +2128,7 @@ int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
   // Queue IDs are process-local and start at one. Equivalent runtime queues in
   // different processes therefore share XCD resources while each process still
   // distributes additional queues across the device.
-  auto *target_cp = gpu->soc->assign_queue_cp(proc.next_queue_id_ - 1);
+  auto *target_cp = gpu->soc->assign_queue_owner_cp(proc.next_queue_id_ - 1);
   if (!target_cp)
     return -EINVAL;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -479,7 +479,12 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
 
     if (memory_ && memory_->resolve_host_ptr(wave_scratch, pkt.process_id) == nullptr &&
         scratch_allocator_) {
-      uint64_t total_scratch = per_wave_size * pkt.total_wgs * waves_per_wg;
+      // Size against the whole grid, not this XCD's share: wave_scratch above is
+      // indexed by the grid-wide workgroup id, so every XCD of a fanned-out
+      // dispatch addresses the same full-size pool. Sizing it from total_wgs would
+      // leave the tail of the grid unbacked and would re-enter the allocator, which
+      // remaps the pool VA and would drop live waves' spill data.
+      uint64_t total_scratch = per_wave_size * pkt.grid_total_wgs() * waves_per_wg;
       scratch_allocator_(pkt.process_id, scratch_pool, static_cast<size_t>(total_scratch));
     }
 
@@ -530,6 +535,7 @@ void CommandProcessor::startup() {
   completion_->set_plugin_group(plugin_group_);
   completion_->set_dispatch_retired_callback(
       [this](const DispatchEntry &entry) { erase_cluster_workgroups(entry.dispatch_id); });
+  completion_->set_grid_retired_callback([this](const DispatchEntry &) { wake_all_xcds(); });
   if (interrupt_cb_)
     completion_->set_interrupt_callback(interrupt_cb_);
 }
@@ -543,6 +549,142 @@ void CommandProcessor::shutdown() {
   completion_.reset();
 }
 
+void CommandProcessor::set_xcd_topology(uint32_t rank, std::vector<CommandProcessor *> peers) {
+  assert(rank < peers.size() && "XCD rank must index its own SoC's CP list");
+  assert(peers[rank] == this && "XCD rank must be this CP's own position");
+  xcd_rank_ = rank;
+  xcd_peers_ = std::move(peers);
+  // Carve this XCD its own dispatch-id space; see allocate_dispatch_id().
+  dispatch_id_stride_ = static_cast<uint32_t>(xcd_peers_.size());
+  dispatch_id_base_ = 1 + rank;
+  next_dispatch_id_ = dispatch_id_base_;
+}
+
+HwQueueState *CommandProcessor::find_queue_state(uint32_t queue_id, uint32_t process_id) {
+  for (size_t i = 0; i < hw_queues_.size(); ++i) {
+    if (hw_queues_[i].queue_id == queue_id && hw_queues_[i].process_id == process_id)
+      return &new_queue_states_[i];
+  }
+  return nullptr;
+}
+
+void CommandProcessor::accept_fanout_shard(DispatchEntry shard) {
+  {
+    util::Logger::cp([&](auto &os) {
+      os << std::format("{}: FANOUT_SHARD d={} rank={}/{} wgs={}", name(), shard.dispatch_id,
+                        shard.shard.rank(), shard.shard.stride(), shard.total_wgs);
+    });
+    // Deliberately NOT hw_queue_mutex_. The caller runs under its own CP's
+    // hw_queue_mutex_ (fan-out happens inside handle_doorbell), so taking a peer's
+    // hw_queue_mutex_ here would let two CPs fanning out concurrently acquire each
+    // other's locks in opposite orders. Nothing that can lead back to another CP's
+    // hw_queue_mutex_ is acquired while holding this one, and it is held only for
+    // the push so a peer's engine thread never blocks on it for long.
+    std::lock_guard<std::mutex> lock(fanout_inbox_mutex_);
+    fanout_inbox_.push_back(std::move(shard));
+  }
+  // Cross-thread and cross-partition safe: the engine buffers the event and drains
+  // it into this CP's partition at its next safe point. Dispatching inline here
+  // would reach into another partition's compute units.
+  if (engine())
+    engine()->schedule_event_now(doorbell_event());
+}
+
+void CommandProcessor::drain_fanout_inbox() {
+  std::vector<DispatchEntry> inbox;
+  {
+    std::lock_guard<std::mutex> lock(fanout_inbox_mutex_);
+    inbox.swap(fanout_inbox_);
+  }
+  // Real work arrived: the next wait this CP takes starts from a tight re-check.
+  // Reset here rather than in accept_fanout_shard(), which runs on the OWNER's
+  // thread -- writing this CP's backoff from there races the reads and writes its
+  // own partition thread makes in arm_stall_recheck(). The shard is not visible to
+  // this CP until it is drained anyway, and the drain runs before the re-arm in the
+  // same handler pass, so resetting here is both correct and correctly ordered.
+  if (inbox.empty())
+    return;
+  stall_recheck_backoff_ = 1;
+
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  for (auto &shard : inbox) {
+    auto *qs = find_queue_state(shard.queue_id, shard.process_id);
+    if (!qs) {
+      // The replica was destroyed between the owner handing this shard over and
+      // this drain. Drop it, exactly as unregister_queue drops a share it never
+      // published: these workgroups have not run and this XCD's caches have not
+      // been written back, so crediting the share would let the owner retire the
+      // grid and fire the completion signal for work that never executed.
+      //
+      // Nothing is stranded by dropping it, for the reason unregister_queue
+      // already relies on: a fan-out queue is destroyed on every XCD at once, so
+      // the teardown that removed this replica removes the owner too. KFD
+      // teardown is what reaches this window -- for_each_cp removes replicas in
+      // XCD order while a later owner is still registered, and an
+      // already-scheduled peer doorbell can drain concurrently.
+      continue;
+    }
+    // Honour the packet's acquire fence on this XCD too. The owner invalidated
+    // only its own CUs; this runs on our partition's thread, so ours are safe
+    // to touch here and the peer ends up with the same view the owner has.
+    if (shard.acquire_invalidate)
+      flush_gpu_caches();
+    qs->push_entry(std::move(shard));
+  }
+}
+
+void CommandProcessor::wake_all_xcds() {
+  // Cross-partition safe: the engine buffers each event into the target's own
+  // partition and never re-enters the component, so this is callable while
+  // holding hw_queue_mutex_.
+  for (auto *peer : xcd_peers_) {
+    if (peer && peer->engine())
+      peer->engine()->schedule_event_now(peer->doorbell_event());
+  }
+}
+
+void CommandProcessor::fan_out_dispatch(DispatchEntry &dp) {
+  const auto num_xcds = static_cast<uint32_t>(xcd_peers_.size());
+  if (num_xcds <= 1)
+    return;
+
+  const uint32_t grid_wgs = dp.total_wgs;
+  auto grid = std::make_shared<GridCompletion>();
+  grid->grid_wgs = grid_wgs;
+
+  for (uint32_t rank = 0; rank < num_xcds; ++rank) {
+    if (rank == xcd_rank_)
+      continue;
+    DispatchEntry shard = dp;
+    shard.grid_completion = grid;
+    shard.fanout_peer = true;
+    // The peer must not fire the dispatch's completion signal; the owning XCD
+    // does that once the grid counter shows every share retired.
+    shard.completion_signal = 0;
+    shard.apply_shard(XcdShard(rank, num_xcds));
+    xcd_peers_[rank]->accept_fanout_shard(std::move(shard));
+  }
+
+  dp.grid_completion = std::move(grid);
+  dp.apply_shard(XcdShard(xcd_rank_, num_xcds));
+}
+
+void CommandProcessor::replicate_non_kernel_entry(const DispatchEntry &dp) {
+  const auto num_xcds = static_cast<uint32_t>(xcd_peers_.size());
+  if (num_xcds <= 1)
+    return;
+
+  assert(dp.is_non_kernel() && "only packets that run no shader are replicated whole");
+  for (uint32_t rank = 0; rank < num_xcds; ++rank) {
+    if (rank == xcd_rank_)
+      continue;
+    DispatchEntry copy = dp;
+    copy.fanout_peer = true;
+    copy.completion_signal = 0;
+    xcd_peers_[rank]->accept_fanout_shard(std::move(copy));
+  }
+}
+
 void CommandProcessor::register_queue(HwQueue queue) {
   util::Logger::cp([&](auto &os) {
     os << std::format("{}: REGISTER_QUEUE id={} pid={} ring={:#x} size={} rptr={:#x} wptr={:#x} "
@@ -551,11 +693,45 @@ void CommandProcessor::register_queue(HwQueue queue) {
                       queue.read_ptr_va, queue.write_ptr_va, queue.doorbell_offset, queue.is_sdma,
                       reinterpret_cast<uintptr_t>(queue.doorbell_base));
   });
-  bool start_poll = queue.host_accessible;
+  // A replica exists only to receive dispatch shards from the XCD that owns the
+  // queue. It must never read the ring or poll the doorbell, or the same packets
+  // would be dispatched once per XCD.
+  bool start_poll = queue.host_accessible && !queue.fanout_replica;
+  // Replicate onto the peer XCDs before taking the lock: accept_fanout_shard()
+  // and the peers' register_queue() take their own locks, and a shard can arrive
+  // only after this returns, so there is no window where a peer has work but no
+  // queue state.
+  {
+    // Checked before replicating, so a rejection cannot leave replicas behind on
+    // the peers. Shard routing keys on (queue_id, process_id), so a duplicate would
+    // silently deliver every shard to whichever slot matched first -- a wrong-answer
+    // bug rather than a crash, which is precisely what an assert compiled out of a
+    // release build would let through. Enforced in every build for that reason.
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    if (find_queue_state(queue.queue_id, queue.process_id) != nullptr) {
+      throw std::runtime_error(
+          std::format("duplicate queue registration on {}: queue_id={} process_id={} is already "
+                      "registered, and fan-out routes dispatch shards by that key",
+                      name(), queue.queue_id, queue.process_id));
+    }
+  }
+  const auto num_xcds = static_cast<uint32_t>(xcd_peers_.size());
+  bool replicate = queue.xcd_fanout && num_xcds > 1;
+  if (replicate) {
+    for (uint32_t rank = 0; rank < num_xcds; ++rank) {
+      if (rank == xcd_rank_)
+        continue;
+      HwQueue replica = queue;
+      replica.xcd_fanout = false;
+      replica.fanout_replica = true;
+      xcd_peers_[rank]->register_queue(std::move(replica));
+    }
+  }
   {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     HwQueueState qs{};
     qs.queue_desc_va = queue.queue_desc_va;
+    qs.fanout_replica = queue.fanout_replica;
     hw_queues_.push_back(std::move(queue));
     new_queue_states_.push_back(std::move(qs));
     // KFD queues rely on the VM-level primary (rj_vm.cpp); only internal test
@@ -621,6 +797,7 @@ bool CommandProcessor::signal_queue_exception(uint32_t queue_id, uint32_t proces
 }
 
 void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) {
+  bool drop_replicas = false;
   {
     // Holds hw_queue_mutex_ across with_wave_state_locked(), which is the order
     // the dispatch path uses too (handle_doorbell -> dispatch_workgroups ->
@@ -642,10 +819,32 @@ void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) 
     }
     for (size_t i = 0; i < hw_queues_.size(); ++i) {
       if (hw_queues_[i].queue_id == queue_id && hw_queues_[i].process_id == process_id) {
+        drop_replicas = hw_queues_[i].xcd_fanout;
+        // Any shares still unpublished here are simply dropped. They cannot be
+        // credited to the grid from this thread: publish_share is the release edge
+        // that must follow this XCD's cache write-back, and flushing walks cus_,
+        // which belong to the engine partition rather than to the caller. Crediting
+        // without the flush would let the owner fire the completion signal with this
+        // XCD's results still cached.
+        //
+        // Dropping them is safe because a fan-out queue is only ever destroyed on
+        // every XCD at once: the KFD paths sweep all command processors, and an
+        // owner cascades to its replicas below. No XCD is left holding a grid that
+        // can no longer retire. Unregistering a lone replica is not supported.
         hw_queues_.erase(hw_queues_.begin() + static_cast<ptrdiff_t>(i));
         new_queue_states_.erase(new_queue_states_.begin() + static_cast<ptrdiff_t>(i));
         break;
       }
+    }
+  }
+  // Tear the replicas down outside our own lock: a peer's unregister_queue takes
+  // that peer's lock, and holding both would fix no order between two CPs whose
+  // queues are being destroyed concurrently.
+  if (drop_replicas) {
+    const auto num_xcds = static_cast<uint32_t>(xcd_peers_.size());
+    for (uint32_t rank = 0; rank < num_xcds; ++rank) {
+      if (rank != xcd_rank_)
+        xcd_peers_[rank]->unregister_queue(queue_id, process_id);
     }
   }
 
@@ -784,7 +983,11 @@ void CommandProcessor::stop_doorbell_monitor_if_idle() {
   std::lock_guard<std::mutex> thread_lock(doorbell_thread_mutex_);
   {
     std::lock_guard<std::recursive_mutex> queue_lock(hw_queue_mutex_);
-    if (has_kfd_queues())
+    // polls_kfd_queues(), not has_kfd_queues(): a fan-out replica is
+    // host-accessible but is never polled, so keying this on presence would
+    // strand a monitor on a CP whose own queue was destroyed while a replica of
+    // some other queue happened to remain.
+    if (polls_kfd_queues())
       return;
   }
   if (doorbell_thread_.joinable()) {
@@ -828,6 +1031,10 @@ bool CommandProcessor::scan_doorbells() {
   bool found = false;
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
   for (auto &q : hw_queues_) {
+    // A replica shares the owner's ring and doorbell. Only the owning XCD may
+    // consume them, or every XCD would dispatch the whole grid.
+    if (q.fanout_replica)
+      continue;
     uint64_t val;
     if (q.host_accessible) {
       if (!q.doorbell_base)
@@ -903,6 +1110,11 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
       {
         std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
         for (size_t i = 0; i < hw_queues_.size(); ++i) {
+          // A replica does not own the queue, so it must not report it idle: its
+          // shards drain before the owner's and the same KFD queue would otherwise
+          // raise this from several CPs at once.
+          if (hw_queues_[i].fanout_replica)
+            continue;
           if (new_queue_states_[i].entries.empty() && hw_queues_[i].process_id != 0)
             idle_pids.push_back(hw_queues_[i].process_id);
         }
@@ -958,9 +1170,12 @@ bool CommandProcessor::barrier_satisfied(const HwQueueState &qs, size_t idx) con
   if (idx == 0 && !qs.implicit_barrier_next)
     return true;
 
-  // Barrier bit: all prior entries must be fully completed.
+  // Barrier bit: all prior entries must be fully completed, device-wide. A prior
+  // entry that is one XCD's share of a fanned-out dispatch is not done just
+  // because this XCD finished it, so gate on the whole grid or this XCD would run
+  // the next packet while a peer is still executing the previous one.
   for (size_t i = 0; i < idx; ++i) {
-    if (!qs.entries[i].fully_completed())
+    if (!qs.entries[i].grid_fully_completed())
       return false;
   }
   return true;
@@ -1251,10 +1466,15 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       [&](uint32_t local_wg_id, uint32_t global_wg_id,
           const ShaderProcessorInput::WorkgroupPlacement &placement) -> bool {
     // Fire the dispatch-execution-begin hook exactly once, on the first workgroup
-    // actually placed on a CU, guarded by the per-dispatch flag.
+    // actually placed on a CU, guarded by the per-dispatch flag. One begin per
+    // dispatch, not per XCD. This cannot be pinned to the XCD that read the
+    // packet: when the grid is smaller than the XCD count that XCD's share may be
+    // empty, so it never places anything. Let whichever XCD places the grid's
+    // first workgroup claim the report.
     if (!entry.execution_begun) {
       entry.execution_begun = true;
-      plugin_group_->onAmdgpuDispatchExecutionBegin(entry.dispatch_id);
+      if (!entry.grid_completion || entry.grid_completion->claim_execution_begin())
+        plugin_group_->onAmdgpuDispatchExecutionBegin(entry.dispatch_id);
     }
     ComputeUnitCore *cu = placement.cu;
     uint32_t lds_base = placement.lds_base;
@@ -1533,6 +1753,10 @@ void CommandProcessor::on_cu_idle() {
     if (was_idle[i] && !cus_[i]->is_idle())
       cus_[i]->schedule_work();
   }
+
+  // The last workgroup of this XCD's share retires here, not in handle_doorbell,
+  // so this is where a fanned-out shard parks to wait for its peers.
+  arm_grid_wait_recheck();
 }
 
 bool CommandProcessor::step() {
@@ -1627,7 +1851,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   uint32_t total_wgs = grid_wgs_x * grid_wgs_y * grid_wgs_z;
 
   DispatchEntry dp{};
-  dp.dispatch_id = next_dispatch_id_++;
+  dp.dispatch_id = allocate_dispatch_id();
   dp.profiling_start_timestamp = hsa_system_timestamp();
   dp.queue_id = queue.queue_id;
   dp.queue_packet_id = queue_packet_id;
@@ -1766,8 +1990,19 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   // Process AQL acquire fence: invalidate caches so the kernel sees the
   // latest host/agent writes (kernarg data, input buffers, etc.).
   // On real hardware the CP issues GL1_INV + GL2_INV for SYSTEM/AGENT scope.
+  // Only this XCD's CUs are reachable from here; a peer XCD's caches belong to
+  // another partition and must not be touched from this thread. The shard carries
+  // the fence instead, and each peer performs the same invalidate on its own thread
+  // when it takes delivery -- see drain_fanout_inbox().
   uint32_t acquire_scope = (pkt.header >> HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) & 0x3;
-  if (acquire_scope >= HSA_FENCE_SCOPE_AGENT && !cus_.empty()) {
+  dp.acquire_invalidate = acquire_scope >= HSA_FENCE_SCOPE_AGENT;
+  if (dp.acquire_invalidate && !cus_.empty()) {
+    // Deliberately the per-CU walk, not the deduplicated flush_gpu_caches(). The
+    // two are equivalent per invocation, but collapsing the repeated sweeps on the
+    // release path caused peer ranks to hang on flags left unpublished in L2, and
+    // that mechanism is still not understood. Until it is, this path -- which
+    // predates fan-out -- keeps exactly the cache behaviour it had, and only the
+    // new peer-side fence in drain_fanout_inbox() uses the collapsed form.
     for (auto *cu : cus_)
       cu->flush_all(queue.process_id);
   }
@@ -1842,22 +2077,74 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
     }
   });
 
-  qs.entries.push_back(std::move(dp));
+  if (queue.xcd_fanout)
+    fan_out_dispatch(dp);
+
+  qs.push_entry(std::move(dp));
+}
+
+void CommandProcessor::arm_grid_wait_recheck() {
+  // A shard whose own share is done but whose grid is still running on another
+  // XCD is a stall like any other, and has to be re-armed as one.
+  //
+  // The XCD that retires the grid does call wake_all_xcds(), but that wake
+  // travels the engine's cross-thread async queue, which neither contributes to
+  // LBTS nor counts as outstanding work when the engine tests for termination.
+  // With one partition per XCD, every partition can publish TICK_MAX in the same
+  // epoch the wake is deposited, and the run ends on that before the next epoch
+  // drains it -- so the XCD holding the completion signal never re-drains and
+  // never writes it. Keeping a re-check on this CP's own event queue holds its
+  // partition's next-event time finite for exactly as long as it is waiting,
+  // which leaves the wake an optimization rather than the only thing standing
+  // between the grid retiring and the signal firing.
+  //
+  // Caller must hold hw_queue_mutex_ and must be on this CP's own partition
+  // thread, which is where the re-check is enqueued.
+  for (const auto &qs : new_queue_states_) {
+    if (qs.entries.empty())
+      continue;
+    const auto &head = qs.entries.front();
+    if (head.fully_completed() && !head.grid_fully_completed()) {
+      arm_stall_recheck(engine()->context(partition_id()).current_tick());
+      return;
+    }
+  }
 }
 
 void CommandProcessor::arm_stall_recheck(simdojo::Tick now) {
-  // A doorbell poll thread runs only for host-accessible (KFD) queues; it re-checks
+  // A doorbell poll thread runs only for queues this CP polls; it re-checks
   // stall_pending_ at its 100us cadence, so the engine can idle instead of spinning.
   // Internal test queues have no poll thread — they are driven by engine->run()/
-  // step() — so there the re-check must be kept alive on the main event queue.
-  if (has_kfd_queues())
+  // step() — and neither do fan-out replicas, so in both cases the re-check must be
+  // kept alive on the main event queue instead.
+  if (polls_kfd_queues()) {
     stall_pending_.store(true, std::memory_order_release);
-  else
-    schedule_event(&doorbell_event_, now + 1);
+    return;
+  }
+  // Back the re-check off rather than re-arming on the very next tick. What
+  // actually ends one of these waits is an external event -- a peer's shard, or
+  // the wake the retiring XCD sends -- and each of those resets the backoff, so
+  // the wait still ends promptly. This event only has to keep the partition's
+  // next-event time finite so the engine cannot decide the run is over while a
+  // cross-thread wake is still undelivered (see arm_grid_wait_recheck).
+  //
+  // At one tick it is a spin, and a costly one: with fan-out every peer XCD waits
+  // on the owner's grid, and a peer re-entered this handler once per simulated
+  // tick -- 17M times on a corpus case that needs 24 doorbells without fan-out,
+  // which is where a 12x slowdown came from. Backing off is nearly free in
+  // simulated time: with no other event pending the engine jumps straight to the
+  // re-check, so a longer interval skips idle ticks rather than adding latency.
+  schedule_event(&doorbell_event_, now + stall_recheck_backoff_);
+  stall_recheck_backoff_ = std::min(stall_recheck_backoff_ * 2, kMaxStallRecheckBackoff);
 }
 
 void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now) {
   if (!memory_)
+    return;
+  // A replica's work arrives as dispatch shards, not from the ring. Reading the
+  // ring here would also advance a read pointer the owning XCD owns, and its
+  // suspension flags are the owner's copy rather than state this CP maintains.
+  if (queue.fanout_replica)
     return;
   if (queue.debug_suspended || queue.runtime_suspended) {
     // A command-processor event can race a debugger suspension even when this
@@ -2033,7 +2320,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
       sig = read_gpu_u64(pkt_addr + SIG_OFF, queue.process_id);
 
       DispatchEntry dp{
-          .dispatch_id = next_dispatch_id_++,
+          .dispatch_id = allocate_dispatch_id(),
           .queue_id = queue.queue_id,
           .process_id = queue.process_id,
           .completion_signal = sig,
@@ -2041,7 +2328,9 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
           .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
       };
 
-      qs.entries.push_back(std::move(dp));
+      if (queue.xcd_fanout)
+        replicate_non_kernel_entry(dp);
+      qs.push_entry(std::move(dp));
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
@@ -2089,7 +2378,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
         }
 
         DispatchEntry dp{
-            .dispatch_id = next_dispatch_id_++,
+            .dispatch_id = allocate_dispatch_id(),
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = barrier.completion_signal.handle,
@@ -2097,7 +2386,9 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .barrier_bit = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
-        qs.entries.push_back(std::move(dp));
+        if (queue.xcd_fanout)
+          replicate_non_kernel_entry(dp);
+        qs.push_entry(std::move(dp));
       } else if (ext.amd_format == kHsaAmdPacketTypeExtKernelDispatch) {
         if (ext.dep_signal.handle != 0) {
           constexpr uint32_t SIG_VAL_OFF = 8;
@@ -2150,7 +2441,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
         const uint64_t sig = read_gpu_u64(pkt_addr + SIG_OFF, queue.process_id);
 
         DispatchEntry dp{
-            .dispatch_id = next_dispatch_id_++,
+            .dispatch_id = allocate_dispatch_id(),
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = sig,
@@ -2158,7 +2449,9 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
-        qs.entries.push_back(std::move(dp));
+        if (queue.xcd_fanout)
+          replicate_non_kernel_entry(dp);
+        qs.push_entry(std::move(dp));
       } else {
         throw std::runtime_error("Unsupported AMD vendor-specific AQL packet format: " +
                                  std::to_string(ext.amd_format));
@@ -2190,6 +2483,10 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
 
+  // Take delivery of any shares peer XCDs handed us. Done before the lock so the
+  // inbox mutex stays a leaf; the drain acquires hw_queue_mutex_ itself.
+  drain_fanout_inbox();
+
   std::unique_lock<std::recursive_mutex> lock(hw_queue_mutex_);
 
   size_t entries_before = 0;
@@ -2207,6 +2504,13 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
   size_t entries_after = 0;
   for (auto &qs : new_queue_states_)
     entries_after += qs.entries.size();
+  // Any new work restarts the stall re-check at a tight interval. Shard delivery
+  // resets it too, but not every wait here ends with a shard -- a barrier or a
+  // cross-rank dependency is satisfied by a value another partition (or the
+  // daemon) writes, and that arrives as fetched entries rather than as an inbox
+  // hand-off. Without this, a CP that had backed off would stay backed off.
+  if (entries_after != entries_before)
+    stall_recheck_backoff_ = 1;
   util::Logger::cp([&](auto &os) {
     os << std::format("{}: FETCHED {} new entries (total={})", name(),
                       entries_after - entries_before, entries_after);
@@ -2333,6 +2637,8 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
   }
   if (completion_)
     completion_->drain_completions(new_queue_states_);
+
+  arm_grid_wait_recheck();
 
   // Register as primary on first dispatch (internal test queues only).
   // KFD queues rely on the VM-level primary registered at rj_vm.cpp.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -85,6 +86,15 @@ struct HwQueue {
   /// the queue's read_dispatch_id at a trapped dispatch (so packets are not
   /// re-fetched). See fetch_from_queue and serialize_queue_debug_waves.
   uint64_t fetch_cursor = 0;
+  /// Spread each of this queue's dispatches over every XCD of the SoC, the way a
+  /// multi-XCD part does when it runs as a single partition. Set by the queue
+  /// creation path that models such a device; registering the queue replicates it
+  /// onto the peer XCDs.
+  bool xcd_fanout = false;
+  /// Set on the replicas that xcd_fanout creates. A replica never reads the ring
+  /// and never polls a doorbell; work reaches it as dispatch shards from the XCD
+  /// that owns the queue.
+  bool fanout_replica = false;
 };
 
 enum class SdmaPacketDialect {
@@ -156,8 +166,29 @@ public:
     scratch_wave_divisor_ = se_per_xcc == 0 ? 1 : se_per_xcc;
   }
 
+  /// @brief Tell this CP where its XCD sits among the SoC's XCDs.
+  ///
+  /// @details @p peers lists every XCD's command processor in XCD index order and
+  /// includes this one at index @p rank. A dispatch on a fanned-out queue is split
+  /// so that XCD i takes the grid chunks congruent to i modulo peers.size(); the
+  /// rank is the XCD's own index, not its position relative to the queue's owner,
+  /// so the workgroup-to-XCD mapping does not depend on which XCD a queue landed on.
+  /// @param rank This CP's XCD index.
+  /// @param peers All XCD command processors of the SoC, in XCD index order.
+  void set_xcd_topology(uint32_t rank, std::vector<CommandProcessor *> peers);
+
   void register_queue(HwQueue queue);
   void unregister_queue(uint32_t queue_id, uint32_t process_id);
+
+  /// @brief Take one XCD's share of a dispatch fanned out by a peer XCD.
+  ///
+  /// @details Thread-safe, and safe to call from another partition's thread while
+  /// the caller holds its own CP's hw_queue_mutex_: the shard is parked in an inbox
+  /// guarded by a leaf mutex and the CP is woken through the engine's cross-thread
+  /// event queue rather than dispatched inline. The shard reaches the queue state
+  /// when this CP next drains the inbox on its own thread.
+  /// @param shard The share of the grid this XCD is to run.
+  void accept_fanout_shard(DispatchEntry shard);
   void update_queue(uint32_t queue_id, uint32_t process_id, uint64_t ring_base_va,
                     uint32_t ring_size, uint32_t queue_percentage);
   void set_queue_debug_suspended(uint32_t queue_id, uint32_t process_id, bool suspended);
@@ -198,7 +229,7 @@ public:
 
   void set_workgroup_id_offset(uint32_t offset) { workgroup_id_offset_ = offset; }
 
-  size_t dispatched_count() const { return total_dispatched_; }
+  [[nodiscard]] size_t dispatched_count() const { return total_dispatched_; }
 
   /// @brief Total workgroups this CP has placed on its own XCD's compute units.
   /// @details Distinct from dispatched_count(), which counts AQL packets. This is
@@ -213,7 +244,39 @@ public:
     return dispatched_workgroups_.load(std::memory_order_relaxed);
   }
 
-  size_t next_cu_index() const { return next_cu_; }
+  [[nodiscard]] size_t next_cu_index() const { return next_cu_; }
+
+  /// @brief Deepest (@p queue_id, @p process_id) ever got on this CP.
+  ///
+  /// @details Test-only. A replica's entry list is otherwise unobservable: a packet
+  /// that runs no shader retires in zero time, so once a run finishes every queue is
+  /// empty whether or not those packets were ever placed on the peers at all. The
+  /// peak is recorded by the owning CP as it pushes, under its own queue mutex, so
+  /// this is read AFTER a run rather than sampled during one. Sampling was the
+  /// earlier design and was wrong: it reached into every peer CP from inside a
+  /// workgroup callback that already held the dispatching CP's mutex, which is a
+  /// lock-order inversion between any two CPs the moment more than one thread runs.
+  [[nodiscard]] size_t peak_queued_entry_count_for_test(uint32_t queue_id, uint32_t process_id) {
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    const auto *qs = find_queue_state(queue_id, process_id);
+    return qs == nullptr ? 0 : qs->peak_entries;
+  }
+
+  /// @brief Step a dispatch id within one XCD's residue class.
+  ///
+  /// @details Public and static only so the wrap can be pinned by a test: it is
+  /// otherwise ~2^29 dispatches away, and the case that matters is a
+  /// non-power-of-two XCD count, where running off the end of uint32_t would
+  /// interleave the classes and let two XCDs mint the same id.
+  /// @param current The id just handed out.
+  /// @param base First id of this XCD's class, where the sequence restarts.
+  /// @param stride Number of participating XCDs.
+  /// @returns The next id in the same class.
+  [[nodiscard]] static uint32_t step_dispatch_id(uint32_t current, uint32_t base, uint32_t stride) {
+    if (current > std::numeric_limits<uint32_t>::max() - stride)
+      return base;
+    return current + stride;
+  }
 
   const std::vector<simdojo::Port *> &dispatch_ports() const { return dispatch_ports_; }
   const std::vector<ComputeUnitCore *> &compute_units() const { return cus_; }
@@ -225,9 +288,11 @@ public:
   /// @brief Test-only view of the doorbell monitor lifecycle flag.
   ///
   /// @details Exposes doorbell_running_ so a regression test can observe the
-  /// monitor stopping after the last host-accessible queue is destroyed and
-  /// restarting when a new one registers. Read under doorbell_thread_mutex_ so it
-  /// never races monitor teardown or ensure_doorbell_monitor().
+  /// monitor stopping after the last polled queue is destroyed and restarting
+  /// when a new one registers. Polled, not host-accessible: the monitor stops as
+  /// soon as this CP owns no ring of its own, which can leave host-accessible
+  /// fan-out replicas registered behind it. Read under doorbell_thread_mutex_ so
+  /// it never races monitor teardown or ensure_doorbell_monitor().
   [[nodiscard]] bool doorbell_monitor_running_for_test() {
     std::lock_guard<std::mutex> lock(doorbell_thread_mutex_);
     return doorbell_running_;
@@ -281,6 +346,13 @@ private:
   /// re-check must be kept alive by rescheduling the doorbell event at @p now + 1.
   void arm_stall_recheck(simdojo::Tick now);
 
+  /// @brief Re-arm a re-check while this CP holds a shard whose grid is still
+  /// running on another XCD.
+  /// @details Caller MUST hold hw_queue_mutex_ and MUST be on this CP's own
+  /// partition thread. No-op unless a queue head is a share this XCD has
+  /// finished but the grid has not retired device-wide.
+  void arm_grid_wait_recheck();
+
   /// @brief Fetch AQL packets from a single HW queue.
   void fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdojo::Tick now);
 
@@ -318,6 +390,79 @@ private:
   read_kernel_descriptor(uint64_t kernel_object, uint32_t vmid, bool host_accessible = false);
   /// @brief Dispatch workgroups from entry to CUs. Returns number dispatched.
   uint32_t dispatch_workgroups(DispatchEntry &entry);
+
+  /// @brief Split a dispatch across the SoC's XCDs, keeping this XCD's share.
+  ///
+  /// @details Narrows @p dp to this XCD's share and hands the remaining shares to
+  /// the peer XCDs, all sharing one GridCompletion so the completion signal fires
+  /// once. Does nothing when the SoC has a single XCD.
+  ///
+  /// Every XCD gets an entry even when the grid is too small to give it any
+  /// workgroups. An empty share is what keeps the replicas' queues in step with
+  /// the owner's for the packets that are replicated, and barrier_satisfied()
+  /// reads that ordering from the entries sitting ahead of a barrier'd packet;
+  /// skipping the empty ones would leave a replica with a shorter prefix than the
+  /// owner and let it start a barrier'd packet while a sibling was still running
+  /// the one before it. Packets that run no shader are copied across as well, by
+  /// replicate_non_kernel_entry(), so a replica's entry list is the owner's whole
+  /// sequence rather than a subsequence of it.
+  void fan_out_dispatch(DispatchEntry &dp);
+
+  /// @brief Give every peer XCD a copy of a packet that runs no shader.
+  ///
+  /// @details A kernel dispatch is split across the XCDs, but a barrier or an IB
+  /// has no workgroups to split -- what the peers need is the entry itself. The
+  /// ordering barrier_satisfied() reads from the entries sitting ahead of a
+  /// barrier'd packet is only device-wide if every XCD sees the same packets, so a
+  /// replica that skipped these would hold a strict subsequence of the owner's list
+  /// and could start a barrier'd packet while the owner still had an unretired one
+  /// in front of its own copy.
+  ///
+  /// The copy carries no completion signal. A packet is owed exactly one, and the
+  /// XCD that read it keeps that duty, exactly as it does for a kernel shard.
+  void replicate_non_kernel_entry(const DispatchEntry &dp);
+
+  /// @brief Move shards handed over by peer XCDs into their queue states.
+  /// @details Runs on this CP's own thread, under hw_queue_mutex_. Kept separate
+  /// from accept_fanout_shard() so that no CP ever takes a peer's hw_queue_mutex_.
+  void drain_fanout_inbox();
+
+  /// @brief Schedule a doorbell on every XCD of the SoC, this one included.
+  /// @details Used when a dispatch retires device-wide: the XCD holding the
+  /// completion signal may be parked with nothing left to rouse it, and a peer may
+  /// be parked behind a barrier bit this dispatch was blocking. Replicas run no
+  /// doorbell poll thread of their own, so nothing else would re-examine them.
+  void wake_all_xcds();
+
+  /// @brief Allocate a dispatch id unique across every XCD of the SoC.
+  ///
+  /// @details Fan-out copies a dispatch id onto peer XCDs, and completion
+  /// bookkeeping (notify_wg_complete, the cluster placement keys, the CU's
+  /// per-workgroup refcounts) looks entries up by that id. If two XCDs could mint
+  /// the same id, a peer holding a shard of one dispatch and an own dispatch with
+  /// the same id would credit workgroup completions to whichever it found first.
+  /// Seeding each CP at its XCD rank and stepping by the XCD count keeps the id
+  /// spaces disjoint without a shared counter: each XCD owns one residue class
+  /// modulo the XCD count.
+  ///
+  /// The wrap is explicit rather than left to the type. Letting the counter run
+  /// off the end of uint32_t preserves disjointness only when the XCD count
+  /// divides 2^32, and XcdShard deliberately accepts any count >= 1, so the two
+  /// contracts would disagree for a non-power-of-two topology -- after the wrap
+  /// the classes interleave and two XCDs mint the same id. Returning to the base
+  /// of this XCD's own class keeps them disjoint for every count. It is ~2^29
+  /// dispatches per XCD away in any case.
+  uint32_t allocate_dispatch_id() {
+    const uint32_t id = next_dispatch_id_;
+    next_dispatch_id_ = step_dispatch_id(next_dispatch_id_, dispatch_id_base_, dispatch_id_stride_);
+    return id;
+  }
+
+  /// @brief Locate the queue state for a (queue_id, process_id) pair.
+  /// @returns Pointer into new_queue_states_, or null when not registered. Caller
+  /// must hold hw_queue_mutex_ and must not use the result across a registration
+  /// change.
+  HwQueueState *find_queue_state(uint32_t queue_id, uint32_t process_id);
 
   void register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
                                   uint32_t global_wg_id, ComputeUnitCore *cu, uint32_t lds_base);
@@ -363,9 +508,26 @@ private:
     return total;
   }
 
+  /// @brief Whether any host-accessible queue is registered here, replicas included.
+  ///
+  /// @details Answers whether this CP's lifecycle is anchored by the VM-level
+  /// primary, which a fan-out replica does anchor just as its owner does.
   bool has_kfd_queues() const {
     for (const auto &q : hw_queues_)
       if (q.host_accessible)
+        return true;
+    return false;
+  }
+
+  /// @brief Whether any queue here is one whose doorbell this CP actually polls.
+  ///
+  /// @details A fan-out replica is host-accessible but is never polled: its work
+  /// arrives as dispatch shards from the XCD that owns the queue. Anything scoped
+  /// to the doorbell monitor must ask this rather than has_kfd_queues(), or a CP
+  /// left holding only replicas keeps a monitor alive for a ring it never reads.
+  bool polls_kfd_queues() const {
+    for (const auto &q : hw_queues_)
+      if (q.host_accessible && !q.fanout_replica)
         return true;
     return false;
   }
@@ -388,6 +550,20 @@ private:
   std::vector<ComputeUnitCore *> cus_;
   std::vector<simdojo::Port *> dispatch_ports_;
 
+  uint32_t xcd_rank_ = 0;
+  // Every XCD's CP in XCD index order, including this one. Empty until the SoC
+  // wires the topology, which leaves fan-out disabled. Raw pointers: the SoC owns
+  // every XCD and destroys them together, so a peer outlives any use of it here,
+  // including the cross-thread uses in accept_fanout_shard() and wake_all_xcds().
+  std::vector<CommandProcessor *> xcd_peers_;
+
+  // Shards handed over by peer XCDs, awaiting this CP's next pass. Guarded by a
+  // leaf mutex, never hw_queue_mutex_: a peer appends here while holding its own
+  // hw_queue_mutex_, so acquiring anything else under this one would reintroduce
+  // the cross-CP lock cycle it exists to avoid.
+  std::mutex fanout_inbox_mutex_;
+  std::vector<DispatchEntry> fanout_inbox_;
+
   size_t next_cu_ = 0;
   size_t next_queue_idx_ = 0;
   // Almost always accessed under hw_queue_mutex_, but the teardown path in
@@ -403,6 +579,11 @@ private:
   // the decoder cannot infer this dialect from the packet header alone.
   SdmaPacketDialect sdma_packet_dialect_ = SdmaPacketDialect::Legacy;
   uint32_t next_dispatch_id_ = 1;
+  // Step between successive dispatch ids from this CP. Set to the XCD count when
+  // the SoC wires the topology so no two XCDs ever mint the same id.
+  uint32_t dispatch_id_stride_ = 1;
+  /// First id of this XCD's residue class; where allocate_dispatch_id() restarts.
+  uint32_t dispatch_id_base_ = 1;
   size_t total_dispatched_ = 0;
   std::atomic<uint64_t> dispatched_workgroups_{0};
 
@@ -435,7 +616,7 @@ private:
   std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
-  std::recursive_mutex hw_queue_mutex_;
+  mutable std::recursive_mutex hw_queue_mutex_;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 
@@ -454,7 +635,10 @@ private:
   void write_gpu_block(uint64_t va, const void *src, size_t size, uint32_t vmid);
 
   void stop_doorbell_monitor();
-  /// @brief Stop and join the monitor only when no host-accessible queue remains.
+  /// @brief Stop and join the monitor only when no polled queue remains.
+  /// @details Polled rather than host-accessible: a CP left holding only fan-out
+  /// replicas still has host-accessible queues registered, but no ring it reads,
+  /// so its monitor must retire.
   /// @details Caller MUST NOT hold hw_queue_mutex_: this helper takes that mutex
   /// to recheck the queue set, then may join a poller that needs the same mutex to
   /// finish its current scan. Serializing the recheck with startup ensures a
@@ -476,6 +660,12 @@ private:
   std::atomic<bool> invalid_pending_{false};
 
   std::atomic<uint64_t> doorbell_handle_count_{0};
+  /// @brief Ticks to wait before the next stall re-check, doubled on each idle
+  /// re-check and reset to 1 whenever work arrives.
+  /// @details Only the no-poll-thread path uses this; a CP that polls KFD queues
+  /// re-checks on its poll thread's own cadence instead.
+  simdojo::Tick stall_recheck_backoff_ = 1;
+  static constexpr simdojo::Tick kMaxStallRecheckBackoff = 4096;
 
   // Set when a queue stalls on an unsatisfied barrier/dependency signal (or an
   // SDMA VA not yet translatable) — a wait on progress that is external to the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -51,10 +51,43 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
                           entry.completed_wgs, entry.total_wgs, entry.completion_signal);
       });
 
-      flush_caches(entry.process_id);
-      plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
-      if (entry.completion_signal != 0) {
-        fire_signal(entry);
+      // Publish this XCD's share only after its own caches are flushed. The
+      // release in publish_share() pairs with the acquire in grid_retired(), so
+      // the XCD that fires the signal cannot do so while another XCD's results
+      // are still sitting in its caches.
+      // Both are done exactly once per entry. A shard that finished ahead of its
+      // siblings stays parked at the head of this queue below, so the loop
+      // re-enters on it every time the tracker drains; re-flushing every CU of the
+      // XCD on each of those passes would be pure waste.
+      if (!entry.grid_share_published) {
+        // Latch only after the flush actually ran. flush_caches walks every CU and
+        // writes back; if it threw, latching first would leave this share forever
+        // unpublished and park the owner on a grid that can never retire.
+        flush_caches(entry.process_id);
+        entry.grid_share_published = true;
+        // publish_share elects a single caller as the one whose share completed
+        // the grid, so the wake happens once rather than once per racing XCD.
+        if (entry.grid_completion && entry.grid_completion->publish_share(entry.total_wgs) &&
+            grid_retired_cb_)
+          grid_retired_cb_(entry);
+      }
+
+      // Every XCD holds the head of its queue until the dispatch is done
+      // device-wide, peers included. Popping a peer's shard as soon as its own
+      // share finished would erase the only evidence that the packet is still
+      // outstanding, and barrier_satisfied() -- which inspects the entries still
+      // sitting ahead of a barrier'd packet -- would then let this XCD start the
+      // next packet while a sibling was still running this one.
+      if (!entry.grid_fully_completed())
+        break;
+
+      // Only the XCD that read the packet reports the dispatch and signals it.
+      // The retired callback is per-XCD local cleanup, so every XCD runs it.
+      if (!entry.fanout_peer) {
+        plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
+        if (entry.completion_signal != 0) {
+          fire_signal(entry);
+        }
       }
       if (dispatch_retired_cb_)
         dispatch_retired_cb_(entry);
@@ -67,7 +100,10 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
     // HQD idle: write the queue's inactive signal and fire the interrupt.
     // On real hardware the CP writes the HQD status to amd_signal_t::value
     // and kfd_signal_event_interrupt broadcasts to all type-0 events.
-    if (had_entries && qs.entries.empty() && last_process_id != 0) {
+    // A fan-out replica does not own the queue and must not report it idle: its
+    // shards drain ahead of the owning XCD's, so it would signal idle while the
+    // dispatch is still running elsewhere.
+    if (had_entries && qs.entries.empty() && last_process_id != 0 && !qs.fanout_replica) {
       if (qs.queue_desc_va != 0)
         fire_queue_idle_signal(qs.queue_desc_va, last_process_id);
       if (interrupt_cb_)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -26,6 +26,10 @@ class CompletionTracker {
 public:
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
   using DispatchRetiredCallback = std::function<void(const DispatchEntry &entry)>;
+  /// Called by the one shard whose publish completes a fanned-out dispatch, so
+  /// every participating XCD can be woken: the owner to fire the completion
+  /// signal, and any peer parked behind a barrier bit waiting on this dispatch.
+  using GridRetiredCallback = std::function<void(const DispatchEntry &entry)>;
 
   CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus)
       : memory_(mem), cus_(cus) {}
@@ -38,6 +42,7 @@ public:
   void set_dispatch_retired_callback(DispatchRetiredCallback cb) {
     dispatch_retired_cb_ = std::move(cb);
   }
+  void set_grid_retired_callback(GridRetiredCallback cb) { grid_retired_cb_ = std::move(cb); }
 
   /// @brief Notify that a workgroup has completed all its wavefronts.
   void notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id, std::vector<HwQueueState> &queues);
@@ -61,6 +66,7 @@ private:
   std::vector<ComputeUnitCore *> &cus_;
   InterruptCallback interrupt_cb_;
   DispatchRetiredCallback dispatch_retired_cb_;
+  GridRetiredCallback grid_retired_cb_;
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -14,9 +14,12 @@
 
 #include "rocjitsu/vm/amdgpu/xcd_shard.h"
 
+#include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <deque>
+#include <memory>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -54,6 +57,43 @@ enum class DispatchPacketKind : uint8_t {
   Kernel,
   /// @brief A packet that runs no shader: barrier, barrier-value, PM4 IB.
   NonKernel,
+};
+
+/// @brief Grid-wide retirement state shared by every shard of one dispatch.
+///
+/// @details When a dispatch is fanned out, each participating XCD retires its own
+/// share independently, but the dispatch's completion signal must fire once, after
+/// the last workgroup anywhere on the device. Each XCD flushes its own caches and
+/// then publishes its share here; the owning XCD fires the signal only once the
+/// published total covers the grid. Publishing releases and the owner's check
+/// acquires, so every XCD's flush is visible before the signal is written.
+struct GridCompletion {
+  /// Workgroups retired across all participating XCDs.
+  std::atomic<uint32_t> completed_wgs{0};
+  /// Workgroups in the whole grid.
+  uint32_t grid_wgs = 0;
+  /// Cleared by the first XCD to place a workgroup, so the dispatch reports that
+  /// it began exactly once however the grid is split. An XCD whose share is empty
+  /// never places anything, so this cannot be tied to the XCD that read the packet.
+  std::atomic_flag execution_begun{};
+
+  /// @brief Add one XCD's retired workgroups to the grid total.
+  /// @returns True for the single caller whose contribution completed the grid, so
+  /// the follow-on wake happens exactly once rather than once per racing XCD.
+  [[nodiscard]] bool publish_share(uint32_t wgs) {
+    uint32_t before = completed_wgs.fetch_add(wgs, std::memory_order_acq_rel);
+    return before < grid_wgs && before + wgs >= grid_wgs;
+  }
+
+  /// @returns True once every XCD has published its share.
+  [[nodiscard]] bool grid_retired() const {
+    return completed_wgs.load(std::memory_order_acquire) >= grid_wgs;
+  }
+
+  /// @returns True for the first caller only.
+  [[nodiscard]] bool claim_execution_begin() {
+    return !execution_begun.test_and_set(std::memory_order_relaxed);
+  }
 };
 
 /// @brief Per-dispatch tracking entry created by the AQL Packet Processor.
@@ -137,9 +177,42 @@ struct DispatchEntry {
   bool host_signal = false;
   bool barrier_bit = false;
   bool execution_begun = false;
+  /// The packet carried an acquire fence of at least agent scope. Recorded on the
+  /// entry so that every XCD running part of the grid can invalidate its own caches
+  /// on its own thread, not just the one that read the packet.
+  bool acquire_invalidate = false;
+
+  /// Grid-wide retirement state, shared by every shard of a fanned-out dispatch.
+  /// Null when this entry owns the whole grid by itself.
+  std::shared_ptr<GridCompletion> grid_completion{};
+  /// True on the shards handed to peer XCDs. The shard left on the XCD that read
+  /// the packet keeps the completion signal and the dispatch-level callbacks.
+  bool fanout_peer = false;
+  /// Set once this shard has published its retired workgroups to grid_completion,
+  /// so a repeated drain cannot double-count them.
+  bool grid_share_published = false;
 
   bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }
   bool fully_completed() const { return completed_wgs >= total_wgs; }
+
+  /// @returns Workgroups in the whole grid, as opposed to total_wgs which after
+  /// a fan-out counts only this XCD's share. Anything sized or indexed against the
+  /// grid -- scratch backing, whose per-wave offset comes from the grid-wide
+  /// workgroup id -- must use this and not total_wgs.
+  [[nodiscard]] uint32_t grid_total_wgs() const {
+    return grid_completion ? grid_completion->grid_wgs : total_wgs;
+  }
+
+  /// @returns True when the dispatch has finished everywhere, not merely on this
+  /// XCD. The AQL barrier bit means "no later packet starts until every preceding
+  /// packet has completed", which for a fanned-out dispatch is a property of the
+  /// whole grid: this XCD finishing its share says nothing about the others.
+  [[nodiscard]] bool grid_fully_completed() const {
+    if (grid_completion)
+      return grid_completion->grid_retired();
+    return fully_completed();
+  }
+
   /// @returns True for packets that run no shader at all (barrier, barrier-value,
   /// PM4 IB). Deliberately a stored kind rather than `total_wgs == 0`: a kernel
   /// dispatch split across XCDs can legitimately leave one XCD an empty share,
@@ -224,7 +297,9 @@ struct DispatchEntry {
   }
 
   /// @brief Chunk the grid walk advances by: a cluster, else a single workgroup.
-  uint32_t dispatch_chunk_wgs() const { return has_workgroup_clusters() ? cluster_size() : 1u; }
+  [[nodiscard]] uint32_t dispatch_chunk_wgs() const {
+    return has_workgroup_clusters() ? cluster_size() : 1u;
+  }
 
   /// @brief Grid-wide chunk ordinal for this entry's @p shard_chunk_index -th chunk.
   ///
@@ -236,7 +311,7 @@ struct DispatchEntry {
   /// workgroup that does not exist. Bound it here, where the share size is known.
   /// @param shard_chunk_index Zero-based chunk index within this entry's share.
   /// @returns The chunk's ordinal in the whole grid.
-  uint32_t chunk_ordinal_for(uint32_t shard_chunk_index) const {
+  [[nodiscard]] uint32_t chunk_ordinal_for(uint32_t shard_chunk_index) const {
     assert(static_cast<uint64_t>(shard_chunk_index) * dispatch_chunk_wgs() < total_wgs &&
            "chunk index is shard-local and must lie within this entry's share");
     return shard.nth_owned_chunk(shard_chunk_index);
@@ -361,9 +436,28 @@ struct HwQueueState {
 
   Status status = Status::IDLE;
   std::deque<DispatchEntry> entries;
+  /// @brief High-water mark of entries.size(), for tests.
+  /// @details A replica's entry list is otherwise unobservable: a packet that runs
+  /// no shader retires in zero time, so once a run finishes every queue is empty
+  /// whether or not those packets were ever placed on the peers at all. Recording
+  /// the peak as entries are pushed lets the assertion happen AFTER the run, so a
+  /// test never has to reach into a peer CP while that peer is running.
+  size_t peak_entries = 0;
   bool implicit_barrier_next = false;
   size_t next_dispatch_idx = 0;
   uint64_t queue_desc_va = 0;
+  /// True on a peer XCD's replica of a fanned-out queue. Such a replica never
+  /// reads the ring and never owns the queue's idle signal; it only receives
+  /// dispatch shards from the XCD that does.
+  bool fanout_replica = false;
+
+  /// @brief Append an entry, maintaining peak_entries.
+  /// @details The single push site, so the high-water mark cannot drift from the
+  /// deque. Callers already hold the CP's queue mutex.
+  void push_entry(DispatchEntry entry) {
+    entries.push_back(std::move(entry));
+    peak_entries = std::max(peak_entries, entries.size());
+  }
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -6,8 +6,10 @@
 #include "simdojo/sim/simulation.h"
 #include "simdojo/sim/topology.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace rocjitsu {
 
@@ -104,6 +106,21 @@ void SoC::flush_all() {
 }
 
 void SoC::initialize() {
+  // Let every XCD's command processor see its siblings, so a queue marked for
+  // fan-out can split its dispatches across the whole device. Each CP's rank is
+  // its own XCD index, which fixes the workgroup-to-XCD mapping independently of
+  // which XCD a given queue happened to be assigned to.
+  {
+    std::vector<amdgpu::CommandProcessor *> cps;
+    cps.reserve(xcds_.size());
+    for (auto *xcd_ptr : xcds_)
+      cps.push_back(xcd_ptr->command_processor());
+    if (std::find(cps.begin(), cps.end(), nullptr) == cps.end()) {
+      for (uint32_t i = 0; i < cps.size(); ++i)
+        cps[i]->set_xcd_topology(i, cps);
+    }
+  }
+
   if (iods_.empty()) {
     // No IOD modeling: wire each L2's req port directly to the standalone HBM controller.
     // Create the HBM controller lazily if set_memory() was called but the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -99,14 +99,18 @@ public:
   /// @returns Const reference to the vector of XCD pointers.
   const std::vector<amdgpu::Xcd *> &xcds() const { return xcds_; }
 
-  /// @brief MES-like queue assignment across XCD command processors.
+  /// @brief Pick the XCD command processor that will own a HW queue.
   ///
   /// @details On real MI300X hardware, the MES firmware distributes HW queues
   /// across XCDs. Use the process-local queue ordinal so equivalent queues from
-  /// independent processes compete for the same XCD resources.
+  /// independent processes compete for the same XCD resources. The owner reads
+  /// the queue's ring and holds each dispatch's completion signal. It is not the
+  /// only XCD that runs the work: a queue marked HwQueue::xcd_fanout spreads each
+  /// dispatch over every XCD, and which XCD owns the queue does not change the
+  /// workgroup-to-XCD mapping.
   ///
   /// @returns Pointer to the selected CommandProcessor, or nullptr if no XCDs.
-  amdgpu::CommandProcessor *assign_queue_cp(uint32_t queue_ordinal) {
+  amdgpu::CommandProcessor *assign_queue_owner_cp(uint32_t queue_ordinal) {
     if (xcds_.empty())
       return nullptr;
     uint32_t idx = queue_ordinal % static_cast<uint32_t>(xcds_.size());

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -20,6 +20,7 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <thread>
 
 namespace rocjitsu::test {
@@ -36,11 +37,27 @@ public:
   static constexpr uint64_t DEFAULT_WRITE_PTR_ADDR = 0xF0010008ULL;
   static constexpr uint64_t DEFAULT_DOORBELL_ADDR = 0xF0010010ULL;
 
+  /// @brief Register a queue with one command processor.
+  /// @param memory Simulator GPU memory holding the ring and its pointers.
+  /// @param cp Command processor to register with.
+  /// @param ring_addr Ring buffer base address.
+  /// @param ring_size Ring buffer size in bytes.
+  /// @param read_ptr_addr Address of the read pointer.
+  /// @param write_ptr_addr Address of the write pointer.
+  /// @param doorbell_addr Address of the doorbell.
+  /// @param xcd_fanout Spread each dispatch over every XCD. This helper is the only
+  /// thing that sets the flag today; it models the fan-out path the KFD create-queue
+  /// ioctl is to opt into for compute queues on a multi-XCD part. Off by default so
+  /// a test that binds a queue to one command processor keeps its CUs to itself.
+  /// @param queue_id Queue id. A fan-out queue is replicated onto every XCD and its
+  /// shards are routed back by (queue_id, process_id), so a test creating more than
+  /// one fan-out queue must give each a distinct id.
   AqlQueue(amdgpu::GpuMemory *memory, amdgpu::CommandProcessor *cp,
            uint64_t ring_addr = DEFAULT_RING_ADDR, uint32_t ring_size = DEFAULT_RING_SIZE,
            uint64_t read_ptr_addr = DEFAULT_READ_PTR_ADDR,
            uint64_t write_ptr_addr = DEFAULT_WRITE_PTR_ADDR,
-           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR)
+           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR, bool xcd_fanout = false,
+           uint32_t queue_id = 1)
       : memory_(memory), cp_(cp), ring_addr_(ring_addr), ring_size_(ring_size),
         read_ptr_addr_(read_ptr_addr), write_ptr_addr_(write_ptr_addr),
         doorbell_addr_(doorbell_addr) {
@@ -50,12 +67,13 @@ public:
     memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, doorbell_addr_);
 
     amdgpu::HwQueue hw{};
-    hw.queue_id = 1;
+    hw.queue_id = queue_id;
     hw.ring_base_va = ring_addr_;
     hw.ring_size = ring_size_;
     hw.read_ptr_va = read_ptr_addr_;
     hw.write_ptr_va = write_ptr_addr_;
     hw.doorbell_va = doorbell_addr_;
+    hw.xcd_fanout = xcd_fanout;
     cp_->register_queue(std::move(hw));
   }
 
@@ -100,6 +118,51 @@ public:
     submit(pkt);
   }
 
+  /// Same as dispatch(), with the AQL barrier bit set: the packet must not start
+  /// until every preceding packet on this queue has completed.
+  void dispatch_with_barrier(uint64_t kernel_object, uint32_t grid_size_x,
+                             uint16_t workgroup_size_x = 64, uint64_t kernarg_addr = 0) {
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH | (1u << HSA_PACKET_HEADER_BARRIER);
+    pkt.setup = 1;
+    pkt.workgroup_size_x = workgroup_size_x;
+    pkt.workgroup_size_y = 1;
+    pkt.workgroup_size_z = 1;
+    pkt.grid_size_x = grid_size_x;
+    pkt.grid_size_y = 1;
+    pkt.grid_size_z = 1;
+    pkt.kernel_object = kernel_object;
+    pkt.kernarg_address = reinterpret_cast<void *>(kernarg_addr);
+    submit(pkt);
+  }
+
+  /// Submit a BarrierAND packet.
+  ///
+  /// @param dep_signal_va Address of a dependency signal object, or 0 for none.
+  /// A barrier with no dependencies is satisfied as soon as it is read; one whose
+  /// signal still holds a positive value stalls the queue's reader, which is what
+  /// must keep a following dispatch from being handed to any XCD.
+  void barrier_and(uint64_t dep_signal_va = 0) {
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_BARRIER_AND;
+    // Dependency signal handles start at byte 8 of the barrier packet.
+    std::memcpy(reinterpret_cast<uint8_t *>(&pkt) + 8, &dep_signal_va, sizeof(dep_signal_va));
+    submit(pkt);
+  }
+
+  /// Submit an AMD vendor PM4 indirect-buffer packet.
+  ///
+  /// @details Runs no shader, so it is one of the packets a fanned-out queue has
+  /// to place on every XCD rather than split.
+  /// @param completion_signal_va Signal to decrement when it retires, or 0.
+  void pm4_ib(uint64_t completion_signal_va = 0) {
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+    pkt.setup = amdgpu::kAmdAqlFormatPm4Ib;
+    pkt.completion_signal.handle = completion_signal_va;
+    submit(pkt);
+  }
+
   /// Build and submit an AMD extended kernel dispatch packet with cluster shape.
   void dispatch_clustered(uint64_t kernel_object, uint32_t cluster_count_x, uint8_t cluster_size_x,
                           uint16_t workgroup_size_x = 64, uint64_t kernarg_addr = 0,
@@ -133,5 +196,19 @@ private:
   uint64_t doorbell_addr_;
   uint64_t write_idx_ = 0;
 };
+
+/// @brief Build a fan-out queue without spelling out the defaulted addresses.
+/// @param memory Simulator GPU memory holding the ring and its pointers.
+/// @param cp Command processor that will own the queue.
+/// @param queue_id Must be distinct per fan-out queue; shards route by it.
+/// @param ring_addr Ring buffer base; the pointers are placed relative to it.
+/// @returns A registered fan-out queue.
+inline std::unique_ptr<AqlQueue>
+make_fanout_queue(amdgpu::GpuMemory *memory, amdgpu::CommandProcessor *cp, uint32_t queue_id = 1,
+                  uint64_t ring_addr = AqlQueue::DEFAULT_RING_ADDR) {
+  return std::make_unique<AqlQueue>(memory, cp, ring_addr, AqlQueue::DEFAULT_RING_SIZE,
+                                    ring_addr + 0x10000, ring_addr + 0x10008, ring_addr + 0x10010,
+                                    /*xcd_fanout=*/true, queue_id);
+}
 
 } // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -365,13 +365,19 @@ TEST(Gfx1250SimulationTest, Ttmp8EncodesQueuePacketId) {
   step_until_xcd_halted(sim);
 
   ASSERT_EQ(sim.snapshot->snapshots().size(), 2u);
-  std::array<uint32_t, 2> queue_packet_ids{};
+  // Dispatch ids increase per packet but are not dense: each command processor
+  // mints them strided by the XCD count so ids from different XCDs cannot
+  // collide. Order the observations by id instead of indexing with it.
+  std::array<std::pair<uint32_t, uint32_t>, 2> by_dispatch{};
+  size_t i = 0;
   for (const auto &wf : sim.snapshot->snapshots()) {
     ASSERT_GE(wf.dispatch_id, 1u);
-    ASSERT_LE(wf.dispatch_id, 2u);
-    queue_packet_ids[wf.dispatch_id - 1] = wf.ttmp(8) & 0x1FFFFFFu;
+    by_dispatch[i++] = {wf.dispatch_id, wf.ttmp(8) & 0x1FFFFFFu};
   }
-  EXPECT_EQ(queue_packet_ids, (std::array<uint32_t, 2>{0, 1}));
+  std::sort(by_dispatch.begin(), by_dispatch.end());
+  ASSERT_LT(by_dispatch[0].first, by_dispatch[1].first);
+  EXPECT_EQ(by_dispatch[0].second, 0u);
+  EXPECT_EQ(by_dispatch[1].second, 1u);
 }
 
 TEST(Gfx1250SimulationTest, GlobalStoreWritesVisibleMemory) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -71,9 +71,9 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
   EXPECT_EQ(xcd->num_shader_engines(), 4u);
   EXPECT_EQ(xcd->shader_engine(0)->num_compute_units(), 9u);
   EXPECT_EQ(kmd::drm_cu_active_number(loaded.device.simd_count, loaded.device.simd_per_cu), 256u);
-  EXPECT_EQ(soc->assign_queue_cp(0), soc->xcd(0)->command_processor());
-  EXPECT_EQ(soc->assign_queue_cp(1), soc->xcd(1)->command_processor());
-  EXPECT_EQ(soc->assign_queue_cp(soc->num_xcds()), soc->xcd(0)->command_processor());
+  EXPECT_EQ(soc->assign_queue_owner_cp(0), soc->xcd(0)->command_processor());
+  EXPECT_EQ(soc->assign_queue_owner_cp(1), soc->xcd(1)->command_processor());
+  EXPECT_EQ(soc->assign_queue_owner_cp(soc->num_xcds()), soc->xcd(0)->command_processor());
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {

--- a/emulation/rocjitsu/tests/dbi/dbi_spill_sim_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/dbi_spill_sim_test.cpp
@@ -148,6 +148,8 @@ public:
   }
 
   amdgpu::GpuMemory *mem() { return mem_; }
+
+  uint32_t queue_seq_ = 0;
   amdgpu::CommandProcessor *cp() { return soc_->xcd(0)->command_processor(); }
   amdgpu::ComputeUnitCore *cu() { return soc_->xcd(0)->shader_engine(0)->compute_unit(0); }
 
@@ -176,7 +178,17 @@ public:
   std::vector<uint32_t> run_and_read_vgpr(const std::vector<uint32_t> &code, uint32_t private_bytes,
                                           uint32_t reg) {
     const uint64_t ko = write_kernel(0x1000, code, private_bytes);
-    test::AqlQueue queue(mem_, cp());
+    // Callers reuse one DbiSim for several dispatches, and each AqlQueue leaves
+    // its registration behind on the CP, so every run needs its own queue --
+    // its own id, since two live queues sharing one on a CP are rejected (fan-out
+    // routes shards back by (queue_id, process_id)), and its own ring and pointer
+    // page, since queues sharing a ring would let one doorbell be fetched and
+    // dispatched once per registration.
+    const uint32_t queue_id = ++queue_seq_;
+    const uint64_t ring = test::AqlQueue::DEFAULT_RING_ADDR + uint64_t{queue_id} * 0x100000ULL;
+    test::AqlQueue queue(mem_, cp(), ring, test::AqlQueue::DEFAULT_RING_SIZE, ring + 0x10000,
+                         ring + 0x10008, ring + 0x10010, /*xcd_fanout=*/false,
+                         /*queue_id=*/queue_id);
     queue.dispatch(ko, /*grid_size_x=*/wave_size_, /*workgroup_size_x=*/wave_size_);
     engine_->run();
 

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -26,6 +26,8 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
 RJ_DIAGNOSTIC_POP
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/soc.h"
 
 #include "simdojo/sim/simulation.h"
@@ -34,9 +36,11 @@ RJ_DIAGNOSTIC_POP
 #include <gtest/gtest.h>
 
 #include <bit>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -60,6 +64,9 @@ constexpr uint64_t A_ADDR = 0x100000;
 constexpr uint64_t B_ADDR = 0x200000;
 constexpr uint64_t C_ADDR = 0x300000;
 constexpr uint64_t KERNARG_ADDR = 0x400000;
+constexpr uint64_t SIGNAL_ADDR = 0x500000;
+// amd_signal_t::value sits 8 bytes into the signal object.
+constexpr uint32_t SIGNAL_VALUE_OFFSET = 8;
 
 TEST(VectorAddStressTest, AllCUsGoldenReference) {
   // Load the compiled vector_add kernel.
@@ -219,6 +226,385 @@ TEST(VectorAddCodeObjectTest, LoadsAndDecodes) {
   const auto *data = reinterpret_cast<const uint32_t *>(text->data());
   std::unique_ptr<Instruction> inst(decode_valid(*decoder, data));
   EXPECT_NE(inst, nullptr) << "Failed to decode first instruction";
+}
+
+// One queue, one dispatch, spread over all 8 XCDs by fan-out rather than by the
+// caller splitting the grid by hand. Proves the parts that a workgroup histogram
+// cannot: that a shard's workgroup ids address the right slice of the grid, that
+// each XCD's caches are published before the dispatch retires, and that the
+// completion signal fires once, after the last workgroup anywhere on the device.
+void run_fanout_golden_reference(uint32_t num_threads) {
+  Executable exec(kernel_path("vector_add"));
+  ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  loaded.engine_config.num_threads = num_threads;
+  auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  engine->topology().set_root(loaded.take_root());
+  loaded.wire_links(engine->topology());
+  if (num_threads > 1) {
+    ASSERT_TRUE(amdgpu::partition_topology_by_xcds(engine->topology(), soc, num_threads));
+  }
+  engine->create();
+
+  co->load_to_memory(memory, KD_ADDR);
+  uint64_t kernel_object = KD_ADDR + co->kernel_descriptor_offset("vector_add");
+  ASSERT_NE(kernel_object, KD_ADDR);
+
+  size_t vec_bytes = N * sizeof(float);
+  std::vector<float> A(N), B(N), C_expected(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    A[i] = static_cast<float>(i % 97) * 0.1f;
+    B[i] = static_cast<float>(i % 61) * 0.2f;
+    C_expected[i] = A[i] + B[i];
+  }
+
+  memory->load_image(reinterpret_cast<const uint8_t *>(A.data()), vec_bytes, A_ADDR);
+  memory->load_image(reinterpret_cast<const uint8_t *>(B.data()), vec_bytes, B_ADDR);
+  std::vector<float> zeros(N, 0.0f);
+  memory->load_image(reinterpret_cast<const uint8_t *>(zeros.data()), vec_bytes, C_ADDR);
+
+  struct {
+    uint64_t A, B, C;
+    uint32_t N;
+  } args = {A_ADDR, B_ADDR, C_ADDR, N};
+  memory->load_image(reinterpret_cast<const uint8_t *>(&args), sizeof(args), KERNARG_ADDR);
+
+  auto *cp = soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(memory, cp);
+  queue->dispatch(kernel_object, N, WF_SIZE, KERNARG_ADDR);
+
+  engine->run();
+  soc->flush_all();
+
+  auto counts = soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), TOTAL_XCDS);
+  for (uint32_t xi = 0; xi < TOTAL_XCDS; ++xi)
+    EXPECT_EQ(counts[xi], TOTAL_CUS / TOTAL_XCDS) << "xcd" << xi;
+
+  unsigned mismatches = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
+    if (std::abs(actual - C_expected[i]) > 1e-6f) {
+      if (mismatches < 10)
+        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << C_expected[i];
+      ++mismatches;
+    }
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " elements differ (showing first 10)";
+}
+
+// Every fan-out test above writes its inputs before any cache is filled, and
+// AqlQueue::dispatch leaves the packet's acquire scope at NONE, so none of them
+// depends on the peer-side invalidate at all: they would pass with the fence
+// removed. This primes each XCD's L2 with stale inputs first, so a peer that
+// skips the invalidate computes from data that is provably out of date.
+//
+// @param acquire_scope HSA_FENCE_SCOPE_AGENT to fence, HSA_FENCE_SCOPE_NONE for
+// the control that shows the fence is what produced the result.
+// @returns Number of elements that disagree with the golden reference, or nullopt
+// if the run never happened. Deliberately not a count: zero mismatches is the
+// PASSING result for the agent-scope case, so returning it when a prerequisite is
+// missing would report a dispatch that never ran as a clean one.
+std::optional<unsigned> run_fanout_with_primed_peer_caches(uint32_t acquire_scope) {
+  Executable exec(kernel_path("vector_add"));
+  EXPECT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
+  auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  EXPECT_NE(co, nullptr);
+  if (!co)
+    return std::nullopt;
+
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  engine->topology().set_root(loaded.take_root());
+  loaded.wire_links(engine->topology());
+  engine->create();
+
+  co->load_to_memory(memory, KD_ADDR);
+  uint64_t kernel_object = KD_ADDR + co->kernel_descriptor_offset("vector_add");
+
+  const size_t vec_bytes = N * sizeof(float);
+  std::vector<float> stale(N, -1.0f);
+  std::vector<float> A(N), B(N), C_expected(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    A[i] = static_cast<float>(i % 97) * 0.1f;
+    B[i] = static_cast<float>(i % 61) * 0.2f;
+    C_expected[i] = A[i] + B[i];
+  }
+
+  // 1. Stale inputs reach the backing store.
+  memory->load_image(reinterpret_cast<const uint8_t *>(stale.data()), vec_bytes, A_ADDR);
+  memory->load_image(reinterpret_cast<const uint8_t *>(stale.data()), vec_bytes, B_ADDR);
+  std::vector<float> zeros(N, 0.0f);
+  memory->load_image(reinterpret_cast<const uint8_t *>(zeros.data()), vec_bytes, C_ADDR);
+
+  // 2. Pull them through every XCD's L2, so each one now holds the stale lines.
+  std::vector<uint8_t> sink(vec_bytes);
+  for (uint32_t xi = 0; xi < TOTAL_XCDS; ++xi) {
+    auto *l2 = soc->xcd(xi)->l2_cache();
+    EXPECT_NE(l2, nullptr) << "xcd" << xi << " has no L2 to prime";
+    if (!l2)
+      return std::nullopt;
+    l2->read(A_ADDR, sink.data(), static_cast<uint32_t>(vec_bytes));
+    l2->read(B_ADDR, sink.data(), static_cast<uint32_t>(vec_bytes));
+  }
+
+  // 3. Update the backing store behind those caches. Every XCD is now stale.
+  memory->load_image(reinterpret_cast<const uint8_t *>(A.data()), vec_bytes, A_ADDR);
+  memory->load_image(reinterpret_cast<const uint8_t *>(B.data()), vec_bytes, B_ADDR);
+
+  struct {
+    uint64_t A, B, C;
+    uint32_t N;
+  } args = {A_ADDR, B_ADDR, C_ADDR, N};
+  memory->load_image(reinterpret_cast<const uint8_t *>(&args), sizeof(args), KERNARG_ADDR);
+
+  auto *cp = soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  EXPECT_NE(cp, nullptr);
+  if (!cp)
+    return std::nullopt;
+  auto queue = test::make_fanout_queue(memory, cp);
+
+  // 4. One fanned-out dispatch carrying the requested acquire scope. Only the
+  // owner would invalidate if the fence did not travel with each shard.
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header =
+      HSA_PACKET_TYPE_KERNEL_DISPATCH | (acquire_scope << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
+  pkt.setup = 1;
+  pkt.workgroup_size_x = WF_SIZE;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = N;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  pkt.kernarg_address = reinterpret_cast<void *>(KERNARG_ADDR);
+  queue->submit(pkt);
+
+  engine->run();
+  soc->flush_all();
+
+  unsigned mismatches = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
+    if (std::abs(actual - C_expected[i]) > 1e-6f)
+      ++mismatches;
+  }
+  return mismatches;
+}
+
+// With an agent-scope acquire, every shard invalidates its own XCD's caches on
+// its own thread and reads the updated inputs.
+TEST(VectorAddStressTest, FanoutAgentAcquireReachesEveryXcdsCaches) {
+  auto mismatches = run_fanout_with_primed_peer_caches(HSA_FENCE_SCOPE_AGENT);
+  ASSERT_TRUE(mismatches.has_value()) << "the primed fan-out dispatch never ran";
+  EXPECT_EQ(*mismatches, 0u)
+      << "a peer XCD computed from inputs it had cached before they were updated";
+}
+
+// The control. Without the fence the stale lines survive, so this must NOT come
+// out clean -- otherwise the test above proves nothing about the acquire path
+// and the priming is what is broken.
+TEST(VectorAddStressTest, FanoutWithoutAcquireKeepsStalePeerCaches) {
+  auto mismatches = run_fanout_with_primed_peer_caches(HSA_FENCE_SCOPE_NONE);
+  ASSERT_TRUE(mismatches.has_value()) << "the primed fan-out dispatch never ran";
+  EXPECT_GT(*mismatches, 0u)
+      << "priming did not make any XCD stale, so the acquire test is vacuous";
+}
+
+// Watches a fanned-out dispatch's completion signal from inside the run.
+//
+// The signal is the only thing a host waits on, so "fires exactly once" is not
+// the whole contract: it must also not fire while any XCD still has workgroups
+// to run, or a host that woke on it would read a half-written buffer. Checking
+// the value after engine->run() cannot tell those apart, so sample it as the
+// grid retires instead.
+class SignalOrderPlugin : public ExecutionPlugin {
+public:
+  SignalOrderPlugin(amdgpu::GpuMemory *memory, uint64_t initial_value, uint32_t total_wgs,
+                    const std::vector<float> &expected)
+      : ExecutionPlugin("fanout-signal-order"), memory_(memory), initial_value_(initial_value),
+        total_wgs_(total_wgs), expected_(expected) {}
+
+  void onAmdgpuWorkgroupCompleted(uint32_t, uint32_t) override {
+    ++wgs_completed_;
+    if (memory_->read64(SIGNAL_ADDR + SIGNAL_VALUE_OFFSET) == initial_value_)
+      return;
+    // The signal moved. Record the first time we saw that, and whether the whole
+    // grid's results had reached memory by then.
+    if (signal_moved_after_wgs_ != 0)
+      return;
+    signal_moved_after_wgs_ = wgs_completed_;
+    results_visible_when_signal_moved_ = 0;
+    for (uint32_t i = 0; i < expected_.size(); ++i) {
+      float actual = std::bit_cast<float>(memory_->read32(C_ADDR + i * sizeof(float)));
+      if (std::abs(actual - expected_[i]) <= 1e-6f)
+        ++results_visible_when_signal_moved_;
+    }
+  }
+
+  uint32_t wgs_completed() const { return wgs_completed_; }
+  /// Workgroups that had retired the first time the signal was seen changed, or
+  /// 0 if it never changed while the grid was still running.
+  uint32_t signal_moved_after_wgs() const { return signal_moved_after_wgs_; }
+  uint32_t results_visible_when_signal_moved() const { return results_visible_when_signal_moved_; }
+  uint32_t total_wgs() const { return total_wgs_; }
+
+private:
+  amdgpu::GpuMemory *memory_;
+  uint64_t initial_value_;
+  uint32_t total_wgs_;
+  const std::vector<float> &expected_;
+  uint32_t wgs_completed_ = 0;
+  uint32_t signal_moved_after_wgs_ = 0;
+  uint32_t results_visible_when_signal_moved_ = 0;
+};
+
+// A real completion signal on a fanned-out dispatch, watched while the grid
+// retires rather than only after it.
+//
+// Every other fan-out test leaves completion_signal at zero, so none of them
+// enters the signalling path at all. The one that does check the value reads it
+// after engine->run(), which cannot distinguish one final decrement from a
+// decrement issued as soon as the owning XCD finished its own eighth of the
+// grid: both leave the same value behind. This runs the real vector_add kernel,
+// so each shard writes results a host could actually read, and samples the
+// signal on every workgroup retirement. An implementation that signalled at its
+// own share's retirement would be caught by the 252 of 288 samples that follow.
+//
+// @param num_threads 1 for the single drain loop, TOTAL_XCDS for one engine
+// thread per XCD -- the case where an XCD can genuinely still be running while
+// the owner's share is done.
+void run_fanout_signal_ordering(uint32_t num_threads) {
+  Executable exec(kernel_path("vector_add"));
+  ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
+  auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  loaded.engine_config.num_threads = num_threads;
+  auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  engine->topology().set_root(loaded.take_root());
+  loaded.wire_links(engine->topology());
+  if (num_threads > 1) {
+    ASSERT_TRUE(amdgpu::partition_topology_by_xcds(engine->topology(), soc, num_threads));
+  }
+  engine->create();
+
+  co->load_to_memory(memory, KD_ADDR);
+  const uint64_t kernel_object = KD_ADDR + co->kernel_descriptor_offset("vector_add");
+  ASSERT_NE(kernel_object, KD_ADDR);
+
+  const size_t vec_bytes = N * sizeof(float);
+  std::vector<float> A(N), B(N), C_expected(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    A[i] = static_cast<float>(i % 97) * 0.1f;
+    B[i] = static_cast<float>(i % 61) * 0.2f;
+    C_expected[i] = A[i] + B[i];
+  }
+  memory->load_image(reinterpret_cast<const uint8_t *>(A.data()), vec_bytes, A_ADDR);
+  memory->load_image(reinterpret_cast<const uint8_t *>(B.data()), vec_bytes, B_ADDR);
+  std::vector<float> zeros(N, 0.0f);
+  memory->load_image(reinterpret_cast<const uint8_t *>(zeros.data()), vec_bytes, C_ADDR);
+
+  struct {
+    uint64_t A, B, C;
+    uint32_t N;
+  } args = {A_ADDR, B_ADDR, C_ADDR, N};
+  memory->load_image(reinterpret_cast<const uint8_t *>(&args), sizeof(args), KERNARG_ADDR);
+
+  // Not 1, so a signal written rather than decremented is also visible.
+  constexpr uint64_t kInitialSignal = 5;
+  memory->write64(SIGNAL_ADDR + SIGNAL_VALUE_OFFSET, kInitialSignal);
+
+  constexpr uint32_t kTotalWgs = N / WF_SIZE;
+  auto plugin = std::make_unique<SignalOrderPlugin>(memory, kInitialSignal, kTotalWgs, C_expected);
+  auto *watch = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  soc->set_plugin_group(group);
+
+  auto *cp = soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(memory, cp);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH |
+               (HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
+  pkt.setup = 1;
+  pkt.workgroup_size_x = WF_SIZE;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = N;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  pkt.kernarg_address = reinterpret_cast<void *>(KERNARG_ADDR);
+  pkt.completion_signal.handle = SIGNAL_ADDR;
+  queue->submit(pkt);
+
+  engine->run();
+  soc->flush_all();
+
+  // The grid really was spread, or none of this says anything about fan-out.
+  auto counts = soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), TOTAL_XCDS);
+  for (uint32_t xi = 0; xi < TOTAL_XCDS; ++xi)
+    ASSERT_EQ(counts[xi], TOTAL_CUS / TOTAL_XCDS) << "xcd" << xi;
+  // ...and every workgroup was sampled, or the watch above saw nothing.
+  ASSERT_EQ(watch->wgs_completed(), kTotalWgs);
+
+  // The ordering claim. Seeing the signal move at all while workgroups were still
+  // retiring means a host could have woken on it early.
+  if (watch->signal_moved_after_wgs() != 0) {
+    EXPECT_EQ(watch->signal_moved_after_wgs(), watch->total_wgs())
+        << "the completion signal moved with " << (kTotalWgs - watch->signal_moved_after_wgs())
+        << " workgroups of the grid still outstanding";
+    EXPECT_EQ(watch->results_visible_when_signal_moved(), N)
+        << "the completion signal moved before every XCD's results reached memory";
+  }
+
+  // ...and it moved exactly once, not once per share.
+  EXPECT_EQ(memory->read64(SIGNAL_ADDR + SIGNAL_VALUE_OFFSET), kInitialSignal - 1)
+      << "a fanned-out dispatch must decrement its completion signal once, not once per XCD";
+
+  unsigned mismatches = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
+    if (std::abs(actual - C_expected[i]) > 1e-6f)
+      ++mismatches;
+  }
+  EXPECT_EQ(mismatches, 0u) << "the shards did not write the results the signal stands for";
+}
+
+TEST(VectorAddStressTest, FanoutHoldsTheSignalUntilTheWholeGridRetires) {
+  run_fanout_signal_ordering(/*num_threads=*/1);
+}
+
+TEST(VectorAddStressTest, FanoutHoldsTheSignalUntilTheWholeGridRetires_MultiThreaded) {
+  run_fanout_signal_ordering(/*num_threads=*/TOTAL_XCDS);
+}
+
+TEST(VectorAddStressTest, FanoutSingleQueueGoldenReference) {
+  run_fanout_golden_reference(/*num_threads=*/1);
+}
+
+// The same dispatch with one engine thread per XCD. Here the owning XCD hands
+// shards to command processors on other partitions and the last XCD to finish
+// wakes the owner to fire the completion signal, so this is the case where the
+// cross-partition handoff and the flush-before-publish ordering actually matter.
+TEST(VectorAddStressTest, FanoutSingleQueueGoldenReference_MultiThreaded) {
+  run_fanout_golden_reference(/*num_threads=*/TOTAL_XCDS);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -11,6 +11,9 @@
 #include "rocjitsu/code/builders/instruction_builder.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/partitioning.h"
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/soc.h"
 
 #include "simdojo/sim/simulation.h"
@@ -24,8 +27,12 @@ RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -42,6 +49,18 @@ constexpr uint32_t kTotalCus = kTotalXcds * kCusPerXcd;
 constexpr uint64_t kKdAddr = 0x10000;
 constexpr uint32_t kWavefrontSize = 64;
 
+/// How many worker threads the fixture's engine runs on.
+enum class Threading {
+  /// One thread drives every XCD, as the config ships. Any ordering between two
+  /// XCDs is then a property of the single drain loop rather than of the code
+  /// under test.
+  Single,
+  /// One thread per XCD, via the XCD-aware partitioning policy. This is what puts
+  /// two command processors on genuinely opposing threads, so the cross-CP inbox
+  /// lock ordering and the cross-thread shard handoff are actually exercised.
+  ThreadPerXcd,
+};
+
 /// A loaded gfx950 SoC plus a trivial s_endpgm kernel resident in GPU memory.
 struct XcdDistributionFixture {
   config::LoadedConfig loaded;
@@ -49,12 +68,20 @@ struct XcdDistributionFixture {
   SoC *soc = nullptr;
   amdgpu::GpuMemory *memory = nullptr;
 
-  XcdDistributionFixture() : loaded(config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema)) {
+  explicit XcdDistributionFixture(Threading threading = Threading::Single)
+      : loaded(config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema)) {
     soc = loaded.soc();
     memory = loaded.memory();
+    if (threading == Threading::ThreadPerXcd)
+      loaded.engine_config.num_threads =
+          amdgpu::clamp_xcd_partition_count(soc, static_cast<uint32_t>(soc->num_xcds()));
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
     engine->topology().set_root(loaded.take_root());
     loaded.wire_links(engine->topology());
+    if (loaded.engine_config.num_threads > 1 &&
+        !amdgpu::partition_topology_by_xcds(engine->topology(), soc,
+                                            loaded.engine_config.num_threads))
+      ADD_FAILURE() << "multi-threaded topology requires per-XCD partitioning";
     engine->create();
 
     using namespace rocr::llvm::amdhsa;
@@ -80,23 +107,120 @@ uint32_t assigned_xcd_index(const SoC &soc, const amdgpu::CommandProcessor *cp) 
   return 0;
 }
 
+// Records the interleaving of workgroup dispatch and completion across all XCDs.
+class WorkgroupOrderPlugin : public ExecutionPlugin {
+public:
+  WorkgroupOrderPlugin() : ExecutionPlugin("xcd-wg-order") {}
+
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t, uint32_t, uint32_t,
+                                   std::span<amdgpu::Wavefront *>) override {
+    if (first_dispatched_.find(dispatch_id) == first_dispatched_.end())
+      first_dispatched_[dispatch_id] = step_;
+    ++step_;
+  }
+
+  void onAmdgpuWorkgroupCompleted(uint32_t dispatch_id, uint32_t) override {
+    last_completed_[dispatch_id] = step_++;
+  }
+
+  /// Step at which the first workgroup of @p dispatch_id was placed on any XCD.
+  uint64_t first_dispatched(uint32_t dispatch_id) const {
+    auto it = first_dispatched_.find(dispatch_id);
+    return it == first_dispatched_.end() ? UINT64_MAX : it->second;
+  }
+  /// Step at which the last workgroup of @p dispatch_id retired on any XCD.
+  uint64_t last_completed(uint32_t dispatch_id) const {
+    auto it = last_completed_.find(dispatch_id);
+    return it == last_completed_.end() ? UINT64_MAX : it->second;
+  }
+  size_t dispatch_count() const { return first_dispatched_.size(); }
+
+  /// Dispatch ids in the order their first workgroup was placed.
+  std::vector<uint32_t> dispatch_ids() const {
+    std::vector<uint32_t> ids;
+    for (const auto &[id, step] : first_dispatched_)
+      ids.push_back(id);
+    std::sort(ids.begin(), ids.end(),
+              [&](uint32_t a, uint32_t b) { return first_dispatched(a) < first_dispatched(b); });
+    return ids;
+  }
+
+private:
+  uint64_t step_ = 0;
+  std::map<uint32_t, uint64_t> first_dispatched_;
+  std::map<uint32_t, uint64_t> last_completed_;
+};
+
+/// Records the grid-wide dispatch callbacks alongside workgroup completion.
+///
+/// @details Ordering comes from the shared counter rather than from wall clock:
+/// the lock that guards it also serializes the callbacks, so the steps are a
+/// total order consistent with the order the plugin actually observed them, even
+/// with one thread per XCD.
+class ExecutionSpanPlugin : public ExecutionPlugin {
+public:
+  struct Event {
+    uint32_t dispatch_id;
+    uint64_t step;
+  };
+
+  ExecutionSpanPlugin() : ExecutionPlugin("xcd-exec-span") {}
+
+  void onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    begins_.push_back({dispatch_id, step_++});
+  }
+
+  void onAmdgpuWorkgroupCompleted(uint32_t, uint32_t) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++workgroups_completed_;
+    last_workgroup_step_ = step_++;
+  }
+
+  void onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ends_.push_back({dispatch_id, step_++});
+  }
+
+  std::vector<Event> begins() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return begins_;
+  }
+  std::vector<Event> ends() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return ends_;
+  }
+  uint32_t workgroups_completed() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return workgroups_completed_;
+  }
+  /// Step at which the last workgroup anywhere on the device retired.
+  uint64_t last_workgroup_step() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return last_workgroup_step_;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  uint64_t step_ = 0;
+  uint32_t workgroups_completed_ = 0;
+  uint64_t last_workgroup_step_ = 0;
+  std::vector<Event> begins_;
+  std::vector<Event> ends_;
+};
+
 } // namespace
 
-// One HW queue is placed on one XCD by SoC::assign_queue_cp(), which is the
-// selector the KFD CREATE_QUEUE path uses. Every workgroup of a dispatch on that
-// queue is therefore placed by that one XCD's command processor, on that one
-// XCD's compute units.
-//
-// This pins CURRENT behavior, which is a fidelity gap: a multi-XCD part running
-// as one partition spreads a dispatch over every XCD. The topology here
-// instantiates 288 CUs, so a single-queue application reaches an eighth of them.
-// Follow-on work in this stack flips this expectation to an even spread.
-TEST(XcdDistributionTest, SingleQueueGridLandsOnOneXcd) {
+// Fan-out is a property of the queue, not of the device. A queue registered
+// directly against one command processor, as a test that wants that command
+// processor's CUs to itself does, keeps the whole grid on that one XCD. Opting
+// in is what spreads it; see FanoutQueueGridSpreadsOverAllXcds.
+TEST(XcdDistributionTest, QueueWithoutFanoutKeepsGridOnOneXcd) {
   XcdDistributionFixture fx;
   ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
   ASSERT_EQ(fx.soc->all_cus().size(), kTotalCus);
 
-  auto *cp = fx.soc->assign_queue_cp(/*queue_ordinal=*/0);
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
   ASSERT_NE(cp, nullptr);
   test::AqlQueue queue(fx.memory, cp);
   queue.dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
@@ -117,9 +241,323 @@ TEST(XcdDistributionTest, SingleQueueGridLandsOnOneXcd) {
   EXPECT_EQ(counts[assigned_xcd_index(*fx.soc, cp)], kTotalCus);
 }
 
-// assign_queue_cp() rotates queues across XCDs, so N queues do reach N XCDs.
-// This is the only XCD spreading that exists today, and it only helps an
-// application that opens more than one HW queue.
+// A queue marked for fan-out spreads each dispatch over every XCD, round-robin
+// one workgroup at a time. The permutation is part of the contract: kernels that
+// swizzle their workgroup index for cache locality assume workgroup i runs on XCD
+// i % num_xcds.
+TEST(XcdDistributionTest, FanoutQueueGridSpreadsOverAllXcds) {
+  XcdDistributionFixture fx;
+  ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), kTotalXcds);
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), kTotalCus);
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    EXPECT_EQ(counts[xi], kTotalCus / kTotalXcds) << "xcd" << xi;
+}
+
+// The split must not depend on which XCD the queue landed on: rank is the XCD's
+// own index, so the workgroup-to-XCD mapping is the same for every queue.
+TEST(XcdDistributionTest, FanoutIsIndependentOfOwningXcd) {
+  XcdDistributionFixture fx;
+
+  // Ask for an ordinal that lands the queue on an XCD other than xcd0.
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/3);
+  ASSERT_NE(cp, nullptr);
+  ASSERT_NE(cp, fx.soc->xcd(0)->command_processor());
+
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    EXPECT_EQ(counts[xi], kTotalCus / kTotalXcds) << "xcd" << xi;
+}
+
+// A grid with fewer workgroups than XCDs still reaches one workgroup per XCD for
+// as far as it goes; the remaining XCDs take an empty share. The empty shares are
+// what keep every XCD's view of the queue in step, so ordering still works.
+TEST(XcdDistributionTest, GridSmallerThanXcdCountSpreadsOnePerXcd) {
+  XcdDistributionFixture fx;
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  constexpr uint32_t kWgs = kTotalXcds - 3;
+  queue->dispatch(kKdAddr, kWgs * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), kTotalXcds);
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), kWgs);
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    EXPECT_EQ(counts[xi], xi < kWgs ? 1u : 0u) << "xcd" << xi;
+}
+
+// A dispatch too small to reach every XCD still has to hold up a following
+// barrier'd packet on the XCDs it never touched. Those XCDs only know the packet
+// exists because fan-out gives them an empty share of it, so this is the case
+// that breaks if empty shares are skipped as an optimization.
+TEST(XcdDistributionTest, BarrierAfterSmallDispatchStillOrders) {
+  XcdDistributionFixture fx;
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  // Two workgroups: only two of the eight XCDs run any of it.
+  queue->dispatch(kKdAddr, 2 * kWavefrontSize, kWavefrontSize);
+  queue->dispatch_with_barrier(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto ids = order->dispatch_ids();
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_GT(order->first_dispatched(ids[1]), order->last_completed(ids[0]))
+      << "an XCD with no share of the first dispatch started the barrier'd one early";
+}
+
+// A barrier packet whose dependency is still unsatisfied stops the owner from
+// reading further, and that is the only thing holding the dispatch behind it
+// back on every XCD. Barrier packets are never handed to peers -- only kernel
+// shards are -- so a peer's replica would see Kernel/Kernel with nothing between
+// them. If shards were issued at fetch time rather than gated on the owner
+// getting past the barrier, every peer would run the second dispatch while the
+// barrier was still stalled.
+TEST(XcdDistributionTest, BarrierOnPriorDispatchOrdersEveryXcd) {
+  XcdDistributionFixture fx;
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  // The barrier waits on the first dispatch's own completion signal, so it clears
+  // only once that dispatch has retired device-wide. amd_signal_t::value lives 8
+  // bytes into the signal object.
+  constexpr uint64_t kDepSignalAddr = 0x60000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  fx.memory->write64(kDepSignalAddr + kSignalValueOffset, 1);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  hsa_kernel_dispatch_packet_t first{};
+  first.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  first.setup = 1;
+  first.workgroup_size_x = kWavefrontSize;
+  first.workgroup_size_y = 1;
+  first.workgroup_size_z = 1;
+  first.grid_size_x = kTotalCus * kWavefrontSize;
+  first.grid_size_y = 1;
+  first.grid_size_z = 1;
+  first.kernel_object = kKdAddr;
+  first.completion_signal.handle = kDepSignalAddr;
+  queue->submit(first);
+
+  queue->barrier_and(kDepSignalAddr);
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  // Both dispatches ran, spread over every XCD.
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), 2 * kTotalCus);
+
+  auto ids = order->dispatch_ids();
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_GT(order->first_dispatched(ids[1]), order->last_completed(ids[0]))
+      << "an XCD started the post-barrier dispatch before the barrier's dependency cleared";
+}
+
+// A packet that runs no shader has no grid to split, so every XCD gets the entry
+// itself rather than a share of it. It is still one packet owed one completion:
+// the copies carry no signal, or an IB would decrement its signal once per XCD.
+TEST(XcdDistributionTest, FanoutReplicatesNonKernelPacketsButSignalsThemOnce) {
+  XcdDistributionFixture fx;
+
+  // amd_signal_t::value lives 8 bytes into the signal object. Not 1, so a signal
+  // written rather than decremented is also visible.
+  constexpr uint64_t kSignalAddr = 0x70000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  constexpr uint64_t kInitialValue = 5;
+  fx.memory->write64(kSignalAddr + kSignalValueOffset, kInitialValue);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  queue->pm4_ib(kSignalAddr);
+
+  fx.engine->run();
+
+  EXPECT_EQ(fx.memory->read64(kSignalAddr + kSignalValueOffset), kInitialValue - 1)
+      << "a replicated packet must still signal once, not once per XCD";
+}
+
+// The replication itself. Every XCD must end up holding the IB entry alongside
+// its share of the kernel ahead of it, so the ordering each XCD reads from the
+// entries in front of a barrier'd packet is the owner's ordering and not a
+// shortened one.
+//
+// The depth is read from each CP's own high-water mark AFTER the run, not sampled
+// during it. An earlier version sampled every peer from inside a workgroup callback,
+// which took a second CP's queue mutex while already holding the dispatching CP's --
+// an inversion between any two CPs, and one ThreadSanitizer reports even on a
+// single-threaded run. Recording the peak where the push happens removes the
+// cross-CP reach entirely, which is why this can run one thread per XCD.
+TEST(XcdDistributionTest, EveryXcdHoldsTheNonKernelPacketsOfItsQueue) {
+  XcdDistributionFixture fx(Threading::ThreadPerXcd);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  // A long kernel, so the IB behind it is still queued while workgroups run and the
+  // queue genuinely reaches depth two.
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+  queue->pm4_ib();
+
+  fx.engine->run();
+
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
+    EXPECT_GE(fx.soc->xcd(xi)->command_processor()->peak_queued_entry_count_for_test(
+                  /*queue_id=*/1, /*process_id=*/0),
+              2u)
+        << "xcd" << xi << " never held both the kernel share and the IB behind it";
+  }
+}
+
+// The mix that makes the replication load-bearing: a barrier'd kernel sitting
+// behind a packet that runs no shader. A peer reads its ordering from the entries
+// ahead of the barrier'd packet in its own queue, so unless the IB is placed there
+// too the peer decides against a shorter prefix than the owner's.
+TEST(XcdDistributionTest, BarrierdKernelBehindAnIbOrdersOnEveryXcd) {
+  XcdDistributionFixture fx(Threading::ThreadPerXcd);
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+  queue->pm4_ib();
+  queue->dispatch_with_barrier(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), uint64_t{2} * kTotalCus);
+
+  auto ids = order->dispatch_ids();
+  ASSERT_EQ(ids.size(), 2u) << "the IB runs no shader, so only the two kernels report workgroups";
+  EXPECT_GT(order->first_dispatched(ids[1]), order->last_completed(ids[0]))
+      << "an XCD started the barrier'd kernel while a peer still ran the one before the IB";
+}
+
+// Fan-out copies a dispatch id onto peer XCDs, and completion bookkeeping looks
+// entries up by that id. If two XCDs could mint the same id, a peer holding both
+// a shard of one dispatch and its own dispatch with the same id would credit
+// workgroup completions to whichever it found first. Drive this through real
+// dispatches on queues owned by different XCDs rather than the id counter alone.
+TEST(XcdDistributionTest, DispatchIdsAreDisjointAcrossXcds) {
+  XcdDistributionFixture fx;
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  // One queue per XCD, so every XCD mints ids for dispatches of its own while
+  // also holding shards minted by the other seven.
+  std::vector<std::unique_ptr<test::AqlQueue>> queues;
+  for (uint32_t qi = 0; qi < kTotalXcds; ++qi) {
+    auto *cp = fx.soc->assign_queue_owner_cp(qi);
+    ASSERT_NE(cp, nullptr);
+    uint64_t ring = 0xF0000000ULL + qi * 0x100000ULL;
+    // Distinct queue ids: a fan-out queue is replicated onto every XCD, and each
+    // CP routes an incoming shard back by (queue_id, process_id).
+    queues.push_back(test::make_fanout_queue(fx.memory, cp, /*queue_id=*/qi + 1, ring));
+    queues.back()->dispatch(kKdAddr, kTotalXcds * kWavefrontSize, kWavefrontSize);
+  }
+
+  fx.engine->run();
+
+  // Every dispatch must be distinguishable; a collision would have merged two of
+  // them into one id and lost a completion.
+  EXPECT_EQ(order->dispatch_count(), kTotalXcds);
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}),
+            uint64_t{kTotalXcds} * kTotalXcds);
+}
+
+// Two fanned-out dispatches, the second carrying the AQL barrier bit. The barrier
+// means no later packet starts until every preceding packet has completed, which
+// for a fanned-out dispatch is a property of the whole grid: an XCD that finished
+// its own share of the first dispatch must still not begin the second while a
+// peer is running.
+//
+// Resource pressure cannot show this — these workgroups retire immediately and
+// never fill the device — so observe the interleaving directly. Since fan-out
+// gives every shard of a dispatch the same dispatch id, "first workgroup of the
+// second dispatch placed anywhere" must come after "last workgroup of the first
+// dispatch retired anywhere".
+TEST(XcdDistributionTest, BarrierBitWaitsForEveryXcdsShare) {
+  XcdDistributionFixture fx;
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+  queue->dispatch_with_barrier(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), kTotalXcds);
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), uint64_t{2} * kTotalCus);
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    EXPECT_EQ(counts[xi], 2 * (kTotalCus / kTotalXcds)) << "xcd" << xi;
+
+  // Fan-out shares one dispatch id per dispatch, so exactly two ids appear.
+  auto ids = order->dispatch_ids();
+  ASSERT_EQ(ids.size(), 2u) << "expected exactly two distinct dispatch ids";
+  EXPECT_GT(order->first_dispatched(ids[1]), order->last_completed(ids[0]))
+      << "an XCD began the barrier'd dispatch before every XCD retired the previous one";
+}
+
+// Queue ownership still rotates across XCDs. With fan-out that no longer decides
+// where the work runs, but it does spread ring reads and completion signalling.
 TEST(XcdDistributionTest, QueuesRotateAcrossXcds) {
   XcdDistributionFixture fx;
   ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
@@ -128,7 +566,7 @@ TEST(XcdDistributionTest, QueuesRotateAcrossXcds) {
   constexpr uint32_t kWgsPerQueue = kCusPerXcd;
   std::vector<std::unique_ptr<test::AqlQueue>> queues;
   for (uint32_t qi = 0; qi < kTotalXcds; ++qi) {
-    auto *cp = fx.soc->assign_queue_cp(qi);
+    auto *cp = fx.soc->assign_queue_owner_cp(qi);
     ASSERT_NE(cp, nullptr);
     uint64_t ring = 0xF0000000ULL + qi * 0x100000ULL;
     queues.push_back(std::make_unique<test::AqlQueue>(fx.memory, cp, ring, 4096, ring + 0x10000,
@@ -154,7 +592,7 @@ TEST(XcdDistributionTest, CounterAccumulatesAcrossDispatchesOnOneQueue) {
   ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
   ASSERT_EQ(fx.soc->all_cus().size(), kTotalCus);
 
-  auto *cp = fx.soc->assign_queue_cp(/*queue_ordinal=*/0);
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
   ASSERT_NE(cp, nullptr);
   const uint32_t xi = assigned_xcd_index(*fx.soc, cp);
 
@@ -172,4 +610,322 @@ TEST(XcdDistributionTest, CounterAccumulatesAcrossDispatchesOnOneQueue) {
       << "counter must accumulate across packets, not restart per packet";
   EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}),
             uint64_t{kFirstWgs} + kSecondWgs);
+}
+
+// The id classes must stay disjoint across the 32-bit wrap, which
+// DispatchIdsAreDisjointAcrossXcds cannot reach: it is ~2^29 dispatches per XCD
+// away. The case that breaks is a non-power-of-two XCD count, which XcdShard
+// explicitly permits -- letting the counter run off the end of the type keeps
+// the classes disjoint only when the count divides 2^32. With stride 3, rank 0
+// would step 4294967295 -> 2 and collide with rank 1's class.
+TEST(XcdDistributionTest, DispatchIdClassesStayDisjointAcrossTheWrap) {
+  using amdgpu::CommandProcessor;
+  constexpr uint32_t kMax = std::numeric_limits<uint32_t>::max();
+
+  for (uint32_t stride : {1u, 3u, 5u, 6u, 7u, 8u}) {
+    // Walk each rank's class from just below the top, through the wrap, and on
+    // past its restart, collecting every id any rank can produce there.
+    std::map<uint32_t, uint32_t> owner_of_id;
+    for (uint32_t rank = 0; rank < stride; ++rank) {
+      const uint32_t base = 1 + rank;
+
+      // Fast-forward to the last id of this class without enumerating it.
+      const uint32_t last = base + ((kMax - base) / stride) * stride;
+      ASSERT_LE(last, kMax);
+      ASSERT_GT(last, kMax - stride) << "last really is the final id of the class";
+
+      uint32_t id = last;
+      for (int step = 0; step < 4; ++step) {
+        EXPECT_EQ(id % stride, base % stride)
+            << "stride " << stride << " rank " << rank << " left its residue class";
+        auto [it, inserted] = owner_of_id.emplace(id, rank);
+        EXPECT_TRUE(inserted || it->second == rank)
+            << "stride " << stride << ": id " << id << " minted by rank " << rank << " and rank "
+            << it->second;
+        id = CommandProcessor::step_dispatch_id(id, base, stride);
+      }
+      // The wrap returns to the class's own base, never past the end of it.
+      EXPECT_EQ(CommandProcessor::step_dispatch_id(last, base, stride), base)
+          << "stride " << stride << " rank " << rank;
+    }
+  }
+}
+
+// Every other fan-out test leaves completion_signal at zero, so none of them
+// enters fire_signal at all: the owner-only signalling rule is unexercised, and
+// the barrier and plugin assertions would still pass if the user-visible signal
+// were never written, or were written once per XCD.
+//
+// A fanned-out grid is split eight ways, so a signal fired per share would land
+// eight decrements instead of one. Check the value itself, not just that it
+// moved.
+//
+// Two independent mechanisms keep it at one: fan_out_dispatch() zeroes each
+// peer's completion_signal, and drain_completions() fires only for the shard
+// that is not a peer. Defeating either alone still yields one decrement, so this
+// pins the property rather than either implementation of it.
+void run_fanout_completion_signal(Threading threading) {
+  XcdDistributionFixture fx(threading);
+  ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
+
+  // amd_signal_t::value lives 8 bytes into the signal object.
+  constexpr uint64_t kSignalAddr = 0x50000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  constexpr uint64_t kInitialValue = 5;
+  fx.memory->write64(kSignalAddr + kSignalValueOffset, kInitialValue);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  test::AqlQueue queue(fx.memory, cp, test::AqlQueue::DEFAULT_RING_ADDR,
+                       test::AqlQueue::DEFAULT_RING_SIZE, test::AqlQueue::DEFAULT_READ_PTR_ADDR,
+                       test::AqlQueue::DEFAULT_WRITE_PTR_ADDR,
+                       test::AqlQueue::DEFAULT_DOORBELL_ADDR, /*xcd_fanout=*/true);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = kWavefrontSize;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = kTotalCus * kWavefrontSize;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kKdAddr;
+  pkt.completion_signal.handle = kSignalAddr;
+  queue.submit(pkt);
+
+  fx.engine->run();
+
+  // The grid really was spread, or this would prove nothing about fan-out.
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), kTotalCus);
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    ASSERT_EQ(counts[xi], kTotalCus / kTotalXcds) << "xcd" << xi;
+
+  EXPECT_EQ(fx.memory->read64(kSignalAddr + kSignalValueOffset), kInitialValue - 1)
+      << "the dispatch must decrement its completion signal once, not once per XCD";
+}
+
+TEST(XcdDistributionTest, FanoutFiresTheCompletionSignalExactlyOnce) {
+  run_fanout_completion_signal(Threading::Single);
+}
+
+// The same, with one engine thread per XCD. On a single thread the XCD that
+// completes the grid and the XCD that owns the signal are driven by the same
+// drain loop, so the wake that rouses a parked owner is never actually needed.
+// Here they are on different threads and it is.
+TEST(XcdDistributionTest, FanoutFiresTheCompletionSignalExactlyOnceThreaded) {
+  run_fanout_completion_signal(Threading::ThreadPerXcd);
+}
+
+// The two ordering regressions above run on a single engine thread, where every
+// XCD is driven by one drain loop and two command processors never actually run
+// at the same time. That leaves the properties they check resting on an
+// accident of the drain order: the cross-CP inbox lock ordering, the
+// cross-thread shard handoff, and wake_all_xcds() rousing a peer parked behind a
+// barrier are all unexercised.
+//
+// Re-run both with one thread per XCD. ExecutionPluginGroup already serializes
+// the callbacks WorkgroupOrderPlugin records, so the observations stay valid.
+
+TEST(XcdDistributionTest, DispatchIdsAreDisjointAcrossXcdsThreaded) {
+  XcdDistributionFixture fx(Threading::ThreadPerXcd);
+  ASSERT_GT(fx.loaded.engine_config.num_threads, 1u) << "fixture did not actually go concurrent";
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  // One queue per XCD, so the XCDs are opposing owners: each mints ids for its
+  // own dispatches while concurrently holding shards minted by the other seven.
+  std::vector<std::unique_ptr<test::AqlQueue>> queues;
+  for (uint32_t qi = 0; qi < kTotalXcds; ++qi) {
+    auto *cp = fx.soc->assign_queue_owner_cp(qi);
+    ASSERT_NE(cp, nullptr);
+    uint64_t ring = 0xF0000000ULL + qi * 0x100000ULL;
+    queues.push_back(test::make_fanout_queue(fx.memory, cp, /*queue_id=*/qi + 1, ring));
+    queues.back()->dispatch(kKdAddr, kTotalXcds * kWavefrontSize, kWavefrontSize);
+  }
+
+  fx.engine->run();
+
+  EXPECT_EQ(order->dispatch_count(), kTotalXcds)
+      << "two XCDs minted the same dispatch id and their completions merged";
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}),
+            uint64_t{kTotalXcds} * kTotalXcds);
+}
+
+TEST(XcdDistributionTest, BarrierBitWaitsForEveryXcdsShareThreaded) {
+  XcdDistributionFixture fx(Threading::ThreadPerXcd);
+  ASSERT_GT(fx.loaded.engine_config.num_threads, 1u) << "fixture did not actually go concurrent";
+
+  auto plugin = std::make_unique<WorkgroupOrderPlugin>();
+  auto *order = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+
+  queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+  queue->dispatch_with_barrier(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(counts.size(), kTotalXcds);
+  EXPECT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), uint64_t{2} * kTotalCus);
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    EXPECT_EQ(counts[xi], 2 * (kTotalCus / kTotalXcds)) << "xcd" << xi;
+
+  auto ids = order->dispatch_ids();
+  ASSERT_EQ(ids.size(), 2u) << "expected exactly two distinct dispatch ids";
+  EXPECT_GT(order->first_dispatched(ids[1]), order->last_completed(ids[0]))
+      << "an XCD began the barrier'd dispatch while a peer still ran the previous one";
+}
+
+// One matched begin/end pair is owed per packet, not per share, and the pair
+// spans the whole grid rather than the owner's part of it. The hard case is a
+// grid smaller than the XCD count whose owner draws an empty share: begin cannot
+// be pinned to the XCD that read the packet, because that XCD never places a
+// workgroup, so it is claimed by whichever XCD places the grid's first one --
+// while end stays with the owner. Threaded, so the two are genuinely different
+// CPs on different threads and the claim is a real race rather than a formality.
+TEST(XcdDistributionTest, FanoutReportsOneExecutionPairWhenTheOwnerShareIsEmpty) {
+  XcdDistributionFixture fx(Threading::ThreadPerXcd);
+  ASSERT_GT(fx.loaded.engine_config.num_threads, 1u) << "fixture did not actually go concurrent";
+
+  auto plugin = std::make_unique<ExecutionSpanPlugin>();
+  auto *span = plugin.get();
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  fx.soc->set_plugin_group(group);
+
+  // Fewer workgroups than XCDs, on a queue owned by an XCD past the end of the
+  // grid, so the owner's share really is empty.
+  constexpr uint32_t kWgs = 2;
+  static_assert(kWgs < kTotalXcds, "the owner can only draw an empty share on a small grid");
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/3);
+  ASSERT_NE(cp, nullptr);
+  const uint32_t owner_xcd = assigned_xcd_index(*fx.soc, cp);
+  ASSERT_GE(owner_xcd, kWgs) << "the owning XCD must fall outside the grid for this test";
+
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  queue->dispatch(kKdAddr, kWgs * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  ASSERT_EQ(std::accumulate(counts.begin(), counts.end(), uint64_t{0}), kWgs);
+  ASSERT_EQ(counts[owner_xcd], 0u)
+      << "the owning XCD was supposed to draw an empty share, so this proves nothing";
+
+  auto begins = span->begins();
+  auto ends = span->ends();
+  ASSERT_EQ(begins.size(), 1u) << "a fanned-out dispatch owes exactly one execution begin";
+  ASSERT_EQ(ends.size(), 1u) << "a fanned-out dispatch owes exactly one execution end";
+  EXPECT_EQ(begins.front().dispatch_id, ends.front().dispatch_id)
+      << "the begin and end must name the same dispatch";
+  EXPECT_EQ(span->workgroups_completed(), kWgs);
+  EXPECT_LT(begins.front().step, ends.front().step);
+  EXPECT_GT(ends.front().step, span->last_workgroup_step())
+      << "execution end was reported before the grid's last workgroup retired";
+}
+
+// Scratch is the one resource a shard cannot size from its own share. A wave's
+// scratch slot is indexed by its *grid-wide* workgroup id, so the high-index
+// workgroups a peer XCD runs address the far end of the pool. Sizing the
+// allocation from an XCD's own share would leave that end unbacked, and the
+// allocator would then be re-entered mid-dispatch, remapping the pool VA out
+// from under waves already spilling into it.
+//
+// Every fan-out test elsewhere uses a kernel with no scratch, so none of them
+// reaches this path at all. Record what the allocator is actually asked for.
+TEST(XcdDistributionTest, FanoutSizesScratchForTheWholeGridNotOneShare) {
+  XcdDistributionFixture fx;
+  ASSERT_EQ(fx.soc->num_xcds(), kTotalXcds);
+
+  constexpr uint32_t kPrivateBytes = 64;
+  constexpr uint64_t kScratchKdAddr = 0x20000;
+
+  // A second kernel descriptor, identical to the fixture's but demanding scratch.
+  {
+    using namespace rocr::llvm::amdhsa;
+    kernel_descriptor_t kd{};
+    kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                    ((256 / 8) - 1));
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                    ((104 / 8) - 1));
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+    kd.private_segment_fixed_size = kPrivateBytes;
+    fx.memory->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), kScratchKdAddr);
+    fx.memory->write32(kScratchKdAddr + sizeof(kernel_descriptor_t),
+                       build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4));
+  }
+
+  struct ScratchRequest {
+    uint64_t gpu_va;
+    size_t size;
+  };
+  std::vector<ScratchRequest> requests;
+  std::mutex requests_mutex;
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
+    fx.soc->xcd(xi)->command_processor()->set_scratch_backing_allocator(
+        [&](uint32_t, uint64_t gpu_va, size_t size) -> bool {
+          {
+            std::lock_guard<std::mutex> lock(requests_mutex);
+            requests.push_back({gpu_va, size});
+          }
+          // Actually back it, or every wave would find the pool unmapped and
+          // re-enter the allocator, hiding the very duplication under test.
+          std::vector<uint8_t> zeros(size, 0);
+          fx.memory->load_image(zeros.data(), size, gpu_va);
+          return true;
+        });
+  }
+
+  auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
+  ASSERT_NE(cp, nullptr);
+  auto queue = test::make_fanout_queue(fx.memory, cp);
+  queue->dispatch(kScratchKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
+
+  fx.engine->run();
+
+  // The grid really was spread, or the sizing claim below is untested.
+  auto counts = fx.soc->dispatched_workgroups_per_xcd();
+  for (uint32_t xi = 0; xi < kTotalXcds; ++xi)
+    ASSERT_EQ(counts[xi], kTotalCus / kTotalXcds) << "xcd" << xi;
+
+  ASSERT_FALSE(requests.empty()) << "the scratch path was never reached";
+
+  // Every request is sized against the whole grid, not the requesting XCD's
+  // share. This is the claim that matters: a wave's slot is indexed by its
+  // grid-wide workgroup id, so a share-sized pool would be an eighth as large
+  // and the workgroups above it would spill past the end of it.
+  const uint64_t per_wave = uint64_t{kPrivateBytes} * kWavefrontSize;
+  const uint64_t waves_per_wg = 1; // one wavefront-sized workgroup
+  const uint64_t grid_wide = per_wave * kTotalCus * waves_per_wg;
+  const uint64_t share_wide = per_wave * (kTotalCus / kTotalXcds) * waves_per_wg;
+  for (const auto &request : requests) {
+    EXPECT_EQ(request.size, grid_wide)
+        << "scratch was sized from a shard's share rather than from the whole grid";
+    EXPECT_NE(request.size, share_wide) << "sized from this XCD's own share";
+  }
+
+  // Requests come from more than one XCD, so the sizing above is being checked
+  // on peer shards and not only on the owner's.
+  EXPECT_GT(requests.size(), 1u);
+
+  // NOTE: the companion claim -- that the pool is *mapped* once rather than once
+  // per XCD -- is deliberately not asserted here. The allocator is skipped only
+  // when resolve_host_ptr() already answers for the pool, which needs a KFD
+  // process page table; this fixture dispatches on vmid 0, where nothing
+  // resolves, so the allocator is re-entered per wave and the idempotent path is
+  // unreachable. Pinning it needs a KFD-backed dispatch.
 }


### PR DESCRIPTION
A HW queue was bound to a single XCD, so every workgroup of every dispatch on that queue ran on that one XCD's compute units. On the 8-XCD CDNA4 topologies a single-queue application reached 32 of the 256 advertised CUs, and the workgroup-index swizzles kernels apply for cache locality were undoing a round-robin that never happened.

Mark a queue for fan-out and registering it replicates the queue onto the peer XCDs; each dispatch is then split so XCD i takes the grid chunks congruent to i modulo the XCD count, using the XCD's own index so the mapping does not depend on which XCD the queue landed on. Replicas never read the ring or poll the doorbell. Each XCD flushes its own caches and publishes its share to a shared counter, and the owning XCD fires the completion signal once that counter covers the grid, so the signal still fires once and no XCD's results are still cached when it does. Grids with fewer chunks than XCDs are left unsplit, since an empty share is indistinguishable from a barrier packet. Nothing on the KFD path sets the flag yet; only the new tests opt in.