### PR TITLE
[rocjitsu] Model gfx1250 wave ABI state

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -272,12 +272,12 @@ def _vcc_write_stmt(ctx: LoweringContext) -> str:
     if ctx.vcc_dst and ctx.vcc_dst != '__vcc__':
         return _write_vcc_mask_to_explicit_dst(ctx.vcc_dst)
     if ctx.vcc_dst == '__vcc__':
-        return 'wf.set_vcc(vcc);'
+        return 'wf.set_vcc_mask(vcc);'
     if ctx.operand_map:
         dst = ctx.operand_map.dst(0)
         if dst:
             return _write_vcc_mask_to_explicit_dst(dst.name)
-    return 'wf.set_vcc(vcc);'
+    return 'wf.set_vcc_mask(vcc);'
 
 
 def _indent(ctx: LoweringContext) -> str:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -163,12 +163,12 @@ def gen_vector_cmp_class(
     L.append('  }')
     if is_cmpx:
         if cmpx_writes_vcc:
-            L.append('  wf.set_vcc(result);')
+            L.append('  wf.set_vcc_mask(result);')
         L.append('  wf.set_exec(result);')
     elif dst:
         L.extend(_write_explicit_lane_mask(dst[0], 'vcc'))
     else:
-        L.append('  wf.set_vcc(vcc);')
+        L.append('  wf.set_vcc_mask(vcc);')
     return '\n'.join(L)
 
 
@@ -372,7 +372,7 @@ def gen_vector_cmp(
         L.extend(_write_explicit_lane_mask(dst[0], 'vcc'))
     else:
         # VOPC: write to VCC.
-        L.append('  wf.set_vcc(vcc);')
+        L.append('  wf.set_vcc_mask(vcc);')
     return '\n'.join(L)
 
 
@@ -412,7 +412,7 @@ def gen_vector_cmpx(
         if dst and is_vop3:
             L.extend(_write_explicit_lane_mask(dst[0], 'result'))
         else:
-            L.append('  wf.set_vcc(result);')
+            L.append('  wf.set_vcc_mask(result);')
     L.append('  wf.set_exec(result);')
     return '\n'.join(L)
 
@@ -498,5 +498,5 @@ def gen_vector_add_co(
         # VOP3_SDST_ENC: carry-out goes to sdst (any SGPR pair).
         L.extend(_write_explicit_lane_mask(dst[1], 'vcc'))
     else:
-        L.append('  wf.set_vcc(vcc);')
+        L.append('  wf.set_vcc_mask(vcc);')
     return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -586,7 +586,7 @@ def gen_vector_div_scale(
     if len(dst) > 1:
         L.append(f'  amdgpu::write_wave_mask_scalar({dst[1]}, wf, vcc);')
     else:
-        L.append('  wf.set_vcc(vcc);')
+        L.append('  wf.set_vcc_mask(vcc);')
     return '\n'.join(L)
 
 

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_gen_vector_cmpx.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_gen_vector_cmpx.py
@@ -101,7 +101,7 @@ def _make_codegen(profile) -> CodeGenerator:
 
 # Regex tolerant to whitespace and identifier choice. We anchor on the
 # stable parts of the contract — the wave-mask helper calls
-# ``set_vcc``, ``set_exec``) and the dst identifier — not on the exact
+# ``set_vcc_mask``, ``set_exec``) and the dst identifier — not on the exact
 # variable name of the result-mask local.
 def _re_write_wave_mask(dst_ident: str) -> re.Pattern[str]:
     return re.compile(
@@ -110,7 +110,7 @@ def _re_write_wave_mask(dst_ident: str) -> re.Pattern[str]:
     )
 
 
-_RE_SET_VCC = re.compile(r'\bwf\s*\.\s*set_vcc\s*\(\s*\w+\s*\)\s*;')
+_RE_SET_VCC = re.compile(r'\bwf\s*\.\s*set_vcc_mask\s*\(\s*\w+\s*\)\s*;')
 _RE_SET_EXEC = re.compile(r'\bwf\s*\.\s*set_exec\s*\(\s*\w+\s*\)\s*;')
 _RE_ANY_WRITE_WAVE_MASK = re.compile(r'\bamdgpu::write_wave_mask_scalar\s*\(')
 
@@ -147,7 +147,7 @@ class TestGenVectorCmpxWriteBacks:
       * ``set_exec`` is emitted unconditionally.
       * a wave-size-width-aware write on the SDST is emitted iff
         ``profile.cmpx_writes_vcc and is_vop3 and dst``.
-      * ``set_vcc`` is emitted iff
+      * ``set_vcc_mask`` is emitted iff
         ``profile.cmpx_writes_vcc and not (is_vop3 and dst)``.
 
     The ``op='t'`` shortcut is intentional: it bypasses ``_cmp_condition``
@@ -200,11 +200,11 @@ class TestGenVectorCmpxWriteBacks:
         # VCC write: must appear iff expected.
         vcc_match = _RE_SET_VCC.search(body)
         if expect_vcc_write:
-            assert vcc_match, f'Expected wf.set_vcc(...) call; body was:\n{body}'
+            assert vcc_match, f'Expected wf.set_vcc_mask(...) call; body was:\n{body}'
         else:
             assert (
                 not vcc_match
-            ), f'Did not expect wf.set_vcc(...) call; body was:\n{body}'
+            ), f'Did not expect wf.set_vcc_mask(...) call; body was:\n{body}'
 
         # Mutual exclusion: a single V_CMPX never writes both VCC and SDST.
         assert not (

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vop3_exec.cpp
@@ -2903,7 +2903,7 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2951,7 +2951,7 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3076,7 +3076,7 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/vopc_exec.cpp
@@ -95,7 +95,7 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -147,7 +147,7 @@ void VCmpxClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -231,7 +231,7 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -681,7 +681,7 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -720,7 +720,7 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -759,7 +759,7 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -798,7 +798,7 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -837,7 +837,7 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -876,7 +876,7 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -915,7 +915,7 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -954,7 +954,7 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -993,7 +993,7 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1032,7 +1032,7 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1071,7 +1071,7 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1110,7 +1110,7 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1149,7 +1149,7 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1188,7 +1188,7 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1227,7 +1227,7 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1261,7 +1261,7 @@ void VCmpxTruF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1711,7 +1711,7 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1748,7 +1748,7 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1785,7 +1785,7 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1822,7 +1822,7 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1859,7 +1859,7 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1896,7 +1896,7 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1933,7 +1933,7 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1970,7 +1970,7 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2007,7 +2007,7 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2044,7 +2044,7 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2081,7 +2081,7 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2118,7 +2118,7 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2155,7 +2155,7 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2192,7 +2192,7 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2229,7 +2229,7 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2263,7 +2263,7 @@ void VCmpxTruF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2347,7 +2347,7 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2362,7 +2362,7 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2377,7 +2377,7 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2392,7 +2392,7 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2407,7 +2407,7 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2422,7 +2422,7 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2437,7 +2437,7 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2452,7 +2452,7 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2467,7 +2467,7 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2482,7 +2482,7 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2497,7 +2497,7 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2512,7 +2512,7 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2527,7 +2527,7 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2542,7 +2542,7 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2557,7 +2557,7 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2569,7 +2569,7 @@ void VCmpxTruF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3011,7 +3011,7 @@ void VCmpxFI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3048,7 +3048,7 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3085,7 +3085,7 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3122,7 +3122,7 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3159,7 +3159,7 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3196,7 +3196,7 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3233,7 +3233,7 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3267,7 +3267,7 @@ void VCmpxTI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3301,7 +3301,7 @@ void VCmpxFU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3338,7 +3338,7 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3375,7 +3375,7 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3412,7 +3412,7 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3449,7 +3449,7 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3486,7 +3486,7 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3523,7 +3523,7 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3557,7 +3557,7 @@ void VCmpxTU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4007,7 +4007,7 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4044,7 +4044,7 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4081,7 +4081,7 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4118,7 +4118,7 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4155,7 +4155,7 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4192,7 +4192,7 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4229,7 +4229,7 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4263,7 +4263,7 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4297,7 +4297,7 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4334,7 +4334,7 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4371,7 +4371,7 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4408,7 +4408,7 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4445,7 +4445,7 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4482,7 +4482,7 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4519,7 +4519,7 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4553,7 +4553,7 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4637,7 +4637,7 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4652,7 +4652,7 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4667,7 +4667,7 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4682,7 +4682,7 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4697,7 +4697,7 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4712,7 +4712,7 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4727,7 +4727,7 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4739,7 +4739,7 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4751,7 +4751,7 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4766,7 +4766,7 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4781,7 +4781,7 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4796,7 +4796,7 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4811,7 +4811,7 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4826,7 +4826,7 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4841,7 +4841,7 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4853,7 +4853,7 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vop3_exec.cpp
@@ -2879,7 +2879,7 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2927,7 +2927,7 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3052,7 +3052,7 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/vopc_exec.cpp
@@ -95,7 +95,7 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -147,7 +147,7 @@ void VCmpxClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -231,7 +231,7 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -681,7 +681,7 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -720,7 +720,7 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -759,7 +759,7 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -798,7 +798,7 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -837,7 +837,7 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -876,7 +876,7 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -915,7 +915,7 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -954,7 +954,7 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -993,7 +993,7 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1032,7 +1032,7 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1071,7 +1071,7 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1110,7 +1110,7 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1149,7 +1149,7 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1188,7 +1188,7 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1227,7 +1227,7 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1261,7 +1261,7 @@ void VCmpxTruF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1711,7 +1711,7 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1748,7 +1748,7 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1785,7 +1785,7 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1822,7 +1822,7 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1859,7 +1859,7 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1896,7 +1896,7 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1933,7 +1933,7 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1970,7 +1970,7 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2007,7 +2007,7 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2044,7 +2044,7 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2081,7 +2081,7 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2118,7 +2118,7 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2155,7 +2155,7 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2192,7 +2192,7 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2229,7 +2229,7 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2263,7 +2263,7 @@ void VCmpxTruF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2347,7 +2347,7 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2362,7 +2362,7 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2377,7 +2377,7 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2392,7 +2392,7 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2407,7 +2407,7 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2422,7 +2422,7 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2437,7 +2437,7 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2452,7 +2452,7 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2467,7 +2467,7 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2482,7 +2482,7 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2497,7 +2497,7 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2512,7 +2512,7 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2527,7 +2527,7 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2542,7 +2542,7 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2557,7 +2557,7 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2569,7 +2569,7 @@ void VCmpxTruF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3011,7 +3011,7 @@ void VCmpxFI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3048,7 +3048,7 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3085,7 +3085,7 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3122,7 +3122,7 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3159,7 +3159,7 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3196,7 +3196,7 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3233,7 +3233,7 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3267,7 +3267,7 @@ void VCmpxTI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3301,7 +3301,7 @@ void VCmpxFU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3338,7 +3338,7 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3375,7 +3375,7 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3412,7 +3412,7 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3449,7 +3449,7 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3486,7 +3486,7 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3523,7 +3523,7 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3557,7 +3557,7 @@ void VCmpxTU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4007,7 +4007,7 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4044,7 +4044,7 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4081,7 +4081,7 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4118,7 +4118,7 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4155,7 +4155,7 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4192,7 +4192,7 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4229,7 +4229,7 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4263,7 +4263,7 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4297,7 +4297,7 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4334,7 +4334,7 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4371,7 +4371,7 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4408,7 +4408,7 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4445,7 +4445,7 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4482,7 +4482,7 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4519,7 +4519,7 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4553,7 +4553,7 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4637,7 +4637,7 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4652,7 +4652,7 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4667,7 +4667,7 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4682,7 +4682,7 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4697,7 +4697,7 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4712,7 +4712,7 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4727,7 +4727,7 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4739,7 +4739,7 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4751,7 +4751,7 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4766,7 +4766,7 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4781,7 +4781,7 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4796,7 +4796,7 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4811,7 +4811,7 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4826,7 +4826,7 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4841,7 +4841,7 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4853,7 +4853,7 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vop3_exec.cpp
@@ -3014,7 +3014,7 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3062,7 +3062,7 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3187,7 +3187,7 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/vopc_exec.cpp
@@ -95,7 +95,7 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -147,7 +147,7 @@ void VCmpxClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -231,7 +231,7 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -681,7 +681,7 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -720,7 +720,7 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -759,7 +759,7 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -798,7 +798,7 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -837,7 +837,7 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -876,7 +876,7 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -915,7 +915,7 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -954,7 +954,7 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -993,7 +993,7 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1032,7 +1032,7 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1071,7 +1071,7 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1110,7 +1110,7 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1149,7 +1149,7 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1188,7 +1188,7 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1227,7 +1227,7 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1261,7 +1261,7 @@ void VCmpxTruF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1711,7 +1711,7 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1748,7 +1748,7 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1785,7 +1785,7 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1822,7 +1822,7 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1859,7 +1859,7 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1896,7 +1896,7 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1933,7 +1933,7 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1970,7 +1970,7 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2007,7 +2007,7 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2044,7 +2044,7 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2081,7 +2081,7 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2118,7 +2118,7 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2155,7 +2155,7 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2192,7 +2192,7 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2229,7 +2229,7 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2263,7 +2263,7 @@ void VCmpxTruF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2347,7 +2347,7 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2362,7 +2362,7 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2377,7 +2377,7 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2392,7 +2392,7 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2407,7 +2407,7 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2422,7 +2422,7 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2437,7 +2437,7 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2452,7 +2452,7 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2467,7 +2467,7 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2482,7 +2482,7 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2497,7 +2497,7 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2512,7 +2512,7 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2527,7 +2527,7 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2542,7 +2542,7 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2557,7 +2557,7 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2569,7 +2569,7 @@ void VCmpxTruF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3011,7 +3011,7 @@ void VCmpxFI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3048,7 +3048,7 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3085,7 +3085,7 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3122,7 +3122,7 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3159,7 +3159,7 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3196,7 +3196,7 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3233,7 +3233,7 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3267,7 +3267,7 @@ void VCmpxTI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3301,7 +3301,7 @@ void VCmpxFU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3338,7 +3338,7 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3375,7 +3375,7 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3412,7 +3412,7 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3449,7 +3449,7 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3486,7 +3486,7 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3523,7 +3523,7 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3557,7 +3557,7 @@ void VCmpxTU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4007,7 +4007,7 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4044,7 +4044,7 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4081,7 +4081,7 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4118,7 +4118,7 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4155,7 +4155,7 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4192,7 +4192,7 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4229,7 +4229,7 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4263,7 +4263,7 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4297,7 +4297,7 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4334,7 +4334,7 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4371,7 +4371,7 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4408,7 +4408,7 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4445,7 +4445,7 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4482,7 +4482,7 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4519,7 +4519,7 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4553,7 +4553,7 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4637,7 +4637,7 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4652,7 +4652,7 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4667,7 +4667,7 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4682,7 +4682,7 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4697,7 +4697,7 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4712,7 +4712,7 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4727,7 +4727,7 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4739,7 +4739,7 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4751,7 +4751,7 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4766,7 +4766,7 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4781,7 +4781,7 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4796,7 +4796,7 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4811,7 +4811,7 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4826,7 +4826,7 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4841,7 +4841,7 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4853,7 +4853,7 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3_exec.cpp
@@ -7331,7 +7331,7 @@ void VCmpxClassF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -7379,7 +7379,7 @@ void VCmpxClassF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -7504,7 +7504,7 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vopc_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vopc_exec.cpp
@@ -95,7 +95,7 @@ void VCmpxClassF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -147,7 +147,7 @@ void VCmpxClassF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -231,7 +231,7 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (match)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -681,7 +681,7 @@ void VCmpxFF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -720,7 +720,7 @@ void VCmpxLtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -759,7 +759,7 @@ void VCmpxEqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -798,7 +798,7 @@ void VCmpxLeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -837,7 +837,7 @@ void VCmpxGtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -876,7 +876,7 @@ void VCmpxLgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -915,7 +915,7 @@ void VCmpxGeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -954,7 +954,7 @@ void VCmpxOF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -993,7 +993,7 @@ void VCmpxUF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1032,7 +1032,7 @@ void VCmpxNgeF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1071,7 +1071,7 @@ void VCmpxNlgF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1110,7 +1110,7 @@ void VCmpxNgtF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1149,7 +1149,7 @@ void VCmpxNleF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1188,7 +1188,7 @@ void VCmpxNeqF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1227,7 +1227,7 @@ void VCmpxNltF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1261,7 +1261,7 @@ void VCmpxTruF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1711,7 +1711,7 @@ void VCmpxFF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1748,7 +1748,7 @@ void VCmpxLtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1785,7 +1785,7 @@ void VCmpxEqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1822,7 +1822,7 @@ void VCmpxLeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1859,7 +1859,7 @@ void VCmpxGtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1896,7 +1896,7 @@ void VCmpxLgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1933,7 +1933,7 @@ void VCmpxGeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -1970,7 +1970,7 @@ void VCmpxOF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2007,7 +2007,7 @@ void VCmpxUF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2044,7 +2044,7 @@ void VCmpxNgeF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2081,7 +2081,7 @@ void VCmpxNlgF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2118,7 +2118,7 @@ void VCmpxNgtF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2155,7 +2155,7 @@ void VCmpxNleF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2192,7 +2192,7 @@ void VCmpxNeqF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2229,7 +2229,7 @@ void VCmpxNltF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2263,7 +2263,7 @@ void VCmpxTruF32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -2347,7 +2347,7 @@ void VCmpxFF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2362,7 +2362,7 @@ void VCmpxLtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2377,7 +2377,7 @@ void VCmpxEqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2392,7 +2392,7 @@ void VCmpxLeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2407,7 +2407,7 @@ void VCmpxGtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2422,7 +2422,7 @@ void VCmpxLgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1 || s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2437,7 +2437,7 @@ void VCmpxGeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2452,7 +2452,7 @@ void VCmpxOF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!std::isnan(s0) && !std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2467,7 +2467,7 @@ void VCmpxUF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2482,7 +2482,7 @@ void VCmpxNgeF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 >= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2497,7 +2497,7 @@ void VCmpxNlgF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1 || s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2512,7 +2512,7 @@ void VCmpxNgtF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 > s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2527,7 +2527,7 @@ void VCmpxNleF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 <= s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2542,7 +2542,7 @@ void VCmpxNeqF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2557,7 +2557,7 @@ void VCmpxNltF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(s0 < s1))
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -2569,7 +2569,7 @@ void VCmpxTruF64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -3011,7 +3011,7 @@ void VCmpxFI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3048,7 +3048,7 @@ void VCmpxLtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3085,7 +3085,7 @@ void VCmpxEqI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3122,7 +3122,7 @@ void VCmpxLeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3159,7 +3159,7 @@ void VCmpxGtI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3196,7 +3196,7 @@ void VCmpxNeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3233,7 +3233,7 @@ void VCmpxGeI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3267,7 +3267,7 @@ void VCmpxTI16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3301,7 +3301,7 @@ void VCmpxFU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3338,7 +3338,7 @@ void VCmpxLtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3375,7 +3375,7 @@ void VCmpxEqU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3412,7 +3412,7 @@ void VCmpxLeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3449,7 +3449,7 @@ void VCmpxGtU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3486,7 +3486,7 @@ void VCmpxNeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3523,7 +3523,7 @@ void VCmpxGeU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -3557,7 +3557,7 @@ void VCmpxTU16Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4007,7 +4007,7 @@ void VCmpxFI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4044,7 +4044,7 @@ void VCmpxLtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4081,7 +4081,7 @@ void VCmpxEqI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4118,7 +4118,7 @@ void VCmpxLeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4155,7 +4155,7 @@ void VCmpxGtI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4192,7 +4192,7 @@ void VCmpxNeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4229,7 +4229,7 @@ void VCmpxGeI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4263,7 +4263,7 @@ void VCmpxTI32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4297,7 +4297,7 @@ void VCmpxFU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4334,7 +4334,7 @@ void VCmpxLtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4371,7 +4371,7 @@ void VCmpxEqU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4408,7 +4408,7 @@ void VCmpxLeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4445,7 +4445,7 @@ void VCmpxGtU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4482,7 +4482,7 @@ void VCmpxNeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4519,7 +4519,7 @@ void VCmpxGeU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4553,7 +4553,7 @@ void VCmpxTU32Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
   if (inst_.src0 == amdgpu::SRC_SDWA && sdwa_sd_) {
     uint64_t cmp_result = wf.vcc();
@@ -4637,7 +4637,7 @@ void VCmpxFI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4652,7 +4652,7 @@ void VCmpxLtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4667,7 +4667,7 @@ void VCmpxEqI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4682,7 +4682,7 @@ void VCmpxLeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4697,7 +4697,7 @@ void VCmpxGtI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4712,7 +4712,7 @@ void VCmpxNeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4727,7 +4727,7 @@ void VCmpxGeI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4739,7 +4739,7 @@ void VCmpxTI64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4751,7 +4751,7 @@ void VCmpxFU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     (void)lane;
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4766,7 +4766,7 @@ void VCmpxLtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 < s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4781,7 +4781,7 @@ void VCmpxEqU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 == s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4796,7 +4796,7 @@ void VCmpxLeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 <= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4811,7 +4811,7 @@ void VCmpxGtU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 > s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4826,7 +4826,7 @@ void VCmpxNeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 != s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4841,7 +4841,7 @@ void VCmpxGeU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (s0 >= s1)
       result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 
@@ -4853,7 +4853,7 @@ void VCmpxTU64Vopc::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     result |= (1ULL << lane);
   }
-  wf.set_vcc(result);
+  wf.set_vcc_mask(result);
   wf.set_exec(result);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -2836,7 +2836,7 @@ inline void execute_v_add_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(w);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -2890,7 +2890,7 @@ inline void execute_v_add_co_u32_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
       return static_cast<uint32_t>(w);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -3275,7 +3275,7 @@ inline void execute_v_addc_co_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(w);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4020,7 +4020,7 @@ inline void execute_v_cmp_class_f16_vopc([[maybe_unused]] Inst &inst,
     if (match)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4150,7 +4150,7 @@ inline void execute_v_cmp_class_f32_vopc([[maybe_unused]] Inst &inst,
     if (match)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4288,7 +4288,7 @@ inline void execute_v_cmp_class_f64_vopc([[maybe_unused]] Inst &inst,
     if (match)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4338,7 +4338,7 @@ inline void execute_v_cmp_eq_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4382,7 +4382,7 @@ inline void execute_v_cmp_eq_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4428,7 +4428,7 @@ inline void execute_v_cmp_eq_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4460,7 +4460,7 @@ inline void execute_v_cmp_eq_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4490,7 +4490,7 @@ inline void execute_v_cmp_eq_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4520,7 +4520,7 @@ inline void execute_v_cmp_eq_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4549,7 +4549,7 @@ inline void execute_v_cmp_eq_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4579,7 +4579,7 @@ inline void execute_v_cmp_eq_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4609,7 +4609,7 @@ inline void execute_v_cmp_eq_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4639,7 +4639,7 @@ inline void execute_v_cmp_f_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4667,7 +4667,7 @@ inline void execute_v_cmp_f_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4695,7 +4695,7 @@ inline void execute_v_cmp_f_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4712,7 +4712,7 @@ inline void execute_v_cmp_f_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4740,7 +4740,7 @@ inline void execute_v_cmp_f_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4769,7 +4769,7 @@ inline void execute_v_cmp_f_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4784,7 +4784,7 @@ inline void execute_v_cmp_f_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4812,7 +4812,7 @@ inline void execute_v_cmp_f_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4841,7 +4841,7 @@ inline void execute_v_cmp_f_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (0)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4891,7 +4891,7 @@ inline void execute_v_cmp_ge_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4935,7 +4935,7 @@ inline void execute_v_cmp_ge_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -4981,7 +4981,7 @@ inline void execute_v_cmp_ge_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5013,7 +5013,7 @@ inline void execute_v_cmp_ge_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5043,7 +5043,7 @@ inline void execute_v_cmp_ge_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5073,7 +5073,7 @@ inline void execute_v_cmp_ge_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5102,7 +5102,7 @@ inline void execute_v_cmp_ge_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5132,7 +5132,7 @@ inline void execute_v_cmp_ge_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5162,7 +5162,7 @@ inline void execute_v_cmp_ge_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5211,7 +5211,7 @@ inline void execute_v_cmp_gt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5255,7 +5255,7 @@ inline void execute_v_cmp_gt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5301,7 +5301,7 @@ inline void execute_v_cmp_gt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5333,7 +5333,7 @@ inline void execute_v_cmp_gt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5363,7 +5363,7 @@ inline void execute_v_cmp_gt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5393,7 +5393,7 @@ inline void execute_v_cmp_gt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5422,7 +5422,7 @@ inline void execute_v_cmp_gt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5452,7 +5452,7 @@ inline void execute_v_cmp_gt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5482,7 +5482,7 @@ inline void execute_v_cmp_gt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5532,7 +5532,7 @@ inline void execute_v_cmp_le_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5576,7 +5576,7 @@ inline void execute_v_cmp_le_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5622,7 +5622,7 @@ inline void execute_v_cmp_le_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5654,7 +5654,7 @@ inline void execute_v_cmp_le_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5684,7 +5684,7 @@ inline void execute_v_cmp_le_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5714,7 +5714,7 @@ inline void execute_v_cmp_le_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5743,7 +5743,7 @@ inline void execute_v_cmp_le_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5773,7 +5773,7 @@ inline void execute_v_cmp_le_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5803,7 +5803,7 @@ inline void execute_v_cmp_le_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5860,7 +5860,7 @@ inline void execute_v_cmp_lg_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
         }()))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5910,7 +5910,7 @@ inline void execute_v_cmp_lg_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
         }()))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -5962,7 +5962,7 @@ inline void execute_v_cmp_lg_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
         }()))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6011,7 +6011,7 @@ inline void execute_v_cmp_lt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6055,7 +6055,7 @@ inline void execute_v_cmp_lt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6101,7 +6101,7 @@ inline void execute_v_cmp_lt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6133,7 +6133,7 @@ inline void execute_v_cmp_lt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6163,7 +6163,7 @@ inline void execute_v_cmp_lt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6193,7 +6193,7 @@ inline void execute_v_cmp_lt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6222,7 +6222,7 @@ inline void execute_v_cmp_lt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6252,7 +6252,7 @@ inline void execute_v_cmp_lt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6282,7 +6282,7 @@ inline void execute_v_cmp_lt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6314,7 +6314,7 @@ inline void execute_v_cmp_ne_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6344,7 +6344,7 @@ inline void execute_v_cmp_ne_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int32_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6374,7 +6374,7 @@ inline void execute_v_cmp_ne_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<int64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6403,7 +6403,7 @@ inline void execute_v_cmp_ne_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6433,7 +6433,7 @@ inline void execute_v_cmp_ne_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6463,7 +6463,7 @@ inline void execute_v_cmp_ne_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
          static_cast<uint64_t>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6515,7 +6515,7 @@ inline void execute_v_cmp_neq_f16_vopc([[maybe_unused]] Inst &inst,
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6561,7 +6561,7 @@ inline void execute_v_cmp_neq_f32_vopc([[maybe_unused]] Inst &inst,
          std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6609,7 +6609,7 @@ inline void execute_v_cmp_neq_f64_vopc([[maybe_unused]] Inst &inst,
          std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6661,7 +6661,7 @@ inline void execute_v_cmp_nge_f16_vopc([[maybe_unused]] Inst &inst,
                static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6707,7 +6707,7 @@ inline void execute_v_cmp_nge_f32_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6755,7 +6755,7 @@ inline void execute_v_cmp_nge_f64_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6807,7 +6807,7 @@ inline void execute_v_cmp_ngt_f16_vopc([[maybe_unused]] Inst &inst,
                static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6853,7 +6853,7 @@ inline void execute_v_cmp_ngt_f32_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6901,7 +6901,7 @@ inline void execute_v_cmp_ngt_f64_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6953,7 +6953,7 @@ inline void execute_v_cmp_nle_f16_vopc([[maybe_unused]] Inst &inst,
                static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -6999,7 +6999,7 @@ inline void execute_v_cmp_nle_f32_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7047,7 +7047,7 @@ inline void execute_v_cmp_nle_f64_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7106,7 +7106,7 @@ inline void execute_v_cmp_nlg_f16_vopc([[maybe_unused]] Inst &inst,
         }())))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7158,7 +7158,7 @@ inline void execute_v_cmp_nlg_f32_vopc([[maybe_unused]] Inst &inst,
         }())))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7212,7 +7212,7 @@ inline void execute_v_cmp_nlg_f64_vopc([[maybe_unused]] Inst &inst,
         }())))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7264,7 +7264,7 @@ inline void execute_v_cmp_nlt_f16_vopc([[maybe_unused]] Inst &inst,
                static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7310,7 +7310,7 @@ inline void execute_v_cmp_nlt_f32_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7358,7 +7358,7 @@ inline void execute_v_cmp_nlt_f64_vopc([[maybe_unused]] Inst &inst,
            std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7410,7 +7410,7 @@ inline void execute_v_cmp_o_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7456,7 +7456,7 @@ inline void execute_v_cmp_o_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
          !std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7506,7 +7506,7 @@ inline void execute_v_cmp_o_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
              std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7519,7 +7519,7 @@ inline void execute_v_cmp_t_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7546,7 +7546,7 @@ inline void execute_v_cmp_t_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7573,7 +7573,7 @@ inline void execute_v_cmp_t_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7590,7 +7590,7 @@ inline void execute_v_cmp_t_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7618,7 +7618,7 @@ inline void execute_v_cmp_t_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7646,7 +7646,7 @@ inline void execute_v_cmp_t_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7661,7 +7661,7 @@ inline void execute_v_cmp_t_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7689,7 +7689,7 @@ inline void execute_v_cmp_t_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7718,7 +7718,7 @@ inline void execute_v_cmp_t_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7750,7 +7750,7 @@ inline void execute_v_cmp_tru_f16_vopc([[maybe_unused]] Inst &inst,
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7780,7 +7780,7 @@ inline void execute_v_cmp_tru_f32_vopc([[maybe_unused]] Inst &inst,
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7810,7 +7810,7 @@ inline void execute_v_cmp_tru_f64_vopc([[maybe_unused]] Inst &inst,
     if (1)
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7862,7 +7862,7 @@ inline void execute_v_cmp_u_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
              static_cast<uint16_t>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane))))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7908,7 +7908,7 @@ inline void execute_v_cmp_u_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
          std::isnan(std::bit_cast<float>(amdgpu::RegisterAccess(wf).read_lane(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -7958,7 +7958,7 @@ inline void execute_v_cmp_u_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
              std::bit_cast<double>(amdgpu::RegisterAccess(wf).read_lane64(inst.vsrc1, lane)))))
       vcc |= (1ULL << lane);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18330,7 +18330,7 @@ inline void execute_v_sub_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18381,7 +18381,7 @@ inline void execute_v_sub_co_u32_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
       return a - b;
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18688,7 +18688,7 @@ inline void execute_v_subb_co_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18747,7 +18747,7 @@ inline void execute_v_subbrev_co_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18799,7 +18799,7 @@ inline void execute_v_subrev_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>
@@ -18851,7 +18851,7 @@ inline void execute_v_subrev_co_u32_vop2([[maybe_unused]] Inst &inst,
       return a - b;
     }());
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/scalar_operand_resolve.h
@@ -26,9 +26,9 @@ namespace amdgpu {
 // value for this arch (124 on most arches; 125 on RDNA 3 / RDNA 3.5 / RDNA4
 // / GFX1250, where 124 is the NULL slot).
 inline uint32_t resolve_src_scalar(const Wavefront &wf, int ev, int m0_ev) {
-  if (ev == 102)
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102)
     return static_cast<uint32_t>(wf.scratch_base());
-  if (ev == 103)
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 103)
     return static_cast<uint32_t>(wf.scratch_base() >> 32);
   if (ev <= 105)
     return RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev));
@@ -85,13 +85,9 @@ inline uint32_t resolve_src_scalar(const Wavefront &wf, int ev, int m0_ev) {
   if (ev == 250)
     return 0u; // NULL
   if (ev == 251)
-    return (wf.vcc() & (wf.wf_size() >= 64 ? ~0ULL : ((1ULL << wf.wf_size()) - 1ULL))) == 0
-               ? 1u
-               : 0u; // VCCZ
-  if (ev == 252) {
-    uint64_t active = wf.wf_size() >= 64 ? ~0ULL : ((1ULL << wf.wf_size()) - 1ULL);
-    return (wf.exec() & active) == 0 ? 1u : 0u; // EXECZ
-  }
+    return wf.vcc_mask() == 0 ? 1u : 0u; // VCCZ
+  if (ev == 252)
+    return wf.exec() == 0 ? 1u : 0u; // EXECZ
   if (ev == 253)
     return wf.read_scc() ? 1u : 0u; // SCC
   throw std::logic_error("Unsupported encoding value for scalar read: " + std::to_string(ev));
@@ -139,7 +135,7 @@ inline bool can_resolve_src_scalar(int ev, int m0_ev) {
 }
 
 inline uint64_t resolve_src_scalar64(const Wavefront &wf, int ev, int m0_ev) {
-  if (ev == 102)
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102)
     return wf.scratch_base();
   if (ev <= 105) {
     uint32_t lo = RegisterAccess(wf).read_sgpr(wf.sgpr_alloc().base + static_cast<uint32_t>(ev));
@@ -197,12 +193,12 @@ inline uint64_t resolve_src_scalar64(const Wavefront &wf, int ev, int m0_ev) {
 }
 
 inline void resolve_dst_write(Wavefront &wf, int ev, uint32_t val, int m0_ev) {
-  if (ev == 102) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102) {
     uint64_t sb = wf.scratch_base();
     wf.set_scratch_base((sb & 0xFFFFFFFF00000000ULL) | val);
     return;
   }
-  if (ev == 103) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 103) {
     uint64_t sb = wf.scratch_base();
     wf.set_scratch_base((sb & 0x00000000FFFFFFFFULL) | (static_cast<uint64_t>(val) << 32));
     return;
@@ -241,7 +237,7 @@ inline void resolve_dst_write(Wavefront &wf, int ev, uint32_t val, int m0_ev) {
 }
 
 inline void resolve_dst_write64(Wavefront &wf, int ev, uint64_t val) {
-  if (ev == 102) {
+  if (arch_uses_legacy_flat_scratch_sgprs(wf.cu().arch()) && ev == 102) {
     wf.set_scratch_base(val);
     return;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -628,7 +628,7 @@ template <typename Inst, typename CarryOp>
         carry_bits |= (1ULL << i);
     vcc_out = (vcc_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
   }
-  wf.set_vcc(vcc_out);
+  wf.set_vcc_mask(vcc_out);
   return true;
 }
 
@@ -1182,7 +1182,7 @@ template <typename T, typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
   return true;
 }
 
@@ -1218,7 +1218,7 @@ template <typename T, typename Inst, typename CmpOp>
     const uint64_t cmp_bits = cmp_bits64<T>(a, b, cmp_op);
     vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
   return true;
 }
 
@@ -1259,7 +1259,7 @@ template <typename Inst, typename CmpOp>
     const uint64_t cmp_bits = cmp_class_f64_bits(s, mask, cmp_op);
     vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  wf.set_vcc(vcc);
+  wf.set_vcc_mask(vcc);
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_traits.h
@@ -99,6 +99,29 @@ template <GpuIsa Isa> inline constexpr bool supports_wave_size(uint32_t wf) {
          arch == ROCJITSU_CODE_ARCH_RDNA4;
 }
 
+/// @brief Return true when scalar selectors 102 and 103 name FLAT_SCRATCH.
+///
+/// @details GFX10+ makes those selectors ordinary SGPRs. Keep both the legacy
+/// and modern architecture sets explicit so an unclassified future target does
+/// not silently inherit the legacy register alias.
+[[nodiscard]] inline constexpr bool arch_uses_legacy_flat_scratch_sgprs(rj_code_arch_t arch) {
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_CDNA1:
+  case ROCJITSU_CODE_ARCH_CDNA2:
+  case ROCJITSU_CODE_ARCH_CDNA3:
+  case ROCJITSU_CODE_ARCH_CDNA4:
+    return true;
+  case ROCJITSU_CODE_ARCH_RDNA1:
+  case ROCJITSU_CODE_ARCH_RDNA2:
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
+  default:
+    return false;
+  }
+}
+
 /// @brief Maximum SGPR allocation encodable in an AMDHSA descriptor for @p arch.
 ///
 /// @details CDNA descriptors account for reserved architectural SGPRs such as

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -71,11 +71,14 @@ static_assert(kMaxClusterWorkgroups <= 16,
 // and cluster identity sequences.
 constexpr uint32_t kGfx12Ttmp6 = 114;
 constexpr uint32_t kGfx12Ttmp7 = 115;
+constexpr uint32_t kGfx12Ttmp8 = 116;
 constexpr uint32_t kGfx12Ttmp9 = 117;
 
 // LLVM's gfx1250 architected-SGPR ABI maps TTMP6 as seven 4-bit fields:
 // cluster-local XYZ, cluster-max XYZ, and max-flat-ID from low to high bits.
-// TTMP7 holds 16-bit cluster-grid Y/Z IDs, while TTMP9 holds cluster-grid X.
+// TTMP7 holds 16-bit cluster-grid Y/Z IDs. TTMP8 holds queue-packet ID
+// [24:0], wave-in-workgroup [29:25], grid-Y/Z-valid [30], and debug-mark
+// [31]. TTMP9 holds cluster-grid X.
 constexpr uint32_t kGfx12Ttmp6ClusterLocalXShift = 0;
 constexpr uint32_t kGfx12Ttmp6ClusterLocalYShift = 4;
 constexpr uint32_t kGfx12Ttmp6ClusterLocalZShift = 8;
@@ -84,6 +87,9 @@ constexpr uint32_t kGfx12Ttmp6ClusterMaxYShift = 16;
 constexpr uint32_t kGfx12Ttmp6ClusterMaxZShift = 20;
 constexpr uint32_t kGfx12Ttmp6ClusterMaxFlatIdShift = 24;
 constexpr uint32_t kGfx12Ttmp7ClusterGridDimensionMask = 0xFFFFu;
+constexpr uint32_t kGfx12Ttmp8QueuePacketIdMask = 0x1FFFFFFu;
+constexpr uint32_t kGfx12Ttmp8WaveIdInGroupShift = 25;
+constexpr uint32_t kGfx12Ttmp8GridYzValidShift = 30;
 
 struct PlannedWorkgroup {
   uint32_t local_wg_id = 0;
@@ -397,6 +403,10 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     uint32_t ttmp6 = 0;
     uint32_t ttmp7 = ((wg_id_z & kGfx12Ttmp7ClusterGridDimensionMask) << 16) |
                      (wg_id_y & kGfx12Ttmp7ClusterGridDimensionMask);
+    uint32_t ttmp8 = pkt.queue_packet_id & kGfx12Ttmp8QueuePacketIdMask;
+    ttmp8 |= wf_index_in_wg << kGfx12Ttmp8WaveIdInGroupShift;
+    if (pkt.grid_yz_valid)
+      ttmp8 |= 1u << kGfx12Ttmp8GridYzValidShift;
     uint32_t ttmp9 = grid_wg_id_x;
     if (properties.uses_cluster_ttmp_workgroup_ids) {
       const uint32_t cluster_size_x = nonzero_or_one(pkt.cluster_size_x);
@@ -424,6 +434,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     }
     cu->write_sgpr(sbase + kGfx12Ttmp6, ttmp6);
     cu->write_sgpr(sbase + kGfx12Ttmp7, ttmp7);
+    cu->write_sgpr(sbase + kGfx12Ttmp8, ttmp8);
     cu->write_sgpr(sbase + kGfx12Ttmp9, ttmp9);
   }
 
@@ -1286,7 +1297,8 @@ static const uint8_t *find_elf_base(const uint8_t *ptr, const uint8_t *limit) {
 }
 
 void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt,
-                                          const HwQueue &queue, uint64_t pkt_addr, HwQueueState &qs,
+                                          const HwQueue &queue, uint64_t pkt_addr,
+                                          uint32_t queue_packet_id, HwQueueState &qs,
                                           ClusterDispatchShape cluster_shape) {
   bool host_accessible = queue.host_accessible;
   using namespace rocr::llvm::amdhsa;
@@ -1320,6 +1332,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.dispatch_id = next_dispatch_id_++;
   dp.profiling_start_timestamp = hsa_system_timestamp();
   dp.queue_id = queue.queue_id;
+  dp.queue_packet_id = queue_packet_id;
   dp.process_id = queue.process_id;
   dp.kernel_entry_pc = entry_pc;
   dp.total_wgs = total_wgs;
@@ -1386,6 +1399,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.grid_wgs_x = (num_dims <= 1) ? total_wgs : grid_wgs_x;
   dp.grid_wgs_y = (num_dims >= 2) ? grid_wgs_y : 1;
   dp.grid_wgs_z = (num_dims >= 3) ? grid_wgs_z : 1;
+  dp.grid_yz_valid = num_dims >= 2;
   dp.cluster_size_x = nonzero_or_one(cluster_shape.size_x);
   dp.cluster_size_y = nonzero_or_one(cluster_shape.size_y);
   dp.cluster_size_z = nonzero_or_one(cluster_shape.size_z);
@@ -1612,7 +1626,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
     }
 
     if (pkt_type == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
-      process_aql_packet(pkt, queue, pkt_addr, qs);
+      process_aql_packet(pkt, queue, pkt_addr, slot, qs);
     } else if (pkt_type == HSA_PACKET_TYPE_BARRIER_AND || pkt_type == HSA_PACKET_TYPE_BARRIER_OR) {
       constexpr uint32_t DEP_OFF = 8;
       constexpr uint32_t SIG_OFF = 56;
@@ -1772,7 +1786,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
         cluster_shape.size_x = ext.cluster_size_x;
         cluster_shape.size_y = ext.cluster_size_y;
         cluster_shape.size_z = ext.cluster_size_z;
-        process_aql_packet(dispatch, queue, pkt_addr, qs, cluster_shape);
+        process_aql_packet(dispatch, queue, pkt_addr, slot, qs, cluster_shape);
       } else if (ext.amd_format == kAmdAqlFormatPm4Ib) {
         constexpr uint32_t SIG_OFF = 56;
         const uint64_t sig = read_gpu_u64(pkt_addr + SIG_OFF, queue.process_id);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -241,7 +241,7 @@ private:
 
   /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and create a DispatchEntry.
   void process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt, const HwQueue &queue,
-                          uint64_t pkt_addr, HwQueueState &qs,
+                          uint64_t pkt_addr, uint32_t queue_packet_id, HwQueueState &qs,
                           ClusterDispatchShape cluster_shape = {});
 
   rocr::llvm::amdhsa::kernel_descriptor_t

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -44,6 +44,7 @@ struct ClusterDispatchShape {
 struct DispatchEntry {
   uint32_t dispatch_id = 0;
   uint32_t queue_id = 0;
+  uint32_t queue_packet_id = 0;
   uint32_t process_id = 0;
 
   uint64_t kernel_entry_pc = 0;
@@ -66,6 +67,7 @@ struct DispatchEntry {
   uint32_t grid_wgs_x = 0;
   uint32_t grid_wgs_y = 1;
   uint32_t grid_wgs_z = 1;
+  bool grid_yz_valid = false;
   uint32_t cluster_count_x = 0;
   uint32_t cluster_count_y = 0;
   uint32_t cluster_count_z = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -245,13 +245,27 @@ public:
   /// @brief Set the raw architectural EXEC register pair.
   void set_exec_raw(uint64_t val) { exec_ = val; }
 
-  /// @brief Return the VCC scalar register pair.
-  /// @returns Raw VCC register value.
+  /// @brief Return the raw architectural VCC register pair.
+  /// @returns Raw VCC register value, including non-lane bits in wave32 mode.
   uint64_t vcc() const { return vcc_; }
 
-  /// @brief Set the VCC scalar register pair.
-  /// @param val New VCC value.
+  /// @brief Return the active-lane portion of the VCC register pair.
+  /// @returns VCC mask with non-lane bits cleared.
+  uint64_t vcc_mask() const { return vcc_ & lane_mask(); }
+
+  /// @brief Set the raw architectural VCC register pair.
+  /// @param val New raw VCC value.
+  ///
+  /// Scalar operand writes may update either half directly. Vector predicate
+  /// and carry producers must use set_vcc_mask() to preserve wave32 VCC_HI.
   void set_vcc(uint64_t val) { vcc_ = val; }
+
+  /// @brief Set the active-lane portion of the VCC register pair.
+  /// @param val New lane-mask value.
+  ///
+  /// Wave32 leaves VCC_HI available as scalar scratch. Vector instructions
+  /// that produce a predicate or carry mask must preserve those non-lane bits.
+  void set_vcc_mask(uint64_t val) { vcc_ = (vcc_ & ~lane_mask()) | (val & lane_mask()); }
 
   /// @brief Return the M0 special register.
   /// @returns M0 register value.

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -334,6 +334,44 @@ TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {
   // TTMP9 (s117) holds grid_wg_id_x; TTMP7 (s115) packs wg_id_y/z.
   EXPECT_EQ(target->sgpr(117), 1u);
   EXPECT_EQ(target->sgpr(115), 1u);
+  EXPECT_NE(target->sgpr(116) & (1u << 30), 0u);
+}
+
+TEST(Gfx1250SimulationTest, Ttmp8EncodesWaveIdWithinWorkgroup) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 64, 64);
+  step_until_xcd_halted(sim);
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 2u);
+  std::vector<uint32_t> ttmp8_values;
+  for (const auto &wf : sim.snapshot->snapshots())
+    ttmp8_values.push_back(wf.sgpr(116));
+  std::sort(ttmp8_values.begin(), ttmp8_values.end());
+  EXPECT_EQ(ttmp8_values, (std::vector<uint32_t>{0, 1u << 25}));
+}
+
+TEST(Gfx1250SimulationTest, Ttmp8EncodesQueuePacketId) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 32, 32);
+  queue.dispatch(kernel_object, 32, 32);
+  step_until_xcd_halted(sim);
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 2u);
+  std::array<uint32_t, 2> queue_packet_ids{};
+  for (const auto &wf : sim.snapshot->snapshots()) {
+    ASSERT_GE(wf.dispatch_id, 1u);
+    ASSERT_LE(wf.dispatch_id, 2u);
+    queue_packet_ids[wf.dispatch_id - 1] = wf.sgpr(116) & 0x1FFFFFFu;
+  }
+  EXPECT_EQ(queue_packet_ids, (std::array<uint32_t, 2>{0, 1}));
 }
 
 TEST(Gfx1250SimulationTest, GlobalStoreWritesVisibleMemory) {

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -24,6 +24,120 @@ TEST(Gfx1250ExecutionTest, TargetProvidesImmutableExecutionBackend) {
   EXPECT_TRUE(cdna5::Operand::full_execution_backend_complete());
 }
 
+TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+
+  constexpr uint64_t kScratchBase = 0xabcde00012345000ull;
+  wf->set_scratch_base(kScratchBase);
+  write_wave_sgpr(*cu, *wf, 90, 0x11223344u);
+  write_wave_sgpr(*cu, *wf, 91, 0x55667788u);
+  write_wave_sgpr(*cu, *wf, 92, 0xaabbccddu);
+  write_wave_sgpr(*cu, *wf, 93, 0xeeff0011u);
+  write_wave_sgpr(*cu, *wf, 102, 0);
+  write_wave_sgpr(*cu, *wf, 103, 0);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  constexpr std::array<uint32_t, 3> kMove64 = {
+      0xbee6015au, // s_mov_b64 s[102:103], s[90:91]
+      0,
+      0,
+  };
+  std::unique_ptr<Instruction> move64(decoder->decode(kMove64.data()));
+  ASSERT_NE(move64, nullptr);
+  EXPECT_EQ(move64->mnemonic(), "s_mov_b64");
+  EXPECT_EQ(move64->size(), 4);
+  move64->execute(*move64, wf);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 102), 0x11223344u);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 103), 0x55667788u);
+  EXPECT_EQ(wf->scratch_base(), kScratchBase);
+
+  constexpr std::array<uint32_t, 3> kWriteS102 = {
+      0xbee6005cu, // s_mov_b32 s102, s92
+      0,
+      0,
+  };
+  constexpr std::array<uint32_t, 3> kWriteS103 = {
+      0xbee7005du, // s_mov_b32 s103, s93
+      0,
+      0,
+  };
+  for (const auto *words : {kWriteS102.data(), kWriteS103.data()}) {
+    std::unique_ptr<Instruction> move32(decoder->decode(words));
+    ASSERT_NE(move32, nullptr);
+    EXPECT_EQ(move32->mnemonic(), "s_mov_b32");
+    EXPECT_EQ(move32->size(), 4);
+    move32->execute(*move32, wf);
+  }
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 102), 0xaabbccddu);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 103), 0xeeff0011u);
+
+  constexpr std::array<uint32_t, 3> kReadS102 = {
+      0xbed20066u, // s_mov_b32 s82, s102
+      0,
+      0,
+  };
+  constexpr std::array<uint32_t, 3> kReadS103 = {
+      0xbed30067u, // s_mov_b32 s83, s103
+      0,
+      0,
+  };
+  for (const auto *words : {kReadS102.data(), kReadS103.data()}) {
+    std::unique_ptr<Instruction> move32(decoder->decode(words));
+    ASSERT_NE(move32, nullptr);
+    EXPECT_EQ(move32->mnemonic(), "s_mov_b32");
+    EXPECT_EQ(move32->size(), 4);
+    move32->execute(*move32, wf);
+  }
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 82), 0xaabbccddu);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 83), 0xeeff0011u);
+
+  constexpr std::array<uint32_t, 3> kReadS102S103 = {
+      0xbed00166u, // s_mov_b64 s[80:81], s[102:103]
+      0,
+      0,
+  };
+  std::unique_ptr<Instruction> read64(decoder->decode(kReadS102S103.data()));
+  ASSERT_NE(read64, nullptr);
+  EXPECT_EQ(read64->mnemonic(), "s_mov_b64");
+  EXPECT_EQ(read64->size(), 4);
+  read64->execute(*read64, wf);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 80), 0xaabbccddu);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 81), 0xeeff0011u);
+  EXPECT_EQ(wf->scratch_base(), kScratchBase);
+}
+
+TEST(Gfx1250ExecutionTest, Wave32VectorComparePreservesVccHiScratch) {
+  ForceScalarGuard force_scalar_guard;
+  for (const bool force_scalar : {false, true}) {
+    SCOPED_TRACE(force_scalar ? "scalar" : "simd");
+    util::set_force_scalar_for_testing(force_scalar);
+
+    Gfx1250Sim sim;
+    auto *cu = sim.cu();
+    auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+    ASSERT_NE(wf, nullptr);
+    wf->set_exec(0x3u);
+    wf->set_vcc(0x000001c0ffffffffull);
+    write_wave_sgpr(*cu, *wf, 28, 7u);
+    const uint32_t vgpr_base = wf->vgpr_alloc().base;
+    cu->write_vgpr(vgpr_base + 18, 0, 6u);
+    cu->write_vgpr(vgpr_base + 18, 1, 8u);
+
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+    ASSERT_NE(decoder, nullptr);
+    constexpr auto kCompare = cdna5::build_vopc(cdna5::kVCmpGtI32Vopc, {.src0 = 28, .vsrc1 = 18});
+    std::unique_ptr<Instruction> decoded(decoder->decode(kCompare.data()));
+    ASSERT_NE(decoded, nullptr);
+    EXPECT_EQ(decoded->mnemonic(), "v_cmp_gt_i32_e32");
+    decoded->execute(*decoded, wf);
+    EXPECT_EQ(wf->vcc(), 0x000001c000000001ull);
+  }
+}
+
 TEST(Gfx1250ExecutionTest, DivScaleWritesExplicitSdstMask) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();


### PR DESCRIPTION
Model the architectural wave state that gfx1250 compiler-generated kernels and debugger paths consume instead of relying on legacy scalar register conventions.

Treat scalar selectors 102 and 103 as ordinary SGPRs on GFX10+ targets, preserve Wave32 VCC_HI scratch across vector predicate and carry writes, and expose explicit masked VCC access for VCCZ. Keep the flat-scratch encoding policy architecture-explicit so unknown future targets do not inherit the legacy alias.

Populate the gfx1250 TTMP launch payload from the AQL dispatch: encode the queue packet index, wave-in-workgroup position, and Y/Z validity in TTMP8, while retaining the architected workgroup and cluster coordinates in TTMP6, TTMP7, and TTMP9. Extend execution and dispatch tests across every scalar resolver direction, both VCC execution paths, one- and two-dimensional TTMP layouts, and nonzero queue slots.