### PR TITLE
fix(rocjitsu): back caller-placed allocations at KFD map time

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1451,7 +1451,11 @@ int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
         proc.imported_dmabufs_.erase(dmabuf_it);
       }
     }
-    if (alloc.host_ptr && !alloc.user_va)
+    // unmap_from_gpu only drops page-table entries; it never munmaps, so it is
+    // safe for a caller-placed range whose pages the driver does not own. FREE
+    // erases the allocation record below, so skipping it here would strand live
+    // PTEs pointing into memory the caller is free to reuse.
+    if (alloc.host_ptr)
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
     if (alloc.memfd >= 0) {
       {
@@ -1498,6 +1502,45 @@ int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
                       alloc.handle, alloc.gpu_va, alloc.size, args->n_devices,
                       alloc.host_ptr != nullptr);
   });
+  // A caller-placed allocation reaches MAP with no backing store: ROCr reserves
+  // the VA itself with a PROT_NONE mmap and asks the driver to back it, and for
+  // such an allocation alloc_memory_ioctl deliberately creates neither a memfd
+  // nor a host mapping. MAP is then the only chance to back it (no mmap of the
+  // KFD fd follows for device memory), so adopt the caller's reservation the way
+  // dispatch_mmap adopts MAP_FIXED pages: lift the PROT_NONE and keep the pages
+  // caller-owned so teardown never unmaps them. USERPTR already carries the
+  // caller's own pages, and a DOORBELL range must keep reaching the doorbell
+  // path rather than become ordinary memory. Daemon mode is excluded because
+  // the guest's pages are in another process there and MAP has a memfd to work
+  // with; backing it is a separate change.
+  //
+  // The cost is that the caller's PROT_NONE reservation becomes readable and
+  // writable for the life of the allocation, so a stray host dereference of a
+  // device pointer no longer faults the way it would on real hardware. That is
+  // the same trade dispatch_mmap already makes, and the alternative is a range
+  // the GPU cannot translate at all.
+  const bool is_userptr = (alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR) != 0;
+  const bool is_doorbell = (alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL) != 0;
+  if (!daemon_mode_ && alloc.user_va && alloc.host_ptr == nullptr && !is_userptr && !is_doorbell) {
+    auto *reserved = reinterpret_cast<void *>(alloc.gpu_va);
+    if (libc_passthrough().mprotect(reserved, alloc.size, PROT_READ | PROT_WRITE) == 0) {
+      alloc.host_ptr = reserved;
+      alloc.host_ptr_owned = false;
+    } else {
+      // mprotect failing says the range is not wholly mapped in this process,
+      // which for a local caller means it never reserved this VA. Report
+      // success anyway and leave the range unbacked: such a client used to fall
+      // through to passthrough, and a newly failing ioctl would regress it.
+      // Note mprotect is not required to be atomic -- on a range with a hole
+      // Linux may widen the mapped prefix before returning ENOMEM -- so the
+      // caller's pages can come back readable even down this path.
+      const int mprotect_errno = errno; // Logger::cp below may clobber it.
+      util::Logger::cp([&](auto &os) {
+        os << std::format("MAP_MEMORY_UNBACKED handle={} gpu_va={:#x} size={} errno={}",
+                          alloc.handle, alloc.gpu_va, alloc.size, mprotect_errno);
+      });
+    }
+  }
   if (alloc.host_ptr)
     map_to_gpu(proc, alloc.gpu_va, alloc.host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));
   args->n_success = args->n_devices;

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -2057,6 +2058,159 @@ TEST_F(KfdIoctlTest, DestructorDrainsMultiplyOpenedProcess) {
   }
   // No crash / no leak reported == pass. (pid intentionally unused past scope.)
   (void)pid;
+}
+
+// ROCr places its own VA for a device allocation: it reserves the range with a
+// PROT_NONE mmap, calls ALLOC_MEMORY_OF_GPU with that va_addr, and then asks the
+// driver to back it with MAP_MEMORY_TO_GPU -- no mmap of the KFD fd ever follows
+// for VRAM. MAP is therefore the only chance the driver gets to make the range
+// usable, so it must back the reservation and enter it into the process page
+// table. Regression: MAP only mapped an allocation that already had a host
+// pointer, which a caller-placed allocation never has, so the range stayed
+// absent from the page table and accesses only "worked" by falling through to
+// passthrough.
+TEST_F(KfdIoctlTest, MapMemoryBacksCallerPlacedAllocation) {
+  constexpr size_t kSize = 2 * rocjitsu::KfdProcess::kPageSize;
+  void *reserved =
+      mmap(nullptr, kSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  ASSERT_NE(reserved, MAP_FAILED);
+  const auto gpu_va = reinterpret_cast<uint64_t>(reserved);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = gpu_va;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+  EXPECT_EQ(alloc.va_addr, gpu_va);
+
+  uint32_t gpu_id = kGpuId;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(map.n_success, 1u);
+
+  auto proc = driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(proc, nullptr);
+  {
+    std::shared_lock<std::shared_mutex> lock(proc->page_table_mutex_);
+    for (uint64_t offset = 0; offset < kSize; offset += rocjitsu::KfdProcess::kPageSize) {
+      auto page = proc->page_table_.find((gpu_va + offset) >> rocjitsu::KfdProcess::kPageShift);
+      ASSERT_NE(page, proc->page_table_.end()) << "gpu_va+" << offset << " is not mapped";
+      ASSERT_EQ(page->second.host_extents.size(), 1u);
+      EXPECT_EQ(page->second.host_extents.front().host_ptr,
+                static_cast<uint8_t *>(reserved) + offset);
+    }
+  }
+
+  // The adopted reservation must be readable/writable storage: the caller mapped
+  // it PROT_NONE, so a page table entry pointing at pages the driver never
+  // unprotected would fault on first access.
+  auto *backing = static_cast<volatile uint32_t *>(reserved);
+  backing[0] = 0xfeedfaceu;
+  EXPECT_EQ(backing[0], 0xfeedfaceu);
+
+  kfd_ioctl_unmap_memory_from_gpu_args unmap{};
+  unmap.handle = alloc.handle;
+  unmap.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  unmap.n_devices = 1;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU, &unmap), 0);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  munmap(reserved, kSize);
+}
+
+// FREE releases the allocation record, so it must also drop the page-table
+// entries for it -- a client is not required to UNMAP first. Regression: FREE
+// skipped the teardown for any caller-placed allocation, which was inert while
+// such an allocation never had a host pointer and became live once MAP started
+// backing them, stranding PTEs that point into memory the caller may reuse.
+TEST_F(KfdIoctlTest, FreeWithoutUnmapDropsCallerPlacedPageTableEntries) {
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+  void *reserved =
+      mmap(nullptr, kSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  ASSERT_NE(reserved, MAP_FAILED);
+  const auto gpu_va = reinterpret_cast<uint64_t>(reserved);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = gpu_va;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  uint32_t gpu_id = kGpuId;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+
+  auto proc = driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(proc, nullptr);
+  const uint64_t page = gpu_va >> rocjitsu::KfdProcess::kPageShift;
+  {
+    std::shared_lock<std::shared_mutex> lock(proc->page_table_mutex_);
+    ASSERT_NE(proc->page_table_.find(page), proc->page_table_.end());
+  }
+
+  // No UNMAP: FREE alone must leave nothing behind.
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+  {
+    std::shared_lock<std::shared_mutex> lock(proc->page_table_mutex_);
+    EXPECT_EQ(proc->page_table_.find(page), proc->page_table_.end());
+  }
+
+  munmap(reserved, kSize);
+}
+
+// A caller-placed VA need not be a host VA at all: a client may hand the driver
+// a GPU-only address it never reserved in its own address space. Backing it is
+// then impossible, and MAP must tolerate that -- report success and leave the
+// range unbacked (the pre-existing passthrough behaviour) rather than fail the
+// ioctl for a client that used to get away with it.
+TEST_F(KfdIoctlTest, MapMemoryToleratesCallerPlacedVaThatIsNotAHostVa) {
+  constexpr uint64_t kGpuOnlyVa = 0x0000210000000000ULL;
+  constexpr size_t kSize = rocjitsu::KfdProcess::kPageSize;
+
+  // Precondition: the VA really is absent from this process's address space, so
+  // the driver cannot back it. mincore reports ENOMEM for an unmapped range.
+  std::array<uint8_t, 1> resident{};
+  ASSERT_EQ(mincore(reinterpret_cast<void *>(kGpuOnlyVa), kSize, resident.data()), -1);
+  ASSERT_EQ(errno, ENOMEM);
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kGpuOnlyVa;
+  alloc.size = kSize;
+  alloc.gpu_id = kGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0);
+
+  uint32_t gpu_id = kGpuId;
+  kfd_ioctl_map_memory_to_gpu_args map{};
+  map.handle = alloc.handle;
+  map.device_ids_array_ptr = reinterpret_cast<uint64_t>(&gpu_id);
+  map.n_devices = 1;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_MAP_MEMORY_TO_GPU, &map), 0);
+  EXPECT_EQ(map.n_success, 1u);
+
+  auto proc = driver_->find_process(driver_->local_process_id());
+  ASSERT_NE(proc, nullptr);
+  {
+    std::shared_lock<std::shared_mutex> lock(proc->page_table_mutex_);
+    EXPECT_EQ(proc->page_table_.count(kGpuOnlyVa >> rocjitsu::KfdProcess::kPageShift), 0u);
+  }
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
 }
 
 TEST_F(KfdIoctlTest, DbgTrapDeviceSnapshotEnumeratesAgent) {


### PR DESCRIPTION
## Motivation

`SimulatedKfd::map_memory_ioctl` never backs a caller-placed allocation.

In local (non-daemon) mode `alloc_memory_ioctl` creates neither a memfd nor a
host mapping when the caller supplies `va_addr` and the allocation is not
`USERPTR`, so `alloc.host_ptr` stays null. `map_memory_ioctl` then gates its
backing on `if (alloc.host_ptr && !alloc.user_va)` and skips it, and MAP is the
last chance to back the allocation — no `mmap` of the KFD fd follows for device
memory.

This is the shape ROCr actually uses: it reserves the VA itself with a
`PROT_NONE` mmap and asks the driver to back it. Today that only appears to
work because the access falls through to passthrough.

## Technical Details

At MAP time, adopt the caller's reservation the way `dispatch_mmap` already
adopts `MAP_FIXED` pages: lift the `PROT_NONE` with `mprotect` and record the
pages as caller-owned (`host_ptr_owned = false`) so teardown never unmaps
memory the caller owns.

Guarded to the case it is meant for — local mode only, only when there is a
`user_va` and no `host_ptr`, and never for `USERPTR` (which already carries the
caller's own pages) or `DOORBELL` (which must keep reaching the doorbell path).

If the `mprotect` fails, the GPU VA was never a host VA the caller reserved.
That is left unbacked and the ioctl still reports success, because such a
client previously fell through to passthrough and a failing ioctl would be a
regression for it. The case is logged through `util::Logger::vm`.

Changed files:

- `emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp`
- `emulation/rocjitsu/tests/kfd_ioctl_test.cpp`

### Scope note

An earlier revision of this PR also tagged tensor-DMA byte copies with the
issuing process id. That half is now **already fixed on `develop`** —
`Wavefront::write_gpu_memory()` passes `process_id_` through to
`memory->write_block()`, and `copy_dense_tensor` routes through it (#9775).
This PR has been narrowed to the KFD half, which is still present.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10331

## Test Plan

Written test-first: the regression tests were added and observed to fail
against `develop` before any source change, then the fix was applied and the
tests re-run.

## Test Result

Full suite on current `develop` (60c29efb39): **100% tests passed, 0 failed out
of 3218**.
