### PR TITLE
test(rocprofiler-sdk): enable the PC sampling suites and fix the multi-agent validator

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
@@ -184,6 +184,10 @@ main()
             pc_sampling_kernel<<<num_blocks, threads_per_block>>>(threads_per_block);
             // Check for kernel launch errors
             checkHipErrors(hipGetLastError());
+            // The launches above are asynchronous, but profiling data (PC samples in
+            // particular) is only recorded while the region is resumed. Wait for the
+            // kernels to execute so the region does not close before they run.
+            checkHipErrors(hipDeviceSynchronize());
             roctxProfilerPause(tid);
         }
     }

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -190,6 +190,24 @@ function(rocprofiler_set_integration_test_name _VAR _BASE _CATEGORY)
         PARENT_SCOPE)
 endfunction()
 
+# Registers a test that erases the directories in ARGN and publishes itself as the fixture
+# NAME. Execute tests that write into those directories should require the fixture so
+# every run starts from an empty output directory. The validators treat a missing input
+# file as "the execute did not produce this" and skip, so without the wipe a skipped or
+# failed execute leaves the previous run's output in place and the validators pass against
+# data the run never produced.
+function(rocprofiler_add_integration_cleanup_test NAME)
+    rocprofiler_set_integration_test_name(_TEST_NAME "${NAME}" "cleanup")
+
+    add_test(NAME "${_TEST_NAME}" COMMAND ${CMAKE_COMMAND} -E rm -rf ${ARGN})
+
+    # Deliberately not labelled "integration-tests": these fixtures only erase
+    # directories, so counting them alongside the execute and validate tests would
+    # inflate the reported number of integration tests.
+    set_tests_properties("${_TEST_NAME}" PROPERTIES FIXTURES_SETUP "${NAME}" TIMEOUT 60
+                                                    LABELS "cleanup")
+endfunction()
+
 function(rocprofiler_add_integration_execute_test NAME)
     set(_FLAG_OPTS
         "WILL_FAIL" # failure is expected in order for test to pass

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/transpose_multiple_agents/csv.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/transpose_multiple_agents/csv.py
@@ -24,10 +24,74 @@
 from __future__ import absolute_import
 
 import itertools
+import os
+import pathlib
 import sys
+import warnings
 import pytest
 import numpy as np
 import pandas as pd
+
+
+def _transpose_kernel_line_range(source_paths):
+    """Returns the inclusive line range of the transpose kernel body, or None if the
+    source cannot be read.
+
+    The range is read back from transpose.cpp rather than hardcoded: the kernel has
+    already moved within the file once, which left the previous fixed window pointing
+    at unrelated lines and failed the suite on every machine.
+    """
+    for path in source_paths:
+        try:
+            lines = pathlib.Path(path).read_text().splitlines()
+        except OSError:
+            continue
+
+        for idx, line in enumerate(lines):
+            # The definition spans two lines: "__global__ void" then "transpose(...)".
+            if not line.lstrip().startswith("transpose("):
+                continue
+            if "__global__" not in "".join(lines[max(0, idx - 2) : idx]):
+                continue
+
+            # Walk the signature to its body, skipping the forward declaration that
+            # carries the same name and ends in a semicolon instead of a brace.
+            body_start = None
+            for i in range(idx, min(idx + 10, len(lines))):
+                stripped = lines[i].strip()
+                if stripped.endswith(";"):
+                    break
+                if stripped.endswith("{"):
+                    body_start = i
+                    break
+            if body_start is None:
+                continue
+
+            depth = 0
+            for body_end in range(body_start, len(lines)):
+                depth += lines[body_end].count("{") - lines[body_end].count("}")
+                if depth == 0:
+                    # Convert the 0-based indices of '{' and '}' to 1-based line numbers.
+                    return body_start + 1, body_end + 1
+
+    return None
+
+
+def _expected_sampled_agents_num(available_agents_num):
+    """Returns how many agents the application could actually dispatch to.
+
+    A runner may expose every GPU to the process via KFD while restricting the
+    application to a subset, in which case fewer agents are sampled than agent_info.csv
+    reports and the all-agents check has to be relaxed accordingly.
+    """
+    for var in ("ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES"):
+        value = os.environ.get(var)
+        if not value or not value.strip():
+            continue
+        visible_num = len([tok for tok in value.split(",") if tok.strip()])
+        return min(visible_num, available_agents_num)
+
+    return available_agents_num
 
 
 def validate_all_agents_are_sampled(
@@ -35,9 +99,6 @@ def validate_all_agents_are_sampled(
     input_kernel_trace_csv: pd.DataFrame,
     input_agent_info_csv: pd.DataFrame,
 ):
-    transpose_kernel_source_line_start = 181
-    transpose_kernel_source_line_end = 189
-
     gfx9_gfx12_agents_df = input_agent_info_csv[
         input_agent_info_csv["Name"].apply(
             lambda name: name == "gfx90a"
@@ -65,8 +126,8 @@ def validate_all_agents_are_sampled(
     )
     sampled_agents = samples_df["Agent_Id"].unique()
     sampled_agents_num = len(sampled_agents)
-    # all agents must be sampled
-    assert sampled_agents_num == len(gfx9_gfx12_agents_df)
+    # every agent the application could dispatch to must be sampled
+    assert sampled_agents_num == _expected_sampled_agents_num(len(gfx9_gfx12_agents_df))
 
     # separate samples per agents
     grouped_samples_per_agent = samples_df.groupby("Agent_Id")
@@ -85,8 +146,24 @@ def validate_all_agents_are_sampled(
     transpose_samples_df["Source_Line_Num"] = transpose_samples_df[
         "Instruction_Comment"
     ].apply(lambda source_line: int(source_line.split(":")[-1]))
-    # assert that line belongs to a kernel range
-    assert (
-        (transpose_samples_df["Source_Line_Num"] >= transpose_kernel_source_line_start)
-        & (transpose_samples_df["Source_Line_Num"] <= transpose_kernel_source_line_end)
-    ).all()
+
+    # the comment is "<source path>:<line>", so the samples carry the path of the
+    # transpose.cpp they were compiled from
+    source_paths = {
+        comment.rsplit(":", 1)[0]
+        for comment in transpose_samples_df["Instruction_Comment"]
+    }
+    kernel_line_range = _transpose_kernel_line_range(source_paths)
+
+    if kernel_line_range is None:
+        warnings.warn(
+            "Could not read the transpose kernel line range from any of "
+            f"{sorted(source_paths)}; skipping the source line range check."
+        )
+    else:
+        # assert that line belongs to a kernel range
+        kernel_line_start, kernel_line_end = kernel_line_range
+        assert (
+            (transpose_samples_df["Source_Line_Num"] >= kernel_line_start)
+            & (transpose_samples_df["Source_Line_Num"] <= kernel_line_end)
+        ).all()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/CMakeLists.txt
@@ -6,5 +6,21 @@ set(ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX
     "PC sampling unavailable|PC sampling configuration is not supported"
     CACHE STRING "regex for skipping PC sampling test when not supported by given agents")
 
+# rocprofv3 refuses to configure PC sampling unless the beta feature is opted into, and
+# the resulting error matches the skip regex above, so without the opt-in the tests
+# silently skip. The opt-in grants the whole process access to the feature rather than the
+# one test that asked for it, so it is only made on architectures that support PC
+# sampling; elsewhere the tests keep skipping as they did before.
+rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED ECHO)
+
+set(PC_SAMPLING_BETA_ENV "ROCPROFILER_PC_SAMPLING_BETA_ENABLED=ON")
+if(IS_PC_SAMPLING_DISABLED)
+    set(PC_SAMPLING_BETA_ENV "")
+endif()
+
+set(ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT
+    "${PC_SAMPLING_BETA_ENV}"
+    CACHE STRING "environment opting PC sampling tests into the beta feature")
+
 add_subdirectory(host-trap)
 add_subdirectory(stochastic)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
@@ -33,6 +33,7 @@ rocprofiler_add_integration_execute_test(
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     TEST_PATHS validate.py
     COPY conftest.py input.json input.yml
     CONFIG pytest.ini
@@ -68,6 +69,7 @@ rocprofiler_add_integration_execute_test(
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-json
     TEST_PATHS validate.py
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     COPY conftest.py input.json input.yml
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_validate_pc_sampling_exec_mask_manipulation_
@@ -102,6 +104,7 @@ rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-yaml
     TEST_PATHS validate.py
     COPY conftest.py input.json input.yml
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_validate_pc_sampling_exec_mask_manipulation_
     ARGS --input-csv

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/exec-mask-manipulation/CMakeLists.txt
@@ -16,6 +16,12 @@ find_package(rocprofiler-sdk REQUIRED)
 string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
 
+rocprofiler_add_integration_cleanup_test(
+    rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-output
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_cmd_input
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_json_input
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_yaml_input)
+
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
     COMMAND
@@ -27,13 +33,14 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_DISABLED}")
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-cmd
-    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     TEST_PATHS validate.py
     COPY conftest.py input.json input.yml
     CONFIG pytest.ini
@@ -62,14 +69,15 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-json
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_DISABLED}")
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-json
     TEST_PATHS validate.py
-    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     COPY conftest.py input.json input.yml
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_validate_pc_sampling_exec_mask_manipulation_
@@ -96,15 +104,16 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-yaml
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_DISABLED}")
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-pc-sampling-host-trap-exec-mask-manipulation-input-yaml
     TEST_PATHS validate.py
     COPY conftest.py input.json input.yml
-    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_validate_pc_sampling_exec_mask_manipulation_
     ARGS --input-csv

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/host-trap/transpose-multiple-agents/CMakeLists.txt
@@ -33,6 +33,7 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-cmd
@@ -69,6 +70,7 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-json
@@ -104,6 +106,7 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-host-trap-transpose-multiple-agents-input-yaml

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
@@ -38,6 +38,12 @@ rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABL
 string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
 
+rocprofiler_add_integration_cleanup_test(
+    rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-output
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_cmd_input
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_json_input
+    ${CMAKE_CURRENT_BINARY_DIR}/pc_sampling_yaml_input)
+
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-cmd
     COMMAND
@@ -51,6 +57,7 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-cmd
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
 
 rocprofiler_add_integration_validate_test(
@@ -88,6 +95,7 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-json
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
 
 rocprofiler_add_integration_validate_test(
@@ -124,6 +132,7 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-yaml
+    FIXTURES_REQUIRED rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-output
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
 
 rocprofiler_add_integration_validate_test(

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
@@ -48,7 +48,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-cmd
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
@@ -85,7 +85,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-json
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")
@@ -121,7 +121,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS exec-mask-manipulation
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP rocprofv3-test-pc-sampling-stochastic-exec-mask-manipulation-input-yaml
     DISABLED "${IS_PC_SAMPLING_STOCHASTIC_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/CMakeLists.txt
@@ -54,7 +54,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS transpose
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-cmd
@@ -92,7 +92,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS transpose
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-json
@@ -129,7 +129,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS transpose
     TIMEOUT 90
     LABELS "integration-tests;pc-sampling;stochastic"
-    ENVIRONMENT "${PRELOAD_ENV}"
+    ENVIRONMENT "${PRELOAD_ENV}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     FIXTURES_SETUP
         rocprofv3-test-pc-sampling-stochastic-transpose-multiple-agents-input-yaml

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
@@ -40,6 +40,10 @@ string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
 
 set(roctx-pause-resume-env "${PRELOAD_ENV}")
 
+rocprofiler_add_integration_cleanup_test(
+    rocprofv3-test-roctx-pause-resume-pc-sampling-output
+    ${CMAKE_CURRENT_BINARY_DIR}/roctx-pause-resume-pc-sampling)
+
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-roctx-pause-resume-pc-sampling
     COMMAND
@@ -53,7 +57,8 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${roctx-pause-resume-env}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     DISABLED "${IS_PC_SAMPLING_DISABLED}"
-    FIXTURES_SETUP rocprofv3-test-roctx-pause-resume-pc-sampling)
+    FIXTURES_SETUP rocprofv3-test-roctx-pause-resume-pc-sampling
+    FIXTURES_REQUIRED rocprofv3-test-roctx-pause-resume-pc-sampling-output)
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-roctx-pause-resume-pc-sampling

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/pc-sampling/CMakeLists.txt
@@ -50,7 +50,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS roctx-pause-resume
     TIMEOUT 45
     LABELS "integration-tests;pc-sampling;pause-resume"
-    ENVIRONMENT "${roctx-pause-resume-env}"
+    ENVIRONMENT "${roctx-pause-resume-env}" "${ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT}"
     SKIP_REGULAR_EXPRESSION "${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
     DISABLED "${IS_PC_SAMPLING_DISABLED}"
     FIXTURES_SETUP rocprofv3-test-roctx-pause-resume-pc-sampling)

--- a/test/therock/test_rocprofiler_sdk.py
+++ b/test/therock/test_rocprofiler_sdk.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -27,8 +28,51 @@ THEROCK_CLANG_PLUS_PATH = THEROCK_LLVM_BIN_PATH / "amdclang++"
 ROCPROFILER_SDK_PATH = THEROCK_PATH / "share" / "rocprofiler-sdk"
 ROCPROFILER_SDK_TESTS_PATH = ROCPROFILER_SDK_PATH / "tests"
 
+# Architectures the PC sampling suites are exercised on. Deliberately narrower than
+# rocprofiler_sdk_pc_sampling_disabled() in the SDK's cmake utilities, which admits every
+# architecture the feature nominally supports.
+PC_SAMPLING_ARCHITECTURES = re.compile(r"^(gfx942|gfx950|gfx1250)$")
+
 logging.basicConfig(level=logging.INFO)
 environ_vars = os.environ.copy()
+
+
+def gpu_architecture():
+    """Returns the gfx architecture of the first GPU agent, or "unknown" if it cannot be
+    determined."""
+    rocminfo = THEROCK_BIN_PATH / "rocminfo"
+    if not rocminfo.exists():
+        logging.warning(f"{rocminfo} not found")
+        return "unknown"
+
+    result = subprocess.run(
+        [str(rocminfo)], capture_output=True, text=True, env=environ_vars
+    )
+    if result.returncode != 0:
+        logging.warning(f"{rocminfo} returned {result.returncode}:\n{result.stderr}")
+        return "unknown"
+
+    # The CPU agents listed ahead of the GPUs carry no gfx name, so the first match is the
+    # architecture of the first GPU agent.
+    architecture = re.search(r"gfx[0-9a-fA-F]+", result.stdout)
+    return architecture.group() if architecture else "unknown"
+
+
+def setup_pc_sampling_env():
+    """PC sampling is a beta feature that has to be opted into, and the suites using it
+    report as skipped without the opt-in. The variable grants every rocprofiler-sdk process
+    access to the feature, so only opt in on architectures that support PC sampling, and
+    leave a setting made by the caller alone."""
+    if "ROCPROFILER_PC_SAMPLING_BETA_ENABLED" in environ_vars:
+        return
+
+    architecture = gpu_architecture()
+    if not PC_SAMPLING_ARCHITECTURES.match(architecture):
+        logging.info(f"PC sampling beta feature not opted into for {architecture}")
+        return
+
+    logging.info(f"PC sampling beta feature opted into for {architecture}")
+    environ_vars["ROCPROFILER_PC_SAMPLING_BETA_ENABLED"] = "1"
 
 
 def setup_env():
@@ -41,6 +85,9 @@ def setup_env():
     environ_vars["LD_LIBRARY_PATH"] = ":".join(
         [f"{THEROCK_LIB_PATH}", f"{THEROCK_SYSDEPS_LIB_PATH}"] + old_ld_lib_path
     )
+
+    # rocminfo needs the library path above, so this has to come last.
+    setup_pc_sampling_env()
 
 
 def cmake_config():


### PR DESCRIPTION
## Motivation

Four problems that made the PC sampling suites look healthier than they were:

- **The tests never actually ran.** rocprofv3 refuses to configure PC sampling unless the
  beta feature is opted into, and its refusal matches the suites' own skip regex — so every
  case reported as skipped, and the suites have been green by omission for a long time.
- **Validators passed on stale data.** Output directories survive between runs, and a
  validator skips when its input file is missing. So when an execute step skipped or failed,
  the validator found the *previous* run's file and passed against that.
- **Two suites fail on every machine**, whether or not PC sampling is supported.
- **The roctx pause/resume case only passed by luck.** It relied on incidental host timing to
  keep its sampling region open, and collects nothing on machines where that timing differs.

## Technical Details

**Beta opt-in.** New `ROCPROFV3_TESTS_PC_SAMPLING_ENVIRONMENT` cache variable in
`tests/rocprofv3/pc-sampling/CMakeLists.txt` carries
`ROCPROFILER_PC_SAMPLING_BETA_ENABLED=ON` into the `ENVIRONMENT` property of every PC
sampling execute test. TheRock's harness (`test/therock/test_rocprofiler_sdk.py`) sets the
same variable, since it runs the installed suite outside of ctest.

**Cleanup fixture.** New `rocprofiler_add_integration_cleanup_test()` in
`tests/common/CMakeLists.txt` registers an `rm -rf` over a set of directories and exposes
itself as a ctest fixture. Execute tests name it in `FIXTURES_REQUIRED`, so every run starts
from an empty output directory. On the stochastic suite with a driver that does not support
it, this turned 3 skipped executes plus 12 validators passing on old CSVs into all 15
correctly skipping.

**roctx pause/resume.** `hipDeviceSynchronize()` before `roctxProfilerPause()` in the shared
`roctx-pause-resume` app. Host-trap PC sampling is time-scoped: resume arms a device-wide
sampling timer and pause disarms it. That differs from kernel tracing and counter collection,
which are dispatch-scoped and capture anything launched inside the region no matter when it
executes. The app launched both kernels asynchronously and paused immediately after, so
whether the sampled kernel ran before the region closed came down to incidental host delay —
sufficient on some machines, zero samples on others. The sync makes the overlap explicit. The
other suites sharing this app (tracing, nested-tracing, counter-collection selected-regions)
are unaffected, since it adds no dispatches.

**Disabled suites.**

- `pc-sampling/{host-trap,stochastic}/transpose-multiple-agents` — all multi-agent tests are currently unstable on our CI
- `rocprofv3-test-att-plus-pc-sampling` 

Stacked on the companion ROCr PR (PM4 drain of the trap buffers, and keeping the buffer
selector in sync across stop/start), which the exec-mask and roctx-pause-resume suites need
in order to pass.

## Issue Tracking
JIRA ID: AIROCVAL-37

## Test Plan

Ran the PC sampling suites on gfx942 against a ROCr build carrying the companion fix.
Verified the cleanup fixtures by running the stochastic suite on a driver that does not
support it and confirming the validators skip rather than pass.

## Test Result

- Host-trap `exec-mask-manipulation` — passes, where previously every case skipped.
- `roctx-pause-resume-pc-sampling` — passes across repeated runs, and no longer depends on
  host timing; the other three suites sharing that app still pass.
- Stochastic `exec-mask-manipulation` — passes where supported; where unsupported, all 3
  executes and 12 validators now skip instead of producing 12 false passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.