### PR TITLE
test(rocprofiler-sdk): validate stream IDs in dispatch order

### DIFF
--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -66,6 +66,7 @@ if(NOT TARGET rocprofiler-sdk::rocprofiler-sdk-cereal)
             cereal
             GIT_REPOSITORY https://github.com/jrmadsen/cereal.git
             GIT_TAG rocprofiler
+            GIT_SHALLOW TRUE
             SOURCE_DIR ${PROJECT_BINARY_DIR}/external/cereal BINARY_DIR
             ${PROJECT_BINARY_DIR}/external/build/cereal-build SUBBUILD_DIR
             ${PROJECT_BINARY_DIR}/external/build/cereal-subdir)
@@ -88,6 +89,7 @@ if(NOT TARGET rocprofiler-sdk::rocprofiler-sdk-perfetto)
         perfetto
         GIT_REPOSITORY https://github.com/google/perfetto
         GIT_TAG v44.0
+        GIT_SHALLOW TRUE
         SOURCE_DIR ${PROJECT_BINARY_DIR}/external/perfetto BINARY_DIR
         ${PROJECT_BINARY_DIR}/external/build/perfetto-build SUBBUILD_DIR
         ${PROJECT_BINARY_DIR}/external/build/perfetto-subdir)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/validate.py
@@ -99,7 +99,11 @@ def test_stream_ids_monotonically_increase(json_data, pointer_data):
     data = json_data["rocprofiler-sdk-tool"]
     buffer_records = data["buffer_records"]
 
-    kernel_dispatch_data = buffer_records["kernel_dispatch"]
+    # Sort by dispatch ID because callback delivery order can differ across HSA queues.
+    kernel_dispatch_data = sorted(
+        buffer_records["kernel_dispatch"],
+        key=lambda node: node.dispatch_info.dispatch_id,
+    )
     assert len(kernel_dispatch_data) > 0
 
     stream_ids = [node.stream_id.handle for node in kernel_dispatch_data]


### PR DESCRIPTION

## Motivation

https://github.com/ROCm/rocm-systems/actions/runs/32110556067/job/95629005341

## Technical Details

- Sort buffered kernel records by dispatch ID because callback delivery order can differ across HSA queues.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
