### PR TITLE
fix(rccl-tests): declare the hipified headers as object dependencies

### DIFF
--- a/projects/rccl-tests/src/Makefile
+++ b/projects/rccl-tests/src/Makefile
@@ -194,13 +194,13 @@ os.%:
 
 .PRECIOUS: ${DST_DIR}/%.o
 
-${DST_DIR}/%.o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
+${DST_DIR}/%.o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	@mkdir -p ${DST_DIR}
 	echo "$(HIPCC) $(HIPCUFLAGS) -I. -c -o $@ $<"
 	$(HIPCC) $(HIPCUFLAGS) -I. -I${HIPIFY_DIR} -c -o $@ $<
 
-${DST_DIR}/%$(NAME_SUFFIX).o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
+${DST_DIR}/%$(NAME_SUFFIX).o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	@mkdir -p ${DST_DIR}
 	echo "$(HIPCC) $(HIPCUFLAGS) -I. -c -o $@ $<"

--- a/projects/rccl-tests/src/Makefile
+++ b/projects/rccl-tests/src/Makefile
@@ -194,13 +194,13 @@ os.%:
 
 .PRECIOUS: ${DST_DIR}/%.o
 
-${DST_DIR}/%.o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
+${DST_DIR}/%.o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h ${HIPIFY_DIR}/verifiable.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	@mkdir -p ${DST_DIR}
 	echo "$(HIPCC) $(HIPCUFLAGS) -I. -c -o $@ $<"
 	$(HIPCC) $(HIPCUFLAGS) -I. -I${HIPIFY_DIR} -c -o $@ $<
 
-${DST_DIR}/%$(NAME_SUFFIX).o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
+${DST_DIR}/%$(NAME_SUFFIX).o: ${HIPIFY_DIR}/%.cu.cpp ${HIPIFY_DIR}/common.h ${HIPIFY_DIR}/util.h ${HIPIFY_DIR}/collector.h ${HIPIFY_DIR}/rccl_vector_types.h ${HIPIFY_DIR}/multimem_ops.h ${HIPIFY_DIR}/rccl_float8.h ${HIPIFY_DIR}/verifiable.h $(TEST_VERIFIABLE_HDRS) $(GIT_VERSION_FILE)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	@mkdir -p ${DST_DIR}
 	echo "$(HIPCC) $(HIPCUFLAGS) -I. -c -o $@ $<"


### PR DESCRIPTION
## Motivation

rccl-tests intermittently fails to build in parallel, and the compiler rejects a type that plainly exists:

```
build/hipify/common.cu.cpp:804:9: error: unknown type name 'rccl_float8'
  804 |         rccl_float8 fp8_e4m3; rccl_bfloat8 fp8_e5m2;
make[1]: *** [Makefile:207: build/common.o] Error 1
```

Seventeen errors in all: the two fp8 types, then one per member of the anonymous union that failed to parse (`use of undeclared identifier 'i8'`, `'u8'`, `'f16'` and so on). It showed up on a build of #10222, whose changes do not touch rccl-tests at all, and two runs of that pull request split on it, one clean and one failed. That points at the build graph rather than at the code being compiled.

## Technical Details

`src/common.cu:11` includes `"rccl_float8.h"`. A quoted include is resolved from the directory of the including file first, and after hipify that file lives in `${HIPIFY_DIR}`, so the include picks up `${HIPIFY_DIR}/rccl_float8.h` and not `src/rccl_float8.h`.

That copy is produced by a rule in `verifiable/verifiable.mk` and was named as a prerequisite of `verifiable.o` alone. The object rules in `src/Makefile` listed the five other hipified headers but not this one, and `$(TEST_VERIFIABLE_HDRS)` expands to `../verifiable/verifiable.h` only. `install.sh` builds with `-j$(nproc)`, so make was free to run the hipify of the header and the compile of `common.o` at the same time. The shell truncates the target the moment `hipify-perl ... > $@` starts, which leaves a window in which the compiler opens a zero-byte header and every fp8 type declared there disappears.

The first commit adds `${HIPIFY_DIR}/rccl_float8.h` to both object rules. `verifiable.mk` is included above them, and its explicit rule wins over the `${HIPIFY_DIR}/%.h: %.h` pattern rule, so the header keeps exactly one producer.

The failure is rare because it needs the header to exist *and* be empty. Had the file been missing outright, `-I.` would have found `src/rccl_float8.h` and the build would have passed.

Review turned up a second header in the same state. `src/common.cu:29` includes `"verifiable.h"`, and that hipified copy is produced by `verifiable/verifiable.mk`, which likewise ordered it against `verifiable.o` alone; the object rules named `$(TEST_VERIFIABLE_HDRS)`, which expands to the pre-hipify `../verifiable/verifiable.h`. It has no fallback either, since no `-I` points at `../verifiable`, so the include resolves to nothing when the copy is missing or half-written. The second commit adds it to both rules, which between them now cover all seven hipified headers.

The CMake build is unaffected: `src/CMakeLists.txt` already lists `rccl_float8.h` in `COMMON_FILES`, and `rccl_common` depends on the `hipify` target that covers all of them.

## Issue Tracking

JIRA ID: AICOMRCCL-1972

## Test Plan

1. Dependency check: `make -n <builddir>/common.o` with and without the change.
2. Race reproduction with a deliberately slow hipify. A stub sleeps before copying the header under test, a stub compiler fails when it opens that header empty or absent, and `make -j8 <builddir>/common.o <builddir>/verifiable/verifiable.o` puts both targets in flight the way the real build does. Five runs on each side. Both headers were exercised this way.
3. `make -n build` for makefile sanity.
4. CI.

## Test Result

1. Before the change, `make -n` produces five hipify steps for `common.o` and never touches `rccl_float8.h`. After it, the header is hipified before the compile.
2. Reproduction, five runs each:

| Makefile | header raced | passed | failed |
| --- | --- | --- | --- |
| before commit 1 | `rccl_float8.h` | 0 | 5 |
| after commit 1 | `rccl_float8.h` | 5 | 0 |
| after commit 1 | `verifiable.h` | 0 | 5 |
| after commit 2 | `verifiable.h` | 5 | 0 |

Every fp8 failure reproduced the CI message down to the makefile line:

```
BUILD/hipify/common.cu.cpp:804:9: error: unknown type name 'rccl_float8' [BUILD/hipify/rccl_float8.h is 0 bytes]
make: *** [Makefile:207: BUILD/common.o] Error 1
```

Asking for `common.o` alone is the sharper case for `verifiable.h`: before the second commit it fails deterministically with `common.cu.cpp:29:10: fatal error: 'verifiable.h' file not found`, because nothing else requests the hipified copy.

3. `make -n build` completes with no circular dependency and no overriding-recipe warnings.
4. Pending.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

**(AI Asist)**
