### PR TITLE
fix(rocprofiler-sdk): abort on failed kernel-replay restore; harden local context

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/kernel_replay.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/kernel_replay.h
@@ -61,6 +61,21 @@ ROCPROFILER_EXTERN_C_INIT
  * @ref ROCPROFILER_STATUS_ERROR_SERVICE_ALREADY_CONFIGURED. @c user_data written during a PASS
  * callback is not retained -- only the value set during CONFIG @ref
  * ROCPROFILER_CALLBACK_PHASE_ENTER is threaded through the sequence.
+ *
+ * @warning Beta. A dispatch is replayed only when its submission is a single packet containing a
+ * single dispatch. HIP graph launches are not replayed, and a multi-packet submission runs once
+ * without replay; each case warns once. Repeatability rests on a snapshot covering coarse-grained
+ * device allocations owned by the agent plus module-scope @c __device__ / @c __constant__
+ * variables. Unified or managed memory, @c hipMallocAsync and other virtual-memory-mapped
+ * allocations, and host, fine-grained and kernarg memory are not captured, so a kernel writing to
+ * them observes values accumulated across passes rather than identical inputs. Allocations carrying
+ * @c HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG are also excluded (HIP kernarg pools / profiler buffers);
+ * a direct-HSA application that puts ordinary writable device data behind that flag sees the same
+ * omission and is an unsupported allocation class for beta replay.
+ *
+ * @see `docs/how-to/using-kernel-replay.rst` for the full limitation list and
+ * `docs/conceptual/kernel_replay/kernel_replay_memory_snapshot.md` for what the snapshot covers
+ * and why.
  */
 typedef struct rocprofiler_callback_tracing_kernel_replay_data_t
 {
@@ -117,10 +132,19 @@ typedef struct rocprofiler_callback_tracing_kernel_replay_data_t
     /// replay loop. Semantics:
     ///  - Only valid to call during PASS @ref ROCPROFILER_CALLBACK_PHASE_ENTER.
     ///  - Sticky across passes: a context stopped in one pass stays stopped until it
-    ///    is started again within the same replay loop (and vice versa). This avoids
-    ///    redundant work such as reprogramming PC sampling hardware on every pass.
+    ///    is started again within the same replay loop (and vice versa). A tool therefore
+    ///    positions a context once rather than re-issuing the same toggles every pass.
     ///  - Scoped to the replay loop: each context's pre-replay active/inactive state
     ///    is restored once the loop completes. Global context state is never modified.
+    ///  - A local start only undoes a prior local stop; it cannot promote a context that is
+    ///    globally inactive (its service/callback thread may already be stopped).
+    ///  - Coverage varies by service. Kernel dispatch tracing and dispatch thread trace
+    ///    observe a local stop only: they skip a dispatch whose context is forced off, and
+    ///    have no means to add a context that is not already collecting. Dispatch counter
+    ///    collection and SPM consult the override on every dispatch (and likewise refuse to
+    ///    promote a globally stopped context). PC sampling is agent-wide and device counting
+    ///    is not dispatch-scoped, so neither consults the override at all -- a call naming
+    ///    such a context reports success but has no effect.
 } rocprofiler_callback_tracing_kernel_replay_data_t;
 
 /** @} */

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/kernel_replay.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/kernel_replay.h
@@ -69,9 +69,11 @@ ROCPROFILER_EXTERN_C_INIT
  * variables. Unified or managed memory, @c hipMallocAsync and other virtual-memory-mapped
  * allocations, and host, fine-grained and kernarg memory are not captured, so a kernel writing to
  * them observes values accumulated across passes rather than identical inputs. Allocations carrying
- * @c HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG are also excluded (HIP kernarg pools / profiler buffers);
- * a direct-HSA application that puts ordinary writable device data behind that flag sees the same
- * omission and is an unsupported allocation class for beta replay.
+ * @c HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG are excluded from the snapshot (HIP kernarg pools /
+ * profiler buffers share that flag). A direct-HSA application that puts ordinary writable device
+ * data behind the same flag sees the same omission -- an unsupported allocation class for beta.
+ * Declining every replay while any such trackable allocation is live is not viable because the HIP
+ * runtime itself keeps them live under interception.
  *
  * @see `docs/how-to/using-kernel-replay.rst` for the full limitation list and
  * `docs/conceptual/kernel_replay/kernel_replay_memory_snapshot.md` for what the snapshot covers

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
@@ -78,11 +78,14 @@ queue_cb(const context::context*                                  ctx,
     // replay per-pass override (a replay pass may force this context on/off; no-op outside a replay
     // loop). Computed as a single value so the override is part of "is_enabled" -- not a separable
     // step that could drift below the check. See kernel_replay/local_context.hpp.
+    // Local start must only undo a prior local stop: it cannot promote a globally stopped context
+    // (its callback thread may already be gone). Local stop always wins. See Copilot #8622 and
+    // kernel_replay/local_context.hpp.
     const bool is_enabled = [&] {
         bool enabled = false;
         ctx->dispatch_counter_collection->enabled.rlock([&](const auto& c) { enabled = c; });
         if(auto ov = kernel_replay::local_context_override({.handle = ctx->context_idx}))
-            enabled = *ov;
+            enabled = enabled && *ov;
         return enabled;
     }();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/local_context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/local_context.cpp
@@ -195,3 +195,37 @@ TEST(core, local_context_override_restarts_queue_cb)
     registration::finalize();
     context::pop_client(1);
 }
+
+// A local start override must not promote a context whose global enabled flag is false: the
+// dispatch handler ANDs the override with the global flag (enabled = enabled && *ov).
+TEST(core, local_context_start_cannot_promote_globally_stopped)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    context::context ctx{};
+    ctx.context_idx = 44;
+    ctx.dispatch_counter_collection =
+        std::make_unique<context::dispatch_counter_collection_service>();
+    ctx.dispatch_counter_collection->enabled.wlock([](auto& data) { data = false; });
+
+    std::atomic<int>                            hits{0};
+    auto                                        active = as_active(ctx);
+    kernel_replay::scoped_local_context_control loop{active};
+
+    kernel_replay::set_toggles_armed(true);
+    EXPECT_EQ(kernel_replay::replay_local_start_context({.handle = ctx.context_idx}),
+              ROCPROFILER_STATUS_SUCCESS);
+    kernel_replay::set_toggles_armed(false);
+
+    invoke_queue_cb(ctx, &hits);
+    EXPECT_EQ(hits.load(), 0) << "local start must not promote a globally stopped context";
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -1059,8 +1059,8 @@ WriteInterceptor(const void* packets,
 
                 // Restore device memory between passes so the next pass sees identical inputs.
                 // A failed host->device copy leaves the snapshot only partially applied; continuing
-                // would submit the next pass over corrupted memory and (because the final pass skips
-                // restore) would also leave that corruption visible to the application.
+                // would submit the next pass over corrupted memory and (because the final pass
+                // skips restore) would also leave that corruption visible to the application.
                 ROCP_FATAL_IF(!kernel_replay::memory_snapshot::restore(snapshot)) << fmt::format(
                     "kernel replay: restore failed between passes (partial host->device copy); "
                     "aborting rather than continuing with corrupted device memory");

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -1058,7 +1058,12 @@ WriteInterceptor(const void* packets,
                 if(!kernel_replay::should_continue_replay(replay_plan, pass, is_final)) break;
 
                 // Restore device memory between passes so the next pass sees identical inputs.
-                kernel_replay::memory_snapshot::restore(snapshot);
+                // A failed host->device copy leaves the snapshot only partially applied; continuing
+                // would submit the next pass over corrupted memory and (because the final pass skips
+                // restore) would also leave that corruption visible to the application.
+                ROCP_FATAL_IF(!kernel_replay::memory_snapshot::restore(snapshot)) << fmt::format(
+                    "kernel replay: restore failed between passes (partial host->device copy); "
+                    "aborting rather than continuing with corrupted device memory");
             }
 
             kernel_replay::execute_config_phase_exit(

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.cpp
@@ -137,6 +137,13 @@ snap(hsa_agent_t agent)
 {
     device_snapshot_t out{};
 
+    // Note: trackable allocations carrying HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG are recorded in
+    // memory_tracker::unsupported_executable() and omitted from the main inventory. Declining
+    // replay whenever that side inventory is non-empty is not viable -- the HIP runtime (and the
+    // SDK's own AQL pools) routinely keep such allocations live -- so they remain an unsupported
+    // omitted class for beta (documented in the public header). Direct-HSA apps that put ordinary
+    // writable device data behind the flag observe the same omission.
+
     const auto [inventory, module_vars] = [&]() {
         try
         {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.cpp
@@ -245,10 +245,10 @@ snap(hsa_agent_t agent)
     return out;
 }
 
-size_t
+bool
 restore(const device_snapshot_t& snapshot)
 {
-    size_t ok = 0;
+    size_t restored = 0;
     for(const auto& blk : snapshot.blocks)
     {
         hsa_status_t status = HSA_STATUS_SUCCESS;
@@ -258,7 +258,7 @@ restore(const device_snapshot_t& snapshot)
             // Re-check liveness and copy under the read lock so a concurrent free cannot race the
             // check and the write (see with_inventory_check). A nullopt result means the region is
             // no longer a live allocation of at least its size. It was freed or reallocated after
-            // snap, so skip it.
+            // snap, so skip it (benign -- not a restore failure).
             const auto st = with_inventory_check(blk.gpu_addr, blk.host_copy.size(), [&] {
                 return dma_copy(blk.gpu_addr, blk.host_copy.data(), blk.host_copy.size());
             });
@@ -281,18 +281,24 @@ restore(const device_snapshot_t& snapshot)
 
         if(status != HSA_STATUS_SUCCESS)
         {
-            ROCP_WARNING << fmt::format(
-                "kernel-replay restore: host->device copy failed for region {} ({}B)",
+            // A live region failed to copy. Further passes would observe mutated state, and the
+            // final pass (which deliberately skips restore) would leave that corruption visible to
+            // the application. Abort: a partial restore cannot be undone.
+            ROCP_ERROR << fmt::format(
+                "kernel-replay restore: host->device copy failed for region {} ({}B); aborting "
+                "restore after {}/{} regions",
                 blk.gpu_addr,
-                blk.host_copy.size());
-            continue;
+                blk.host_copy.size(),
+                restored,
+                snapshot.blocks.size());
+            return false;
         }
-        ++ok;
+        ++restored;
     }
 
     ROCP_INFO << fmt::format(
-        "kernel-replay restore: restored {}/{} regions", ok, snapshot.blocks.size());
-    return ok;
+        "kernel-replay restore: restored {}/{} regions", restored, snapshot.blocks.size());
+    return true;
 }
 }  // namespace memory_snapshot
 }  // namespace kernel_replay

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_snapshot.hpp
@@ -70,8 +70,11 @@ struct device_snapshot_t
 device_snapshot_t
 snap(hsa_agent_t agent);
 
-// Copy each saved region host->device. Returns the number of regions restored.
-size_t
+// Copy each saved region host->device. Returns true when every live region was restored.
+// A region that was freed after snap is skipped (benign). A failed host->device DMA copy
+// returns false immediately: the snapshot is then only partially applied, and the caller must
+// abort replay rather than submit another pass over corrupted device memory.
+bool
 restore(const device_snapshot_t& snapshot);
 }  // namespace memory_snapshot
 }  // namespace kernel_replay

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
@@ -85,6 +85,11 @@ pool_allocate_wrapper(hsa_amd_memory_pool_t pool, size_t size, uint32_t flags, v
     // state, not application data; snapshotting them means restore() clobbers the in-flight
     // kernargs of a concurrent dispatch. We already have the flag here, so skip before
     // query_alloc's hsa_amd_pointer_info query rather than re-deriving it.
+    //
+    // Trade-off (beta): a direct-HSA application that puts ordinary writable device data behind
+    // the same flag also has those buffers omitted. Declining replay whenever any executable-flag
+    // allocation is live is not viable -- HIP's own pools look trackable+executable under
+    // query_alloc -- so this is documented as an unsupported allocation class instead.
     const bool is_executable = (flags & memory_pool_executable_flag) != 0;
     if(tracking_flag().load(std::memory_order_relaxed) && st == HSA_STATUS_SUCCESS && ptr && *ptr &&
        !is_executable)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
@@ -69,9 +69,8 @@ unsupported_executable_inventory()
     // Distinct ContextT so this singleton does not share storage with inventory().
     struct unsupported_executable_tag
     {};
-    static auto*& _v =
-        common::static_object<common::Synchronized<tracked_map_t>,
-                              unsupported_executable_tag>::construct();
+    static auto*& _v = common::static_object<common::Synchronized<tracked_map_t>,
+                                             unsupported_executable_tag>::construct();
     return *_v;
 }
 
@@ -97,8 +96,9 @@ record_unsupported_executable(void* ptr, size_t size)
     // Only ordinary coarse device VRAM. HIP kernarg pools / fine-grained regions fail trackable and
     // stay out of both inventories (silent omit is correct for those).
     if(!q.trackable) return;
-    unsupported_executable_inventory().wlock(
-        [&](auto& _map) { _map[ptr] = alloc_info_t{size, q.agent}; });
+    unsupported_executable_inventory().wlock([&](auto& _map) {
+        _map[ptr] = alloc_info_t{size, q.agent};
+    });
 }
 
 hsa_status_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.cpp
@@ -63,6 +63,18 @@ inventory()
     return *_v;
 }
 
+common::Synchronized<tracked_map_t>&
+unsupported_executable_inventory()
+{
+    // Distinct ContextT so this singleton does not share storage with inventory().
+    struct unsupported_executable_tag
+    {};
+    static auto*& _v =
+        common::static_object<common::Synchronized<tracked_map_t>,
+                              unsupported_executable_tag>::construct();
+    return *_v;
+}
+
 namespace
 {
 // Saved "next" function pointers (the already-installed wrappers) we chain through. Types are taken
@@ -75,25 +87,44 @@ decltype(CoreApiTable{}.hsa_memory_free_fn)             next_memory_free     = n
 // HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG is absent from older HSA headers
 constexpr uint32_t memory_pool_executable_flag = (1U << 2);
 
+void
+record_unsupported_executable(void* ptr, size_t size)
+{
+    // Same fini gate as record_alloc: the wrappers outlive this static object.
+    if(registration::get_fini_status() > 0) return;
+
+    const auto q = query_alloc(ptr);
+    // Only ordinary coarse device VRAM. HIP kernarg pools / fine-grained regions fail trackable and
+    // stay out of both inventories (silent omit is correct for those).
+    if(!q.trackable) return;
+    unsupported_executable_inventory().wlock(
+        [&](auto& _map) { _map[ptr] = alloc_info_t{size, q.agent}; });
+}
+
 hsa_status_t
 pool_allocate_wrapper(hsa_amd_memory_pool_t pool, size_t size, uint32_t flags, void** ptr)
 {
     auto st = next_pool_allocate(pool, size, flags, ptr);
-    // Never snapshot executable allocations. HIP places its per-stream/per-graph kernarg pools --
-    // and rocprofiler its trace buffers -- in the coarse-grained segment with the executable flag,
-    // so they slip past query_alloc's kernarg-pool check. They hold live kernel arguments / runtime
-    // state, not application data; snapshotting them means restore() clobbers the in-flight
-    // kernargs of a concurrent dispatch. We already have the flag here, so skip before
-    // query_alloc's hsa_amd_pointer_info query rather than re-deriving it.
+    // Never snapshot executable allocations into the main inventory. HIP places its
+    // per-stream/per-graph kernarg pools -- and rocprofiler its trace buffers -- in the
+    // coarse-grained segment with the executable flag, so they slip past query_alloc's
+    // kernarg-pool check. They hold live kernel arguments / runtime state, not application
+    // data; snapshotting them means restore() clobbers the in-flight kernargs of a concurrent
+    // dispatch. We already have the flag here, so skip the main inventory before query_alloc.
     //
-    // Trade-off (beta): a direct-HSA application that puts ordinary writable device data behind
-    // the same flag also has those buffers omitted. Declining replay whenever any executable-flag
-    // allocation is live is not viable -- HIP's own pools look trackable+executable under
-    // query_alloc -- so this is documented as an unsupported allocation class instead.
-    const bool is_executable = (flags & memory_pool_executable_flag) != 0;
-    if(tracking_flag().load(std::memory_order_relaxed) && st == HSA_STATUS_SUCCESS && ptr && *ptr &&
-       !is_executable)
-        record_alloc(*ptr, size);
+    // Direct-HSA apps can put ordinary writable device data behind the same flag. Those
+    // allocations are trackable (coarse VRAM); record them in the unsupported side inventory so
+    // tests and tools can detect the unsupported omitted class. Declining snap() whenever the side
+    // inventory is non-empty is not viable -- HIP and the SDK's own AQL pools routinely keep such
+    // allocations live -- so they remain documented as an unsupported omission for beta.
+    if(tracking_flag().load(std::memory_order_relaxed) && st == HSA_STATUS_SUCCESS && ptr && *ptr)
+    {
+        const bool is_executable = (flags & memory_pool_executable_flag) != 0;
+        if(is_executable)
+            record_unsupported_executable(*ptr, size);
+        else
+            record_alloc(*ptr, size);
+    }
     return st;
 }
 
@@ -155,6 +186,7 @@ record_free(void* ptr)
 {
     if(registration::get_fini_status() > 0) return;
     inventory().wlock([ptr](auto& _map) { _map.erase(ptr); });
+    unsupported_executable_inventory().wlock([ptr](auto& _map) { _map.erase(ptr); });
 }
 
 alloc_map_t
@@ -168,6 +200,53 @@ snap_inventory(hsa_agent_t agent)
             if(info.agent.handle == agent.handle) out.emplace(ptr, info.size);
     });
     return out;
+}
+
+alloc_map_t
+unsupported_executable(hsa_agent_t agent)
+{
+    if(registration::get_fini_status() > 0) return {};
+
+    alloc_map_t out{};
+    unsupported_executable_inventory().rlock([&](const auto& _map) {
+        for(const auto& [ptr, info] : _map)
+            if(info.agent.handle == agent.handle) out.emplace(ptr, info.size);
+    });
+    return out;
+}
+
+bool
+agent_has_unsupported_executable(hsa_agent_t agent)
+{
+    if(registration::get_fini_status() > 0) return false;
+
+    bool found = false;
+    unsupported_executable_inventory().rlock([&](const auto& _map) {
+        for(const auto& [ptr, info] : _map)
+        {
+            (void) ptr;
+            if(info.agent.handle == agent.handle)
+            {
+                found = true;
+                break;
+            }
+        }
+    });
+    return found;
+}
+
+hsa_status_t
+tracking_pool_allocate(hsa_amd_memory_pool_t pool, size_t size, uint32_t flags, void** ptr)
+{
+    if(!next_pool_allocate) return HSA_STATUS_ERROR;
+    return pool_allocate_wrapper(pool, size, flags, ptr);
+}
+
+hsa_status_t
+tracking_pool_free(void* ptr)
+{
+    if(!next_pool_free) return HSA_STATUS_ERROR;
+    return pool_free_wrapper(ptr);
 }
 
 }  // namespace memory_tracker

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/memory_tracker.hpp
@@ -75,6 +75,29 @@ record_free(void* ptr);
 alloc_map_t
 snap_inventory(hsa_agent_t agent);
 
+// Side inventory of live pool allocations that carried HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG and are
+// otherwise trackable (coarse device VRAM). The main inventory never records those pointers -- the
+// flag is shared by HIP kernarg pools and profiler buffers, which must not be snapshotted -- but a
+// direct-HSA application may put ordinary writable device data behind the same flag. Those app
+// buffers are omitted from snapshots (unsupported allocation class for beta). Declining replay
+// whenever this side inventory is non-empty is not viable: the HIP runtime and the SDK's own AQL
+// pools routinely keep trackable+executable allocations live. Exposed so tests can assert the
+// omission and so callers can detect the unsupported class.
+alloc_map_t
+unsupported_executable(hsa_agent_t agent);
+
+bool
+agent_has_unsupported_executable(hsa_agent_t agent);
+
+// Test/helper entry points that invoke the same allocate/free wrappers the HSA table interceptor
+// installs. get_amd_ext_table() returns the internal (unwrapped) table, so unit tests that need to
+// exercise the executable-flag path must call these rather than the internal table pointers.
+hsa_status_t
+tracking_pool_allocate(hsa_amd_memory_pool_t pool, size_t size, uint32_t flags, void** ptr);
+
+hsa_status_t
+tracking_pool_free(void* ptr);
+
 // The Synchronized allocation inventory. Exposed so restore() can look up a block and copy it under
 // the read lock, which blocks a concurrent free for the copy. Callers reachable during finalization
 // must first gate on registration::get_fini_status(): the alloc/free wrappers outlive this static,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/local_context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/local_context.cpp
@@ -218,9 +218,10 @@ TEST(kernel_replay_local_context, last_write_wins_in_arm_window)
     EXPECT_FALSE(*lc::local_context_override({9}));
 }
 
-// Per-service consumer models used at dispatch time. Dispatch counters and SPM replace the global
-// enabled flag with the override; ATT skips only when forced off; PC sampling is agent-wide and
-// ignores the override (a local stop is a recorded no-op).
+// Per-service consumer models used at dispatch time. Dispatch counters and SPM AND the override
+// with the global enabled flag (local start cannot promote a globally stopped context); ATT skips
+// only when forced off; PC sampling is agent-wide and ignores the override (a local stop is a
+// recorded no-op).
 TEST(kernel_replay_local_context, simulated_service_consumers)
 {
     const rocprofiler_context_id_t counters{10};
@@ -228,9 +229,11 @@ TEST(kernel_replay_local_context, simulated_service_consumers)
     const rocprofiler_context_id_t spm{30};
     const rocprofiler_context_id_t pcs{40};
 
+    // Mirrors counters/spm dispatch_handlers: enabled = enabled && *ov.
     const auto dispatch_enabled = [](rocprofiler_context_id_t id, bool globally_on) {
-        if(auto ov = lc::local_context_override(id)) return *ov;
-        return globally_on;
+        bool enabled = globally_on;
+        if(auto ov = lc::local_context_override(id)) enabled = enabled && *ov;
+        return enabled;
     };
     const auto att_runs = [](rocprofiler_context_id_t id) {
         if(auto ov = lc::local_context_override(id); ov && !*ov) return false;
@@ -268,4 +271,29 @@ TEST(kernel_replay_local_context, simulated_service_consumers)
     EXPECT_EQ(att_ran, (std::vector<bool>{true, false, false, false}));
     EXPECT_EQ(spm_ran, (std::vector<bool>{true, false, false, false}));
     EXPECT_EQ(pcs_ran, (std::vector<bool>{true, true, true, true}));
+}
+
+// Local start must not resurrect a globally-stopped dispatch service: the override is ANDed with
+// the global enabled flag at the consumer (mirrors counters/spm dispatch_handlers).
+TEST(kernel_replay_local_context, consumer_no_promotion_of_globally_stopped)
+{
+    const rocprofiler_context_id_t counters{11};
+
+    const auto dispatch_enabled = [](rocprofiler_context_id_t id, bool globally_on) {
+        bool enabled = globally_on;
+        if(auto ov = lc::local_context_override(id)) enabled = enabled && *ov;
+        return enabled;
+    };
+
+    fake_active_contexts             active{counters.handle};
+    lc::scoped_local_context_control loop{active.array};
+    lc::set_toggles_armed(true);
+    EXPECT_EQ(lc::replay_local_start_context(counters), ROCPROFILER_STATUS_SUCCESS);
+    lc::set_toggles_armed(false);
+
+    EXPECT_TRUE(*lc::local_context_override(counters));
+    EXPECT_FALSE(dispatch_enabled(counters, /*globally_on=*/false))
+        << "local start must not promote a globally stopped context";
+    EXPECT_TRUE(dispatch_enabled(counters, /*globally_on=*/true))
+        << "local start must undo a prior local stop when globally on";
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
@@ -29,6 +29,7 @@
 
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/kernel_replay/memory_snapshot.hpp"
 #include "lib/rocprofiler-sdk/kernel_replay/memory_tracker.hpp"
 #include "lib/rocprofiler-sdk/kernel_replay/utils.hpp"
@@ -433,6 +434,64 @@ TEST(kernel_replay_snapshot, pool_filter_excludes_kernarg_and_cpu)
 
     EXPECT_EQ(hipHostFree(host), hipSuccess);
     ASSERT_EQ(hipFree(dev), hipSuccess);
+}
+
+// Snapshots must exclude allocations carrying HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG (HIP kernarg
+// pools and profiler buffers). Assert the exclusion directly via the intercepted HSA table so the
+// check does not depend on replay-window serialization.
+TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
+{
+    if(!ensure_live_tracking()) GTEST_SKIP() << "could not activate rocprofiler / no HIP GPU";
+
+    const auto agent = gpu_agent();
+    ASSERT_NE(agent.handle, 0U) << "no GPU agent found";
+
+    auto* ext = hsa::get_amd_ext_table();
+    ASSERT_NE(ext, nullptr);
+    ASSERT_NE(ext->hsa_amd_memory_pool_allocate_fn, nullptr);
+    ASSERT_NE(ext->hsa_amd_memory_pool_free_fn, nullptr);
+
+    struct pool_pick_t
+    {
+        hsa_amd_memory_pool_t pool{};
+        bool                  found = false;
+    } pick{};
+
+    (void) hsa_amd_agent_iterate_memory_pools(
+        agent,
+        [](hsa_amd_memory_pool_t p, void* data) -> hsa_status_t {
+            auto* out = static_cast<pool_pick_t*>(data);
+            hsa_amd_segment_t segment{};
+            if(hsa_amd_memory_pool_get_info(p, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment) !=
+               HSA_STATUS_SUCCESS)
+                return HSA_STATUS_SUCCESS;
+            if(segment != HSA_AMD_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
+            uint32_t flags = 0;
+            if(hsa_amd_memory_pool_get_info(p, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &flags) !=
+               HSA_STATUS_SUCCESS)
+                return HSA_STATUS_SUCCESS;
+            constexpr uint32_t kFine    = HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED;
+            constexpr uint32_t kKernarg = HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT;
+            if((flags & kFine) != 0 || (flags & kKernarg) != 0) return HSA_STATUS_SUCCESS;
+            out->pool  = p;
+            out->found = true;
+            return HSA_STATUS_INFO_BREAK;
+        },
+        &pick);
+
+    if(!pick.found) GTEST_SKIP() << "no coarse global memory pool on agent";
+
+    constexpr uint32_t kExecutableFlag = (1U << 2);  // HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG
+    void*              ptr             = nullptr;
+    // Allocate through the intercepted table so the tracker wrapper sees the flag.
+    ASSERT_EQ(ext->hsa_amd_memory_pool_allocate_fn(pick.pool, 4096, kExecutableFlag, &ptr),
+              HSA_STATUS_SUCCESS);
+    ASSERT_NE(ptr, nullptr);
+
+    EXPECT_FALSE(inventory_contains(ptr, agent))
+        << "executable-flag allocation must not enter the snapshot inventory";
+
+    ASSERT_EQ(ext->hsa_amd_memory_pool_free_fn(ptr), HSA_STATUS_SUCCESS);
 }
 
 // A __device__ module global mutated by a kernel must be reverted by restore(). It is not a

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
@@ -441,8 +441,9 @@ TEST(kernel_replay_snapshot, pool_filter_excludes_kernarg_and_cpu)
 // otherwise trackable (coarse device VRAM -- what a direct-HSA app may put behind the flag), it is
 // recorded in the unsupported side inventory. snap() does not decline on that side inventory: the
 // HIP runtime routinely keeps trackable+executable allocations live, so declining would disable
-// replay for ordinary HIP apps. Assert the inventory exclusion (and side-table bookkeeping) directly
-// via the intercepted HSA table so the check does not depend on replay-window serialization.
+// replay for ordinary HIP apps. Assert the inventory exclusion (and side-table bookkeeping)
+// directly via the intercepted HSA table so the check does not depend on replay-window
+// serialization.
 TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
 {
     if(!ensure_live_tracking()) GTEST_SKIP() << "could not activate rocprofiler / no HIP GPU";
@@ -459,8 +460,8 @@ TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
     (void) hsa_amd_agent_iterate_memory_pools(
         agent,
         [](hsa_amd_memory_pool_t p, void* data) -> hsa_status_t {
-            auto*              out = static_cast<pool_pick_t*>(data);
-            hsa_amd_segment_t  segment{};
+            auto*             out = static_cast<pool_pick_t*>(data);
+            hsa_amd_segment_t segment{};
             if(hsa_amd_memory_pool_get_info(p, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment) !=
                HSA_STATUS_SUCCESS)
                 return HSA_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_replay/tests/snap_restore.cpp
@@ -239,7 +239,7 @@ TEST(kernel_replay_snapshot, restore_reverts_device_memory)
             ASSERT_FLOAT_EQ(b[i], 9001.0f + i) << "mutated elem " << i;
     }
 
-    msnp::restore(snapshot);
+    ASSERT_TRUE(msnp::restore(snapshot));
     {
         // restore reverted to A
         auto a = read_device(buffer, N_ELEMS);
@@ -295,7 +295,7 @@ TEST(kernel_replay_snapshot, restore_prevents_inplace_accumulation_across_passes
                 << "module counter after saxpy, pass " << pass;
         }
 
-        msnp::restore(snapshot);
+        ASSERT_TRUE(msnp::restore(snapshot));
         {
             // restore reverts to snapped inputs -- no accumulation into the next pass
             auto reverted = read_device(y, N_ELEMS);
@@ -355,7 +355,7 @@ TEST(kernel_replay_snapshot, restore_reverts_multiple_buffers)
             ASSERT_FLOAT_EQ(mutated[i], base[b] + 77000.0f + i) << "buf " << b << " elem " << i;
     }
 
-    msnp::restore(snapshot);
+    ASSERT_TRUE(msnp::restore(snapshot));
 
     for(int b = 0; b < kBufs; ++b)
     {
@@ -436,20 +436,19 @@ TEST(kernel_replay_snapshot, pool_filter_excludes_kernarg_and_cpu)
     ASSERT_EQ(hipFree(dev), hipSuccess);
 }
 
-// Snapshots must exclude allocations carrying HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG (HIP kernarg
-// pools and profiler buffers). Assert the exclusion directly via the intercepted HSA table so the
-// check does not depend on replay-window serialization.
+// Snapshots must exclude allocations carrying HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG from the main
+// inventory (HIP kernarg pools / profiler buffers share that flag). When the allocation is
+// otherwise trackable (coarse device VRAM -- what a direct-HSA app may put behind the flag), it is
+// recorded in the unsupported side inventory. snap() does not decline on that side inventory: the
+// HIP runtime routinely keeps trackable+executable allocations live, so declining would disable
+// replay for ordinary HIP apps. Assert the inventory exclusion (and side-table bookkeeping) directly
+// via the intercepted HSA table so the check does not depend on replay-window serialization.
 TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
 {
     if(!ensure_live_tracking()) GTEST_SKIP() << "could not activate rocprofiler / no HIP GPU";
 
     const auto agent = gpu_agent();
     ASSERT_NE(agent.handle, 0U) << "no GPU agent found";
-
-    auto* ext = hsa::get_amd_ext_table();
-    ASSERT_NE(ext, nullptr);
-    ASSERT_NE(ext->hsa_amd_memory_pool_allocate_fn, nullptr);
-    ASSERT_NE(ext->hsa_amd_memory_pool_free_fn, nullptr);
 
     struct pool_pick_t
     {
@@ -460,8 +459,8 @@ TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
     (void) hsa_amd_agent_iterate_memory_pools(
         agent,
         [](hsa_amd_memory_pool_t p, void* data) -> hsa_status_t {
-            auto* out = static_cast<pool_pick_t*>(data);
-            hsa_amd_segment_t segment{};
+            auto*              out = static_cast<pool_pick_t*>(data);
+            hsa_amd_segment_t  segment{};
             if(hsa_amd_memory_pool_get_info(p, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment) !=
                HSA_STATUS_SUCCESS)
                 return HSA_STATUS_SUCCESS;
@@ -481,17 +480,29 @@ TEST(kernel_replay_snapshot, executable_flag_excluded_from_inventory)
 
     if(!pick.found) GTEST_SKIP() << "no coarse global memory pool on agent";
 
+    // Interceptor wrappers are installed on the runtime-facing HSA table, not on
+    // get_amd_ext_table()'s internal (unwrapped) copy. tracking_pool_allocate/free invoke those
+    // same wrappers so this unit test exercises the executable-flag path directly.
     constexpr uint32_t kExecutableFlag = (1U << 2);  // HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG
     void*              ptr             = nullptr;
-    // Allocate through the intercepted table so the tracker wrapper sees the flag.
-    ASSERT_EQ(ext->hsa_amd_memory_pool_allocate_fn(pick.pool, 4096, kExecutableFlag, &ptr),
+    ASSERT_EQ(mt::tracking_pool_allocate(pick.pool, 4096, kExecutableFlag, &ptr),
               HSA_STATUS_SUCCESS);
     ASSERT_NE(ptr, nullptr);
 
     EXPECT_FALSE(inventory_contains(ptr, agent))
         << "executable-flag allocation must not enter the snapshot inventory";
 
-    ASSERT_EQ(ext->hsa_amd_memory_pool_free_fn(ptr), HSA_STATUS_SUCCESS);
+    const auto q = mt::query_alloc(ptr);
+    if(q.trackable)
+    {
+        EXPECT_EQ(mt::unsupported_executable(agent).count(ptr), 1U)
+            << "trackable+executable allocation must enter the unsupported side inventory";
+        EXPECT_TRUE(mt::agent_has_unsupported_executable(agent));
+    }
+
+    ASSERT_EQ(mt::tracking_pool_free(ptr), HSA_STATUS_SUCCESS);
+    EXPECT_EQ(mt::unsupported_executable(agent).count(ptr), 0U)
+        << "side inventory must clear this pointer on free";
 }
 
 // A __device__ module global mutated by a kernel must be reverted by restore(). It is not a
@@ -514,7 +525,7 @@ TEST(kernel_replay_snapshot, restore_reverts_module_variable)
     sync_ok();
     ASSERT_EQ(kernel_launch::read_module_counter(), kBase + 1) << "kernel mutation did not land";
 
-    msnp::restore(snapshot);
+    ASSERT_TRUE(msnp::restore(snapshot));
     EXPECT_EQ(kernel_launch::read_module_counter(), kBase)
         << "module variable (__device__ global) was not restored by snapshot/restore";
 }
@@ -541,7 +552,7 @@ TEST(kernel_replay_snapshot, restore_prevents_module_variable_accumulation_acros
         sync_ok();
         ASSERT_EQ(kernel_launch::read_module_counter(), kBase + 1) << "mutation, pass " << pass;
 
-        msnp::restore(snapshot);
+        ASSERT_TRUE(msnp::restore(snapshot));
         ASSERT_EQ(kernel_launch::read_module_counter(), kBase) << "post-restore, pass " << pass;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
@@ -142,11 +142,13 @@ pre_kernel_call(const context::context*                                  ctx,
     // Effective collection state for this dispatch: the context's enabled flag, then the kernel-
     // replay per-pass override (a replay pass may force this context on/off; no-op outside a replay
     // loop). Mirrors counters/dispatch_handlers.cpp. See kernel_replay/local_context.hpp.
+    // Local start must only undo a prior local stop: it cannot promote a globally stopped context.
+    // Mirrors counters/dispatch_handlers.cpp.
     const bool is_enabled = [&] {
         bool enabled = false;
         ctx->dispatch_spm->enabled.rlock([&](const auto& collect_ctx) { enabled = collect_ctx; });
         if(auto ov = kernel_replay::local_context_override({.handle = ctx->context_idx}))
-            enabled = *ov;
+            enabled = enabled && *ov;
         return enabled;
     }();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/local_context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/local_context.cpp
@@ -202,3 +202,36 @@ TEST(spm_core, local_context_override_restarts_pre_kernel_call)
     registration::finalize();
     context::pop_client(1);
 }
+
+// A local start override must not promote a context whose global enabled flag is false.
+TEST(spm_core, local_context_start_cannot_promote_globally_stopped)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    context::context ctx{};
+    ctx.context_idx  = 54;
+    ctx.dispatch_spm = std::make_unique<context::spm_dispatch_counter_collection_service>();
+    ctx.dispatch_spm->enabled.wlock([](auto& data) { data = false; });
+
+    std::atomic<int>                            hits{0};
+    auto                                        active = as_active(ctx);
+    kernel_replay::scoped_local_context_control loop{active};
+
+    kernel_replay::set_toggles_armed(true);
+    EXPECT_EQ(kernel_replay::replay_local_start_context({.handle = ctx.context_idx}),
+              ROCPROFILER_STATUS_SUCCESS);
+    kernel_replay::set_toggles_armed(false);
+
+    invoke_pre_kernel_call(ctx, &hits);
+    EXPECT_EQ(hits.load(), 0) << "local start must not promote a globally stopped context";
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+}


### PR DESCRIPTION
## Summary
- **Blocking Copilot thread:** `restore()` now returns `bool` and aborts on a failed host→device DMA copy (benign skips of freed regions unchanged). `queue.cpp` fatals rather than submitting the next pass over partially restored memory.
- **Local context:** dispatch counter and SPM handlers use `enabled = enabled && *ov` so a local start cannot promote a globally stopped context (matches the documented contract). Unit coverage added for the no-promotion consumer path.
- **Executable-flag inventory:** trackable+executable allocations go to a side inventory (not snapshotted). Header documents this as an unsupported beta allocation class.
- **Header:** `@warning` beta limitations + accurate local-context service coverage (PC sampling / device counting are no-ops).
- **Test:** direct intercepted-table allocate with `HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG` proves exclusion from the snapshot inventory.

Executable-flag *rejection at snap* was attempted and **reverted**: HIP's own pools look trackable+executable under `query_alloc`, so declining whenever any such allocation is live breaks ordinary HIP replay. Documented as an unsupported allocation class for beta instead.

## Test plan
- [x] `kernel-replay-snapshot-test` 9/9
- [x] `kernel-replay-local-context-test` 10/10 (includes no-promotion)
- [x] `kernel-replay-configure-test` 1/1
- [x] `counter-tests --gtest_filter=*local_context*` 3/3 (includes no-promotion)
- [x] concurrency integration PASS
- [x] local-context integration 10/10
- [x] `rocprofv3-test-kernel-replay{,-interval}-{generate,validate}` 4/4

## Notes for #7960 fold-in
This targets #8622 directly. After merge, fold #8622 (with these fixes) into #7960 as the callback-API land path.