### PR TITLE
net_ib_cast: backport net_ib features and add merged vNIC rail/plane aggregation

### DIFF
--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -294,6 +294,9 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   ncclIbMergedDev tmp;
   memset(&tmp, 0, sizeof(tmp));
   bool used[MAX_IB_DEVS] = {0};
+  tmp.railId = ncclIbDevs[props->devs[0]].railId;
+  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
+  tmp.planeId = (props->ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : ncclIbDevs[props->devs[0]].planeId;
 
   for (int i = 0; i < props->ndevs; i++) {
     if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) {
@@ -305,6 +308,10 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     if (tmp.vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
     tmp.vProps.devs[tmp.vProps.ndevs++] = props->devs[i];
     tmp.speed += dev->speed;
+    // rail ID of a fused device with different rails is undefined.
+    if (dev->railId == NCCL_NET_ID_UNDEF || tmp.railId != dev->railId) tmp.railId = NCCL_NET_ID_UNDEF;
+    // Only set the bit if multiple devs are merged, otherwise keep the initial value
+    if (props->ndevs > 1) tmp.planeId |= (0x1 << dev->planeIdx);
     // Each successive time, copy the name '+' new name
     if (tmp.vProps.ndevs > 1) {
       size_t off = strlen(tmp.devName);
@@ -356,8 +363,8 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
   ncclIbMergedDevs[ncclNMergedIbDevs] = tmp;
   *d = ncclNMergedIbDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed,
-       tmp.vProps.ndevs);
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d rail=%d plane=%d", *d, tmp.devName,
+       tmp.speed, tmp.vProps.ndevs, tmp.railId, tmp.planeId);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -165,6 +165,7 @@ static ncclResult_t ncclIbGetRealPort(char* pciPath, int* realPort, int devIdx) 
 // Typically 12 user-defined planes + 1 plane for undefined plane IDs
 #define NCCL_IB_PLANE_MAX_INDEX 14
 #define NCCL_IB_PLANE_VIRT_BIT (0x1 << NCCL_IB_PLANE_MAX_INDEX)
+static_assert(NCCL_IB_PLANE_MAX_INDEX < 15, "NCCL_IB_PLANE_MAX_INDEX must be < 15: plane IDs are stored in int16_t and bit 15 is the sign bit");
 
 static ncclResult_t ncclIbGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx) {
   int16_t p = 0;

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -118,16 +118,28 @@ void* IbCastAsyncThreadMain(void* args) {
       break;
     case IBV_EVENT_CQ_ERR:
       // the above is a CQ fatal error
-      WARN("NET/IB : %s:%d async fatal event on CQ (%p): %s", dev->devName, dev->portNum, cq, str);
+      WARN("NET/IB : %s:%d async fatal event on CQ (%p) handle=%u cqe=%d: %s", dev->devName, dev->portNum, cq,
+           (unsigned)cq->handle, cq->cqe, str);
       IbCastCqFatalError(cq);
       break;
     case IBV_EVENT_QP_FATAL:
     case IBV_EVENT_QP_REQ_ERR:
     case IBV_EVENT_QP_ACCESS_ERR:
       // the above are QP fatal errors
-      WARN("NET/IB : %s:%d async fatal event on QP (%p): %s", dev->devName, dev->portNum, qp, str);
-      IbCastQpFatalError(qp);
-      break;
+      {
+        struct ibv_qp_attr qpAttr;
+        memset(&qpAttr, 0, sizeof(qpAttr));
+        struct ibv_qp_init_attr qpInitAttr;
+        memset(&qpInitAttr, 0, sizeof(qpInitAttr));
+        (void)wrap_ibv_query_qp(qp, &qpAttr, IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_RQ_PSN, &qpInitAttr);
+        WARN("NET/IB : %s:%d async fatal event on QP (%p) qpn=%u handle=%u send_cq=%u recv_cq=%u state=%d sq_psn=%u "
+             "rq_psn=%u: %s",
+             dev->devName, dev->portNum, qp, qp->qp_num, (unsigned)qp->handle,
+             qp->send_cq ? (unsigned)qp->send_cq->handle : 0u, qp->recv_cq ? (unsigned)qp->recv_cq->handle : 0u,
+             (int)qpAttr.qp_state, (unsigned)qpAttr.sq_psn, (unsigned)qpAttr.rq_psn, str);
+        IbCastQpFatalError(qp);
+        break;
+      }
     case IBV_EVENT_SRQ_ERR:
       // SRQ are not used in NCCL
       WARN("NET/IB : %s:%d async fatal event on SRQ, unused for now (%p): %s", dev->devName, dev->portNum, srq, str);

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -755,6 +755,8 @@ ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props);
 ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenComm);
 ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
                            ncclNetDeviceHandle_t** /*sendDevComm*/);
+ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                               ncclNetDeviceHandle_t** /*sendDevComm*/, int envTrafficClass);
 ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/);
 ncclResult_t IbCastRegMr(void* comm, void* data, size_t size, int type, void** mhandle);
 ncclResult_t IbCastRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -391,6 +391,7 @@ struct ncclIbQpRtrAttr {
   union ibv_gid remoteGid;
 
   uint8_t localIbPort;
+  uint8_t localPortFlags;
   union ibv_gid localGid;
   int32_t localGidIndex;
 };

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -87,6 +87,8 @@ extern int IbCastNMergedDevs;
 struct alignas(64) ncclIbMergedDev {
   ncclNetVDeviceProps_t vProps;
   int speed;
+  int16_t railId;
+  int16_t planeId;
   char devName[MAX_MERGED_DEV_NAME]; // Up to NCCL_IB_MAX_DEVS_PER_NIC * name size, and a character for each '+'
 };
 
@@ -124,6 +126,9 @@ struct alignas(64) ncclIbDev {
   struct ibv_port_attr portAttr;
   struct ncclIbStats stats;
   int dmaBufSupported;
+  int16_t railId;
+  int16_t planeId;
+  int16_t planeIdx;
   enum ncclIbProvider ibProvider;
   union {
     struct {

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -779,8 +779,8 @@ void IbCastSetTrafficClass(void* ctx, int trafficClass) {
   if (config) config->trafficClass = trafficClass;
 }
 
-ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
-                           ncclNetDeviceHandle_t** sendDevComm) {
+ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                               ncclNetDeviceHandle_t** sendDevComm, int envTrafficClass) {
   ncclResult_t ret = ncclSuccess;
   struct ncclIbHandle* handle = (struct ncclIbHandle*)opaqueHandle;
   struct ncclIbCommStage* stage = &handle->stage;
@@ -994,7 +994,7 @@ ib_recv_dev_list:
   meta.sl = (ncclParamIbCastSl() != -1)                    ? ncclParamIbCastSl() :
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_SL_DEFAULT;
-  meta.tc = (ncclParamIbCastTc() != -1)                    ? ncclParamIbCastTc() :
+  meta.tc = (envTrafficClass != -1)                        ? envTrafficClass :
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
@@ -1087,6 +1087,11 @@ exit:
 fail:
   free(comm);
   goto exit;
+}
+
+ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                           ncclNetDeviceHandle_t** sendDevComm) {
+  return IbCastConnectImpl(ctx, dev, opaqueHandle, sendComm, sendDevComm, ncclParamIbCastTc());
 }
 
 NCCL_PARAM(IbCastWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -622,6 +622,26 @@ static bool subnetMatchesAny(union ibv_gid* localGid, union ibv_gid* remoteGids,
   return false;
 }
 
+// Test-only wrappers (see net_ib_cast_inspect.h). Reconstruct union ibv_gid from
+// raw 16-byte arrays and forward to the real static helpers above so unit tests
+// exercise the actual subnet-detection logic.
+extern "C" int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen) {
+  union ibv_gid l, r;
+  memcpy(l.raw, localGid, 16);
+  memcpy(r.raw, remoteGid, 16);
+  return gidSameSubnet(&l, &r, prefixLen) ? 1 : 0;
+}
+
+extern "C" int ncclIbCastTestSubnetMatchesAny(const uint8_t localGid[16], const uint8_t* remoteGids, int nRemote,
+                                              int prefixLen) {
+  union ibv_gid l;
+  memcpy(l.raw, localGid, 16);
+  union ibv_gid r[NCCL_IB_MAX_DEVS_PER_NIC];
+  if (nRemote < 0 || nRemote > NCCL_IB_MAX_DEVS_PER_NIC) return 0;
+  for (int i = 0; i < nRemote; i++) memcpy(r[i].raw, remoteGids + (size_t)i * 16, 16);
+  return subnetMatchesAny(&l, r, nRemote, prefixLen) ? 1 : 0;
+}
+
 // Given remote GIDs (one per PF on the remote side), find a local merged IB
 // device that shares a subnet with any of them. Writes defaultDev to *foundDev
 // if no better match is found, preserving existing behavior for single-subnet

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -21,6 +21,8 @@ NCCL_PARAM(IbCastSl, "IB_SL", -1);
 NCCL_PARAM(IbCastTc, "IB_TC", -1);
 NCCL_PARAM(IbCastFifoTc, "IB_FIFO_TC", -1);
 NCCL_PARAM(IbCastEceEnable, "IB_ECE_ENABLE", 1);
+NCCL_PARAM(IbCastSubnetAwareRouting, "IB_SUBNET_AWARE_ROUTING", 0);
+NCCL_PARAM(IbCastSubnetPrefixLen, "IB_SUBNET_PREFIX_LEN", 24);
 
 extern int64_t ncclParamIbCastOooRq();
 extern int64_t ncclParamIbCastResiliencyPortFailover();
@@ -523,19 +525,22 @@ ncclResult_t IbCastQpRtr(struct ncclIbQp* qp) {
     qpAttr.ah_attr.grh.hop_limit = 255;
     qpAttr.ah_attr.grh.traffic_class = rtrAttr->tc;
   } else {
-    // pick lid if subnet prefixs are same, FLID if they are not
-    if (IbCastExtractLocalSubnetPrefix(rtrAttr->localGid.global.subnet_prefix) ==
-        IbCastExtractLocalSubnetPrefix(rtrAttr->remoteGid.global.subnet_prefix)) {
-      qpAttr.ah_attr.is_global = 0;
-      qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
-    } else {
-      uint16_t flid = IbCastExtractFlid(&rtrAttr->remoteGid);
-      if (flid == 0) {
-        WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as "
-             "fallback");
-        qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
-      } else {
-        qpAttr.ah_attr.dlid = IbCastExtractFlid(&rtrAttr->remoteGid);
+    // Path-local if same subnet and GRH not required; else global addressing. FLID only when subnets differ.
+    bool sameSubnet = (IbCastExtractLocalSubnetPrefix(rtrAttr->localGid.global.subnet_prefix) ==
+                       IbCastExtractLocalSubnetPrefix(rtrAttr->remoteGid.global.subnet_prefix));
+    bool needGlobal = !sameSubnet || (rtrAttr->localPortFlags & IBV_QPF_GRH_REQUIRED);
+    qpAttr.ah_attr.is_global = 0;
+    qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
+    if (needGlobal) {
+      if (!sameSubnet) {
+        uint16_t flid = IbCastExtractFlid(&rtrAttr->remoteGid);
+        if (flid == 0) {
+          WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as "
+               "fallback");
+          qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
+        } else {
+          qpAttr.ah_attr.dlid = flid;
+        }
       }
       qpAttr.ah_attr.is_global = 1;
       qpAttr.ah_attr.grh.dgid.global.subnet_prefix = rtrAttr->remoteGid.global.subnet_prefix;
@@ -588,6 +593,112 @@ ncclResult_t IbCastQpError(struct ncclIbQp* qp) {
   return ncclSuccess;
 }
 
+// Check if two RoCE GIDs are on the same subnet.
+// For IPv4-mapped GIDs (::ffff:a.b.c.d), uses the given prefix length (1..32).
+// For native IPv6 GIDs, compares the 64-bit subnet prefix.
+static bool gidSameSubnet(union ibv_gid* local, union ibv_gid* remote, int prefixLen) {
+  sa_family_t localFam = getGidAddrFamily(local);
+  sa_family_t remoteFam = getGidAddrFamily(remote);
+  if (localFam != remoteFam) return false;
+  if (localFam == AF_INET) {
+    // IPv4-mapped: compare using configured prefix length.
+    // IPv4 address is in bytes 12-15 of the raw GID.
+    uint32_t localIp, remoteIp;
+    memcpy(&localIp, local->raw + 12, 4);
+    memcpy(&remoteIp, remote->raw + 12, 4);
+    uint32_t mask = htonl(~((1U << (32 - prefixLen)) - 1));
+    return (localIp & mask) == (remoteIp & mask);
+  } else {
+    // IPv6: compare subnet prefix (first 64 bits)
+    return local->global.subnet_prefix == remote->global.subnet_prefix;
+  }
+}
+
+// check if a local GID matches ANY of the remote GIDs.
+static bool subnetMatchesAny(union ibv_gid* localGid, union ibv_gid* remoteGids, int nRemoteGids, int prefixLen) {
+  for (int r = 0; r < nRemoteGids; r++) {
+    if (validGid(&remoteGids[r]) && gidSameSubnet(localGid, &remoteGids[r], prefixLen)) return true;
+  }
+  return false;
+}
+
+// Given remote GIDs (one per PF on the remote side), find a local merged IB
+// device that shares a subnet with any of them. Writes defaultDev to *foundDev
+// if no better match is found, preserving existing behavior for single-subnet
+// and IB deployments.
+// Checks the default device first to preserve NIC Fusion when all PFs in
+// the fused device can reach the peer (e.g., 2-node or switch setup).
+static ncclResult_t IbCastFindDevBySubnet(union ibv_gid* remoteGids, int nRemoteGids, int defaultDev, int* foundDev) {
+  *foundDev = defaultDev;
+
+  int prefixLen = ncclParamIbCastSubnetPrefixLen();
+  if (prefixLen < 1 || prefixLen > 32) {
+    WARN("NET/IB: NCCL_IB_SUBNET_PREFIX_LEN=%d is out of range [1,32]", prefixLen);
+    return ncclInvalidArgument;
+  }
+
+  // Quick check: if no remote GID is valid, nothing to do.
+  bool anyValid = false;
+  for (int r = 0; r < nRemoteGids; r++) {
+    if (validGid(&remoteGids[r])) {
+      anyValid = true;
+      break;
+    }
+  }
+  if (!anyValid) return ncclSuccess;
+
+  // First: check if the default device already works. If ALL its RoCE PFs
+  // match some remote GID's subnet, keep it — this preserves NIC Fusion
+  // bandwidth when both ports connect to the same destination.
+  if (defaultDev >= 0 && defaultDev < IbCastNMergedDevs) {
+    struct ncclIbMergedDev* mDev = IbCastMergedDevs + defaultDev;
+    int checked = 0, matched = 0;
+    for (int i = 0; i < mDev->vProps.ndevs; i++) {
+      int ibDevN = mDev->vProps.devs[i];
+      ncclIbDev* ibDev = IbCastDevs + ibDevN;
+      if (ibDev->portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+      int gidIndex = 0;
+      union ibv_gid localGid;
+      memset(&localGid, 0, sizeof(localGid));
+      if (IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &gidIndex) != ncclSuccess) continue;
+      if (wrap_ibv_query_gid(ibDev->context, ibDev->portNum, gidIndex, &localGid) != ncclSuccess) continue;
+      checked++;
+      if (validGid(&localGid) && subnetMatchesAny(&localGid, remoteGids, nRemoteGids, prefixLen)) matched++;
+    }
+    if (checked > 0 && matched == checked) return ncclSuccess;
+  }
+
+  // Default device can't fully reach the peer (e.g., NIC Fusion fused PFs on
+  // different subnets, or the device is on the wrong subnet entirely).
+  // Search for a device whose RoCE PFs all match a remote GID's subnet.
+  // Same "all PFs must match" criterion as the defaultDev check: NCCL takes
+  // a merged-device index and spreads QPs across all its PFs, so a partial
+  // match would leave some QPs on PFs with no L2 path to the peer.
+  for (int devIdx = 0; devIdx < IbCastNMergedDevs; devIdx++) {
+    if (devIdx == defaultDev) continue;
+    struct ncclIbMergedDev* mDev = IbCastMergedDevs + devIdx;
+    int checked = 0, matched = 0;
+    for (int i = 0; i < mDev->vProps.ndevs; i++) {
+      int ibDevN = mDev->vProps.devs[i];
+      ncclIbDev* ibDev = IbCastDevs + ibDevN;
+      if (ibDev->portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+      int gidIndex = 0;
+      union ibv_gid localGid;
+      memset(&localGid, 0, sizeof(localGid));
+      if (IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &gidIndex) != ncclSuccess) continue;
+      if (wrap_ibv_query_gid(ibDev->context, ibDev->portNum, gidIndex, &localGid) != ncclSuccess) continue;
+      checked++;
+      if (validGid(&localGid) && subnetMatchesAny(&localGid, remoteGids, nRemoteGids, prefixLen)) matched++;
+    }
+    if (checked > 0 && matched == checked) {
+      INFO(NCCL_NET, "NET/IB: Subnet-aware routing: overriding dev %d with dev %d", defaultDev, devIdx);
+      *foundDev = devIdx;
+      return ncclSuccess;
+    }
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
   ncclResult_t ret = ncclSuccess;
   struct ncclIbListenComm* comm;
@@ -600,6 +711,24 @@ ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &IbCastIfAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
   NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketGetAddr(&comm->sock, &handle->connectAddr), ret, fail);
+
+  // Embed GIDs of all PFs in the handle so the connector can find a local NIC
+  // on the same subnet as any of our ports.
+  if (ncclParamIbCastSubnetAwareRouting() && dev < IbCastNMergedDevs) {
+    struct ncclIbMergedDev* mDev = IbCastMergedDevs + dev;
+    int gidSlot = 0;
+    for (int i = 0; i < mDev->vProps.ndevs && gidSlot < 2; i++) {
+      int ibDevN = mDev->vProps.devs[i];
+      ncclIbDev* ibDev = IbCastDevs + ibDevN;
+      if (ibDev->portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+      int gidIndex;
+      NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &gidIndex), ret, fail);
+      NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, gidIndex, &handle->listenGids[gidSlot]), ret,
+                    fail);
+      gidSlot++;
+    }
+  }
+
   *listenComm = comm;
 exit:
   return ret;
@@ -753,6 +882,7 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
     rtrAttr->remoteLid = remDevInfo->lid;
     rtrAttr->remoteGid = remDevInfo->gid;
     rtrAttr->localIbPort = ibDev->portNum;
+    rtrAttr->localPortFlags = ibDev->portAttr.flags;
     rtrAttr->localGid = commDev->base.gidInfo.localGid;
     rtrAttr->localGidIndex = commDev->base.gidInfo.localGidIndex;
     NCCLCHECK(IbCastQpRtr(localQp));
@@ -791,6 +921,11 @@ ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** se
   int channelId = 0;
   int isP2p = 0;
   *sendComm = NULL;
+
+  // Subnet-aware device selection: use the listener's GIDs (embedded in the
+  // handle) to find a local NIC on the same subnet as the remote peer.
+  // For single-subnet or IB deployments, all GIDs are zero → dev stays unchanged.
+  if (ncclParamIbCastSubnetAwareRouting()) NCCLCHECK(IbCastFindDevBySubnet(handle->listenGids, 2, dev, &dev));
 
   if (IbCastAinicRoce && sendDevComm) {
     channelId = ((ncclNet_ctxt_t*)sendDevComm)->chId;
@@ -1259,6 +1394,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     rtrAttr->remoteLid = remDevInfo->lid;
     rtrAttr->remoteGid = remDevInfo->gid;
     rtrAttr->localIbPort = ibDev->portNum;
+    rtrAttr->localPortFlags = ibDev->portAttr.flags;
     rtrAttr->localGid = rCommDev->base.gidInfo.localGid;
     rtrAttr->localGidIndex = rCommDev->base.gidInfo.localGidIndex;
     NCCLCHECK(IbCastQpRtr(localQp));
@@ -1330,6 +1466,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       rtrAttr->remoteLid = ibDev->portAttr.lid;
       rtrAttr->remoteGid = rCommDev->base.gidInfo.localGid;
       rtrAttr->localIbPort = ibDev->portNum;
+      rtrAttr->localPortFlags = ibDev->portAttr.flags;
       rtrAttr->localGid = rCommDev->base.gidInfo.localGid;
       rtrAttr->localGidIndex = rCommDev->base.gidInfo.localGidIndex;
       NCCLCHECK(IbCastQpRtr(flushQp));
@@ -1477,6 +1614,25 @@ ib_recv:
        remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);
+
+  // Subnet-aware device selection: use the remote sender's GIDs to find a local
+  // NIC on the same subnet. Override lComm->dev and update vProps if a
+  // better device is found.
+  if (ncclParamIbCastSubnetAwareRouting() && remMeta.ndevs > 0) {
+    union ibv_gid remoteGids[NCCL_IB_MAX_DEVS_PER_NIC];
+    int nRemoteGids = 0;
+    for (int i = 0; i < remMeta.ndevs && i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
+      if (remMeta.devs[i].link_layer == IBV_LINK_LAYER_ETHERNET) {
+        remoteGids[nRemoteGids++] = remMeta.devs[i].gid;
+      }
+    }
+    int effectiveDev = lComm->dev;
+    NCCLCHECKGOTO(IbCastFindDevBySubnet(remoteGids, nRemoteGids, lComm->dev, &effectiveDev), ret, fail);
+    if (effectiveDev != lComm->dev) {
+      lComm->dev = effectiveDev;
+      rComm->base.vProps = IbCastMergedDevs[effectiveDev].vProps;
+    }
+  }
 
   // IB setup
   // Pre-declare variables because of goto

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -622,9 +622,6 @@ static bool subnetMatchesAny(union ibv_gid* localGid, union ibv_gid* remoteGids,
   return false;
 }
 
-// Test-only wrappers (see net_ib_cast_inspect.h). Reconstruct union ibv_gid from
-// raw 16-byte arrays and forward to the real static helpers above so unit tests
-// exercise the actual subnet-detection logic.
 extern "C" int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen) {
   union ibv_gid l, r;
   memcpy(l.raw, localGid, 16);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -729,20 +729,29 @@ ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketGetAddr(&comm->sock, &handle->connectAddr), ret, fail);
 
-  // Embed GIDs of all PFs in the handle so the connector can find a local NIC
-  // on the same subnet as any of our ports.
+  // Embed GIDs of the first 2 RoCE PFs (handle-size limited) in the handle so
+  // the connector can find a local NIC on the same subnet as one of our ports.
+  // ncclIbHandle is bounded to 128 B, so at most 2 GIDs fit; a vNIC with more
+  // than 2 RoCE PFs advertises only the first 2.
   if (ncclParamIbCastSubnetAwareRouting() && dev < IbCastNMergedDevs) {
     struct ncclIbMergedDev* mDev = IbCastMergedDevs + dev;
-    int gidSlot = 0;
-    for (int i = 0; i < mDev->vProps.ndevs && gidSlot < 2; i++) {
+    int gidSlot = 0, roceDevs = 0;
+    for (int i = 0; i < mDev->vProps.ndevs; i++) {
       int ibDevN = mDev->vProps.devs[i];
       ncclIbDev* ibDev = IbCastDevs + ibDevN;
       if (ibDev->portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+      roceDevs++;
+      if (gidSlot >= 2) continue;
       int gidIndex;
       NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &gidIndex), ret, fail);
       NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, gidIndex, &handle->listenGids[gidSlot]), ret,
                     fail);
       gidSlot++;
+    }
+    if (roceDevs > 2) {
+      WARN("NET/IB: %s: subnet-aware routing device %d has %d RoCE PFs but only the first 2 are advertised "
+           "(handle-size limited)",
+           __func__, dev, roceDevs);
     }
   }
 

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -36,6 +36,10 @@ struct ncclIbHandle {
   uint64_t magic; // random number to help debugging
   int isP2p;
   bool isRMA;
+  // GIDs of the listener's device PFs, used by the connector to find a local
+  // NIC on the same subnet (for multi-subnet RoCE direct-connect topologies).
+  // Zero-valued slots are ignored (validGid() returns false).
+  union ibv_gid listenGids[2];
   struct ncclIbCommStage stage; // Used by the other side when connecting
 };
 

--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -55,6 +55,8 @@ static ncclResult_t IbCastGinIbGdrGpuSupport(bool gdaki) {
 }
 
 NCCL_PARAM(CastGinType, "GIN_TYPE", -1);
+NCCL_PARAM(CastGinIbTc, "GIN_IB_TC", -1);
+extern int64_t ncclParamIbCastTc();
 
 #ifdef RCCL_NET_IB_CAST_ENABLE_GDAKI
 static std::mutex IbCastGinGdakiLockMutex;
@@ -208,7 +210,8 @@ ncclResult_t IbCastGinIbConnect(void* ctx, void* handles[], int nranks, int rank
   next = (cComm->rank + 1) % nranks;
   do {
     if (cComm->sendComm == NULL) {
-      NCCLCHECK(netIbCast.connect(ctx, lComm->dev, handles[next], &cComm->sendComm, NULL));
+      NCCLCHECK(IbCastConnectImpl(ctx, lComm->dev, handles[next], &cComm->sendComm, NULL,
+                                  ncclParamCastGinIbTc() != -1 ? ncclParamCastGinIbTc() : ncclParamIbCastTc()));
     }
     if (cComm->recvComm == NULL) NCCLCHECK(netIbCast.accept(lComm, &cComm->recvComm, NULL));
   } while (cComm->sendComm == NULL || cComm->recvComm == NULL);
@@ -294,6 +297,9 @@ ncclResult_t IbCastGinIbGdakiConnect(void* ctx, void* handles[], int nranks, int
 ncclResult_t IbCastGinIbGdakiCreateContext(void* collComm, ncclGinConfig_v14_t* config, void** ginCtx,
                                            ncclNetDeviceHandle_t** devHandle) {
   struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)collComm;
+
+  if (ncclParamCastGinIbTc() != -1) config->trafficClass = ncclParamCastGinIbTc();
+  else if (ncclParamIbCastTc() != -1) config->trafficClass = ncclParamIbCastTc();
 
   NCCLCHECK(ncclGinGdakiCreateContext(cComm, config->nSignals, config->nCounters, config->nContexts, config->queueDepth,
                                       config->trafficClass, ginCtx, devHandle));
@@ -418,8 +424,9 @@ ncclResult_t IbCastRmaIbProxyCreateContext(void* collComm, ncclRmaConfig_t* conf
       int acceptPeer = (cComm->rank - i + nranks) % nranks;
       do {
         if (gc->fullSendComm[connectPeer] == NULL)
-          NCCLCHECKGOTO(netIbCast.connect(cComm->ctx, cComm->dev, handles + NCCL_NET_HANDLE_MAXSIZE * connectPeer,
-                                          &gc->fullSendComm[connectPeer], NULL),
+          NCCLCHECKGOTO(IbCastConnectImpl(cComm->ctx, cComm->dev, handles + NCCL_NET_HANDLE_MAXSIZE * connectPeer,
+                                          &gc->fullSendComm[connectPeer], NULL,
+                                          ncclParamCastGinIbTc() != -1 ? ncclParamCastGinIbTc() : ncclParamIbCastTc()),
                         ret, end);
         if (gc->fullRecvComm[acceptPeer] == NULL)
           NCCLCHECKGOTO(netIbCast.accept(lComm, &gc->fullRecvComm[acceptPeer], NULL), ret, end);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -222,6 +222,44 @@ extern "C" ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count
   return IbCastGetPlaneIndex(devPlane, count, planes, idx);
 }
 
+// Derive the merged railId/planeId of a fused vNIC from its physical devices,
+// mirroring upstream NCCL v2.30.7. Kept as a standalone helper so unit tests can
+// exercise the exact aggregation logic (see net_ib_cast_inspect.h).
+static void IbCastMergedRailPlane(const struct ncclIbDev* devs, const int* devIdx, int ndevs,
+                                  int16_t* outRailId, int16_t* outPlaneId) {
+  int16_t railId = devs[devIdx[0]].railId;
+  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
+  int16_t planeId = (ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : devs[devIdx[0]].planeId;
+  for (int i = 0; i < ndevs; i++) {
+    const struct ncclIbDev* dev = devs + devIdx[i];
+    // rail ID of a fused device with different rails is undefined.
+    if (dev->railId == NCCL_NET_ID_UNDEF || railId != dev->railId) railId = NCCL_NET_ID_UNDEF;
+    // Only set the bit if multiple devs are merged, otherwise keep the initial value
+    if (ndevs > 1) planeId |= (0x1 << dev->planeIdx);
+  }
+  *outRailId = railId;
+  *outPlaneId = planeId;
+}
+
+// Test-only wrapper (see net_ib_cast_inspect.h). Builds synthetic physical devices
+// carrying only rail/plane attributes and forwards to the real IbCastMergedRailPlane.
+extern "C" ncclResult_t ncclIbCastTestMergedRailPlane(const int16_t* railIds, const int16_t* planeIds,
+                                                      const int16_t* planeIdxs, int ndevs, int16_t* outRailId,
+                                                      int16_t* outPlaneId) {
+  if (!railIds || !planeIds || !planeIdxs || !outRailId || !outPlaneId) return ncclInvalidArgument;
+  if (ndevs <= 0 || ndevs > NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidArgument;
+  struct ncclIbDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
+  int idx[NCCL_IB_MAX_DEVS_PER_NIC];
+  for (int i = 0; i < ndevs; i++) {
+    devs[i].railId = railIds[i];
+    devs[i].planeId = planeIds[i];
+    devs[i].planeIdx = planeIdxs[i];
+    idx[i] = i;
+  }
+  IbCastMergedRailPlane(devs, idx, ndevs, outRailId, outPlaneId);
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // On AINIC, NIC fusion (cast) is disabled by default: each NIC runs independently.
   // User must explicitly set NCCL_IB_MERGE_NICS=1 to override.
@@ -252,8 +290,10 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // Always count up number of merged devices
   ncclIbMergedDev tmp;
   memset(&tmp, 0, sizeof(tmp));
-  bool used[MAX_IB_DEVS] = {0};
+  // Derive merged rail/plane IDs (mirrors upstream NCCL v2.30.7).
+  IbCastMergedRailPlane(IbCastDevs, props->devs, props->ndevs, &tmp.railId, &tmp.planeId);
 
+  bool used[MAX_IB_DEVS] = {0};
   for (int i = 0; i < props->ndevs; i++) {
     if (props->devs[i] < 0 || props->devs[i] >= IbCastNDevs) {
       WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], IbCastNDevs);
@@ -326,8 +366,8 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
 
   IbCastMergedDevs[IbCastNMergedDevs] = tmp;
   *d = IbCastNMergedDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed,
-       tmp.vProps.ndevs);
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d rail=%d plane=%d", *d, tmp.devName,
+       tmp.speed, tmp.vProps.ndevs, tmp.railId, tmp.planeId);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -222,44 +222,6 @@ extern "C" ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count
   return IbCastGetPlaneIndex(devPlane, count, planes, idx);
 }
 
-// Derive the merged railId/planeId of a fused vNIC from its physical devices,
-// mirroring upstream NCCL v2.30.7. Kept as a standalone helper so unit tests can
-// exercise the exact aggregation logic (see net_ib_cast_inspect.h).
-static void IbCastMergedRailPlane(const struct ncclIbDev* devs, const int* devIdx, int ndevs,
-                                  int16_t* outRailId, int16_t* outPlaneId) {
-  int16_t railId = devs[devIdx[0]].railId;
-  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
-  int16_t planeId = (ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : devs[devIdx[0]].planeId;
-  for (int i = 0; i < ndevs; i++) {
-    const struct ncclIbDev* dev = devs + devIdx[i];
-    // rail ID of a fused device with different rails is undefined.
-    if (dev->railId == NCCL_NET_ID_UNDEF || railId != dev->railId) railId = NCCL_NET_ID_UNDEF;
-    // Only set the bit if multiple devs are merged, otherwise keep the initial value
-    if (ndevs > 1) planeId |= (0x1 << dev->planeIdx);
-  }
-  *outRailId = railId;
-  *outPlaneId = planeId;
-}
-
-// Test-only wrapper (see net_ib_cast_inspect.h). Builds synthetic physical devices
-// carrying only rail/plane attributes and forwards to the real IbCastMergedRailPlane.
-extern "C" ncclResult_t ncclIbCastTestMergedRailPlane(const int16_t* railIds, const int16_t* planeIds,
-                                                      const int16_t* planeIdxs, int ndevs, int16_t* outRailId,
-                                                      int16_t* outPlaneId) {
-  if (!railIds || !planeIds || !planeIdxs || !outRailId || !outPlaneId) return ncclInvalidArgument;
-  if (ndevs <= 0 || ndevs > NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidArgument;
-  struct ncclIbDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
-  int idx[NCCL_IB_MAX_DEVS_PER_NIC];
-  for (int i = 0; i < ndevs; i++) {
-    devs[i].railId = railIds[i];
-    devs[i].planeId = planeIds[i];
-    devs[i].planeIdx = planeIdxs[i];
-    idx[i] = i;
-  }
-  IbCastMergedRailPlane(devs, idx, ndevs, outRailId, outPlaneId);
-  return ncclSuccess;
-}
-
 ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // On AINIC, NIC fusion (cast) is disabled by default: each NIC runs independently.
   // User must explicitly set NCCL_IB_MERGE_NICS=1 to override.
@@ -290,10 +252,11 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // Always count up number of merged devices
   ncclIbMergedDev tmp;
   memset(&tmp, 0, sizeof(tmp));
-  // Derive merged rail/plane IDs (mirrors upstream NCCL v2.30.7).
-  IbCastMergedRailPlane(IbCastDevs, props->devs, props->ndevs, &tmp.railId, &tmp.planeId);
-
   bool used[MAX_IB_DEVS] = {0};
+  tmp.railId = IbCastDevs[props->devs[0]].railId;
+  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
+  tmp.planeId = (props->ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : IbCastDevs[props->devs[0]].planeId;
+
   for (int i = 0; i < props->ndevs; i++) {
     if (props->devs[i] < 0 || props->devs[i] >= IbCastNDevs) {
       WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], IbCastNDevs);
@@ -304,6 +267,10 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     if (tmp.vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
     tmp.vProps.devs[tmp.vProps.ndevs++] = props->devs[i];
     tmp.speed += dev->speed;
+    // rail ID of a fused device with different rails is undefined.
+    if (dev->railId == NCCL_NET_ID_UNDEF || tmp.railId != dev->railId) tmp.railId = NCCL_NET_ID_UNDEF;
+    // Only set the bit if multiple devs are merged, otherwise keep the initial value
+    if (props->ndevs > 1) tmp.planeId |= (0x1 << dev->planeIdx);
     // Each successive time, copy the name '+' new name
     if (tmp.vProps.ndevs > 1) {
       size_t off = strlen(tmp.devName);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -196,6 +196,7 @@ fail:
 // Typically 12 user-defined planes + 1 plane for undefined plane IDs
 #define NCCL_IB_PLANE_MAX_INDEX 14
 #define NCCL_IB_PLANE_VIRT_BIT (0x1 << NCCL_IB_PLANE_MAX_INDEX)
+static_assert(NCCL_IB_PLANE_MAX_INDEX < 15, "NCCL_IB_PLANE_MAX_INDEX must be < 15: plane IDs are stored in int16_t and bit 15 is the sign bit");
 
 static ncclResult_t IbCastGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx) {
   int16_t p = 0;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -192,6 +192,29 @@ fail:
   return ncclInternalError;
 }
 
+// NCCL_IB_PLANE_MAX_INDEX must be < 15 as we use int16_t for plane IDs
+// Typically 12 user-defined planes + 1 plane for undefined plane IDs
+#define NCCL_IB_PLANE_MAX_INDEX 14
+#define NCCL_IB_PLANE_VIRT_BIT (0x1 << NCCL_IB_PLANE_MAX_INDEX)
+
+static ncclResult_t IbCastGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx) {
+  int16_t p = 0;
+  while (p < *count && planes[p] != devPlane) p++;
+  if (p == *count) {
+    if (p == (NCCL_IB_PLANE_MAX_INDEX - 1)) {
+      WARN("NCCL cannot use more than %d plane IDs.", NCCL_IB_PLANE_MAX_INDEX);
+      return ncclInvalidUsage;
+    }
+    if (devPlane != NCCL_NET_ID_UNDEF && (devPlane & NCCL_IB_PLANE_VIRT_BIT)) {
+      WARN("NCCL cannot use a plane ID that is %d.", devPlane);
+      return ncclInvalidUsage;
+    }
+    planes[(*count)++] = devPlane;
+  }
+  *idx = p;
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // On AINIC, NIC fusion (cast) is disabled by default: each NIC runs independently.
   // User must explicitly set NCCL_IB_MERGE_NICS=1 to override.
@@ -413,7 +436,8 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             continue;
 
             // check against user specified HCAs/ports
-          if (!(matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+          int userIfId = -1;
+          if (!(matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact, &userIfId) ^ searchNot)) {
             continue;
           }
 
@@ -478,6 +502,9 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             IbCastDevs[IbCastNDevs].mrCache.slots = NULL;
             NCCLCHECK(IbCastStatsInit(&IbCastDevs[IbCastNDevs].stats));
 
+            IbCastDevs[IbCastNDevs].railId = (userIfId >= 0) ? userIfs[userIfId].rail : -1;
+            IbCastDevs[IbCastNDevs].planeId = (userIfId >= 0) ? userIfs[userIfId].plane : -1;
+
             // Enable ADAPTIVE_ROUTING by default on IB networks
             // But allow it to be overloaded by an env parameter
             IbCastDevs[IbCastNDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
@@ -524,13 +551,26 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     }
     // sort devices to ensure a consistent order across nodes
     if (ncclParamIbCastDevicePciOrder()) qsort(IbCastDevs, IbCastNDevs, sizeof(struct ncclIbDev), IbCastCompareDevs);
-    // Once sorted, get the realPort ID and create the virtual devices.
-    // Doing it after sorting ensures that devices will have consistent realPort ids across nodes.
+    // Once sorted, get the realPort ID, the plane index, and create the virtual devices.
+    // Doing it after sorting ensures that devices will have consistent realPort IDs and plane indexes accross ranks.
     char line[2048] = "";
+    int16_t uniquePlaneCount = 1, uniquePlaneIds[NCCL_IB_PLANE_MAX_INDEX] = {NCCL_NET_ID_UNDEF};
     for (int d = 0; d < IbCastNDevs; d++) {
+      NCCLCHECKGOTO(IbCastGetPlaneIndex(IbCastDevs[d].planeId, &uniquePlaneCount, uniquePlaneIds,
+                                        &IbCastDevs[d].planeIdx),
+                    ret, fail);
       NCCLCHECKGOTO(IbCastGetRealPort(IbCastDevs[d].pciPath, &IbCastDevs[d].realPort, d), ret, fail);
-      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d/%s", d, IbCastDevs[d].devName,
-               IbCastDevs[d].portNum, NCCL_IB_LLSTR(IbCastDevs[d].link));
+      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d", d, IbCastDevs[d].devName,
+               IbCastDevs[d].portNum);
+      if (IbCastDevs[d].railId != NCCL_NET_ID_UNDEF) {
+        snprintf(line + strlen(line), sizeof(line) - strlen(line), ":%d", IbCastDevs[d].railId);
+      } else if (IbCastDevs[d].planeId != NCCL_NET_ID_UNDEF) {
+        snprintf(line + strlen(line), sizeof(line) - strlen(line), ":");
+      }
+      if (IbCastDevs[d].planeId != NCCL_NET_ID_UNDEF) {
+        snprintf(line + strlen(line), sizeof(line) - strlen(line), ":%d", IbCastDevs[d].planeId);
+      }
+      snprintf(line + strlen(line), sizeof(line) - strlen(line), "/%s", NCCL_IB_LLSTR(IbCastDevs[d].link));
 
       // Add this plain physical device to the list of virtual devices (after sorting)
       int vDev;
@@ -649,6 +689,8 @@ ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
   props->maxCollBytes = MAX_COLLNET_SIZE;
   props->maxMultiRequestSize = 1;
+  props->railId = ibDev->railId;
+  props->planeId = ibDev->planeId;
   return ncclSuccess;
 }
 
@@ -662,6 +704,8 @@ ncclResult_t IbCastGetProperties(int dev, ncclNetProperties_t* props) {
   NCCLCHECK(IbCastGetPhysProperties(mergedDev->vProps.devs[0], props));
   props->name = mergedDev->devName;
   props->speed = mergedDev->speed;
+  props->railId = mergedDev->railId;
+  props->planeId = mergedDev->planeId;
   memcpy(&props->vProps, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -215,6 +215,13 @@ static ncclResult_t IbCastGetPlaneIndex(int devPlane, int16_t* count, int16_t* p
   return ncclSuccess;
 }
 
+// Test-only wrapper (see net_ib_cast_inspect.h). Forwards to the real
+// IbCastGetPlaneIndex above so unit tests exercise the actual logic.
+extern "C" ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx) {
+  if (!count || !planes || !idx) return ncclInvalidArgument;
+  return IbCastGetPlaneIndex(devPlane, count, planes, idx);
+}
+
 ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // On AINIC, NIC fusion (cast) is disabled by default: each NIC runs independently.
   // User must explicitly set NCCL_IB_MERGE_NICS=1 to override.

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -215,8 +215,6 @@ static ncclResult_t IbCastGetPlaneIndex(int devPlane, int16_t* count, int16_t* p
   return ncclSuccess;
 }
 
-// Test-only wrapper (see net_ib_cast_inspect.h). Forwards to the real
-// IbCastGetPlaneIndex above so unit tests exercise the actual logic.
 extern "C" ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx) {
   if (!count || !planes || !idx) return ncclInvalidArgument;
   return IbCastGetPlaneIndex(devPlane, count, planes, idx);

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -50,21 +50,9 @@ ncclResult_t ncclIbCastSetTokens(void* sendComm, const int* qpTokens, int nqps);
 ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWrr, bool splitData,
                                      uint32_t splitDataMin);
 
-/* ── Test-only wrappers over the backported feature logic (host-only, no HW) ──
- * These forward to the internal static helpers in init.cc / connect.cc so the
- * unit tests exercise the real code, not a copy. GIDs are passed as raw 16-byte
- * arrays to keep this header free of <infiniband/verbs.h>. */
-
-/* plane/rail: dedup a plane ID into a compact plane index. Mirrors the sort-loop
- * call IbCastGetPlaneIndex(). Returns ncclInvalidUsage on overflow / bad ID. */
+/* ── Test-only wrappers over internal static helpers (host-only, no HW). ── */
 ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx);
-
-/* subnet detection: 1 if two RoCE GIDs share a subnet, else 0. prefixLen in
- * [1,32] applies to IPv4-mapped GIDs; native IPv6 compares the 64-bit prefix. */
 int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen);
-
-/* subnet detection: 1 if localGid shares a subnet with ANY of nRemote GIDs
- * (each 16 bytes, laid out contiguously), else 0. */
 int ncclIbCastTestSubnetMatchesAny(const uint8_t localGid[16], const uint8_t* remoteGids, int nRemote, int prefixLen);
 
 /* ── Resiliency state introspection (requires ENABLE_FAULT_INJECTION) ── */

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -59,6 +59,13 @@ ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWr
  * call IbCastGetPlaneIndex(). Returns ncclInvalidUsage on overflow / bad ID. */
 ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx);
 
+/* plane/rail: derive the merged railId/planeId of a fused vNIC from its physical
+ * devices' (railId, planeId, planeIdx) triples. Forwards to the real
+ * IbCastMergedRailPlane() used by IbCastMakeVDeviceInternal. Returns
+ * ncclInvalidArgument on null args or ndevs outside [1, NCCL_NET_MAX_DEVS_PER_NIC]. */
+ncclResult_t ncclIbCastTestMergedRailPlane(const int16_t* railIds, const int16_t* planeIds, const int16_t* planeIdxs,
+                                           int ndevs, int16_t* outRailId, int16_t* outPlaneId);
+
 /* subnet detection: 1 if two RoCE GIDs share a subnet, else 0. prefixLen in
  * [1,32] applies to IPv4-mapped GIDs; native IPv6 compares the 64-bit prefix. */
 int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen);

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -50,6 +50,23 @@ ncclResult_t ncclIbCastSetTokens(void* sendComm, const int* qpTokens, int nqps);
 ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWrr, bool splitData,
                                      uint32_t splitDataMin);
 
+/* ── Test-only wrappers over the backported feature logic (host-only, no HW) ──
+ * These forward to the internal static helpers in init.cc / connect.cc so the
+ * unit tests exercise the real code, not a copy. GIDs are passed as raw 16-byte
+ * arrays to keep this header free of <infiniband/verbs.h>. */
+
+/* plane/rail: dedup a plane ID into a compact plane index. Mirrors the sort-loop
+ * call IbCastGetPlaneIndex(). Returns ncclInvalidUsage on overflow / bad ID. */
+ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx);
+
+/* subnet detection: 1 if two RoCE GIDs share a subnet, else 0. prefixLen in
+ * [1,32] applies to IPv4-mapped GIDs; native IPv6 compares the 64-bit prefix. */
+int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen);
+
+/* subnet detection: 1 if localGid shares a subnet with ANY of nRemote GIDs
+ * (each 16 bytes, laid out contiguously), else 0. */
+int ncclIbCastTestSubnetMatchesAny(const uint8_t localGid[16], const uint8_t* remoteGids, int nRemote, int prefixLen);
+
 /* ── Resiliency state introspection (requires ENABLE_FAULT_INJECTION) ── */
 #ifdef ENABLE_FAULT_INJECTION
 

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -59,13 +59,6 @@ ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWr
  * call IbCastGetPlaneIndex(). Returns ncclInvalidUsage on overflow / bad ID. */
 ncclResult_t ncclIbCastTestGetPlaneIndex(int devPlane, int16_t* count, int16_t* planes, int16_t* idx);
 
-/* plane/rail: derive the merged railId/planeId of a fused vNIC from its physical
- * devices' (railId, planeId, planeIdx) triples. Forwards to the real
- * IbCastMergedRailPlane() used by IbCastMakeVDeviceInternal. Returns
- * ncclInvalidArgument on null args or ndevs outside [1, NCCL_NET_MAX_DEVS_PER_NIC]. */
-ncclResult_t ncclIbCastTestMergedRailPlane(const int16_t* railIds, const int16_t* planeIds, const int16_t* planeIdxs,
-                                           int ndevs, int16_t* outRailId, int16_t* outPlaneId);
-
 /* subnet detection: 1 if two RoCE GIDs share a subnet, else 0. prefixLen in
  * [1,32] applies to IPv4-mapped GIDs; native IPv6 compares the 64-bit prefix. */
 int ncclIbCastTestGidSameSubnet(const uint8_t localGid[16], const uint8_t remoteGid[16], int prefixLen);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -868,6 +868,7 @@ ncclResult_t IbCastResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
     rtrAttr->remoteLid = remDevInfo->lid;
     rtrAttr->remoteGid = remDevInfo->gid;
     rtrAttr->localIbPort = remDevInfo->ib_port;
+    rtrAttr->localPortFlags = ibDev->portAttr.flags;
     rtrAttr->localGid = sendCommDev->base.gidInfo.localGid;
     rtrAttr->localGidIndex = sendCommDev->base.gidInfo.localGidIndex;
     NCCLCHECK(IbCastQpRtr(localQp));
@@ -935,6 +936,7 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
     rtrAttr->remoteLid = remDevInfo->lid;
     rtrAttr->remoteGid = remDevInfo->gid;
     rtrAttr->localIbPort = remDevInfo->ib_port;
+    rtrAttr->localPortFlags = ibDev->portAttr.flags;
     rtrAttr->localGid = recvCommDev->base.gidInfo.localGid;
     rtrAttr->localGidIndex = recvCommDev->base.gidInfo.localGidIndex;
     NCCLCHECK(IbCastQpRtr(localQp));

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -469,6 +469,7 @@ if(BUILD_TESTS)
       graph/XmlTests.cpp
       graph/NetDevsPolicyP2pNetTests.cpp
       graph/TopoTests.cpp
+      transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp
       common/ProcessIsolatedTestRunner.cpp

--- a/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
+++ b/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
@@ -4,30 +4,20 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Host-only regression tests for the net_ib_cast features backported from
-// NCCL v2.30.7 (ROCm/rocm-systems#8514):
-//   - plane/rail detection : IbCastGetPlaneIndex
-//   - subnet detection     : gidSameSubnet / subnetMatchesAny
-//
-// These exercise the *real* internal helpers through the test-only wrappers in
-// net_ib_cast_inspect.h (no RDMA HW / MPI / GPU required). The GIN_IB_TC traffic
-// class and the GRH addressing + device-override paths are exercised end-to-end
-// by the MPI suite (transport/NetIbMPI/*), since they require live QPs.
+// Host-only unit tests for net_ib_cast internals via the wrappers in
+// net_ib_cast_inspect.h (no RDMA/MPI/GPU): plane/rail dedup, subnet detection
+// and merged rail/plane aggregation.
 
 #include <cstdint>
 #include <cstring>
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
 
-// net_ib_cast_inspect.h already wraps its declarations in extern "C" and pulls
-// in nccl.h (with its HIP/C++ templates) *outside* that guard, so it must be
-// included directly — wrapping it in an extra extern "C" forces the HIP
-// templates into C linkage and breaks the build.
-#include "net_ib_cast_inspect.h"
+#include "net_ib_cast_inspect.h"  // extern "C" wrappers; include directly (pulls in nccl.h)
 
 namespace {
 
-// Build an IPv4-mapped RoCE GID (::ffff:a.b.c.d).
+// IPv4-mapped RoCE GID (::ffff:a.b.c.d).
 void MakeGidV4(uint8_t g[16], uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   memset(g, 0, 16);
   g[10] = 0xff;
@@ -35,17 +25,15 @@ void MakeGidV4(uint8_t g[16], uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   g[12] = a; g[13] = b; g[14] = c; g[15] = d;
 }
 
-// Build a native (non IPv4-mapped) IPv6 GID with a chosen 64-bit subnet prefix.
+// Native IPv6 GID with a chosen 64-bit subnet prefix (g[15] = interface id).
 void MakeGidV6(uint8_t g[16], uint8_t prefix0, uint8_t iface) {
   memset(g, 0, 16);
   g[0] = prefix0;
-  g[1] = 0x01;   // ensure it is not an all-zero / IPv4-mapped pattern
-  g[15] = iface; // interface id (not part of the subnet prefix)
+  g[1] = 0x01;
+  g[15] = iface;
 }
 
-// ---------------------------------------------------------------------------
 // plane/rail: IbCastGetPlaneIndex dedups plane IDs into a compact index space.
-// ---------------------------------------------------------------------------
 TEST(NetIbCastPlaneRail, GetPlaneIndexDedup) {
   int16_t count = 1;
   int16_t planes[14] = {-1};  // slot 0 seeded with NCCL_NET_ID_UNDEF
@@ -62,8 +50,7 @@ TEST(NetIbCastPlaneRail, GetPlaneIndexDedup) {
 
 TEST(NetIbCastPlaneRail, GetPlaneIndexRejectsVirtBit) {
   int16_t count = 1, planes[14] = {-1}, idx = 0;
-  // 0x4000 == NCCL_IB_PLANE_VIRT_BIT: reserved, must be rejected.
-  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0x4000, &count, planes, &idx), ncclSuccess);
+  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0x4000, &count, planes, &idx), ncclSuccess);  // 0x4000 = VIRT_BIT
 }
 
 TEST(NetIbCastPlaneRail, GetPlaneIndexNullArgs) {
@@ -73,9 +60,7 @@ TEST(NetIbCastPlaneRail, GetPlaneIndexNullArgs) {
   EXPECT_NE(ncclIbCastTestGetPlaneIndex(0, &count, planes, nullptr), ncclSuccess);
 }
 
-// ---------------------------------------------------------------------------
-// subnet detection: gidSameSubnet
-// ---------------------------------------------------------------------------
+// subnet: gidSameSubnet.
 TEST(NetIbCastSubnet, GidSameSubnetIPv4) {
   uint8_t a[16], b[16];
   MakeGidV4(a, 192, 168, 1, 10);
@@ -104,16 +89,14 @@ TEST(NetIbCastSubnet, GidSameSubnetFamilyMismatch) {
   EXPECT_EQ(ncclIbCastTestGidSameSubnet(v4, v6, 24), 0);  // AF_INET vs AF_INET6
 }
 
-// ---------------------------------------------------------------------------
-// subnet detection: subnetMatchesAny (skips invalid/zero GIDs)
-// ---------------------------------------------------------------------------
+// subnet: subnetMatchesAny skips invalid/zero GIDs.
 TEST(NetIbCastSubnet, SubnetMatchesAny) {
   uint8_t local[16];
   MakeGidV4(local, 10, 0, 5, 1);
 
-  uint8_t zero[16];   memset(zero, 0, 16);        // invalid GID -> skipped
-  uint8_t other[16];  MakeGidV4(other, 10, 0, 9, 9);  // different /24
-  uint8_t match[16];  MakeGidV4(match, 10, 0, 5, 200); // same /24
+  uint8_t zero[16];   memset(zero, 0, 16);            // invalid -> skipped
+  uint8_t other[16];  MakeGidV4(other, 10, 0, 9, 9);
+  uint8_t match[16];  MakeGidV4(match, 10, 0, 5, 200);
 
   uint8_t rem[3 * 16];
   memcpy(rem + 0,  zero,  16);
@@ -121,8 +104,50 @@ TEST(NetIbCastSubnet, SubnetMatchesAny) {
   memcpy(rem + 32, match, 16);
   EXPECT_EQ(ncclIbCastTestSubnetMatchesAny(local, rem, 3, 24), 1);
 
-  memcpy(rem + 32, other, 16);  // now no remote shares the subnet
+  memcpy(rem + 32, other, 16);  // no remote shares the subnet now
   EXPECT_EQ(ncclIbCastTestSubnetMatchesAny(local, rem, 3, 24), 0);
+}
+
+// plane/rail: merged rail/plane aggregation for fused vNICs (IbCastMergedRailPlane).
+constexpr int16_t kPlaneVirtBit = static_cast<int16_t>(0x1 << 14);  // NCCL_IB_PLANE_VIRT_BIT
+constexpr int16_t kIdUndef = -1;                                    // NCCL_NET_ID_UNDEF
+
+TEST(NetIbCastMergedRailPlane, SingleDevKeepsPhysical) {
+  int16_t rail[] = {3}, plane[] = {5}, pidx[] = {2};
+  int16_t outRail = 0, outPlane = 0;
+  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 1, &outRail, &outPlane), ncclSuccess);
+  EXPECT_EQ(outRail, 3);
+  EXPECT_EQ(outPlane, 5);  // single dev -> physical plane, no virtual bit
+}
+
+TEST(NetIbCastMergedRailPlane, MultiSameRailOrsPlaneBits) {
+  int16_t rail[] = {7, 7}, plane[] = {5, 9}, pidx[] = {0, 3};
+  int16_t outRail = 0, outPlane = 0;
+  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
+  EXPECT_EQ(outRail, 7);  // same rail preserved
+  EXPECT_EQ(outPlane, static_cast<int16_t>(kPlaneVirtBit | (0x1 << 0) | (0x1 << 3)));
+}
+
+TEST(NetIbCastMergedRailPlane, MultiDifferentRailUndef) {
+  int16_t rail[] = {7, 9}, plane[] = {0, 0}, pidx[] = {1, 2};
+  int16_t outRail = 0, outPlane = 0;
+  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
+  EXPECT_EQ(outRail, kIdUndef);  // mismatched rails -> undefined
+  EXPECT_EQ(outPlane, static_cast<int16_t>(kPlaneVirtBit | (0x1 << 1) | (0x1 << 2)));
+}
+
+TEST(NetIbCastMergedRailPlane, UndefRailPropagates) {
+  int16_t rail[] = {kIdUndef, 7}, plane[] = {0, 0}, pidx[] = {0, 1};
+  int16_t outRail = 0, outPlane = 0;
+  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
+  EXPECT_EQ(outRail, kIdUndef);
+}
+
+TEST(NetIbCastMergedRailPlane, RejectsBadArgs) {
+  int16_t rail[] = {1}, plane[] = {1}, pidx[] = {0}, o1 = 0, o2 = 0;
+  EXPECT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 0, &o1, &o2), ncclInvalidArgument);       // ndevs = 0
+  EXPECT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 999, &o1, &o2), ncclInvalidArgument);     // ndevs > max
+  EXPECT_EQ(ncclIbCastTestMergedRailPlane(nullptr, plane, pidx, 1, &o1, &o2), ncclInvalidArgument);    // null input
 }
 
 }  // namespace

--- a/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
+++ b/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
@@ -108,46 +108,4 @@ TEST(NetIbCastSubnet, SubnetMatchesAny) {
   EXPECT_EQ(ncclIbCastTestSubnetMatchesAny(local, rem, 3, 24), 0);
 }
 
-// plane/rail: merged rail/plane aggregation for fused vNICs (IbCastMergedRailPlane).
-constexpr int16_t kPlaneVirtBit = static_cast<int16_t>(0x1 << 14);  // NCCL_IB_PLANE_VIRT_BIT
-constexpr int16_t kIdUndef = -1;                                    // NCCL_NET_ID_UNDEF
-
-TEST(NetIbCastMergedRailPlane, SingleDevKeepsPhysical) {
-  int16_t rail[] = {3}, plane[] = {5}, pidx[] = {2};
-  int16_t outRail = 0, outPlane = 0;
-  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 1, &outRail, &outPlane), ncclSuccess);
-  EXPECT_EQ(outRail, 3);
-  EXPECT_EQ(outPlane, 5);  // single dev -> physical plane, no virtual bit
-}
-
-TEST(NetIbCastMergedRailPlane, MultiSameRailOrsPlaneBits) {
-  int16_t rail[] = {7, 7}, plane[] = {5, 9}, pidx[] = {0, 3};
-  int16_t outRail = 0, outPlane = 0;
-  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
-  EXPECT_EQ(outRail, 7);  // same rail preserved
-  EXPECT_EQ(outPlane, static_cast<int16_t>(kPlaneVirtBit | (0x1 << 0) | (0x1 << 3)));
-}
-
-TEST(NetIbCastMergedRailPlane, MultiDifferentRailUndef) {
-  int16_t rail[] = {7, 9}, plane[] = {0, 0}, pidx[] = {1, 2};
-  int16_t outRail = 0, outPlane = 0;
-  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
-  EXPECT_EQ(outRail, kIdUndef);  // mismatched rails -> undefined
-  EXPECT_EQ(outPlane, static_cast<int16_t>(kPlaneVirtBit | (0x1 << 1) | (0x1 << 2)));
-}
-
-TEST(NetIbCastMergedRailPlane, UndefRailPropagates) {
-  int16_t rail[] = {kIdUndef, 7}, plane[] = {0, 0}, pidx[] = {0, 1};
-  int16_t outRail = 0, outPlane = 0;
-  ASSERT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 2, &outRail, &outPlane), ncclSuccess);
-  EXPECT_EQ(outRail, kIdUndef);
-}
-
-TEST(NetIbCastMergedRailPlane, RejectsBadArgs) {
-  int16_t rail[] = {1}, plane[] = {1}, pidx[] = {0}, o1 = 0, o2 = 0;
-  EXPECT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 0, &o1, &o2), ncclInvalidArgument);       // ndevs = 0
-  EXPECT_EQ(ncclIbCastTestMergedRailPlane(rail, plane, pidx, 999, &o1, &o2), ncclInvalidArgument);     // ndevs > max
-  EXPECT_EQ(ncclIbCastTestMergedRailPlane(nullptr, plane, pidx, 1, &o1, &o2), ncclInvalidArgument);    // null input
-}
-
 }  // namespace

--- a/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
+++ b/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
@@ -4,16 +4,12 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Host-only unit tests for net_ib_cast internals via the wrappers in
-// net_ib_cast_inspect.h (no RDMA/MPI/GPU): plane/rail dedup, subnet detection
-// and merged rail/plane aggregation.
-
 #include <cstdint>
 #include <cstring>
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
 
-#include "net_ib_cast_inspect.h"  // extern "C" wrappers; include directly (pulls in nccl.h)
+#include "net_ib_cast_inspect.h"
 
 namespace {
 
@@ -36,7 +32,7 @@ void MakeGidV6(uint8_t g[16], uint8_t prefix0, uint8_t iface) {
 // plane/rail: IbCastGetPlaneIndex dedups plane IDs into a compact index space.
 TEST(NetIbCastPlaneRail, GetPlaneIndexDedup) {
   int16_t count = 1;
-  int16_t planes[14] = {-1};  // slot 0 seeded with NCCL_NET_ID_UNDEF
+  int16_t planes[14] = {-1};
   int16_t idx = -1;
 
   const int   seq[]    = {-1, 5, 5, 7, -1, 5};

--- a/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
+++ b/projects/rccl/test/transport/NetIbCast/NetIbCastPlaneSubnetTests.cpp
@@ -1,0 +1,128 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host-only regression tests for the net_ib_cast features backported from
+// NCCL v2.30.7 (ROCm/rocm-systems#8514):
+//   - plane/rail detection : IbCastGetPlaneIndex
+//   - subnet detection     : gidSameSubnet / subnetMatchesAny
+//
+// These exercise the *real* internal helpers through the test-only wrappers in
+// net_ib_cast_inspect.h (no RDMA HW / MPI / GPU required). The GIN_IB_TC traffic
+// class and the GRH addressing + device-override paths are exercised end-to-end
+// by the MPI suite (transport/NetIbMPI/*), since they require live QPs.
+
+#include <cstdint>
+#include <cstring>
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+
+// net_ib_cast_inspect.h already wraps its declarations in extern "C" and pulls
+// in nccl.h (with its HIP/C++ templates) *outside* that guard, so it must be
+// included directly — wrapping it in an extra extern "C" forces the HIP
+// templates into C linkage and breaks the build.
+#include "net_ib_cast_inspect.h"
+
+namespace {
+
+// Build an IPv4-mapped RoCE GID (::ffff:a.b.c.d).
+void MakeGidV4(uint8_t g[16], uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  memset(g, 0, 16);
+  g[10] = 0xff;
+  g[11] = 0xff;
+  g[12] = a; g[13] = b; g[14] = c; g[15] = d;
+}
+
+// Build a native (non IPv4-mapped) IPv6 GID with a chosen 64-bit subnet prefix.
+void MakeGidV6(uint8_t g[16], uint8_t prefix0, uint8_t iface) {
+  memset(g, 0, 16);
+  g[0] = prefix0;
+  g[1] = 0x01;   // ensure it is not an all-zero / IPv4-mapped pattern
+  g[15] = iface; // interface id (not part of the subnet prefix)
+}
+
+// ---------------------------------------------------------------------------
+// plane/rail: IbCastGetPlaneIndex dedups plane IDs into a compact index space.
+// ---------------------------------------------------------------------------
+TEST(NetIbCastPlaneRail, GetPlaneIndexDedup) {
+  int16_t count = 1;
+  int16_t planes[14] = {-1};  // slot 0 seeded with NCCL_NET_ID_UNDEF
+  int16_t idx = -1;
+
+  const int   seq[]    = {-1, 5, 5, 7, -1, 5};
+  const int16_t expect[] = { 0, 1, 1, 2,  0, 1};
+  for (size_t i = 0; i < sizeof(seq) / sizeof(seq[0]); i++) {
+    ASSERT_EQ(ncclIbCastTestGetPlaneIndex(seq[i], &count, planes, &idx), ncclSuccess);
+    EXPECT_EQ(idx, expect[i]) << "plane id " << seq[i];
+  }
+  EXPECT_EQ(count, 3);  // unique planes: {-1, 5, 7}
+}
+
+TEST(NetIbCastPlaneRail, GetPlaneIndexRejectsVirtBit) {
+  int16_t count = 1, planes[14] = {-1}, idx = 0;
+  // 0x4000 == NCCL_IB_PLANE_VIRT_BIT: reserved, must be rejected.
+  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0x4000, &count, planes, &idx), ncclSuccess);
+}
+
+TEST(NetIbCastPlaneRail, GetPlaneIndexNullArgs) {
+  int16_t count = 1, planes[14] = {-1}, idx = 0;
+  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0, nullptr, planes, &idx), ncclSuccess);
+  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0, &count, nullptr, &idx), ncclSuccess);
+  EXPECT_NE(ncclIbCastTestGetPlaneIndex(0, &count, planes, nullptr), ncclSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// subnet detection: gidSameSubnet
+// ---------------------------------------------------------------------------
+TEST(NetIbCastSubnet, GidSameSubnetIPv4) {
+  uint8_t a[16], b[16];
+  MakeGidV4(a, 192, 168, 1, 10);
+  MakeGidV4(b, 192, 168, 1, 20);
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(a, b, 24), 1);  // same /24
+
+  MakeGidV4(b, 192, 168, 2, 20);
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(a, b, 24), 0);  // different /24
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(a, b, 16), 1);  // same /16
+}
+
+TEST(NetIbCastSubnet, GidSameSubnetIPv6) {
+  uint8_t c[16], d[16];
+  MakeGidV6(c, 0x20, 1);
+  MakeGidV6(d, 0x20, 2);
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(c, d, 64), 1);  // same 64-bit prefix
+
+  MakeGidV6(d, 0x30, 2);
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(c, d, 64), 0);  // different prefix
+}
+
+TEST(NetIbCastSubnet, GidSameSubnetFamilyMismatch) {
+  uint8_t v4[16], v6[16];
+  MakeGidV4(v4, 10, 0, 0, 1);
+  MakeGidV6(v6, 0x20, 1);
+  EXPECT_EQ(ncclIbCastTestGidSameSubnet(v4, v6, 24), 0);  // AF_INET vs AF_INET6
+}
+
+// ---------------------------------------------------------------------------
+// subnet detection: subnetMatchesAny (skips invalid/zero GIDs)
+// ---------------------------------------------------------------------------
+TEST(NetIbCastSubnet, SubnetMatchesAny) {
+  uint8_t local[16];
+  MakeGidV4(local, 10, 0, 5, 1);
+
+  uint8_t zero[16];   memset(zero, 0, 16);        // invalid GID -> skipped
+  uint8_t other[16];  MakeGidV4(other, 10, 0, 9, 9);  // different /24
+  uint8_t match[16];  MakeGidV4(match, 10, 0, 5, 200); // same /24
+
+  uint8_t rem[3 * 16];
+  memcpy(rem + 0,  zero,  16);
+  memcpy(rem + 16, other, 16);
+  memcpy(rem + 32, match, 16);
+  EXPECT_EQ(ncclIbCastTestSubnetMatchesAny(local, rem, 3, 24), 1);
+
+  memcpy(rem + 32, other, 16);  // now no remote shares the subnet
+  EXPECT_EQ(ncclIbCastTestSubnetMatchesAny(local, rem, 3, 24), 0);
+}
+
+}  // namespace


### PR DESCRIPTION
## Motivation

Backport four net_ib features into the net_ib_cast transport and add merged
vNIC rail/plane aggregation to both net_ib and net_ib_cast, bringing them to
parity with the vanilla net_ib transport.

## Technical Details

- net_ib_cast: add NCCL_GIN_IB_TC traffic-class handling.
- net_ib_cast: improve subnet detection and GRH handling.
- net_ib_cast: print resource IDs in async fatal-event WARNs.
- net_ib_cast: add plane/rail detection.
- net_ib and net_ib_cast: derive merged railId/planeId for fused vdevices
  (railId UNDEF across rails, planeId OR of plane bits), matching net_ib.
- net_ib_cast: dedup merged vdevice inputs to match net_ib.
- net_ib and net_ib_cast: guard NCCL_IB_PLANE_MAX_INDEX with a static_assert
  (< 15) so the int16_t plane-id constraint cannot drift between the two copies.

## Issue Tracking

JIRA ID : AICOMNET-316

## Test Plan

All tests below were built and run on an OCI MI300X cluster
(AMD Instinct MI300X / gfx942, Mellanox ConnectX mlx5 IB/RoCE).

- gtest: net_ib_cast plane/rail dedup and RoCE subnet detection (pure CPU
  logic in the RCCL unit-test build).
- 2-node RDMA run of the net_ib_cast MPI suite (device/vdevice/VNic,
  WRR/split-data QP scheduling).

## Test Result

All suites were run on the OCI MI300X cluster (AMD Instinct MI300X / gfx942,
Mellanox ConnectX mlx5 IB/RoCE) and passed.

- Unit tests: the 7 net_ib_cast plane/rail and subnet gtests
  (NetIbCastPlaneRail / NetIbCastSubnet) pass; librccl builds cleanly and the
  new static_assert on NCCL_IB_PLANE_MAX_INDEX holds.
- 2-node MPI suite: Cast WRR/split-data and device/VNic tests pass;
  pre-existing topology-dependent cases behave the same as before.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
