### PR TITLE
fix(rocr): serialize PC sampling PM4 submissions and guard conflicting buffer strides

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1023,9 +1023,6 @@ class GpuAgent : public GpuAgentInt {
     /* Per-XCC data array - cache-line aligned AoS for optimal cache behavior */
     per_xcc_pcs_data_t* xcc_data;  // Array of per-XCC structs (size = num_xcc)
 
-    /* PM4 fallback flag (resources are per-XCC in per_xcc_pcs_data_t) */
-    bool use_pm4_fallback;           // true if large-BAR not available
-
     /* Consumer thread for aggregated callback delivery */
     std::thread consumer_thread;            // Aggregates data and delivers callbacks
     std::mutex consumer_mutex;              // Protects consumer_cv, pending_flush_count, consumer_exit (for notify)
@@ -1052,12 +1049,7 @@ class GpuAgent : public GpuAgentInt {
   void PcSamplingDeliverAggregatedSamples(pcs_data_t& pcs_data,
                                           pcs::PcsRuntime::PcSamplingSession& session);
 
-  // @brief Flush device buffers for per-XCC PC sampling architecture (CPU atomic path)
-  hsa_status_t PcSamplingFlushDeviceBuffersPerXCC(pcs_data_t* pcs_data,
-                                                  pcs::PcsRuntime::PcSamplingSession& session,
-                                                  uint32_t xcc_id);
-
-  // @brief Flush device buffers using PM4 commands (fallback for non-large-BAR systems)
+  // @brief Flush device buffers for per-XCC PC sampling architecture using PM4 commands
   hsa_status_t PcSamplingFlushDeviceBuffersPerXCC_PM4(pcs_data_t* pcs_data,
                                                       pcs::PcsRuntime::PcSamplingSession& session,
                                                       uint32_t xcc_id);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1086,6 +1086,11 @@ class GpuAgent : public GpuAgentInt {
   // structure for stochastic sampling
   pcs_data_t pcs_stochastic_data_;
 
+  // Serializes PM4 submit-and-wait on queues_[QueuePCSampling]: ExecutePM4 reuses a single
+  // per-queue indirect buffer, so only one submission may be in flight at a time.
+  // Lock order: host_buffer_mutex -> pcs_pm4_mutex_.
+  std::mutex pcs_pm4_mutex_;
+
   /// @brief XGMI CPU<->GPU
   bool xgmi_cpu_gpu_;
   /// @brief Is PCIe large BAR enabled.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1610,6 +1610,8 @@ void AqlQueue::SetProfiling(bool enabled) {
 // If in_signal is provided, then ExecutePM4 will return and caller may wait for in_signal
 // Note: On gfx8, there is no completion signal support, so ExecutePM4 will block even if
 // in_signal is provided, and it is still valid to check in_signal after ExecutePM4 returns.
+// Note: cmd_data is staged in pm4_ib_buf_, one indirect buffer per queue that the next call
+// reuses, so with in_signal the caller must wait on it before issuing another PM4 here.
 void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
                           hsa_fence_scope_t releaseFence, hsa_signal_t* in_signal) {
   // pm4_ib_buf_ is a shared resource, so mutually exclude here.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3773,13 +3773,6 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Initialize per-XCC structures
   pcs_data->num_xcc = properties_.NumXcc;
 
-  // Always drain on the GPU, never with a CPU memcpy. The buf_written_val handshake does not
-  // order the trap handler's GL2 payload writes against the count it publishes as seen through
-  // the large-BAR aperture, so a CPU reader can observe the count while the payload behind it is
-  // still in flight and copy a torn record. PM4 issues the copy on the same queue as the
-  // handshake, which does order the two.
-  pcs_data->use_pm4_fallback = true;
-
   // Allocate cache-line aligned per-XCC data array
   // Each per_xcc_pcs_data_t is 64-byte aligned to prevent false sharing between XCCs
   pcs_data->xcc_data = new per_xcc_pcs_data_t[pcs_data->num_xcc]();
@@ -3841,8 +3834,8 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
     }
   });
 
-  // PM4 fallback requires PCSampling queue and per-XCC resources
-  if (pcs_data->use_pm4_fallback) {
+  // The PM4 drain requires the PCSampling queue and per-XCC resources
+  {
     // Force creating of PC Sampling queue to trigger exception early in case we exceed max
     // available CP queues on this agent
     queues_[QueuePCSampling].touch();
@@ -4548,140 +4541,10 @@ hsa_status_t GpuAgent::PcSamplingStop(pcs::PcsRuntime::PcSamplingSession& sessio
   return (retKmt == HSAKMT_STATUS_SUCCESS) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
 }
 
-hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC(
-    pcs_data_t* pcs_data, pcs::PcsRuntime::PcSamplingSession& session, uint32_t xcc_id) {
-  // pcs_data is passed directly - no method dispatch needed (eliminates branch in hot path)
-
-  if (!pcs_data->xcc_data[xcc_id].device_data) {
-    return HSA_STATUS_SUCCESS;
-  }
-
-  uint32_t next_buffer;
-  uint64_t reset_write_val;
-  uint32_t to_copy = 0;
-  uint8_t* buffer[2];
-
-  // Get references to this XCC's buffers and state (using cached values)
-  uint32_t& which_buffer = pcs_data->xcc_data[xcc_id].which_buffer;
-  const size_t per_xcc_host_buffer_size = pcs_data->per_xcc_host_buffer_size;
-  uint8_t* host_buffer_begin = pcs_data->xcc_data[xcc_id].host_buffer_begin;
-  const size_t samples_per_trap_buffer = pcs_data->samples_per_trap_buffer;
-
-  // Double buffers start after the metadata structure
-  buffer[0] = reinterpret_cast<uint8_t*>(pcs_data->xcc_data[xcc_id].device_data) + sizeof(pcs_sampling_data_t);
-  buffer[1] = buffer[0] + samples_per_trap_buffer * session.sample_size();
-
-  /*
-   * Double-buffer atomic swap mechanism:
-   * We use a double-buffer mechanism so that trap handler calls are writing to one buffer while
-   * rocr is copying data from the other buffer.
-   *
-   * 1. Atomically swap buffers on the device. Future trap handler calls will put their data into
-   *    next_buffer.
-   * 2. Return a 64-bit packed value to ROCr; the upper bit is the old buffer and can be ignored.
-   *    The lower 63 bits are how many trap handler entrances happened before the atomic swap
-   *    i.e., what value to wait for in buf_written_val to know all previous trap entries were
-   *    done.
-   *
-   * CPU atomic exchange on fine-grained memory bypasses per-XCC GL2 cache.
-   */
-  next_buffer = (which_buffer + 1) % 2;
-  reset_write_val = (uint64_t)next_buffer << 63;
-
-  uint64_t sample_count = rocr::atomic::Exchange(
-      reinterpret_cast<uint64_t*>(&pcs_data->xcc_data[xcc_id].device_data->buf_write_val), reset_write_val,
-      std::memory_order_acq_rel);
-
-  // Mask off upper bit to get sample count from old value
-  sample_count &= (ULLONG_MAX >> 1);
-
-  // Clamp to buffer capacity if overflow occurred (samples were lost)
-  if (sample_count > samples_per_trap_buffer) {
-    pcs_data->xcc_data[xcc_id].lost_sample_count.fetch_add(
-        sample_count - samples_per_trap_buffer, std::memory_order_relaxed);
-    sample_count = samples_per_trap_buffer;
-  }
-
-  to_copy = sample_count * session.sample_size();
-
-  // Calculate write position in this XCC's circular host buffer region
-  uint64_t write_offset = pcs_data->xcc_data[xcc_id].host_write_offset;
-
-  uint64_t buffer_offset = write_offset % per_xcc_host_buffer_size;
-  uint8_t* host_write_ptr = host_buffer_begin + buffer_offset;
-  size_t contiguous_space = per_xcc_host_buffer_size - buffer_offset;
-  size_t bytes_copied = 0;
-
-  if (to_copy > 0) {
-    // Use atomics for synchronization with GPU - rocr::atomic provides
-    // cross-platform atomic operations with proper memory ordering.
-    uint32_t* bwv_written = (which_buffer == 0)
-        ? &pcs_data->xcc_data[xcc_id].device_data->buf_written_val0
-        : &pcs_data->xcc_data[xcc_id].device_data->buf_written_val1;
-
-    // Wait for GPU to finish writing samples (per-XCC isolation eliminates contention)
-    // Check session.isActive() to avoid spinning forever if session is stopping.
-    uint32_t expected_written = (uint32_t)sample_count;
-
-    while (rocr::atomic::Load(bwv_written, std::memory_order_acquire) < expected_written) {
-      // Exit early if session is being stopped - prevents infinite spin during shutdown
-      if (!session.isActive()) {
-        uint32_t actual_written = rocr::atomic::Load(bwv_written, std::memory_order_acquire);
-        if (actual_written < expected_written) {
-          pcs_data->xcc_data[xcc_id].lost_sample_count.fetch_add(
-              expected_written - actual_written, std::memory_order_relaxed);
-        }
-        sample_count = actual_written;
-        to_copy = sample_count * session.sample_size();
-        break;
-      }
-#if defined(_MSC_VER)
-      _mm_pause();
-#elif defined(__x86_64__) || defined(__i386__)
-      __builtin_ia32_pause();
-#endif
-    }
-
-    // NOTE: Caller (PcSamplingFlush or PcSamplingThreadPerXCC) must hold host_buffer_mutex.
-    // Lock protects host_read_offset and prevents TOCTOU race with consumer thread.
-
-    // Guard against host buffer overflow: ensure write doesn't lap the reader
-    uint64_t read_offset = pcs_data->xcc_data[xcc_id].host_read_offset;
-    bytes_copied = to_copy;
-
-    if ((write_offset + bytes_copied) - read_offset > per_xcc_host_buffer_size) {
-      // Host buffer overflow: would overwrite unread data. Drop samples to prevent corruption.
-      size_t overflow_bytes = (write_offset + bytes_copied) - read_offset - per_xcc_host_buffer_size;
-      pcs_data->xcc_data[xcc_id].lost_sample_count.fetch_add(
-          overflow_bytes / session.sample_size(), std::memory_order_relaxed);
-      debug_print("PC Sampling XCC %u: host buffer overflow, dropped %zu bytes\n",
-                  xcc_id, overflow_bytes);
-      // Clamp bytes_copied to available space
-      bytes_copied = per_xcc_host_buffer_size - (write_offset - read_offset);
-    }
-
-    // Copy samples to host buffer, handling wrap-around if needed
-    if (bytes_copied > 0) {
-      size_t first_copy = std::min(bytes_copied, contiguous_space);
-      size_t second_copy = bytes_copied - first_copy;
-      memcpy(host_write_ptr, buffer[which_buffer], first_copy);
-      if (second_copy > 0) {
-        memcpy(host_buffer_begin, buffer[which_buffer] + first_copy, second_copy);
-      }
-      pcs_data->xcc_data[xcc_id].host_write_offset = write_offset + bytes_copied;
-    }
-
-    // Reset written counter so trap handler can reuse this buffer
-    rocr::atomic::Store(bwv_written, 0U, std::memory_order_release);
-  }
-
-  which_buffer = next_buffer;
-  return HSA_STATUS_SUCCESS;
-}
-
 hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
     pcs_data_t* pcs_data, pcs::PcsRuntime::PcSamplingSession& session, uint32_t xcc_id) {
-  // PM4 fallback for non-large-BAR systems where CPU cannot directly access VRAM.
+  // Drains the trap buffers on the GPU rather than with a CPU memcpy, so that the copy is
+  // ordered against the trap handler's payload writes by the queue rather than by the aperture.
   // Uses ATOMIC_MEM for buffer swap, WAIT_REG_MEM + DMA_DATA for copy, WRITE_DATA for reset.
 
   if (!pcs_data->xcc_data[xcc_id].device_data) {
@@ -5005,9 +4868,8 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
       {
         std::lock_guard<std::mutex> lock(xcc.host_buffer_mutex);
 
-        hsa_status_t flush_status = pcs_data.use_pm4_fallback
-            ? PcSamplingFlushDeviceBuffersPerXCC_PM4(&pcs_data, session, xcc_id)
-            : PcSamplingFlushDeviceBuffersPerXCC(&pcs_data, session, xcc_id);
+        hsa_status_t flush_status =
+            PcSamplingFlushDeviceBuffersPerXCC_PM4(&pcs_data, session, xcc_id);
 
         if (flush_status != HSA_STATUS_SUCCESS) {
           debug_print("%s (XCC %u)::Flush failed with status %d\n", thread_name, xcc_id, flush_status);
@@ -5176,9 +5038,7 @@ hsa_status_t GpuAgent::PcSamplingFlush(pcs::PcsRuntime::PcSamplingSession& sessi
     per_xcc_pcs_data_t& xcc = pcs_data->xcc_data[xcc_id];
     std::lock_guard<std::mutex> lock(xcc.host_buffer_mutex);
 
-    hsa_status_t flush_status = pcs_data->use_pm4_fallback
-        ? PcSamplingFlushDeviceBuffersPerXCC_PM4(pcs_data, session, xcc_id)
-        : PcSamplingFlushDeviceBuffersPerXCC(pcs_data, session, xcc_id);
+    hsa_status_t flush_status = PcSamplingFlushDeviceBuffersPerXCC_PM4(pcs_data, session, xcc_id);
 
     if (flush_status != HSA_STATUS_SUCCESS) {
       if (first_error == HSA_STATUS_SUCCESS) first_error = flush_status;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4110,6 +4110,22 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
 
   // Allocate contiguous device memory for all XCCs, each XCC gets deviceAllocSize bytes
   size_t deviceAllocSize = AlignUp(sizeof(pcs_sampling_data_t) + (2 * trap_buffer_size), 256);
+
+  // TMA2 holds one per-XCC stride shared by the hosttrap and stochastic buffer arrays, so an
+  // active session of the other method with a different stride would index past its allocation.
+  // Reading the other method's session without a lock is safe: PcsRuntime serializes create,
+  // destroy and start under pc_sampling_lock_, so it cannot change underneath this check.
+  const pcs_data_t& other_pcs_data = (sampling_method == HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1)
+      ? pcs_stochastic_data_
+      : pcs_hosttrap_data_;
+  if (other_pcs_data.session && other_pcs_data.per_xcc_device_stride != deviceAllocSize) {
+    debug_print(
+        "PC Sampling: cannot start session, active session uses per-XCC stride %zu but this "
+        "session needs %zu\n",
+        other_pcs_data.per_xcc_device_stride, deviceAllocSize);
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
   size_t totalDeviceAllocSize = deviceAllocSize * pcs_data->num_xcc;
   pcs_data->per_xcc_device_stride = deviceAllocSize;  // Cache for trap handler update in Destroy
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3773,8 +3773,12 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Initialize per-XCC structures
   pcs_data->num_xcc = properties_.NumXcc;
 
-  // Detect if we need PM4 fallback (non-large-BAR systems cannot use CPU atomics on VRAM)
-  pcs_data->use_pm4_fallback = !LargeBarEnabled();
+  // Always drain on the GPU, never with a CPU memcpy. The buf_written_val handshake does not
+  // order the trap handler's GL2 payload writes against the count it publishes as seen through
+  // the large-BAR aperture, so a CPU reader can observe the count while the payload behind it is
+  // still in flight and copy a torn record. PM4 issues the copy on the same queue as the
+  // handshake, which does order the two.
+  pcs_data->use_pm4_fallback = true;
 
   // Allocate cache-line aligned per-XCC data array
   // Each per_xcc_pcs_data_t is 64-byte aligned to prevent false sharing between XCCs

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4668,6 +4668,12 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
     return HSA_STATUS_SUCCESS;
   }
 
+  // Every XCC of both sampling methods submits through queues_[QueuePCSampling], and ExecutePM4
+  // returns as soon as the doorbell rings while reusing one indirect buffer per queue. Hold the
+  // lock across both submit-and-wait pairs below, or a concurrent submission overwrites commands
+  // the command processor has not fetched yet.
+  std::lock_guard<std::mutex> pm4_lock(pcs_pm4_mutex_);
+
   uint32_t next_buffer;
   uint64_t reset_write_val;
   uint32_t to_copy = 0;


### PR DESCRIPTION
## Motivation

Replaces #9574, which is unmergeable (`rebaseable: false`, ~1200 commits behind) and whose
author is no longer available. Taking it over rather than rebasing, and dropping the one
change that has since been superseded.

**The headline fix of #9574 must not be merged.** It removed the `which_buffer = 0` reset in
`PcSamplingStart` so the host shadow would track the device across stop/start. #9531 fixed the
same buffer-parity hang the opposite way: it kept `which_buffer = 0` and reset the device
counters with `DmaFill`. #9531 merged on Aug 5. Applying #9574 on top would leave `which_buffer`
stale while the device is zeroed, reintroducing the same hang mirrored. That commit is dropped
here; the remaining three defects are still present on `develop`.

## Technical Details

**Concurrent PM4 submissions could overwrite each other.** `AqlQueue::ExecutePM4` stages its
command stream in `pm4_ib_buf_`, one indirect buffer per queue that the next call reuses, and
returns as soon as the doorbell is rung when a completion signal is supplied. Every XCC of both
sampling methods drains through `queues_[QueuePCSampling]`, and the callers hold only the
per-XCC `host_buffer_mutex`, so two XCCs could submit concurrently and one would overwrite
commands the command processor had not fetched yet. A new `pcs_pm4_mutex_` is held across both
submit-and-wait pairs in `PcSamplingFlushDeviceBuffersPerXCC_PM4`, and the constraint is
documented at `ExecutePM4` itself.

**Two sessions could disagree on the buffer stride.** TMA2 carries a single per-XCC stride that
the trap handler applies to both the hosttrap and the stochastic buffer array. If a session of
one method is already active with a different stride, the other array gets indexed outside its
allocation. `PcSamplingCreateFromId` now returns `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.

**The CPU drain could read torn records.** `use_pm4_fallback` was `!LargeBarEnabled()`, so
large-BAR systems drained with a CPU memcpy. The `buf_written_val` handshake does not order the
trap handler's GL2 payload writes against the count it publishes as seen through the large-BAR
aperture, so a CPU reader can observe the count while the payload behind it is still in flight.

## Carried-over review comments from #9574

@cfreeamd left three comments on the original. All are addressed here:

1. *"The sentence ... reads like a condition under which the CPU path is safe, but the code then
   unconditionally forces PM4"* ([thread](https://github.com/ROCm/rocm-systems/pull/9574#discussion_r3789873799)).
   Reworded to state the hazard directly: the aperture does not order the payload-before-count
   publish, which is why PM4 is required.
2. *"[`use_pm4_fallback` is now set to `true`](https://github.com/ROCm/rocm-systems/pull/9574#discussion_r3789873801) and never set `false` ... a reader sees a boolean
   that can never be false."* Resolved by deletion rather than a note. The final commit removes
   the field, the branches, and the 130-line `PcSamplingFlushDeviceBuffersPerXCC`. It is a
   separate commit from the behavioural change so the two can be reverted independently.
3. *"[This guard reads `other_pcs_data.session`](https://github.com/ROCm/rocm-systems/pull/9574#discussion_r3789873804) and `per_xcc_device_stride` without holding a
   lock. Is create/destroy ... mutually serialized at a higher layer?"* Yes.
   `PcsRuntime::PcSamplingCreateInternal`, `PcSamplingDestroy` and `PcSamplingStart` all take
   `pc_sampling_lock_`, so the other method's session cannot change underneath the check. Noted
   in the comment.

## Test Plan

Built against `develop` and exercised on an 8x gfx942 (MI300X) box. Note the caveat below.

## Test Result

- Builds clean.
- Multi-XCC, multi-agent host-trap sampling over 4 agents: 1,530,934 samples collected, all 4
  agents represented, no deadlock or stall from the new mutex.

**Caveat:** GPU 0 on this machine returns zero PC samples for any workload, with or without
these changes, while GPUs 1-7 sample normally. That is being reported separately and is not
caused by this PR, but it means the stop/start and torn-record paths could not be exercised on
that agent here. The `use_pm4_fallback` change in particular is the least directly verified of
the three, which is why it is isolated in its own commit.

## Issue Tracking

JIRA ID: AIROCVAL-37

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md

Made with [Cursor](https://cursor.com)
