### PR TITLE
fix(rocprofiler-compute): read git revision from the source directory

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -73,6 +73,7 @@ set(COMP_TYPE "main")
 # version control info
 execute_process(
     COMMAND git log --pretty=format:%h -n 1
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE ROCPROFCOMPUTE_GIT_REV
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
## Motivation

`rocprof-compute --version` reports the commit of whichever repo owns cmake's working directory rather than the rocm-systems commit the sources came from. Superbuilds that configure from their own tree, such as TheRock, stamp their own HEAD.

JIRA ID: AIPROFCOMP-822

## Technical Details

- Pass `WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}` to the `git log` call that generates `VERSION.sha`, matching `projects/rocprofiler-sdk/CMakeLists.txt:61-65`.
- Resolves correctly when rocm-systems is checked out as a submodule, since the source tree's git metadata points at rocm-systems.

## Test Plan

Configure a project nested inside an outer git repo and compare the revision the call returns with and without `WORKING_DIRECTORY`.

## Test Result

Reproduced locally with a throwaway project: an inner source repo at `9c9d0a4` nested in an outer repo at `9e9af08`, configured from a build directory under the outer repo. Before the change the call returned `9e9af08`; after it returned `9c9d0a4`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.