### PR TITLE
fix(rocjitsu): Fix gaps with block-scale wmma/mfma

### DIFF
--- a/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
+++ b/emulation/rocjitsu/fuzz/decode/decode_fuzz_main.cpp
@@ -136,7 +136,7 @@ size_t emit_seeds(const std::filesystem::path &directory, std::string_view targe
     constexpr std::array<uint32_t, 3> kFmamkF64 = {0x46040504u, 0x00000000u, 0xC1F00000u};
     constexpr std::array<uint32_t, 3> kFmaakF64 = {0x48040504u, 0x00000000u, 0xC1F00000u};
     constexpr std::array<uint32_t, 3> kTrue16Literal = {0xD7620086u, 0x02030CFFu, 0x000000FFu};
-    constexpr std::array<uint32_t, 4> kWmmaScale = {0xCC350000u, 0x02020900u, 0xCC330006u,
+    constexpr std::array<uint32_t, 4> kWmmaScale = {0xCC350000u, 0x04020900u, 0xCC330006u,
                                                     0x02026912u};
     write("v_fmamk_f64_literal", words_to_window(kFmamkF64));
     write("v_fmaak_f64_literal", words_to_window(kFmaakF64));

--- a/emulation/rocjitsu/lib/python/amdisa/__init__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/__init__.py
@@ -13,6 +13,7 @@ from amdisa.gpuisa import (
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
+    Cdna4Profile,
     CdnaProfile,
     EncodingModifier,
     Cdna5Profile,
@@ -42,6 +43,7 @@ from amdisa.legalization import (
 __all__ = [
     'Cdna1Profile',
     'Cdna2Profile',
+    'Cdna4Profile',
     'CdnaProfile',
     'CodegenConfig',
     'CodeGenerator',

--- a/emulation/rocjitsu/lib/python/amdisa/__main__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/__main__.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as elem_tree
 from amdisa import (
     Cdna1Profile,
     Cdna2Profile,
+    Cdna4Profile,
     CdnaProfile,
     CodegenConfig,
     CodeGenerator,
@@ -45,7 +46,7 @@ _PROFILES = {
     'cdna1': Cdna1Profile,
     'cdna2': Cdna2Profile,
     'cdna3': CdnaProfile,
-    'cdna4': CdnaProfile,
+    'cdna4': Cdna4Profile,
     'rdna1': Rdna1Profile,
     'rdna2': Rdna2Profile,
     'rdna3': Rdna3Profile,

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4637,8 +4637,10 @@ class CodeGenerator:
               const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
               const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
               const bool scale16 = scale->op == 0x3au;
+              // Accept LLVM's encoding as an alias for the ISA-canonical constant.
+              const bool fixed_src2_valid = scale->src2 == 0x080u || scale->src2 == 0x100u;
               if (scale->vdst != 0u || (scale->neg_hi & 0x4u) != 0u ||
-                  (scale->opsel & 0x2u) != 0u || scale->clamp != 0u || scale->src2 != 0x100u ||
+                  (scale->opsel & 0x2u) != 0u || scale->clamp != 0u || !fixed_src2_valid ||
                   (scale->opsel_hi & 0x2u) != 0u || (scale->neg & 0x4u) != 0u ||
                   (matrix->neg_hi & 0x3u) != 0u || matrix->clamp != 0u ||
                   (matrix->neg & 0x3u) != 0u)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4637,6 +4637,12 @@ class CodeGenerator:
               const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
               const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
               const bool scale16 = scale->op == 0x3au;
+              if (scale->vdst != 0u || (scale->neg_hi & 0x4u) != 0u ||
+                  (scale->opsel & 0x2u) != 0u || scale->clamp != 0u || scale->src2 != 0x100u ||
+                  (scale->opsel_hi & 0x2u) != 0u || (scale->neg & 0x4u) != 0u ||
+                  (matrix->neg_hi & 0x3u) != 0u || matrix->clamp != 0u ||
+                  (matrix->neg & 0x3u) != 0u)
+                return false;
               if (!isGfx1250WmmaScaleSource(scale->src0, scale16) ||
                   !isGfx1250WmmaScaleSource(scale->src1, scale16))
                 return false;
@@ -10284,7 +10290,7 @@ class CodeGenerator:
                     class_func_impls.model.insert(
                         0, cgen.Line(self._emit_mfma_operand_helpers())
                     )
-                    if self.isa_spec.arch_name.lower() == 'cdna4':
+                    if self._supports_cdna_mfma_f8f6f4_vop3px2():
                         class_func_impls.model.insert(
                             0, cgen.Line(self._emit_cdna4_matrix_fmt_helpers())
                         )
@@ -13235,9 +13241,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                 '    return decodeInvalid(opcode, emit_error);\n'
                             ),
                             cgen.Line(dense_factory_cases),
-                            cgen.Statement(
-                                'return decodeInvalid(opcode, emit_error)'
-                            ),
+                            cgen.Statement('return decodeInvalid(opcode, emit_error)'),
                         ]
                     )
                     _custom_decode_bodies[_pfx] = cgen.Block(

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4344,8 +4344,10 @@ class CodeGenerator:
                 '                                             : "v_wmma_scale_f32_16x16x128_f8f6f4";\n'
                 '}\n'
                 '\n'
-                'int cdna5_scale_operand_size_bits(const MachineInst *inst) {\n'
-                '  return cdna5_scaled_wmma_is_scale16(inst) ? 64 : 32;\n'
+                'int cdna5_scale_operand_size_bits(const MachineInst *inst, uint32_t selector) {\n'
+                '  const bool is_vgpr = selector >= OpSelSrcSimple::OPR_SRC_SIMPLE_VGPR_MIN &&\n'
+                '                       selector <= OpSelSrcSimple::OPR_SRC_SIMPLE_VGPR_MAX;\n'
+                '  return cdna5_scaled_wmma_is_scale16(inst) && is_vgpr ? 64 : 32;\n'
                 '}\n'
                 '\n'
                 'int cdna5_scaled_wmma_dst_size_bits(const MachineInst *inst) {\n'
@@ -4462,9 +4464,13 @@ class CodeGenerator:
                        reinterpret_cast<const OpEncoding *>(inst + 2)->src1),
                   src2(cdna5_scaled_wmma_dst_size_bits(inst), OperandType::OPR_SRC_VGPR_OR_INLINE,
                        reinterpret_cast<const OpEncoding *>(inst + 2)->src2),
-                  scale_src0(cdna5_scale_operand_size_bits(inst), OperandType::OPR_SRC_SIMPLE,
+                  scale_src0(cdna5_scale_operand_size_bits(
+                                 inst, reinterpret_cast<const OpEncoding *>(inst)->src0),
+                             OperandType::OPR_SRC_SIMPLE,
                              reinterpret_cast<const OpEncoding *>(inst)->src0),
-                  scale_src1(cdna5_scale_operand_size_bits(inst), OperandType::OPR_SRC_SIMPLE,
+                  scale_src1(cdna5_scale_operand_size_bits(
+                                 inst, reinterpret_cast<const OpEncoding *>(inst)->src1),
+                             OperandType::OPR_SRC_SIMPLE,
                              reinterpret_cast<const OpEncoding *>(inst)->src1),
                   scale_inst_(*reinterpret_cast<const OpEncoding *>(inst)) {
               raw_words_ = {inst[0], inst[1], inst[2], inst[3]};

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3938,14 +3938,178 @@ class CodeGenerator:
             and self.isa_spec.profile.generate_scaled_wmma_vop3px2
         )
 
+    def _cdna_mfma_f8f6f4_vop3px2_specs(self):
+        instruction_names = {
+            inst.name for enc in self.isa_spec.inst_encodings for inst in enc.insts
+        }
+        return tuple(
+            spec
+            for spec in getattr(self.isa_spec.profile, "mfma_scale_vop3px2_specs", ())
+            if spec.dense_name in instruction_names
+        )
+
     def _supports_cdna_mfma_f8f6f4_vop3px2(self) -> bool:
-        return self.isa_spec.arch_name.lower() == 'cdna4'
+        return bool(self._cdna_mfma_f8f6f4_vop3px2_specs())
 
     def _is_cdna_mfma_f8f6f4_vop3px2_suffix(self, inst: Instruction) -> bool:
-        return (
-            self._supports_cdna_mfma_f8f6f4_vop3px2()
-            and inst.name in self.isa_spec.profile.inst_size_overrides
+        return any(
+            inst.name == spec.dense_name
+            for spec in self._cdna_mfma_f8f6f4_vop3px2_specs()
         )
+
+    def _emit_cdna_mfma_f8f6f4_vop3px2_decoder_helpers(self) -> str:
+        opcodes = ' || '.join(
+            f'op2 == {spec.opcode}' for spec in self._cdna_mfma_f8f6f4_vop3px2_specs()
+        )
+        prefix_opcode = self._cdna_mfma_f8f6f4_vop3px2_specs()[0].prefix_opcode
+        return textwrap.dedent(f'''\
+            namespace {{
+
+            bool isLegalMfmaScaleF8f6f4Selector(uint32_t selector) {{
+              return (selector >= 240 && selector <= 248) || (selector >= 256 && selector <= 511);
+            }}
+
+            bool isLegalMfmaF8f6f4Format(uint32_t format) {{ return format <= 4; }}
+
+            bool isMfmaScaleF8f6f4Vop3px2(const MachineInst *opcode) {{
+              constexpr uint32_t VOP3P_MFMA_ENC = 423;
+              constexpr uint32_t PREFIX_OP = {prefix_opcode};
+              auto enc0 = (opcode[0] >> 23) & 0x1FFu;
+              auto op0 = (opcode[0] >> 16) & 0x7Fu;
+              if (enc0 != VOP3P_MFMA_ENC || op0 != PREFIX_OP)
+                return false;
+              auto enc2 = (opcode[2] >> 23) & 0x1FFu;
+              auto op2 = (opcode[2] >> 16) & 0x7Fu;
+              auto abid2 = (opcode[2] >> 11) & 0xFu;
+              return enc2 == VOP3P_MFMA_ENC && ({opcodes}) && abid2 == 1u;
+            }}
+
+            bool isValidMfmaScaleF8f6f4(const MachineInst *opcode) {{
+              auto scale_src0 = opcode[1] & 0x1FFu;
+              auto scale_src1 = (opcode[1] >> 9) & 0x1FFu;
+              if (!isLegalMfmaScaleF8f6f4Selector(scale_src0) ||
+                  !isLegalMfmaScaleF8f6f4Selector(scale_src1))
+                return false;
+              auto suffix = *reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode + 2);
+              if (!isLegalMfmaF8f6f4Format(suffix.cbsz) ||
+                  !isLegalMfmaF8f6f4Format(suffix.blgp))
+                return false;
+              auto neg = (opcode[1] >> 29) & 0x7u;
+              auto neg_hi = (opcode[0] >> 8) & 0x7u;
+              return (neg & 0x3u) == 0 && (neg_hi & 0x3u) == 0;
+            }}
+
+            }} // namespace
+            ''')
+
+    def _emit_cdna_mfma_f8f6f4_vop3px2_classes(self) -> str:
+        classes = []
+        for spec in self._cdna_mfma_f8f6f4_vop3px2_specs():
+            classes.append(textwrap.dedent(f'''\
+                    class {spec.class_name} : public Vop3pMfma {{
+                    public:
+                      {spec.class_name}(const MachineInst *inst);
+                      void execute_impl(amdgpu::Wavefront &wf);
+
+                      Operand vdst;
+                      Operand src0;
+                      Operand src1;
+                      Operand src2;
+                      Operand scale_src0;
+                      Operand scale_src1;
+
+                    private:
+                      std::array<uint32_t, 4> raw_words_{{}};
+                    }};
+                    '''))
+        return '\n'.join(classes)
+
+    def _emit_cdna_mfma_f8f6f4_vop3px2_impls(self) -> _ImplOutputs:
+        outputs = _ImplOutputs()
+        for spec in self._cdna_mfma_f8f6f4_vop3px2_specs():
+            exec_fn = self._split_execute_expr(spec.class_name)
+            output_bits = spec.m * spec.n * 32 // 64
+            outputs.model.append(textwrap.dedent(f'''\
+                    {spec.class_name}::{spec.class_name}(const MachineInst *inst)
+                        : Vop3pMfma("{spec.mnemonic}",
+                                    reinterpret_cast<const OpEncoding *>(inst + 2), {exec_fn}),
+                          vdst({output_bits}, OperandType::OPR_VGPR_OR_ACCVGPR,
+                               (reinterpret_cast<const OpEncoding *>(inst + 2)->vdst +
+                                (reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd
+                                     ? OpSelVgprOrAccvgpr::OPR_VGPR_OR_ACCVGPR_ACC_MIN
+                                     : 0))),
+                          src0(cdna4_matrix_fmt_operand_size_bits(
+                                   reinterpret_cast<const OpEncoding *>(inst + 2)->cbsz,
+                                   {spec.m}, {spec.k}),
+                               OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+                               (reinterpret_cast<const OpEncoding *>(inst + 2)->src0 +
+                                ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x1u)
+                                     ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                                        OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                                     : 0))),
+                          src1(cdna4_matrix_fmt_operand_size_bits(
+                                   reinterpret_cast<const OpEncoding *>(inst + 2)->blgp,
+                                   {spec.n}, {spec.k}),
+                               OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+                               (reinterpret_cast<const OpEncoding *>(inst + 2)->src1 +
+                                ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x2u)
+                                     ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                                        OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                                     : 0))),
+                          src2({output_bits}, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
+                               mfma_src2_encoding(
+                                   reinterpret_cast<const OpEncoding *>(inst + 2)->src2,
+                                   reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd)),
+                          scale_src0(32, OperandType::OPR_SRC_SIMPLE,
+                                     reinterpret_cast<const OpEncoding *>(inst)->src0),
+                          scale_src1(32, OperandType::OPR_SRC_SIMPLE,
+                                     reinterpret_cast<const OpEncoding *>(inst)->src1),
+                          raw_words_{{inst[0], inst[1], inst[2], inst[3]}} {{
+                      size_ = 16;
+                      raw_encoding_ = raw_words_.data();
+                      dst_operands_[0] = &vdst;
+                      src_operands_[0] = &src0;
+                      src_operands_[1] = &src1;
+                      src_operands_[2] = &src2;
+                      src_operands_[3] = &scale_src0;
+                      src_operands_[4] = &scale_src1;
+                      num_src_ = 5;
+                      num_dst_ = 1;
+                      flags_ |= MFMA;
+                    }}
+                    '''))
+            outputs.execution.append(textwrap.dedent(f'''\
+                    void {spec.class_name}::execute_impl(amdgpu::Wavefront &wf) {{
+                      auto &cu = wf.cu();
+                      uint32_t vb = wf.vgpr_alloc().base;
+                      uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+                      uint32_t const_acc;
+                      uint32_t s2 = amdgpu::resolve_acc(
+                          vb, dst, src2.encoding_value_, const_acc,
+                          [&] {{ return amdgpu::RegisterAccess(wf).read_scalar(src2); }});
+                      uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+                      uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+                      uint32_t scale_a = raw_words_[1] & 0x1FFu;
+                      uint32_t scale_b = (raw_words_[1] >> 9) & 0x1FFu;
+                      uint32_t scale_a_byte =
+                          ((raw_words_[0] >> 11) & 1u) | (((raw_words_[1] >> 27) & 1u) << 1);
+                      uint32_t scale_b_byte =
+                          ((raw_words_[0] >> 12) & 1u) | (((raw_words_[1] >> 28) & 1u) << 1);
+                      uint32_t c_modifier = amdgpu::wmma_c_modifier(
+                          (raw_words_[1] >> 29) & 7u, (raw_words_[0] >> 8) & 7u);
+                      bool dispatched = amdgpu::dispatch_matrix_fmt_pair(
+                          inst_.cbsz, inst_.blgp,
+                          [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {{
+                            amdgpu::exec_f32_scaled_mixed(
+                                cu, {spec.m}, {spec.n}, {spec.k}, 1, a_bits, b_bits, dst, s0b,
+                                s1b, s2, ea, eb, const_acc, vb, scale_a, scale_b, scale_a_byte,
+                                scale_b_byte, c_modifier);
+                          }});
+                      if (!dispatched)
+                        throw util::UnimplementedInst(mnemonic());
+                    }}
+                    '''))
+        return outputs
 
     def _cdna5_f8f6f4_wmma_shape(
         self, inst: Instruction
@@ -3963,12 +4127,14 @@ class CodeGenerator:
     def _cdna4_f8f6f4_mfma_shape(
         self, inst: Instruction
     ) -> tuple[int, int, int] | None:
-        if not self._is_cdna_mfma_f8f6f4_vop3px2_suffix(inst):
-            return None
-        m = re.match(r'V_MFMA_F32_(\d+)X(\d+)X(\d+)_?F8F6F4$', inst.name)
-        if not m:
-            return None
-        return tuple(int(x) for x in m.groups())
+        return next(
+            (
+                (spec.m, spec.n, spec.k)
+                for spec in self._cdna_mfma_f8f6f4_vop3px2_specs()
+                if inst.name == spec.dense_name
+            ),
+            None,
+        )
 
     def _cdna5_swmmac_has_modifiers(self, inst: Instruction) -> bool:
         return self.isa_spec.arch_name == 'cdna5' and inst.name.startswith('V_SWMMAC_')
@@ -4385,13 +4551,21 @@ class CodeGenerator:
               const uint32_t matrix_a_scale_fmt = scale_inst_.neg & 0x3u;
               const uint32_t matrix_b_scale_fmt = scale_inst_.neg_hi & 0x3u;
               const bool scale16 = scale_inst_.op == 0x3a;
+              const bool scale0_inline_zero =
+                  scale_src0.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN;
+              const bool scale1_inline_zero =
+                  scale_src1.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN;
 
               auto scale_word = [&](const Operand &operand, uint32_t lane) -> uint64_t {
-                // For regular scaled WMMA, the inline integer-zero encoding
-                // selects a neutral E8M0 word rather than the numerical value 0.
-                if (!scale16 &&
-                    operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
-                  return 0x7f7f7f7fu;
+                // Inline zero supplies a neutral E8M0 scale for every K block.
+                if (operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
+                  return 0x7f7f7f7f7f7f7f7full;
+                // Scalar scale sources use only bits 7:0, repeated for every K
+                // block. VGPR scale sources retain their packed per-block bytes.
+                if (operand.encoding_value() >= 0 && operand.encoding_value() <= 105) {
+                  const uint64_t byte = amdgpu::RegisterAccess(wf).read_lane(operand, lane) & 0xffu;
+                  return byte * 0x0101010101010101ull;
+                }
                 return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(operand, lane)
                                : amdgpu::RegisterAccess(wf).read_lane(operand, lane);
               };
@@ -4408,7 +4582,8 @@ class CodeGenerator:
                                                    src1_base, s2, amdgpu::extract_fp4,
                                                    amdgpu::extract_fp4, const_acc, scale0, scale1,
                                                    matrix_a_scale, matrix_b_scale,
-                                                   matrix_a_scale_fmt, matrix_b_scale_fmt, scale16,
+                                                   scale0_inline_zero ? 0u : matrix_a_scale_fmt,
+                                                   scale1_inline_zero ? 0u : matrix_b_scale_fmt, scale16,
                                                    amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
                 dispatched = true;
               } else {
@@ -4418,7 +4593,8 @@ class CodeGenerator:
                       amdgpu::exec_wmma_f32_scaled_mixed(
                           cu, 16, 16, 128, a_bits, b_bits, dst, src0_base, src1_base, s2,
                           extract_a, extract_b, const_acc, scale0, scale1, matrix_a_scale,
-                          matrix_b_scale, matrix_a_scale_fmt, matrix_b_scale_fmt, scale16,
+                          matrix_b_scale, scale0_inline_zero ? 0u : matrix_a_scale_fmt,
+                          scale1_inline_zero ? 0u : matrix_b_scale_fmt, scale16,
                           amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
                     });
               }
@@ -4435,6 +4611,44 @@ class CodeGenerator:
 
             bool isVop3pOp(const MachineInst opcode, uint32_t op) {
               return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
+            }
+
+            bool isGfx1250WmmaScaleSource(uint32_t selector, bool scale16) {
+              if (selector <= 105u || selector == 128u)
+                return true;
+              if (selector < 256u || selector > 511u)
+                return false;
+              return !scale16 || ((selector - 256u) % 2u == 0u && selector < 511u);
+            }
+
+            bool isGfx1250WmmaScaleFormatPairLegal(uint32_t matrix_a_fmt, uint32_t matrix_b_fmt,
+                                                   uint32_t scale_a_fmt, uint32_t scale_b_fmt) {
+              if (matrix_a_fmt > 4u || matrix_b_fmt > 4u || scale_a_fmt > 2u || scale_b_fmt > 2u)
+                return false;
+              if (scale_a_fmt == 0u && scale_b_fmt == 0u)
+                return true;
+              if ((scale_a_fmt != 0u && matrix_a_fmt != 4u) ||
+                  (scale_b_fmt != 0u && matrix_b_fmt != 4u))
+                return false;
+              return matrix_a_fmt != 4u || matrix_b_fmt != 4u || scale_a_fmt == scale_b_fmt;
+            }
+
+            bool isGfx1250WmmaScalePairValid(const MachineInst *opcode) {
+              const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
+              const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
+              const bool scale16 = scale->op == 0x3au;
+              if (!isGfx1250WmmaScaleSource(scale->src0, scale16) ||
+                  !isGfx1250WmmaScaleSource(scale->src1, scale16))
+                return false;
+
+              const uint32_t scale_a_fmt = scale->neg & 0x3u;
+              const uint32_t scale_b_fmt = scale->neg_hi & 0x3u;
+              if (matrix->op == 0x88u)
+                return isGfx1250WmmaScaleFormatPairLegal(4u, 4u, scale_a_fmt, scale_b_fmt);
+              const uint32_t matrix_a_fmt = matrix->opsel;
+              const uint32_t matrix_b_fmt = (matrix->pad_14 << 2u) | matrix->opsel_hi;
+              return isGfx1250WmmaScaleFormatPairLegal(matrix_a_fmt, matrix_b_fmt, scale_a_fmt,
+                                                       scale_b_fmt);
             }
 
             } // namespace
@@ -8247,12 +8461,7 @@ class CodeGenerator:
 
                     class_ctor_decl = cgen.FunctionDeclaration(
                         cgen.Value('', inst.fmt_name),
-                        [cgen.Value('const MachineInst *', 'inst')]
-                        + (
-                            [cgen.Value('bool', 'has_vop3px2_prefix = false')]
-                            if self._is_cdna_mfma_f8f6f4_vop3px2_suffix(inst)
-                            else []
-                        ),
+                        [cgen.Value('const MachineInst *', 'inst')],
                     )
                     public_members.append(class_ctor_decl)
                     public_members.append(
@@ -9109,40 +9318,10 @@ class CodeGenerator:
                     # EXEC-state all-ones reasoning.
                     ctor_body_parts.extend(_result_combinator_flag_stmts(_mem_sem))
 
-                    # Per-instruction size overrides (e.g., VOP3PX2 128-bit
-                    # instructions decoded under 64-bit VOP3P_MFMA).
-                    _size_overrides = self.isa_spec.profile.inst_size_overrides
-                    if inst.name in _size_overrides:
-                        if self._is_cdna_mfma_f8f6f4_vop3px2_suffix(inst):
-                            ctor_body_parts.append(
-                                f'if (has_vop3px2_prefix) {{'
-                                f' size_ = {_size_overrides[inst.name]};'
-                                ' raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};'
-                                ' raw_encoding_ = raw_words_.data();'
-                                '}'
-                            )
-                        else:
-                            ctor_body_parts.append(
-                                f'size_ = {_size_overrides[inst.name]};'
-                            )
-                            ctor_body_parts.append(
-                                'raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};'
-                                'raw_encoding_ = raw_words_.data();'
-                            )
-                        private_members.append(
-                            cgen.Statement('std::array<uint32_t, 4> raw_words_{}')
-                        )
-
                     ctor_body = ''.join(ctor_body_parts)
                     class_ctor_impl_str = (
                         f'{inst.fmt_name}::'
-                        f'{inst.fmt_name}(const MachineInst *inst'
-                        + (
-                            ', bool has_vop3px2_prefix'
-                            if self._is_cdna_mfma_f8f6f4_vop3px2_suffix(inst)
-                            else ''
-                        )
-                        + ') '
+                        f'{inst.fmt_name}(const MachineInst *inst) '
                         f': {init_list} '
                         f'{{{ctor_body}}}'
                     )
@@ -10007,23 +10186,37 @@ class CodeGenerator:
                         False,
                     ),
                 ]
-                _has_size_overrides = any(
-                    i.name in self.isa_spec.profile.inst_size_overrides
-                    for i in all_insts
+                needs_compound_array = (
+                    self._supports_cdna_mfma_f8f6f4_vop3px2()
+                    and enc.enc_name.upper() == 'ENC_VOP3P'
                 )
-                if _has_size_overrides:
-                    h_includes.append(('array', True))
                 if (
                     self._supports_cdna5_scaled_wmma_vop3px2()
                     and enc.enc_name.upper() == 'ENC_VOP3P'
                 ):
-                    if not _has_size_overrides:
+                    if not needs_compound_array:
                         h_includes.append(('array', True))
                     cpp_includes.append(('array', True))
                     inst_classes.append(
                         cgen.Line(self._emit_cdna5_scaled_wmma_vop3px2_class())
                     )
                     scaled_outputs = self._emit_cdna5_scaled_wmma_vop3px2_impls()
+                    class_func_impls.model.extend(
+                        cgen.Line(impl) for impl in scaled_outputs.model
+                    )
+                    class_func_impls.execution.extend(
+                        cgen.Line(impl) for impl in scaled_outputs.execution
+                    )
+
+                if (
+                    self._supports_cdna_mfma_f8f6f4_vop3px2()
+                    and enc.enc_name.upper() == 'ENC_VOP3P'
+                ):
+                    h_includes.append(('array', True))
+                    inst_classes.append(
+                        cgen.Line(self._emit_cdna_mfma_f8f6f4_vop3px2_classes())
+                    )
+                    scaled_outputs = self._emit_cdna_mfma_f8f6f4_vop3px2_impls()
                     class_func_impls.model.extend(
                         cgen.Line(impl) for impl in scaled_outputs.model
                     )
@@ -12846,6 +13039,26 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             class_impl.append(
                 cgen.Line(self._emit_cdna5_scaled_wmma_vop3px2_decoder_helpers())
             )
+        if self._supports_cdna_mfma_f8f6f4_vop3px2():
+            factory_cases = ''.join(
+                f'    if (op2 == {spec.opcode})\n'
+                f'      return std::make_unique<{spec.class_name}>(opcode);\n'
+                for spec in self._cdna_mfma_f8f6f4_vop3px2_specs()
+            )
+            class_impl.append(
+                cgen.Line(self._emit_cdna_mfma_f8f6f4_vop3px2_decoder_helpers())
+            )
+            decode_body.append(
+                cgen.Line(
+                    '  if (isMfmaScaleF8f6f4Vop3px2(opcode)) {\n'
+                    '    if (!isValidMfmaScaleF8f6f4(opcode))\n'
+                    '      return decodeInvalid(opcode, emit_error);\n'
+                    '    auto op2 = (opcode[2] >> 16) & 0x7Fu;\n'
+                    f'{factory_cases}'
+                    '    return decodeInvalid(opcode, emit_error);\n'
+                    '  }\n'
+                )
+            )
         decode_body.extend(
             [
                 cgen.Statement(
@@ -12961,6 +13174,8 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                 '  if (!isVop3pOp(opcode[2], 0x33) && '
                                 '!isVop3pOp(opcode[2], 0x88))\n'
                                 '    return decodeInvalid(opcode, emit_error);\n'
+                                '  if (!isGfx1250WmmaScalePairValid(opcode))\n'
+                                '    return decodeInvalid(opcode, emit_error);\n'
                             ),
                             cgen.Statement(
                                 'return std::make_unique<VWmmaScaleF32Vop3px2>(opcode)'
@@ -12971,68 +13186,66 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             else:
                 raise ValueError('gfx1250 scaled WMMA requires a VOP3P decode table')
 
-        _vop3px2_opcode = self.isa_spec.profile.vop3px2_prefix_opcode
-        if _vop3px2_opcode is not None:
-            _ie_names = {
-                inst.name for ie in self.isa_spec.inst_encodings for inst in ie.insts
-            }
-            _vop3px2_active = any(
-                n in _ie_names for n in self.isa_spec.profile.inst_size_overrides
-            )
-            if _vop3px2_active:
-                for _dte in self.isa_spec.primary_decode_table:
-                    if (
-                        _dte is not None
-                        and not _dte.is_primary
-                        and _dte.sub_decode_funcs is not None
-                        and _dte.sub_decode_table
-                        and 'vop3p' in _dte.sub_decode_table
+        _vop3px2_specs = self._cdna_mfma_f8f6f4_vop3px2_specs()
+        if _vop3px2_specs:
+            for _dte in self.isa_spec.primary_decode_table:
+                if (
+                    _dte is not None
+                    and not _dte.is_primary
+                    and _dte.sub_decode_funcs is not None
+                    and _dte.sub_decode_table
+                    and 'vop3p' in _dte.sub_decode_table
+                ):
+                    _pfx = 'decodeVop3pX2Prefix'
+                    _prefix_opcode = _vop3px2_specs[0].prefix_opcode
+                    if _dte.sub_decode_funcs[_prefix_opcode] not in (
+                        'decodeInvalid',
+                        _pfx,
                     ):
-                        _pfx = 'decodeVop3pX2Prefix'
-                        _dte.sub_decode_funcs[_vop3px2_opcode] = _pfx
-                        for ie in self.isa_spec.inst_encodings:
-                            for inst in ie.insts:
-                                if (
-                                    inst.name
-                                    in self.isa_spec.profile.inst_size_overrides
-                                    and not self._is_cdna_mfma_f8f6f4_vop3px2_suffix(
-                                        inst
-                                    )
-                                ):
-                                    _dte.sub_decode_funcs[inst.opcode] = 'decodeInvalid'
-                        if self._supports_cdna_mfma_f8f6f4_vop3px2():
-                            _custom_decode_bodies[_pfx] = cgen.Block(
-                                [
-                                    cgen.Line(
-                                        '  const uint32_t suffix_encoding = '
-                                        '(opcode[2] >> 23) & 0x1FFu;\n'
-                                        '  const uint32_t suffix_opcode = '
-                                        '(opcode[2] >> 16) & 0x7Fu;\n'
-                                        '  if (suffix_encoding != encoding::kVop3pMfma ||\n'
-                                        '      (suffix_opcode != '
-                                        'kVMfmaF3216x16x128F8f6f4Vop3pMfma &&\n'
-                                        '       suffix_opcode != '
-                                        'kVMfmaF3232x32x64F8f6f4Vop3pMfma))\n'
-                                        '    return decodeInvalid(opcode, emit_error);\n'
-                                        '  if (suffix_opcode == '
-                                        'kVMfmaF3216x16x128F8f6f4Vop3pMfma)\n'
-                                        '    return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true);\n'
-                                        '  return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true);\n'
-                                    )
-                                ]
+                        raise ValueError(
+                            f'CDNA scaled MFMA prefix conflicts with VOP3P opcode '
+                            f'{_prefix_opcode}'
+                        )
+                    _dte.sub_decode_funcs[_prefix_opcode] = _pfx
+                    _suffix_fn = 'decodeCdna4MfmaF8f6f4Suffix'
+                    dense_factory_cases = ''.join(
+                        f'  if (op.op == {spec.opcode})\n'
+                        f'    return std::make_unique<{spec.dense_class_name}>(opcode);\n'
+                        for spec in _vop3px2_specs
+                    )
+                    for spec in _vop3px2_specs:
+                        if _dte.sub_decode_funcs[spec.opcode] not in (
+                            'decodeInvalid',
+                            f'decode{spec.dense_class_name}',
+                            _suffix_fn,
+                        ):
+                            raise ValueError(
+                                f'CDNA scaled MFMA suffix conflicts with VOP3P opcode '
+                                f'{spec.opcode}'
                             )
-                        else:
-                            _custom_decode_bodies[_pfx] = cgen.Block(
-                                [
-                                    cgen.Statement(
-                                        f'auto op = *reinterpret_cast<const {_dte.enc.fmt_enc_name}::OpEncoding *>(opcode + 2)'
-                                    ),
-                                    cgen.Statement(
-                                        f'return {_dte.sub_decode_table}[op.op](opcode + 2, emit_error)'
-                                    ),
-                                ]
-                            )
-                        break
+                        _dte.sub_decode_funcs[spec.opcode] = _suffix_fn
+                    _custom_decode_bodies[_suffix_fn] = cgen.Block(
+                        [
+                            cgen.Statement(
+                                "auto op = *reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode)"
+                            ),
+                            cgen.Line(
+                                '  if (op.abid != 0u || !isLegalMfmaF8f6f4Format(op.cbsz) ||\n'
+                                '      !isLegalMfmaF8f6f4Format(op.blgp))\n'
+                                '    return decodeInvalid(opcode, emit_error);\n'
+                            ),
+                            cgen.Line(dense_factory_cases),
+                            cgen.Statement(
+                                'return decodeInvalid(opcode, emit_error)'
+                            ),
+                        ]
+                    )
+                    _custom_decode_bodies[_pfx] = cgen.Block(
+                        [cgen.Statement('return decodeInvalid(opcode, emit_error)')]
+                    )
+                    break
+            else:
+                raise ValueError('CDNA scaled MFMA requires a VOP3P decode table')
         for _fn, _body in _custom_primary_decode_bodies.items():
             _decl = cgen.FunctionDeclaration(
                 cgen.Value('static DecodeResult', _fn),

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -608,40 +608,17 @@ def gen_mfma(
             # correct extract functions and bit widths.
             L.append(f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);')
             L.append(f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);')
-            L.append('  bool dispatched;')
-            L.append('  if (!(inst_.abid & 1u)) {')
             L.append(
-                '    dispatched = amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,'
+                '  bool dispatched = amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,'
+            )
+            L.append('      [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {')
+            L.append(
+                f'        amdgpu::exec_f32_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits,'
             )
             L.append(
-                '        [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {'
+                f'                               dst, s0b, s1b, s2, ea, eb, const_acc);'
             )
-            L.append(
-                f'          amdgpu::exec_f32_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits,'
-            )
-            L.append(
-                f'                                 dst, s0b, s1b, s2, ea, eb, const_acc);'
-            )
-            L.append('        });')
-            L.append('  } else {')
-            L.append(
-                '    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);'
-            )
-            L.append(
-                '    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);'
-            )
-            L.append('    dispatched = amdgpu::dispatch_matrix_fmt_pair(')
-            L.append(
-                '        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {'
-            )
-            L.append(
-                f'          amdgpu::exec_f32_scaled_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits, dst, s0b, s1b, s2, ea,'
-            )
-            L.append(
-                f'                                        eb, const_acc, sa_base, sb_base);'
-            )
-            L.append('        });')
-            L.append('  }')
+            L.append('      });')
             L.append('  if (!dispatched)')
             L.append('    throw util::UnimplementedInst(mnemonic());')
         elif uses_gfx11_wmma_layout and result_type in ('F16', 'BF16'):

--- a/emulation/rocjitsu/lib/python/amdisa/encoding_translator_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/encoding_translator_codegen.py
@@ -18,10 +18,10 @@ Fields are classified as:
 Usage::
 
     from amdisa import Parser
-    from amdisa.isa_profile import CdnaProfile, Rdna4Profile
+    from amdisa.isa_profile import Cdna4Profile, Rdna4Profile
     from amdisa.encoding_translator_codegen import generate_encoding_translators
 
-    cdna4 = Parser('amdgpu_isa_cdna4.xml', CdnaProfile()).parse()
+    cdna4 = Parser('amdgpu_isa_cdna4.xml', Cdna4Profile()).parse()
     rdna4 = Parser('amdgpu_isa_rdna4.xml', Rdna4Profile()).parse()
     generate_encoding_translators(cdna4, rdna4, 'cdna4', 'rdna4', 'output/')
 """

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -122,6 +122,22 @@ class VopdEncodingPrefix:
     is_vopd3: bool = False
 
 
+@dataclass(frozen=True)
+class MfmaScaleVop3px2Spec:
+    """One compound CDNA block-scale MFMA decoded from a VOP3PX2 pair."""
+
+    dense_name: str
+    dense_class_name: str
+    scaled_name: str
+    class_name: str
+    mnemonic: str
+    opcode: int
+    m: int
+    n: int
+    k: int
+    prefix_opcode: int = 0x2C
+
+
 _VOPD_COMMON_F32_SLOT_OPS = (
     VopdSlotOp('VopdFmacF32', 0, 'v_dual_fmac_f32'),
     VopdSlotOp('VopdFmaakF32', 1, 'v_dual_fmaak_f32'),
@@ -256,24 +272,18 @@ class IsaProfile(ABC):
 
     @property
     def inst_size_overrides(self) -> dict[str, int]:
-        """Per-instruction size overrides in bytes.
-
-        Used for instructions whose encoding size differs from their
-        parent encoding (e.g., VOP3PX2 instructions are 128-bit but
-        decoded under the 64-bit VOP3P_MFMA encoding).
-        """
+        """Per-instruction size overrides in bytes."""
         return {}
 
     @property
     def vop3px2_prefix_opcode(self) -> int | None:
-        """VOP3P opcode slot for the VOP3PX2 128-bit prefix decoder.
-
-        Returns the opcode index in the VOP3P sub-decode table where the
-        VOP3PX2 prefix handler should be placed.  The prefix reads the
-        actual MFMA opcode from DW2-DW3 and re-dispatches.  ``None``
-        means VOP3PX2 is not supported.
-        """
+        """VOP3P opcode slot for a VOP3PX2 prefix decoder, if any."""
         return None
+
+    @property
+    def mfma_scale_vop3px2_specs(self) -> tuple[MfmaScaleVop3px2Spec, ...]:
+        """Compound block-scale MFMA encodings supplied by this profile."""
+        return ()
 
     @property
     def source_split_max_bytes(self) -> dict[str, int]:
@@ -1110,17 +1120,39 @@ class CdnaProfile(_AmdgpuProfileBase):
 
     @property
     def inst_size_overrides(self) -> dict[str, int]:
-        # VOP3PX2 instructions are 128-bit (16 bytes) but decoded under
-        # the 64-bit VOP3P_MFMA encoding. Override their size so the PC
-        # advances correctly past the 128-bit instruction.
-        return {
-            'V_MFMA_F32_16X16X128_F8F6F4': 16,
-            'V_MFMA_F32_32X32X64_F8F6F4': 16,
-        }
+        return {spec.dense_name: 16 for spec in self.mfma_scale_vop3px2_specs}
 
     @property
     def vop3px2_prefix_opcode(self) -> int | None:
-        return 0x2C
+        specs = self.mfma_scale_vop3px2_specs
+        return specs[0].prefix_opcode if specs else None
+
+    @property
+    def mfma_scale_vop3px2_specs(self) -> tuple[MfmaScaleVop3px2Spec, ...]:
+        return (
+            MfmaScaleVop3px2Spec(
+                dense_name='V_MFMA_F32_16X16X128_F8F6F4',
+                dense_class_name='VMfmaF3216x16x128F8f6f4Vop3pMfma',
+                scaled_name='V_MFMA_SCALE_F32_16X16X128_F8F6F4',
+                class_name='VMfmaScaleF3216x16x128F8f6f4Vop3px2',
+                mnemonic='v_mfma_scale_f32_16x16x128_f8f6f4',
+                opcode=45,
+                m=16,
+                n=16,
+                k=128,
+            ),
+            MfmaScaleVop3px2Spec(
+                dense_name='V_MFMA_F32_32X32X64_F8F6F4',
+                dense_class_name='VMfmaF3232x32x64F8f6f4Vop3pMfma',
+                scaled_name='V_MFMA_SCALE_F32_32X32X64_F8F6F4',
+                class_name='VMfmaScaleF3232x32x64F8f6f4Vop3px2',
+                mnemonic='v_mfma_scale_f32_32x32x64_f8f6f4',
+                opcode=46,
+                m=32,
+                n=32,
+                k=64,
+            ),
+        )
 
     # ISA dimension properties for CDNA3/4 (the two ISAs this profile covers).
     # Cdna1Profile and Cdna2Profile override the ones that differ.

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -1057,7 +1057,7 @@ class CdnaProfile(_AmdgpuProfileBase):
     XML bugs worked around:
 
     - ENC_VOP3PX2 (CDNA4 only) has zero encoding identifier entries and
-      an all-zeros mask; it is skipped entirely.
+      an all-zeros mask; it is skipped entirely by the CDNA4 profile.
     - V_SWAP_B32 operands are marked output-only in CDNA4 XML even though
       the instruction reads both registers; the codegen compensates (see
       ``codegen.py:_gen_execute_body``).
@@ -1129,30 +1129,7 @@ class CdnaProfile(_AmdgpuProfileBase):
 
     @property
     def mfma_scale_vop3px2_specs(self) -> tuple[MfmaScaleVop3px2Spec, ...]:
-        return (
-            MfmaScaleVop3px2Spec(
-                dense_name='V_MFMA_F32_16X16X128_F8F6F4',
-                dense_class_name='VMfmaF3216x16x128F8f6f4Vop3pMfma',
-                scaled_name='V_MFMA_SCALE_F32_16X16X128_F8F6F4',
-                class_name='VMfmaScaleF3216x16x128F8f6f4Vop3px2',
-                mnemonic='v_mfma_scale_f32_16x16x128_f8f6f4',
-                opcode=45,
-                m=16,
-                n=16,
-                k=128,
-            ),
-            MfmaScaleVop3px2Spec(
-                dense_name='V_MFMA_F32_32X32X64_F8F6F4',
-                dense_class_name='VMfmaF3232x32x64F8f6f4Vop3pMfma',
-                scaled_name='V_MFMA_SCALE_F32_32X32X64_F8F6F4',
-                class_name='VMfmaScaleF3232x32x64F8f6f4Vop3px2',
-                mnemonic='v_mfma_scale_f32_32x32x64_f8f6f4',
-                opcode=46,
-                m=32,
-                n=32,
-                k=64,
-            ),
-        )
+        return ()
 
     # ISA dimension properties for CDNA3/4 (the two ISAs this profile covers).
     # Cdna1Profile and Cdna2Profile override the ones that differ.
@@ -1195,6 +1172,37 @@ class CdnaProfile(_AmdgpuProfileBase):
         # bit [3] for destination half selection. Low-destination writes
         # zero the upper half; see the CDNA ISA OP_SEL field description.
         return True
+
+
+class Cdna4Profile(CdnaProfile):
+    """ISA profile for CDNA4-only encoding capabilities."""
+
+    @property
+    def mfma_scale_vop3px2_specs(self) -> tuple[MfmaScaleVop3px2Spec, ...]:
+        return (
+            MfmaScaleVop3px2Spec(
+                dense_name='V_MFMA_F32_16X16X128_F8F6F4',
+                dense_class_name='VMfmaF3216x16x128F8f6f4Vop3pMfma',
+                scaled_name='V_MFMA_SCALE_F32_16X16X128_F8F6F4',
+                class_name='VMfmaScaleF3216x16x128F8f6f4Vop3px2',
+                mnemonic='v_mfma_scale_f32_16x16x128_f8f6f4',
+                opcode=45,
+                m=16,
+                n=16,
+                k=128,
+            ),
+            MfmaScaleVop3px2Spec(
+                dense_name='V_MFMA_F32_32X32X64_F8F6F4',
+                dense_class_name='VMfmaF3232x32x64F8f6f4Vop3pMfma',
+                scaled_name='V_MFMA_SCALE_F32_32X32X64_F8F6F4',
+                class_name='VMfmaScaleF3232x32x64F8f6f4Vop3px2',
+                mnemonic='v_mfma_scale_f32_32x32x64_f8f6f4',
+                opcode=46,
+                m=32,
+                n=32,
+                k=64,
+            ),
+        )
 
 
 class Cdna1Profile(CdnaProfile):

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_cross_isa_analyzer.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_cross_isa_analyzer.py
@@ -35,8 +35,9 @@ def _get_profiles():
     global _PROFILES
     if _PROFILES is None:
         from amdisa.isa_profile import (
-            CdnaProfile,
             Cdna1Profile,
+            Cdna4Profile,
+            CdnaProfile,
             Rdna1Profile,
             Rdna2Profile,
             Rdna3Profile,
@@ -46,7 +47,7 @@ def _get_profiles():
 
         _PROFILES = {
             'cdna1': Cdna1Profile(),
-            'cdna4': CdnaProfile(),
+            'cdna4': Cdna4Profile(),
             'rdna1': Rdna1Profile(),
             'rdna2': Rdna2Profile(),
             'rdna3': Rdna3Profile(),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_gen_vector_cmpx.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_gen_vector_cmpx.py
@@ -29,6 +29,7 @@ from amdisa.codegen import CodeGenerator
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
+    Cdna4Profile,
     CdnaProfile,
     Rdna1Profile,
     Rdna2Profile,
@@ -41,7 +42,7 @@ from amdisa.isa_profile import (
 # Layer 1: profile contract
 # ---------------------------------------------------------------------------
 
-_CDNA_PROFILES = [CdnaProfile, Cdna1Profile, Cdna2Profile]
+_CDNA_PROFILES = [CdnaProfile, Cdna1Profile, Cdna2Profile, Cdna4Profile]
 _RDNA_PROFILES = [
     Rdna1Profile,
     Rdna2Profile,

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3414,9 +3414,8 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
 
     assert codegen._supports_cdna5_scaled_wmma_vop3px2()
     assert 'VWmmaScaleF32Vop3px2' in (codegen._emit_cdna5_scaled_wmma_vop3px2_class())
-    model_impl = ' '.join(
-        codegen._emit_cdna5_scaled_wmma_vop3px2_impls().model[0].split()
-    )
+    impls = codegen._emit_cdna5_scaled_wmma_vop3px2_impls()
+    model_impl = ' '.join(impls.model[0].split())
     assert (
         'reinterpret_cast<const OpEncoding *>(inst + 2), '
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
@@ -3425,7 +3424,15 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
 
     helpers = codegen._emit_cdna5_scaled_wmma_vop3px2_decoder_helpers()
     assert 'isVop3pOp' in helpers
+    assert 'isGfx1250WmmaScaleSource' in helpers
+    assert 'isGfx1250WmmaScaleFormatPairLegal' in helpers
+    assert 'isGfx1250WmmaScalePairValid' in helpers
     assert 'isWmmaScaleF32Vop3px2' not in helpers
+
+    execution_impl = impls.execution[0]
+    assert '0x7f7f7f7f7f7f7f7full' in execution_impl
+    assert 'byte * 0x0101010101010101ull' in execution_impl
+    assert 'scale0_inline_zero ? 0u : matrix_a_scale_fmt' in execution_impl
 
     decoder = (gfx1250_generated_root / 'decoder.cpp').read_text()
     decode_body = decoder.split(
@@ -3435,6 +3442,7 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
     assert 'isWmmaScaleF32Vop3px2' not in decode_body
     assert decoder.count('&DecoderImpl::decodeVWmmaScaleF32Vop3px2,') == 2
     assert 'if (!isVop3pOp(opcode[2], 0x33)' in decoder
+    assert 'if (!isGfx1250WmmaScalePairValid(opcode))' in decoder
 
 
 def test_generated_decoders_publish_instruction_lookahead_bounds(
@@ -3558,23 +3566,6 @@ def test_instruction_lookahead_derivation_covers_each_width_source() -> None:
         generator_for(arch_name='cdna5', scaled_wmma=True)._max_instruction_word_count()
         == 4
     )
-
-
-def test_cdna4_vop3px2_prefix_decoder_validates_suffix(cdna4_generated_root: Path):
-    decoder = (cdna4_generated_root / 'decoder.cpp').read_text()
-    decode_body = decoder.split(
-        'DecodeResult DecoderImpl::decode(const MachineInst *opcode, '
-        'const DecodeErrorEmitter &emit_error) {'
-    )[1].split('DecodeResult DecoderImpl::decodeInvalid', 1)[0]
-
-    assert 'isMfmaScaleF8f6f4Vop3px2' not in decode_body
-    assert 'suffix_encoding != encoding::kVop3pMfma' in decoder
-    assert 'kVMfmaF3216x16x128F8f6f4Vop3pMfma' in decoder
-    assert 'kVMfmaF3232x32x64F8f6f4Vop3pMfma' in decoder
-    assert 'return decodeInvalid(opcode, emit_error);' in decoder
-    assert 'VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
-    assert 'VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
-    assert '#include "rocjitsu/isa/arch/amdgpu/generated/cdna4/opcodes.h"' in decoder
 
 
 @pytest.mark.parametrize(
@@ -4351,20 +4342,94 @@ def test_generated_operand_validation_switch_is_shared_by_constructors(
         assert literal16_constructor in operand
 
 
-def test_cdna4_mfma_f8f6f4_accepts_standalone_and_prefixed_encodings(
+def test_cdna4_mfma_f8f6f4_decodes_dense_and_exact_abid1_scaled_encodings(
     amdgpu_generated_root: Path,
 ):
     decoder = (amdgpu_generated_root / 'cdna4' / 'decoder.cpp').read_text()
     header = (amdgpu_generated_root / 'cdna4' / 'vop3p.h').read_text()
     source = (amdgpu_generated_root / 'cdna4' / 'vop3p.cpp').read_text()
+    exec_source = (amdgpu_generated_root / 'cdna4' / 'vop3p_exec.cpp').read_text()
 
-    assert 'VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true)' in decoder
-    assert 'decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,' in source
-    assert 'decodeVMfmaF3216x16x128F8f6f4Vop3pMfma' in decoder
-    assert 'bool has_vop3px2_prefix = false' in header
-    assert 'if (has_vop3px2_prefix)' in source
+    assert 'VMfmaScaleF3216x16x128F8f6f4Vop3px2>(opcode)' in decoder
+    assert 'VMfmaScaleF3232x32x64F8f6f4Vop3px2>(opcode)' in decoder
+    assert 'isLegalMfmaScaleF8f6f4Selector(uint32_t selector)' in decoder
+    assert 'selector >= 240 && selector <= 248' in decoder
+    assert 'selector >= 256 && selector <= 511' in decoder
+    assert 'auto abid2 = (opcode[2] >> 11) & 0xFu;' in decoder
+    assert (
+        'return enc2 == VOP3P_MFMA_ENC && (op2 == 45 || op2 == 46) && abid2 == 1u;'
+        in decoder
+    )
+    assert 'decodeCdna4MfmaF8f6f4Suffix' in decoder
+    assert 'DecodeResult DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode,' in decoder
+    assert 'return decodeInvalid(opcode, emit_error);' in decoder
+    assert 'reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode)' in decoder
+    assert 'isLegalMfmaF8f6f4Format(uint32_t format)' in decoder
+    assert (
+        'op.abid != 0u || !isLegalMfmaF8f6f4Format(op.cbsz) || '
+        '!isLegalMfmaF8f6f4Format(op.blgp)' in decoder
+    )
+    assert (
+        'return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);' in decoder
+    )
+    assert (
+        'return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode);' in decoder
+    )
+    assert 'if (!isValidMfmaScaleF8f6f4(opcode))' in decoder
+    assert decoder.count('return false;') >= 2
+    assert 'return (neg & 0x3u) == 0 && (neg_hi & 0x3u) == 0;' in decoder
+    assert 'class VMfmaScaleF3216x16x128F8f6f4Vop3px2 : public Vop3pMfma' in header
+    assert 'class VMfmaScaleF3232x32x64F8f6f4Vop3px2 : public Vop3pMfma' in header
+    for class_name, mnemonic in (
+        (
+            'VMfmaScaleF3216x16x128F8f6f4Vop3px2',
+            'v_mfma_scale_f32_16x16x128_f8f6f4',
+        ),
+        (
+            'VMfmaScaleF3232x32x64F8f6f4Vop3px2',
+            'v_mfma_scale_f32_32x32x64_f8f6f4',
+        ),
+    ):
+        wrapper = _generated_constructor_body(source, class_name)
+        assert f'Vop3pMfma("{mnemonic}"' in wrapper
+        assert f'InstructionExecutionId::{class_name}' in wrapper
+        assert wrapper.count('OperandType::OPR_SRC_SIMPLE') == 2
+        assert 'reinterpret_cast<const OpEncoding *>(inst)->src0' in wrapper
+        assert 'reinterpret_cast<const OpEncoding *>(inst)->src1' in wrapper
+        assert 'raw_words_{inst[0], inst[1], inst[2], inst[3]}' in wrapper
+        assert 'src_operands_[3] = &scale_src0;' in wrapper
+        assert 'src_operands_[4] = &scale_src1;' in wrapper
+        assert 'num_src_ = 5;' in wrapper
+        assert f'void {class_name}::execute_impl' in exec_source
+    assert 'has_vop3px2_prefix' not in header
+    assert 'has_vop3px2_prefix' not in source
     assert 'cdna4_matrix_fmt_element_bits' in source
     assert 'cdna4_matrix_fmt_element_bits(fmt) / 64' in source
+
+    for arch in (
+        'cdna1',
+        'cdna2',
+        'cdna3',
+        'cdna5',
+        'rdna1',
+        'rdna2',
+        'rdna3',
+        'rdna3_5',
+        'rdna4',
+    ):
+        arch_root = amdgpu_generated_root / arch
+        combined = '\n'.join(
+            (arch_root / rel).read_text()
+            for rel in ('decoder.cpp', 'vop3p.h', 'vop3p.cpp', 'vop3p_exec.cpp')
+            if (arch_root / rel).exists()
+        )
+        assert 'VMfmaScaleF32' not in combined
+        assert 'decodeVop3pX2Prefix' not in combined
+        assert 'decodeCdna4MfmaF8f6f4Suffix' not in combined
+        assert 'has_vop3px2_prefix' not in combined
+        assert 'exec_f32_scaled_mixed' not in combined
+        assert 'v_mfma_scale_f32_16x16x128_f8f6f4' not in combined
+        assert 'v_mfma_scale_f32_32x32x64_f8f6f4' not in combined
 
     mfma16 = source.split(
         'VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma'

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3422,6 +3422,17 @@ def test_gfx1250_helper_blocks_emit_scaled_wmma_table_decoder(
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
         'Vop3p::ExtensionDecodePolicy::Skip),'
     ) in model_impl
+    assert model_impl.count('cdna5_scale_operand_size_bits( inst,') == 2
+
+    helper_model = ' '.join(codegen._emit_cdna5_matrix_fmt_helpers().model[0].split())
+    assert (
+        'int cdna5_scale_operand_size_bits(const MachineInst *inst, uint32_t selector)'
+        in helper_model
+    )
+    assert (
+        'return cdna5_scaled_wmma_is_scale16(inst) && is_vgpr ? 64 : 32;'
+        in helper_model
+    )
 
     helpers = codegen._emit_cdna5_scaled_wmma_vop3px2_decoder_helpers()
     assert 'isVop3pOp' in helpers

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -37,6 +37,7 @@ from amdisa.gpuisa import Instruction, Operand
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
+    Cdna4Profile,
     CdnaProfile,
     Cdna5Profile,
     Rdna1Profile,
@@ -111,7 +112,7 @@ def _profile_for_arch(arch_name: str):
         'cdna1': Cdna1Profile,
         'cdna2': Cdna2Profile,
         'cdna3': CdnaProfile,
-        'cdna4': CdnaProfile,
+        'cdna4': Cdna4Profile,
         'rdna1': Rdna1Profile,
         'rdna2': Rdna2Profile,
         'rdna3': Rdna3Profile,
@@ -394,7 +395,7 @@ def test_parser_separates_logical_arch_directory_and_cpp_namespace():
         ('cdna1', Cdna1Profile),
         ('cdna2', Cdna2Profile),
         ('cdna3', CdnaProfile),
-        ('cdna4', CdnaProfile),
+        ('cdna4', Cdna4Profile),
         ('rdna1', Rdna1Profile),
         ('rdna2', Rdna2Profile),
         ('rdna3', Rdna3Profile),
@@ -3449,9 +3450,9 @@ def test_generated_decoders_publish_instruction_lookahead_bounds(
     amdgpu_generated_root: Path,
 ) -> None:
     expected_bounds = {
-        'cdna1': 4,
-        'cdna2': 4,
-        'cdna3': 4,
+        'cdna1': 2,
+        'cdna2': 2,
+        'cdna3': 2,
         'cdna4': 4,
         'cdna5': 4,
         'rdna1': 3,
@@ -3472,10 +3473,10 @@ def test_generated_decoders_publish_instruction_lookahead_bounds(
 @pytest.mark.parametrize(
     ('arch_name', 'profile_type', 'expected_bound'),
     [
-        ('cdna1', Cdna1Profile, 4),
-        ('cdna2', Cdna2Profile, 4),
-        ('cdna3', CdnaProfile, 4),
-        ('cdna4', CdnaProfile, 4),
+        ('cdna1', Cdna1Profile, 2),
+        ('cdna2', Cdna2Profile, 2),
+        ('cdna3', CdnaProfile, 2),
+        ('cdna4', Cdna4Profile, 4),
         ('cdna5', Cdna5Profile, 4),
         ('rdna1', Rdna1Profile, 3),
         ('rdna2', Rdna2Profile, 3),
@@ -3505,6 +3506,7 @@ def test_instruction_lookahead_derivation_covers_each_width_source() -> None:
         has_vopd: bool = False,
         arch_name: str = 'synthetic',
         scaled_wmma: bool = False,
+        compound_mfma: bool = False,
         owns_dpp_extension: bool = False,
     ) -> CodeGenerator:
         instruction = SimpleNamespace(
@@ -3525,6 +3527,9 @@ def test_instruction_lookahead_derivation_covers_each_width_source() -> None:
             inst_size_overrides=size_overrides or {},
             has_vopd=has_vopd,
             generate_scaled_wmma_vop3px2=scaled_wmma,
+            mfma_scale_vop3px2_specs=(
+                (SimpleNamespace(dense_name='SYNTHETIC'),) if compound_mfma else ()
+            ),
         )
         generator = object.__new__(CodeGenerator)
         generator.isa_spec = SimpleNamespace(
@@ -3561,7 +3566,8 @@ def test_instruction_lookahead_derivation_covers_each_width_source() -> None:
         == 5
     )
     assert generator_for(has_vopd=True)._max_instruction_word_count() == 3
-    assert generator_for(arch_name='cdna4')._max_instruction_word_count() == 4
+    assert generator_for(arch_name='cdna4')._max_instruction_word_count() == 1
+    assert generator_for(compound_mfma=True)._max_instruction_word_count() == 4
     assert (
         generator_for(arch_name='cdna5', scaled_wmma=True)._max_instruction_word_count()
         == 4
@@ -3641,6 +3647,7 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
 ):
     encodings_h = (gfx1250_generated_root / 'encodings.h').read_text()
     encodings_cpp = (gfx1250_generated_root / 'encodings.cpp').read_text()
+    decoder_cpp = (gfx1250_generated_root / 'decoder.cpp').read_text()
     vop3p_cpp = ' '.join((gfx1250_generated_root / 'vop3p.cpp').read_text().split())
 
     assert 'enum class ExtensionDecodePolicy { Decode, Skip };' in encodings_h
@@ -3674,6 +3681,11 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
         'Vop3p::ExtensionDecodePolicy::Skip)'
     ) in vop3p_cpp
+    assert 'scale->src2 != 0x100u' in decoder_cpp
+    assert '(scale->opsel & 0x2u) != 0u' in decoder_cpp
+    assert '(scale->opsel_hi & 0x2u) != 0u' in decoder_cpp
+    assert '(matrix->neg_hi & 0x3u) != 0u' in decoder_cpp
+    assert '(matrix->neg & 0x3u) != 0u' in decoder_cpp
 
 
 @pytest.mark.parametrize(
@@ -3682,7 +3694,7 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
         ('cdna1', Cdna1Profile()),
         ('cdna2', Cdna2Profile()),
         ('cdna3', CdnaProfile()),
-        ('cdna4', CdnaProfile()),
+        ('cdna4', Cdna4Profile()),
         ('rdna1', Rdna1Profile()),
         ('rdna2', Rdna2Profile()),
         ('rdna3', Rdna3Profile()),
@@ -4361,7 +4373,10 @@ def test_cdna4_mfma_f8f6f4_decodes_dense_and_exact_abid1_scaled_encodings(
         in decoder
     )
     assert 'decodeCdna4MfmaF8f6f4Suffix' in decoder
-    assert 'DecodeResult DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode,' in decoder
+    assert (
+        'DecodeResult DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode,'
+        in decoder
+    )
     assert 'return decodeInvalid(opcode, emit_error);' in decoder
     assert 'reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode)' in decoder
     assert 'isLegalMfmaF8f6f4Format(uint32_t format)' in decoder

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -3681,7 +3681,8 @@ def test_gfx1250_scaled_wmma_skips_vop3p_extension_decode(
         'selected_exec_fn(InstructionExecutionId::VWmmaScaleF32Vop3px2), '
         'Vop3p::ExtensionDecodePolicy::Skip)'
     ) in vop3p_cpp
-    assert 'scale->src2 != 0x100u' in decoder_cpp
+    assert 'scale->src2 == 0x080u || scale->src2 == 0x100u' in decoder_cpp
+    assert '!fixed_src2_valid' in decoder_cpp
     assert '(scale->opsel & 0x2u) != 0u' in decoder_cpp
     assert '(scale->opsel_hi & 0x2u) != 0u' in decoder_cpp
     assert '(matrix->neg_hi & 0x3u) != 0u' in decoder_cpp

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_instruction_encoding_availability.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_instruction_encoding_availability.py
@@ -8,7 +8,7 @@ import pytest
 
 from amdisa.codegen import CodeGenerator
 from amdisa.gpuisa import Instruction
-from amdisa.isa_profile import CdnaProfile, Rdna4Profile
+from amdisa.isa_profile import Cdna4Profile, Rdna4Profile
 from amdisa.parser import Parser
 
 
@@ -25,7 +25,7 @@ def _find_instruction(spec, encoding_name: str, instruction_name: str):
 
 
 def test_cdna4_preserves_conditional_dpp_encoding_availability():
-    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), CdnaProfile()).parse()
+    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), Cdna4Profile()).parse()
     inst = _find_instruction(spec, 'ENC_VOP1', 'V_CVT_F64_I32')
 
     assert 'VOP1_VOP_DPP' in inst.available_encodings
@@ -50,7 +50,7 @@ def test_rdna4_distinguishes_vop1_instructions_with_and_without_dpp():
 
 
 def test_cdna4_distinguishes_vop1_instructions_with_and_without_sdwa():
-    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), CdnaProfile()).parse()
+    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), Cdna4Profile()).parse()
     supported = _find_instruction(spec, 'ENC_VOP1', 'V_MOV_B32')
     unsupported = _find_instruction(spec, 'ENC_VOP1', 'V_CVT_F64_I32')
 
@@ -63,7 +63,7 @@ def test_cdna4_distinguishes_vop1_instructions_with_and_without_sdwa():
 
 
 def test_modifier_availability_requires_explicit_encoding_provenance():
-    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), CdnaProfile()).parse()
+    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_cdna4.xml'), Cdna4Profile()).parse()
     generator = CodeGenerator(spec, '')
     unknown = Instruction('V_SYNTHETIC', 'ENC_VOP1', 0, [])
     known_absent = Instruction(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -20,6 +20,7 @@ from amdisa.isa_properties_codegen import emit_isa_properties
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
+    Cdna4Profile,
     CdnaProfile,
     Cdna5Profile,
     MemoryCoherencyModel,
@@ -234,7 +235,7 @@ def test_checked_in_isa_properties_matches_all_profiles(tmp_path):
         ('cdna1', Cdna1Profile()),
         ('cdna2', Cdna2Profile()),
         ('cdna3', CdnaProfile()),
-        ('cdna4', CdnaProfile()),
+        ('cdna4', Cdna4Profile()),
         ('rdna1', Rdna1Profile()),
         ('rdna2', Rdna2Profile()),
         ('rdna3', Rdna3Profile()),
@@ -390,7 +391,7 @@ def test_cdna1_split_operand_emits_simd_dispatch_methods(tmp_path):
 
 
 class TestCdnaProfile:
-    """CdnaProfile represents CDNA3 and CDNA4."""
+    """CdnaProfile holds capabilities shared by CDNA3 and CDNA4."""
 
     def setup_method(self):
         self.p = CdnaProfile()
@@ -441,6 +442,24 @@ class TestCdnaProfile:
 
     def test_field_renames_other_enc_empty(self):
         assert self.p.field_renames('ENC_VOP2') == {}
+
+    def test_compound_mfma_is_not_a_family_default(self):
+        assert self.p.mfma_scale_vop3px2_specs == ()
+        assert self.p.inst_size_overrides == {}
+        assert self.p.vop3px2_prefix_opcode is None
+
+
+class TestCdna4Profile:
+    def setup_method(self):
+        self.p = Cdna4Profile()
+
+    def test_compound_mfma_is_explicitly_enabled(self):
+        assert tuple(spec.opcode for spec in self.p.mfma_scale_vop3px2_specs) == (
+            45,
+            46,
+        )
+        assert set(self.p.inst_size_overrides.values()) == {16}
+        assert self.p.vop3px2_prefix_opcode == 0x2C
 
 
 class TestCdna1Profile:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -37,6 +37,7 @@
 #include "rocjitsu/isa/isa_traits.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <deque>
@@ -58,6 +59,41 @@
 namespace rocjitsu {
 
 namespace {
+
+/// @brief Adapt B0 scaled-WMMA prefixes for the common A0-oriented decoder.
+///
+/// @details Legacy B0 source objects may populate the architecturally unused prefix SRC2 field
+/// with a noncanonical selector (the offline oracle uses inline zero, 0x080), while A0 requires
+/// that field to encode VGPR0 (0x100). Keep this normalization inside the revision-specific
+/// translation path so the architecture decoder can enforce the A0 fixed-field contract
+/// everywhere else.
+class Gfx1250B0ToA0CanonicalizingDecoder final : public Decoder {
+public:
+  explicit Gfx1250B0ToA0CanonicalizingDecoder(std::unique_ptr<Decoder> decoder)
+      : decoder_(std::move(decoder)) {
+    assert(decoder_ != nullptr);
+    assert(decoder_->max_instruction_words() <= kLookaheadWords);
+  }
+
+  DecodeResult decode(const rj_code_binary_inst_t *inst,
+                      const DecodeErrorEmitter &emit_error) override {
+    const uint32_t prefix_op = (inst[0] >> 16) & 0xffu;
+    if ((inst[0] >> 24) != 0xccu || (prefix_op != 0x35u && prefix_op != 0x3au))
+      return decoder_->decode(inst, emit_error);
+
+    std::array<rj_code_binary_inst_t, kLookaheadWords> canonical{};
+    std::copy_n(inst, kLookaheadWords, canonical.begin());
+    constexpr uint32_t kSrc2Mask = 0x1ffu << 18;
+    canonical[1] = (canonical[1] & ~kSrc2Mask) | (0x100u << 18);
+    return decoder_->decode(canonical.data(), emit_error);
+  }
+
+  std::size_t max_instruction_words() const override { return decoder_->max_instruction_words(); }
+
+private:
+  static constexpr std::size_t kLookaheadWords = 4;
+  std::unique_ptr<Decoder> decoder_;
+};
 
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
@@ -2407,6 +2443,8 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
                  "unsupported guest_arch: no decoder available");
     return leave_unchanged();
   }
+  if (is_gfx1250_b0_to_a0())
+    decoder = std::make_unique<Gfx1250B0ToA0CanonicalizingDecoder>(std::move(decoder));
 
   // Phase 1: descriptor translation gives DBT the source kernel roots and any
   // target descriptor/prologue bytes that must be materialized with the body.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -60,13 +60,14 @@ namespace rocjitsu {
 
 namespace {
 
-/// @brief Adapt B0 scaled-WMMA prefixes for the common A0-oriented decoder.
+/// @brief Normalize legacy scaled-WMMA prefixes for the common decoder.
 ///
-/// @details Legacy B0 source objects may populate the architecturally unused prefix SRC2 field
-/// with a noncanonical selector (the offline oracle uses inline zero, 0x080), while A0 requires
-/// that field to encode VGPR0 (0x100). Keep this normalization inside the revision-specific
-/// translation path so the architecture decoder can enforce the A0 fixed-field contract
-/// everywhere else.
+/// @details Legacy source objects may populate the architecturally unused prefix SRC2 field
+/// with a noncanonical selector (the offline oracle uses inline zero, 0x080), while the ISA
+/// requires that field to encode VGPR0 (0x100). Normalize it inside the revision-specific
+/// translation path so translated objects remain ISA-canonical; the architecture decoder
+/// separately accepts LLVM's exact compatibility encoding without weakening other fixed-field
+/// checks.
 class Gfx1250B0ToA0CanonicalizingDecoder final : public Decoder {
 public:
   explicit Gfx1250B0ToA0CanonicalizingDecoder(std::unique_ptr<Decoder> decoder)
@@ -367,6 +368,10 @@ generated_branch_island_pool_offsets(std::span<const uint8_t> text, rj_code_arch
   auto decoder = Decoder::create(arch);
   if (!decoder)
     return offsets;
+  const std::size_t lookahead_words = decoder->max_instruction_words();
+  if (lookahead_words == 0)
+    return offsets;
+  std::vector<uint32_t> slot_words(lookahead_words, 0);
 
   const uint32_t marker = build_s_nop(kBranchIslandPoolMarkerNopImmediate, arch);
   const uint32_t skip_pool =
@@ -388,7 +393,7 @@ generated_branch_island_pool_offsets(std::span<const uint8_t> text, rj_code_arch
           offset + (kGeneratedIslandPoolHeaderWords + slot) * sizeof(uint32_t);
       // A malformed slot can select an extension-bearing format. Pad the
       // speculative decode so pool recognition never reads beyond its input.
-      const std::array<uint32_t, 3> slot_words = {text_word_at(text, slot_offset), 0, 0};
+      slot_words[0] = text_word_at(text, slot_offset);
       DecodeResult decoded = decoder->decode(slot_words.data());
       if (decoded.succeeded()) {
         const std::unique_ptr<Instruction> &slot_inst = decoded.value();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/decoder.h
@@ -21,7 +21,7 @@ namespace cdna1 {
 
 class Decoder {
 public:
-  static constexpr std::size_t kMaxInstructionWords = 4;
+  static constexpr std::size_t kMaxInstructionWords = 2;
   static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/decoder.h
@@ -21,7 +21,7 @@ namespace cdna2 {
 
 class Decoder {
 public:
-  static constexpr std::size_t kMaxInstructionWords = 4;
+  static constexpr std::size_t kMaxInstructionWords = 2;
   static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/decoder.h
@@ -21,7 +21,7 @@ namespace cdna3 {
 
 class Decoder {
 public:
-  static constexpr std::size_t kMaxInstructionWords = 4;
+  static constexpr std::size_t kMaxInstructionWords = 2;
   static DecodeResult decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/decoder.cpp
@@ -1705,8 +1705,6 @@ DecodeResult decodeVMed3I16Vop3(const MachineInst *opcode, const DecodeErrorEmit
 DecodeResult decodeVMed3I32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMed3U16Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMed3U32Vop3(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
-DecodeResult decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,
-                                                    const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *opcode,
                                                  const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *opcode,
@@ -1751,8 +1749,6 @@ DecodeResult decodeVMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *opcode,
                                                   const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *opcode,
                                                  const DecodeErrorEmitter &emit_error);
-DecodeResult decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode,
-                                                   const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMfmaF3232x32x8Bf16Vop3pMfma(const MachineInst *opcode,
                                                 const DecodeErrorEmitter &emit_error);
 DecodeResult decodeVMfmaF3232x32x8F16Vop3pMfma(const MachineInst *opcode,
@@ -2069,6 +2065,8 @@ private:
                                      const DecodeErrorEmitter &emit_error);
   static DecodeResult decodeVop3pX2Prefix(const MachineInst *opcode,
                                           const DecodeErrorEmitter &emit_error);
+  static DecodeResult decodeCdna4MfmaF8f6f4Suffix(const MachineInst *opcode,
+                                                  const DecodeErrorEmitter &emit_error);
   static DecodeResult subDecodeDs(const MachineInst *opcode, const DecodeErrorEmitter &emit_error);
   static DecodeResult subDecodeFlat(const MachineInst *opcode,
                                     const DecodeErrorEmitter &emit_error);
@@ -2091,11 +2089,57 @@ private:
   static const std::array<DecodeFunc, 16> sub_decode_mtbuf;
 };
 
+namespace {
+
+bool isLegalMfmaScaleF8f6f4Selector(uint32_t selector) {
+  return (selector >= 240 && selector <= 248) || (selector >= 256 && selector <= 511);
+}
+
+bool isLegalMfmaF8f6f4Format(uint32_t format) { return format <= 4; }
+
+bool isMfmaScaleF8f6f4Vop3px2(const MachineInst *opcode) {
+  constexpr uint32_t VOP3P_MFMA_ENC = 423;
+  constexpr uint32_t PREFIX_OP = 44;
+  auto enc0 = (opcode[0] >> 23) & 0x1FFu;
+  auto op0 = (opcode[0] >> 16) & 0x7Fu;
+  if (enc0 != VOP3P_MFMA_ENC || op0 != PREFIX_OP)
+    return false;
+  auto enc2 = (opcode[2] >> 23) & 0x1FFu;
+  auto op2 = (opcode[2] >> 16) & 0x7Fu;
+  auto abid2 = (opcode[2] >> 11) & 0xFu;
+  return enc2 == VOP3P_MFMA_ENC && (op2 == 45 || op2 == 46) && abid2 == 1u;
+}
+
+bool isValidMfmaScaleF8f6f4(const MachineInst *opcode) {
+  auto scale_src0 = opcode[1] & 0x1FFu;
+  auto scale_src1 = (opcode[1] >> 9) & 0x1FFu;
+  if (!isLegalMfmaScaleF8f6f4Selector(scale_src0) || !isLegalMfmaScaleF8f6f4Selector(scale_src1))
+    return false;
+  auto suffix = *reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode + 2);
+  if (!isLegalMfmaF8f6f4Format(suffix.cbsz) || !isLegalMfmaF8f6f4Format(suffix.blgp))
+    return false;
+  auto neg = (opcode[1] >> 29) & 0x7u;
+  auto neg_hi = (opcode[0] >> 8) & 0x7u;
+  return (neg & 0x3u) == 0 && (neg_hi & 0x3u) == 0;
+}
+
+} // namespace
+
 DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
   return DecoderImpl::decode(opcode, emit_error);
 }
 
 DecodeResult DecoderImpl::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  if (isMfmaScaleF8f6f4Vop3px2(opcode)) {
+    if (!isValidMfmaScaleF8f6f4(opcode))
+      return decodeInvalid(opcode, emit_error);
+    auto op2 = (opcode[2] >> 16) & 0x7Fu;
+    if (op2 == 45)
+      return std::make_unique<VMfmaScaleF3216x16x128F8f6f4Vop3px2>(opcode);
+    if (op2 == 46)
+      return std::make_unique<VMfmaScaleF3232x32x64F8f6f4Vop3px2>(opcode);
+    return decodeInvalid(opcode, emit_error);
+  }
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode, emit_error);
 }
@@ -2155,15 +2199,19 @@ DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
 
 DecodeResult DecoderImpl::decodeVop3pX2Prefix(const MachineInst *opcode,
                                               const DecodeErrorEmitter &emit_error) {
-  const uint32_t suffix_encoding = (opcode[2] >> 23) & 0x1FFu;
-  const uint32_t suffix_opcode = (opcode[2] >> 16) & 0x7Fu;
-  if (suffix_encoding != encoding::kVop3pMfma ||
-      (suffix_opcode != kVMfmaF3216x16x128F8f6f4Vop3pMfma &&
-       suffix_opcode != kVMfmaF3232x32x64F8f6f4Vop3pMfma))
+  return decodeInvalid(opcode, emit_error);
+}
+
+DecodeResult DecoderImpl::decodeCdna4MfmaF8f6f4Suffix(const MachineInst *opcode,
+                                                      const DecodeErrorEmitter &emit_error) {
+  auto op = *reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode);
+  if (op.abid != 0u || !isLegalMfmaF8f6f4Format(op.cbsz) || !isLegalMfmaF8f6f4Format(op.blgp))
     return decodeInvalid(opcode, emit_error);
-  if (suffix_opcode == kVMfmaF3216x16x128F8f6f4Vop3pMfma)
-    return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2, true);
-  return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2, true);
+  if (op.op == 45)
+    return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);
+  if (op.op == 46)
+    return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode);
+  return decodeInvalid(opcode, emit_error);
 }
 
 DecodeResult DecoderImpl::subDecodeDs(const MachineInst *opcode,
@@ -4496,8 +4544,8 @@ const std::array<DecoderImpl::DecodeFunc, 128> DecoderImpl::sub_decode_vop3p = {
     &detail::decodeVDot8I32I4Vop3p,
     &detail::decodeVDot8U32U4Vop3p,
     &DecoderImpl::decodeVop3pX2Prefix,
-    &detail::decodeVMfmaF3216x16x128F8f6f4Vop3pMfma,
-    &detail::decodeVMfmaF3232x32x64F8f6f4Vop3pMfma,
+    &DecoderImpl::decodeCdna4MfmaF8f6f4Suffix,
+    &DecoderImpl::decodeCdna4MfmaF8f6f4Suffix,
     &DecoderImpl::decodeInvalid,
     &detail::decodeVPkFmaF32Vop3p,
     &detail::decodeVPkMulF32Vop3p,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend.h
@@ -734,6 +734,8 @@ enum class InstructionExecutionId : size_t {
   VSmfmacF3232x32x32Bf8Fp8Vop3pMfma,
   VSmfmacF3232x32x32Fp8Bf8Vop3pMfma,
   VSmfmacF3232x32x32Fp8Fp8Vop3pMfma,
+  VMfmaScaleF3216x16x128F8f6f4Vop3px2,
+  VMfmaScaleF3232x32x64F8f6f4Vop3px2,
   VNopVop3,
   VMovB32Vop3,
   VReadfirstlaneB32Vop3,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/execution_backend_exec.cpp
@@ -741,6 +741,8 @@ constexpr InstructionCallbackTable kInstructionCallbacks{{
     &execute_with_backend<VSmfmacF3232x32x32Bf8Fp8Vop3pMfma>,
     &execute_with_backend<VSmfmacF3232x32x32Fp8Bf8Vop3pMfma>,
     &execute_with_backend<VSmfmacF3232x32x32Fp8Fp8Vop3pMfma>,
+    &execute_with_backend<VMfmaScaleF3216x16x128F8f6f4Vop3px2>,
+    &execute_with_backend<VMfmaScaleF3232x32x64F8f6f4Vop3px2>,
     &execute_with_backend<VNopVop3>,
     &execute_with_backend<VMovB32Vop3>,
     &execute_with_backend<VReadfirstlaneB32Vop3>,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.cpp
@@ -984,8 +984,7 @@ DecodeResult decodeVAccvgprWriteVop3p(const MachineInst *opcode,
 }
 } // namespace detail
 
-VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *inst,
-                                                                   bool has_vop3px2_prefix)
+VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *inst)
     : Vop3pMfma("v_mfma_f32_16x16x128_f8f6f4", reinterpret_cast<const OpEncoding *>(inst),
                 selected_exec_fn(InstructionExecutionId::VMfmaF3216x16x128F8f6f4Vop3pMfma)),
       vdst(128, OperandType::OPR_VGPR_OR_ACCVGPR,
@@ -1019,27 +1018,9 @@ VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const Machine
   num_src_ = 3;
   num_dst_ = 1;
   flags_ |= MFMA;
-  if (has_vop3px2_prefix) {
-    size_ = 16;
-    raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};
-    raw_encoding_ = raw_words_.data();
-  }
 }
 
-namespace detail {
-DecodeResult decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode,
-                                                    const DecodeErrorEmitter &emit_error) {
-  Result validation = Vop3pMfma::validate_encoding(
-      "v_mfma_f32_16x16x128_f8f6f4", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
-      emit_error);
-  if (validation.failed()) [[unlikely]]
-    return Result::failure();
-  return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);
-}
-} // namespace detail
-
-VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *inst,
-                                                                 bool has_vop3px2_prefix)
+VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *inst)
     : Vop3pMfma("v_mfma_f32_32x32x64_f8f6f4", reinterpret_cast<const OpEncoding *>(inst),
                 selected_exec_fn(InstructionExecutionId::VMfmaF3232x32x64F8f6f4Vop3pMfma)),
       vdst(512, OperandType::OPR_VGPR_OR_ACCVGPR,
@@ -1073,24 +1054,7 @@ VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineIn
   num_src_ = 3;
   num_dst_ = 1;
   flags_ |= MFMA;
-  if (has_vop3px2_prefix) {
-    size_ = 16;
-    raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};
-    raw_encoding_ = raw_words_.data();
-  }
 }
-
-namespace detail {
-DecodeResult decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode,
-                                                   const DecodeErrorEmitter &emit_error) {
-  Result validation = Vop3pMfma::validate_encoding(
-      "v_mfma_f32_32x32x64_f8f6f4", reinterpret_cast<const Vop3pMfma::OpEncoding *>(opcode),
-      emit_error);
-  if (validation.failed()) [[unlikely]]
-    return Result::failure();
-  return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode);
-}
-} // namespace detail
 
 VMfmaF3216x16x32Bf16Vop3pMfma::VMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *inst)
     : Vop3pMfma("v_mfma_f32_16x16x32_bf16", reinterpret_cast<const OpEncoding *>(inst),
@@ -3879,6 +3843,92 @@ DecodeResult decodeVSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *opcode,
   return std::make_unique<VSmfmacF3232x32x32Fp8Fp8Vop3pMfma>(opcode);
 }
 } // namespace detail
+
+VMfmaScaleF3216x16x128F8f6f4Vop3px2::VMfmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst)
+    : Vop3pMfma("v_mfma_scale_f32_16x16x128_f8f6f4", reinterpret_cast<const OpEncoding *>(inst + 2),
+                selected_exec_fn(InstructionExecutionId::VMfmaScaleF3216x16x128F8f6f4Vop3px2)),
+      vdst(128, OperandType::OPR_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->vdst +
+            (reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd
+                 ? OpSelVgprOrAccvgpr::OPR_VGPR_OR_ACCVGPR_ACC_MIN
+                 : 0))),
+      src0(cdna4_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst + 2)->cbsz,
+                                              16, 128),
+           OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->src0 +
+            ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x1u)
+                 ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                    OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                 : 0))),
+      src1(cdna4_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst + 2)->blgp,
+                                              16, 128),
+           OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->src1 +
+            ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x2u)
+                 ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                    OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                 : 0))),
+      src2(128, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
+           mfma_src2_encoding(reinterpret_cast<const OpEncoding *>(inst + 2)->src2,
+                              reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd)),
+      scale_src0(32, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      scale_src1(32, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1),
+      raw_words_{inst[0], inst[1], inst[2], inst[3]} {
+  size_ = 16;
+  raw_encoding_ = raw_words_.data();
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  src_operands_[2] = &src2;
+  src_operands_[3] = &scale_src0;
+  src_operands_[4] = &scale_src1;
+  num_src_ = 5;
+  num_dst_ = 1;
+  flags_ |= MFMA;
+}
+
+VMfmaScaleF3232x32x64F8f6f4Vop3px2::VMfmaScaleF3232x32x64F8f6f4Vop3px2(const MachineInst *inst)
+    : Vop3pMfma("v_mfma_scale_f32_32x32x64_f8f6f4", reinterpret_cast<const OpEncoding *>(inst + 2),
+                selected_exec_fn(InstructionExecutionId::VMfmaScaleF3232x32x64F8f6f4Vop3px2)),
+      vdst(512, OperandType::OPR_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->vdst +
+            (reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd
+                 ? OpSelVgprOrAccvgpr::OPR_VGPR_OR_ACCVGPR_ACC_MIN
+                 : 0))),
+      src0(cdna4_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst + 2)->cbsz,
+                                              32, 64),
+           OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->src0 +
+            ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x1u)
+                 ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                    OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                 : 0))),
+      src1(cdna4_matrix_fmt_operand_size_bits(reinterpret_cast<const OpEncoding *>(inst + 2)->blgp,
+                                              32, 64),
+           OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
+           (reinterpret_cast<const OpEncoding *>(inst + 2)->src1 +
+            ((reinterpret_cast<const OpEncoding *>(inst + 2)->acc & 0x2u)
+                 ? (OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_ACC_MIN -
+                    OpSelSrcVgprOrAccvgpr::OPR_SRC_VGPR_OR_ACCVGPR_VGPR_MIN)
+                 : 0))),
+      src2(512, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
+           mfma_src2_encoding(reinterpret_cast<const OpEncoding *>(inst + 2)->src2,
+                              reinterpret_cast<const OpEncoding *>(inst + 2)->acc_cd)),
+      scale_src0(32, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      scale_src1(32, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1),
+      raw_words_{inst[0], inst[1], inst[2], inst[3]} {
+  size_ = 16;
+  raw_encoding_ = raw_words_.data();
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  src_operands_[2] = &src2;
+  src_operands_[3] = &scale_src0;
+  src_operands_[4] = &scale_src1;
+  num_src_ = 5;
+  num_dst_ = 1;
+  flags_ |= MFMA;
+}
 
 } // namespace cdna4
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p.h
@@ -376,24 +376,22 @@ public:
 
 class VMfmaF3216x16x128F8f6f4Vop3pMfma : public Vop3pMfma {
 public:
-  VMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *inst, bool has_vop3px2_prefix = false);
+  VMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
   Operand vdst;
   Operand src0;
   Operand src1;
   Operand src2;
-  std::array<uint32_t, 4> raw_words_{};
 };
 
 class VMfmaF3232x32x64F8f6f4Vop3pMfma : public Vop3pMfma {
 public:
-  VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *inst, bool has_vop3px2_prefix = false);
+  VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
   Operand vdst;
   Operand src0;
   Operand src1;
   Operand src2;
-  std::array<uint32_t, 4> raw_words_{};
 };
 
 class VMfmaF3216x16x32Bf16Vop3pMfma : public Vop3pMfma {
@@ -1034,6 +1032,38 @@ public:
   Operand src0;
   Operand src1;
   Operand src2;
+};
+
+class VMfmaScaleF3216x16x128F8f6f4Vop3px2 : public Vop3pMfma {
+public:
+  VMfmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst);
+  void execute_impl(amdgpu::Wavefront &wf);
+
+  Operand vdst;
+  Operand src0;
+  Operand src1;
+  Operand src2;
+  Operand scale_src0;
+  Operand scale_src1;
+
+private:
+  std::array<uint32_t, 4> raw_words_{};
+};
+
+class VMfmaScaleF3232x32x64F8f6f4Vop3px2 : public Vop3pMfma {
+public:
+  VMfmaScaleF3232x32x64F8f6f4Vop3px2(const MachineInst *inst);
+  void execute_impl(amdgpu::Wavefront &wf);
+
+  Operand vdst;
+  Operand src0;
+  Operand src1;
+  Operand src2;
+  Operand scale_src0;
+  Operand scale_src1;
+
+private:
+  std::array<uint32_t, 4> raw_words_{};
 };
 
 } // namespace cdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/vop3p_exec.cpp
@@ -294,22 +294,11 @@ void VMfmaF3216x16x128F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                     [&] { return amdgpu::RegisterAccess(wf).read_scalar(src2); });
   uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
   uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
-  bool dispatched;
-  if (!(inst_.abid & 1u)) {
-    dispatched = amdgpu::dispatch_matrix_fmt_pair(
-        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-          amdgpu::exec_f32_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
-                                 const_acc);
-        });
-  } else {
-    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
-    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
-    dispatched = amdgpu::dispatch_matrix_fmt_pair(
-        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-          amdgpu::exec_f32_scaled_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
-                                        eb, const_acc, sa_base, sb_base);
-        });
-  }
+  bool dispatched = amdgpu::dispatch_matrix_fmt_pair(
+      inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+        amdgpu::exec_f32_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                               const_acc);
+      });
   if (!dispatched)
     throw util::UnimplementedInst(mnemonic());
 }
@@ -323,22 +312,11 @@ void VMfmaF3232x32x64F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                     [&] { return amdgpu::RegisterAccess(wf).read_scalar(src2); });
   uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
   uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
-  bool dispatched;
-  if (!(inst_.abid & 1u)) {
-    dispatched = amdgpu::dispatch_matrix_fmt_pair(
-        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-          amdgpu::exec_f32_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
-                                 const_acc);
-        });
-  } else {
-    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
-    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
-    dispatched = amdgpu::dispatch_matrix_fmt_pair(
-        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-          amdgpu::exec_f32_scaled_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
-                                        eb, const_acc, sa_base, sb_base);
-        });
-  }
+  bool dispatched = amdgpu::dispatch_matrix_fmt_pair(
+      inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+        amdgpu::exec_f32_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                               const_acc);
+      });
   if (!dispatched)
     throw util::UnimplementedInst(mnemonic());
 }
@@ -1059,6 +1037,56 @@ void VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
   amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
                                        amdgpu::smfmac_read_fp8);
+}
+
+void VMfmaScaleF3216x16x128F8f6f4Vop3px2::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t const_acc;
+  uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
+                                    [&] { return amdgpu::RegisterAccess(wf).read_scalar(src2); });
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t scale_a = raw_words_[1] & 0x1FFu;
+  uint32_t scale_b = (raw_words_[1] >> 9) & 0x1FFu;
+  uint32_t scale_a_byte = ((raw_words_[0] >> 11) & 1u) | (((raw_words_[1] >> 27) & 1u) << 1);
+  uint32_t scale_b_byte = ((raw_words_[0] >> 12) & 1u) | (((raw_words_[1] >> 28) & 1u) << 1);
+  uint32_t c_modifier =
+      amdgpu::wmma_c_modifier((raw_words_[1] >> 29) & 7u, (raw_words_[0] >> 8) & 7u);
+  bool dispatched = amdgpu::dispatch_matrix_fmt_pair(
+      inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+        amdgpu::exec_f32_scaled_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                                      const_acc, vb, scale_a, scale_b, scale_a_byte, scale_b_byte,
+                                      c_modifier);
+      });
+  if (!dispatched)
+    throw util::UnimplementedInst(mnemonic());
+}
+
+void VMfmaScaleF3232x32x64F8f6f4Vop3px2::execute_impl(amdgpu::Wavefront &wf) {
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t const_acc;
+  uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
+                                    [&] { return amdgpu::RegisterAccess(wf).read_scalar(src2); });
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t scale_a = raw_words_[1] & 0x1FFu;
+  uint32_t scale_b = (raw_words_[1] >> 9) & 0x1FFu;
+  uint32_t scale_a_byte = ((raw_words_[0] >> 11) & 1u) | (((raw_words_[1] >> 27) & 1u) << 1);
+  uint32_t scale_b_byte = ((raw_words_[0] >> 12) & 1u) | (((raw_words_[1] >> 28) & 1u) << 1);
+  uint32_t c_modifier =
+      amdgpu::wmma_c_modifier((raw_words_[1] >> 29) & 7u, (raw_words_[0] >> 8) & 7u);
+  bool dispatched = amdgpu::dispatch_matrix_fmt_pair(
+      inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+        amdgpu::exec_f32_scaled_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                                      const_acc, vb, scale_a, scale_b, scale_a_byte, scale_b_byte,
+                                      c_modifier);
+      });
+  if (!dispatched)
+    throw util::UnimplementedInst(mnemonic());
 }
 
 } // namespace cdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
@@ -2325,8 +2325,10 @@ bool isGfx1250WmmaScalePairValid(const MachineInst *opcode) {
   const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
   const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
   const bool scale16 = scale->op == 0x3au;
+  // Accept LLVM's encoding as an alias for the ISA-canonical constant.
+  const bool fixed_src2_valid = scale->src2 == 0x080u || scale->src2 == 0x100u;
   if (scale->vdst != 0u || (scale->neg_hi & 0x4u) != 0u || (scale->opsel & 0x2u) != 0u ||
-      scale->clamp != 0u || scale->src2 != 0x100u || (scale->opsel_hi & 0x2u) != 0u ||
+      scale->clamp != 0u || !fixed_src2_valid || (scale->opsel_hi & 0x2u) != 0u ||
       (scale->neg & 0x4u) != 0u || (matrix->neg_hi & 0x3u) != 0u || matrix->clamp != 0u ||
       (matrix->neg & 0x3u) != 0u)
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
@@ -2302,6 +2302,42 @@ bool isVop3pOp(const MachineInst opcode, uint32_t op) {
   return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
 }
 
+bool isGfx1250WmmaScaleSource(uint32_t selector, bool scale16) {
+  if (selector <= 105u || selector == 128u)
+    return true;
+  if (selector < 256u || selector > 511u)
+    return false;
+  return !scale16 || ((selector - 256u) % 2u == 0u && selector < 511u);
+}
+
+bool isGfx1250WmmaScaleFormatPairLegal(uint32_t matrix_a_fmt, uint32_t matrix_b_fmt,
+                                       uint32_t scale_a_fmt, uint32_t scale_b_fmt) {
+  if (matrix_a_fmt > 4u || matrix_b_fmt > 4u || scale_a_fmt > 2u || scale_b_fmt > 2u)
+    return false;
+  if (scale_a_fmt == 0u && scale_b_fmt == 0u)
+    return true;
+  if ((scale_a_fmt != 0u && matrix_a_fmt != 4u) || (scale_b_fmt != 0u && matrix_b_fmt != 4u))
+    return false;
+  return matrix_a_fmt != 4u || matrix_b_fmt != 4u || scale_a_fmt == scale_b_fmt;
+}
+
+bool isGfx1250WmmaScalePairValid(const MachineInst *opcode) {
+  const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
+  const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
+  const bool scale16 = scale->op == 0x3au;
+  if (!isGfx1250WmmaScaleSource(scale->src0, scale16) ||
+      !isGfx1250WmmaScaleSource(scale->src1, scale16))
+    return false;
+
+  const uint32_t scale_a_fmt = scale->neg & 0x3u;
+  const uint32_t scale_b_fmt = scale->neg_hi & 0x3u;
+  if (matrix->op == 0x88u)
+    return isGfx1250WmmaScaleFormatPairLegal(4u, 4u, scale_a_fmt, scale_b_fmt);
+  const uint32_t matrix_a_fmt = matrix->opsel;
+  const uint32_t matrix_b_fmt = (matrix->pad_14 << 2u) | matrix->opsel_hi;
+  return isGfx1250WmmaScaleFormatPairLegal(matrix_a_fmt, matrix_b_fmt, scale_a_fmt, scale_b_fmt);
+}
+
 } // namespace
 
 DecodeResult Decoder::decode(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
@@ -2371,6 +2407,8 @@ DecodeResult DecoderImpl::subDecodeVop3p(const MachineInst *opcode,
 DecodeResult DecoderImpl::decodeVWmmaScaleF32Vop3px2(const MachineInst *opcode,
                                                      const DecodeErrorEmitter &emit_error) {
   if (!isVop3pOp(opcode[2], 0x33) && !isVop3pOp(opcode[2], 0x88))
+    return decodeInvalid(opcode, emit_error);
+  if (!isGfx1250WmmaScalePairValid(opcode))
     return decodeInvalid(opcode, emit_error);
   return std::make_unique<VWmmaScaleF32Vop3px2>(opcode);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/decoder.cpp
@@ -2325,6 +2325,11 @@ bool isGfx1250WmmaScalePairValid(const MachineInst *opcode) {
   const auto *scale = reinterpret_cast<const Vop3pMachineInst *>(opcode);
   const auto *matrix = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
   const bool scale16 = scale->op == 0x3au;
+  if (scale->vdst != 0u || (scale->neg_hi & 0x4u) != 0u || (scale->opsel & 0x2u) != 0u ||
+      scale->clamp != 0u || scale->src2 != 0x100u || (scale->opsel_hi & 0x2u) != 0u ||
+      (scale->neg & 0x4u) != 0u || (matrix->neg_hi & 0x3u) != 0u || matrix->clamp != 0u ||
+      (matrix->neg & 0x3u) != 0u)
+    return false;
   if (!isGfx1250WmmaScaleSource(scale->src0, scale16) ||
       !isGfx1250WmmaScaleSource(scale->src1, scale16))
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p.cpp
@@ -76,8 +76,10 @@ const char *cdna5_scaled_wmma_mnemonic(const MachineInst *inst) {
                                             : "v_wmma_scale_f32_16x16x128_f8f6f4";
 }
 
-int cdna5_scale_operand_size_bits(const MachineInst *inst) {
-  return cdna5_scaled_wmma_is_scale16(inst) ? 64 : 32;
+int cdna5_scale_operand_size_bits(const MachineInst *inst, uint32_t selector) {
+  const bool is_vgpr = selector >= OpSelSrcSimple::OPR_SRC_SIMPLE_VGPR_MIN &&
+                       selector <= OpSelSrcSimple::OPR_SRC_SIMPLE_VGPR_MAX;
+  return cdna5_scaled_wmma_is_scale16(inst) && is_vgpr ? 64 : 32;
 }
 
 int cdna5_scaled_wmma_dst_size_bits(const MachineInst *inst) {
@@ -4623,10 +4625,12 @@ VWmmaScaleF32Vop3px2::VWmmaScaleF32Vop3px2(const MachineInst *inst)
            reinterpret_cast<const OpEncoding *>(inst + 2)->src1),
       src2(cdna5_scaled_wmma_dst_size_bits(inst), OperandType::OPR_SRC_VGPR_OR_INLINE,
            reinterpret_cast<const OpEncoding *>(inst + 2)->src2),
-      scale_src0(cdna5_scale_operand_size_bits(inst), OperandType::OPR_SRC_SIMPLE,
-                 reinterpret_cast<const OpEncoding *>(inst)->src0),
-      scale_src1(cdna5_scale_operand_size_bits(inst), OperandType::OPR_SRC_SIMPLE,
-                 reinterpret_cast<const OpEncoding *>(inst)->src1),
+      scale_src0(
+          cdna5_scale_operand_size_bits(inst, reinterpret_cast<const OpEncoding *>(inst)->src0),
+          OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      scale_src1(
+          cdna5_scale_operand_size_bits(inst, reinterpret_cast<const OpEncoding *>(inst)->src1),
+          OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1),
       scale_inst_(*reinterpret_cast<const OpEncoding *>(inst)) {
   raw_words_ = {inst[0], inst[1], inst[2], inst[3]};
   raw_encoding_ = raw_words_.data();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop3p_exec.cpp
@@ -2539,12 +2539,21 @@ void VWmmaScaleF32Vop3px2::execute_impl(amdgpu::Wavefront &wf) {
   const uint32_t matrix_a_scale_fmt = scale_inst_.neg & 0x3u;
   const uint32_t matrix_b_scale_fmt = scale_inst_.neg_hi & 0x3u;
   const bool scale16 = scale_inst_.op == 0x3a;
+  const bool scale0_inline_zero =
+      scale_src0.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN;
+  const bool scale1_inline_zero =
+      scale_src1.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN;
 
   auto scale_word = [&](const Operand &operand, uint32_t lane) -> uint64_t {
-    // For regular scaled WMMA, the inline integer-zero encoding
-    // selects a neutral E8M0 word rather than the numerical value 0.
-    if (!scale16 && operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
-      return 0x7f7f7f7fu;
+    // Inline zero supplies a neutral E8M0 scale for every K block.
+    if (operand.encoding_value() == OpSelSrcSimple::OPR_SRC_SIMPLE_POS_INT_MIN)
+      return 0x7f7f7f7f7f7f7f7full;
+    // Scalar scale sources use only bits 7:0, repeated for every K
+    // block. VGPR scale sources retain their packed per-block bytes.
+    if (operand.encoding_value() >= 0 && operand.encoding_value() <= 105) {
+      const uint64_t byte = amdgpu::RegisterAccess(wf).read_lane(operand, lane) & 0xffu;
+      return byte * 0x0101010101010101ull;
+    }
     return scale16 ? amdgpu::RegisterAccess(wf).read_lane64(operand, lane)
                    : amdgpu::RegisterAccess(wf).read_lane(operand, lane);
   };
@@ -2553,20 +2562,22 @@ void VWmmaScaleF32Vop3px2::execute_impl(amdgpu::Wavefront &wf) {
 
   bool dispatched = false;
   if (inst_.op == 0x88) {
-    amdgpu::exec_wmma_f32_scaled_mixed(cu, 32, 16, 128, 4, 4, dst, src0_base, src1_base, s2,
-                                       amdgpu::extract_fp4, amdgpu::extract_fp4, const_acc, scale0,
-                                       scale1, matrix_a_scale, matrix_b_scale, matrix_a_scale_fmt,
-                                       matrix_b_scale_fmt, scale16,
-                                       amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
+    amdgpu::exec_wmma_f32_scaled_mixed(
+        cu, 32, 16, 128, 4, 4, dst, src0_base, src1_base, s2, amdgpu::extract_fp4,
+        amdgpu::extract_fp4, const_acc, scale0, scale1, matrix_a_scale, matrix_b_scale,
+        scale0_inline_zero ? 0u : matrix_a_scale_fmt, scale1_inline_zero ? 0u : matrix_b_scale_fmt,
+        scale16, amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
     dispatched = true;
   } else {
     dispatched = amdgpu::dispatch_matrix_fmt_pair(
         matrix_a_fmt, matrix_b_fmt,
         [&](uint32_t a_bits, uint32_t b_bits, auto extract_a, auto extract_b) {
-          amdgpu::exec_wmma_f32_scaled_mixed(
-              cu, 16, 16, 128, a_bits, b_bits, dst, src0_base, src1_base, s2, extract_a, extract_b,
-              const_acc, scale0, scale1, matrix_a_scale, matrix_b_scale, matrix_a_scale_fmt,
-              matrix_b_scale_fmt, scale16, amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
+          amdgpu::exec_wmma_f32_scaled_mixed(cu, 16, 16, 128, a_bits, b_bits, dst, src0_base,
+                                             src1_base, s2, extract_a, extract_b, const_acc, scale0,
+                                             scale1, matrix_a_scale, matrix_b_scale,
+                                             scale0_inline_zero ? 0u : matrix_a_scale_fmt,
+                                             scale1_inline_zero ? 0u : matrix_b_scale_fmt, scale16,
+                                             amdgpu::wmma_c_modifier(inst_.neg, inst_.neg_hi));
         });
   }
   if (!dispatched)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -301,6 +301,41 @@ inline InputLoc wmma_packed_input_loc(uint32_t lane, uint32_t slot, uint32_t dat
   return {bit / 32, lane, sub_element, bit_in_word, data_bits};
 }
 
+/// Compute an input element location for CDNA4 block-scale F8F6F4 MFMA.
+///
+/// The sub-byte physical layout depends on whether the other operand is an
+/// eight-bit or sub-byte format. The supported scaled MFMA shapes both use one
+/// matrix block distributed across a wave64.
+inline InputLoc mfma_scale_f8f6f4_input_loc(uint32_t dim, uint32_t K, uint32_t index, uint32_t k,
+                                            uint32_t data_bits, uint32_t other_data_bits) {
+  if (!((dim == 16 && K == 128) || (dim == 32 && K == 64)))
+    throw util::UnimplementedInst("unsupported CDNA4 block-scale MFMA input shape");
+  if (data_bits == 8)
+    return input_loc(dim, K, /*B=*/1, index, k, /*b=*/0, data_bits);
+  if ((data_bits != 4 && data_bits != 6) ||
+      (other_data_bits != 4 && other_data_bits != 6 && other_data_bits != 8))
+    throw util::UnimplementedInst("unsupported CDNA4 block-scale MFMA input format");
+
+  uint32_t lane;
+  uint32_t slot;
+  if (other_data_bits == 8) {
+    if (dim == 16) {
+      lane = 16u * (k / 32u) + index;
+      slot = 16u * ((k / 16u) & 1u) + (k & 15u);
+    } else {
+      lane = 32u * (k / 32u) + index;
+      slot = k & 31u;
+    }
+  } else if (dim == 16) {
+    lane = 16u * ((k % 64u) / 16u) + index;
+    slot = 16u * (k / 64u) + (k & 15u);
+  } else {
+    lane = 32u * ((k % 32u) / 16u) + index;
+    slot = 16u * (k / 32u) + (k & 15u);
+  }
+  return wmma_packed_input_loc(lane, slot, data_bits);
+}
+
 inline InputLoc gfx12_wmma_input_loc(uint32_t wave_size, uint32_t dim, uint32_t K, uint32_t i,
                                      uint32_t k, uint32_t data_bits) {
   require_gfx12_wmma_wave_size(wave_size);
@@ -630,10 +665,26 @@ inline uint32_t permute_b_lane(uint32_t lane, uint32_t blgp) {
 
 inline uint32_t packed_mask(uint32_t bits) { return bits >= 32 ? UINT32_MAX : ((1u << bits) - 1u); }
 
+inline uint32_t matrix_vgpr_word(const RegisterAccess::VgprReadRegion &region,
+                                 uint32_t physical_reg, uint32_t lane) {
+  assert(physical_reg >= region.base() && physical_reg - region.base() < region.reg_count() &&
+         "matrix read exceeds acquired VGPR region");
+  return region.lane(physical_reg - region.base(), lane);
+}
+
+inline uint32_t matrix_vgpr_word(RegisterAccess::VgprReadRegion &region, uint32_t physical_reg,
+                                 uint32_t lane) {
+  return matrix_vgpr_word(std::as_const(region), physical_reg, lane);
+}
+
+inline uint32_t matrix_vgpr_word(auto &cu, uint32_t physical_reg, uint32_t lane) {
+  return RegisterAccess(cu).read_vgpr(physical_reg, lane);
+}
+
 inline uint32_t read_packed(auto &cu, uint32_t base, const InputLoc &loc) {
-  uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane) >> loc.bit_offset;
+  uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane) >> loc.bit_offset;
   if (loc.bit_offset + loc.data_bits > 32) {
-    uint32_t next = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset + 1, loc.lane);
+    uint32_t next = matrix_vgpr_word(cu, base + loc.vgpr_offset + 1, loc.lane);
     raw |= next << (32 - loc.bit_offset);
   }
   return raw & packed_mask(loc.data_bits);
@@ -641,14 +692,14 @@ inline uint32_t read_packed(auto &cu, uint32_t base, const InputLoc &loc) {
 
 struct ExtractF32 {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    return std::bit_cast<float>(RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane));
+    return std::bit_cast<float>(matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane));
   }
 };
 inline constexpr ExtractF32 extract_f32{};
 
 struct ExtractF16 {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::f16_to_f32(static_cast<uint16_t>((raw >> (loc.sub_element * 16)) & 0xFFFF));
   }
 };
@@ -656,7 +707,7 @@ inline constexpr ExtractF16 extract_f16{};
 
 struct ExtractBf16 {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::bf16_to_f32(static_cast<uint16_t>((raw >> (loc.sub_element * 16)) & 0xFFFF));
   }
 };
@@ -664,7 +715,7 @@ inline constexpr ExtractBf16 extract_bf16{};
 
 struct ExtractI8 {
   int32_t operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return static_cast<int32_t>(static_cast<int8_t>((raw >> (loc.sub_element * 8)) & 0xFF));
   }
 };
@@ -672,7 +723,7 @@ inline constexpr ExtractI8 extract_i8{};
 
 struct ExtractU8 {
   int32_t operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return static_cast<int32_t>((raw >> (loc.sub_element * 8)) & 0xFF);
   }
 };
@@ -699,7 +750,7 @@ inline constexpr ExtractU4 extract_u4{};
 
 struct ExtractFp8Ocp {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::fp8_e4m3_ocp_to_f32(static_cast<uint8_t>((raw >> (loc.sub_element * 8)) & 0xFF));
   }
 };
@@ -707,7 +758,7 @@ inline constexpr ExtractFp8Ocp extract_fp8_ocp{};
 
 struct ExtractBf8Ocp {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::bf8_e5m2_ocp_to_f32(static_cast<uint8_t>((raw >> (loc.sub_element * 8)) & 0xFF));
   }
 };
@@ -715,7 +766,7 @@ inline constexpr ExtractBf8Ocp extract_bf8_ocp{};
 
 struct ExtractFp8Fnuz {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::fp8_e4m3_fnuz_to_f32(static_cast<uint8_t>((raw >> (loc.sub_element * 8)) & 0xFF));
   }
 };
@@ -723,7 +774,7 @@ inline constexpr ExtractFp8Fnuz extract_fp8_fnuz{};
 
 struct ExtractBf8Fnuz {
   float operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t raw = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
+    uint32_t raw = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
     return util::bf8_e5m2_fnuz_to_f32(static_cast<uint8_t>((raw >> (loc.sub_element * 8)) & 0xFF));
   }
 };
@@ -766,8 +817,8 @@ inline constexpr ExtractBf6 extract_bf6{};
 
 struct ExtractF64 {
   double operator()(auto &cu, uint32_t base, const InputLoc &loc) const {
-    uint32_t lo = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset, loc.lane);
-    uint32_t hi = RegisterAccess(cu).read_vgpr(base + loc.vgpr_offset + 1, loc.lane);
+    uint32_t lo = matrix_vgpr_word(cu, base + loc.vgpr_offset, loc.lane);
+    uint32_t hi = matrix_vgpr_word(cu, base + loc.vgpr_offset + 1, loc.lane);
     return std::bit_cast<double>(static_cast<uint64_t>(hi) << 32 | lo);
   }
 };
@@ -779,6 +830,8 @@ inline float decode_wmma_scale_byte(uint8_t raw, uint32_t fmt) {
   switch (fmt) {
   case 0:
     return decode_e8m0_scale(raw);
+  case 1:
+    return util::fp8_e5m3_to_f32(raw);
   case 2:
     return util::fp8_e4m3_to_f32(raw);
   default:
@@ -1142,6 +1195,25 @@ public:
   std::optional<RegisterAccess::VgprReadRegion> acc;
 };
 
+inline MatrixReadRegions read_mixed_matrix_fast_path_regions(auto &cu, uint32_t s0, uint32_t s1,
+                                                             uint32_t s2, uint64_t a_elements,
+                                                             uint32_t a_bits, uint64_t b_elements,
+                                                             uint32_t b_bits, uint64_t acc_elements,
+                                                             uint32_t acc_bits, uint32_t const_acc,
+                                                             uint32_t wf_size) {
+  RegisterAccess regs(cu);
+  const uint64_t lane_mask = mfma_full_lane_mask(wf_size);
+  const uint32_t a_regs = mfma_dense_reg_count(a_elements, a_bits, wf_size);
+  const uint32_t b_regs = mfma_dense_reg_count(b_elements, b_bits, wf_size);
+  std::optional<RegisterAccess::VgprReadRegion> acc_region;
+  if (const_acc == ACC_FROM_VGPR) {
+    const uint32_t acc_regs = mfma_dense_reg_count(acc_elements, acc_bits, wf_size);
+    acc_region.emplace(regs.read_vgpr_region(s2, acc_regs, lane_mask));
+  }
+  return MatrixReadRegions(regs.read_vgpr_region(s0, a_regs, lane_mask),
+                           regs.read_vgpr_region(s1, b_regs, lane_mask), std::move(acc_region));
+}
+
 inline MatrixReadRegions read_mfma_fast_path_regions(auto &cu, uint32_t s0, uint32_t s1,
                                                      uint32_t s2, uint32_t M, uint32_t N,
                                                      uint32_t K, uint32_t B, uint32_t data_bits,
@@ -1392,8 +1464,8 @@ void exec_f32(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, uint32_t
 
 /// Column (N) leading-dimension pitch rounding A/B/C buffers up to a SIMD-width
 /// multiple, so every matmul row starts W-aligned. Bounds every real WMMA shape
-/// (M,N <= 16, K <= 128); anything larger falls back to the scalar path.
-constexpr size_t WMMA_SIMD_MAX_AB = 2048;      // max M*K
+/// (M <= 32, N <= 16, K <= 128); anything larger falls back to the scalar path.
+constexpr size_t WMMA_SIMD_MAX_AB = 4096;      // max M*K
 constexpr size_t WMMA_SIMD_MAX_BSTRIDE = 4096; // max K*stride
 constexpr size_t WMMA_SIMD_MAX_C = 1024;       // max M*stride
 // Combined stack frame for the WMMA/SWMMAC staging buffers (currently 28 KiB for
@@ -1605,26 +1677,30 @@ void exec_wmma_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t 
         static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
       run_scalar();
     } else {
+      auto reads = read_mixed_matrix_fast_path_regions(cu, s0, s1, s2, static_cast<uint64_t>(M) * K,
+                                                       a_bits, static_cast<uint64_t>(N) * K, b_bits,
+                                                       static_cast<uint64_t>(M) * N,
+                                                       /*acc_bits=*/32, const_acc, wave_size);
       alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
       alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
       alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t col = 0; col < N; ++col) {
           auto out = gfx12_wmma_output_loc_32(wave_size, M, N, row, col);
-          Cbuf[row * stride + col] = apply_wmma_c_modifier(
-              (const_acc != ACC_FROM_VGPR)
-                  ? std::bit_cast<float>(const_acc)
-                  : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane)),
-              c_modifier);
+          Cbuf[row * stride + col] =
+              apply_wmma_c_modifier((const_acc != ACC_FROM_VGPR)
+                                        ? std::bit_cast<float>(const_acc)
+                                        : std::bit_cast<float>(reads.acc->lane(out.reg, out.lane)),
+                                    c_modifier);
         }
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t k = 0; k < K; ++k)
           Abuf[row * K + k] =
-              ea(cu, s0, gfx12_wmma_a_input_loc(wave_size, M, K, row, k, a_bits, b_bits));
+              ea(reads.a, s0, gfx12_wmma_a_input_loc(wave_size, M, K, row, k, a_bits, b_bits));
       for (uint32_t k = 0; k < K; ++k)
         for (uint32_t col = 0; col < N; ++col)
           Bbuf[k * stride + col] =
-              eb(cu, s1, gfx12_wmma_b_input_loc(wave_size, N, K, col, k, a_bits, b_bits));
+              eb(reads.b, s1, gfx12_wmma_b_input_loc(wave_size, N, K, col, k, a_bits, b_bits));
       wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t col = 0; col < N; ++col) {
@@ -1636,8 +1712,9 @@ void exec_wmma_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t 
     run_scalar();
   }
 
+  auto writes = write_wmma_output_region(cu, dst, M, N, /*output_bits=*/32, wave_size);
   for (const auto &r : results)
-    RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
+    writes.set_lane(r.reg, r.lane, r.val);
 }
 
 template <typename ExtractA, typename ExtractB>
@@ -1791,6 +1868,7 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
   const bool mixed_subbyte_a = a_bits < 8 && b_bits == 8;
   const bool mixed_subbyte_b = b_bits < 8 && a_bits == 8;
   const bool mixed_pair = mixed_subbyte_a || mixed_subbyte_b;
+  const uint32_t num_scale_blocks = scale16 ? 8u : 4u;
 
   auto scale_for = [](uint64_t scale_word, uint32_t scale_byte, uint32_t scale_fmt) -> float {
     return decode_wmma_scale_byte(static_cast<uint8_t>((scale_word >> (scale_byte * 8)) & 0xffu),
@@ -1809,14 +1887,18 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
         const uint64_t a_scale_word =
             scale_a_word(wmma_a_scale_lane(M, K, row, matrix_a_scale, a_bits, b_bits));
         const uint64_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
-        for (uint32_t k = 0; k < K; ++k) {
-          auto al = wmma_a_input_loc(M, K, row, k, a_bits, b_bits);
-          auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
-          const uint32_t a_scale_byte = wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16);
-          const uint32_t b_scale_byte = wmma_f8f6f4_scale_byte(k, b_bits, mixed_pair, scale16);
-          acc += ea(cu, s0, al) * eb(cu, s1, bl) *
-                 scale_for(a_scale_word, a_scale_byte, matrix_a_scale_fmt) *
-                 scale_for(b_scale_word, b_scale_byte, matrix_b_scale_fmt);
+        for (uint32_t block = 0; block < num_scale_blocks; ++block) {
+          float block_sum = 0.0f;
+          for (uint32_t k = 0; k < K; ++k) {
+            if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) != block)
+              continue;
+            auto al = wmma_a_input_loc(M, K, row, k, a_bits, b_bits);
+            auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
+            block_sum = std::fma(ea(cu, s0, al), eb(cu, s1, bl), block_sum);
+          }
+          block_sum *= scale_for(a_scale_word, block, matrix_a_scale_fmt);
+          block_sum *= scale_for(b_scale_word, block, matrix_b_scale_fmt);
+          acc += block_sum;
         }
         results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
@@ -1831,50 +1913,84 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
         static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
       run_scalar();
     } else {
+      auto reads = read_mixed_matrix_fast_path_regions(cu, s0, s1, s2, static_cast<uint64_t>(M) * K,
+                                                       a_bits, static_cast<uint64_t>(N) * K, b_bits,
+                                                       static_cast<uint64_t>(M) * N,
+                                                       /*acc_bits=*/32, const_acc, /*wf_size=*/32);
       alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
       alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
-      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      alignas(64) float Cacc[WMMA_SIMD_MAX_C] = {};
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t col = 0; col < N; ++col) {
           auto out = wmma_output_loc_32(M, N, row, col);
-          Cbuf[row * stride + col] = apply_wmma_c_modifier(
-              (const_acc != ACC_FROM_VGPR)
-                  ? std::bit_cast<float>(const_acc)
-                  : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane)),
-              c_modifier);
+          Cacc[row * N + col] =
+              apply_wmma_c_modifier((const_acc != ACC_FROM_VGPR)
+                                        ? std::bit_cast<float>(const_acc)
+                                        : std::bit_cast<float>(reads.acc->lane(out.reg, out.lane)),
+                                    c_modifier);
         }
       for (uint32_t row = 0; row < M; ++row) {
-        const uint64_t a_scale_word =
-            scale_a_word(wmma_a_scale_lane(M, K, row, matrix_a_scale, a_bits, b_bits));
         for (uint32_t k = 0; k < K; ++k) {
           auto al = wmma_a_input_loc(M, K, row, k, a_bits, b_bits);
-          const uint32_t a_scale_byte = wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16);
-          Abuf[row * K + k] =
-              ea(cu, s0, al) * scale_for(a_scale_word, a_scale_byte, matrix_a_scale_fmt);
+          Abuf[row * K + k] = ea(reads.a, s0, al);
         }
       }
       for (uint32_t col = 0; col < N; ++col) {
-        const uint64_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
         for (uint32_t k = 0; k < K; ++k) {
           auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
-          const uint32_t b_scale_byte = wmma_f8f6f4_scale_byte(k, b_bits, mixed_pair, scale16);
-          Bbuf[k * stride + col] =
-              eb(cu, s1, bl) * scale_for(b_scale_word, b_scale_byte, matrix_b_scale_fmt);
+          Bbuf[k * stride + col] = eb(reads.b, s1, bl);
         }
       }
-      wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
+      for (uint32_t row = 0; row < M; ++row) {
+        const uint64_t a_scale_word =
+            scale_a_word(wmma_a_scale_lane(M, K, row, matrix_a_scale, a_bits, b_bits));
+        for (uint32_t block = 0; block < num_scale_blocks; ++block) {
+          uint32_t col = 0;
+          alignas(64) float block_sums[64];
+          for (; col + W <= N; col += W) {
+            util::native<float> block_sum(0.0f);
+            for (uint32_t k = 0; k < K; ++k) {
+              if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) != block)
+                continue;
+              util::native<float> a(Abuf[row * K + k]);
+              util::native<float> bv;
+              bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+              block_sum = util::stdx::fma(a, bv, block_sum);
+            }
+            block_sum.copy_to(block_sums, util::stdx::vector_aligned);
+            for (uint32_t j = 0; j < W; ++j) {
+              float scaled = block_sums[j] * scale_for(a_scale_word, block, matrix_a_scale_fmt);
+              const uint64_t b_scale_word = scale_b_word(wmma_scale_lane(col + j, matrix_b_scale));
+              scaled *= scale_for(b_scale_word, block, matrix_b_scale_fmt);
+              Cacc[row * N + col + j] += scaled;
+            }
+          }
+          for (; col < N; ++col) {
+            float block_sum = 0.0f;
+            for (uint32_t k = 0; k < K; ++k) {
+              if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) == block)
+                block_sum = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], block_sum);
+            }
+            block_sum *= scale_for(a_scale_word, block, matrix_a_scale_fmt);
+            const uint64_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
+            block_sum *= scale_for(b_scale_word, block, matrix_b_scale_fmt);
+            Cacc[row * N + col] += block_sum;
+          }
+        }
+      }
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t col = 0; col < N; ++col) {
           auto out = wmma_output_loc_32(M, N, row, col);
-          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[row * stride + col])});
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cacc[row * N + col])});
         }
     }
   } else {
     run_scalar();
   }
 
+  auto writes = write_wmma_output_region(cu, dst, M, N, /*output_bits=*/32, /*wf_size=*/32);
   for (const auto &r : results)
-    RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
+    writes.set_lane(r.reg, r.lane, r.val);
 }
 
 template <typename ExtractA, typename ExtractB>
@@ -2970,19 +3086,11 @@ void exec_swmmac_bf16(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t in_
       [](float val) { return util::f32_to_bf16(val); }, const_acc, wave_size);
 }
 
-/// Scaled MFMA execute for f32 output with FP8/FP6/FP4 input (VOP3PX2).
-///
-/// Applies per-32-K-element-block E8M0 exponent biases from scale VGPRs.
-/// Scale format: 8-bit biased exponent (bias=127), so 2^(scale - 127).
-/// Each lane's scale VGPR holds packed 8-bit scale values (one byte per block).
-///
-/// @param scale_a_base  VGPR base for A-matrix scale values.
-/// @param scale_b_base  VGPR base for B-matrix scale values.
-template <typename ExtractA, typename ExtractB>
-void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, uint32_t in_bits,
-                     uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2, ExtractA ea, ExtractB eb,
-                     uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp,
-                     uint32_t scale_a_base, uint32_t scale_b_base) {
+template <typename ExtractA, typename ExtractB, typename ScaleBlock>
+void exec_f32_scaled_impl(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, uint32_t a_bits,
+                          uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                          ExtractA ea, ExtractB eb, ScaleBlock scale_block_sum, uint32_t const_acc,
+                          uint32_t c_modifier) {
   constexpr uint32_t BLOCK_K = 32;
   const uint32_t wf = cu.wf_size();
   struct Result {
@@ -2994,16 +3102,6 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
   results.reserve(M * N * B);
   uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;
 
-  // Per-block E8M0 scale factor for output (row,col,b) in K-block blk.
-  auto scale_exp_for = [&](uint32_t row, uint32_t col, uint32_t b, uint32_t blk) -> int {
-    auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
-    uint32_t sa_raw = RegisterAccess(cu).read_vgpr(scale_a_base, out.lane);
-    uint32_t sb_raw = RegisterAccess(cu).read_vgpr(scale_b_base, out.lane);
-    uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
-    uint8_t sb_e8m0 = static_cast<uint8_t>((sb_raw >> (blk * 8)) & 0xFF);
-    return static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
-  };
-
   auto run_scalar = [&]() {
     for (uint32_t b = 0; b < B; ++b) {
       for (uint32_t row = 0; row < M; ++row) {
@@ -3013,21 +3111,19 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
               (const_acc != ACC_FROM_VGPR)
                   ? std::bit_cast<float>(const_acc)
                   : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
+          acc = apply_wmma_c_modifier(acc, c_modifier);
           for (uint32_t blk = 0; blk < num_blocks; ++blk) {
             float block_sum = 0.0f;
             uint32_t k_start = blk * BLOCK_K;
             uint32_t k_end = std::min(k_start + BLOCK_K, K);
             for (uint32_t k = k_start; k < k_end; ++k) {
-              auto al = input_loc(M, K, B, row, k, b, in_bits);
-              auto bl = input_loc(N, K, B, col, k, b, in_bits);
-              if (cbsz != 0)
-                al.lane = permute_a_lane(al.lane, cbsz, abid);
-              if (blgp != 0)
-                bl.lane = permute_b_lane(bl.lane, blgp);
-              block_sum +=
-                  ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
+              auto al = mfma_scale_f8f6f4_input_loc(M, K, row, k, a_bits, b_bits);
+              auto bl = mfma_scale_f8f6f4_input_loc(N, K, col, k, b_bits, a_bits);
+              const float a = ea(cu, s0, physicalize_loc(al, wf));
+              const float b_val = eb(cu, s1, physicalize_loc(bl, wf));
+              block_sum = std::fma(a, b_val, block_sum);
             }
-            acc += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
+            acc += scale_block_sum(block_sum, row, col, b, blk);
           }
           results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }
@@ -3054,6 +3150,10 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * N > MAX_C) {
       run_scalar();
     } else {
+      auto reads = read_mixed_matrix_fast_path_regions(
+          cu, s0, s1, s2, static_cast<uint64_t>(M) * K * B, a_bits,
+          static_cast<uint64_t>(N) * K * B, b_bits, static_cast<uint64_t>(M) * N * B,
+          /*acc_bits=*/32, const_acc, wf);
       // Zero-initialized staging buffers (uniform convention; see
       // wmma_simd_matmul). Cacc is pre-seeded below.
       alignas(64) float Abuf[MAX_AB] = {};
@@ -3062,25 +3162,22 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t k = 0; k < K; ++k) {
-            auto al = input_loc(M, K, B, row, k, b, in_bits);
-            if (cbsz != 0)
-              al.lane = permute_a_lane(al.lane, cbsz, abid);
-            Abuf[row * K + k] = ea(cu, s0, physicalize_loc(al, wf));
+            auto al = mfma_scale_f8f6f4_input_loc(M, K, row, k, a_bits, b_bits);
+            Abuf[row * K + k] = ea(reads.a, s0, physicalize_loc(al, wf));
           }
         for (uint32_t k = 0; k < K; ++k)
           for (uint32_t col = 0; col < N; ++col) {
-            auto bl = input_loc(N, K, B, col, k, b, in_bits);
-            if (blgp != 0)
-              bl.lane = permute_b_lane(bl.lane, blgp);
-            Bbuf[k * stride + col] = eb(cu, s1, physicalize_loc(bl, wf));
+            auto bl = mfma_scale_f8f6f4_input_loc(N, K, col, k, b_bits, a_bits);
+            Bbuf[k * stride + col] = eb(reads.b, s1, physicalize_loc(bl, wf));
           }
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
             auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
-            Cacc[row * N + col] =
+            Cacc[row * N + col] = apply_wmma_c_modifier(
                 (const_acc != ACC_FROM_VGPR)
                     ? std::bit_cast<float>(const_acc)
-                    : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
+                    : std::bit_cast<float>(reads.acc->lane(out.reg, out.lane)),
+                c_modifier);
           }
         for (uint32_t row = 0; row < M; ++row) {
           for (uint32_t blk = 0; blk < num_blocks; ++blk) {
@@ -3098,13 +3195,13 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
               }
               acc.copy_to(bs, util::stdx::vector_aligned);
               for (uint32_t j = 0; j < W; ++j)
-                Cacc[row * N + col + j] += std::ldexp(bs[j], scale_exp_for(row, col + j, b, blk));
+                Cacc[row * N + col + j] += scale_block_sum(bs[j], row, col + j, b, blk);
             }
             for (; col < N; ++col) {
               float block_sum = 0.0f;
               for (uint32_t k = k_start; k < k_end; ++k)
                 block_sum = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], block_sum);
-              Cacc[row * N + col] += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
+              Cacc[row * N + col] += scale_block_sum(block_sum, row, col, b, blk);
             }
           }
         }
@@ -3119,8 +3216,39 @@ void exec_f32_scaled(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, u
     run_scalar();
   }
 
+  auto writes = write_mfma_acc32_region(cu, dst, M, N, B, wf);
   for (const auto &r : results)
-    RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
+    writes.set_lane(r.reg, r.lane, r.val);
+}
+
+inline uint8_t mfma_inline_scale_e8m0(uint32_t selector) {
+  switch (selector) {
+  case 240: // +0.5f
+  case 241: // -0.5f
+    return 126;
+  case 242: // +1.0f
+  case 243: // -1.0f
+    return 127;
+  case 244: // +2.0f
+  case 245: // -2.0f
+    return 128;
+  case 246: // +4.0f
+  case 247: // -4.0f
+    return 129;
+  case 248: // 1/(2*pi)
+    return 124;
+  default:
+    return 0;
+  }
+}
+
+inline uint8_t read_mfma_scale_e8m0(auto &cu, uint32_t vgpr_base, uint32_t selector, uint32_t lane,
+                                    uint32_t byte_index) {
+  if (selector >= 240 && selector <= 248)
+    return mfma_inline_scale_e8m0(selector);
+  uint8_t byte_mask = static_cast<uint8_t>(1u << byte_index);
+  uint32_t raw = RegisterAccess(cu).read_vgpr(src_base(vgpr_base, selector), lane, byte_mask);
+  return static_cast<uint8_t>((raw >> (byte_index * 8)) & 0xffu);
 }
 
 /// Scaled MFMA for mixed-format f8f6f4: A and B may have different bit widths.
@@ -3129,47 +3257,19 @@ template <typename ExtractA, typename ExtractB>
 void exec_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
                            uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1,
                            uint32_t s2, ExtractA ea, ExtractB eb, uint32_t const_acc,
-                           uint32_t scale_a_base, uint32_t scale_b_base) {
-  constexpr uint32_t BLOCK_K = 32;
-  const uint32_t wf = cu.wf_size();
-  struct Result {
-    uint32_t reg;
-    uint32_t lane;
-    uint32_t val;
+                           uint32_t vgpr_base, uint32_t scale_a, uint32_t scale_b,
+                           uint32_t scale_a_byte, uint32_t scale_b_byte, uint32_t c_modifier = 0) {
+  auto scale_block_sum = [&](float block_sum, uint32_t row, uint32_t col, uint32_t,
+                             uint32_t blk) -> float {
+    uint8_t sa_e8m0 = read_mfma_scale_e8m0(cu, vgpr_base, scale_a, M * blk + row, scale_a_byte);
+    uint8_t sb_e8m0 = read_mfma_scale_e8m0(cu, vgpr_base, scale_b, N * blk + col, scale_b_byte);
+    if (sa_e8m0 == 0xffu || sb_e8m0 == 0xffu)
+      return std::numeric_limits<float>::quiet_NaN();
+    int scale_exp = static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
+    return std::ldexp(block_sum, scale_exp);
   };
-  std::vector<Result> results;
-  results.reserve(M * N * B);
-  uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;
-  for (uint32_t b = 0; b < B; ++b) {
-    for (uint32_t row = 0; row < M; ++row) {
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
-        float acc =
-            (const_acc != ACC_FROM_VGPR)
-                ? std::bit_cast<float>(const_acc)
-                : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
-        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
-          float block_sum = 0.0f;
-          uint32_t k_start = blk * BLOCK_K;
-          uint32_t k_end = std::min(k_start + BLOCK_K, K);
-          for (uint32_t k = k_start; k < k_end; ++k) {
-            auto al = input_loc(M, K, B, row, k, b, a_bits);
-            auto bl = input_loc(N, K, B, col, k, b, b_bits);
-            block_sum += ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
-          }
-          uint32_t sa_raw = RegisterAccess(cu).read_vgpr(scale_a_base, M * blk + row);
-          uint32_t sb_raw = RegisterAccess(cu).read_vgpr(scale_b_base, N * blk + col);
-          uint8_t sa_e8m0 = static_cast<uint8_t>(sa_raw & 0xFFu);
-          uint8_t sb_e8m0 = static_cast<uint8_t>(sb_raw & 0xFFu);
-          int scale_exp = static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
-          acc += std::ldexp(block_sum, scale_exp);
-        }
-        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
-      }
-    }
-  }
-  for (const auto &r : results)
-    RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
+  exec_f32_scaled_impl(cu, M, N, K, B, a_bits, b_bits, dst, s0, s1, s2, ea, eb, scale_block_sum,
+                       const_acc, c_modifier);
 }
 
 /// MFMA execute for i32 output with i8 input: D = C + A x B.

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -5454,6 +5454,21 @@ std::unique_ptr<Instruction> decode_gfx1250(const std::array<uint32_t, 2> &words
   return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, words.data()) : nullptr);
 }
 
+std::unique_ptr<Instruction> decode_gfx1250_compound(const std::array<uint32_t, 4> &words) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, words.data()) : nullptr);
+}
+
+std::array<uint32_t, 4> gfx1250_scale16_words(uint16_t scale_src0, uint16_t scale_src1) {
+  constexpr uint16_t kVgprEncoding = 256;
+  const auto prefix =
+      cdna5::build_vop3p(0x3a, {.src0 = scale_src0, .src1 = scale_src1, .src2 = 256});
+  const auto matrix = cdna5::build_vop3p(
+      cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
+      {.vdst = 96, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 32, .src2 = 256 + 96});
+  return {prefix[0], prefix[1], matrix[0], matrix[1]};
+}
+
 TEST(GeneratedInstDefUse, Gfx1250Vop3CompareDefinesOneSgpr) {
   // v_cmp_eq_u32_e64 s53, 32, v4. gfx1250 is wave32-only, so the comparison
   // mask occupies s53 and must not make liveness treat the adjacent s54 as
@@ -5465,6 +5480,35 @@ TEST(GeneratedInstDefUse, Gfx1250Vop3CompareDefinesOneSgpr) {
   InstDefUse idu(*inst);
   EXPECT_TRUE(idu.defs.contains({RegClass::SGPR, 53, 1}));
   EXPECT_FALSE(idu.defs.contains({RegClass::SGPR, 54, 1}));
+}
+
+TEST(GeneratedInstDefUse, Gfx1250Scale16ScalarSourcesUseSingleSgprs) {
+  auto inst = decode_gfx1250_compound(gfx1250_scale16_words(0, 2));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse idu(*inst);
+  EXPECT_TRUE(idu.uses.contains({RegClass::SGPR, 0, 1}));
+  EXPECT_TRUE(idu.uses.contains({RegClass::SGPR, 2, 1}));
+  EXPECT_FALSE(idu.uses.contains({RegClass::SGPR, 1, 1}));
+  EXPECT_FALSE(idu.uses.contains({RegClass::SGPR, 3, 1}));
+}
+
+TEST(GeneratedInstDefUse, Gfx1250Scale16VectorSourcesUseVgprPairs) {
+  auto inst = decode_gfx1250_compound(gfx1250_scale16_words(256 + 64, 256 + 66));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse idu(*inst);
+  EXPECT_TRUE(idu.uses.contains({RegClass::VGPR, 64, 2}));
+  EXPECT_TRUE(idu.uses.contains({RegClass::VGPR, 66, 2}));
+}
+
+TEST(GeneratedInstDefUse, Gfx1250Scale16InlineSourcesUseNoRegisters) {
+  auto inst = decode_gfx1250_compound(gfx1250_scale16_words(128, 128));
+  ASSERT_NE(inst, nullptr);
+
+  InstDefUse idu(*inst);
+  EXPECT_FALSE(idu.uses.contains({RegClass::SGPR, 0, 1}));
+  EXPECT_FALSE(idu.uses.contains({RegClass::VGPR, 128, 1}));
 }
 
 // DPP word1 fields (CDNA4): vsrc0[7:0], dpp_ctrl[16:8], bound_ctrl[19],

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -550,6 +550,25 @@ TEST(Gfx1250DecodeTest, WmmaScaleF8f6f4ConsumesVop3px2Pair) {
             "v_wmma_scale_f32_16x16x128_f8f6f4 v[6:13], v[18:33], v[52:67], 0, v0, v4");
 }
 
+TEST(Gfx1250DecodeTest, WmmaScaleAcceptsLlvmAndIsaFixedSrc2Encodings) {
+  auto isa_words = build_scaled_wmma_words(0x35, 0, 0, 0, 0, 128, 128);
+  auto llvm_words = isa_words;
+  constexpr uint32_t kSrc2Mask = 0x1ffu << 18;
+  llvm_words[1] = (llvm_words[1] & ~kSrc2Mask) | (0x080u << 18);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> isa_inst(decode_valid(*decoder, isa_words.data()));
+  std::unique_ptr<Instruction> llvm_inst(decode_valid(*decoder, llvm_words.data()));
+  ASSERT_NE(isa_inst, nullptr);
+  ASSERT_NE(llvm_inst, nullptr);
+  EXPECT_EQ(llvm_inst->mnemonic(), isa_inst->mnemonic());
+  EXPECT_EQ(llvm_inst->size(), isa_inst->size());
+  EXPECT_EQ(llvm_inst->num_src_operands(), isa_inst->num_src_operands());
+  EXPECT_EQ(llvm_inst->num_dst_operands(), isa_inst->num_dst_operands());
+  EXPECT_EQ(llvm_inst->disassemble(), isa_inst->disassemble());
+}
+
 TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidEmbeddedSourceSelectors) {
   constexpr uint32_t invalid_src0_selectors[] = {255u, 250u, 233u, 234u};
   for (const uint32_t embedded_src0 : invalid_src0_selectors) {
@@ -596,7 +615,7 @@ TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidFixedAndReservedFields) {
     EXPECT_TRUE(decode_fails(*decoder, words.data()));
   }
 
-  for (uint32_t fixed_src2 : {0u, 128u, 255u, 511u}) {
+  for (uint32_t fixed_src2 : {0u, 255u, 511u}) {
     SCOPED_TRACE(::testing::Message() << "prefix_src2=" << fixed_src2);
     auto words = build_scaled_wmma_words(0x35, 0, 0, 0, 0, 128, 128);
     constexpr uint32_t kSrc2Mask = 0x1ffu << 18;
@@ -767,10 +786,17 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
   constexpr auto inline_matrix = cdna5::build_vop3p(
       cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
       {.vdst = 40, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 16, .src2 = kVgprEncoding + 40});
+  constexpr auto llvm_matrix = cdna5::build_vop3p(
+      cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
+      {.vdst = 48, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 16, .src2 = kVgprEncoding + 48});
   const std::array<uint32_t, 4> scalar_words = {scalar_prefix[0], scalar_prefix[1],
                                                 scalar_matrix[0], scalar_matrix[1]};
   const std::array<uint32_t, 4> inline_words = {inline_prefix[0], inline_prefix[1],
                                                 inline_matrix[0], inline_matrix[1]};
+  std::array<uint32_t, 4> llvm_words = {inline_prefix[0], inline_prefix[1], llvm_matrix[0],
+                                        llvm_matrix[1]};
+  constexpr uint32_t kSrc2Mask = 0x1ffu << 18;
+  llvm_words[1] = (llvm_words[1] & ~kSrc2Mask) | (0x080u << 18);
 
   write_wave_sgpr(*cu, *wf, 0, 0x807e007fu);
   write_wave_sgpr(*cu, *wf, 1, 0x0102037fu);
@@ -783,10 +809,13 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
   ASSERT_NE(decoder, nullptr);
   std::unique_ptr<Instruction> scalar_inst(decode_valid(*decoder, scalar_words.data()));
   std::unique_ptr<Instruction> inline_inst(decode_valid(*decoder, inline_words.data()));
+  std::unique_ptr<Instruction> llvm_inst(decode_valid(*decoder, llvm_words.data()));
   ASSERT_NE(scalar_inst, nullptr);
   ASSERT_NE(inline_inst, nullptr);
+  ASSERT_NE(llvm_inst, nullptr);
   cu->execute_instruction(scalar_inst.get(), *wf);
   cu->execute_instruction(inline_inst.get(), *wf);
+  cu->execute_instruction(llvm_inst.get(), *wf);
 
   for (uint32_t reg = 0; reg < 8; ++reg)
     for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
@@ -794,6 +823,8 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
       EXPECT_EQ(scalar_result, std::bit_cast<uint32_t>(128.0f))
           << "reg " << reg << ", lane " << lane;
       EXPECT_EQ(cu->read_vgpr(vgpr_base + 40 + reg, lane), scalar_result)
+          << "reg " << reg << ", lane " << lane;
+      EXPECT_EQ(cu->read_vgpr(vgpr_base + 48 + reg, lane), scalar_result)
           << "reg " << reg << ", lane " << lane;
     }
 }

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -643,6 +643,30 @@ TEST(Gfx1250DecodeTest, WmmaScale16F8f6f4ConsumesVop3px2Pair) {
             "v[26:27], v[28:29] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
 }
 
+TEST(Gfx1250DecodeTest, WmmaScale16ScalarSourcesUseSingleSgprs) {
+  const auto words = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, 0, 2);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->disassemble(),
+            "v_wmma_scale16_f32_16x16x128_f8f6f4 v[64:71], v[0:15], v[32:47], v[64:71], "
+            "s0, s2");
+}
+
+TEST(Gfx1250DecodeTest, WmmaScale16InlineScaleSourcesRemainInline) {
+  const auto words = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, 128, 128);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  EXPECT_EQ(inst->disassemble(),
+            "v_wmma_scale16_f32_16x16x128_f8f6f4 v[64:71], v[0:15], v[32:47], v[64:71], "
+            "0, 0");
+}
+
 TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
   const uint32_t words[] = {
       0xCC350000u,

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -535,7 +535,7 @@ TEST(Gfx1250DecodeTest, WmmaF8f6f4UsesMatrixFormatOperandWidths) {
 TEST(Gfx1250DecodeTest, WmmaScaleF8f6f4ConsumesVop3px2Pair) {
   const uint32_t words[] = {
       0xCC350000u,
-      0x02020900u,
+      0x04020900u,
       0xCC330006u,
       0x02026912u,
   };
@@ -556,7 +556,7 @@ TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidEmbeddedSourceSelectors) {
     SCOPED_TRACE(embedded_src0);
     const uint32_t words[] = {
         0xCC350000u,
-        0x20020700u,
+        0x24020700u,
         0xCC330000u,
         0xD600D400u | embedded_src0,
     };
@@ -567,10 +567,48 @@ TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidEmbeddedSourceSelectors) {
   }
 }
 
+TEST(Gfx1250DecodeTest, WmmaScalePairRejectsInvalidFixedAndReservedFields) {
+  struct InvalidField {
+    const char *name;
+    size_t word;
+    uint32_t bits;
+  };
+  constexpr std::array invalid_fields = {
+      InvalidField{"prefix_vdst", 0, 1u << 0},
+      InvalidField{"prefix_neg_hi_reserved", 0, 1u << 10},
+      InvalidField{"prefix_opsel_reserved", 0, 1u << 12},
+      InvalidField{"prefix_clamp", 0, 1u << 15},
+      InvalidField{"prefix_opsel_hi_reserved", 1, 1u << 28},
+      InvalidField{"prefix_neg_reserved", 1, 1u << 31},
+      InvalidField{"matrix_neg_hi_reserved_0", 2, 1u << 8},
+      InvalidField{"matrix_neg_hi_reserved_1", 2, 1u << 9},
+      InvalidField{"matrix_clamp", 2, 1u << 15},
+      InvalidField{"matrix_neg_reserved_0", 3, 1u << 29},
+      InvalidField{"matrix_neg_reserved_1", 3, 1u << 30},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &field : invalid_fields) {
+    SCOPED_TRACE(field.name);
+    auto words = build_scaled_wmma_words(0x35, 0, 0, 0, 0, 128, 128);
+    words[field.word] |= field.bits;
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
+  }
+
+  for (uint32_t fixed_src2 : {0u, 128u, 255u, 511u}) {
+    SCOPED_TRACE(::testing::Message() << "prefix_src2=" << fixed_src2);
+    auto words = build_scaled_wmma_words(0x35, 0, 0, 0, 0, 128, 128);
+    constexpr uint32_t kSrc2Mask = 0x1ffu << 18;
+    words[1] = (words[1] & ~kSrc2Mask) | (fixed_src2 << 18);
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
+  }
+}
+
 TEST(Gfx1250DecodeTest, WmmaScale16F8f6f4ConsumesVop3px2Pair) {
   const uint32_t words[] = {
       0xCC3A0000u,
-      0x0202391Au,
+      0x0402391Au,
       0xCC336012u,
       0x02021502u,
   };
@@ -589,7 +627,7 @@ TEST(Gfx1250DecodeTest, WmmaScale16F8f6f4ConsumesVop3px2Pair) {
 TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
   const uint32_t words[] = {
       0xCC350000u,
-      0x02025328u,
+      0x04025328u,
       0xCC884000u,
       0x1A024110u,
   };
@@ -607,7 +645,7 @@ TEST(Gfx1250DecodeTest, WmmaScaleF4_32x16x128ConsumesVop3px2Pair) {
 TEST(Gfx1250DecodeTest, WmmaScalePrefixRejectsNonWmmaSuffix) {
   const uint32_t words[] = {
       0xCC350000u,
-      0x02020900u,
+      0x04020900u,
       0xCC340006u,
       0x02026912u,
   };

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -3,6 +3,8 @@
 
 #include "cdna5_sim_test_common.h"
 #include "decode_test_util.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "util/data_types.h"
 
 namespace {
 
@@ -17,6 +19,75 @@ template <typename T> void append_bytes(std::vector<uint8_t> &bytes, const T &va
 size_t align_up(size_t value, size_t alignment) {
   return (value + alignment - 1) & ~(alignment - 1);
 }
+
+std::array<uint32_t, 4> build_scaled_wmma_words(uint8_t prefix_op, uint32_t matrix_a_fmt,
+                                                uint32_t matrix_b_fmt, uint32_t scale_a_fmt,
+                                                uint32_t scale_b_fmt, uint16_t scale_src0,
+                                                uint16_t scale_src1, uint8_t vdst = 64) {
+  constexpr uint16_t kVgprEncoding = 256;
+  auto prefix = cdna5::build_vop3p(prefix_op, {.neg_hi = static_cast<uint8_t>(scale_b_fmt),
+                                               .src0 = scale_src0,
+                                               .src1 = scale_src1,
+                                               .src2 = 256,
+                                               .neg = static_cast<uint8_t>(scale_a_fmt)});
+  auto matrix = cdna5::build_vop3p(cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
+                                   {.vdst = vdst,
+                                    .opsel = static_cast<uint8_t>(matrix_a_fmt),
+                                    .src0 = kVgprEncoding,
+                                    .src1 = kVgprEncoding + 32,
+                                    .src2 = static_cast<uint16_t>(kVgprEncoding + vdst),
+                                    .opsel_hi = static_cast<uint8_t>(matrix_b_fmt & 0x3u)});
+  matrix[0] |= (matrix_b_fmt >> 2u) << 14u;
+  return {prefix[0], prefix[1], matrix[0], matrix[1]};
+}
+
+uint32_t wmma_format_bits(uint32_t fmt) {
+  if (fmt == 4)
+    return 4;
+  if (fmt == 2 || fmt == 3)
+    return 6;
+  return 8;
+}
+
+uint8_t encode_wmma_one(uint32_t fmt) {
+  switch (fmt) {
+  case 0:
+    return util::f32_to_fp8_e4m3_rne(1.0f);
+  case 1:
+    return util::f32_to_bf8_e5m2_rne(1.0f);
+  case 2:
+    return util::f32_to_fp6_e2m3_rne(1.0f);
+  case 3:
+    return util::f32_to_bf6_e3m2_rne(1.0f);
+  case 4:
+    return util::f32_to_fp4_e2m1_rne(1.0f);
+  default:
+    return 0;
+  }
+}
+
+void write_wmma_packed(amdgpu::ComputeUnitCore &cu, uint32_t base, const amdgpu::InputLoc &loc,
+                       uint8_t value) {
+  const uint32_t mask = (1u << loc.data_bits) - 1u;
+  const uint32_t bits = static_cast<uint32_t>(value) & mask;
+  const uint32_t first_bits = std::min(loc.data_bits, 32u - loc.bit_offset);
+  const uint32_t first_mask = ((1u << first_bits) - 1u) << loc.bit_offset;
+  uint32_t word = cu.read_vgpr(base + loc.vgpr_offset, loc.lane);
+  word = (word & ~first_mask) | ((bits << loc.bit_offset) & first_mask);
+  cu.write_vgpr(base + loc.vgpr_offset, loc.lane, word);
+  if (first_bits != loc.data_bits) {
+    const uint32_t remaining = loc.data_bits - first_bits;
+    const uint32_t second_mask = (1u << remaining) - 1u;
+    word = cu.read_vgpr(base + loc.vgpr_offset + 1, loc.lane);
+    word = (word & ~second_mask) | ((bits >> first_bits) & second_mask);
+    cu.write_vgpr(base + loc.vgpr_offset + 1, loc.lane, word);
+  }
+}
+
+struct ForceScalarGuard {
+  bool old = util::force_scalar();
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(old); }
+};
 
 std::vector<uint8_t> make_minimal_gfx1250_elf() {
   constexpr uint8_t text[] = {0x00, 0x00, 0xB0, 0xBF};
@@ -546,6 +617,102 @@ TEST(Gfx1250DecodeTest, WmmaScalePrefixRejectsNonWmmaSuffix) {
   EXPECT_TRUE(decode_fails(*decoder, words));
 }
 
+TEST(Gfx1250DecodeTest, WmmaScaleEnforcesMatrixAndScaleFormatLegality) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  for (uint32_t matrix_a_fmt = 0; matrix_a_fmt <= 4; ++matrix_a_fmt) {
+    for (uint32_t matrix_b_fmt = 0; matrix_b_fmt <= 4; ++matrix_b_fmt) {
+      for (uint32_t scale_a_fmt = 0; scale_a_fmt <= 2; ++scale_a_fmt) {
+        for (uint32_t scale_b_fmt = 0; scale_b_fmt <= 2; ++scale_b_fmt) {
+          SCOPED_TRACE(::testing::Message()
+                       << "matrix_a_fmt=" << matrix_a_fmt << " matrix_b_fmt=" << matrix_b_fmt
+                       << " scale_a_fmt=" << scale_a_fmt << " scale_b_fmt=" << scale_b_fmt);
+          const bool both_e8 = scale_a_fmt == 0 && scale_b_fmt == 0;
+          const bool non_e8_only_on_f4 =
+              (scale_a_fmt == 0 || matrix_a_fmt == 4) && (scale_b_fmt == 0 || matrix_b_fmt == 4);
+          const bool matching_f4_scales =
+              matrix_a_fmt != 4 || matrix_b_fmt != 4 || scale_a_fmt == scale_b_fmt;
+          const bool legal = both_e8 || (non_e8_only_on_f4 && matching_f4_scales);
+          const auto words = build_scaled_wmma_words(0x35, matrix_a_fmt, matrix_b_fmt, scale_a_fmt,
+                                                     scale_b_fmt, 128, 128);
+          if (legal)
+            EXPECT_FALSE(decode_fails(*decoder, words.data()));
+          else
+            EXPECT_TRUE(decode_fails(*decoder, words.data()));
+        }
+      }
+    }
+  }
+}
+
+TEST(Gfx1250DecodeTest, WmmaScaleRejectsIllegalScaleSources) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  for (uint16_t selector : {106u, 127u, 129u, 255u}) {
+    SCOPED_TRACE(selector);
+    const auto invalid = build_scaled_wmma_words(0x35, 0, 0, 0, 0, selector, 128);
+    EXPECT_TRUE(decode_fails(*decoder, invalid.data()));
+  }
+
+  for (uint16_t selector : {1u, 128u, 256u, 510u}) {
+    SCOPED_TRACE(::testing::Message() << "legal Scale16 selector=" << selector);
+    const auto valid = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, selector, 128);
+    EXPECT_FALSE(decode_fails(*decoder, valid.data()));
+  }
+  for (uint16_t selector : {257u, 509u, 511u}) {
+    SCOPED_TRACE(::testing::Message() << "illegal Scale16 selector=" << selector);
+    const auto invalid = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, selector, 128);
+    EXPECT_TRUE(decode_fails(*decoder, invalid.data()));
+  }
+}
+
+TEST(Gfx1250ExecutionTest, WmmaScaleExecutesAllMatrixFormatPairs) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  ForceScalarGuard scalar_guard;
+
+  for (bool force_scalar : {true, false}) {
+    util::set_force_scalar_for_testing(force_scalar);
+    for (uint32_t matrix_a_fmt = 0; matrix_a_fmt <= 4; ++matrix_a_fmt) {
+      for (uint32_t matrix_b_fmt = 0; matrix_b_fmt <= 4; ++matrix_b_fmt) {
+        SCOPED_TRACE(::testing::Message() << "force_scalar=" << force_scalar << " matrix_a_fmt="
+                                          << matrix_a_fmt << " matrix_b_fmt=" << matrix_b_fmt);
+        for (uint32_t reg = 0; reg < 72; ++reg)
+          for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+            cu->write_vgpr(vgpr_base + reg, lane, 0);
+
+        const uint32_t a_bits = wmma_format_bits(matrix_a_fmt);
+        const uint32_t b_bits = wmma_format_bits(matrix_b_fmt);
+        const uint8_t a_one = encode_wmma_one(matrix_a_fmt);
+        const uint8_t b_one = encode_wmma_one(matrix_b_fmt);
+        for (uint32_t row = 0; row < 16; ++row)
+          for (uint32_t k = 0; k < 128; ++k)
+            write_wmma_packed(*cu, vgpr_base,
+                              amdgpu::wmma_a_input_loc(16, 128, row, k, a_bits, b_bits), a_one);
+        for (uint32_t col = 0; col < 16; ++col)
+          for (uint32_t k = 0; k < 128; ++k)
+            write_wmma_packed(*cu, vgpr_base + 32,
+                              amdgpu::wmma_b_input_loc(16, 128, col, k, a_bits, b_bits), b_one);
+
+        const auto words =
+            build_scaled_wmma_words(0x35, matrix_a_fmt, matrix_b_fmt, 0, 0, 128, 128);
+        std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+        ASSERT_NE(inst, nullptr);
+        cu->execute_instruction(inst.get(), *wf);
+        for (uint32_t reg = 0; reg < 8; ++reg)
+          for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+            EXPECT_EQ(cu->read_vgpr(vgpr_base + 64 + reg, lane), std::bit_cast<uint32_t>(128.0f));
+      }
+    }
+  }
+}
+
 TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -554,10 +721,8 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
   wf->set_exec(0xffffffffu);
 
   constexpr uint16_t kVgprEncoding = 256;
-  constexpr auto scalar_prefix =
-      cdna5::build_vop3p(0x35, {.src0 = 0, .src1 = 1, .src2 = kVgprEncoding});
-  constexpr auto inline_prefix =
-      cdna5::build_vop3p(0x35, {.src0 = 128, .src1 = 128, .src2 = kVgprEncoding});
+  constexpr auto scalar_prefix = cdna5::build_vop3p(0x35, {.src0 = 0, .src1 = 1, .src2 = 256});
+  constexpr auto inline_prefix = cdna5::build_vop3p(0x35, {.src0 = 128, .src1 = 128, .src2 = 256});
   constexpr auto scalar_matrix = cdna5::build_vop3p(
       cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
       {.vdst = 32, .src0 = kVgprEncoding, .src1 = kVgprEncoding + 16, .src2 = kVgprEncoding + 32});
@@ -569,8 +734,8 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
   const std::array<uint32_t, 4> inline_words = {inline_prefix[0], inline_prefix[1],
                                                 inline_matrix[0], inline_matrix[1]};
 
-  write_wave_sgpr(*cu, *wf, 0, 0x7f7f7f7fu);
-  write_wave_sgpr(*cu, *wf, 1, 0x7f7f7f7fu);
+  write_wave_sgpr(*cu, *wf, 0, 0x807e007fu);
+  write_wave_sgpr(*cu, *wf, 1, 0x0102037fu);
   const uint32_t vgpr_base = wf->vgpr_alloc().base;
   for (uint32_t reg = 0; reg < 32; ++reg)
     for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
@@ -593,6 +758,136 @@ TEST(Gfx1250ExecutionTest, WmmaRegularScaleInlineZeroMatchesNeutralScalarSources
       EXPECT_EQ(cu->read_vgpr(vgpr_base + 40 + reg, lane), scalar_result)
           << "reg " << reg << ", lane " << lane;
     }
+}
+
+TEST(Gfx1250ExecutionTest, WmmaScale16InlineZeroAndSgprUseNeutralScaleForEveryBlock) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  for (uint32_t reg = 0; reg < 48; ++reg)
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+      cu->write_vgpr(vgpr_base + reg, lane, 0x38383838u);
+  write_wave_sgpr(*cu, *wf, 0, 0x0102037fu);
+  write_wave_sgpr(*cu, *wf, 1, 0x11223344u);
+  write_wave_sgpr(*cu, *wf, 2, 0xa0b0c07fu);
+  write_wave_sgpr(*cu, *wf, 3, 0x55667788u);
+
+  const auto scalar_words = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, 0, 2, 64);
+  const auto inline_words = build_scaled_wmma_words(0x3a, 0, 0, 0, 0, 128, 128, 72);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> scalar_inst(decode_valid(*decoder, scalar_words.data()));
+  std::unique_ptr<Instruction> inline_inst(decode_valid(*decoder, inline_words.data()));
+  ASSERT_NE(scalar_inst, nullptr);
+  ASSERT_NE(inline_inst, nullptr);
+  cu->execute_instruction(scalar_inst.get(), *wf);
+  cu->execute_instruction(inline_inst.get(), *wf);
+
+  for (uint32_t reg = 0; reg < 8; ++reg)
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
+      EXPECT_EQ(cu->read_vgpr(vgpr_base + 64 + reg, lane), std::bit_cast<uint32_t>(128.0f));
+      EXPECT_EQ(cu->read_vgpr(vgpr_base + 72 + reg, lane), std::bit_cast<uint32_t>(128.0f));
+    }
+}
+
+TEST(Gfx1250ExecutionTest, WmmaScaleDecodesE5m3ForFp4Operand) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  for (uint32_t row = 0; row < 16; ++row)
+    for (uint32_t k = 0; k < 128; ++k)
+      write_wmma_packed(*cu, vgpr_base, amdgpu::wmma_a_input_loc(16, 128, row, k, 4, 8),
+                        util::f32_to_fp4_e2m1_rne(1.0f));
+  for (uint32_t col = 0; col < 16; ++col)
+    for (uint32_t k = 0; k < 128; ++k)
+      write_wmma_packed(*cu, vgpr_base + 32, amdgpu::wmma_b_input_loc(16, 128, col, k, 4, 8),
+                        util::f32_to_fp8_e4m3_rne(1.0f));
+  write_wave_sgpr(*cu, *wf, 0, 0x78u);
+  write_wave_sgpr(*cu, *wf, 1, 0x7fu);
+
+  const auto words = build_scaled_wmma_words(0x35, 4, 0, 1, 0, 0, 1);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  cu->execute_instruction(inst.get(), *wf);
+  for (uint32_t reg = 0; reg < 8; ++reg)
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+      EXPECT_EQ(cu->read_vgpr(vgpr_base + 64 + reg, lane), std::bit_cast<uint32_t>(128.0f));
+}
+
+TEST(Gfx1250ExecutionTest, WmmaNonE8ScalesApplyAfterEachBlockDot) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  ForceScalarGuard scalar_guard;
+
+  struct ScaleCase {
+    uint32_t format;
+    uint8_t encoded;
+    float value;
+  };
+  const std::array scale_cases = {
+      ScaleCase{1, util::f32_to_fp8_e5m3_rne(1.5f), 1.5f},
+      ScaleCase{2, util::f32_to_fp8_e4m3_rne(0.75f), 0.75f},
+  };
+  constexpr float kAccumulator = 16777216.0f;
+
+  for (bool force_scalar : {true, false}) {
+    util::set_force_scalar_for_testing(force_scalar);
+    for (bool scale16 : {false, true}) {
+      for (const auto &scale : scale_cases) {
+        SCOPED_TRACE(::testing::Message() << "force_scalar=" << force_scalar << " scale16="
+                                          << scale16 << " scale_format=" << scale.format);
+        for (uint32_t reg = 0; reg < 80; ++reg)
+          for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+            cu->write_vgpr(vgpr_base + reg, lane, 0);
+        for (uint32_t row = 0; row < 16; ++row)
+          for (uint32_t k = 0; k < 128; ++k)
+            write_wmma_packed(*cu, vgpr_base, amdgpu::wmma_a_input_loc(16, 128, row, k, 4, 8),
+                              util::f32_to_fp4_e2m1_rne(0.5f));
+        for (uint32_t col = 0; col < 16; ++col)
+          for (uint32_t k = 0; k < 128; ++k)
+            write_wmma_packed(*cu, vgpr_base + 32, amdgpu::wmma_b_input_loc(16, 128, col, k, 4, 8),
+                              util::f32_to_fp8_e4m3_rne(1.0f));
+        for (uint32_t reg = 0; reg < 8; ++reg)
+          for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+            cu->write_vgpr(vgpr_base + 64 + reg, lane, std::bit_cast<uint32_t>(kAccumulator));
+        write_wave_sgpr(*cu, *wf, 0, scale.encoded);
+        write_wave_sgpr(*cu, *wf, 1, 0x7fu);
+
+        const auto words =
+            build_scaled_wmma_words(scale16 ? 0x3a : 0x35, 4, 0, scale.format, 0, 0, 1);
+        std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+        ASSERT_NE(inst, nullptr);
+        cu->execute_instruction(inst.get(), *wf);
+
+        float expected = kAccumulator;
+        const uint32_t block_size = scale16 ? 16 : 32;
+        for (uint32_t block = 0; block < 128 / block_size; ++block) {
+          float block_dot = 0.0f;
+          for (uint32_t k = 0; k < block_size; ++k)
+            block_dot = std::fma(0.5f, 1.0f, block_dot);
+          block_dot *= scale.value;
+          expected += block_dot;
+        }
+        for (uint32_t reg = 0; reg < 8; ++reg)
+          for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+            EXPECT_EQ(cu->read_vgpr(vgpr_base + 64 + reg, lane), std::bit_cast<uint32_t>(expected));
+      }
+    }
+  }
 }
 
 TEST(Gfx1250DecodeTest, SwmmacPrintsIndexKeyAndReuseModifiers) {

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -59,6 +59,7 @@ RJ_DIAGNOSTIC_POP
 #include <array>
 #include <bit>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -12367,8 +12368,7 @@ TEST(BinaryTranslatorE2E, Gfx1250Scale16RejectsMisalignedOrOutOfRangeVgprPairs) 
       EXPECT_FALSE(result.ok());
       EXPECT_EQ(result.elf_bytes, image);
       EXPECT_TRUE(rocjitsu::test_support::has_error_containing(
-          result, rocjitsu::DiagnosticKind::ExpandFailed,
-          "Scale16 VGPR scale sources must be even-aligned pairs in v0:v255"));
+          result, rocjitsu::DiagnosticKind::Legalization, "Invalid instruction opcode"));
     }
   }
 }
@@ -12899,12 +12899,10 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4PreservesInlineMatrixCForA0) 
 // Numerical evidence that the M=32 FP4 split preserves values. The encoding
 // tests above only prove the right bits are emitted; this one runs both the
 // original B0-only M=32 instruction and the translated pair of scaled M=16
-// halves on the instruction simulator over identical inputs and requires
-// bit-identical destination registers. The two paths dispatch through
-// different execution kernels (exec_wmma_f32 versus
-// exec_wmma_f32_scaled_mixed, the latter substituting the neutral E8M0 word
-// for the inline-zero scale operands), so the comparison is a real
-// differential rather than a tautology.
+// halves on the instruction simulator over identical inputs. The scaled path
+// rounds each block dot before applying its neutral E8M0 scales, as required by
+// the ISA, while the unscaled path accumulates continuously. The results must
+// therefore agree numerically rather than bit-for-bit.
 TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution) {
   // Every operand range stays inside VGPR bank 0 so the lowering needs no
   // s_set_vgpr_msb transitions and the translated body is exactly two pairs.
@@ -13067,16 +13065,29 @@ TEST(BinaryTranslatorE2E, Gfx1250Standalone32x16Fp4SplitMatchesUnsplitExecution)
   EXPECT_EQ(executed, 2u);
   const std::vector<uint32_t> run_b = snapshot_destination();
 
-  EXPECT_EQ(run_a, run_b);
-  if (run_a != run_b) {
-    for (size_t i = 0; i < run_a.size(); ++i) {
-      if (run_a[i] == run_b[i])
-        continue;
-      ADD_FAILURE() << "first divergence at D reg " << (i / lanes) << " lane " << (i % lanes)
-                    << ": unsplit=0x" << std::hex << run_a[i] << " split=0x" << run_b[i]
-                    << std::dec;
-      break;
-    }
+  auto ordered_float_bits = [](uint32_t bits) {
+    return (bits & 0x80000000u) != 0u ? ~bits : bits | 0x80000000u;
+  };
+  for (size_t i = 0; i < run_a.size(); ++i) {
+    if (run_a[i] == run_b[i])
+      continue;
+    const float unsplit = std::bit_cast<float>(run_a[i]);
+    const float split = std::bit_cast<float>(run_b[i]);
+    if (std::isnan(unsplit) && std::isnan(split))
+      continue;
+    if (unsplit == split)
+      continue;
+    ASSERT_TRUE(std::isfinite(unsplit) && std::isfinite(split))
+        << "D reg " << (i / lanes) << " lane " << (i % lanes) << ": unsplit=0x" << std::hex
+        << run_a[i] << " split=0x" << run_b[i] << std::dec;
+    const uint32_t unsplit_ordered = ordered_float_bits(run_a[i]);
+    const uint32_t split_ordered = ordered_float_bits(run_b[i]);
+    const uint32_t ulps = unsplit_ordered > split_ordered ? unsplit_ordered - split_ordered
+                                                          : split_ordered - unsplit_ordered;
+    // Reassociating a 128-term dot at the ISA's block boundaries can move a
+    // finite result by several dozen ULPs, especially after cancellation.
+    EXPECT_LE(ulps, 64u) << "D reg " << (i / lanes) << " lane " << (i % lanes) << ": unsplit=0x"
+                         << std::hex << run_a[i] << " split=0x" << run_b[i] << std::dec;
   }
 
   if (!wf->is_halted())

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -8711,11 +8711,11 @@ TEST(SemanticTranslator, Gfx1250ResidualChecksRecognizeEveryActionableSourceRule
                                 {.vdst = 8, .src0 = 256, .src1 = 264, .src2 = 272}));
 
   constexpr auto regular_scale =
-      cdna5::build_vop3p(0x35, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0});
+      cdna5::build_vop3p(0x35, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 256});
   constexpr auto scale16 =
-      cdna5::build_vop3p(0x3a, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 0});
+      cdna5::build_vop3p(0x3a, {.src0 = 256 + 64, .src1 = 256 + 66, .src2 = 256});
   constexpr auto scale_body =
-      cdna5::build_vop3p(cdna5::kVWmmaF3216x16x128F8f6f4Vop3p,
+      cdna5::build_vop3p(cdna5::kVWmmaF3232x16x128F4Vop3p,
                          {.vdst = 96, .src0 = 256 + 16, .src1 = 256 + 32, .src2 = 256 + 48});
   add_compound_sample(regular_scale, scale_body);
   add_compound_sample(scale16, scale_body);
@@ -11812,8 +11812,9 @@ TEST(BinaryTranslatorE2E, Gfx1250TensorLoadDoesNotReuseMaskPrefixBypassedByBranc
 
 TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesSrc2AndWaitsForCompletion) {
   // Real VOP3PX2 encoding from the mxscale offline oracle. Bits [58:50] are
-  // zero in the B0 object even though SQ decodes that unused field as a scalar
-  // dependency. The A0 output must encode VGPR0 without changing other bits.
+  // the inline-zero selector in the B0 object even though SQ decodes that unused
+  // field as a scalar dependency. The A0 output must encode VGPR0 without changing
+  // other bits.
   constexpr std::array<uint32_t, 4> source_scale = {0xCC350000u, 0x0202954Eu, 0xCC332042u,
                                                     0x050A01CAu};
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
@@ -11851,13 +11852,12 @@ TEST(BinaryTranslatorE2E, Gfx1250FloatingScaledWmmaRejectsNonzeroCmFields) {
     uint16_t prefix_opcode;
     uint8_t prefix_cm;
     uint8_t matrix_cm;
-    const char *diagnostic;
   };
   constexpr std::array cases = {
-      CmCase{"regular_prefix", 0x35, 1, 0, "SCL_CM must be set to zero"},
-      CmCase{"regular_matrix", 0x35, 0, 1, "CLAMP \"must be set to zero\""},
-      CmCase{"scale16_prefix", 0x3a, 1, 0, "SCL_CM must be set to zero"},
-      CmCase{"scale16_matrix", 0x3a, 0, 1, "CLAMP \"must be set to zero\""},
+      CmCase{"regular_prefix", 0x35, 1, 0},
+      CmCase{"regular_matrix", 0x35, 0, 1},
+      CmCase{"scale16_prefix", 0x3a, 1, 0},
+      CmCase{"scale16_matrix", 0x3a, 0, 1},
   };
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
 
@@ -11883,7 +11883,7 @@ TEST(BinaryTranslatorE2E, Gfx1250FloatingScaledWmmaRejectsNonzeroCmFields) {
     EXPECT_FALSE(result.ok());
     EXPECT_EQ(result.elf_bytes, image);
     EXPECT_TRUE(rocjitsu::test_support::has_error_containing(
-        result, rocjitsu::DiagnosticKind::ExpandFailed, test_case.diagnostic));
+        result, rocjitsu::DiagnosticKind::Legalization, "Invalid instruction opcode"));
   }
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -3611,6 +3611,33 @@ TEST(BinaryTranslatorE2E, Gfx1250InvalidPoolCandidateFallsBackToNormalDecodeDiag
       result, rocjitsu::DiagnosticKind::Legalization, "does not support 32-bit literals"));
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250FourWordMalformedPoolCandidateFailsSafely) {
+  constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
+  std::vector<uint32_t> words = {
+      rocjitsu::build_s_nop(rocjitsu::kBranchIslandPoolMarkerNopImmediate,
+                            ROCJITSU_CODE_ARCH_CDNA5),
+      rocjitsu::build_s_branch(static_cast<int16_t>(rocjitsu::kDirectBranchIslandPoolSlots),
+                               ROCJITSU_CODE_ARCH_CDNA5),
+  };
+  words.insert(words.end(), rocjitsu::kDirectBranchIslandPoolSlots,
+               rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA5));
+  // Force speculative pool recognition down the four-word VOP3PX2 decode path.
+  words[rocjitsu::kGeneratedIslandPoolHeaderWords] = 0xCC350000u;
+  words.push_back(kGfx1250SEndpgm);
+
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image);
+}
+
 TEST(BinaryTranslatorE2E, Gfx1250RejectsNearMissGeneratedIslandPool) {
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
   std::vector<uint32_t> words = {
@@ -11815,35 +11842,40 @@ TEST(BinaryTranslatorE2E, Gfx1250RegularWmmaScaleEncodesSrc2AndWaitsForCompletio
   // the inline-zero selector in the B0 object even though SQ decodes that unused
   // field as a scalar dependency. The A0 output must encode VGPR0 without changing
   // other bits.
-  constexpr std::array<uint32_t, 4> source_scale = {0xCC350000u, 0x0202954Eu, 0xCC332042u,
-                                                    0x050A01CAu};
+  constexpr std::array<uint32_t, 4> base_scale = {0xCC350000u, 0x0202954Eu, 0xCC332042u,
+                                                  0x050A01CAu};
   constexpr uint32_t kGfx1250SEndpgm = 0xBFB00000u;
-  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
-      {source_scale[0], source_scale[1], source_scale[2], source_scale[3], kGfx1250SEndpgm});
-  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
-
-  rocjitsu::BinaryTranslator translator(
-      ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
-      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
-                               rocjitsu::ProcessorRevision::Gfx1250A0));
-  auto result = translator.translate(source);
-  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
-                                                          : result.diagnostics.front().message);
-
-  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-  ASSERT_FALSE(translated.text_sections().empty());
-  const auto *target_words =
-      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
-  ASSERT_EQ(target_word_count, 6u);
   constexpr uint32_t kScaleSrc2Mask = 0x1ffu << 18;
   constexpr auto completion_wait = kGfx1250WmmaCompletionWait;
-  EXPECT_EQ(target_words[0], source_scale[0]);
-  EXPECT_EQ(target_words[1], (source_scale[1] & ~kScaleSrc2Mask) | (0x100u << 18));
-  EXPECT_EQ(target_words[2], source_scale[2]);
-  EXPECT_EQ(target_words[3], source_scale[3]);
-  EXPECT_EQ(target_words[4], completion_wait[0]);
-  EXPECT_EQ(target_words[5], kGfx1250SEndpgm);
+  for (const uint32_t source_src2 : {0x080u, 0x100u}) {
+    SCOPED_TRACE(::testing::Message() << "source_src2=" << source_src2);
+    auto source_scale = base_scale;
+    source_scale[1] = (source_scale[1] & ~kScaleSrc2Mask) | (source_src2 << 18);
+    auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+        {source_scale[0], source_scale[1], source_scale[2], source_scale[3], kGfx1250SEndpgm});
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+
+    rocjitsu::BinaryTranslator translator(
+        ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
+        gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                                 rocjitsu::ProcessorRevision::Gfx1250A0));
+    auto result = translator.translate(source);
+    ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                            : result.diagnostics.front().message);
+
+    rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+    ASSERT_FALSE(translated.text_sections().empty());
+    const auto *target_words =
+        reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+    const size_t target_word_count = translated.text_sections()[0]->size() / sizeof(uint32_t);
+    ASSERT_EQ(target_word_count, 6u);
+    EXPECT_EQ(target_words[0], source_scale[0]);
+    EXPECT_EQ(target_words[1], (source_scale[1] & ~kScaleSrc2Mask) | (0x100u << 18));
+    EXPECT_EQ(target_words[2], source_scale[2]);
+    EXPECT_EQ(target_words[3], source_scale[3]);
+    EXPECT_EQ(target_words[4], completion_wait[0]);
+    EXPECT_EQ(target_words[5], kGfx1250SEndpgm);
+  }
 }
 
 TEST(BinaryTranslatorE2E, Gfx1250FloatingScaledWmmaRejectsNonzeroCmFields) {

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -1796,17 +1796,18 @@ TEST(Cdna4DecodeTest, MfmaF8f6f4SourceWidthsFollowFormatSelectors) {
 TEST(Cdna4DecodeTest, MfmaScaleF8f6f4ConsumesVop3px2Prefix) {
   const uint32_t words[] = {
       0xD3AC0000u,
-      0x00000000u,
-      0xD3AD0000u,
-      0x04020100u,
+      0x0002C360u,
+      0xD3AD0C40u,
+      0x84822100u,
   };
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
   ASSERT_NE(decoder, nullptr);
   std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
   ASSERT_NE(inst, nullptr);
-  EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_16x16x128_f8f6f4");
+  EXPECT_EQ(inst->mnemonic(), "v_mfma_scale_f32_16x16x128_f8f6f4");
   EXPECT_EQ(inst->size(), sizeof(words));
+  EXPECT_EQ(inst->num_src_operands(), 5);
 }
 
 // v_accvgpr_read's 9-bit src0 field encodes accumulator N as 256 + N, which the
@@ -1875,19 +1876,4 @@ TEST(Cdna4DecodeTest, RejectsVop3px2PrefixWithoutMfmaSuffix) {
   EXPECT_TRUE(decode_fails(*decoder, wrong_encoding));
 }
 
-TEST(Cdna4DecodeTest, MfmaScaleF8f6f4AcceptsSecondVop3px2Suffix) {
-  const uint32_t words[] = {
-      0xD3AC0000u,
-      0x00000000u,
-      0xD3AE0000u,
-      0x04020100u,
-  };
-
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
-  ASSERT_NE(decoder, nullptr);
-  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
-  ASSERT_NE(inst, nullptr);
-  EXPECT_EQ(inst->mnemonic(), "v_mfma_f32_32x32x64_f8f6f4");
-  EXPECT_EQ(inst->size(), sizeof(words));
-}
 } // namespace

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -11,6 +11,7 @@
 
 #include "aql_queue.h"
 #include "decode_test_util.h"
+#include "mma_test_util.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -116,6 +117,10 @@ constexpr uint32_t sopp(uint32_t op, uint16_t simm16 = 0) {
 constexpr uint32_t S_NOP = sopp(0);
 constexpr uint32_t S_ENDPGM = sopp(1);
 constexpr uint32_t S_BARRIER = sopp(10);
+
+constexpr uint32_t vgpr_src(uint32_t reg) { return 256u + reg; }
+
+using mma_test::make_cdna4_mfma_scale_words;
 
 // CDNA4 VOP2: opcode[30:25], vdst[24:17], vsrc1[16:9], src0[8:0]. Bit 31 = 0.
 constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
@@ -2508,6 +2513,144 @@ TEST(ExecutionPluginTest, MfmaReadObservationSkipsConstantAccumulator) {
   expect_vgpr_read_set(vgpr_read_events(*plugin), vb,
                        {S0 + 0, S0 + 1, S0 + 2, S0 + 3, S1 + 0, S1 + 1, S1 + 2, S1 + 3},
                        ~uint64_t{0});
+}
+
+TEST(ExecutionPluginTest, Cdna4BlockScaleMfmaAbidZeroPrefixRejectsBeforeExecuteCallbacks) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  const auto scale = make_cdna4_mfma_scale_words(45, /*abid=*/0, vgpr_src(96), vgpr_src(97));
+  const std::array<uint32_t, 5> code = {scale[0], scale[1], scale[2], scale[3], S_ENDPGM};
+
+  f.run_kernel(code.data(), code.size());
+
+  size_t before_count = 0;
+  for (const auto &event : plugin->events)
+    if (event.kind == HookEvent::BEFORE_INSTRUCTION)
+      ++before_count;
+  EXPECT_EQ(before_count, 0u);
+}
+
+TEST(ExecutionPluginTest, Cdna4BlockScaleMfmaCompoundAdvancesCallbacksByFullPrefixSize) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  const auto scale = make_cdna4_mfma_scale_words(45, /*abid=*/1, vgpr_src(96), vgpr_src(97));
+  const std::array<uint32_t, 5> code = {scale[0], scale[1], scale[2], scale[3], S_ENDPGM};
+
+  f.run_kernel(code.data(), code.size());
+
+  std::vector<HookEvent> before_events;
+  for (const auto &event : plugin->events)
+    if (event.kind == HookEvent::BEFORE_INSTRUCTION)
+      before_events.push_back(event);
+  ASSERT_EQ(before_events.size(), 2u);
+  EXPECT_EQ(before_events[0].mnemonic, "v_mfma_scale_f32_16x16x128_f8f6f4");
+  EXPECT_EQ(before_events[1].mnemonic, "s_endpgm");
+  ASSERT_GE(before_events[1].pc, before_events[0].pc);
+  EXPECT_EQ(before_events[1].pc - before_events[0].pc, 16u);
+}
+
+TEST(ExecutionPluginTest, Cdna4BlockScaleMfmaScaleReadsUseSelectedByteMask) {
+  constexpr uint32_t kSrc0 = 0;
+  constexpr uint32_t kSrc1 = 16;
+  constexpr uint32_t kAccumulator = 32;
+  constexpr uint32_t kScaleA = 96;
+  constexpr uint32_t kScaleB = 97;
+
+  for (uint32_t byte = 0; byte < 4; ++byte) {
+    PluginFixture f(/*num_wf_slots=*/1);
+    auto *plugin = f.attach_ordering_plugin();
+    auto *cu = f.cu();
+    auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+    ASSERT_NE(wf, nullptr);
+    wf->set_exec(~uint64_t{0});
+
+    const uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
+      for (uint32_t reg = 0; reg < 8; ++reg) {
+        cu->write_vgpr(vb + kSrc0 + reg, lane, 0x2222'2222u);
+        cu->write_vgpr(vb + kSrc1 + reg, lane, 0x2222'2222u);
+      }
+      for (uint32_t reg = 0; reg < 4; ++reg)
+        cu->write_vgpr(vb + kAccumulator + reg, lane, 0);
+      cu->write_vgpr(vb + kScaleA, lane, 0x7F7F'7F7Fu);
+      cu->write_vgpr(vb + kScaleB, lane, 0x7F7F'7F7Fu);
+    }
+
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    const auto words = make_cdna4_mfma_scale_words(45, /*abid=*/1, vgpr_src(kScaleA),
+                                                   vgpr_src(kScaleB), byte, byte);
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+    ASSERT_NE(inst, nullptr);
+    cu->execute_instruction(inst.get(), *wf);
+
+    const uint8_t expected_mask = static_cast<uint8_t>(1u << byte);
+    bool saw_scale_a = false;
+    bool saw_scale_b = false;
+    std::map<uint32_t, std::pair<uint64_t, uint8_t>> read_unions;
+    const auto reads = vgpr_read_events(*plugin);
+    for (const auto &event : reads) {
+      auto &[lane_mask, byte_mask] = read_unions[event.physical_reg];
+      lane_mask |= event.lane_mask;
+      byte_mask |= event.byte_mask;
+      if (event.physical_reg == vb + kScaleA) {
+        EXPECT_EQ(event.byte_mask, expected_mask) << "A byte=" << byte;
+        saw_scale_a = true;
+      } else if (event.physical_reg == vb + kScaleB) {
+        EXPECT_EQ(event.byte_mask, expected_mask) << "B byte=" << byte;
+        saw_scale_b = true;
+      }
+    }
+    EXPECT_TRUE(saw_scale_a) << "byte=" << byte;
+    EXPECT_TRUE(saw_scale_b) << "byte=" << byte;
+
+    std::map<uint32_t, std::pair<uint64_t, uint8_t>> expected_unions;
+    for (uint32_t reg :
+         {kSrc0, kSrc0 + 1, kSrc0 + 2, kSrc0 + 3, kSrc1, kSrc1 + 1, kSrc1 + 2, kSrc1 + 3,
+          kAccumulator, kAccumulator + 1, kAccumulator + 2, kAccumulator + 3})
+      expected_unions.emplace(vb + reg, std::pair{~uint64_t{0}, ExecutionPlugin::kFullByteMask});
+    expected_unions.emplace(vb + kScaleA, std::pair{~uint64_t{0}, expected_mask});
+    expected_unions.emplace(vb + kScaleB, std::pair{~uint64_t{0}, expected_mask});
+    EXPECT_EQ(read_unions, expected_unions) << "byte=" << byte;
+  }
+}
+
+TEST(ExecutionPluginTest, Cdna4BlockScaleMfmaInlineScalesDoNotReadVgprs) {
+  constexpr uint32_t kSrc0 = 0;
+  constexpr uint32_t kSrc1 = 16;
+  constexpr uint32_t kAccumulator = 32;
+
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(~uint64_t{0});
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < wf->wf_size(); ++lane) {
+    for (uint32_t reg = 0; reg < 4; ++reg) {
+      cu->write_vgpr(vb + kSrc0 + reg, lane, 0x2222'2222u);
+      cu->write_vgpr(vb + kSrc1 + reg, lane, 0x2222'2222u);
+      cu->write_vgpr(vb + kAccumulator + reg, lane, 0);
+    }
+  }
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  const auto words = make_cdna4_mfma_scale_words(45, /*abid=*/1, /*+1.0f=*/242,
+                                                 /*1/(2*pi)=*/248);
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  cu->execute_instruction(inst.get(), *wf);
+
+  std::set<uint32_t> actual_regs;
+  for (const auto &event : vgpr_read_events(*plugin))
+    actual_regs.insert(event.physical_reg - vb);
+  std::set<uint32_t> expected_regs;
+  for (uint32_t reg :
+       {kSrc0, kSrc0 + 1, kSrc0 + 2, kSrc0 + 3, kSrc1, kSrc1 + 1, kSrc1 + 2, kSrc1 + 3,
+        kAccumulator, kAccumulator + 1, kAccumulator + 2, kAccumulator + 3})
+    expected_regs.insert(reg);
+  EXPECT_EQ(actual_regs, expected_regs);
 }
 
 TEST(ExecutionPluginTest, WmmaReadObservationUsesWave32RegisterSet) {

--- a/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
+++ b/emulation/rocjitsu/tests/fuzz/decode/decode_fuzz_test.cpp
@@ -99,7 +99,7 @@ TEST_F(DecodeFuzzCoreTest, DecodesSopTwoWithLiteralWithoutAborting) {
 
 TEST_F(DecodeFuzzCoreTest, PreservesSixteenByteInstruction) {
   const auto input =
-      make_window(std::array<uint32_t, 4>{0xCC350000u, 0x02020900u, 0xCC330006u, 0x02026912u});
+      make_window(std::array<uint32_t, 4>{0xCC350000u, 0x04020900u, 0xCC330006u, 0x02026912u});
   const DecodeRecord record = decode_window(*decoder, input);
   ASSERT_TRUE(record.valid);
   EXPECT_EQ(record.size, 16);

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -10,6 +10,7 @@
 /// expectation for that ISA.
 
 #include "decode_test_util.h"
+#include "mma_test_util.h"
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/isa.h"
@@ -83,6 +84,9 @@ constexpr uint32_t pack16(uint16_t lo, uint16_t hi) {
 }
 
 constexpr uint32_t vgpr_src(uint32_t reg) { return 256u + reg; }
+constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
+
+using mma_test::make_cdna4_mfma_scale_words;
 
 constexpr std::array<uint32_t, 2> encode_vop3(uint32_t op, uint32_t vdst, uint32_t src0,
                                               uint32_t src1, uint32_t src2, uint32_t abs = 0,
@@ -1079,6 +1083,660 @@ TEST(Cdna4Dot2Vop3pExecutionTest, Bf16WidensAsBf16Simd) {
 
 TEST(Cdna4Dot2Vop3pExecutionTest, Bf16WidensAsBf16Scalar) {
   run_cdna4_dot2_f32_bf16(/*force_scalar=*/true);
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, ExposesTruthfulIdentityAndScaleOperands) {
+  struct Case {
+    std::array<uint32_t, 4> words;
+    std::string_view mnemonic;
+    RegisterRef destination;
+    RegisterRef accumulator;
+    std::string_view disassembly;
+  };
+  constexpr std::array cases = {
+      Case{{0xD3AC0000u, 0x0002C360u, 0xD3AD0C40u, 0x84822100u},
+           "v_mfma_scale_f32_16x16x128_f8f6f4",
+           {RegClass::VGPR, 64, 4},
+           {RegClass::VGPR, 32, 4},
+           "v_mfma_scale_f32_16x16x128_f8f6f4 v[64:67], v[0:3], v[16:19], "
+           "v[32:35], v96, v97"},
+      Case{{0xD3AC0000u, 0x0002C360u, 0xD3AE0C40u, 0x84822100u},
+           "v_mfma_scale_f32_32x32x64_f8f6f4",
+           {RegClass::VGPR, 64, 16},
+           {RegClass::VGPR, 32, 16},
+           "v_mfma_scale_f32_32x32x64_f8f6f4 v[64:79], v[0:3], v[16:19], "
+           "v[32:47], v96, v97"},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &test_case : cases) {
+    SCOPED_TRACE(test_case.mnemonic);
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, test_case.words.data()));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->mnemonic(), test_case.mnemonic);
+    EXPECT_EQ(inst->size(), sizeof(test_case.words));
+    ASSERT_EQ(inst->num_dst_operands(), 1);
+    ASSERT_EQ(inst->num_src_operands(), 5);
+
+    EXPECT_EQ(inst->dst_operand(0)->encoding_value(), 64u);
+    EXPECT_EQ(inst->dst_operand(0)->size_bits(), test_case.destination.width * 32u);
+    EXPECT_EQ(inst->dst_operand(0)->to_register_ref(), test_case.destination);
+
+    constexpr std::array<uint32_t, 5> source_selectors = {256u, 272u, 288u, 352u, 353u};
+    const std::array source_refs = {
+        RegisterRef{RegClass::VGPR, 0, 4},
+        RegisterRef{RegClass::VGPR, 16, 4},
+        test_case.accumulator,
+        RegisterRef{RegClass::VGPR, 96, 1},
+        RegisterRef{RegClass::VGPR, 97, 1},
+    };
+    const std::array<uint32_t, 5> source_sizes = {
+        128u, 128u, test_case.accumulator.width * 32u, 32u, 32u,
+    };
+    for (size_t index = 0; index < source_selectors.size(); ++index) {
+      ASSERT_NE(inst->src_operand(index), nullptr);
+      EXPECT_EQ(inst->src_operand(index)->encoding_value(), source_selectors[index]);
+      EXPECT_EQ(inst->src_operand(index)->size_bits(), source_sizes[index]);
+      EXPECT_EQ(inst->src_operand(index)->to_register_ref(), source_refs[index]);
+    }
+    EXPECT_EQ(inst->disassemble(), test_case.disassembly);
+  }
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, ValidCompoundConsumesPrefixAndSuffixThenAdvancesToNextPc) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  constexpr auto scale = make_cdna4_mfma_scale_words(45, 1, vgpr_src(96), vgpr_src(97));
+  constexpr std::array<uint32_t, 8> stream = {scale[0],      scale[1], scale[2], scale[3],
+                                              kCdna4SEndpgm, 0,        0,        0};
+
+  std::vector<uint64_t> pcs;
+  std::vector<int> sizes;
+  std::vector<std::string_view> mnemonics;
+  for (uint64_t byte_pc = 0; byte_pc < 5 * sizeof(uint32_t);) {
+    std::unique_ptr<Instruction> inst(
+        decode_valid(*decoder, stream.data() + byte_pc / sizeof(uint32_t)));
+    ASSERT_NE(inst, nullptr);
+    pcs.push_back(byte_pc);
+    sizes.push_back(inst->size());
+    mnemonics.push_back(inst->mnemonic());
+    if (inst->mnemonic() == "s_endpgm")
+      break;
+    byte_pc += static_cast<uint64_t>(inst->size());
+  }
+
+  EXPECT_EQ(pcs, (std::vector<uint64_t>{0, 16}));
+  EXPECT_EQ(sizes, (std::vector<int>{16, 4}));
+  EXPECT_EQ(mnemonics,
+            (std::vector<std::string_view>{"v_mfma_scale_f32_16x16x128_f8f6f4", "s_endpgm"}));
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, RejectsUnsupportedPrefixAtPrefixPc) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  for (uint32_t op : {45u, 46u}) {
+    for (uint32_t abid = 0; abid < 16; ++abid) {
+      SCOPED_TRACE(testing::Message() << "op=" << op << " abid=" << abid);
+      const auto words = make_cdna4_mfma_scale_words(op, abid, vgpr_src(96), vgpr_src(97));
+      if (abid == 1) {
+        std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+        ASSERT_NE(inst, nullptr);
+        EXPECT_EQ(inst->size(), 16u);
+        EXPECT_EQ(inst->num_src_operands(), 5);
+      } else {
+        EXPECT_TRUE(decode_fails(*decoder, words.data()));
+      }
+    }
+  }
+
+  constexpr auto abid_zero = make_cdna4_mfma_scale_words(45, 0, vgpr_src(96), vgpr_src(97));
+  std::unique_ptr<Instruction> suffix_inst(decode_valid(*decoder, abid_zero.data() + 2));
+  ASSERT_NE(suffix_inst, nullptr);
+  EXPECT_EQ(suffix_inst->mnemonic(), "v_mfma_f32_16x16x128_f8f6f4");
+  EXPECT_EQ(suffix_inst->size(), 8u);
+  EXPECT_EQ(suffix_inst->num_src_operands(), 3);
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, RejectsMalformedPrefixSuffixPairsAndBareNonzeroSuffix) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  auto non_mfma_suffix = make_cdna4_mfma_scale_words(45, 1, vgpr_src(96), vgpr_src(97));
+  non_mfma_suffix[2] = kCdna4SEndpgm;
+  EXPECT_TRUE(decode_fails(*decoder, non_mfma_suffix.data()));
+
+  auto wrong_suffix_opcode = make_cdna4_mfma_scale_words(47, 1, vgpr_src(96), vgpr_src(97));
+  EXPECT_TRUE(decode_fails(*decoder, wrong_suffix_opcode.data()));
+
+  for (uint32_t op : {45u, 46u}) {
+    SCOPED_TRACE(testing::Message() << "op=" << op);
+    for (uint32_t abid = 1; abid < 16; ++abid) {
+      SCOPED_TRACE(testing::Message() << "abid=" << abid);
+      const auto marked_suffix = make_cdna4_mfma_scale_words(op, abid, vgpr_src(96), vgpr_src(97));
+      EXPECT_TRUE(decode_fails(*decoder, marked_suffix.data() + 2));
+    }
+
+    const auto dense_suffix = make_cdna4_mfma_scale_words(op, 0, vgpr_src(96), vgpr_src(97));
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, dense_suffix.data() + 2));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->size(), 8u);
+    EXPECT_EQ(inst->num_src_operands(), 3);
+  }
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, RejectsIllegalScaleSelectors) {
+  struct InvalidSelector {
+    uint32_t selector;
+    std::string_view name;
+  };
+  constexpr std::array invalid_selectors = {
+      InvalidSelector{0, "sgpr"},      InvalidSelector{128, "integer inline"},
+      InvalidSelector{251, "special"}, InvalidSelector{249, "reserved"},
+      InvalidSelector{255, "literal"},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &invalid : invalid_selectors) {
+    for (uint32_t scale_position = 0; scale_position < 2; ++scale_position) {
+      SCOPED_TRACE(testing::Message() << invalid.name << " scale_position=" << scale_position);
+      auto words = make_cdna4_mfma_scale_words(45, 1, vgpr_src(96), vgpr_src(97));
+      if (scale_position == 0)
+        words[1] = (words[1] & ~(0x1FFu)) | invalid.selector;
+      else
+        words[1] = (words[1] & ~(0x1FFu << 9)) | (invalid.selector << 9);
+      EXPECT_TRUE(decode_fails(*decoder, words.data()));
+    }
+  }
+}
+
+TEST(Cdna4BlockScaleMfmaDecodeTest, RejectsReservedFormatsAndSourceModifiers) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  for (uint32_t format = 5; format < 8; ++format) {
+    for (bool is_b_format : {false, true}) {
+      SCOPED_TRACE(testing::Message() << "format=" << format << " is_b_format=" << is_b_format);
+      const uint32_t a_format = is_b_format ? 0u : format;
+      const uint32_t b_format = is_b_format ? format : 0u;
+      const auto words =
+          make_cdna4_mfma_scale_words(45, 1, vgpr_src(96), vgpr_src(97), 0, 0, a_format, b_format);
+      EXPECT_TRUE(decode_fails(*decoder, words.data()));
+      EXPECT_TRUE(decode_fails(*decoder, words.data() + 2));
+    }
+  }
+
+  for (const auto &[word, bit] :
+       std::array<std::pair<uint32_t, uint32_t>, 4>{{{0, 8}, {0, 9}, {1, 29}, {1, 30}}}) {
+    SCOPED_TRACE(testing::Message() << "word=" << word << " bit=" << bit);
+    auto words = make_cdna4_mfma_scale_words(45, 1, vgpr_src(96), vgpr_src(97));
+    words[word] |= 1u << bit;
+    EXPECT_TRUE(decode_fails(*decoder, words.data()));
+  }
+}
+
+class Cdna4BlockScaleMfmaExecutionTest : public testing::Test {
+protected:
+  using ComputeUnit = amdgpu::IsaExecComputeUnit<simdojo::ExecMode::FUNCTIONAL, cdna4::Isa>;
+
+  static constexpr uint32_t kSrc0 = 0;
+  static constexpr uint32_t kSrc1 = 16;
+  static constexpr uint32_t kAccumulator = 32;
+  static constexpr uint32_t kDst = 64;
+  static constexpr uint32_t kScaleA = 96;
+  static constexpr uint32_t kScaleB = 97;
+
+  void SetUp() override {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = 106;
+    cfg.vgprs_per_wf = 256;
+    cfg.lds_size_kb = 64;
+
+    cu = std::make_unique<ComputeUnit>("cdna4_block_scale_mfma", cfg, &gpu_mem, &l2);
+    ASSERT_NE(cu, nullptr);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_NE(decoder, nullptr);
+    wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+    ASSERT_NE(wf, nullptr);
+    wf->set_exec(~uint64_t{0});
+    vgpr_base = wf->vgpr_alloc().base;
+  }
+
+  void TearDown() override {
+    if (wf && !wf->is_halted())
+      wf->halt();
+  }
+
+  void seed_inputs(uint32_t packed_value) {
+    for (uint32_t reg = 0; reg < 8; ++reg) {
+      for (uint32_t lane = 0; lane < 64; ++lane) {
+        cu->write_vgpr(vgpr_base + kSrc0 + reg, lane, packed_value);
+        cu->write_vgpr(vgpr_base + kSrc1 + reg, lane, packed_value);
+      }
+    }
+  }
+
+  void seed_accumulator(uint32_t bits, uint32_t output_registers) {
+    for (uint32_t reg = 0; reg < output_registers; ++reg)
+      for (uint32_t lane = 0; lane < 64; ++lane)
+        cu->write_vgpr(vgpr_base + kAccumulator + reg, lane, bits);
+  }
+
+  void seed_scale(uint32_t reg, uint32_t word) {
+    for (uint32_t lane = 0; lane < 64; ++lane)
+      cu->write_vgpr(vgpr_base + reg, lane, word);
+  }
+
+  void seed_scale_lane(uint32_t reg, uint32_t lane, uint32_t word) {
+    cu->write_vgpr(vgpr_base + reg, lane, word);
+  }
+
+  void write_input_element(uint32_t base_reg, uint32_t dim, uint32_t k_size, uint32_t outer,
+                           uint32_t k, uint32_t bits, uint32_t other_bits, uint32_t raw) {
+    auto loc = amdgpu::physicalize_loc(
+        amdgpu::mfma_scale_f8f6f4_input_loc(dim, k_size, outer, k, bits, other_bits),
+        wf->wf_size());
+    const uint32_t value_mask = bits == 32 ? 0xFFFF'FFFFu : ((1u << bits) - 1u);
+    const uint32_t reg = vgpr_base + base_reg + loc.vgpr_offset;
+    const uint64_t shifted_mask = static_cast<uint64_t>(value_mask) << loc.bit_offset;
+    const uint64_t shifted_value = static_cast<uint64_t>(raw & value_mask) << loc.bit_offset;
+    const uint32_t old_low = cu->read_vgpr(reg, loc.lane);
+    cu->write_vgpr(reg, loc.lane,
+                   (old_low & ~static_cast<uint32_t>(shifted_mask)) |
+                       static_cast<uint32_t>(shifted_value));
+    if (loc.bit_offset + bits > 32) {
+      const uint32_t old_high = cu->read_vgpr(reg + 1, loc.lane);
+      const uint32_t high_mask = static_cast<uint32_t>(shifted_mask >> 32);
+      cu->write_vgpr(reg + 1, loc.lane,
+                     (old_high & ~high_mask) | static_cast<uint32_t>(shifted_value >> 32));
+    }
+  }
+
+  static float nonuniform_a_seed(uint32_t row, uint32_t k) {
+    constexpr std::array<float, 4> values = {1.0f, -0.5f, 1.5f, 0.25f};
+    return values[(row + 3u * k) & 3u];
+  }
+
+  static float nonuniform_b_seed(uint32_t col, uint32_t k) {
+    constexpr std::array<float, 4> values = {1.0f, -1.0f, 0.5f, 2.0f};
+    return values[(col + k) & 3u];
+  }
+
+  static uint8_t nonuniform_a_raw(uint32_t row, uint32_t k) {
+    return util::f32_to_fp8_e4m3_rne(nonuniform_a_seed(row, k));
+  }
+
+  static uint8_t nonuniform_b_raw(uint32_t col, uint32_t k) {
+    return util::f32_to_fp4_e2m1_rne(nonuniform_b_seed(col, k));
+  }
+
+  static uint32_t format_bits(uint32_t fmt) {
+    constexpr std::array<uint32_t, 5> bits = {8, 8, 6, 6, 4};
+    return bits.at(fmt);
+  }
+
+  static uint8_t format_raw(uint32_t fmt, float value) {
+    switch (fmt) {
+    case 0:
+      return util::f32_to_fp8_e4m3_rne(value);
+    case 1:
+      return util::f32_to_bf8_e5m2_rne(value);
+    case 2:
+      return util::f32_to_fp6_e2m3_rne(value);
+    case 3:
+      return util::f32_to_bf6_e3m2_rne(value);
+    case 4:
+      return util::f32_to_fp4_e2m1_rne(value);
+    default:
+      return 0;
+    }
+  }
+
+  static float format_matrix_a(uint32_t row, uint32_t k) {
+    return ((row + 3u * k) & 1u) ? -1.0f : 1.0f;
+  }
+
+  static float format_matrix_b(uint32_t col, uint32_t k) {
+    return ((col + k / 3u) & 1u) ? -1.0f : 1.0f;
+  }
+
+  void seed_format_pair(uint32_t matrix_size, uint32_t a_fmt, uint32_t b_fmt) {
+    seed_inputs(0);
+    const uint32_t k_size = matrix_size == 16 ? 128u : 64u;
+    const uint32_t a_bits = format_bits(a_fmt);
+    const uint32_t b_bits = format_bits(b_fmt);
+    for (uint32_t row = 0; row < matrix_size; ++row)
+      for (uint32_t k = 0; k < k_size; ++k)
+        write_input_element(kSrc0, matrix_size, k_size, row, k, a_bits, b_bits,
+                            format_raw(a_fmt, format_matrix_a(row, k)));
+    for (uint32_t col = 0; col < matrix_size; ++col)
+      for (uint32_t k = 0; k < k_size; ++k)
+        write_input_element(kSrc1, matrix_size, k_size, col, k, b_bits, a_bits,
+                            format_raw(b_fmt, format_matrix_b(col, k)));
+  }
+
+  static float reference_format_pair(uint32_t matrix_size, uint32_t row, uint32_t col) {
+    const uint32_t k_size = matrix_size == 16 ? 128u : 64u;
+    float result = 0.0f;
+    for (uint32_t k = 0; k < k_size; ++k)
+      result += format_matrix_a(row, k) * format_matrix_b(col, k);
+    return result;
+  }
+
+  static uint8_t nonuniform_scale_a_exp(uint32_t row, uint32_t blk) {
+    return static_cast<uint8_t>(126u + ((row + blk) & 3u));
+  }
+
+  static uint8_t nonuniform_scale_b_exp(uint32_t col, uint32_t blk) {
+    return static_cast<uint8_t>(125u + ((col + 2u * blk) & 3u));
+  }
+
+  void seed_nonuniform_fp8_fp4_case() {
+    seed_inputs(0);
+    seed_scale(kScaleA, 0);
+    seed_scale(kScaleB, 0);
+
+    for (uint32_t row = 0; row < 16; ++row)
+      for (uint32_t k = 0; k < 128; ++k)
+        write_input_element(kSrc0, /*dim=*/16, /*k_size=*/128, row, k, /*bits=*/8,
+                            /*other_bits=*/4, nonuniform_a_raw(row, k));
+    for (uint32_t col = 0; col < 16; ++col)
+      for (uint32_t k = 0; k < 128; ++k)
+        write_input_element(kSrc1, /*dim=*/16, /*k_size=*/128, col, k, /*bits=*/4,
+                            /*other_bits=*/8, nonuniform_b_raw(col, k));
+
+    for (uint32_t blk = 0; blk < 4; ++blk) {
+      for (uint32_t row = 0; row < 16; ++row)
+        seed_scale_lane(kScaleA, 16 * blk + row, nonuniform_scale_a_exp(row, blk));
+      for (uint32_t col = 0; col < 16; ++col)
+        seed_scale_lane(kScaleB, 16 * blk + col, nonuniform_scale_b_exp(col, blk));
+    }
+  }
+
+  static float reference_nonuniform_fp8_fp4(uint32_t row, uint32_t col) {
+    float acc = 0.25f;
+    for (uint32_t blk = 0; blk < 4; ++blk) {
+      float block_sum = 0.0f;
+      for (uint32_t k = blk * 32; k < (blk + 1) * 32; ++k) {
+        const float a = util::fp8_e4m3_ocp_to_f32(nonuniform_a_raw(row, k));
+        const float b = util::fp4_e2m1_to_f32(nonuniform_b_raw(col, k));
+        block_sum = std::fma(a, b, block_sum);
+      }
+      const int scale_exp = static_cast<int>(nonuniform_scale_a_exp(row, blk)) +
+                            static_cast<int>(nonuniform_scale_b_exp(col, blk)) - 254;
+      acc += std::ldexp(block_sum, scale_exp);
+    }
+    return acc;
+  }
+
+  uint32_t read_output(uint32_t matrix_size, uint32_t row, uint32_t col) const {
+    const auto out = amdgpu::physicalize_out(
+        amdgpu::output_loc_32(matrix_size, matrix_size, row, col, 0), wf->wf_size());
+    return cu->read_vgpr(vgpr_base + kDst + out.reg, out.lane);
+  }
+
+  std::vector<uint32_t> capture_outputs(uint32_t output_registers) const {
+    std::vector<uint32_t> words;
+    words.reserve(output_registers * wf->wf_size());
+    for (uint32_t reg = 0; reg < output_registers; ++reg)
+      for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+        words.push_back(cu->read_vgpr(vgpr_base + kDst + reg, lane));
+    return words;
+  }
+
+  uint32_t captured_output(const std::vector<uint32_t> &words, uint32_t matrix_size, uint32_t row,
+                           uint32_t col) const {
+    const auto out = amdgpu::physicalize_out(
+        amdgpu::output_loc_32(matrix_size, matrix_size, row, col, 0), wf->wf_size());
+    return words.at(out.reg * wf->wf_size() + out.lane);
+  }
+
+  uint32_t execute(uint32_t matrix_size, bool has_prefix, uint32_t abid, uint32_t scale_a,
+                   uint32_t scale_b, uint32_t a_byte = 0, uint32_t b_byte = 0, bool c_abs = false,
+                   bool c_neg = false, uint32_t src2 = vgpr_src(kAccumulator), uint32_t cbsz = 4,
+                   uint32_t blgp = 4) {
+    const uint32_t op = matrix_size == 16 ? 45u : 46u;
+    const uint32_t suffix0 =
+        kDst | ((cbsz & 0x7u) << 8) | ((abid & 0xfu) << 11) | (op << 16) | (423u << 23);
+    const uint32_t suffix1 =
+        vgpr_src(kSrc0) | (vgpr_src(kSrc1) << 9) | (src2 << 18) | ((blgp & 0x7u) << 29);
+    std::array<uint32_t, 4> words{};
+    const uint32_t *encoding = nullptr;
+    if (has_prefix) {
+      const uint32_t op_sel = (a_byte & 1u) | ((b_byte & 1u) << 1);
+      const uint32_t op_sel_hi = ((a_byte >> 1) & 1u) | (((b_byte >> 1) & 1u) << 1);
+      words = {0xD3AC0000u | (static_cast<uint32_t>(c_abs) << 10) | (op_sel << 11),
+               (scale_a & 0x1ffu) | ((scale_b & 0x1ffu) << 9) | (op_sel_hi << 27) |
+                   (static_cast<uint32_t>(c_neg) << 31),
+               suffix0, suffix1};
+      encoding = words.data();
+    } else {
+      words = {suffix0, suffix1, 0, 0};
+      encoding = words.data();
+    }
+
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, encoding));
+    EXPECT_NE(inst, nullptr);
+    if (!inst)
+      return 0;
+    EXPECT_EQ(inst->size(), has_prefix && abid == 1u ? 16u : 8u);
+    static_cast<amdgpu::ComputeUnitCore &>(*cu).execute_instruction(inst.get(), *wf);
+    return cu->read_vgpr(vgpr_base + kDst, 0);
+  }
+
+  amdgpu::GpuMemory gpu_mem{"cdna4_block_scale_mfma_mem"};
+  amdgpu::L2Cache l2{"cdna4_block_scale_mfma_l2"};
+  std::unique_ptr<ComputeUnit> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+  uint32_t vgpr_base = 0;
+};
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, VgprScaleByteSelectorsAreIndependent) {
+  seed_inputs(0x22222222u); // Eight packed FP4 1.0 values.
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 4);
+  constexpr std::array<uint8_t, 4> a_exponents = {0x7f, 0x80, 0x7e, 0x81};
+  constexpr std::array<uint8_t, 4> b_exponents = {0x80, 0x7d, 0x82, 0x7c};
+  seed_scale(kScaleA, 0x817E807Fu);
+  seed_scale(kScaleB, 0x7C827D80u);
+
+  for (uint32_t a_byte = 0; a_byte < 4; ++a_byte) {
+    for (uint32_t b_byte = 0; b_byte < 4; ++b_byte) {
+      const uint32_t actual =
+          execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB), a_byte, b_byte);
+      const float expected = std::ldexp(128.0f, static_cast<int>(a_exponents[a_byte]) +
+                                                    static_cast<int>(b_exponents[b_byte]) - 254);
+      EXPECT_EQ(actual, std::bit_cast<uint32_t>(expected))
+          << "a_byte=" << a_byte << " b_byte=" << b_byte;
+    }
+  }
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, VgprScaleWorksFor32x32x64Shape) {
+  seed_inputs(0x22222222u);
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 16);
+  seed_scale(kScaleA, 0x817E807Fu);
+  seed_scale(kScaleB, 0x7C827D80u);
+
+  const uint32_t actual = execute(32, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB), /*a_byte=*/3,
+                                  /*b_byte=*/2);
+  EXPECT_EQ(actual, std::bit_cast<uint32_t>(2048.0f));
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, ScaleLaneUsesIndependentBlockRowAndColumn) {
+  seed_inputs(0x22222222u);
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 4);
+  seed_scale(kScaleA, 0x7F7F7F7Fu);
+  seed_scale(kScaleB, 0x7F7F7F7Fu);
+
+  constexpr uint32_t row = 3;
+  constexpr uint32_t col = 5;
+  constexpr uint32_t block = 2;
+  constexpr uint32_t a_lane = 16 * block + row;
+  constexpr uint32_t b_lane = 16 * block + col;
+  seed_scale_lane(kScaleA, a_lane, 0x00000080u);
+  seed_scale_lane(kScaleA, b_lane, 0x0000007Du);
+  seed_scale_lane(kScaleB, a_lane, 0x00000082u);
+  execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB));
+
+  const auto out = amdgpu::physicalize_out(amdgpu::output_loc_32(16, 16, row, col, 0), 64);
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + kDst + out.reg, out.lane), std::bit_cast<uint32_t>(160.0f));
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, GeneratedMixedScaleScalarAndSimdMatchReference) {
+  seed_nonuniform_fp8_fp4_case();
+
+  auto run = [&](bool force_scalar) {
+    ForceScalarGuard guard(force_scalar);
+    seed_accumulator(std::bit_cast<uint32_t>(0.25f), 4);
+    execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB), /*a_byte=*/0, /*b_byte=*/0,
+            /*c_abs=*/false, /*c_neg=*/false, vgpr_src(kAccumulator), /*cbsz=*/0, /*blgp=*/4);
+    return capture_outputs(/*output_registers=*/4);
+  };
+
+  const auto scalar = run(true);
+  const auto simd = run(false);
+  EXPECT_EQ(simd, scalar);
+
+  for (const auto &[row, col] :
+       std::array<std::pair<uint32_t, uint32_t>, 4>{{{0, 0}, {3, 5}, {9, 2}, {15, 15}}}) {
+    const float expected = reference_nonuniform_fp8_fp4(row, col);
+    EXPECT_EQ(captured_output(simd, 16, row, col), std::bit_cast<uint32_t>(expected))
+        << "row=" << row << " col=" << col;
+  }
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, AllFormatPairsMatchPhysicalLayoutReference) {
+  seed_scale(kScaleA, 0x7F7F7F7Fu);
+  seed_scale(kScaleB, 0x7F7F7F7Fu);
+
+  for (uint32_t matrix_size : {16u, 32u}) {
+    for (uint32_t a_fmt = 0; a_fmt <= 4; ++a_fmt) {
+      for (uint32_t b_fmt = 0; b_fmt <= 4; ++b_fmt) {
+        SCOPED_TRACE(testing::Message()
+                     << "matrix_size=" << matrix_size << " a_fmt=" << a_fmt << " b_fmt=" << b_fmt);
+        seed_format_pair(matrix_size, a_fmt, b_fmt);
+        auto run = [&](bool force_scalar) {
+          ForceScalarGuard guard(force_scalar);
+          const uint32_t output_registers = matrix_size == 16 ? 4u : 16u;
+          seed_accumulator(std::bit_cast<uint32_t>(0.0f), output_registers);
+          execute(matrix_size, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB), 0, 0, false, false,
+                  vgpr_src(kAccumulator), a_fmt, b_fmt);
+          return capture_outputs(output_registers);
+        };
+
+        const auto scalar = run(true);
+        const auto simd = run(false);
+        EXPECT_EQ(simd, scalar);
+        for (uint32_t row = 0; row < matrix_size; ++row) {
+          for (uint32_t col = 0; col < matrix_size; ++col) {
+            EXPECT_EQ(captured_output(simd, matrix_size, row, col),
+                      std::bit_cast<uint32_t>(reference_format_pair(matrix_size, row, col)))
+                << "row=" << row << " col=" << col;
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, GeneratedScaleHalfUlpContributionRoundsToEven) {
+  seed_inputs(0x22222222u); // Eight packed FP4 1.0 values.
+  seed_scale(kScaleA, 0);
+  seed_scale(kScaleB, 0);
+  seed_scale_lane(kScaleA, /*lane=*/0, /*e8m0 2^0*/ 0x7Fu);
+  seed_scale_lane(kScaleB, /*lane=*/0, /*e8m0 2^-29*/ 0x62u);
+
+  for (bool force_scalar : {true, false}) {
+    ForceScalarGuard guard(force_scalar);
+    seed_accumulator(std::bit_cast<uint32_t>(1.0f), 4);
+    execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB));
+
+    // row0/col0 block0 contributes 32 * 2^-29 == 2^-24, exactly one half ULP
+    // at 1.0f. Round-to-nearest-even must keep the accumulator at 1.0f.
+    EXPECT_EQ(read_output(16, /*row=*/0, /*col=*/0), std::bit_cast<uint32_t>(1.0f))
+        << "force_scalar=" << force_scalar;
+  }
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, FloatInlineScalesUseOnlyTheirExponent) {
+  seed_inputs(0x22222222u);
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 4);
+  constexpr std::array<uint8_t, 9> inline_exponents = {126, 126, 127, 127, 128, 128, 129, 129, 124};
+
+  for (uint32_t selector = 240; selector <= 248; ++selector) {
+    const uint32_t actual = execute(16, true, 1, selector, /*+1.0f=*/242);
+    const float expected =
+        std::ldexp(128.0f, static_cast<int>(inline_exponents[selector - 240]) - 127);
+    EXPECT_EQ(actual, std::bit_cast<uint32_t>(expected)) << "selector=" << selector;
+  }
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, PrefixAndAbidMarkerEnableScaling) {
+  seed_inputs(0x22222222u);
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 4);
+  seed_scale(kScaleA, 0x80808080u);
+  seed_scale(kScaleB, 0x80808080u);
+
+  EXPECT_EQ(execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB)),
+            std::bit_cast<uint32_t>(512.0f));
+  EXPECT_EQ(execute(16, false, 0, vgpr_src(kScaleA), vgpr_src(kScaleB)),
+            std::bit_cast<uint32_t>(128.0f));
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, E8m0FfScaleProducesNan) {
+  seed_inputs(0x22222222u);
+  seed_accumulator(std::bit_cast<uint32_t>(0.0f), 4);
+  seed_scale(kScaleA, 0xFFFFFFFFu);
+  seed_scale(kScaleB, 0x7F7F7F7Fu);
+
+  EXPECT_TRUE(
+      std::isnan(std::bit_cast<float>(execute(16, true, 1, vgpr_src(kScaleA), vgpr_src(kScaleB)))));
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, PrefixCModifiersApplyAbsBeforeNegate) {
+  seed_inputs(0);
+  constexpr std::array<float, 4> expected = {-3.0f, 3.0f, 3.0f, -3.0f};
+  for (uint32_t modifiers = 0; modifiers < 4; ++modifiers) {
+    seed_accumulator(std::bit_cast<uint32_t>(-3.0f), 4);
+    const uint32_t actual =
+        execute(16, true, 1, /*+1.0f=*/242, /*+1.0f=*/242, 0, 0, modifiers & 2u, modifiers & 1u);
+    EXPECT_EQ(actual, std::bit_cast<uint32_t>(expected[modifiers])) << "modifiers=" << modifiers;
+  }
+
+  EXPECT_EQ(execute(16, true, 1, /*+1.0f=*/242, /*+1.0f=*/242, 0, 0,
+                    /*c_abs=*/true, /*c_neg=*/false, /*-1.0f=*/243),
+            std::bit_cast<uint32_t>(1.0f));
+}
+
+TEST_F(Cdna4BlockScaleMfmaExecutionTest, BareFp4FormatBitsDoNotModifyAccumulator) {
+  seed_inputs(0);
+  seed_accumulator(std::bit_cast<uint32_t>(-3.0f), 4);
+  EXPECT_EQ(execute(16, false, 0, 0, 0), std::bit_cast<uint32_t>(-3.0f));
+
+  auto hostile_prefix = make_cdna4_mfma_scale_words(45, 0, vgpr_src(kScaleA), vgpr_src(kScaleB));
+  hostile_prefix[0] |= 1u << 10;
+  EXPECT_TRUE(decode_fails(*decoder, hostile_prefix.data()));
+}
+
+TEST(Cdna4BlockScaleMfmaModifierTest, SignedZeroTruthTable) {
+  constexpr uint32_t negative_zero = 0x80000000u;
+  EXPECT_EQ(std::bit_cast<uint32_t>(
+                amdgpu::apply_wmma_c_modifier(std::bit_cast<float>(negative_zero), /*none=*/0)),
+            negative_zero);
+  EXPECT_EQ(std::bit_cast<uint32_t>(
+                amdgpu::apply_wmma_c_modifier(std::bit_cast<float>(negative_zero), /*neg=*/1)),
+            0u);
+  EXPECT_EQ(std::bit_cast<uint32_t>(
+                amdgpu::apply_wmma_c_modifier(std::bit_cast<float>(negative_zero), /*abs=*/2)),
+            0u);
+  EXPECT_EQ(std::bit_cast<uint32_t>(amdgpu::apply_wmma_c_modifier(
+                std::bit_cast<float>(negative_zero), /*abs-then-neg=*/3)),
+            negative_zero);
 }
 
 // v_permlane16_swap_b32 on a wave64 swaps ALL FOUR 16-lane groups: it exchanges

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -9,17 +9,22 @@
 /// Both modes run in the same process; the `amdgpu::simd_force_scalar()`
 /// thread-local flag flips the kernel between its dense native-width matmul
 /// (SIMD) and the per-output scalar triple-loop. The benchmark drives the
-/// execute kernels directly (no decode) so it isolates the matmul body, then
-/// reports ns/MFMA and speedup and checks SIMD-vs-scalar agreement:
+/// execute kernels directly so they isolate the matmul body, then report
+/// ns/MFMA and speedup and check SIMD-vs-scalar agreement. The generated
+/// block-scale benchmark decodes once up front and invokes the generated
+/// instruction implementation in the timed loop:
 ///   - i32/i8 output: integer MAC is exact, bit-identical.
 ///   - f32/f64 output: SIMD uses fused FMA (matching GFX9 MFMA hardware) while
 ///     the scalar reference is non-fused, so results agree to a small relative
 ///     tolerance, not bit-exactly.
 
+#include "decode_test_util.h"
 #include "mma_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -30,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <bit>
 #include <chrono>
 #include <cmath>
@@ -57,6 +63,8 @@ constexpr uint32_t S0_OFF = 0;
 constexpr uint32_t S1_OFF = 64;
 constexpr uint32_t DST_OFF = 128;
 constexpr uint32_t OUT_REGS = 32; // dst window read back for the correctness check.
+
+constexpr uint32_t vgpr_src(uint32_t reg) { return 256u + reg; }
 
 struct BenchFixture {
   amdgpu::GpuMemory gpu_mem;
@@ -499,26 +507,32 @@ TEST(MfmaSimdBenchmark, I32_32x32x32_i8_Specialized) {
   bench("v_mfma_i32_32x32x32_i8 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/true);
 }
 
-// v_mfma_scale_f32_16x16x128_f8f6f4: MX-scaled fp8 path (exec_f32_scaled),
-// in_bits=8, K=128 (4 K-blocks), N=16. Scales seeded to e8m0 127 (factor 1).
+// v_mfma_scale_f32_16x16x128_f8f6f4: MX-scaled fp8 path through the generated
+// CDNA4 instruction implementation. Scales are e8m0 127 (factor 1).
 TEST(MfmaSimdBenchmark, F32Scaled_16x16x128_fp8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
-  constexpr uint32_t M = 16, N = 16, K = 128, B = 1, bits = 8;
+  constexpr uint32_t M = 16, N = 16, K = 128, B = 1;
   constexpr uint32_t SCALE_A = 192, SCALE_B = 200;
-  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(13));
-  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(14));
+  fx.seed(S0_OFF, 8, /*bit_width=*/8, mma_test::SmallGen(13));
+  fx.seed(S1_OFF, 8, /*bit_width=*/8, mma_test::SmallGen(14));
   for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
     fx.cu->write_vgpr(fx.vbase + SCALE_A, lane, 0x7F7F7F7Fu); // e8m0 = 127 per block
     fx.cu->write_vgpr(fx.vbase + SCALE_B, lane, 0x7F7F7F7Fu);
   }
-  auto run = [&] {
-    amdgpu::exec_f32_scaled(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
-                            fx.vbase + S1_OFF, 0, amdgpu::extract_fp8, amdgpu::extract_fp8,
-                            /*const_acc=*/0, /*cbsz=*/0, /*abid=*/0, /*blgp=*/0, fx.vbase + SCALE_A,
-                            fx.vbase + SCALE_B);
-  };
-  bench("v_mfma_scale_f32_16x16x128_fp8", fx, run, double(M) * N * K * B, /*is_int=*/false);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  const auto words = mma_test::make_cdna4_mfma_scale_words(
+      45, /*abid=*/1, vgpr_src(SCALE_A), vgpr_src(SCALE_B), /*a_byte=*/0,
+      /*b_byte=*/0, /*cbsz=*/0, /*blgp=*/0, DST_OFF, vgpr_src(S0_OFF), vgpr_src(S1_OFF),
+      vgpr_src(32));
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(std::string_view(inst->mnemonic()), "v_mfma_scale_f32_16x16x128_f8f6f4");
+
+  auto run = [&] { fx.cu->execute_instruction(inst.get(), *fx.wf); };
+  bench("v_mfma_scale_f32_16x16x128_f8f6f4 [generated]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
 }
 
 // v_mfma_f64_16x16x4_f64: f64 path (native<double> == 8 lanes, N=16).

--- a/emulation/rocjitsu/tests/mma_test_util.h
+++ b/emulation/rocjitsu/tests/mma_test_util.h
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstdint>
 #include <random>
 
 namespace mma_test {
@@ -25,6 +27,21 @@ constexpr uint32_t WMMA_WF_SIZE = 32; // gfx1250 / RDNA WMMA is wave32.
 constexpr uint32_t SGPRS_PER_WF = 106;
 constexpr uint32_t VGPRS_PER_WF = 256;
 constexpr int BENCH_ITERATIONS = 4000;
+
+constexpr std::array<uint32_t, 4>
+make_cdna4_mfma_scale_words(uint32_t op, uint32_t abid, uint32_t scale_a, uint32_t scale_b,
+                            uint32_t a_byte = 0, uint32_t b_byte = 0, uint32_t cbsz = 4,
+                            uint32_t blgp = 4, uint32_t vdst = 64, uint32_t src0 = 256,
+                            uint32_t src1 = 272, uint32_t src2 = 288) {
+  const uint32_t op_sel = (a_byte & 1u) | ((b_byte & 1u) << 1);
+  const uint32_t op_sel_hi = ((a_byte >> 1) & 1u) | (((b_byte >> 1) & 1u) << 1);
+  return {0xD3AC0000u | (op_sel << 11),
+          (scale_a & 0x1FFu) | ((scale_b & 0x1FFu) << 9) | (op_sel_hi << 27),
+          (vdst & 0xFFu) | ((cbsz & 0x7u) << 8) | ((abid & 0xFu) << 11) | ((op & 0x7Fu) << 16) |
+              (423u << 23),
+          (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) |
+              ((blgp & 0x7u) << 29)};
+}
 
 // Small finite generator: values in roughly [-1, 1], deterministic per call.
 struct SmallGen {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -721,6 +721,95 @@ TEST(MfmaExecTest, WmmaF8f6f4K128InputLocUsesPairAwareSubbyteLayouts) {
             3u);
 }
 
+TEST(MfmaExecTest, WmmaF8f6f4K128InputLocMatchesManualLayoutsExhaustively) {
+  for (uint32_t data_bits : {4u, 6u, 8u}) {
+    for (uint32_t index = 0; index < 16; ++index) {
+      for (uint32_t k = 0; k < 128; ++k) {
+        SCOPED_TRACE(::testing::Message()
+                     << "data_bits=" << data_bits << " index=" << index << " k=" << k);
+        const uint32_t expected_lane = index + 16u * ((k >> 2u) & 1u);
+        const uint32_t expected_reg = ((k >> 1u) & 1u) + 2u * ((k >> 3u) & 1u) +
+                                      4u * ((k >> 4u) & 1u) + 8u * ((k >> 5u) & 1u) +
+                                      16u * ((k >> 6u) & 1u);
+        const uint32_t expected_slot = 2u * expected_reg + (k & 1u);
+        const uint32_t expected_bit = expected_slot * data_bits;
+        const auto actual =
+            amdgpu::wmma_f8f6f4_input_loc(16, 128, index, k, data_bits, /*mixed_subbyte=*/false);
+        EXPECT_EQ(actual.lane, expected_lane);
+        EXPECT_EQ(actual.vgpr_offset, expected_bit / 32u);
+        EXPECT_EQ(actual.bit_offset, expected_bit % 32u);
+        EXPECT_EQ(actual.data_bits, data_bits);
+      }
+    }
+  }
+
+  for (uint32_t data_bits : {4u, 6u}) {
+    for (uint32_t index = 0; index < 16; ++index) {
+      for (uint32_t k = 0; k < 128; ++k) {
+        SCOPED_TRACE(::testing::Message()
+                     << "mixed data_bits=" << data_bits << " index=" << index << " k=" << k);
+        const uint32_t expected_lane = index + 16u * ((k >> 5u) & 1u);
+        const uint32_t expected_slot = 32u * ((k >> 6u) & 1u) + 16u * ((k >> 2u) & 1u) +
+                                       8u * ((k >> 4u) & 1u) + 4u * ((k >> 3u) & 1u) +
+                                       2u * ((k >> 1u) & 1u) + (k & 1u);
+        const uint32_t expected_bit = expected_slot * data_bits;
+        const auto actual =
+            amdgpu::wmma_f8f6f4_input_loc(16, 128, index, k, data_bits, /*mixed_subbyte=*/true);
+        EXPECT_EQ(actual.lane, expected_lane);
+        EXPECT_EQ(actual.vgpr_offset, expected_bit / 32u);
+        EXPECT_EQ(actual.bit_offset, expected_bit % 32u);
+        EXPECT_EQ(actual.data_bits, data_bits);
+      }
+    }
+  }
+}
+
+TEST(MfmaExecTest, Cdna4ScaledMfmaInputLocMatchesSiliconQualifiedLayouts) {
+  constexpr std::array<uint32_t, 3> widths = {8, 6, 4};
+  for (const auto &[dim, k_size] :
+       std::array<std::pair<uint32_t, uint32_t>, 2>{{{16, 128}, {32, 64}}}) {
+    for (uint32_t data_bits : widths) {
+      for (uint32_t other_bits : widths) {
+        for (uint32_t index = 0; index < dim; ++index) {
+          for (uint32_t k = 0; k < k_size; ++k) {
+            SCOPED_TRACE(::testing::Message()
+                         << "dim=" << dim << " k_size=" << k_size << " data_bits=" << data_bits
+                         << " other_bits=" << other_bits << " index=" << index << " k=" << k);
+            uint32_t expected_lane;
+            uint32_t expected_slot;
+            if (data_bits == 8) {
+              const uint32_t lanes_per_block = 64u / dim;
+              const uint32_t chunk = k / 16u;
+              expected_lane = (chunk % lanes_per_block) * dim + index;
+              expected_slot = (chunk / lanes_per_block) * 16u + (k & 15u);
+            } else if (other_bits == 8 && dim == 16) {
+              expected_lane = 16u * (k / 32u) + index;
+              expected_slot = 16u * ((k / 16u) & 1u) + (k & 15u);
+            } else if (other_bits == 8) {
+              expected_lane = 32u * (k / 32u) + index;
+              expected_slot = k & 31u;
+            } else if (dim == 16) {
+              expected_lane = 16u * ((k % 64u) / 16u) + index;
+              expected_slot = 16u * (k / 64u) + (k & 15u);
+            } else {
+              expected_lane = 32u * ((k % 32u) / 16u) + index;
+              expected_slot = 16u * (k / 32u) + (k & 15u);
+            }
+
+            const auto actual =
+                amdgpu::mfma_scale_f8f6f4_input_loc(dim, k_size, index, k, data_bits, other_bits);
+            const uint32_t expected_bit = expected_slot * data_bits;
+            EXPECT_EQ(actual.lane, expected_lane);
+            EXPECT_EQ(actual.vgpr_offset, expected_bit / 32u);
+            EXPECT_EQ(actual.bit_offset, expected_bit % 32u);
+            EXPECT_EQ(actual.data_bits, data_bits);
+          }
+        }
+      }
+    }
+  }
+}
+
 TEST(MfmaExecTest, WmmaF4_32x16x128UsesConsecutiveM16ALayoutAndScaleLane) {
   auto row0 = amdgpu::wmma_a_input_loc(32, 128, /*row=*/0, /*k=*/0, 4, 4);
   EXPECT_EQ(row0.lane, 0u);

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -321,9 +321,10 @@ TEST(MfmaSimdExact, F32Scaled) {
     run_case(label, fmt, Fmt::F32, [=](MfmaFixture &fx, uint32_t const_acc) {
       fx.seed_words(SCALE_A, 4, 0xA5);
       fx.seed_words(SCALE_B, 4, 0x5A);
-      amdgpu::exec_f32_scaled(*fx.cu, m, n, k, 1, 8, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
-                              fx.vbase + ACC, ex, ex, const_acc, 0, 0, 0, fx.vbase + SCALE_A,
-                              fx.vbase + SCALE_B);
+      amdgpu::exec_f32_scaled_mixed(*fx.cu, m, n, k, 1, 8, 8, fx.vbase + DST, fx.vbase + S0,
+                                    fx.vbase + S1, fx.vbase + ACC, ex, ex, const_acc, fx.vbase,
+                                    256u + SCALE_A, 256u + SCALE_B,
+                                    /*scale_a_byte=*/0, /*scale_b_byte=*/0);
     });
   };
   scaled("scaled_fp8_16x16x128", Fmt::FP8, 16, 16, 128, amdgpu::extract_fp8);

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -16,9 +16,14 @@
 ///   - f32/f16/bf16 output: SIMD uses fused FMA (matching the hardware) while the
 ///     scalar reference is non-fused, so results agree to a small tolerance.
 
+#include "decode_test_util.h"
 #include "mma_test_util.h"
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/builders.h"
+#include "rocjitsu/isa/arch/amdgpu/generated/cdna5/opcodes.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -29,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <bit>
 #include <chrono>
 #include <cmath>
@@ -36,6 +42,7 @@
 #include <cstdio>
 #include <functional>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -56,7 +63,7 @@ constexpr uint32_t S0_OFF = 0;
 constexpr uint32_t S1_OFF = 32;
 constexpr uint32_t S2_OFF = 64;
 constexpr uint32_t INDEX_OFF = 96;
-constexpr uint32_t OUT_REGS = 8; // dst window read back for the correctness check.
+constexpr uint32_t OUT_REGS = 8; // Default dst window read back for the correctness check.
 
 constexpr uint32_t INDEX_ENTRIES = 16;
 constexpr uint32_t INDEX_KEY = 0;
@@ -139,9 +146,9 @@ struct BenchFixture {
         cu->write_vgpr(vbase + off + reg, lane, value);
   }
 
-  std::vector<uint32_t> snapshot_out() const {
-    std::vector<uint32_t> out(OUT_REGS * WF_SIZE);
-    for (uint32_t reg = 0; reg < OUT_REGS; ++reg)
+  std::vector<uint32_t> snapshot_out(uint32_t out_regs = OUT_REGS) const {
+    std::vector<uint32_t> out(out_regs * WF_SIZE);
+    for (uint32_t reg = 0; reg < out_regs; ++reg)
       for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
         out[reg * WF_SIZE + lane] = cu->read_vgpr(vbase + S2_OFF + reg, lane);
     return out;
@@ -190,16 +197,16 @@ void compare(const char *label, Cmp cmp, const std::vector<uint32_t> &sc,
 
 // Drive one WMMA kernel A/B: run scalar then SIMD, compare dst, then time both.
 void bench(const char *label, BenchFixture &fx, const std::function<void()> &run, double macs,
-           Cmp cmp) {
+           Cmp cmp, uint32_t out_regs = OUT_REGS) {
   ASSERT_NE(fx.cu, nullptr);
   ASSERT_NE(fx.wf, nullptr);
 
   util::set_force_scalar_for_testing(true);
   run();
-  auto result_scalar = fx.snapshot_out();
+  auto result_scalar = fx.snapshot_out(out_regs);
   util::set_force_scalar_for_testing(false);
   run();
-  auto result_simd = fx.snapshot_out();
+  auto result_simd = fx.snapshot_out(out_regs);
   compare(label, cmp, result_scalar, result_simd);
 
   auto time_mode = [&](bool force_scalar) -> double {
@@ -462,6 +469,62 @@ TEST(WmmaSimdBenchmark, F32_16x16x64_fp8_Specialized) {
                                                           fx.vbase + S2_OFF, /*const_acc=*/0);
   };
   bench("v_wmma_f32_16x16x64_fp8_fp8 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+TEST(WmmaSimdBenchmark, DecodedScaleF32_16x16x128_fp4) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 128;
+  const uint32_t fp4_one = util::f32_to_fp4_e2m1_rne(1.0f);
+  const uint32_t packed_fp4_one = fp4_one * 0x11111111u;
+  fx.seed_words(S0_OFF, 8, packed_fp4_one);
+  fx.seed_words(S1_OFF, 8, packed_fp4_one);
+  fx.seed_words(S2_OFF, OUT_REGS, 0);
+
+  constexpr auto prefix = cdna5::build_vop3p(0x35, {.src0 = 128, .src1 = 128, .src2 = 256});
+  auto matrix = cdna5::build_vop3p(cdna5::kVWmmaF3216x16x128F8f6f4Vop3p, {.vdst = S2_OFF,
+                                                                          .opsel = 4,
+                                                                          .src0 = 256 + S0_OFF,
+                                                                          .src1 = 256 + S1_OFF,
+                                                                          .src2 = 128,
+                                                                          .opsel_hi = 0});
+  matrix[0] |= 1u << 14;
+  const std::array<uint32_t, 4> words = {prefix[0], prefix[1], matrix[0], matrix[1]};
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+  ASSERT_NE(inst, nullptr);
+  auto run = [&] { fx.cu->execute_instruction(inst.get(), *fx.wf); };
+  bench("decoded v_wmma_scale_f32_16x16x128_fp4_fp4", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+TEST(WmmaSimdBenchmark, DecodedScaleF32_32x16x128_fp4) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 16, K = 128;
+  constexpr uint32_t kM32OutRegs = 16;
+  const uint32_t fp4_one = util::f32_to_fp4_e2m1_rne(1.0f);
+  const uint32_t packed_fp4_one = fp4_one * 0x11111111u;
+  fx.seed_words(S0_OFF, 16, packed_fp4_one);
+  fx.seed_words(S1_OFF, 8, packed_fp4_one);
+  fx.seed_words(S2_OFF, kM32OutRegs, 0);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &[prefix_op, label] : std::array<std::pair<uint16_t, const char *>, 2>{
+           {{0x35, "decoded v_wmma_scale_f32_32x16x128_fp4"},
+            {0x3a, "decoded v_wmma_scale16_f32_32x16x128_fp4"}}}) {
+    const auto prefix = cdna5::build_vop3p(prefix_op, {.src0 = 128, .src1 = 128, .src2 = 256});
+    auto matrix = cdna5::build_vop3p(
+        cdna5::kVWmmaF3232x16x128F4Vop3p,
+        {.vdst = S2_OFF, .src0 = 256 + S0_OFF, .src1 = 256 + S1_OFF, .src2 = 128, .opsel_hi = 3});
+    matrix[0] |= 1u << 14;
+    const std::array<uint32_t, 4> words = {prefix[0], prefix[1], matrix[0], matrix[1]};
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+    ASSERT_NE(inst, nullptr);
+    auto run = [&] { fx.cu->execute_instruction(inst.get(), *fx.wf); };
+    bench(label, fx, run, double(M) * N * K, Cmp::F32Tol, kM32OutRegs);
+  }
 }
 
 // Dense WMMA, f32 output, bf8 input, K=128 — specialized.


### PR DESCRIPTION
## Motivation

Block-scale wmma/mfma had several gaps. This PR addresses them.

## Technical Details
Fixed the following:
  - CDNA4: Block scales were not correctly affecting MFMA results.
  - CDNA4: The scale-load prefix and MFMA suffix were not handled as one compound instruction.
  - CDNA4: Scale values were selected from the wrong lanes/bytes across K blocks, rows, and columns.
  - CDNA4: Mixed FP8/FP6/FP4 operands used incorrect physical layouts.
  - CDNA4: Inline scale sources, NaN scales, and C modifiers were not fully modeled.
  - gfx1250: Block scales were applied at the wrong point in the dot-product calculation.
  - gfx1250: E5M3 scale decoding was missing.
  - gfx1250: SGPR scales used the wrong value for later K blocks.
  - gfx1250: Inline zero acted like zero instead of the neutral 1.0 scale for Scale16.
  - Both: Scalar and SIMD implementations did not agree with ISA formula.


## Issue Tracking

N/A

## Test Plan

New ctests + ci

## Test Result

Pass
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
