### PR TITLE
fix(clr) : Avoid creating temp file in cwd for unique name generation…

### DIFF
--- a/projects/clr/hipamd/src/hip_comgr_helper.cpp
+++ b/projects/clr/hipamd/src/hip_comgr_helper.cpp
@@ -5,8 +5,11 @@
  */
 
 #include "hip_comgr_helper.hpp"
+#include <atomic>
 #if defined(_WIN32)
-#include <io.h>
+#include <process.h>
+#else
+#include <unistd.h>
 #endif
 #include "../src/amd_hsa_elf.hpp"
 
@@ -548,20 +551,22 @@ bool createExecutable(const comgr_helper::ComgrDataSetUniqueHandle& linkInputs,
 }
 
 void GenerateUniqueFileName(std::string& name) {
-#if !defined(_WIN32)
-  char* name_template = const_cast<char*>(name.c_str());
-  int temp_fd = mkstemp(name_template);
+  // Generate the unique Comgr label in memory (pid + atomic counter) instead of
+  // mkstemp, which created/unlinked a temp file in the CWD at scale (ROCM-29636).
+  static std::atomic<uint64_t> counter{0};
+#if defined(_WIN32)
+  const auto pid = _getpid();
 #else
-  char* name_template = new char[name.length() + 1];
-  strcpy_s(name_template, name.length() + 1, name.data());
-  int sizeinchars = strnlen(name_template, 20) + 1;
-  _mktemp_s(name_template, sizeinchars);
+  const auto pid = getpid();
 #endif
-  name = name_template;
-#if !defined(_WIN32)
-  unlink(name_template);
-  close(temp_fd);
-#endif
+  // Strip a trailing mkstemp-style "XXXXXX" template if present, then append a
+  // process-unique suffix (e.g. "CompileSourceXXXXXX" -> "CompileSource1234_0").
+  const size_t last_non_x = name.find_last_not_of('X');
+  if (last_non_x != std::string::npos) {
+    name.resize(last_non_x + 1);
+  }
+  name += std::to_string(static_cast<int64_t>(pid)) + "_" +
+          std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
 }
 
 bool demangleName(const std::string& mangledName, std::string& demangledName) {

--- a/projects/clr/hipamd/src/hip_comgr_helper.cpp
+++ b/projects/clr/hipamd/src/hip_comgr_helper.cpp
@@ -559,11 +559,13 @@ void GenerateUniqueFileName(std::string& name) {
 #else
   const auto pid = getpid();
 #endif
-  // Strip a trailing mkstemp-style "XXXXXX" template if present, then append a
+  // Strip only an exact trailing mkstemp-style "XXXXXX" template, then append a
   // process-unique suffix (e.g. "CompileSourceXXXXXX" -> "CompileSource1234_0").
-  const size_t last_non_x = name.find_last_not_of('X');
-  if (last_non_x != std::string::npos) {
-    name.resize(last_non_x + 1);
+  static constexpr char kTemplate[] = "XXXXXX";
+  static constexpr size_t kTemplateLen = sizeof(kTemplate) - 1;
+  if (name.size() >= kTemplateLen &&
+      name.compare(name.size() - kTemplateLen, kTemplateLen, kTemplate) == 0) {
+    name.resize(name.size() - kTemplateLen);
   }
   name += std::to_string(static_cast<int64_t>(pid)) + "_" +
           std::to_string(counter.fetch_add(1, std::memory_order_relaxed));


### PR DESCRIPTION
… in hiprtc

## Motivation
- hiprtcCreateProgram generated a unique name via mkstemp("CompileSourceXXXXXX"), creating and immediately
  unlinking a temp file in the current working directory.
- At scale, tens of thousands of ranks doing create+unlink in a shared directory on a parallel filesystem         
  (Lustre/GPFS) cause severe metadata-server contention.
- The name is only used as an in-memory Comgr label, so it is now generated in memory (pid + atomic counter) with 
  no filesystem access.

## Technical Details
- Update the GenerateUniqueFileName helper in hip_comgr_helper.cpp to use pid+ atomic counter for filename generation.

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

JIRA ID : ROCM-29636

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
