### PR TITLE
[clr][hip-tests] Fix bfloat16x2 comparison and mask semantics

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1460,7 +1460,7 @@ __BF16_HOST_DEVICE_STATIC__ bool __hbne2(const __hip_bfloat162 a, const __hip_bf
  * \brief Check for a != b
  */
 __BF16_HOST_DEVICE_STATIC__ bool __hbneu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
-  return __hneu(a.x, b.x) || __hneu(a.y, b.y);
+  return __hneu(a.x, b.x) && __hneu(a.y, b.y);
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1620,8 +1620,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator!=(const __hip_bfloat162& l, const __hi
  * \brief Operator to perform a less than on two __hip_bfloat16 numbers
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator<(const __hip_bfloat162& l, const __hip_bfloat162& r) {
-  float2 fl = l, fr = r;
-  return fl.x < fr.x && fl.y < fr.y;
+  return __hblt2(l, r);
 }
 
 /**
@@ -1629,8 +1628,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator<(const __hip_bfloat162& l, const __hip
  * \brief Operator to perform a less than equal on two __hip_bfloat16 numbers
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator<=(const __hip_bfloat162& l, const __hip_bfloat162& r) {
-  float2 fl = l, fr = r;
-  return fl.x <= fr.x && fl.y <= fr.y;
+  return __hble2(l, r);
 }
 
 /**
@@ -1638,8 +1636,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator<=(const __hip_bfloat162& l, const __hi
  * \brief Operator to perform a greater than on two __hip_bfloat16 numbers
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator>(const __hip_bfloat162& l, const __hip_bfloat162& r) {
-  float2 fl = l, fr = r;
-  return fl.x > fr.x && fl.y > fr.y;
+  return __hbgt2(l, r);
 }
 
 /**
@@ -1647,8 +1644,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator>(const __hip_bfloat162& l, const __hip
  * \brief Operator to perform a greater than equal on two __hip_bfloat16 numbers
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator>=(const __hip_bfloat162& l, const __hip_bfloat162& r) {
-  float2 fl = l, fr = r;
-  return fl.x >= fr.x && fl.y >= fr.y;
+  return __hbge2(l, r);
 }
 
 #if defined(__clang__) && defined(__HIP__)

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1621,7 +1621,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator!=(const __hip_bfloat162& l, const __hi
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator<(const __hip_bfloat162& l, const __hip_bfloat162& r) {
   float2 fl = l, fr = r;
-  return fl.x < fr.x && fl.x < fr.y;
+  return fl.x < fr.x && fl.y < fr.y;
 }
 
 /**
@@ -1630,7 +1630,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator<(const __hip_bfloat162& l, const __hip
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator<=(const __hip_bfloat162& l, const __hip_bfloat162& r) {
   float2 fl = l, fr = r;
-  return fl.x <= fr.x && fl.x <= fr.y;
+  return fl.x <= fr.x && fl.y <= fr.y;
 }
 
 /**
@@ -1639,7 +1639,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator<=(const __hip_bfloat162& l, const __hi
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator>(const __hip_bfloat162& l, const __hip_bfloat162& r) {
   float2 fl = l, fr = r;
-  return fl.x > fr.x && fl.x > fr.y;
+  return fl.x > fr.x && fl.y > fr.y;
 }
 
 /**
@@ -1648,7 +1648,7 @@ __BF16_HOST_DEVICE_STATIC__ bool operator>(const __hip_bfloat162& l, const __hip
  */
 __BF16_HOST_DEVICE_STATIC__ bool operator>=(const __hip_bfloat162& l, const __hip_bfloat162& r) {
   float2 fl = l, fr = r;
-  return fl.x >= fr.x && fl.x >= fr.y;
+  return fl.x >= fr.x && fl.y >= fr.y;
 }
 
 #if defined(__clang__) && defined(__HIP__)

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1490,7 +1490,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __hge2(const __hip_bfloat162 a,
 __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __hgt2(const __hip_bfloat162 a,
                                                    const __hip_bfloat162 b) {
   return __hip_bfloat162{{__hgt(a.x, b.x) ? HIPRT_ONE_BF16 : HIPRT_ZERO_BF16},
-                         {__hgt(a.y, b.y) ? HIPRT_ONE_BF16 : HIPRT_ONE_BF16}};
+                         {__hgt(a.y, b.y) ? HIPRT_ONE_BF16 : HIPRT_ZERO_BF16}};
 }
 
 /**
@@ -1499,7 +1499,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __hgt2(const __hip_bfloat162 a,
  */
 __BF16_HOST_DEVICE_STATIC__ __hip_bfloat162 __hisnan2(const __hip_bfloat162 a) {
   return __hip_bfloat162{{__hisnan(a.x) ? HIPRT_ONE_BF16 : HIPRT_ZERO_BF16},
-                         {__hisnan(a.y) ? HIPRT_ONE_BF16 : HIPRT_ONE_BF16}};
+                         {__hisnan(a.y) ? HIPRT_ONE_BF16 : HIPRT_ZERO_BF16}};
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1457,7 +1457,7 @@ __BF16_HOST_DEVICE_STATIC__ bool __hbne2(const __hip_bfloat162 a, const __hip_bf
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT162_COMP
- * \brief Check for a != b
+ * \brief Check for a != b - unordered
  */
 __BF16_HOST_DEVICE_STATIC__ bool __hbneu2(const __hip_bfloat162 a, const __hip_bfloat162 b) {
   return __hneu(a.x, b.x) && __hneu(a.y, b.y);

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
@@ -860,6 +860,21 @@ HIP_TEST_CASE(Unit_bf162_operators_host) {
     REQUIRE_FALSE(__hbneu2(a, eq_y));  // one lane equal -> false (was true with ||)
     REQUIRE_FALSE(__hbneu2(a, same));  // both equal -> false
   }
+
+  SECTION("__hgt2 / __hisnan2 high-lane mask") {
+    // Regression: __hgt2 and __hisnan2 returned 1.0 for the high (.y) lane
+    // unconditionally (both ternary branches were HIPRT_ONE_BF16).
+    __hip_bfloat162 a = {__float2bfloat16(5.0f), __float2bfloat16(1.0f)};
+    __hip_bfloat162 b = {__float2bfloat16(2.0f), __float2bfloat16(3.0f)};
+    float2 gt = __hgt2(a, b);  // lane0: 5>2 -> 1.0, lane1: 1>3 -> 0.0
+    REQUIRE(gt.x == 1.0f);
+    REQUIRE(gt.y == 0.0f);     // was 1.0f with the bug
+
+    __hip_bfloat162 n = {__float2bfloat16(NAN), __float2bfloat16(1.0f)};
+    float2 isn = __hisnan2(n);  // lane0: NaN -> 1.0, lane1: not NaN -> 0.0
+    REQUIRE(isn.x == 1.0f);
+    REQUIRE(isn.y == 0.0f);     // was 1.0f with the bug
+  }
 }
 
 // Bunch of tests which make sure we are packaging stuff correctly.

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16.cc
@@ -820,6 +820,46 @@ HIP_TEST_CASE(Unit_bf162_operators_host) {
     REQUIRE((l + -l) == __hip_bfloat162{HIPRT_ZERO_BF16, HIPRT_ZERO_BF16});
     REQUIRE((l / -l) == -__hip_bfloat162{HIPRT_ONE_BF16, HIPRT_ONE_BF16});
   }
+
+  SECTION("Compare mismatched lanes") {
+    // Regression: the __hip_bfloat162 relational operators must compare each lane
+    // against its counterpart. A prior bug compared l.x against both r.x and r.y
+    // (ignoring l.y), so vectors whose two lanes differ were mis-compared.
+    __hip_bfloat162 la = {__float2bfloat16(1.0f), __float2bfloat16(4.0f)};
+    __hip_bfloat162 ra = {__float2bfloat16(2.0f), __float2bfloat16(3.0f)};
+    // lane0: 1<2 (true), lane1: 4<3 (false) -> overall false
+    REQUIRE_FALSE(la < ra);
+    REQUIRE_FALSE(la <= ra);
+
+    __hip_bfloat162 lc = {__float2bfloat16(4.0f), __float2bfloat16(1.0f)};
+    __hip_bfloat162 rc = {__float2bfloat16(3.0f), __float2bfloat16(2.0f)};
+    // lane0: 4>3 (true), lane1: 1>2 (false) -> overall false
+    REQUIRE_FALSE(lc > rc);
+    REQUIRE_FALSE(lc >= rc);
+
+    // sanity: both lanes satisfy the relation -> true
+    __hip_bfloat162 lo = {__float2bfloat16(1.0f), __float2bfloat16(2.0f)};
+    __hip_bfloat162 hi = {__float2bfloat16(3.0f), __float2bfloat16(4.0f)};
+    REQUIRE(lo < hi);
+    REQUIRE(lo <= hi);
+    REQUIRE(hi > lo);
+    REQUIRE(hi >= lo);
+  }
+
+  SECTION("__hbneu2 both-lane reduction") {
+    // Regression: __hbneu2 (unordered not-equal) must be true only when BOTH lanes
+    // are not-equal (&&), not when either lane differs (||).
+    __hip_bfloat162 a = {__float2bfloat16(1.0f), __float2bfloat16(2.0f)};
+    __hip_bfloat162 eq_x = {__float2bfloat16(1.0f), __float2bfloat16(3.0f)};  // lane0 equal
+    __hip_bfloat162 eq_y = {__float2bfloat16(9.0f), __float2bfloat16(2.0f)};  // lane1 equal
+    __hip_bfloat162 both = {__float2bfloat16(5.0f), __float2bfloat16(6.0f)};  // both differ
+    __hip_bfloat162 same = a;                                                // both equal
+
+    REQUIRE(__hbneu2(a, both));        // both lanes not-equal -> true
+    REQUIRE_FALSE(__hbneu2(a, eq_x));  // one lane equal -> false (was true with ||)
+    REQUIRE_FALSE(__hbneu2(a, eq_y));  // one lane equal -> false (was true with ||)
+    REQUIRE_FALSE(__hbneu2(a, same));  // both equal -> false
+  }
 }
 
 // Bunch of tests which make sure we are packaging stuff correctly.


### PR DESCRIPTION
## Motivation

Fix incorrect `__hip_bfloat162` comparison and mask results caused by using the wrong lane or reduction operator.

## Technical Details

- Use the `.y` lane in the second term of the packed relational operators.
- Make `__hbneu2` require both lanes to be unordered-not-equal.
- Correct the high-lane results returned by `__hgt2` and `__hisnan2`.
- Add targeted regression coverage for asymmetric lane values.

## Issue Tracking

JIRA ID: ROCM-29758

## Test Plan

Run `Unit_bf162_operators_host` from the hip-tests deviceLib test suite.

## Test Result

Targeted regression tests added for each corrected operation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.