### PR TITLE
[rocjitsu] Model gfx1250 barrier synchronization

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4706,6 +4706,16 @@ class CodeGenerator:
             L.append('  wf.set_state(amdgpu::WfState::BARRIER);')
             return '\n'.join(L)
 
+        if cls == 'scalar_barrier_wait':
+            L.append(
+                f'  int32_t barrier_id = static_cast<int16_t>({src_ops[0]}.encoding_value_);'
+            )
+            L.append('  wf.barrier_wait(barrier_id);')
+            return '\n'.join(L)
+
+        if cls == 'scalar_barrier_leave':
+            return '  wf.write_scc(wf.barrier_leave());'
+
         if cls == 'branch':
             L.append(
                 f'  int16_t offset = static_cast<int16_t>({src_ops[0]}.encoding_value_);'
@@ -4854,7 +4864,69 @@ class CodeGenerator:
             return '\n'.join(L)
 
         if cls == 'scalar_barrier_state':
-            L.append(f'  amdgpu::RegisterAccess(wf).write_scalar({dst_ops[0]}, 0);')
+            L.append(
+                f'  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar({src_ops[0]});'
+            )
+            L.append(
+                f'  bool source_is_m0 = '
+                f'{src_ops[0]}.encoding_value() == '
+                f'OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;'
+            )
+            L.append(
+                '  int32_t barrier_id = source_is_m0 ? static_cast<int32_t>(source & 0x1fu) '
+                ': static_cast<int32_t>(source);'
+            )
+            L.append(
+                f'  amdgpu::RegisterAccess(wf).write_scalar({dst_ops[0]}, wf.barrier_state(barrier_id));'
+            )
+            return '\n'.join(L)
+
+        if cls in (
+            'scalar_barrier_signal',
+            'scalar_barrier_init',
+            'scalar_barrier_join',
+        ):
+            L.append(
+                f'  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar({src_ops[0]});'
+            )
+            L.append(
+                f'  bool source_is_m0 = '
+                f'{src_ops[0]}.encoding_value() == '
+                f'OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;'
+            )
+            L.append(
+                '  int32_t barrier_id = source_is_m0 ? static_cast<int32_t>(source & 0x1fu) '
+                ': static_cast<int32_t>(source);'
+            )
+            if cls == 'scalar_barrier_signal':
+                L.append(
+                    '  uint32_t member_count = source_is_m0 ? ((source >> 16) & 0x7fu) : 0;'
+                )
+                if op == 'signal_isfirst':
+                    L.append(
+                        '  bool barrier_valid = (wf.barrier_state(barrier_id) & 1u) != 0;'
+                    )
+                    L.append(
+                        '  bool is_first = wf.barrier_signal(barrier_id, member_count);'
+                    )
+                    L.append('  if (barrier_valid) wf.write_scc(is_first);')
+                else:
+                    L.append('  wf.barrier_signal(barrier_id, member_count);')
+            elif cls == 'scalar_barrier_init':
+                has_implicit_m0 = any(
+                    operand.name == 'm0' and operand.is_input
+                    for operand in inst.operands
+                )
+                member_source = (
+                    'wf.m0()'
+                    if has_implicit_m0
+                    else f'amdgpu::RegisterAccess(wf).read_scalar({src_ops[0]})'
+                )
+                L.append(f'  uint32_t member_source = {member_source};')
+                L.append('  uint32_t member_count = (member_source >> 16) & 0x7fu;')
+                L.append('  wf.barrier_init(barrier_id, member_count);')
+            else:
+                L.append('  wf.barrier_join(barrier_id);')
             return '\n'.join(L)
 
         if cls == 'scalar_movrel':
@@ -11749,7 +11821,8 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
         resolve_code = cgen.Line(
             'namespace {\n'
             '\n'
-            f'constexpr int kM0EncodingValue = {125 if scalar_null_precedes_m0 else 124};\n'
+            f'constexpr int kM0EncodingValue = '
+            f'{125 if scalar_null_precedes_m0 else 124};\n'
             '\n'
             + _is_vgpr_only_body
             + '\n\n'

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -1657,6 +1657,14 @@ class Rdna4Profile(_AmdgpuProfileBase):
     def uses_true16_vop3_opsel(self) -> bool:
         return True
 
+    @property
+    def semantic_overrides(self) -> dict[str, tuple[str, ...]]:
+        return {
+            'S_BARRIER_SIGNAL': ('true_nop', '', ''),
+            'S_BARRIER_SIGNAL_ISFIRST': ('true_nop', '', ''),
+            'S_BARRIER_WAIT': ('barrier', '', ''),
+        }
+
     def mnemonic_rule(self, enc_name: str) -> MnemonicRule:
         """RDNA4 mnemonic rules.
 
@@ -1727,6 +1735,17 @@ class Gfx1250Profile(Rdna4Profile):
     @property
     def cpp_namespace(self) -> str | None:
         return 'cdna5'
+
+    @property
+    def semantic_overrides(self) -> dict[str, tuple[str, ...]]:
+        overrides = dict(super().semantic_overrides)
+        for mnemonic in (
+            'S_BARRIER_SIGNAL',
+            'S_BARRIER_SIGNAL_ISFIRST',
+            'S_BARRIER_WAIT',
+        ):
+            overrides.pop(mnemonic, None)
+        return overrides
 
     @property
     def semantic_class_overrides(self) -> dict[str, str]:

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -352,13 +352,12 @@ def _derive_sopp(name: str) -> InstructionSemantics | None:
     }
     if name in _SPLIT_WAIT:
         return InstructionSemantics(name, 'wait_counter', operation=name[2:].lower())
-    # S_BARRIER_WAIT uses the existing whole-workgroup barrier model for the
-    # common split form where S_BARRIER_SIGNAL is immediately followed by
-    # S_BARRIER_WAIT. Arrival accounting and named-barrier ids are not modeled
-    # yet: signal stays a no-op, wait parks the wavefront, and CU release logic
-    # keys only on all non-halted sibling waves in the same workgroup.
-    if name in ('S_BARRIER', 'S_BARRIER_WAIT'):
+    if name == 'S_BARRIER':
         return InstructionSemantics(name, 'barrier')
+    if name == 'S_BARRIER_WAIT':
+        return InstructionSemantics(name, 'scalar_barrier_wait')
+    if name == 'S_BARRIER_LEAVE':
+        return InstructionSemantics(name, 'scalar_barrier_leave', sets_scc='nonzero')
 
     if name == 'S_SET_GPR_IDX_OFF':
         return InstructionSemantics(name, 'gpr_idx', operation='off')
@@ -419,11 +418,11 @@ _SOP1_SPECIAL = {
     'S_MOVRELSD_2': ('scalar_movrel', 'srcdst2'),
     'S_MOVRELSD_2_B32': ('scalar_movrel', 'srcdst2'),
     'S_SENDMSG_RTN': ('scalar_sendmsg_rtn', None),
-    'S_BARRIER_SIGNAL': ('true_nop', None),
-    'S_BARRIER_SIGNAL_ISFIRST': ('true_nop', None),
+    'S_BARRIER_SIGNAL_ISFIRST': ('scalar_barrier_signal', 'signal_isfirst'),
+    'S_BARRIER_SIGNAL': ('scalar_barrier_signal', 'signal'),
     'S_GET_BARRIER_STATE': ('scalar_barrier_state', None, 'b32'),
-    'S_BARRIER_INIT': ('true_nop', None),
-    'S_BARRIER_JOIN': ('true_nop', None),
+    'S_BARRIER_INIT': ('scalar_barrier_init', None),
+    'S_BARRIER_JOIN': ('scalar_barrier_join', None),
     'S_WAKEUP_BARRIER': ('true_nop', None),
     'S_ALLOC_VGPR': ('true_nop', None),
     'S_SLEEP_VAR': ('true_nop', None),
@@ -523,6 +522,8 @@ def _derive_sop1(name: str) -> InstructionSemantics | None:
                 scc = 'none'
             else:
                 scc = 'nonzero'
+        elif cls == 'scalar_barrier_signal' and op == 'signal_isfirst':
+            scc = 'nonzero'
         return InstructionSemantics(
             name, cls, operation=op, data_type=dtype, sets_scc=scc
         )

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -406,14 +406,9 @@ def test_generated_scc_accesses_match_mrisa(isa_name, profile_type):
     }
     assert set(mrisa_scc_accesses) == active_keys
     mismatches = []
-    excluded = {
-        'S_ALLOC_VGPR',
-        'S_BARRIER_LEAVE',
-        'S_BARRIER_SIGNAL_ISFIRST',
-    }
     expected_exclusions = {
         'rdna4': {'S_ALLOC_VGPR', 'S_BARRIER_SIGNAL_ISFIRST'},
-        'gfx1250': excluded,
+        'gfx1250': {'S_ALLOC_VGPR'},
     }
     checked_exclusions = set()
     checked = 0
@@ -428,7 +423,7 @@ def test_generated_scc_accesses_match_mrisa(isa_name, profile_type):
 
             mrisa_reads_scc, mrisa_writes_scc = mrisa_scc_accesses[key]
             sem = semantics.instructions.get(inst.name)
-            if inst.name in excluded:
+            if inst.name in expected_exclusions.get(isa_name, set()):
                 assert (
                     mrisa_writes_scc
                 ), f'{isa_name}: stale SCC exclusion for {inst.name}'
@@ -2235,6 +2230,17 @@ def test_generated_operand_validates_barrier_id_selectors(
 
     gfx1250_test_encodings = (gfx1250_generated_root / 'test_encodings.h').read_text()
     assert '"s_get_barrier_state", {0xBE805080U' in gfx1250_test_encodings
+
+
+def test_gfx1250_barrier_init_reads_member_count_from_implicit_m0(
+    gfx1250_generated_root: Path,
+):
+    sop1_exec = (gfx1250_generated_root / 'sop1_exec.cpp').read_text()
+    body = _generated_method_body(sop1_exec, 'SBarrierInitSop1', 'SBarrierJoinSop1')
+
+    assert 'read_scalar(ssrc0)' in body
+    assert 'uint32_t member_source = wf.m0();' in body
+    assert 'member_count = (member_source >> 16) & 0x7fu' in body
 
 
 def test_generated_operand_validates_direct_selector_namespaces(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -720,10 +720,10 @@ class TestDeriveScalarMovrel:
 
 
 class TestDeriveScalarSplitBarrier:
-    def test_barrier_wait_derives_current_workgroup_barrier_model(self):
+    def test_barrier_wait_derives_barrier_wait_model(self):
         sem = derive_semantics('S_BARRIER_WAIT', 'ENC_SOPP')
         assert sem is not None
-        assert sem.semantic_class == 'barrier'
+        assert sem.semantic_class == 'scalar_barrier_wait'
         assert sem.sets_scc is None
 
     def test_get_barrier_state_derives_idle_state_read(self):
@@ -734,19 +734,30 @@ class TestDeriveScalarSplitBarrier:
         assert sem.sets_scc is None
 
     @pytest.mark.parametrize(
-        'name',
+        ('name', 'semantic_class', 'operation'),
         [
-            'S_BARRIER_SIGNAL',
-            'S_BARRIER_SIGNAL_ISFIRST',
-            'S_BARRIER_INIT',
-            'S_BARRIER_JOIN',
-            'S_WAKEUP_BARRIER',
+            ('S_BARRIER_SIGNAL', 'scalar_barrier_signal', 'signal'),
+            ('S_BARRIER_SIGNAL_ISFIRST', 'scalar_barrier_signal', 'signal_isfirst'),
+            ('S_BARRIER_INIT', 'scalar_barrier_init', None),
+            ('S_BARRIER_JOIN', 'scalar_barrier_join', None),
+            ('S_WAKEUP_BARRIER', 'true_nop', None),
         ],
     )
-    def test_named_barrier_ops_derive_current_noop_model(self, name):
+    def test_named_barrier_ops_derive_execution_model(
+        self, name, semantic_class, operation
+    ):
         sem = derive_semantics(name, 'ENC_SOP1')
         assert sem is not None
-        assert sem.semantic_class == 'true_nop'
+        assert sem.semantic_class == semantic_class
+        assert sem.operation == operation
+        if name == 'S_BARRIER_SIGNAL_ISFIRST':
+            assert sem.sets_scc == 'nonzero'
+
+    def test_barrier_leave_derives_execution_model(self):
+        sem = derive_semantics('S_BARRIER_LEAVE', 'ENC_SOPP')
+        assert sem is not None
+        assert sem.semantic_class == 'scalar_barrier_leave'
+        assert sem.sets_scc == 'nonzero'
 
 
 class TestDeriveVectorUnary:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sop1_exec.cpp
@@ -324,20 +324,51 @@ void SSendmsgRtnB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SBarrierSignalSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_signal_sop1(*this, wf);
+  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  bool source_is_m0 = ssrc0.encoding_value() == OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;
+  int32_t barrier_id =
+      source_is_m0 ? static_cast<int32_t>(source & 0x1fu) : static_cast<int32_t>(source);
+  uint32_t member_count = source_is_m0 ? ((source >> 16) & 0x7fu) : 0;
+  wf.barrier_signal(barrier_id, member_count);
 }
 
 void SBarrierSignalIsfirstSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_signal_isfirst_sop1(*this, wf);
+  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  bool source_is_m0 = ssrc0.encoding_value() == OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;
+  int32_t barrier_id =
+      source_is_m0 ? static_cast<int32_t>(source & 0x1fu) : static_cast<int32_t>(source);
+  uint32_t member_count = source_is_m0 ? ((source >> 16) & 0x7fu) : 0;
+  bool barrier_valid = (wf.barrier_state(barrier_id) & 1u) != 0;
+  bool is_first = wf.barrier_signal(barrier_id, member_count);
+  if (barrier_valid)
+    wf.write_scc(is_first);
 }
 
 void SGetBarrierStateSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::RegisterAccess(wf).write_scalar(sdst, 0);
+  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  bool source_is_m0 = ssrc0.encoding_value() == OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;
+  int32_t barrier_id =
+      source_is_m0 ? static_cast<int32_t>(source & 0x1fu) : static_cast<int32_t>(source);
+  amdgpu::RegisterAccess(wf).write_scalar(sdst, wf.barrier_state(barrier_id));
 }
 
-void SBarrierInitSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
+void SBarrierInitSop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  bool source_is_m0 = ssrc0.encoding_value() == OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;
+  int32_t barrier_id =
+      source_is_m0 ? static_cast<int32_t>(source & 0x1fu) : static_cast<int32_t>(source);
+  uint32_t member_source = wf.m0();
+  uint32_t member_count = (member_source >> 16) & 0x7fu;
+  wf.barrier_init(barrier_id, member_count);
+}
 
-void SBarrierJoinSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
+void SBarrierJoinSop1::execute_impl(amdgpu::Wavefront &wf) {
+  uint32_t source = amdgpu::RegisterAccess(wf).read_scalar(ssrc0);
+  bool source_is_m0 = ssrc0.encoding_value() == OpSelSsrcBarrierId::OPR_SSRC_BARRIER_ID_M0;
+  int32_t barrier_id =
+      source_is_m0 ? static_cast<int32_t>(source & 0x1fu) : static_cast<int32_t>(source);
+  wf.barrier_join(barrier_id);
+}
 
 void SAllocVgprSop1::execute_impl(amdgpu::Wavefront &wf) {
   amdgpu::execute_s_alloc_vgpr_sop1(*this, wf);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/sopp_exec.cpp
@@ -57,10 +57,11 @@ void SDenormModeSopp::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SBarrierWaitSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_wait_sopp(*this, wf);
+  int32_t barrier_id = static_cast<int16_t>(simm16.encoding_value_);
+  wf.barrier_wait(barrier_id);
 }
 
-void SBarrierLeaveSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
+void SBarrierLeaveSopp::execute_impl(amdgpu::Wavefront &wf) { wf.write_scc(wf.barrier_leave()); }
 
 void SCodeEndSopp::execute_impl(amdgpu::Wavefront &wf) {
   amdgpu::execute_s_code_end_sopp(*this, wf);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop1_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sop1_exec.cpp
@@ -313,13 +313,9 @@ void SSendmsgRtnB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
   amdgpu::execute_s_sendmsg_rtn_b64_sop1(*this, wf);
 }
 
-void SBarrierSignalSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_signal_sop1(*this, wf);
-}
+void SBarrierSignalSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
-void SBarrierSignalIsfirstSop1::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_signal_isfirst_sop1(*this, wf);
-}
+void SBarrierSignalIsfirstSop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
 
 void SAllocVgprSop1::execute_impl(amdgpu::Wavefront &wf) {
   amdgpu::execute_s_alloc_vgpr_sop1(*this, wf);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopp_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/sopp_exec.cpp
@@ -67,7 +67,7 @@ void SDenormModeSopp::execute_impl(amdgpu::Wavefront &wf) {
 }
 
 void SBarrierWaitSopp::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_s_barrier_wait_sopp(*this, wf);
+  wf.set_state(amdgpu::WfState::BARRIER);
 }
 
 void SCodeEndSopp::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -713,20 +713,6 @@ inline void execute_s_barrier_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]]
 }
 
 template <typename Inst>
-inline void execute_s_barrier_signal_sop1([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {}
-
-template <typename Inst>
-inline void execute_s_barrier_signal_isfirst_sop1([[maybe_unused]] Inst &inst,
-                                                  [[maybe_unused]] Wavefront &wf) {}
-
-template <typename Inst>
-inline void execute_s_barrier_wait_sopp([[maybe_unused]] Inst &inst,
-                                        [[maybe_unused]] Wavefront &wf) {
-  wf.set_state(amdgpu::WfState::BARRIER);
-}
-
-template <typename Inst>
 inline void execute_s_bcnt0_i32_b32_sop1([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
   uint32_t result =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -855,7 +855,7 @@ void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, ui
                                                   uint32_t lds_base) {
   if (!entry.has_workgroup_clusters())
     return;
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
   uint32_t cluster_base_wg_id =
       entry.cluster_base_local_wg_id(local_wg_id) + entry.workgroup_id_offset;
   uint64_t cluster_key = wg_key(entry.dispatch_id, cluster_base_wg_id);
@@ -872,65 +872,218 @@ void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, ui
     placement.peer_wg_ids.push_back(peer_local_wg_id + entry.workgroup_id_offset);
   }
   cluster_wg_placements_[wg_key(entry.dispatch_id, global_wg_id)] = std::move(placement);
+  auto &barriers = cluster_barriers_[cluster_key];
+  if (barriers.expected_member_count == 0) {
+    barriers.expected_member_count = entry.cluster_size();
+    barriers.member_count = entry.cluster_size();
+  }
+  barriers.registered_workgroups.insert(global_wg_id);
+}
+
+bool CommandProcessor::find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
+                                                         ClusterWorkgroupPlacement *&placement,
+                                                         ClusterBarrierState *&barriers) {
+  if (barrier_id != kClusterBarrierId && barrier_id != kClusterTrapBarrierId)
+    return false;
+  auto placement_it = cluster_wg_placements_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  if (placement_it == cluster_wg_placements_.end())
+    return false;
+  auto barriers_it = cluster_barriers_.find(placement_it->second.cluster_key);
+  if (barriers_it == cluster_barriers_.end() || barriers_it->second.member_count == 0 ||
+      barriers_it->second.registered_workgroups.size() != barriers_it->second.expected_member_count)
+    return false;
+  placement = &placement_it->second;
+  barriers = &barriers_it->second;
+  return true;
+}
+
+bool CommandProcessor::find_valid_cluster_barrier_locked(
+    const Wavefront &wf, int32_t barrier_id, const ClusterWorkgroupPlacement *&placement,
+    const ClusterBarrierState *&barriers) const {
+  if (barrier_id != kClusterBarrierId && barrier_id != kClusterTrapBarrierId)
+    return false;
+  auto placement_it = cluster_wg_placements_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  if (placement_it == cluster_wg_placements_.end())
+    return false;
+  auto barriers_it = cluster_barriers_.find(placement_it->second.cluster_key);
+  if (barriers_it == cluster_barriers_.end() || barriers_it->second.member_count == 0 ||
+      barriers_it->second.registered_workgroups.size() != barriers_it->second.expected_member_count)
+    return false;
+  placement = &placement_it->second;
+  barriers = &barriers_it->second;
+  return true;
+}
+
+bool CommandProcessor::cluster_barrier_valid(const Wavefront &wf, int32_t barrier_id) const {
+  std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+  const ClusterWorkgroupPlacement *placement = nullptr;
+  const ClusterBarrierState *barriers = nullptr;
+  return find_valid_cluster_barrier_locked(wf, barrier_id, placement, barriers);
+}
+
+uint32_t CommandProcessor::cluster_barrier_state(const Wavefront &wf, int32_t barrier_id,
+                                                 uint32_t allocation_blocks) const {
+  std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+  const ClusterWorkgroupPlacement *placement = nullptr;
+  const ClusterBarrierState *barriers = nullptr;
+  if (!find_valid_cluster_barrier_locked(wf, barrier_id, placement, barriers))
+    return 0;
+  const uint32_t index = static_cast<uint32_t>(-barrier_id - kClusterBarrierBit);
+  return 1u | ((barriers->member_count & 0x7fu) << 4) |
+         ((barriers->signaled_workgroups[index].size() & 0x7fu) << 16) |
+         ((allocation_blocks & 0x7u) << 24);
+}
+
+bool CommandProcessor::cluster_barrier_signal(Wavefront &wf, int32_t barrier_id) {
+  bool is_first = false;
+  std::vector<std::pair<ComputeUnitCore *, uint32_t>> peers;
+  const uint8_t completion_bit = static_cast<uint8_t>(-barrier_id);
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+    ClusterWorkgroupPlacement *placement = nullptr;
+    ClusterBarrierState *barriers = nullptr;
+    if (!find_valid_cluster_barrier_locked(wf, barrier_id, placement, barriers))
+      return false;
+
+    const uint32_t index = static_cast<uint32_t>(completion_bit - kClusterBarrierBit);
+    auto [_, inserted] = barriers->signaled_workgroups[index].insert(wf.wg_id());
+    if (!inserted)
+      return false;
+    is_first = barriers->signaled_workgroups[index].size() == 1;
+    if (barriers->signaled_workgroups[index].size() < barriers->member_count)
+      return is_first;
+
+    barriers->signaled_workgroups[index].clear();
+    peers.reserve(placement->peer_wg_ids.size());
+    for (uint32_t peer_wg_id : placement->peer_wg_ids) {
+      auto peer = cluster_wg_placements_.find(wg_key(wf.dispatch_id(), peer_wg_id));
+      if (peer != cluster_wg_placements_.end() && peer->second.cu)
+        peers.emplace_back(peer->second.cu, peer_wg_id);
+    }
+  }
+
+  std::vector<Wavefront *> members;
+  for (auto [cu, peer_wg_id] : peers) {
+    auto peer_members = cu->complete_barrier(wf.dispatch_id(), peer_wg_id, completion_bit);
+    members.insert(members.end(), peer_members.begin(), peer_members.end());
+  }
+  if (!members.empty())
+    plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  return is_first;
 }
 
 void CommandProcessor::mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id) {
-  auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
-  if (it == cluster_wg_placements_.end())
-    return;
-
-  it->second.completed = true;
-  uint64_t cluster_key = it->second.cluster_key;
-  auto peer_wg_ids = it->second.peer_wg_ids;
-  for (uint32_t peer_wg_id : peer_wg_ids) {
-    auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
-    if (peer_it == cluster_wg_placements_.end() || !peer_it->second.completed)
+  std::array<std::vector<std::pair<ComputeUnitCore *, uint32_t>>, 2> resolved_peers;
+  std::vector<ComputeUnitCore *> retired_cus;
+  uint64_t cluster_key = 0;
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+    auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
+    if (it == cluster_wg_placements_.end() || it->second.completed)
       return;
-  }
 
-  for (uint32_t peer_wg_id : peer_wg_ids) {
-    auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
-    if (peer_it != cluster_wg_placements_.end() && peer_it->second.cu) {
-      peer_it->second.cu->unpin_lds_for_cluster(cluster_key);
-      // The waves halted (and freed) before the pin was released, so reclaim each
-      // peer CU's LDS now that the whole cluster is done.
-      peer_it->second.cu->maybe_reset_lds_alloc();
+    it->second.completed = true;
+    cluster_key = it->second.cluster_key;
+    const auto peer_wg_ids = it->second.peer_wg_ids;
+    auto barrier_it = cluster_barriers_.find(cluster_key);
+    if (barrier_it != cluster_barriers_.end() && barrier_it->second.member_count != 0) {
+      auto &barriers = barrier_it->second;
+      --barriers.member_count;
+      for (uint32_t index = 0; index < barriers.signaled_workgroups.size(); ++index) {
+        barriers.signaled_workgroups[index].erase(wg_id);
+        if (barriers.member_count == 0 ||
+            barriers.signaled_workgroups[index].size() < barriers.member_count)
+          continue;
+        barriers.signaled_workgroups[index].clear();
+        for (uint32_t peer_wg_id : peer_wg_ids) {
+          auto peer = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+          if (peer != cluster_wg_placements_.end() && !peer->second.completed && peer->second.cu)
+            resolved_peers[index].emplace_back(peer->second.cu, peer_wg_id);
+        }
+      }
+    }
+
+    const bool all_completed = std::ranges::all_of(peer_wg_ids, [&](uint32_t peer_wg_id) {
+      auto peer = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+      return peer != cluster_wg_placements_.end() && peer->second.completed;
+    });
+    if (!all_completed)
+      cluster_key = 0;
+    else {
+      for (uint32_t peer_wg_id : peer_wg_ids) {
+        auto peer = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+        if (peer != cluster_wg_placements_.end() && peer->second.cu)
+          retired_cus.push_back(peer->second.cu);
+        cluster_wg_placements_.erase(wg_key(dispatch_id, peer_wg_id));
+      }
+      cluster_barriers_.erase(cluster_key);
     }
   }
-  for (uint32_t peer_wg_id : peer_wg_ids)
-    cluster_wg_placements_.erase(wg_key(dispatch_id, peer_wg_id));
+
+  for (uint32_t index = 0; index < resolved_peers.size(); ++index) {
+    std::vector<Wavefront *> members;
+    const uint8_t completion_bit = static_cast<uint8_t>(kClusterBarrierBit + index);
+    for (auto [cu, peer_wg_id] : resolved_peers[index]) {
+      auto peer_members = cu->complete_barrier(dispatch_id, peer_wg_id, completion_bit);
+      members.insert(members.end(), peer_members.begin(), peer_members.end());
+    }
+    if (!members.empty())
+      plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  }
+
+  if (cluster_key != 0) {
+    for (auto *cu : retired_cus) {
+      cu->unpin_lds_for_cluster(cluster_key);
+      // The waves halted before the pin was released, so reclaim LDS after
+      // every workgroup in the cluster has retired.
+      cu->maybe_reset_lds_alloc();
+    }
+  }
 }
 
 void CommandProcessor::erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id) {
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-  auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
-  if (it == cluster_wg_placements_.end())
-    return;
-  if (it->second.cu) {
-    it->second.cu->unpin_lds_for_cluster(it->second.cluster_key);
-    it->second.cu->maybe_reset_lds_alloc();
+  ComputeUnitCore *cu = nullptr;
+  uint64_t cluster_key = 0;
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+    auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
+    if (it == cluster_wg_placements_.end())
+      return;
+    cu = it->second.cu;
+    cluster_key = it->second.cluster_key;
+    cluster_barriers_.erase(cluster_key);
+    cluster_wg_placements_.erase(it);
   }
-  cluster_wg_placements_.erase(it);
+  if (cu) {
+    cu->unpin_lds_for_cluster(cluster_key);
+    cu->maybe_reset_lds_alloc();
+  }
 }
 
 void CommandProcessor::erase_cluster_workgroups(uint32_t dispatch_id) {
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-  for (auto it = cluster_wg_placements_.begin(); it != cluster_wg_placements_.end();) {
-    if ((it->first >> 32) == dispatch_id) {
-      if (it->second.cu) {
-        it->second.cu->unpin_lds_for_cluster(it->second.cluster_key);
-        it->second.cu->maybe_reset_lds_alloc();
+  std::vector<std::pair<ComputeUnitCore *, uint64_t>> retired;
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
+    for (auto it = cluster_wg_placements_.begin(); it != cluster_wg_placements_.end();) {
+      if ((it->first >> 32) == dispatch_id) {
+        cluster_barriers_.erase(it->second.cluster_key);
+        if (it->second.cu)
+          retired.emplace_back(it->second.cu, it->second.cluster_key);
+        it = cluster_wg_placements_.erase(it);
+      } else {
+        ++it;
       }
-      it = cluster_wg_placements_.erase(it);
-    } else {
-      ++it;
     }
+  }
+  for (auto [cu, cluster_key] : retired) {
+    cu->unpin_lds_for_cluster(cluster_key);
+    cu->maybe_reset_lds_alloc();
   }
 }
 
 std::vector<ClusterLdsTarget>
 CommandProcessor::cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id, uint32_t mcast_mask) {
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(cluster_barrier_mutex_);
   std::vector<ClusterLdsTarget> targets;
   auto src_it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
   if (src_it == cluster_wg_placements_.end())
@@ -1056,7 +1209,8 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     }
 
     // All fallible per-wave work succeeded: commit WG bookkeeping and the cluster pin.
-    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
+    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup,
+                        entry.num_named_barriers);
     register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
 
     plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
@@ -1173,13 +1327,18 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
 void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) {
   util::Logger::cp(
       [&](auto &os) { os << std::format("WG_COMPLETE d={} wg={}", dispatch_id, wg_id); });
-  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-  for (auto *spi : spis_)
-    if (spi->release_wgp_workgroup(dispatch_id, wg_id))
-      break;
+  {
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    for (auto *spi : spis_)
+      if (spi->release_wgp_workgroup(dispatch_id, wg_id))
+        break;
+  }
   mark_cluster_workgroup_complete(dispatch_id, wg_id);
-  if (completion_)
-    completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
+  {
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    if (completion_)
+      completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
+  }
 }
 
 // INVARIANT: on_cu_idle() runs on the owning partition's engine thread — it is
@@ -1334,6 +1493,11 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.kernarg_size = kd.kernarg_size;
   dp.num_user_sgprs = user_sgprs;
   dp.kernel_code_properties = kd.kernel_code_properties;
+  if (arch == ROCJITSU_CODE_ARCH_GFX1250) {
+    const uint32_t named_barrier_blocks =
+        AMDHSA_BITS_GET(kd.compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX125_NAMED_BAR_CNT);
+    dp.num_named_barriers = std::min(named_barrier_blocks * 4u, ComputeUnitCore::kMaxNamedBarriers);
+  }
   dp.kernarg_preload = kd.kernarg_preload;
   dp.initial_mode_raw = initial_mode_from_compute_pgm_rsrc1(kd.compute_pgm_rsrc1, arch);
   dp.private_segment_fixed_size = std::max(kd.private_segment_fixed_size, pkt.private_segment_size);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -32,6 +32,7 @@
 #include "simdojo/sim/component.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -40,6 +41,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -195,6 +197,9 @@ public:
   }
 
 private:
+  struct ClusterWorkgroupPlacement;
+  struct ClusterBarrierState;
+
   /// @brief Initialize a wavefront's registers per the AMDHSA ABI.
   void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchEntry &entry,
                            uint32_t global_wg_id, uint32_t wf_index_in_wg);
@@ -251,6 +256,16 @@ private:
 
   void register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
                                   uint32_t global_wg_id, ComputeUnitCore *cu, uint32_t lds_base);
+  bool cluster_barrier_signal(Wavefront &wf, int32_t barrier_id);
+  uint32_t cluster_barrier_state(const Wavefront &wf, int32_t barrier_id,
+                                 uint32_t allocation_blocks) const;
+  bool cluster_barrier_valid(const Wavefront &wf, int32_t barrier_id) const;
+  bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
+                                         ClusterWorkgroupPlacement *&placement,
+                                         ClusterBarrierState *&barriers);
+  bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
+                                         const ClusterWorkgroupPlacement *&placement,
+                                         const ClusterBarrierState *&barriers) const;
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroups(uint32_t dispatch_id);
@@ -333,11 +348,21 @@ private:
     std::vector<uint32_t> peer_wg_ids;
   };
   std::unordered_map<uint64_t, ClusterWorkgroupPlacement> cluster_wg_placements_;
+  struct ClusterBarrierState {
+    uint32_t expected_member_count = 0;
+    uint32_t member_count = 0;
+    std::unordered_set<uint32_t> registered_workgroups;
+    std::array<std::unordered_set<uint32_t>, 2> signaled_workgroups;
+  };
+  std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
+  mutable std::recursive_mutex cluster_barrier_mutex_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
   std::recursive_mutex hw_queue_mutex_;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
+
+  friend class ComputeUnitCore;
 
   /// @brief Read a uint64 from GPU virtual address space via GpuMemory translation.
   uint64_t read_gpu_u64(uint64_t va, uint32_t vmid) const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -29,6 +29,18 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+namespace {
+constexpr uint32_t kPrivilegedStatusBit = 1u << 5;
+
+bool is_privileged(const Wavefront &wf) { return (wf.status_raw() & kPrivilegedStatusBit) != 0; }
+
+uint32_t pack_barrier_state(uint32_t member_count, uint32_t signal_count,
+                            uint32_t allocation_blocks = 0) {
+  return 1u | ((member_count & 0x7fu) << 4) | ((signal_count & 0x7fu) << 16) |
+         ((allocation_blocks & 0x7u) << 24);
+}
+} // namespace
+
 template <GpuIsa Isa> void validate_compute_unit_config(const ComputeUnitCore::Config &config) {
   using Limits = IsaExecComputeUnit<simdojo::ExecMode::FUNCTIONAL, Isa>;
 
@@ -207,12 +219,231 @@ void ComputeUnitCore::maybe_reset_lds_alloc() {
     reset_lds_alloc();
 }
 
+void ComputeUnitCore::begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count,
+                                      uint32_t num_named_barriers) {
+  const uint64_t key = wg_key(dispatch_id, wg_id);
+  active_wgs_[key] = wf_count;
+  if (wf_count <= 1) {
+    // Single-wave workgroups are not allocated workgroup or named barriers.
+    barrier_wgs_.erase(key);
+    return;
+  }
+
+  auto &group = barrier_wgs_[key];
+  group = {};
+  group.allocated_count = std::min(num_named_barriers, kMaxNamedBarriers);
+  for (auto &barrier : group.workgroup)
+    barrier.member_count = wf_count;
+}
+
+void ComputeUnitCore::named_barrier_init(Wavefront &wf, int32_t barrier_id, uint32_t member_count) {
+  auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  if (group == barrier_wgs_.end() || barrier_id <= 0 ||
+      static_cast<uint32_t>(barrier_id) > group->second.allocated_count)
+    return;
+
+  auto &barrier = group->second.named[static_cast<uint32_t>(barrier_id)];
+  if (member_count != 0)
+    barrier.member_count = member_count & 0x7fu;
+  barrier.signal_count = 0;
+}
+
+void ComputeUnitCore::named_barrier_join(Wavefront &wf, int32_t barrier_id) {
+  auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  if (group == barrier_wgs_.end())
+    return;
+  if (barrier_id == 0) {
+    wf.named_barrier_id_ = 0;
+    wf.barrier_complete_[kNamedBarrierBit] = false;
+    if (wf.waiting_barrier_bit_ == kNamedBarrierBit)
+      wf.waiting_barrier_bit_ = Wavefront::kNoBarrierWait;
+    return;
+  }
+  if (barrier_id < 0 || static_cast<uint32_t>(barrier_id) > group->second.allocated_count)
+    return;
+  wf.named_barrier_id_ = static_cast<uint32_t>(barrier_id);
+  wf.barrier_complete_[kNamedBarrierBit] = false;
+  if (wf.waiting_barrier_bit_ == kNamedBarrierBit)
+    wf.waiting_barrier_bit_ = Wavefront::kNoBarrierWait;
+}
+
+bool ComputeUnitCore::barrier_signal(Wavefront &wf, int32_t barrier_id, uint32_t member_count) {
+  if (barrier_id == kClusterBarrierId || barrier_id == kClusterTrapBarrierId) {
+    if (barrier_id == kClusterTrapBarrierId && !is_privileged(wf))
+      return false;
+    return cp_ ? cp_->cluster_barrier_signal(wf, barrier_id) : false;
+  }
+
+  auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  if (group == barrier_wgs_.end() || barrier_id == 0 || barrier_id < kWorkgroupTrapBarrierId)
+    return false;
+
+  BarrierCounter *barrier = nullptr;
+  uint8_t completion_bit = kNamedBarrierBit;
+  uint32_t named_id = 0;
+  if (barrier_id > 0) {
+    named_id = static_cast<uint32_t>(barrier_id);
+    if (named_id > group->second.allocated_count)
+      return false;
+    barrier = &group->second.named[named_id];
+    if (member_count != 0)
+      barrier->member_count = member_count & 0x7fu;
+  } else {
+    if (barrier_id == kWorkgroupTrapBarrierId && !is_privileged(wf))
+      return false;
+    completion_bit = static_cast<uint8_t>(-barrier_id);
+    barrier = &group->second.workgroup[completion_bit - kWorkgroupBarrierBit];
+  }
+
+  if (barrier->member_count == 0)
+    return false;
+  const bool is_first = barrier->signal_count == 0;
+  barrier->signal_count = std::min(barrier->signal_count + 1, 0x7fu);
+  if (barrier->signal_count < barrier->member_count)
+    return is_first;
+
+  barrier->signal_count = 0;
+  auto members = complete_barrier(wf.dispatch_id(), wf.wg_id(), completion_bit, named_id);
+  notify_barrier_complete(members);
+  return is_first;
+}
+
+std::vector<Wavefront *> ComputeUnitCore::complete_barrier(uint32_t dispatch_id, uint32_t wg_id,
+                                                           uint8_t completion_bit,
+                                                           uint32_t named_barrier_id) {
+  std::vector<Wavefront *> members;
+  for (const auto &candidate : wfs_) {
+    if (candidate->is_halted() || candidate->dispatch_id() != dispatch_id ||
+        candidate->wg_id() != wg_id)
+      continue;
+    if (completion_bit == kNamedBarrierBit && candidate->named_barrier_id_ != named_barrier_id)
+      continue;
+    candidate->barrier_complete_[completion_bit] = true;
+    members.push_back(candidate.get());
+  }
+  for (auto *member : members) {
+    if (member->state() == WfState::BARRIER && member->waiting_barrier_bit_ == completion_bit) {
+      member->barrier_complete_[completion_bit] = false;
+      member->waiting_barrier_bit_ = Wavefront::kNoBarrierWait;
+      member->set_state(WfState::RUNNING);
+      member->set_ready_cycle(cycle_counter_);
+    }
+  }
+  return members;
+}
+
+void ComputeUnitCore::notify_barrier_complete(std::span<Wavefront *> members) {
+  if (!members.empty())
+    plugin_group_->onAmdgpuBarrierResolved(members);
+}
+
+uint32_t ComputeUnitCore::barrier_state(const Wavefront &wf, int32_t barrier_id) const {
+  auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  const uint32_t allocation_blocks =
+      group == barrier_wgs_.end() ? 0 : (group->second.allocated_count + 3) / 4;
+
+  if (barrier_id == kClusterBarrierId || barrier_id == kClusterTrapBarrierId) {
+    if (barrier_id == kClusterTrapBarrierId && !is_privileged(wf))
+      return 0;
+    return cp_ ? cp_->cluster_barrier_state(wf, barrier_id, allocation_blocks) : 0;
+  }
+
+  if (group == barrier_wgs_.end() || barrier_id == 0 || barrier_id < kWorkgroupTrapBarrierId)
+    return 0;
+
+  if (barrier_id < 0) {
+    if (barrier_id == kWorkgroupTrapBarrierId && !is_privileged(wf))
+      return 0;
+    const auto &barrier = group->second.workgroup[static_cast<uint32_t>(-barrier_id - 1)];
+    return pack_barrier_state(barrier.member_count, barrier.signal_count, allocation_blocks);
+  }
+
+  const uint32_t id = static_cast<uint32_t>(barrier_id);
+  if (id > group->second.allocated_count)
+    return 0;
+  const auto &barrier = group->second.named[id];
+  return pack_barrier_state(barrier.member_count, barrier.signal_count, allocation_blocks);
+}
+
+void ComputeUnitCore::barrier_wait(Wavefront &wf, int32_t barrier_id) {
+  uint8_t completion_bit = kNamedBarrierBit;
+  if (barrier_id >= 0) {
+    auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+    if (group == barrier_wgs_.end() || wf.named_barrier_id_ == 0 ||
+        wf.named_barrier_id_ > group->second.allocated_count)
+      return;
+  } else {
+    if (barrier_id < kClusterTrapBarrierId ||
+        ((barrier_id == kWorkgroupTrapBarrierId || barrier_id == kClusterTrapBarrierId) &&
+         !is_privileged(wf)))
+      return;
+    completion_bit = static_cast<uint8_t>(-barrier_id);
+    if (completion_bit <= kWorkgroupTrapBarrierBit) {
+      if (!barrier_wgs_.contains(wg_key(wf.dispatch_id(), wf.wg_id())))
+        return;
+    } else if (!cp_ || !cp_->cluster_barrier_valid(wf, barrier_id)) {
+      return;
+    }
+  }
+
+  if (wf.barrier_complete_[completion_bit]) {
+    wf.barrier_complete_[completion_bit] = false;
+    return;
+  }
+  wf.waiting_barrier_bit_ = completion_bit;
+  wf.set_state(WfState::BARRIER);
+}
+
+bool ComputeUnitCore::named_barrier_leave(Wavefront &wf) {
+  auto group = barrier_wgs_.find(wg_key(wf.dispatch_id(), wf.wg_id()));
+  const uint32_t id = wf.named_barrier_id_;
+  if (group == barrier_wgs_.end())
+    return false;
+  if (id == 0)
+    return true;
+  if (id > group->second.allocated_count)
+    return false;
+
+  wf.named_barrier_id_ = 0;
+  wf.barrier_complete_[kNamedBarrierBit] = false;
+  if (wf.waiting_barrier_bit_ == kNamedBarrierBit)
+    wf.waiting_barrier_bit_ = Wavefront::kNoBarrierWait;
+  auto &barrier = group->second.named[id];
+  if (barrier.member_count != 0)
+    --barrier.member_count;
+  if (barrier.signal_count >= barrier.member_count) {
+    barrier.signal_count = 0;
+    auto members = complete_barrier(wf.dispatch_id(), wf.wg_id(), kNamedBarrierBit, id);
+    notify_barrier_complete(members);
+  }
+  return barrier.member_count == 0;
+}
+
 void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id) {
   auto key = wg_key(dispatch_id, wg_id);
+  auto group = barrier_wgs_.find(key);
+  if (group != barrier_wgs_.end()) {
+    const auto retire_member = [&](BarrierCounter &barrier, uint8_t completion_bit,
+                                   uint32_t joined_id = 0) {
+      if (barrier.member_count == 0)
+        return;
+      --barrier.member_count;
+      if (barrier.member_count == 0 || barrier.signal_count < barrier.member_count)
+        return;
+      barrier.signal_count = 0;
+      auto members = complete_barrier(dispatch_id, wg_id, completion_bit, joined_id);
+      notify_barrier_complete(members);
+    };
+
+    retire_member(group->second.workgroup[0], kWorkgroupBarrierBit);
+    retire_member(group->second.workgroup[1], kWorkgroupTrapBarrierBit);
+  }
+
   auto it = active_wgs_.find(key);
   if (it != active_wgs_.end() && --it->second == 0) {
     plugin_group_->onAmdgpuWorkgroupCompleted(dispatch_id, wg_id);
     active_wgs_.erase(it);
+    barrier_wgs_.erase(key);
     if (cp_)
       cp_->notify_wg_complete(dispatch_id, wg_id);
   }
@@ -233,6 +464,7 @@ void ComputeUnitCore::abort_workgroup(uint32_t dispatch_id, uint32_t wg_id) {
       free_wavefront_resources(*w);
   }
   active_wgs_.erase(wg_key(dispatch_id, wg_id));
+  barrier_wgs_.erase(wg_key(dispatch_id, wg_id));
   maybe_reset_lds_alloc();
 }
 
@@ -335,14 +567,15 @@ void ComputeUnitCore::update_wf_states() {
   }
 
   for (auto &w : wfs_) {
-    if (w->state() != WfState::BARRIER)
+    if (w->state() != WfState::BARRIER || w->waiting_barrier_bit_ != Wavefront::kNoBarrierWait)
       continue;
     uint32_t did = w->dispatch_id();
     uint32_t wg = w->wg_id();
     bool all_at_barrier = true;
     for (auto &w2 : wfs_) {
       if (w2->dispatch_id() == did && w2->wg_id() == wg && w2->state() != WfState::HALTED &&
-          w2->state() != WfState::BARRIER) {
+          (w2->state() != WfState::BARRIER ||
+           w2->waiting_barrier_bit_ != Wavefront::kNoBarrierWait)) {
         all_at_barrier = false;
         break;
       }
@@ -350,7 +583,8 @@ void ComputeUnitCore::update_wf_states() {
     if (all_at_barrier) {
       std::vector<Wavefront *> barrier_wfs;
       for (auto &w2 : wfs_)
-        if (w2->dispatch_id() == did && w2->wg_id() == wg && w2->state() == WfState::BARRIER)
+        if (w2->dispatch_id() == did && w2->wg_id() == wg && w2->state() == WfState::BARRIER &&
+            w2->waiting_barrier_bit_ == Wavefront::kNoBarrierWait)
           barrier_wfs.push_back(w2.get());
       plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(barrier_wfs));
       for (auto *bwf : barrier_wfs) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -52,6 +52,17 @@ namespace amdgpu {
 
 class CommandProcessor;
 
+inline constexpr int32_t kWorkgroupBarrierId = -1;
+inline constexpr int32_t kWorkgroupTrapBarrierId = -2;
+inline constexpr int32_t kClusterBarrierId = -3;
+inline constexpr int32_t kClusterTrapBarrierId = -4;
+
+inline constexpr uint8_t kNamedBarrierBit = 0;
+inline constexpr uint8_t kWorkgroupBarrierBit = 1;
+inline constexpr uint8_t kWorkgroupTrapBarrierBit = 2;
+inline constexpr uint8_t kClusterBarrierBit = 3;
+inline constexpr uint8_t kClusterTrapBarrierBit = 4;
+
 /// @brief Base AMDGPU compute unit that owns wavefront slots and register files.
 ///
 /// @details Owns the physical SGPR and VGPR register files and a fixed array of
@@ -75,6 +86,7 @@ class CommandProcessor;
 class ComputeUnitCore : public simdojo::CompositeComponent {
 public:
   static constexpr uint32_t kFunctionalQuantum = 1024;
+  static constexpr uint32_t kMaxNamedBarriers = 16;
 
   /// @brief Configuration for a compute unit.
   struct Config {
@@ -198,9 +210,26 @@ public:
   /// @brief Register a new workgroup with its expected WF count.
   /// @details Called by the DispatchController when assigning a WG to this CU.
   /// Initializes the refcount so release_wf() can detect WG completion.
-  void begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count) {
-    active_wgs_[wg_key(dispatch_id, wg_id)] = wf_count;
-  }
+  void begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count,
+                       uint32_t num_named_barriers = 0);
+
+  /// @brief Initialize a named barrier's member count and clear its signals.
+  void named_barrier_init(Wavefront &wf, int32_t barrier_id, uint32_t member_count);
+
+  /// @brief Associate a wave with one named barrier.
+  void named_barrier_join(Wavefront &wf, int32_t barrier_id);
+
+  /// @brief Signal a split-barrier domain and return whether this was its first signal.
+  bool barrier_signal(Wavefront &wf, int32_t barrier_id, uint32_t member_count);
+
+  /// @brief Return the packed architectural state of a split-barrier domain.
+  uint32_t barrier_state(const Wavefront &wf, int32_t barrier_id) const;
+
+  /// @brief Wait on the completion bit selected by a split-barrier ID.
+  void barrier_wait(Wavefront &wf, int32_t barrier_id);
+
+  /// @brief Leave the wave's currently joined named barrier.
+  bool named_barrier_leave(Wavefront &wf);
 
   /// @brief Called by Wavefront::halt() to decrement the WG refcount.
   /// @details When the refcount reaches zero, all WFs in the WG have halted
@@ -662,6 +691,20 @@ protected:
 
   std::unordered_map<uint64_t, uint32_t> active_wgs_;
 
+  struct BarrierCounter {
+    uint32_t member_count = 0;
+    uint32_t signal_count = 0;
+  };
+  struct WorkgroupBarriers {
+    uint32_t allocated_count = 0;
+    std::array<BarrierCounter, kMaxNamedBarriers + 1> named{};
+    std::array<BarrierCounter, 2> workgroup{};
+  };
+  std::vector<Wavefront *> complete_barrier(uint32_t dispatch_id, uint32_t wg_id,
+                                            uint8_t completion_bit, uint32_t named_barrier_id = 0);
+  void notify_barrier_complete(std::span<Wavefront *> members);
+  std::unordered_map<uint64_t, WorkgroupBarriers> barrier_wgs_;
+
   uint64_t shared_aperture_base_ = 0;
   uint64_t shared_aperture_limit_ = 0;
   uint64_t private_aperture_base_ = 0;
@@ -678,6 +721,8 @@ protected:
   simdojo::Port *req_ = nullptr; ///< Requester port: L2 cache request (structural).
   uint64_t step_count_ = 0;
   bool functional_yield_requested_ = false;
+
+  friend class CommandProcessor;
 };
 
 inline L1ScalarCache &InstructionComputeUnitView::l1_scalar() { return raw_cu().l1_scalar(); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -54,6 +54,7 @@ struct DispatchEntry {
   uint32_t kernarg_size = 0;
   uint32_t num_user_sgprs = 2;
   uint32_t kernel_code_properties = 0;
+  uint32_t num_named_barriers = 0;
   uint16_t kernarg_preload = 0;
   uint32_t initial_mode_raw = 0;
   uint64_t dispatch_ptr = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
@@ -11,14 +11,13 @@ namespace amdgpu {
 
 /// Raw LDS barrier cell used by the gfx1250 DS barrier-arrive instructions.
 ///
-/// The AMDGCN ISA raw async-barrier object uses [15:0] pending, [31:16]
-/// phase, and [47:32] init count. This is intentionally distinct from MLIR's
-/// ds_barrier_state helper; kernels that poll the raw cell directly test bit
-/// 16 for phase parity.
-constexpr uint64_t kLdsBarrierCellPendingMask = 0xffffull;
-constexpr uint64_t kLdsBarrierCellPhaseMask = 0xffffull;
+/// RocJITsu uses the CDNA5 WIDTH=29 form described by the architectural LDS
+/// barrier layout: [28:0] pending, [31:29] phase, and [47:32] init count.
+/// Polling kernels test bit 29 for phase parity.
+constexpr uint64_t kLdsBarrierCellPendingMask = (1ull << 29) - 1;
+constexpr uint64_t kLdsBarrierCellPhaseMask = 0x7ull;
 constexpr uint64_t kLdsBarrierCellInitCountMask = 0xffffull;
-constexpr uint32_t kLdsBarrierCellPhaseShift = 16;
+constexpr uint32_t kLdsBarrierCellPhaseShift = 29;
 constexpr uint32_t kLdsBarrierCellInitCountShift = 32;
 constexpr uint64_t kLdsBarrierCellReservedMask = 0xffff000000000000ull;
 
@@ -27,7 +26,7 @@ inline uint64_t lds_barrier_cell_pending_count(uint64_t state) {
   return state & kLdsBarrierCellPendingMask;
 }
 
-/// Return the raw 16-bit phase counter.
+/// Return the raw three-bit phase counter.
 inline uint64_t lds_barrier_cell_phase(uint64_t state) {
   return (state >> kLdsBarrierCellPhaseShift) & kLdsBarrierCellPhaseMask;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -103,7 +103,8 @@ public:
 
       ComputeUnitCore *cu = placement->cu;
       uint32_t lds_base = placement->lds_base;
-      cu->begin_workgroup(wg.entry->dispatch_id, wg.global_wg_id, wg.entry->wfs_per_workgroup);
+      cu->begin_workgroup(wg.entry->dispatch_id, wg.global_wg_id, wg.entry->wfs_per_workgroup,
+                          wg.entry->num_named_barriers);
       std::vector<Wavefront *> wg_wfs;
       wg_wfs.reserve(wg.entry->wfs_per_workgroup);
       for (uint32_t w = 0; w < wg.entry->wfs_per_workgroup; ++w) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -24,6 +24,24 @@ void Wavefront::write_gpu_memory(uint64_t addr, std::span<const uint8_t> src) {
   cu_.memory()->write_block(addr, src, process_id_);
 }
 
+void Wavefront::barrier_init(int32_t barrier_id, uint32_t member_count) {
+  cu_.named_barrier_init(*this, barrier_id, member_count);
+}
+
+void Wavefront::barrier_join(int32_t barrier_id) { cu_.named_barrier_join(*this, barrier_id); }
+
+bool Wavefront::barrier_signal(int32_t barrier_id, uint32_t member_count) {
+  return cu_.barrier_signal(*this, barrier_id, member_count);
+}
+
+uint32_t Wavefront::barrier_state(int32_t barrier_id) const {
+  return cu_.barrier_state(*this, barrier_id);
+}
+
+void Wavefront::barrier_wait(int32_t barrier_id) { cu_.barrier_wait(*this, barrier_id); }
+
+bool Wavefront::barrier_leave() { return cu_.named_barrier_leave(*this); }
+
 void Wavefront::halt() {
   // s_endpgm terminates the wave, frees its resources, and notifies the CP as one
   // action, mirroring hardware. Order matters:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -171,6 +171,24 @@ public:
   /// @brief Set the per-WG LDS base offset.
   void set_lds_base(uint32_t base) { lds_base_ = base; }
 
+  /// @brief Initialize a workgroup named barrier from an ISA barrier operand.
+  void barrier_init(int32_t barrier_id, uint32_t member_count);
+
+  /// @brief Join one workgroup named barrier.
+  void barrier_join(int32_t barrier_id);
+
+  /// @brief Signal a barrier and report whether this is its first signal.
+  bool barrier_signal(int32_t barrier_id, uint32_t member_count);
+
+  /// @brief Read the packed architectural state of a barrier.
+  uint32_t barrier_state(int32_t barrier_id) const;
+
+  /// @brief Wait on a named, workgroup, trap, or cluster barrier.
+  void barrier_wait(int32_t barrier_id);
+
+  /// @brief Leave the currently joined named barrier.
+  bool barrier_leave();
+
   /// @brief Return the aligned LDS allocation size for this workgroup.
   uint32_t lds_size() const { return lds_size_; }
 
@@ -511,6 +529,9 @@ public:
     shared_aperture_limit_ = 0;
     private_aperture_base_ = 0;
     private_aperture_limit_ = 0;
+    named_barrier_id_ = 0;
+    barrier_complete_.fill(false);
+    waiting_barrier_bit_ = kNoBarrierWait;
     wait_counters_ = {};
     wait_target_ = {};
     ready_cycle_ = 0;
@@ -570,8 +591,13 @@ private:
   uint64_t shared_aperture_limit_ = 0;
   uint64_t private_aperture_base_ = 0;
   uint64_t private_aperture_limit_ = 0;
-  WfState state_ = WfState::HALTED; ///< Current execution state.
-  WaitCounters wait_counters_;      ///< Outstanding memory operation counters.
+  static constexpr uint8_t kNoBarrierWait = 0xff;
+  uint32_t named_barrier_id_ = 0; ///< Currently joined named barrier.
+  /// Completion bits: named, workgroup, workgroup trap, cluster, cluster trap.
+  std::array<bool, 5> barrier_complete_{};
+  uint8_t waiting_barrier_bit_ = kNoBarrierWait; ///< Completion bit awaited by split wait.
+  WfState state_ = WfState::HALTED;              ///< Current execution state.
+  WaitCounters wait_counters_;                   ///< Outstanding memory operation counters.
 
 public:
   uint32_t trace_inst_count_ = 0; ///< Debug: instruction count for trace.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -171,7 +171,7 @@ public:
   /// requires_serial_hot_hooks() returns true.
   virtual void onAmdgpuReadSgpr(const amdgpu::Wavefront * /*wf*/, uint32_t /*physical_reg*/) {}
 
-  /// Called when all waves in a workgroup have reached s_barrier.
+  /// Called with the waves synchronized by a completed barrier domain.
   /// Infrequent hook; see the concurrency contract on requires_serial_hot_hooks().
   virtual void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -8,6 +8,24 @@ namespace {
 using namespace rocjitsu;
 using namespace rocjitsu::test::cdna5;
 
+class BarrierSpanPlugin final : public ExecutionPlugin {
+public:
+  BarrierSpanPlugin() : ExecutionPlugin("barrier_span") {}
+
+  void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) override {
+    span_sizes.push_back(wavefronts.size());
+    std::vector<uint32_t> workgroups;
+    for (const auto *wf : wavefronts)
+      workgroups.push_back(wf->wg_id());
+    std::ranges::sort(workgroups);
+    workgroups.erase(std::unique(workgroups.begin(), workgroups.end()), workgroups.end());
+    workgroup_ids.push_back(std::move(workgroups));
+  }
+
+  std::vector<size_t> span_sizes;
+  std::vector<std::vector<uint32_t>> workgroup_ids;
+};
+
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
   constexpr uint64_t kKernelAddr = 0x10000;
   const uint32_t code[] = {
@@ -257,6 +275,345 @@ TEST(Gfx1250SimulationTest, SplitNamedBarrierOpsReportIdleState) {
   const auto *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
   EXPECT_EQ(wf->sgpr(4), 0u);
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierSignalIsfirstPreservesSccWithoutAllocation) {
+  Gfx1250Sim sim;
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 1> signal_words = {0xBE804F7Du};
+  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  ASSERT_NE(signal, nullptr);
+
+  wf->set_m0((2u << 16) | 1u);
+  wf->write_scc(true);
+  sim.cu()->execute_instruction(signal.get(), *wf);
+  EXPECT_TRUE(wf->read_scc());
+}
+
+void expect_barrier_init_reads_implicit_m0(uint32_t init_encoding, uint32_t init_m0) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2, 4);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 1> init_words = {init_encoding};
+  const std::array<uint32_t, 1> join_words = {0xBE805281u};   // s_barrier_join 1
+  const std::array<uint32_t, 1> signal_words = {0xBE804F81u}; // s_barrier_signal_isfirst 1
+  const std::array<uint32_t, 1> state_words = {0xBE845081u};  // s_get_barrier_state s4, 1
+  std::unique_ptr<Instruction> init(decoder->decode(init_words.data()));
+  std::unique_ptr<Instruction> join(decoder->decode(join_words.data()));
+  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  std::unique_ptr<Instruction> state(decoder->decode(state_words.data()));
+  ASSERT_NE(init, nullptr);
+  ASSERT_NE(join, nullptr);
+  ASSERT_NE(signal, nullptr);
+  ASSERT_NE(state, nullptr);
+
+  wf0->set_m0(init_m0);
+  cu->execute_instruction(init.get(), *wf0);
+  for (auto *wf : {wf0, wf1})
+    cu->execute_instruction(join.get(), *wf);
+
+  cu->execute_instruction(signal.get(), *wf0);
+  EXPECT_TRUE(wf0->read_scc());
+  cu->execute_instruction(state.get(), *wf0);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf0, 4), 0x01010021u);
+  wf0->barrier_wait(1);
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+
+  cu->execute_instruction(signal.get(), *wf1);
+  EXPECT_FALSE(wf1->read_scc());
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+  cu->execute_instruction(state.get(), *wf1);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf1, 4), 0x01000021u);
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierInitImmediateReadsMemberCountFromImplicitM0) {
+  expect_barrier_init_reads_implicit_m0(0xBE805181u, 2u << 16); // s_barrier_init 1
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierInitM0ReadsMemberCountFromImplicitM0) {
+  expect_barrier_init_reads_implicit_m0(0xBE80517Du, (2u << 16) | 1u); // s_barrier_init m0
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierSynchronizesJoinedWavesAcrossPhases) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2, 4);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 1> join_words = {0xBE80527Du};
+  const std::array<uint32_t, 1> signal_words = {0xBE804F7Du};
+  const std::array<uint32_t, 1> wait_words = {0xBF940001u};
+  const std::array<uint32_t, 1> state_words = {0xBE84507Du};
+  std::unique_ptr<Instruction> join(decoder->decode(join_words.data()));
+  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  std::unique_ptr<Instruction> wait(decoder->decode(wait_words.data()));
+  std::unique_ptr<Instruction> state(decoder->decode(state_words.data()));
+  ASSERT_NE(join, nullptr);
+  ASSERT_NE(signal, nullptr);
+  ASSERT_NE(wait, nullptr);
+  ASSERT_NE(state, nullptr);
+  ASSERT_EQ(std::string_view(join->mnemonic()), "s_barrier_join");
+  ASSERT_EQ(std::string_view(signal->mnemonic()), "s_barrier_signal_isfirst");
+  ASSERT_EQ(std::string_view(wait->mnemonic()), "s_barrier_wait");
+  ASSERT_EQ(std::string_view(state->mnemonic()), "s_get_barrier_state");
+
+  for (auto *wf : {wf0, wf1}) {
+    wf->set_m0(1);
+    cu->execute_instruction(join.get(), *wf);
+    wf->set_m0((2u << 16) | 1u);
+  }
+
+  cu->execute_instruction(signal.get(), *wf0);
+  EXPECT_TRUE(wf0->read_scc());
+  cu->execute_instruction(wait.get(), *wf0);
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+
+  cu->execute_instruction(signal.get(), *wf1);
+  EXPECT_FALSE(wf1->read_scc());
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+  cu->execute_instruction(wait.get(), *wf1);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
+
+  cu->execute_instruction(state.get(), *wf0);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf0, 4), 0x01000021u);
+
+  cu->execute_instruction(signal.get(), *wf1);
+  EXPECT_TRUE(wf1->read_scc());
+  cu->execute_instruction(wait.get(), *wf1);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::BARRIER);
+
+  cu->execute_instruction(signal.get(), *wf0);
+  EXPECT_FALSE(wf0->read_scc());
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
+  cu->execute_instruction(wait.get(), *wf0);
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+}
+
+TEST(Gfx1250SimulationTest, WorkgroupBarrierSignalAndWaitUseDedicatedCompletionState) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2, 4);
+
+  EXPECT_TRUE(wf0->barrier_signal(-1, 0));
+  EXPECT_EQ(wf0->barrier_state(-1), 0x01010021u);
+  wf0->barrier_wait(-1);
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+
+  EXPECT_FALSE(wf1->barrier_signal(-1, 0));
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+  EXPECT_EQ(wf1->barrier_state(-1), 0x01000021u);
+  wf1->barrier_wait(-1);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
+}
+
+TEST(Gfx1250SimulationTest, WorkgroupBarrierCompletesAfterUnsignaledWaveTerminates) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *waiting = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *terminating = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(waiting, nullptr);
+  ASSERT_NE(terminating, nullptr);
+  cu->begin_workgroup(0, 0, 2);
+
+  EXPECT_TRUE(waiting->barrier_signal(-1, 0));
+  waiting->barrier_wait(-1);
+  EXPECT_EQ(waiting->state(), amdgpu::WfState::BARRIER);
+
+  terminating->halt();
+  EXPECT_EQ(waiting->state(), amdgpu::WfState::RUNNING);
+  EXPECT_EQ(waiting->barrier_state(-1), 0x00000011u);
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierMembershipPersistsAfterJoinedWaveTerminates) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *waiting = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *terminating = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(waiting, nullptr);
+  ASSERT_NE(terminating, nullptr);
+  cu->begin_workgroup(0, 0, 2, 4);
+
+  waiting->barrier_init(1, 2);
+  waiting->barrier_join(1);
+  terminating->barrier_join(1);
+  EXPECT_TRUE(waiting->barrier_signal(1, 0));
+  waiting->barrier_wait(1);
+  EXPECT_EQ(waiting->state(), amdgpu::WfState::BARRIER);
+
+  terminating->halt();
+  EXPECT_EQ(waiting->state(), amdgpu::WfState::BARRIER);
+  EXPECT_EQ(waiting->barrier_state(1), 0x01010021u);
+}
+
+TEST(Gfx1250SimulationTest, WorkgroupAndTrapBarriersKeepIndependentSignalCounts) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2);
+
+  EXPECT_TRUE(wf0->barrier_signal(-1, 0));
+  EXPECT_EQ(wf0->barrier_state(-1), 0x00010021u);
+  EXPECT_EQ(wf0->barrier_state(-2), 0u);
+
+  wf0->set_status_raw(wf0->status_raw() | (1u << 5));
+  EXPECT_TRUE(wf0->barrier_signal(-2, 0));
+  EXPECT_EQ(wf0->barrier_state(-2), 0x00010021u);
+  EXPECT_EQ(wf0->barrier_state(-1), 0x00010021u);
+}
+
+TEST(Gfx1250SimulationTest, WorkgroupSignalIsfirstAcceptsNegativeInlineBarrierId) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+  const std::array<uint32_t, 1> signal_words = {0xBE804FC1u}; // s_barrier_signal_isfirst -1
+  std::unique_ptr<Instruction> signal(decoder->decode(signal_words.data()));
+  ASSERT_NE(signal, nullptr);
+
+  cu->execute_instruction(signal.get(), *wf0);
+  EXPECT_TRUE(wf0->read_scc());
+  cu->execute_instruction(signal.get(), *wf1);
+  EXPECT_FALSE(wf1->read_scc());
+}
+
+TEST(Gfx1250SimulationTest, NamedBarrierLeaveCompletesReducedMembership) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf0 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2, 4);
+
+  wf0->barrier_init(1, 2);
+  EXPECT_EQ(wf0->barrier_state(1), 0x01000021u);
+  wf0->barrier_join(1);
+  wf1->barrier_join(1);
+  EXPECT_TRUE(wf0->barrier_signal(1, 0));
+  wf0->barrier_wait(7); // Any nonnegative immediate waits on the joined named barrier.
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+
+  EXPECT_FALSE(wf1->barrier_leave());
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+  EXPECT_EQ(wf0->barrier_state(1), 0x01000011u);
+  EXPECT_TRUE(wf0->barrier_leave());
+  EXPECT_EQ(wf0->barrier_state(1), 0x01000001u);
+}
+
+TEST(Gfx1250SimulationTest, AqlDescriptorAllocatesNamedBarriersForTwoWaveKernel) {
+  constexpr uint64_t kKernelAddr = 0x10000;
+  const uint32_t code[] = {
+      0xBEFD0081u, // s_mov_b32 m0, 1
+      0xBE80527Du, // s_barrier_join m0
+      0xBEFD00FFu,
+      0x00020001u, // s_mov_b32 m0, (2 << 16) | 1
+      0xBE804E7Du, // s_barrier_signal m0
+      0xBF940007u, // s_barrier_wait 7 (the joined named barrier)
+      0xBE84507Du, // s_get_barrier_state s4, m0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kKernelAddr, code, std::size(code), 104, 32, 2, false,
+                                            false, false, 0, 0, 0, 0, 0, 1);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 64, 64);
+  step_until_halted(*sim.engine, *sim.cu());
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 2u);
+  for (const auto &wf : sim.snapshot->snapshots())
+    EXPECT_EQ(wf.sgpr(4), 0x01000021u);
+}
+
+TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUnits) {
+  constexpr auto read_first_workitem =
+      cdna5::build_vop1(cdna5::kVReadfirstlaneB32Vop1, {.src0 = 256, .vdst = 4});
+  constexpr auto is_first_wave =
+      cdna5::build_sopc(cdna5::kSCmpEqU32Sopc, {.ssrc0 = 4, .ssrc1 = 128});
+  constexpr auto skip_signal = cdna5::build_sopp(cdna5::kSCbranchScc0Sopp, {.simm16 = 1});
+  const uint32_t code[] = {
+      read_first_workitem[0], // v_readfirstlane_b32 s4, v0
+      is_first_wave[0],       // s_cmp_eq_u32 s4, 0
+      skip_signal[0],         // s_cbranch_scc0 wait
+      0xBE804EC3u,            // s_barrier_signal -3
+      0xBF94FFFDu,            // s_barrier_wait -3
+      0xBE8450C3u,            // s_get_barrier_state s4, -3
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  auto plugin = std::make_unique<BarrierSpanPlugin>();
+  auto *barrier_span = plugin.get();
+  ASSERT_TRUE(sim.plugin_group->add(std::move(plugin)));
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
+                                            false, false, 0, 0, 0, 0, 0, 1);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/64);
+  step_until_xcd_halted(sim);
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 4u);
+  for (const auto &wf : sim.snapshot->snapshots()) {
+    const uint32_t state = wf.sgpr(4);
+    const uint32_t member_count = (state >> 4) & 0x7fu;
+    EXPECT_EQ(state & 0x07000001u, 0x01000001u);
+    EXPECT_EQ((state >> 16) & 0x7fu, 0u);
+    EXPECT_TRUE(member_count == 1 || member_count == 2);
+  }
+  ASSERT_EQ(barrier_span->span_sizes.size(), 1u);
+  EXPECT_EQ(barrier_span->span_sizes[0], 4u);
+  EXPECT_EQ(barrier_span->workgroup_ids[0], (std::vector<uint32_t>{0, 1}));
+}
+
+TEST(Gfx1250SimulationTest, ClusterBarrierCompletesAfterWorkgroupTerminatesEarly) {
+  constexpr auto is_first_workgroup =
+      cdna5::build_sopc(cdna5::kSCmpEqU32Sopc, {.ssrc0 = 2, .ssrc1 = 128});
+  constexpr auto exit_first_workgroup = cdna5::build_sopp(cdna5::kSCbranchScc1Sopp, {.simm16 = 2});
+  const uint32_t code[] = {
+      is_first_workgroup[0],   // s_cmp_eq_u32 s2, 0
+      exit_first_workgroup[0], // s_cbranch_scc1 end
+      0xBE804EC3u,             // s_barrier_signal -3
+      0xBF94FFFDu,             // s_barrier_wait -3
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32);
+  step_until_xcd_halted(sim);
+
+  ASSERT_EQ(sim.snapshot->snapshots().size(), 2u);
 }
 
 TEST(Gfx1250SimulationTest, VgprMsbModeTracksModeRegisterLayout) {

--- a/emulation/rocjitsu/tests/cdna5_sim_test_common.h
+++ b/emulation/rocjitsu/tests/cdna5_sim_test_common.h
@@ -156,7 +156,8 @@ struct Gfx1250Sim {
                         bool enable_wg_id_x = false, bool enable_wg_id_y = false,
                         bool enable_wg_id_z = false, uint32_t kernel_code_properties = 0,
                         uint32_t kernarg_size = 0, uint32_t kernarg_preload_length = 0,
-                        uint32_t kernarg_preload_offset = 0, uint32_t enable_vgpr_workitem_id = 0) {
+                        uint32_t kernarg_preload_offset = 0, uint32_t enable_vgpr_workitem_id = 0,
+                        uint32_t named_barrier_blocks = 0) {
     using namespace rocr::llvm::amdhsa;
     kernel_descriptor_t kd{};
     kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
@@ -174,6 +175,8 @@ struct Gfx1250Sim {
                     enable_wg_id_z);
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_ENABLE_VGPR_WORKITEM_ID,
                     enable_vgpr_workitem_id);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX125_NAMED_BAR_CNT,
+                    named_barrier_blocks);
     kd.kernel_code_properties = kernel_code_properties;
     AMDHSA_BITS_SET(kd.kernarg_preload, KERNARG_PRELOAD_SPEC_LENGTH, kernarg_preload_length);
     AMDHSA_BITS_SET(kd.kernarg_preload, KERNARG_PRELOAD_SPEC_OFFSET, kernarg_preload_offset);

--- a/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_tensor_dma_test.cpp
@@ -698,7 +698,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaRankThreeNullD2MasksTransfersAndCompletes) {
   EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
   EXPECT_TRUE(wf->wait_counters().empty());
   uint64_t barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_EQ(barrier_state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
 
   for (uint32_t i = 0; i < kElements; ++i) {
@@ -718,7 +718,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaRankThreeNullD2MasksTransfersAndCompletes) {
   EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
   EXPECT_TRUE(wf->wait_counters().empty());
   barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_EQ(barrier_state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
 }
 
@@ -1054,7 +1054,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaIterateZeroExtentSkipsLayoutValidationAndCom
   EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
   EXPECT_TRUE(wf->wait_counters().empty());
   uint64_t barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_EQ(barrier_state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
 
   for (uint32_t i = 0; i < 3; ++i)
@@ -1074,7 +1074,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaIterateZeroExtentSkipsLayoutValidationAndCom
   EXPECT_EQ(wf->wait_counters().tensorcnt, 0u);
   EXPECT_TRUE(wf->wait_counters().empty());
   barrier_state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(barrier_state, 0xffffull << 16);
+  EXPECT_EQ(barrier_state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(barrier_state));
 }
 
@@ -1110,11 +1110,11 @@ TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0 * 4), 0x55000000u);
   EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * 4), 0x55000001u);
   const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(state, 0xffffull << 16);
+  EXPECT_EQ(state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 }
 
-TEST(Gfx1250ExecutionTest, SBarrierWaitEntersBarrierState) {
+TEST(Gfx1250ExecutionTest, SBarrierWaitIsNoOpForSingleWaveWorkgroup) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
@@ -1124,17 +1124,17 @@ TEST(Gfx1250ExecutionTest, SBarrierWaitEntersBarrierState) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
 
-  const std::array<uint32_t, 2> wait_words = {0xBF940000u, 0u};
+  const std::array<uint32_t, 2> wait_words = {0xBF94FFFFu, 0u};
   std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
   ASSERT_NE(wait_inst, nullptr);
   ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
 
   cu->execute_instruction(wait_inst.get(), *wf);
 
-  EXPECT_EQ(wf->state(), amdgpu::WfState::BARRIER);
+  EXPECT_EQ(wf->state(), amdgpu::WfState::RUNNING);
 }
 
-TEST(Gfx1250ExecutionTest, SBarrierWaitReleasesOnlyAfterAllSiblingsWait) {
+TEST(Gfx1250ExecutionTest, SBarrierWaitReleasesOnlyAfterSignalQuorum) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   constexpr uint64_t kEndPgmPc = 0x150000;
@@ -1151,24 +1151,22 @@ TEST(Gfx1250ExecutionTest, SBarrierWaitReleasesOnlyAfterAllSiblingsWait) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
   ASSERT_NE(decoder, nullptr);
 
-  const std::array<uint32_t, 2> wait_words = {0xBF940000u, 0u};
+  const std::array<uint32_t, 2> wait_words = {0xBF94FFFFu, 0u};
   std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
   ASSERT_NE(wait_inst, nullptr);
   ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
 
   cu->execute_instruction(wait_inst.get(), *wf0);
-  wf1->wait_counters().increment(amdgpu::WaitCounterType::TENSORCNT);
-  wf1->set_wait_target_tensorcnt(0);
-  wf1->set_state(amdgpu::WfState::WAITCNT);
-
-  ASSERT_TRUE(cu->step());
   EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
-  EXPECT_EQ(wf1->state(), amdgpu::WfState::WAITCNT);
-
-  wf1->release_wait_counter(amdgpu::WaitCounterType::TENSORCNT);
-  ASSERT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
   cu->execute_instruction(wait_inst.get(), *wf1);
   ASSERT_EQ(wf1->state(), amdgpu::WfState::BARRIER);
+
+  EXPECT_TRUE(wf0->barrier_signal(-1, 0));
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::BARRIER);
+  EXPECT_FALSE(wf1->barrier_signal(-1, 0));
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::RUNNING);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
 
   EXPECT_FALSE(cu->step());
   EXPECT_TRUE(wf0->is_halted());
@@ -1226,7 +1224,7 @@ TEST(Gfx1250ExecutionTest, DsAtomicAsyncBarrierArriveFlipsRawBarrierPhase) {
   local_pipeline.issue(arrive_inst, *wf);
 
   const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
-  EXPECT_EQ(state, 0xffffull << 16);
+  EXPECT_EQ(state, amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
   EXPECT_TRUE(wf->wait_counters().empty());
 }
@@ -1258,7 +1256,9 @@ TEST(Gfx1250ExecutionTest, LocalMemPipelineUsesInjectedBarrierDecrementPayload) 
   const uint64_t expected =
       amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(2), decrement);
   EXPECT_EQ(cu->lds().read64(wf->lds_base() + kBarrierLdsAddr), expected);
-  EXPECT_EQ(expected, (1ull << 32) | (0xffffull << 16) | 1ull);
+  EXPECT_EQ(expected, (1ull << 32) |
+                          (amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift) |
+                          1ull);
   EXPECT_TRUE(wf->wait_counters().empty());
 }
 
@@ -1271,7 +1271,9 @@ TEST(Gfx1250ExecutionTest, LdsBarrierCellHandlesSingleAndBatchedArrivals) {
   EXPECT_FALSE(amdgpu::lds_barrier_cell_phase_parity(state));
 
   state = amdgpu::lds_barrier_cell_update_arrive(state);
-  EXPECT_EQ(state, (1ull << 32) | (0xffffull << 16) | 1ull);
+  EXPECT_EQ(state, (1ull << 32) |
+                       (amdgpu::kLdsBarrierCellPhaseMask << amdgpu::kLdsBarrierCellPhaseShift) |
+                       1ull);
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 
   const uint64_t drained =
@@ -1287,7 +1289,8 @@ TEST(Gfx1250ExecutionTest, LdsBarrierCellHandlesSingleAndBatchedArrivals) {
   const uint64_t batched =
       amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(2), 5);
   EXPECT_EQ(batched, iterated);
-  EXPECT_EQ(batched, (1ull << 32) | (0xfffeull << 16));
+  EXPECT_EQ(batched, (1ull << 32) | (0x6ull << amdgpu::kLdsBarrierCellPhaseShift));
+  EXPECT_FALSE(amdgpu::lds_barrier_cell_phase_parity(batched));
 
   for (uint32_t arrivals_per_phase : {0u, 1u}) {
     state = amdgpu::lds_barrier_cell_init_state(arrivals_per_phase);


### PR DESCRIPTION
Implement the CDNA5 split-barrier model used by compiler-generated gfx1250 kernels. Derive the signal, wait, init, join, leave, and state operations for the gfx1250 profile while retaining the RDNA4 behavior inherited by other targets.

Track independent completion state for named, workgroup, trap, cluster, and cluster-trap barriers. Carry workgroup counters in the compute unit and coordinate per-workgroup cluster arrivals across compute units under a dedicated execution-state lock. Shrink membership when waves or clustered workgroups terminate, honor privilege and single-wave rules, and notify execution plugins outside internal locks with the complete synchronized domain.

Decode named-barrier allocation from the AQL kernel descriptor, use the generated M0 operand selector, and align LDS tensor-barrier phase expectations with the architectural layout. Add instruction and dispatch coverage for named membership, negative barrier IDs, independent domains, early termination, cross-CU cluster synchronization, packed state, and barrier transitions.