### PR TITLE
fix(hip-tests): remove duplicate host writes in bit insert tests

### DIFF
--- a/projects/hip-tests/catch/unit/deviceLib/bitInsert.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bitInsert.cc
@@ -100,12 +100,12 @@ HIP_TEST_CASE(Unit_bitInsert) {
     hostSrc032[i] = uint32_src01_dist(rd);
     hostSrc132[i] = uint32_src01_dist(rd);
     hostSrc232[i] = uint32_src23_dist(rd);
-    hostSrc232[i] = uint32_src23_dist(rd);
+    hostSrc332[i] = uint32_src23_dist(rd);
     hostOut64[i] = 0;
     hostSrc064[i] = uint64_src01_dist(rd);
     hostSrc164[i] = uint64_src01_dist(rd);
     hostSrc264[i] = uint64_src23_dist(rd);
-    hostSrc264[i] = uint64_src23_dist(rd);
+    hostSrc364[i] = uint64_src23_dist(rd);
   }
 
   HIP_CHECK(hipMalloc((void**)&deviceOut32, NUM * sizeof(unsigned int)));


### PR DESCRIPTION
## Motivation

We had a duplicate input overwrite. Fix it.

## Technical Details

Nothing to explain. We were overwriting the value and one value left uninitialized.

## Issue Tracking

NA

## Test Plan

The test should pass locally after we update the correct value.

## Test Result

Test passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
