### PR TITLE
fix(rocjitsu): narrow VOP3P packed-16 inline float constants

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -44,6 +44,40 @@ def _pk_f32_word_expr(var: str, half: str, use_cdna5_helpers: bool = False) -> s
     return f'{var}_{half}_w'
 
 
+def _append_pk16_src_reads(L: list[str], srcs: list[str], dtype: str | None) -> None:
+    """Read the packed 16-bit sources of one lane.
+
+    A VOP3P source is 32 bits wide, so read_lane() hands back the
+    single-precision pattern of an inline float constant (1.0 as 0x3F800000)
+    and the packed halves would take its low 16 bits. Re-narrow those nine
+    encodings to the 16-bit form the halves expect. Keyed on the
+    source-selector field rather than on the operand, so a 32-bit literal
+    (selector 255) keeps its value even when that value lands in 240..248 --
+    the same keying read_mix_src uses in the mad_mix bodies below. The
+    narrowed pattern goes in the low half only; read_mix_src instead returns
+    it for either half, because a mad_mix source is one scalar whose half
+    op_sel picks, not a packed v2 pair.
+
+    pk16_src_needs_narrowing also declines a source that is declared 16 bits
+    wide, because Operand::read_lane already resolved that one through the
+    half-precision inline table. CDNA2 builds every packed f16 source that
+    way, CDNA3 does for v_pk_min_f16 / v_pk_max_f16.
+    """
+    narrow = {'f16': 'util::f32_to_f16', 'bf16': 'util::f32_to_bf16'}.get(dtype or '')
+    for i, src in enumerate(srcs):
+        L.append(
+            f'    uint32_t raw{i} = amdgpu::RegisterAccess(wf).read_lane({src}, lane);'
+        )
+    if narrow is None:
+        return
+    for i, src in enumerate(srcs):
+        L.append(
+            f'    if (amdgpu::pk16_src_needs_narrowing(inst_.src{i}, '
+            f'{src}.size_bits()))'
+        )
+        L.append(f'      raw{i} = {narrow}(std::bit_cast<float>(raw{i}));')
+
+
 def gen_pk_binop(
     dst: list[str],
     src: list[str],
@@ -57,8 +91,7 @@ def gen_pk_binop(
     L.append('  uint64_t exec = wf.exec();')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
-    L.append(f'    uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane({s0}, lane);')
-    L.append(f'    uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane({s1}, lane);')
+    _append_pk16_src_reads(L, [s0, s1], dtype)
 
     # op_sel: which half of each src for LO result
     # op_sel_hi: which half for HI result (default = hi)
@@ -215,9 +248,7 @@ def gen_pk_ternary(
     L.append('  uint64_t exec = wf.exec();')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
-    L.append(f'    uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane({s0}, lane);')
-    L.append(f'    uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane({s1}, lane);')
-    L.append(f'    uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane({s2}, lane);')
+    _append_pk16_src_reads(L, [s0, s1, s2], dtype)
     opsel, opsel_hi = opsel_exprs
     L.append(f'    bool sel0_lo = ({opsel} >> 0) & 1;')
     L.append(f'    bool sel1_lo = ({opsel} >> 1) & 1;')
@@ -575,7 +606,7 @@ def gen_mad_mix_f32(
         )
         L.append('                           bool high_half) -> float {')
         L.append('      if (!src_is_f16) return std::bit_cast<float>(raw);')
-        L.append('      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)')
+        L.append('      uint16_t bits = amdgpu::is_inline_float_src(src_selector)')
         L.append(
             '                          ? util::f32_to_f16(std::bit_cast<float>(raw))'
         )
@@ -650,7 +681,7 @@ def gen_mad_mix_lo_hi(
         )
         L.append('                           bool high_half) -> float {')
         L.append('      if (!src_is_f16) return std::bit_cast<float>(raw);')
-        L.append('      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)')
+        L.append('      uint16_t bits = amdgpu::is_inline_float_src(src_selector)')
         L.append(
             '                          ? util::f32_to_f16(std::bit_cast<float>(raw))'
         )
@@ -731,7 +762,7 @@ def gen_mad_mix_bf16(
         )
         L.append('                           bool high_half) -> float {')
         L.append('      if (!src_is_bf16) return std::bit_cast<float>(raw);')
-        L.append('      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)')
+        L.append('      uint16_t bits = amdgpu::is_inline_float_src(src_selector)')
         L.append(
             '                          ? util::f32_to_bf16(std::bit_cast<float>(raw))'
         )
@@ -790,8 +821,9 @@ def gen_dot2(
     L.append('  uint64_t exec = wf.exec();')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
-    L.append(f'    uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane({s0}, lane);')
-    L.append(f'    uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane({s1}, lane);')
+    _append_pk16_src_reads(
+        L, [s0, s1], {'dot2_f32_f16': 'f16', 'dot2_f32_bf16': 'bf16'}.get(cls)
+    )
     L.append(f'    bool sel0_lo = ({opsel} >> 0) & 1;')
     L.append(f'    bool sel1_lo = ({opsel} >> 1) & 1;')
     L.append(f'    bool sel0_hi = ({opsel_hi} >> 0) & 1;')
@@ -900,8 +932,12 @@ def gen_dot2_true16(dst: list[str], src: list[str], cls: str) -> str:
     L.append('    if (!(exec & (1ULL << lane)))')
     L.append('      continue;')
     L.append('    uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);')
-    L.append(f'    uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane({s0}, lane);')
-    L.append(f'    uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane({s1}, lane);')
+    # src0/src1 are 32-bit operands consumed as packed v2 halves, so an inline
+    # float constant needs the same re-narrowing the VOP3P packed bodies do.
+    # Only src2 goes through read_vop3_true16_src, which is already 16-bit.
+    _append_pk16_src_reads(
+        L, [s0, s1], {'dot2_f16_f16': 'f16', 'dot2_bf16_bf16': 'bf16'}[cls]
+    )
     L.append(
         f'    uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src({s2}, wf, lane, opsel, 2);'
     )

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_packed_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_packed_codegen.py
@@ -4,12 +4,16 @@
 """Tests for packed execute code generation."""
 
 from amdisa.codegen.execute.packed import (
+    gen_dot2,
+    gen_dot2_true16,
     gen_dot4,
     gen_dot8,
     gen_mad_mix_bf16,
     gen_mad_mix_f32,
     gen_mad_mix_lo_hi,
+    gen_pk_binop,
     gen_pk_binop_f32,
+    gen_pk_ternary,
 )
 from amdisa.codegen.execute.simd_codegen import vop3p_local_simd_probe_line
 
@@ -30,6 +34,112 @@ def test_dot8_iu4_uses_operand_signedness_modifiers():
     assert 'src1_signed = (inst_.neg & 0x2u) != 0' in cpp
     assert 'raw_a | ~0xF' in cpp
     assert 'raw_b | ~0xF' in cpp
+
+
+def test_pk_f16_binop_narrows_inline_float_constants():
+    cpp = gen_pk_binop(
+        ['vdst'],
+        ['src0', 'src1'],
+        'add',
+        'f16',
+        opsel_exprs=('inst_.op_sel', 'inst_.op_sel_hi'),
+    )
+
+    assert 'if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))' in cpp
+    assert 'raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));' in cpp
+    assert 'if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))' in cpp
+    assert 'raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));' in cpp
+    # Keyed on the selector field, never on the operand: an IsaOperand keeps a
+    # 255-literal's value in encoding_value_.
+    assert 'encoding_value_' not in cpp
+
+
+def test_pk_bf16_ternary_narrows_inline_float_constants_as_bf16():
+    cpp = gen_pk_ternary(
+        ['vdst'],
+        ['src0', 'src1', 'src2'],
+        'fma',
+        'bf16',
+        op_sel_hi_2_expr='inst_.op_sel_hi_2',
+        opsel_exprs=('inst_.op_sel', 'inst_.op_sel_hi'),
+    )
+
+    assert 'raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));' in cpp
+    assert 'raw2 = util::f32_to_bf16(std::bit_cast<float>(raw2));' in cpp
+    assert 'f32_to_f16' not in cpp
+
+
+def test_dot2_half_forms_narrow_inline_float_constants():
+    for cls, narrow in (
+        ('dot2_f32_f16', 'f32_to_f16'),
+        ('dot2_f32_bf16', 'f32_to_bf16'),
+    ):
+        cpp = gen_dot2(
+            ['vdst'],
+            ['src0', 'src1', 'src2'],
+            cls,
+            opsel_exprs=('inst_.op_sel', 'inst_.op_sel_hi'),
+        )
+
+        assert (
+            'if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))' in cpp
+        )
+        assert f'raw0 = util::{narrow}(std::bit_cast<float>(raw0));' in cpp
+        assert (
+            'if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))' in cpp
+        )
+        assert f'raw1 = util::{narrow}(std::bit_cast<float>(raw1));' in cpp
+        # src2 is an f32 accumulator on this family, so it stays 32-bit.
+        assert 'raw2' not in cpp
+
+
+def test_dot2_true16_narrows_inline_float_constants():
+    """v_dot2_f16_f16 / v_dot2_bf16_bf16 read src0/src1 as packed v2 halves off a
+    32-bit read_lane, so they need the same narrowing the VOP3P dots do. Only
+    src2 goes through read_vop3_true16_src, which is already 16-bit."""
+    for cls, narrow in (
+        ('dot2_f16_f16', 'f32_to_f16'),
+        ('dot2_bf16_bf16', 'f32_to_bf16'),
+    ):
+        cpp = gen_dot2_true16(['vdst'], ['src0', 'src1', 'src2'], cls)
+
+        assert (
+            'if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))' in cpp
+        )
+        assert f'raw0 = util::{narrow}(std::bit_cast<float>(raw0));' in cpp
+        assert (
+            'if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))' in cpp
+        )
+        assert f'raw1 = util::{narrow}(std::bit_cast<float>(raw1));' in cpp
+        # src2 is read at 16 bits by read_vop3_true16_src, so it is left alone.
+        assert 'inst_.src2, src2.size_bits()' not in cpp
+
+
+def test_dot2_integer_forms_leave_inline_constants_alone():
+    for cls in ('dot2_i32_i16', 'dot2_u32_u16'):
+        cpp = gen_dot2(
+            ['vdst'],
+            ['src0', 'src1', 'src2'],
+            cls,
+            opsel_exprs=('inst_.op_sel', 'inst_.op_sel_hi'),
+        )
+
+        assert 'pk16_src_needs_narrowing' not in cpp
+        assert 'bit_cast' not in cpp
+
+
+def test_pk_integer_binop_leaves_inline_constants_alone():
+    for dtype in ('i16', 'u16'):
+        cpp = gen_pk_binop(
+            ['vdst'],
+            ['src0', 'src1'],
+            'add',
+            dtype,
+            opsel_exprs=('inst_.op_sel', 'inst_.op_sel_hi'),
+        )
+
+        assert '240u' not in cpp
+        assert 'bit_cast' not in cpp
 
 
 def test_gfx1250_pk_f32_uses_literal_aware_pair_helper():
@@ -107,7 +217,7 @@ def test_mad_mix_applies_abs_before_neg():
     abs_line = 'if (inst_.neg_hi & 1) a = std::fabs(a);'
     neg_line = 'if (inst_.neg & 1) a = -a;'
     assert 'read_mix_src(raw1, inst_.src1' in cpp
-    assert 'src_selector >= 240u && src_selector <= 248u' in cpp
+    assert 'uint16_t bits = amdgpu::is_inline_float_src(src_selector)' in cpp
     assert abs_line in cpp
     assert cpp.index(abs_line) < cpp.index(neg_line)
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p_exec.cpp
@@ -109,6 +109,12 @@ void VPkMinimum3F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst_.op_sel >> 1) & 1;
     bool sel2_lo = (inst_.op_sel >> 2) & 1;
@@ -163,6 +169,12 @@ void VPkMaximum3F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst_.op_sel >> 1) & 1;
     bool sel2_lo = (inst_.op_sel >> 2) & 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
@@ -421,6 +421,12 @@ void VPkFmaF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -467,6 +473,10 @@ void VPkAddF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -503,6 +513,10 @@ void VPkMulF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -540,6 +554,12 @@ void VPkFmaBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_bf16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -687,6 +707,10 @@ void VPkMinNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -723,6 +747,10 @@ void VPkMaxNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -759,6 +787,10 @@ void VPkMinimumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -795,6 +827,10 @@ void VPkMaximumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -984,6 +1020,10 @@ void VPkAddBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -1085,6 +1125,10 @@ void VPkMulBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -1120,6 +1164,10 @@ void VPkMinNumBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -1155,6 +1203,10 @@ void VPkMaxNumBf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -1341,6 +1393,12 @@ void VPkMinimum3F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -1395,6 +1453,12 @@ void VPkMaximum3F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -1449,6 +1513,12 @@ void VPkMin3NumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -1496,6 +1566,12 @@ void VPkMax3NumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop3_exec.cpp
@@ -3781,6 +3781,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::f16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::f16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));
@@ -3836,6 +3840,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::bf16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::bf16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3_exec.cpp
@@ -3781,6 +3781,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::f16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::f16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));
@@ -3836,6 +3840,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::bf16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::bf16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3_exec.cpp
@@ -3886,6 +3886,10 @@ void VDot2F16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::f16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::f16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));
@@ -3941,6 +3945,10 @@ void VDot2Bf16Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t opsel = ::rocjitsu::amdgpu::vop3_opsel(inst_);
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     uint32_t acc_bits = ::rocjitsu::amdgpu::read_vop3_true16_src(src2, wf, lane, opsel, 2);
     float a0 = util::bf16_to_f32(static_cast<uint16_t>(raw0 & 0xffffu));
     float a1 = util::bf16_to_f32(static_cast<uint16_t>((raw0 >> 16) & 0xffffu));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop3p_exec.cpp
@@ -347,6 +347,12 @@ void VPkFmaF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src2, src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel2_lo = (inst_.opsel >> 2) & 1;
@@ -393,6 +399,10 @@ void VPkAddF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -429,6 +439,10 @@ void VPkMulF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -472,6 +486,10 @@ void VDot2F32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -604,6 +622,10 @@ void VDot2F32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -637,6 +659,10 @@ void VPkMinNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -673,6 +699,10 @@ void VPkMaxNumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -709,6 +739,10 @@ void VPkMinimumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -745,6 +779,10 @@ void VPkMaximumF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src0, src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst_.src1, src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst_.opsel >> 0) & 1;
     bool sel1_lo = (inst_.opsel >> 1) & 1;
     bool sel0_hi = (inst_.opsel_hi >> 0) & 1;
@@ -793,7 +831,7 @@ void VFmaMixF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -839,7 +877,7 @@ void VFmaMixloF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -886,7 +924,7 @@ void VFmaMixhiF16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -10143,6 +10143,10 @@ inline void execute_v_dot2_f32_bf16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_bf16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_bf16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;
@@ -10179,6 +10183,10 @@ inline void execute_v_dot2_f32_f16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;
@@ -11220,7 +11228,7 @@ inline void execute_v_fma_mix_f32_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -11262,7 +11270,7 @@ inline void execute_v_fma_mixhi_f16_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -11305,7 +11313,7 @@ inline void execute_v_fma_mixlo_f16_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -13133,7 +13141,7 @@ inline void execute_v_mad_mix_f32_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -13175,7 +13183,7 @@ inline void execute_v_mad_mixhi_f16_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -13218,7 +13226,7 @@ inline void execute_v_mad_mixlo_f16_vop3p([[maybe_unused]] Inst &inst,
                            bool high_half) -> float {
       if (!src_is_f16)
         return std::bit_cast<float>(raw);
-      uint16_t bits = (src_selector >= 240u && src_selector <= 248u)
+      uint16_t bits = amdgpu::is_inline_float_src(src_selector)
                           ? util::f32_to_f16(std::bit_cast<float>(raw))
                           : static_cast<uint16_t>(high_half ? (raw >> 16) : raw);
       return util::f16_to_f32(bits);
@@ -16567,6 +16575,10 @@ inline void execute_v_pk_add_f16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;
@@ -16745,6 +16757,12 @@ inline void execute_v_pk_fma_f16_vop3p([[maybe_unused]] Inst &inst,
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
     uint32_t raw2 = amdgpu::RegisterAccess(wf).read_lane(inst.src2, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src2, inst.src2.size_bits()))
+      raw2 = util::f32_to_f16(std::bit_cast<float>(raw2));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel2_lo = (inst.inst_.op_sel >> 2) & 1;
@@ -16994,6 +17012,10 @@ inline void execute_v_pk_max_f16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;
@@ -17098,6 +17120,10 @@ inline void execute_v_pk_min_f16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;
@@ -17223,6 +17249,10 @@ inline void execute_v_pk_mul_f16_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane);
     uint32_t raw1 = amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane);
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()))
+      raw0 = util::f32_to_f16(std::bit_cast<float>(raw0));
+    if (amdgpu::pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+      raw1 = util::f32_to_f16(std::bit_cast<float>(raw1));
     bool sel0_lo = (inst.inst_.op_sel >> 0) & 1;
     bool sel1_lo = (inst.inst_.op_sel >> 1) & 1;
     bool sel0_hi = (inst.inst_.op_sel_hi >> 0) & 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -48,6 +48,23 @@ using float32_t = float;
 /// flip at runtime.
 inline bool simd_force_scalar() { return util::force_scalar(); }
 
+/// True when a source-selector field names one of the nine inline float
+/// constants (0.5 .. 1/(2*pi)). A 32-bit literal is selector 255, so it never
+/// matches here even when its value lands in the same range.
+inline bool is_inline_float_src(uint32_t selector) { return selector >= 240u && selector <= 248u; }
+
+/// True when a packed 16-bit body has to re-narrow this source itself. An
+/// inline float constant reaches a 32-bit source in single precision, so the
+/// packed halves would take the low half of e.g. 0x3F800000. A source declared
+/// 16 bits wide was already resolved through the half-precision inline table --
+/// Operand::read_lane branches on the same `size_bits_ == 16` -- and narrowing
+/// that again would read the 16-bit pattern as an f32 denormal and flush it to
+/// zero. CDNA2 builds every packed f16 source 16 bits wide, CDNA3 does for
+/// v_pk_min_f16 / v_pk_max_f16.
+inline bool pk16_src_needs_narrowing(uint32_t selector, int src_size_bits) {
+  return is_inline_float_src(selector) && src_size_bits != 16;
+}
+
 inline uint32_t sign_extend_u32(uint32_t value, unsigned bits) {
   assert(bits >= 1 && bits <= 32 && "sign_extend_u32 requires a 1..32 bit width");
   const uint32_t sign = uint32_t{1} << (bits - 1);
@@ -2912,11 +2929,6 @@ inline util::native<float> fma_mix_mul_add(util::native<float> a, util::native<f
   return a * b + c;
 }
 
-inline bool fma_mix_src_is_float_inline(uint32_t src_selector) {
-  // Standard AMDGPU floating inline constants in the shared OPR_SRC encoding.
-  return src_selector >= 240u && src_selector <= 248u;
-}
-
 /// VOP3P fma_mix / mad_mix SIMD fast path. Six ops share one body because all
 /// six differ only in (a) the f16-vs-f32 widening shape per source and (b) the
 /// f16-lo/f16-hi/f32 narrowing shape on the destination. The generated scalar
@@ -2978,9 +2990,8 @@ template <FmaMixDst DstMode, typename Inst>
     F v;
     if (sel_hi_bit) {
       U raw = op.template load_native<uint32_t>(base);
-      U halves = fma_mix_src_is_float_inline(src_selector)
-                     ? util::f32_to_f16_simd(std::bit_cast<F>(raw))
-                     : (sel_bit ? (raw >> 16) : (raw & 0xFFFFu));
+      U halves = is_inline_float_src(src_selector) ? util::f32_to_f16_simd(std::bit_cast<F>(raw))
+                                                   : (sel_bit ? (raw >> 16) : (raw & 0xFFFFu));
       v = util::f16_to_f32_simd(halves);
     } else {
       v = op.template load_native<float>(base);
@@ -3144,6 +3155,12 @@ template <typename Inst, typename Op>
     return false;
   if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
     return false;
+  // Decline exactly the sources the scalar body re-narrows -- an inline float
+  // constant on a 32-bit source -- so the two paths cannot disagree. Keyed on
+  // the source-selector field, so a 32-bit literal (255) still runs here.
+  if (pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()) ||
+      pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
+    return false;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
@@ -3205,6 +3222,13 @@ template <typename Inst, typename Op>
       !inst.src1.simd_capable() || !inst.src2.simd_capable() || !inst.vdst.simd_capable())
     return false;
   if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u || inst.inst_.op_sel_hi_2 != 1u)
+    return false;
+  // Decline exactly the sources the scalar body re-narrows -- an inline float
+  // constant on a 32-bit source -- so the two paths cannot disagree. Keyed on
+  // the source-selector field, so a 32-bit literal (255) still runs here.
+  if (pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()) ||
+      pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()) ||
+      pk16_src_needs_narrowing(inst.inst_.src2, inst.src2.size_bits()))
     return false;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;
@@ -3533,6 +3557,12 @@ template <Vop3pDotHalfFormat Fmt, typename Inst>
       !inst.src1.simd_capable() || !inst.src2.simd_capable() || !inst.vdst.simd_capable())
     return false;
   if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  // Decline exactly the sources the scalar body re-narrows, so the two paths
+  // cannot disagree. src2 is a genuine f32 accumulator, so an inline constant
+  // there is already correct.
+  if (pk16_src_needs_narrowing(inst.inst_.src0, inst.src0.size_bits()) ||
+      pk16_src_needs_narrowing(inst.inst_.src1, inst.src1.size_bits()))
     return false;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -508,6 +508,7 @@ add_executable(
     simd_correctness/vop3_ldexp_simd_correctness_test.cpp
     simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
     simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
+    simd_correctness/vop3p_pk_inline_constant_correctness_test.cpp
     simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
     simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
     simd_correctness/vop3p_dot_simd_correctness_test.cpp

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_inline_constant_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_inline_constant_correctness_test.cpp
@@ -1,0 +1,368 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_pk_inline_constant_correctness_test.cpp
+/// @brief Value-correctness check for VOP3P packed-16 sources fed by an inline
+/// FLOAT constant (encoding values 240..248).
+///
+/// A VOP3P source is built 32 bits wide, so Operand::read_lane resolves an
+/// inline float constant through the single-precision table and 1.0 arrives as
+/// 0x3F800000. The packed halves then take the low 16 bits (0x0000) and the
+/// instruction adds / multiplies by ZERO. ROCm clang emits
+/// "v_pk_add_f16 v2, v2, 1.0 op_sel_hi:[1,0]" for half2 x + 1.0h: the cleared
+/// OPSEL_HI bit points the HIGH lane at the LOW half, which is only correct
+/// when the 16-bit pattern lives there, so both halves read 0 and the add is a
+/// no-op copy.
+///
+/// The neighbouring vop3p_pk_binary_fp16_simd_correctness test only compares
+/// the SIMD fast path against the scalar body with VGPR sources, so it cannot
+/// see this; these cases assert ABSOLUTE results. Two controls pin the
+/// rewrite's boundaries: an inline INTEGER constant is not a float constant and
+/// stays as it is, and a 32-bit LITERAL whose value happens to land in 240..248
+/// must read back verbatim -- the rewrite keys off the instruction's
+/// source-selector field, which is 255 for a literal, not off the operand's
+/// encoding value, where an IsaOperand keeps the literal's value.
+///
+/// The same 32-bit read feeds v_dot2_f32_{f16,bf16}, whose two packed halves
+/// are 16-bit even though the accumulator and the destination are f32, so the
+/// dot cases below assert the narrowing reaches those too.
+///
+/// The packed adds and the integer control run on RDNA4, except v_pk_add_bf16,
+/// which only decodes on CDNA5 (gfx1250). The dots run one case per body: RDNA4 carries
+/// its own generated dot2 bodies and every other target shares one template, so
+/// v_dot2_f32_f16 runs on RDNA4 and v_dot2_f32_bf16 on RDNA3.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna2/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna2/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna3/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna3/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna4/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/rdna4/opcodes.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h"
+#include "rocjitsu/isa/decode_result.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 32; // RDNA4 / CDNA5 wave32
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kSrcVgpr = 0; // src0 = v0, encoding value 256
+constexpr uint32_t kDstVgpr = 4;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+constexpr uint32_t kExec = 0xA5A58001u;
+
+// Source-field encodings: inline 1.0, inline integer 1, and the 32-bit literal
+// escape.
+constexpr uint16_t kInlineOneFloat = 242;
+constexpr uint16_t kInlineInv2Pi = 248; // the last float selector
+constexpr uint16_t kInlineZero = 128;
+constexpr uint16_t kInlineOneInt = 129;
+constexpr uint16_t kLiteral = 255;
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  explicit Fixture(rj_code_arch_t arch)
+      : gpu_mem("vop3p_pk_inline_const_mem"), l2("vop3p_pk_inline_const_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_pk_inline_const", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(arch);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // Seeds every lane of v0 with the same packed pair, runs the encoding, and
+  // returns the per-lane destination.
+  std::array<uint32_t, WF_SIZE> run(const uint32_t *words, uint32_t src_value) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + kSrcVgpr, lane, src_value);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(kExec);
+    DecodeResult decoded = decoder->decode(words);
+    EXPECT_TRUE(decoded.succeeded()) << "decode failed";
+    if (decoded.failed())
+      return {};
+    std::unique_ptr<Instruction> inst = std::move(decoded).value();
+    cu->execute_instruction(inst.get(), *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void expect_all_active(const std::array<uint32_t, WF_SIZE> &out, uint32_t want, const char *label) {
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (kExec >> lane) & 1u;
+    if (active)
+      EXPECT_EQ(out[lane], want) << label << ": lane " << lane;
+    else
+      EXPECT_EQ(out[lane], DST_SENTINEL) << label << ": clobbered inactive lane " << lane;
+  }
+}
+
+// v_pk_add_f16 v4, v0, 1.0 op_sel_hi:[1,0] with v0 = {1.0h, 1.0h}. Both halves
+// must see 1.0h, so the result is {2.0h, 2.0h}. Before the inline-constant fix
+// the packed halves read the low 16 bits of 0x3F800000 and the add was a no-op
+// copy of 0x3C003C00.
+TEST(Vop3pPkInlineConstantCorrectness, AddF16InlineOneReachesBothHalves) {
+  const auto words =
+      rdna4::build_vop3p(rdna4::kVPkAddF16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .opsel_hi = 1});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x3C003C00u);
+  expect_all_active(out, 0x40004000u, "v_pk_add_f16 v4, v0, 1.0 op_sel_hi:[1,0]");
+}
+
+// Same shape for packed BF16, whose 1.0 is 0x3F80 rather than 0x3C00.
+TEST(Vop3pPkInlineConstantCorrectness, AddBf16InlineOneReachesBothHalves) {
+  const auto words =
+      cdna5::build_vop3p(cdna5::kVPkAddBf16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .opsel_hi = 1});
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x3F803F80u);
+  expect_all_active(out, 0x40004000u, "v_pk_add_bf16 v4, v0, 1.0 op_sel_hi:[1,0]");
+}
+
+// A source declared 16 bits wide is a different case: CDNA2 builds every packed
+// f16 source that way (and CDNA3 does for v_pk_min_f16 / v_pk_max_f16), so
+// Operand::read_lane has already resolved the inline constant through the
+// half-precision table and hands back 0x00003C00. Re-narrowing THAT would read
+// the 16-bit pattern as an f32 denormal and flush it to zero, so the rewrite has
+// to decline it -- pk16_src_needs_narrowing checks the operand width for exactly
+// this reason. Same shape and same answer as the RDNA4 case above.
+TEST(Vop3pPkInlineConstantCorrectness, AddF16InlineOneOnSixteenBitSourceOperand) {
+  const auto words =
+      cdna2::build_vop3p(cdna2::kVPkAddF16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .op_sel_hi = 1});
+  Fixture fx(ROCJITSU_CODE_ARCH_CDNA2);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x3C003C00u);
+  expect_all_active(out, 0x40004000u, "cdna2 v_pk_add_f16 v4, v0, 1.0 op_sel_hi:[1,0]");
+}
+
+// v_dot2_f16_f16 is VOP3, not VOP3P, but src0/src1 are still 32-bit operands
+// consumed as packed v2 halves -- only src2 goes through read_vop3_true16_src,
+// which is already 16-bit -- so it needs the same narrowing.
+//
+// v_dot2_f16_f16 v4, v0, 1.0, 0 with v0 = {1.0h, 0} is 1.0*1.0 + 0*0 + 0 = 1.0h.
+// Unnarrowed, src1 reads {lo = 0, hi = 0x3F80} and the answer is 0. The
+// destination is a true16 half, so the low half of v4 is written and the high
+// half keeps its sentinel.
+TEST(Vop3pPkInlineConstantCorrectness, Dot2F16F16InlineOneNarrowsPackedHalves) {
+  const auto words = rdna4::build_vop3(
+      rdna4::kVDot2F16F16Vop3,
+      {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .src2 = kInlineZero});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x00003C00u);
+  expect_all_active(out, (DST_SENTINEL & 0xFFFF0000u) | 0x3C00u, "v_dot2_f16_f16 v4, v0, 1.0, 0");
+}
+
+// Control: a 32-bit literal whose VALUE is an inline-constant encoding value.
+// IsaOperand stores a literal's value in encoding_value_, so a rewrite keyed on
+// the operand rather than on the source-selector field would narrow 0xF2 here.
+//
+// The addend has to be chosen so the two behaviours differ. Narrowing gives
+// f32_to_f16(bit_cast<float>(0xF2)) = 0 -- 0xF2 is an f32 denormal far below
+// the f16 range -- so any seed for which adding 0x00F2 is a no-op passes
+// either way. 0x0800 is 2^-13, where the f16 step is 2^-23 and the literal's
+// 242 * 2^-24 lands exactly on 0x0879. Keyed correctly the result is
+// 0x08790879; keyed on the operand it would stay 0x08000800.
+TEST(Vop3pPkInlineConstantCorrectness, AddF16LiteralValuedLikeInlineConstantIsVerbatim) {
+  const auto base = rdna4::build_vop3p(
+      rdna4::kVPkAddF16Vop3p, {.vdst = kDstVgpr, .src0 = 256, .src1 = kLiteral, .opsel_hi = 1});
+  const std::array words{base[0], base[1], uint32_t{kInlineOneFloat}};
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x08000800u);
+  expect_all_active(out, 0x08790879u, "v_pk_add_f16 v4, v0, lit(0xF2) op_sel_hi:[1,0]");
+}
+
+// Control: inline INTEGER constants are not float constants. v_pk_add_i16 with
+// inline 1 keeps reading 1 from the low half of the resolved value.
+TEST(Vop3pPkInlineConstantCorrectness, AddI16InlineIntegerConstantIsUnchanged) {
+  const auto words =
+      rdna4::build_vop3p(rdna4::kVPkAddI16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneInt, .opsel_hi = 1});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x00050005u);
+  expect_all_active(out, 0x00060006u, "v_pk_add_i16 v4, v0, 1 op_sel_hi:[1,0]");
+}
+
+// Default packing (op_sel_hi = 3) is the one shape the SIMD fast path accepts.
+// The inline-constant rewrite lives in the scalar body only, so the fast path
+// has to decline an inline float source rather than diverge from it.
+//
+// This has to run on an arch that reaches the probe. RDNA4 and CDNA5 emit
+// local v_pk_add_f16 bodies with no ROCJITSU_TRY_SIMD line at all, so both
+// modes would take the same scalar loop and the comparison would be vacuous;
+// CDNA4 delegates to execute_v_pk_add_f16_vop3p, which carries the probe.
+//
+// This shape also pins the HIGH half. An inline float constant occupies a
+// packed-16 source as {lo = the 16-bit pattern, hi = 0}: the LLVM assembler
+// inline-encodes the packed v2f16 immediate 0x00003C00 as "1.0" for
+// v_pk_add_f16 but has to spill 0x3C003C00 to a 32-bit literal, which it would
+// not do if the hardware replicated the constant into both halves. So with
+// op_sel_hi:[1,1] and v0 = {1.0h, 1.0h} the low lane adds 1.0h and the HIGH
+// lane adds +0.0h, giving {1.0h, 2.0h} = 0x3C004000.
+TEST(Vop3pPkInlineConstantCorrectness, AddF16InlineOneDefaultPackingAgreesWithScalar) {
+  ForceScalarGuard gate_guard;
+  const auto words =
+      cdna4::build_vop3p(cdna4::kVPkAddF16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .op_sel_hi = 3});
+
+  const auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx(ROCJITSU_CODE_ARCH_CDNA4);
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    return fx.run(words.data(), 0x3C003C00u);
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (kExec >> lane) & 1u;
+    EXPECT_EQ(scalar_out[lane], simd_out[lane])
+        << "op_sel_hi:[1,1]: SIMD path diverged from scalar body at lane " << lane;
+    if (active)
+      EXPECT_EQ(scalar_out[lane], 0x3C004000u)
+          << "op_sel_hi:[1,1]: inline 1.0 did not land in the low half only, at lane " << lane;
+    else
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << "clobbered inactive lane " << lane;
+  }
+}
+
+// The narrowing has to round, not truncate: selector 248 is 1/(2*pi), whose f32
+// form 0x3E22F983 sits between two f16 values. The emulator's own 16-bit inline
+// table (scalar_operand_resolve.h) spells that constant 0x3118, so RNE is what
+// agrees with the rest of the model; truncating would give 0x3117. Adding it to
+// zero leaves the narrowed pattern intact in both halves.
+TEST(Vop3pPkInlineConstantCorrectness, AddF16InlineInv2PiRoundsToNearestEven) {
+  const auto words =
+      rdna4::build_vop3p(rdna4::kVPkAddF16Vop3p,
+                         {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineInv2Pi, .opsel_hi = 1});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x00000000u);
+  expect_all_active(out, 0x31183118u, "v_pk_add_f16 v4, v0, 0.15915494 op_sel_hi:[1,0]");
+}
+
+// src2 takes the same 32-bit read as src0/src1 on a three-source packed op.
+// v_pk_fma_f16 v4, v0, v0, 1.0 op_sel_hi:[1,1,0] with v0 = {2.0h, 2.0h} is
+// 2*2 + 1 in both halves. Leaving src2 unnarrowed adds 0 and gives 0x44004400.
+TEST(Vop3pPkInlineConstantCorrectness, FmaF16InlineOneOnSrc2ReachesBothHalves) {
+  const auto words = rdna4::build_vop3p(
+      rdna4::kVPkFmaF16Vop3p,
+      {.vdst = kDstVgpr, .src0 = 256, .src1 = 256, .src2 = kInlineOneFloat, .opsel_hi = 3});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x40004000u);
+  expect_all_active(out, 0x45004500u, "v_pk_fma_f16 v4, v0, v0, 1.0 op_sel_hi:[1,1,0]");
+}
+
+// v_dot2_f32_f16 v4, v0, 1.0, 0 with v0 = {1.0h, 0}. The dot is
+// a.lo*b.lo + a.hi*b.hi + c, so the answer is 1.0f. Unnarrowed, src1 reads
+// {lo = 0, hi = 0x3F80} and both products drop out, leaving 0.
+//
+// RDNA4 carries its own generated dot2 bodies, which have no SIMD probe.
+TEST(Vop3pPkInlineConstantCorrectness, Dot2F32F16InlineOneNarrowsOnLocalBody) {
+  const auto words = rdna4::build_vop3p(
+      rdna4::kVDot2F32F16Vop3p,
+      {.vdst = kDstVgpr, .src0 = 256, .src1 = kInlineOneFloat, .src2 = kInlineZero, .opsel_hi = 3});
+  Fixture fx(ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  const auto out = fx.run(words.data(), 0x00003C00u);
+  expect_all_active(out, 0x3F800000u, "v_dot2_f32_f16 v4, v0, 1.0, 0");
+}
+
+// Same dot, packed BF16, on RDNA3 -- which calls the generated dot2 template
+// every target except RDNA4 shares. bf16 1.0 is 0x3F80.
+//
+// The shared body is also the only one that carries the SIMD probe, and
+// op_sel_hi:[1,1] is the packing try_execute_vop3p_dot_f16_simd accepts. The
+// narrowing lives in the scalar body, so the fast path has to decline an inline
+// float source rather than diverge from it; both modes run here.
+TEST(Vop3pPkInlineConstantCorrectness, Dot2F32Bf16InlineOneNarrowsAndSimdAgrees) {
+  ForceScalarGuard gate_guard;
+  const auto words = rdna3::build_vop3p(rdna3::kVDot2F32Bf16Vop3p, {.vdst = kDstVgpr,
+                                                                    .src0 = 256,
+                                                                    .src1 = kInlineOneFloat,
+                                                                    .src2 = kInlineZero,
+                                                                    .op_sel_hi = 3});
+
+  const auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx(ROCJITSU_CODE_ARCH_RDNA3);
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    EXPECT_EQ(fx.wf->wf_size(), WF_SIZE) << "fixture assumes wave32";
+    return fx.run(words.data(), 0x00003F80u);
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    EXPECT_EQ(scalar_out[lane], simd_out[lane])
+        << "v_dot2_f32_bf16: SIMD path diverged from scalar body at lane " << lane;
+    const bool active = (kExec >> lane) & 1u;
+    if (active)
+      EXPECT_EQ(scalar_out[lane], 0x3F800000u) << "v_dot2_f32_bf16 v4, v0, 1.0, 0: lane " << lane;
+    else
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << "clobbered inactive lane " << lane;
+  }
+}
+
+} // namespace


### PR DESCRIPTION
## Motivation

A VOP3P source operand is built 32 bits wide, so `Operand::read_lane` resolves an inline float constant through the single-precision table (`resolve_src_scalar` returns `0x3F800000` for encoding 242) instead of `resolve_src_scalar16`. The packed 16-bit bodies then take the low half of that word, so every f16/bf16 packed op naming an inline float constant added, multiplied by or compared against **zero**.

ROCm clang emits `v_pk_add_f16 v2, v2, 1.0 op_sel_hi:[1,0]` for `half2 x + 1.0h`, so the instruction degenerated into a no-op copy of its first source.

## Technical Details

The defect is in **generated** execute bodies, so the fix is in the generator (`lib/python/amdisa/codegen/execute/packed.py`) and the generated sources are the result of a regeneration, not hand edits.

- The nine packed f16/bf16 encodings re-narrow the constant with `util::f32_to_f16` / `util::f32_to_bf16` before the halves are split out. The rewrite keys off the instruction's **source-selector field**, not the operand: an `IsaOperand` stores a 255-literal's value in `encoding_value_`, so a literal that happens to equal 240..248 would otherwise be corrupted. Packed integer bodies are untouched.
- The rewrite also **declines a source declared 16 bits wide** (`pk16_src_needs_narrowing`): `Operand::read_lane` already resolved that one through the half-precision table, and re-narrowing the 16-bit pattern would read it as an f32 denormal and flush it to zero. CDNA2 builds every packed f16 source that way; CDNA3 does for `v_pk_min_f16` / `v_pk_max_f16`.
- `v_dot2_f32_f16` / `v_dot2_f32_bf16` are the same shape and had the same defect — their two multiplicands are 16-bit even though the accumulator and destination are f32 — so `gen_dot2` routes src0/src1 through the same helper. `src2` is a genuine f32 accumulator and is left alone.
- `v_dot2_f16_f16` / `v_dot2_bf16_bf16` (`gen_dot2_true16`) are VOP3 rather than VOP3P, but src0/src1 are still 32-bit operands consumed as packed v2 halves, so they take the same helper. Only `src2` goes through `read_vop3_true16_src`, which is already 16-bit.
- Knowingly **out of scope** because it is a different shape: `dot4_f32_fp8` (8-bit lanes).
- The packed-fp16 and dot SIMD fast paths **decline** an inline float source, so the narrowing rule has a single home in the scalar body. Hoisting a narrowed splat out of the SIMD chunk loop is possible but would put a second copy of the rule in a second place, which is what this change removes.
- The predicate now has one definition: `simd_glue.h` carried `fma_mix_src_is_float_inline`, a byte-identical copy of `is_inline_float_src` eleven lines away, and the generator open-coded the range test in two more places. All now call `is_inline_float_src`.

The narrowed pattern goes in the **low half only**. The LLVM assembler agrees: it inline-encodes the packed v2f16 immediate `0x00003C00` as `1.0` for `v_pk_add_f16` on gfx950/gfx1201/gfx1250, but spills `0x3C003C00` to a 32-bit literal. `util::f32_to_bf16` truncates rather than rounds, which is also what the assembler expects (bf16 `1/(2*pi)` inline-encodes from `0x3E22`, not `0x3E23`).

This is the packed-16 counterpart of c0c436ea59, which fixed the same class of bug for packed F32.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10328

## Test Plan

`tests/simd_correctness/vop3p_pk_inline_constant_correctness_test.cpp` (11 tests) and `lib/python/amdisa/tests/test_packed_codegen.py` (18 tests).

Behaviour pinned:

- `v_pk_add_f16` / `v_pk_add_bf16` against an inline `1.0` reach both halves.
- Default-packing shape returns `0x3C004000` rather than `0x41C03C00`, and agrees between the scalar body and the SIMD gate.
- `v_pk_fma_f16` with the constant on src2 gives `0x45004500` rather than `0x44004400`.
- Selector 248 narrows to `0x3118` — round-to-nearest-even, matching the emulator's own 16-bit inline table.
- The `v_dot2` forms return `1.0` rather than `0` — `v_dot2_f32_f16`, `v_dot2_f32_bf16` and the true16 `v_dot2_f16_f16`. One case per body: RDNA4 carries its own generated dot2 bodies and every other target shares one template; only the shared one carries the SIMD probe, so that is where the scalar-vs-SIMD comparison runs.

Three controls pin the boundaries: a 32-bit literal valued `0xF2` reads back verbatim — seeded at `2^-13`, where the literal's `242 * 2^-24` lands on a representable f16 so a misapplied narrowing would round it away — `v_pk_add_i16` with an inline integer is unchanged, and CDNA2's 16-bit-wide packed f16 source is left to the half-precision table.

Failure observed before the fix:

```
[ RUN      ] Vop3pPkInlineConstantCorrectness.AddF16InlineOneReachesBothHalves
vop3p_pk_inline_constant_correctness_test.cpp:122: Failure
Expected equality of these values:
  out[lane]
    Which is: 1006648320   (0x3C003C00, the buggy no-op copy)
  want
    Which is: 1073758208   (0x40004000, the correct {2.0h, 2.0h})
v_pk_add_f16 v4, v0, 1.0 op_sel_hi:[1,0]: lane 0
```

Reverting only the dot2 narrowing fails the two dot tests; removing only the SIMD decline gate fails the shared-body agreement test.

## Test Result

```
100% tests passed, 0 tests failed out of 3225
```

