### PR TITLE
fix(rocjitsu): give each wavefront its architected wave id

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -71,6 +71,7 @@ static_assert(kMaxClusterWorkgroups <= 16,
 // and cluster identity sequences.
 constexpr uint32_t kGfx12Ttmp6 = 114;
 constexpr uint32_t kGfx12Ttmp7 = 115;
+constexpr uint32_t kGfx12Ttmp8 = 116;
 constexpr uint32_t kGfx12Ttmp9 = 117;
 
 // LLVM's gfx1250 architected-SGPR ABI maps TTMP6 as seven 4-bit fields:
@@ -84,6 +85,14 @@ constexpr uint32_t kGfx12Ttmp6ClusterMaxYShift = 16;
 constexpr uint32_t kGfx12Ttmp6ClusterMaxZShift = 20;
 constexpr uint32_t kGfx12Ttmp6ClusterMaxFlatIdShift = 24;
 constexpr uint32_t kGfx12Ttmp7ClusterGridDimensionMask = 0xFFFFu;
+
+// TTMP8[29:25] is the wave's index within its workgroup. LLVM lowers
+// llvm.amdgcn.wave.id to exactly this field whenever the subtarget has
+// architected SGPRs -- see legalizeWaveID() and lowerWaveID(), both of which
+// emit an unsigned bitfield extract at offset 25, width 5. A workgroup holds at
+// most 1024 work-items, so at wave32 or wave64 the index always fits in 5 bits.
+constexpr uint32_t kGfx12Ttmp8WaveIdShift = 25;
+constexpr uint32_t kGfx12Ttmp8WaveIdMask = 0x1Fu;
 
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
@@ -397,6 +406,11 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     uint32_t ttmp6 = 0;
     uint32_t ttmp7 = ((wg_id_z & kGfx12Ttmp7ClusterGridDimensionMask) << 16) |
                      (wg_id_y & kGfx12Ttmp7ClusterGridDimensionMask);
+    // Truncating instead would hand two waves the same id, which is exactly
+    // the symptom this field exists to remove -- diagnose rather than mask.
+    assert(wf_index_in_wg <= kGfx12Ttmp8WaveIdMask &&
+           "wave index within workgroup exceeds the 5-bit TTMP8 wave-id field");
+    const uint32_t ttmp8 = (wf_index_in_wg & kGfx12Ttmp8WaveIdMask) << kGfx12Ttmp8WaveIdShift;
     uint32_t ttmp9 = grid_wg_id_x;
     if (properties.uses_cluster_ttmp_workgroup_ids) {
       const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
@@ -424,6 +438,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     }
     cu->write_sgpr(sbase + kGfx12Ttmp6, ttmp6);
     cu->write_sgpr(sbase + kGfx12Ttmp7, ttmp7);
+    cu->write_sgpr(sbase + kGfx12Ttmp8, ttmp8);
     cu->write_sgpr(sbase + kGfx12Ttmp9, ttmp9);
   }
 

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -309,6 +309,41 @@ TEST(Gfx1250SimulationTest, SLoadB32DoesNotScaleImmediateOffset) {
   EXPECT_EQ(sim.snapshot->snapshots().front().sgpr(4), kExpected);
 }
 
+TEST(Gfx1250SimulationTest, TtmpWaveIdCarriesWaveIndexWithinWorkgroup) {
+  // LLVM lowers llvm.amdgcn.wave.id to an unsigned bitfield extract of
+  // TTMP8[29:25] on any subtarget with architected SGPRs (legalizeWaveID(),
+  // lowerWaveID()). Under wavegroup launch mode the backend also builds the
+  // flat work-item ID out of this field rather than reading v0 -- see
+  // buildWorkitemIdWavegroupMode(), which computes mbcnt + (waveId << 5).
+  // Left at zero the field tells every wave in a workgroup that it is wave 0,
+  // so all of them address the slice belonging to the first.
+  // Mirrors kGfx12Ttmp8 / kGfx12Ttmp8WaveIdShift / kGfx12Ttmp8WaveIdMask in
+  // command_processor.cpp, which is a .cpp-local detail of the launch payload.
+  constexpr uint32_t kTtmp8 = 116;
+  constexpr uint32_t kWaveIdShift = 25;
+  constexpr uint32_t kWaveIdMask = 0x1Fu;
+
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  // 128 work-items at wave32 is four waves in a single workgroup.
+  queue.dispatch(kernel_object, 128, 128);
+  step_until_xcd_halted(sim);
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 4u);
+  std::vector<uint32_t> wave_ids;
+  for (const auto &s : sim.snapshot->snapshots()) {
+    // TTMP8 carries no other launch state, so the rest stays clear.
+    EXPECT_EQ(s.sgpr(kTtmp8) & ~(kWaveIdMask << kWaveIdShift), 0u);
+    wave_ids.push_back((s.sgpr(kTtmp8) >> kWaveIdShift) & kWaveIdMask);
+  }
+  // Waves halt in an unspecified order; the dispatch must hand out each index once.
+  std::sort(wave_ids.begin(), wave_ids.end());
+  EXPECT_EQ(wave_ids, (std::vector<uint32_t>{0, 1, 2, 3}));
+}
+
 TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   Gfx1250Sim sim;
   const uint32_t code[] = {S_ENDPGM_GFX12};


### PR DESCRIPTION
## Motivation

CommandProcessor::init_wavefront_regs seeds the architected TTMP launch payload for targets whose isa_properties advertise uses_ttmp_workgroup_ids (RDNA4 and GFX1250) but wrote only TTMP6, TTMP7 and TTMP9; TTMP8 stayed at its zero-initialised value for every wavefront.

## Technical Details

- give each wavefront its architected wave id


## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10329

## Test Plan

New tests:

- `Gfx1250SimulationTest.TtmpWaveIdCarriesWaveIndexWithinWorkgroup`

Failure observed before the fix:

```
/tmp/rj-fix-wave-id/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp:336: Failure
Expected equality of these values:
  wave_ids
    Which is: { 0, 0, 0, 0 }
  (std::vector<uint32_t>{0, 1, 2, 3})
    Which is: { 0, 1, 2, 3 }

[  FAILED  ] Gfx1250SimulationTest.TtmpWaveIdCarriesWaveIndexWithinWorkgroup (708 ms)
```

## Test Result

After the fix the new tests pass and the full suite is green:

```
100% tests passed, 0 tests failed out of 3160
```
