### PR TITLE
feat(ci): Update TheRock hash to `7c4f91f` (2026-08-18)

### DIFF
--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 48ec94d7e3b52731c228f31457087f73b136c9b4 # 2026-08-17
+          ref: 7c4f91fd9f64791276d402830741c760d11bb2d8 # 2026-08-18
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Update TheRock hash to `7c4f91f` (2026-08-18)

Picks up the rocprofiler-compute changes merged in TheRock since `48ec94d`:

- ROCm/TheRock#7427: correct RPATH origin for nested rocprofiler-compute targets
- ROCm/TheRock#7421: wire test-compression for TheRock install-mode CI
- ROCm/TheRock#7425: make `rocm_sysdeps` zlib.pc reliably relocatable