### PR TITLE
fix(hip): prevent command injection in hipdemangleatp

### DIFF
--- a/projects/hip/bin/hipdemangleatp
+++ b/projects/hip/bin/hipdemangleatp
@@ -4,20 +4,35 @@
 #
 # SPDX-License-Identifier: MIT
 
-# usage: hipdemangleatp.sh ATP_FILE
+if [[ $# -ne 1 || ! -f $1 ]]; then
+    echo "Usage: $(basename "$0") ATP_FILE" >&2
+    exit 1
+fi
+
+atp_file=$1
+
+replace_literal() {
+    local search replacement
+    search=$(printf '%s' "$1" | sed 's/[][\\.^$*|]/\\&/g')
+    replacement=$(printf '%s' "$2" | sed 's/[\\&|]/\\&/g')
+    sed -i "s|${search}|${replacement}|g" -- "$3"
+}
 
 # HIP kernels
-kernels=$(grep grid_launch_parm $1 | cut -d" " -f1 | sort | uniq)
-for mangled_sym in $kernels; do
-    real_sym=$(c++filt -p $(c++filt _$mangled_sym | cut -d: -f3 | sed 's/_functor//g' | sed 's/ /\\\&nbsp/g'))
-    #echo "$mangled_sym => $real_sym" >> $1.log
-    sed -i "s/$mangled_sym/$real_sym/g" $1
+mapfile -t kernels < <(grep grid_launch_parm -- "$atp_file" | cut -d" " -f1 | sort -u)
+for mangled_sym in "${kernels[@]}"; do
+    [[ -z $mangled_sym ]] && continue
+    real_sym=$(c++filt -p -- "$(c++filt -- "_${mangled_sym}" | cut -d: -f3 |
+        sed 's/_functor//g; s/ /\&nbsp/g')")
+    replace_literal "$mangled_sym" "$real_sym" "$atp_file"
 done
 
 # HC kernels
-kernels=$(grep cxxamp_trampoline $1 | cut -d" " -f1 | sort | uniq)
-for mangled_sym in $kernels; do
-    real_sym=$(echo $mangled_sym |  sed "s/^/_/g; s/_EC_/$/g" | c++filt -p | cut -d\( -f1 | cut -d" " -f1 --complement | sed 's/ /\\\&nbsp/g')
-    #echo "$mangled_sym => $real_sym" >> $1.log
-    sed -i "s/$mangled_sym/$real_sym/g" $1
+mapfile -t kernels < <(grep cxxamp_trampoline -- "$atp_file" | cut -d" " -f1 | sort -u)
+for mangled_sym in "${kernels[@]}"; do
+    [[ -z $mangled_sym ]] && continue
+    real_sym=$(printf '%s\n' "$mangled_sym" | sed 's/^/_/; s/_EC_/$/g' |
+        c++filt -p | cut -d\( -f1 | cut -d" " -f1 --complement |
+        sed 's/ /\&nbsp/g')
+    replace_literal "$mangled_sym" "$real_sym" "$atp_file"
 done


### PR DESCRIPTION
Treat ATP symbols as literal sed data and quote file arguments so crafted profiles cannot alter the sed program or execute commands.

## Motivation

`hipdemangleatp` interpolated kernel names from ATP profiles directly into a GNU sed expression. A crafted profile could modify the sed program and execute commands as the user running the tool.
This issue was identified by an automated security audit and subsequently confirmed through manual review and focused regression testing.

## Technical Details

- Escape search and replacement values before constructing sed expressions.
- Safely collect symbols using Bash arrays and `mapfile`.
- Quote command arguments and use `--` to prevent option injection.
- Validate that exactly one existing ATP file is provided.

## Issue Tracking

JIRA ID: SWSPLAT-24284
https://amd.atlassian.net/browse/SWSPLAT-24284

## Test Plan

- Verify valid HIP symbol demangling.
- Verify valid HC symbol demangling.
- Process a crafted sed-injection input and confirm no command execution.
- Verify ATP paths containing spaces.

## Test Result

All focused regression tests passed. No linter or whitespace errors were found.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
