### PR TITLE
fix(rocjitsu): round the scalar matrix reference like the hardware

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -929,10 +929,10 @@ template <typename Run> bool dispatch_matrix_fmt_pair(uint32_t a_fmt, uint32_t b
 /// Cbuf[row*stride+col] += sum_k Abuf[row*K+k] * Bbuf[k*stride+col], run as
 /// native-width rows over the col (N) dimension with a scalar tail. A/B/C must
 /// already be hoisted into dense buffers (lane permutation, per-element scale,
-/// and 2:4 sparsity gather folded in by the caller). Float uses fused FMA
-/// (matching the hardware's single-rounding MACs; the scalar reference is
-/// non-fused, so f32 agrees to a few ULP and packed f16/bf16 rounds identically);
-/// integer MAC is exact, so the SIMD and scalar paths are bit-identical.
+/// and 2:4 sparsity gather folded in by the caller). Float uses fused FMA,
+/// matching the hardware's single-rounding MACs; the scalar references in this
+/// file are fused for the same reason, so the two paths are bit-identical.
+/// Integer MAC is exact and already agreed.
 /// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
 /// on a platform without <experimental/simd>.
 ///
@@ -1238,7 +1238,8 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
   results.reserve(M * N * B);
 
   // Scalar reference: D[i][j] = C[i][j] + sum_k A[i][k] * B[k][j], accumulated
-  // per output in K order (non-fused multiply-add).
+  // per output in K order as fused multiply-adds, matching both the hardware's
+  // single-rounding MACs and the SIMD path below.
   auto run_scalar = [&]() {
     for (uint32_t b = 0; b < B; ++b) {
       for (uint32_t row = 0; row < M; ++row) {
@@ -1260,7 +1261,7 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
               bl.lane = permute_b_lane(bl.lane, blgp);
             float a_val = ea(cu, s0, physicalize_loc(al, wf));
             float b_val = eb(cu, s1, physicalize_loc(bl, wf));
-            acc += a_val * b_val;
+            acc = std::fma(a_val, b_val, acc);
           }
           results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }
@@ -1273,9 +1274,9 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
   // row-major (k,col), and C into (row,col) dense f32 buffers (lane
   // permutation folded in during the hoist), then run the dense MxNxK matmul
   // as native-width FMA rows over the N (column) dimension. Uses fused FMA,
-  // matching the GFX9 MFMA hardware's single-rounding MACs (the scalar path
-  // above is non-fused; results agree to a few ULP). N columns that don't
-  // fill a full SIMD lane group fall to a scalar (fused) tail.
+  // matching the GFX9 MFMA hardware's single-rounding MACs and the scalar path
+  // above bit for bit. N columns that don't fill a full SIMD lane group fall to
+  // a scalar (fused) tail.
   if constexpr (util::has_stdx_simd) {
     // Pad the column (N) leading dimension up to a SIMD-width multiple so
     // every matmul row starts W-aligned: the inner loop then uses aligned
@@ -1429,7 +1430,7 @@ void exec_packed16_gfx9(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B
         for (uint32_t k = 0; k < K; ++k) {
           auto al = physicalize_loc(input_loc(M, K, B, row, k, b, in_bits), wf);
           auto bl = physicalize_loc(input_loc(N, K, B, col, k, b, in_bits), wf);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+          acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
         }
         results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
       }
@@ -1588,7 +1589,7 @@ void exec_wmma_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t 
         for (uint32_t k = 0; k < K; ++k) {
           auto al = gfx12_wmma_a_input_loc(wave_size, M, K, row, k, a_bits, b_bits);
           auto bl = gfx12_wmma_b_input_loc(wave_size, N, K, col, k, a_bits, b_bits);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+          acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
         }
         results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
@@ -1665,7 +1666,7 @@ void exec_gfx11_wmma_f32_mixed(auto &cu, uint32_t wave_size, uint32_t M, uint32_
       for (uint32_t k = 0; k < K; ++k) {
         auto al = gfx11_wmma_input_loc(M, K, row, k, a_bits, lane_group);
         auto bl = gfx11_wmma_input_loc(N, K, col, k, b_bits, lane_group);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
     }
@@ -1709,7 +1710,7 @@ void exec_gfx11_wmma_packed16(auto &cu, uint32_t wave_size, uint32_t M, uint32_t
       for (uint32_t k = 0; k < K; ++k) {
         auto al = gfx11_wmma_input_loc(M, K, row, k, in_bits, lane_group);
         auto bl = gfx11_wmma_input_loc(N, K, col, k, in_bits, lane_group);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
       }
       results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
     }
@@ -1814,9 +1815,9 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
           auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
           const uint32_t a_scale_byte = wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16);
           const uint32_t b_scale_byte = wmma_f8f6f4_scale_byte(k, b_bits, mixed_pair, scale16);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl) *
-                 scale_for(a_scale_word, a_scale_byte, matrix_a_scale_fmt) *
-                 scale_for(b_scale_word, b_scale_byte, matrix_b_scale_fmt);
+          acc = std::fma(ea(cu, s0, al) * scale_for(a_scale_word, a_scale_byte, matrix_a_scale_fmt),
+                         eb(cu, s1, bl) * scale_for(b_scale_word, b_scale_byte, matrix_b_scale_fmt),
+                         acc);
         }
         results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
@@ -2282,7 +2283,7 @@ void exec_swmmac_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_
         for (uint32_t ck = 0; ck < compressed_k; ++ck) {
           auto al = swmmac_a_input_loc(wave_size, M, K, row, ck, a_bits);
           auto bl = swmmac_b_input_loc(wave_size, N, K, col, dense_k_for(row, ck), b_bits);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+          acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
         }
         results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
@@ -2367,7 +2368,7 @@ void exec_wmma_packed16(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t i
         for (uint32_t k = 0; k < K; ++k) {
           auto al = gfx12_wmma_input_loc(wave_size, M, K, row, k, in_bits);
           auto bl = gfx12_wmma_input_loc(wave_size, N, K, col, k, in_bits);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+          acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
         }
         results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
       }
@@ -2464,7 +2465,7 @@ inline void exec_wmma_bf16f32_16x16x32_bf16(auto &cu, uint32_t dst, uint32_t s0,
       for (uint32_t k = 0; k < K; ++k) {
         auto al = wmma_input_loc(M, K, row, k, in_bits);
         auto bl = wmma_input_loc(N, K, col, k, in_bits);
-        acc += extract_bf16(cu, s0, al) * extract_bf16(cu, s1, bl);
+        acc = std::fma(extract_bf16(cu, s0, al), extract_bf16(cu, s1, bl), acc);
       }
       auto out = wmma_output_loc_16(M, N, row, col);
       results.push_back({out.reg, out.lane, out.sub_element, util::f32_to_bf16(acc)});
@@ -2531,7 +2532,7 @@ void exec_swmmac_packed16(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t
         for (uint32_t ck = 0; ck < compressed_k; ++ck) {
           auto al = swmmac_a_input_loc(wave_size, M, K, row, ck, in_bits);
           auto bl = swmmac_b_input_loc(wave_size, N, K, col, dense_k_for(row, ck), in_bits);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+          acc = std::fma(ea(cu, s0, al), eb(cu, s1, bl), acc);
         }
         results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
       }
@@ -3024,8 +3025,8 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
                 al.lane = permute_a_lane(al.lane, cbsz, abid);
               if (blgp != 0)
                 bl.lane = permute_b_lane(bl.lane, blgp);
-              block_sum +=
-                  ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
+              block_sum = std::fma(ea(cu, s0, physicalize_loc(al, wf)),
+                                   eb(cu, s1, physicalize_loc(bl, wf)), block_sum);
             }
             acc += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
           }
@@ -3155,7 +3156,8 @@ void exec_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_
           for (uint32_t k = k_start; k < k_end; ++k) {
             auto al = input_loc(M, K, B, row, k, b, a_bits);
             auto bl = input_loc(N, K, B, col, k, b, b_bits);
-            block_sum += ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
+            block_sum = std::fma(ea(cu, s0, physicalize_loc(al, wf)),
+                                 eb(cu, s1, physicalize_loc(bl, wf)), block_sum);
           }
           uint32_t sa_raw = RegisterAccess(cu).read_vgpr(scale_a_base, M * blk + row);
           uint32_t sb_raw = RegisterAccess(cu).read_vgpr(scale_b_base, N * blk + col);
@@ -3625,8 +3627,8 @@ inline void exec_f64(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
           for (uint32_t k = 0; k < K; ++k) {
             auto al = input_loc(M, K, B, row, k, b, 64);
             auto bl = input_loc(N, K, B, col, k, b, 64);
-            acc +=
-                apply_neg(extract_f64(cu, s0, al), 0x1u) * apply_neg(extract_f64(cu, s1, bl), 0x2u);
+            acc = std::fma(apply_neg(extract_f64(cu, s0, al), 0x1u),
+                           apply_neg(extract_f64(cu, s1, bl), 0x2u), acc);
           }
           uint64_t bits = std::bit_cast<uint64_t>(acc);
           results.push_back(
@@ -3816,7 +3818,7 @@ void exec_smfmac_f32_16x16x32_f16(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
         int p0 = field & 3, p1 = (field >> 2) & 3;
         for (int s = 0; s < 2; ++s) {
           float av = ex(cu, s0, (2 * q + s) % 4, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -3854,7 +3856,7 @@ void exec_smfmac_f32_32x32x16_f16(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
         int p0 = field & 3, p1 = (field >> 2) & 3;
         for (int s = 0; s < 2; ++s) {
           float av = ex(cu, s0, (2 * q + s) % 4, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -3891,7 +3893,7 @@ void exec_smfmac_f32_16x16x64_f16(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
         int p0 = field & 3, p1 = (field >> 2) & 3;
         for (int s = 0; s < 2; ++s) {
           float av = ex(cu, s0, (2 * q + s) % 8, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -3931,7 +3933,7 @@ void exec_smfmac_f32_32x32x32_f16(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
         int p0 = field & 3, p1 = (field >> 2) & 3;
         for (int s = 0; s < 2; ++s) {
           float av = ex(cu, s0, (2 * q + s) % 8, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -3973,7 +3975,7 @@ void exec_smfmac_f32_16x16x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
           int cc = 2 * q + s;
           int byte = 4 * (cc / 16) + (cc % 16) % 4;
           float av = ea(cu, s0, byte, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -4017,7 +4019,7 @@ void exec_smfmac_f32_32x32x32_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
           int cc = 2 * q + s;
           int byte = 4 * (cc / 8) + (cc % 8) % 4;
           float av = ea(cu, s0, byte, laneA);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -4059,7 +4061,7 @@ void exec_smfmac_f32_16x16x128_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t
           int hb = 2 * ((cc >> 2) & 1) + ((cc >> 4) & 1);
           int byte = 4 * hb + (cc & 3);
           float av = ea(cu, s0, byte, ga * 16 + row);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -4103,7 +4105,7 @@ void exec_smfmac_f32_32x32x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
           int hb = 2 * ((cc >> 2) & 1) + ((cc >> 3) & 1);
           int byte = 4 * hb + (cc & 3);
           float av = ea(cu, s0, byte, ga * 32 + row);
-          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+          acc = std::fma(av, Bcol[4 * q + (s == 0 ? p0 : p1)], acc);
         }
       }
       results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -452,6 +452,7 @@ add_executable(
     register_access_test.cpp
     register_file_test.cpp
     simd_correctness/mfma_lazy_storage_test.cpp
+    simd_correctness/mma_fused_mac_test.cpp
     vgpr_redispatch_test.cpp
     instruction_execution_harness_test.cpp
     isa_target_registry_test.cpp

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -8,8 +8,8 @@
 ///
 /// Each case runs identical pre-seeded VGPR state through the forced-scalar
 /// path then the SIMD path and asserts the full dst window matches word for
-/// word. Inputs are rounding-free (see mma_exact_test_support.h) so fused
-/// (SIMD) and non-fused (scalar) accumulation cannot legitimately differ.
+/// word. Inputs are rounding-free (see mma_exact_test_support.h) so the two
+/// paths cannot legitimately differ even where a K-sum would otherwise round.
 
 #include "mma_exact_test_support.h"
 

--- a/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
+++ b/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
@@ -4,8 +4,8 @@
 /// @file mma_exact_test_support.h
 /// @brief Shared fixture for MFMA/WMMA SIMD-vs-scalar bit-exact tests.
 ///
-/// The fused-FMA SIMD path and the non-fused scalar path can only round apart
-/// when an intermediate K-sum actually rounds, so the random generators seed
+/// Both paths issue fused MACs, so they can only round apart when an
+/// intermediate K-sum actually rounds; the random generators therefore seed
 /// integer-valued elements that stay exact through every product and partial
 /// sum (max |prod| 64, max K-sum 8192 < 2^24); boundary modes drive the
 /// rounding-free corners directly (NaN, +/-Inf, +/-0, denormals, max-finite

--- a/emulation/rocjitsu/tests/simd_correctness/mma_fused_mac_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mma_fused_mac_test.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mma_fused_mac_test.cpp
+/// @brief One matrix instruction returns one answer: the scalar reference and
+/// the SIMD core of the MFMA kernels round their MACs the same way.
+///
+/// The kernels in mma_exec.h carry two implementations of every f32/f64 matrix
+/// instruction -- a scalar reference and a stdx::simd core -- and the emulator
+/// picks between them on RJ_FORCE_SCALAR, AVX-512 availability and the shape.
+/// The SIMD core has always issued a fused FMA, matching the hardware's
+/// single-rounding MACs; the scalar reference multiplied and then added, so
+/// whenever the product itself rounds the two disagreed. Witnessing that needs
+/// f32 or f64 inputs: an f16/bf16/fp8 product is exact in f32, so those formats
+/// never showed it (which is why the existing bit-exact suites stayed green).
+///
+/// Both witnesses use the same construction. Every A element is a, every B
+/// element is b, and their exact product a*b needs one more bit than the format
+/// holds, so rounding it alone loses a low term d. C is seeded to -K*round(a*b),
+/// which makes the non-fused path cancel to exactly +0 while the fused path
+/// keeps the K accumulated copies of d -- the whole answer, not one low bit.
+
+#include "mma_exact_test_support.h"
+
+namespace {
+
+using namespace rocjitsu;
+using namespace mma_exact;
+
+// --- v_mfma_f32_16x16x4_f32 (wave64) ---
+//
+// a = 1 + 2^-12, b = 1 + 2^-13. The exact product is 1 + 2^-12 + 2^-13 + 2^-25;
+// rounding it to f32 on its own drops the 2^-25 (ulp(1.0) = 2^-23).
+constexpr uint32_t F32_A = 0x3F800800u; // 1 + 2^-12
+constexpr uint32_t F32_B = 0x3F800400u; // 1 + 2^-13
+// C = -4 * round(a*b) = -(4 + 2^-10 + 2^-11), exact in f32.
+constexpr uint32_t F32_C = 0xC0800C00u;
+// Four fused MACs keep the 2^-25 term at every step and land on 4 * 2^-25.
+constexpr uint32_t F32_FUSED = 0x33000000u; // 2^-25
+// Four pre-rounded products cancel C exactly.
+constexpr uint32_t F32_NON_FUSED = 0x00000000u;
+
+// --- v_mfma_f64_16x16x4_f64 (wave64) ---
+//
+// a = b = 1 + 2^-27. The exact square is 1 + 2^-26 + 2^-54; rounding it to f64
+// on its own drops the 2^-54 (ulp(1.0) = 2^-52).
+constexpr uint64_t F64_A = 0x3FF0000002000000ull; // 1 + 2^-27
+// C = -4 * round(a*a) = -(4 + 2^-24), exact in f64.
+constexpr uint64_t F64_C = 0xC010000004000000ull;
+constexpr uint64_t F64_FUSED = 0x3C90000000000000ull; // 4 * 2^-54 = 2^-52
+constexpr uint64_t F64_NON_FUSED = 0ull;
+
+void fill(ExactFixture &fx, uint32_t off, uint32_t regs, uint32_t word) {
+  for (uint32_t reg = 0; reg < regs; ++reg)
+    for (uint32_t lane = 0; lane < fx.wf_size; ++lane)
+      fx.cu->write_vgpr(fx.vbase + off + reg, lane, word);
+}
+
+// 64-bit elements occupy (lo,hi) register pairs; every element gets `value`.
+void fill64(ExactFixture &fx, uint32_t off, uint32_t regs, uint64_t value) {
+  for (uint32_t reg = 0; reg + 1 < regs; reg += 2)
+    for (uint32_t lane = 0; lane < fx.wf_size; ++lane) {
+      fx.cu->write_vgpr(fx.vbase + off + reg, lane, static_cast<uint32_t>(value));
+      fx.cu->write_vgpr(fx.vbase + off + reg + 1, lane, static_cast<uint32_t>(value >> 32));
+    }
+}
+
+// Run `kernel` with the force-scalar gate at `scalar` and assert the dst window
+// matches; `word_expect` maps a word index to its expected value so 64-bit
+// results can alternate lo/hi.
+void expect_dst(const char *label, bool scalar, ExactFixture &fx, const std::function<void()> &seed,
+                const std::function<void()> &kernel, uint32_t dst_off, uint32_t dst_regs,
+                const std::function<uint32_t(size_t)> &word_expect) {
+  ForceScalarGuard guard;
+  seed();
+  util::set_force_scalar_for_testing(scalar);
+  kernel();
+  util::set_force_scalar_for_testing(false);
+  auto got = fx.snapshot(dst_off, dst_regs);
+  for (size_t word = 0; word < got.size(); ++word)
+    ASSERT_EQ(got[word], word_expect(word))
+        << label << (scalar ? " [scalar]" : " [simd]") << ": word " << std::dec << word << " is 0x"
+        << std::hex << got[word] << ", want 0x" << word_expect(word);
+}
+
+constexpr uint32_t S0 = 0, S1 = 8, DST = 16;
+constexpr uint32_t F32_IN_REGS = 2, F32_DST_REGS = 4;
+
+TEST(MmaFusedMac, MfmaF32ScalarAndSimdAgreeOnARoundingProduct) {
+  // Guard the witness: the two candidate answers must differ, or the test would
+  // pass no matter which MAC the kernels use.
+  ASSERT_NE(F32_FUSED, F32_NON_FUSED);
+  auto expect_fused = [](size_t) { return F32_FUSED; };
+  for (bool scalar : {true, false}) {
+    ExactFixture fx(ROCJITSU_CODE_ARCH_CDNA4, mma_test::MFMA_WF_SIZE);
+    ASSERT_NE(fx.wf, nullptr);
+    auto seed = [&] {
+      fill(fx, S0, F32_IN_REGS, F32_A);
+      fill(fx, S1, F32_IN_REGS, F32_B);
+      fill(fx, DST, F32_DST_REGS, 0);
+    };
+    // Generic executor.
+    expect_dst(
+        "exec_f32 16x16x4", scalar, fx, seed,
+        [&] {
+          amdgpu::exec_f32(*fx.cu, 16, 16, 4, 1, 32, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
+                           fx.vbase + DST, amdgpu::extract_f32, amdgpu::extract_f32, F32_C);
+        },
+        DST, F32_DST_REGS, expect_fused);
+    if (testing::Test::HasFatalFailure())
+      return;
+    // Specialized fast path for the same instruction.
+    expect_dst(
+        "exec_f32_mfma_f32_spec<16,16,4,1>", scalar, fx, seed,
+        [&] {
+          amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(
+              *fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + DST, F32_C, 0, 0, 0);
+        },
+        DST, F32_DST_REGS, expect_fused);
+    if (testing::Test::HasFatalFailure())
+      return;
+  }
+}
+
+constexpr uint32_t F64_S0 = 0, F64_S1 = 8, F64_ACC = 16, F64_DST = 32;
+constexpr uint32_t F64_IN_REGS = 2, F64_ACC_REGS = 8, F64_DST_REGS = 8;
+
+TEST(MmaFusedMac, MfmaF64ScalarAndSimdAgreeOnARoundingProduct) {
+  ASSERT_NE(F64_FUSED, F64_NON_FUSED);
+  // Results land as (lo,hi) register pairs.
+  auto expect_fused = [](size_t word) {
+    const bool hi = ((word / mma_test::MFMA_WF_SIZE) & 1u) != 0;
+    return static_cast<uint32_t>(hi ? (F64_FUSED >> 32) : F64_FUSED);
+  };
+  for (bool scalar : {true, false}) {
+    ExactFixture fx(ROCJITSU_CODE_ARCH_CDNA4, mma_test::MFMA_WF_SIZE);
+    ASSERT_NE(fx.wf, nullptr);
+    expect_dst(
+        "exec_f64 16x16x4", scalar, fx,
+        [&] {
+          fill64(fx, F64_S0, F64_IN_REGS, F64_A);
+          fill64(fx, F64_S1, F64_IN_REGS, F64_A);
+          fill64(fx, F64_ACC, F64_ACC_REGS, F64_C);
+          fill(fx, F64_DST, F64_DST_REGS, 0);
+        },
+        [&] {
+          amdgpu::exec_f64(*fx.cu, 16, 16, 4, 1, fx.vbase + F64_DST, fx.vbase + F64_S0,
+                           fx.vbase + F64_S1, fx.vbase + F64_ACC);
+        },
+        F64_DST, F64_DST_REGS, expect_fused);
+    if (testing::Test::HasFatalFailure())
+      return;
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Fixes #10330.

## Problem

Every f32/f64 matrix instruction in `mma_exec.h` is implemented **twice** — a scalar reference and a `std::experimental::simd` core — and the emulator picks between them at run time on `RJ_FORCE_SCALAR`, AVX-512 availability and the shape.

The SIMD core issues a **fused** FMA, matching the hardware's single-rounding MACs. The scalar reference multiplied and *then* added:

```cpp
acc += a_val * b_val;          // two roundings
```

So whenever the product itself rounds, the two implementations return **different answers for the same instruction**, and which one a guest sees depends on the host CPU and on an environment variable. The SIMD answer is the correct one; the scalar reference was wrong.

## Fix

Use `std::fma` for every float MAC in the file. Integer MACs are exact and are left alone.

Eight kernels have a SIMD counterpart that the scalar reference now matches bit for bit:

`exec_f32_mixed`, `exec_wmma_f32_mixed`, `exec_wmma_f32_scaled_mixed`, `exec_swmmac_f32_mixed`, `exec_wmma_packed16`, `exec_swmmac_packed16`, `exec_f32_scaled`, `exec_f64`.

The rest are scalar-only today — the two gfx11 WMMA kernels, `exec_packed16_gfx9`, `exec_wmma_bf16f32_16x16x32_bf16`, `exec_f32_scaled_mixed` and the eight specialised SMFMAC kernels. There is no divergence to witness there, but they were rounding twice where the hardware rounds once, and one rule everywhere keeps the bug from returning the day one of them grows a SIMD path.

`exec_wmma_f32_scaled_mixed` also moves the per-operand scales inside the multiply — `fma(a * sa, b * sb, acc)` — which is exactly what its SIMD hoist already does when it pre-scales `Abuf` and `Bbuf`.

## Why the existing suites stayed green

`MfmaSimdExact` / `WmmaSimdExact` seed integer-valued elements that stay exact through every product and partial sum, and f16/bf16/fp8 products are exact in f32. No product ever rounded, so no divergence could appear. Witnessing this needs **f32 or f64 inputs**.

## Test

`tests/simd_correctness/mma_fused_mac_test.cpp` (new, 156 lines) pins both paths of `v_mfma_f32_16x16x4_f32` — the generic executor and the specialised `exec_f32_mfma_f32_spec<16,16,4,1>` — and `v_mfma_f64_16x16x4_f64`, each run twice under a `ForceScalarGuard` (scalar and SIMD).

Each test fills A with `a` and B with `b` whose exact product needs one bit more than the format holds, and seeds C with `-K * round(a*b)`. The non-fused path then cancels to exactly `+0`; the fused path keeps all four copies of the dropped low term, so the disagreement is the whole answer rather than one low bit:

| | a | b | C | non-fused | fused |
|---|---|---|---|---|---|
| f32 | `1 + 2^-12` | `1 + 2^-13` | `-(4 + 2^-10 + 2^-11)` | `0x00000000` | `0x33000000` (2^-25) |
| f64 | `1 + 2^-27` | `1 + 2^-27` | `-(4 + 2^-24)` | `0x0000000000000000` | `0x3C90000000000000` (2^-52) |

**Failed first.** With the `std::fma` change reverted and the tests in place:

```
[ RUN      ] MmaFusedMac.MfmaF32ScalarAndSimdAgreeOnARoundingProduct
exec_f32 16x16x4 [scalar]: word 0 is 0x0, want 0x33000000
[  FAILED  ] MmaFusedMac.MfmaF32ScalarAndSimdAgreeOnARoundingProduct
[ RUN      ] MmaFusedMac.MfmaF64ScalarAndSimdAgreeOnARoundingProduct
exec_f64 16x16x4 [scalar]: word 64 is 0x0, want 0x3c900000
[  FAILED  ] MmaFusedMac.MfmaF64ScalarAndSimdAgreeOnARoundingProduct
```

The SIMD iterations passed in that same pre-fix run — confirming the SIMD core was already fused and the scalar reference was the side that was wrong.

## Verification

- `MmaFusedMac.*` — 2/2 pass.
- Full suite — `100% tests passed, 0 tests failed out of 3218`.
- `-DRJ_ENABLE_EXPENSIVE_CHECKS=ON`: `MfmaSimdExact` / `WmmaSimdExact` / `MmaFusedMac` — 26 passed, 4 skipped (pre-existing skips).

## Scope

`emulation/` only; one commit; no generated files and no submodule bumps.

`mma_exec.h` is **+35 / -33** — the doc comments that described the scalar path as non-fused are corrected in the same commit, as are the two lines in `mma_exact_test_support.h` / `mfma_simd_exact_test.cpp` that explained why those suites avoid rounding.

## Not in this PR

The K-accumulator is still f32 for f32-output kernels, so a long K sum can lose bits the hardware keeps. That is a separate behaviour change (round-once-on-store with a wider accumulator) resting on a hardware model this tree does not establish, so it is filed as #10344 rather than folded in here.
