### PR TITLE
docs(rocm-smi-lib): note GPU-use counter stays high when a KFD context blocks GFXOFF

### DIFF
--- a/projects/rocm-smi-lib/docs/how-to/use-python.rst
+++ b/projects/rocm-smi-lib/docs/how-to/use-python.rst
@@ -482,6 +482,18 @@ Clock type descriptions
   If we have 5 high and 5 low samples, that means 50% utilization (50% GPU busy, or 50% GPU use).
   The windows and sampling vary from generation to generation, but that is how GPU and VRAM use
   is calculated in a generic sense.
+
+  .. note::
+
+     On GFXOFF-capable hardware, the GPU-use value can remain at or near 100% even when no
+     kernels are executing. A resident KFD/ROCm compute context (for example, a process that
+     has initialized the device but is currently idle) can keep GFXOFF disabled, and while
+     GFXOFF is held off, ``gpu_busy_percent`` can continue to report the graphics block as
+     busy. When the GPU-use value is high but no work seems to be running, cross-check a
+     signal that reflects actual execution before concluding the GPU is busy: package power
+     (the ``power1_average`` sysfs attribute, exposed via hwmon) or the GRBM ``GUI_ACTIVE``
+     status bit (shown by tools such as ``amdgpu_top`` as the GRBM "Graphics Pipe" counter).
+
   ``--showmeminfo`` (and VRAM% in concise output) will show the amount of VRAM used (visible, total, GTT),
   as well as the total available for those partitions. The percentage shown there indicates the
   amount of used memory in terms of current allocations.

--- a/projects/rocm-smi-lib/python_smi_tools/README.md
+++ b/projects/rocm-smi-lib/python_smi_tools/README.md
@@ -428,6 +428,14 @@ if any GPU block (RLC, MEC, PFP, CP) is busy. If so, that's 1 (or high). If not,
 If we have 5 high and 5 low samples, that means 50% utilization (50% GPU busy, or 50% GPU use).
 The windows and sampling vary from generation to generation, but that is how GPU and VRAM use
 is calculated in a generic sense.
+NOTE: On GFXOFF-capable hardware, the GPU-use value can remain at or near 100% even when no
+kernels are executing. A resident KFD/ROCm compute context (for example, a process that has
+initialized the device but is currently idle) can keep GFXOFF disabled, and while GFXOFF is
+held off, gpu_busy_percent can continue to report the graphics block as busy. When the
+GPU-use value is high but no work seems to be running, cross-check a signal that reflects
+actual execution before concluding the GPU is busy: package power (the power1_average sysfs
+attribute, exposed via hwmon) or the GRBM GUI_ACTIVE status bit (shown by tools such as
+amdgpu_top as the GRBM "Graphics Pipe" counter).
 --showmeminfo (and VRAM% in concise output) will show the amount of VRAM used (visible, total, GTT),
 as well as the total available for those partitions. The percentage shown there indicates the
 amount of used memory in terms of current allocations


### PR DESCRIPTION
## Motivation

The `--showuse` documentation explains that `gpu_busy_percent` reflects SMU busy sampling of GPU blocks, but it does not mention that on GFXOFF-capable hardware this value can stay at or near 100% while no kernels are executing: a resident KFD/ROCm compute context (e.g., a process that has initialized the device but is idle) can keep GFXOFF disabled, and `gpu_busy_percent` can continue to report the graphics block as busy in that state. Users monitoring idle systems see a pinned 100% GPU-use value that does not correspond to any executing work, with no pointer to a metric that distinguishes real execution.

## Technical Details

Documentation-only change adding a note to the `--showmemuse | --showuse | --showmeminfo` sections of both doc files:

- `projects/rocm-smi-lib/docs/how-to/use-python.rst`: `.. note::` block after the existing SMU sampling explanation.
- `projects/rocm-smi-lib/python_smi_tools/README.md`: same content, `NOTE:` paragraph.

The note documents (1) the GFXOFF/KFD resident-context caveat above and (2) cross-checks that reflect actual execution before concluding the GPU is busy: package power (`power1_average` sysfs attribute, exposed via hwmon) and the GRBM `GUI_ACTIVE` status bit (shown by tools such as amdgpu_top as the GRBM "Graphics Pipe" counter).

This follows the pattern of caveat-style doc additions such as #8504 and #6688.

## Issue Tracking

No GitHub issue; documentation gap noticed while investigating a seemingly busy idle GPU.

## Test Plan

Rendered both `--showuse` sections; the new reST note reuses the indentation of the surrounding body so the block stays well-formed. Verified `power1_average` against the kernel amdgpu hwmon documentation and the amdgpu_top GRBM counter naming against its source.

## Test Result

N/A. Documentation-only change; no functional testing required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.