### PR TITLE
[rocdbgapi] Add TESTING.md documenting testing strategy

### DIFF
--- a/projects/rocdbgapi/TESTING.md
+++ b/projects/rocdbgapi/TESTING.md
@@ -1,0 +1,32 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+SPDX-License-Identifier: MIT
+-->
+
+# Testing ROCdbgapi
+
+**ROCdbgapi (amd-dbgapi) is the shared library that provides low-level
+control and inspection of AMD GPU execution state** for debuggers and tools
+built on top of it. It has two consumers: **ROCgdb** and **rocr-debug-agent**.
+
+**ROCdbgapi has no test suite of its own.** There is no `test/` directory, no
+`enable_testing()` / `add_test()`, and no unit, functional, or performance
+tier in this project. Every meaningful validation of a ROCdbgapi change
+happens indirectly, by building it and running it through one of its
+consumers' test suites:
+
+- [rocr-debug-agent's test suite](../rocr-debug-agent/TESTING.md) - 8 GPU
+  scenarios exercising wave, register, memory, and code-object handling.
+- [ROCgdb's test suite](https://github.com/ROCm/ROCgdb/blob/amd-staging/TESTING.md) -
+  the `gdb.rocm/` GPU suite plus CPU suites, built `--with-amd-dbgapi`.
+
+## Validating a change to ROCdbgapi
+
+Use [TheRock](https://github.com/ROCm/TheRock) to build ROCdbgapi together
+with rocr-debug-agent and ROCgdb, then run their test suites. TheRock's
+[`debug-tools/README.md`](https://github.com/ROCm/TheRock/blob/main/debug-tools/README.md)
+covers building and testing all three components together.
+
+Always run both rocr-debug-agent's and ROCgdb's test suites whenever a change
+touches ROCdbgapi - they're the only way ROCdbgapi's behavior gets validated.
+CI does the same automatically, since there's no suite of its own to run.


### PR DESCRIPTION
JIRA ID: AIROCGDB-627

## Summary

ROCdbgapi has no in-tree test suite of its own (no `test/` directory, no `enable_testing()`/`add_test()`, no unit or perf tier). This PR adds a `TESTING.md` that documents that honestly and explains how it is actually validated today:

- Azure DevOps runs a **build-only** pipeline (no GPU test job) on `amd-staging`.
- TheRock CI maps `projects/rocdbgapi` changes to the `debug_tools-dbgapi` component and runs its **consumers'** test suites instead (`rocr-debug-agent`, `rocgdb-cpu`, `rocgdb-gpu`), since ROCdbgapi has no native suite of its own.
- All functional/GPU-level validation of a ROCdbgapi change happens indirectly, through rocr-debug-agent's `test/run-test.py` scenarios and/or ROCgdb's `gdb.rocm/` suite.

The document follows the same structure as the already-merged ROCgdb and rocr-debug-agent `TESTING.md` files (testing principles, component-specific guidance, and validation/CI procedures), adapted to call out where ROCdbgapi has no equivalent tier.

## Test plan

- [x] Verified no `test/`/`tests/` directory and no `enable_testing()`/`add_test()` exist in `projects/rocdbgapi`
- [x] Verified `.azuredevops/rocm-ci.yml` triggers and doc-path exclusions
- [x] Verified `therock_matrix.py` mapping (`projects/rocdbgapi` → `debug_tools-dbgapi` → `rocr-debug-agent, rocgdb-cpu, rocgdb-gpu`)
- [x] Verified `SKIPPABLE_PATH_PATTERNS` includes `*.md`, so a docs-only PR like this one does not trigger a TheRock build/test run
- [x] Cross-checked scenario/check counts cited from `projects/rocr-debug-agent/TESTING.md`
- [x] Proofread for spelling, grammar, and factual accuracy against source files