### PR TITLE
docs(rocprofiler-sdk): state kernel-replay snapshot boundaries and local-context coverage

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -1156,6 +1156,8 @@ By default, multiple ``--pmc`` groups are collected using *application replay*: 
 
 This is useful when re-running the whole application per group is expensive or non-deterministic. Without the flag, multiple ``--pmc`` groups use application replay as usual.
 
+Because capture is per-agent rather than per-kernel -- replay makes no attempt to determine which allocations a kernel actually reaches -- host memory use during a replayed dispatch is proportional to the agent's entire tracked device footprint, and both the initial snapshot and every restore between passes scale with it.
+
 .. code-block:: shell
 
    rocprofv3 --pmc SQ_WAVES GRBM_COUNT --pmc GRBM_GUI_ACTIVE --kernel-replay-beta-enabled -- <application_path>
@@ -1175,6 +1177,8 @@ The preceding command collects both counter groups in a single run of ``<applica
    - Only coarse-grained device allocations (and module-scope ``__device__`` / ``__constant__`` variables) are restored. Unified, managed, and ``hipMallocAsync`` memory are not. Snapshot is a full in-memory copy; dirty-page hashing is not implemented in this version.
 
    - HIP graph launches are not supported.
+
+   - Only single-packet, single-dispatch submissions are replayed. A multi-packet submission runs once without replay and warns once.
 
 For usage, limitations, and when to prefer application replay, see :ref:`using-kernel-replay`. Tool authors should see :ref:`kernel-replay-sdk-api`.
 


### PR DESCRIPTION
## Motivation
Make important changes to documentation to define scope and restrictions of kernel replay service. 


Note that this targets `users/mkuriche/kernel-replay-callback-api` so it lands inside #8622 rather than as a separate PR against `develop`. **Documentation only** -- no code paths are touched.

Rebased onto `14e688347b`. That commit fixed the "device memory it touches" wording in the user guide, which this branch originally also fixed, so the overlapping text is dropped here and only the additive parts remain.

## Details
### Public header (`experimental/kernel_replay.h`)

The header described the callback contract but never stated the conditions under which cross-pass repeatability actually holds, leaving a tool author to infer them from the user guide. Added a `@warning` block recording what the snapshot covers, which allocation classes are omitted and therefore accumulate across passes (managed/unified, the `hsa_amd_vmem_*` path including `hipMallocAsync`, and `HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG`), and the single-packet requirement.

Also documented which services actually observe the localized context override, because coverage is uneven and a no-op is currently indistinguishable from success -- the call reports `SUCCESS` either way.

And dropped the stickiness rationale's "reprogramming PC sampling hardware" example. It named the one service that never consults the override, which `pc_sampling/tests/local_context.cpp:45` documents and `local_context_override_does_not_toggle_enabled` pins.

### User guide (`using-rocprofv3.rst`)

Two additions only, both absent from `14e688347b`:

- The cost that follows from per-agent capture. That commit records *what* is snapshotted; this states the consequence, that host memory use during a replayed dispatch tracks the agent's whole tracked footprint and that the snapshot and every per-pass restore scale with it.
- A single-packet bullet alongside the existing HIP graph one.

I deliberately did not re-add bullets for managed memory or graph launches; the note block added in `d901f1b6e9` already covers those.

### Incidental finding, relevant to an open thread

Reading every `local_context_override` consumer to write the coverage text turned up an asymmetry worth recording. Dispatch tracing (`hsa/queue.cpp:609`) and thread trace (`thread_trace/core.cpp:452`) both test `ov && !*ov`, so they can only *remove* a context that was already collecting and cannot promote anything. Counter collection (`counters/dispatch_handlers.cpp:84`) and SPM (`spm/dispatch_handlers.cpp:148`) instead assign `enabled = *ov` unconditionally.

That means the promotion behaviour discussed in https://github.com/ROCm/rocm-systems/pull/8622#discussion_r3800813798 is confined to those two assigning sites, and a fix there would not need to touch the tracing paths.

I left the contested semantics out of the header text on purpose: it documents *which* services consult the override, not whether a local start may promote a globally-stopped context, since that question is still open on that thread. Once you settle it, the bullet is the place to state the answer.

## Test plan

- Documentation only; no functional change and nothing to run.
- Style checked against the surrounding file: `-` bullets rather than `@li` (unused elsewhere in the public headers), header lines within the 100-column limit.
- **Not** rendered locally -- doxygen isn't installed on this host, and `build-docs-from-source` is currently red on #8622 for an unrelated CMake 3.25-vs-3.22.1 container mismatch, so CI won't validate the rendering either until that job is fixed. The added constructs (`@warning`, `@c`, `-` lists, an `.. note::` bullet) are all already used in these files, but a docs render is the one thing worth confirming before merge.