### PR TITLE
ci(github): add rocgdb-corefile to CI test matrix

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -531,7 +531,7 @@ class ConfigureCITest(unittest.TestCase):
             "sanity", "hip-tests", "hipfile", "rocblas", "rocroller",
             "tensilelite", "origami", "hipblas", "amdsmi", "hipblaslt",
             "hipsolver", "rocsolver", "rocprim", "hipcub", "rocgdb-cpu",
-            "rocgdb-gpu", "rocr-debug-agent", "rocthrust", "hipsparse",
+            "rocgdb-gpu", "rocgdb-corefile", "rocr-debug-agent", "rocthrust", "hipsparse",
             "rocsparse", "hipsparselt", "rocrand", "hiprand", "rocfft",
             "hipfft", "miopen", "rccl", "rocshmem", "rocprofiler-sdk",
             "hipdnn", "hipdnn_install", "hipdnn-integration-tests",

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -61,7 +61,7 @@ project_map = {
             "-DTHEROCK_ENABLE_ALL=OFF",
             "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON",
         ],
-        "projects_to_test": "rocr-debug-agent, rocgdb-cpu, rocgdb-gpu",
+        "projects_to_test": "rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocgdb-corefile",
     },
     # debug agent changes don't have to exercise ROCgdb.
     "debug_tools-debug-agent": {
@@ -91,11 +91,11 @@ project_map = {
     # Also test rocr-debug-agent and rocgdb since those depend on runtimes.
     "runtimes": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst, rocprofiler-sdk, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu",
+        "projects_to_test": "hip-tests, rocrtst, rocprofiler-sdk, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocgdb-corefile",
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu",
+        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocgdb-corefile",
     },
     # Same test coverage as TheRock submodule-bump PRs (rocm-systems scope).
     # Nightly (schedule) uses this entry explicitly for alignment.
@@ -103,7 +103,7 @@ project_map = {
     # instead of above blanket addition of all tests, we can add logic to determine which mathlibs to test, based on file changes from last nightly run. Can be handled once the tests scripts move to component/monorepo src
     "nightly": {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
-        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocprim, rocthrust, rocrand, hiprand, hipblaslt, rocblas, hipblas, rocroller, miopen, miopenprovider, hipfft, rocfft, rocsparse, hipsparse, hipsparselt, rocsolver, hipsolver, rocwmma",
+        "projects_to_test": "amdsmi, hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb-cpu, rocgdb-gpu, rocgdb-corefile, rocprim, rocthrust, rocrand, hiprand, hipblaslt, rocblas, hipblas, rocroller, miopen, miopenprovider, hipfft, rocfft, rocsparse, hipsparse, hipsparselt, rocsolver, hipsolver, rocwmma",
     },
 }
 


### PR DESCRIPTION
## Summary

- Add `rocgdb-corefile` as a test target alongside `rocgdb-cpu` and `rocgdb-gpu` in `therock_matrix.py` for the `debug_tools-dbgapi`, `runtimes`, `all`, and `nightly` groups
- Update `valid_test_targets` in the unit test to keep it in sync

## Test plan

- [x] Verify CI picks up `rocgdb-corefile` in the affected build groups
- [x] Confirm unit test in `therock_configure_ci_test.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)