### PR TITLE
fix(rocclr): [ROCM-29126] fix hostcall listener shutdown race at process exit

### DIFF
--- a/projects/clr/rocclr/device/devhostcall.cpp
+++ b/projects/clr/rocclr/device/devhostcall.cpp
@@ -19,7 +19,6 @@
 #include "utils/flags.hpp"
 
 #include <assert.h>
-#include <stdio.h>
 #include <string.h>
 #include <algorithm>
 #include <atomic>
@@ -430,7 +429,8 @@ static struct Init {
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (IS_LINUX && running.load(std::memory_order_acquire) != 0) {
       if (std::chrono::steady_clock::now() > deadline) {
-        fprintf(stderr, "hostcall listener failed to stop; continuing teardown\n");
+        ClPrint(amd::LOG_ERROR, amd::LOG_INIT,
+                "Hostcall listener failed to stop; continuing teardown");
         break;
       }
       amd::Os::yield();

--- a/projects/clr/rocclr/device/devhostcall.cpp
+++ b/projects/clr/rocclr/device/devhostcall.cpp
@@ -19,8 +19,11 @@
 #include "utils/flags.hpp"
 
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <new>
 #include <set>
 
@@ -386,29 +389,67 @@ constexpr static uint64_t kSignalTimeout = K * K;
 constexpr static uint64_t kTimeoutFloor = K * K * 4;
 constexpr static uint64_t kTimeoutCeil = K * K * 16;
 #endif  // USE_NEW_HOSTCALL_IMPL
+// @note: Under Linux thread destruction can be delayed and ROCR may crash in a
+// wait for event occasionally. Hence the runtime must not finalize while a
+// hostcall listener thread is still running. The logic isn't required for
+// Windows.
+//
+// `running` counts listener threads that are live right now. It is raised by
+// the thread's creator before the thread is able to run, and lowered by the
+// thread itself on its way out, so `running == 0` implies that no listener is
+// executing and that none can start without raising it first. Counting live
+// threads rather than recording a state keeps this correct when a listener is
+// started and stopped repeatedly, and when a new listener overlaps one that is
+// still winding down.
+//
+// Both members are constant-initialized, so this object is valid from load
+// time and carries no static initialization order dependency.
 static struct Init {
-  enum class State { kDefault = 0, kInit, kDestroy, kExit };
-  volatile State state = State::kDefault;
+  std::atomic<uint32_t> running{0};
+  std::atomic<bool> shutdown{false};
+
+  //! Called before a listener thread is able to run.
+  void threadCreated() { running.fetch_add(1, std::memory_order_relaxed); }
+
+  //! Called by a listener thread on its way out.
+  void threadFinished() {
+    uint32_t previous = running.fetch_sub(1, std::memory_order_release);
+    assert(previous > 0 && "hostcall listener count underflow");
+    (void)previous;
+  }
+
+  //! Polled by listener threads, which must return promptly once this is set.
+  bool shutdownRequested() const { return shutdown.load(std::memory_order_acquire); }
+
   ~Init() {
-    if (state == State::kInit) {
-      state = State::kDestroy;
-      // @note: Under Linux thread destruction can be delayed and
-      // ROCR may crash in a wait for event occasionally. Hence, runtime needs
-      // an early exit. The logic isn't required for Windows.
-      while (IS_LINUX && (state == State::kDestroy)) {
+    shutdown.store(true, std::memory_order_release);
+    // A running listener notices the request within one wait timeout, so this
+    // is bounded in practice. The deadline is only a backstop against a wedged
+    // thread: proceeding is what the runtime did before the handshake existed,
+    // and is preferable to hanging the process forever.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (IS_LINUX && running.load(std::memory_order_acquire) != 0) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        fprintf(stderr, "hostcall listener failed to stop; continuing teardown\n");
+        break;
       }
+      amd::Os::yield();
     }
   }
 } kHostThreadActive;
+
+//! Lowers the live listener count on every exit path out of consumePackets().
+struct ListenerExitGuard {
+  ~ListenerExitGuard() { kHostThreadActive.threadFinished(); }
+};
 #ifdef USE_NEW_HOSTCALL_IMPL
 void HostcallListener::consumePackets() {
+  ListenerExitGuard exit_guard;
   uint64_t signal_value = SIGNAL_INIT;
-  kHostThreadActive.state = Init::State::kInit;
   uint32_t yield_spins = 0;
 
   while (true) {
-    if (kHostThreadActive.state == Init::State::kDestroy) {
-      kHostThreadActive.state = Init::State::kExit;
+    if (kHostThreadActive.shutdownRequested()) {
       return;
     }
 
@@ -446,13 +487,12 @@ void HostcallListener::consumePackets() {
 }
 #else  // !USE_NEW_HOSTCALL_IMPL
 void HostcallListener::consumePackets() {
+  ListenerExitGuard exit_guard;
   uint64_t timeout = kTimeoutFloor;
   uint64_t signal_value = SIGNAL_INIT;
-  kHostThreadActive.state = Init::State::kInit;
   while (true) {
     while (true) {
-      if (kHostThreadActive.state == Init::State::kDestroy) {
-        kHostThreadActive.state = Init::State::kExit;
+      if (kHostThreadActive.shutdownRequested()) {
         return;
       }
       uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
@@ -487,7 +527,6 @@ void HostcallListener::consumePackets() {
 
 void HostcallListener::terminate() {
   if (thread_.state() >= Thread::FINISHED || amd::Os::isThreadAlive(thread_)) {
-    kHostThreadActive.state = Init::State::kExit;
     doorbell_->Reset(SIGNAL_DONE);
 
     // FIXME_lmoriche: fix termination handshake
@@ -538,9 +577,13 @@ bool HostcallListener::initSignal(const amd::Device& dev) {
   urilocator = dev.createUriLocator();
 #endif
 #endif
-  // If the listener thread was not successfully initialized, clean
-  // everything up and bail out.
-  if (thread_.state() < Thread::INITIALIZED) {
+  // Count the thread as live before it is able to run, so that a finalizer
+  // racing with listener creation cannot conclude that nothing is running.
+  // If the listener thread was not successfully initialized or could not be
+  // started, drop the count again, clean everything up and bail out.
+  kHostThreadActive.threadCreated();
+  if (thread_.state() < Thread::INITIALIZED || !thread_.start(this)) {
+    kHostThreadActive.threadFinished();
     delete doorbell_;
 #ifdef USE_NEW_HOSTCALL_IMPL
     doorbell_ = nullptr;
@@ -556,7 +599,6 @@ bool HostcallListener::initSignal(const amd::Device& dev) {
 #endif
     return false;
   }
-  thread_.start(this);
   return true;
 }
 

--- a/projects/hip-tests/catch/config/configs/unit/printf.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/printf.yaml
@@ -28,3 +28,4 @@ printf:
   Unit_Printf_PrintfAltFormsTsts: *level_2
   Unit_Printf_HostcallLargeStaticTls_Positive: *level_2
   Unit_Printf_HostcallUndersizedStackRequest_Positive: *level_2
+  Unit_Printf_HostcallShutdown_Positive: *level_2

--- a/projects/hip-tests/catch/unit/printf/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/printf/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 if(UNIX)
   set(AMD_TEST_SRC
     hostcallStackSize.cc
+    hostcallShutdown.cc
     printfNonHost.cc
     hipPrintfManyDevices.cc
     hipPrintfStar.cc
@@ -90,5 +91,14 @@ if(UNIX AND HIP_PLATFORM MATCHES "amd")
   set_source_files_properties(hostcallStackSize_exe.cc PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
   set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hostcallStackSize_exe)
   add_dependencies(build_tests hostcallStackSize_exe)
+endif()
+
+# Exercises process teardown itself, so it needs a process that is allowed to finish exiting.
+if(UNIX AND HIP_PLATFORM MATCHES "amd")
+  add_executable(hostcallShutdown_exe EXCLUDE_FROM_ALL hostcallShutdown_exe.cc)
+  set_source_files_properties(hostcallShutdown_exe.cc PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
+  target_link_libraries(hostcallShutdown_exe pthread)
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hostcallShutdown_exe)
+  add_dependencies(build_tests hostcallShutdown_exe)
 endif()
 

--- a/projects/hip-tests/catch/unit/printf/hostcallShutdown.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallShutdown.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_process.hh>
+
+/**
+ * @addtogroup printf printf
+ * @{
+ * @ingroup PrintfTest
+ * `int printf()` -
+ * Method to print the content on output device.
+ */
+
+namespace {
+// The child reproduces the defect nine times in ten on a loaded core, so a few runs make a
+// regression practically impossible to miss while costing a second or so each when it is absent.
+constexpr int kRuns = 5;
+
+// The child arms a watchdog before it exits and leaves with this code if teardown never finishes.
+constexpr int kChildTimedOut = 66;
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Starts and stops the hostcall listener in a child process with the listener thread still
+ *      on its way to its entry point, which is the state the runtime used to mishandle. It could
+ *      be left either believing a listener was running when none was, spinning forever in a static
+ *      destructor, or believing none was running while one still was, finalizing underneath a live
+ *      thread. Both show up only as the process exits, so the child is a separate executable that
+ *      is required to exit promptly and cleanly.
+ *
+ * Test source
+ * ------------------------
+ *    - unit/printf/hostcallShutdown.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_Printf_HostcallShutdown_Positive) {
+  CHECK_PCIE_ATOMIC_SUPPORT
+
+  for (int run = 0; run < kRuns; ++run) {
+    hip::SpawnProc proc("hostcallShutdown_exe");
+    const int result = proc.run();
+    INFO("run " << run << " exited with " << result
+                << (result == kChildTimedOut ? " (watchdog fired: hung while exiting)" : ""));
+    REQUIRE(result == 0);
+  }
+}
+
+/**
+ * End doxygen group PrintfTest.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/printf/hostcallShutdown_exe.cc
+++ b/projects/hip-tests/catch/unit/printf/hostcallShutdown_exe.cc
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Companion executable for hostcallShutdown.cc, standalone because the defect it covers only
+// shows up while the process is exiting, which cannot be observed from inside a shared test
+// binary that has to keep running afterwards.
+//
+// The runtime spawns the hostcall listener when a kernel declaring hidden_hostcall_buffer is
+// dispatched, and stops it when the last such queue goes away. Shutdown has to stay correct even
+// when the listener thread has not been scheduled yet, so this process arranges for exactly that
+// and then requires itself to exit promptly.
+
+#include <hip/hip_runtime.h>
+
+#include <sched.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+namespace {
+// Each cycle starts a listener and stops it again. Only the last one decides whether the runtime
+// is left believing a listener is still running, so a handful is plenty.
+constexpr int kCycles = 3;
+constexpr int kSpinners = 4;
+
+// A clean shutdown takes milliseconds, so anything approaching this is a hang rather than a slow
+// machine.
+constexpr int kExitTimeoutSeconds = 20;
+constexpr int kExitTimedOut = 66;
+
+std::atomic<bool> stopSpinners{false};
+
+// The listener has to still be on its way to its entry point when the runtime tears it down. That
+// is a scheduling window, and it opens reliably when the runtime is driven on a busy core, so
+// confine everything to one CPU and keep it loaded. Pick a CPU this process is already allowed to
+// use rather than assuming CPU 0, since the test may well be running inside a cpuset. Failing to
+// pin is not fatal: the test simply becomes less likely to catch a regression, which beats
+// failing on a host that forbids it.
+void confineToOneCpu() {
+  cpu_set_t allowed;
+  CPU_ZERO(&allowed);
+  if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) {
+    std::fprintf(stderr, "warning: could not read CPU affinity, race window will be narrow\n");
+    return;
+  }
+
+  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (!CPU_ISSET(cpu, &allowed)) {
+      continue;
+    }
+    cpu_set_t one;
+    CPU_ZERO(&one);
+    CPU_SET(cpu, &one);
+    if (sched_setaffinity(0, sizeof(one), &one) != 0) {
+      break;
+    }
+    return;
+  }
+  std::fprintf(stderr, "warning: could not pin to one CPU, race window will be narrow\n");
+}
+
+extern "C" void onExitTimeout(int) {
+  static const char message[] = "process failed to finish exiting, hostcall shutdown hung\n";
+  // Only async-signal-safe calls are legal here.
+  ssize_t ignored = write(STDERR_FILENO, message, sizeof(message) - 1);
+  static_cast<void>(ignored);
+  _exit(kExitTimedOut);
+}
+
+// main() returning is not the end of the story here; the defect hangs in a static destructor
+// afterwards, which nothing inside the process is left running to report. An alarm outlives
+// main() and still fires during teardown, without leaving a thread of our own alive in the very
+// shutdown path under test.
+void armExitWatchdog() {
+  struct sigaction action {};
+  action.sa_handler = onExitTimeout;
+  sigemptyset(&action.sa_mask);
+  if (sigaction(SIGALRM, &action, nullptr) != 0) {
+    std::fprintf(stderr, "warning: could not install exit watchdog\n");
+    return;
+  }
+  alarm(kExitTimeoutSeconds);
+}
+}  // namespace
+
+// printf() makes the compiler declare hidden_hostcall_buffer, which is what makes the runtime
+// spawn the listener. The call is deliberately unreachable: a printf that actually runs would be
+// serviced by the listener, which proves the listener is already up and closes the very window
+// this test is trying to hit.
+__global__ void declaresHostcall(int never) {
+  if (never > 0) {
+    printf("unreachable\n");
+  }
+}
+
+int main() {
+  confineToOneCpu();
+
+  std::vector<std::thread> spinners;
+  spinners.reserve(kSpinners);
+  for (int i = 0; i < kSpinners; ++i) {
+    spinners.emplace_back([] {
+      while (!stopSpinners.load(std::memory_order_relaxed)) {
+      }
+    });
+  }
+
+  int status = 0;
+  for (int i = 0; i < kCycles; ++i) {
+    hipStream_t stream;
+    hipError_t err = hipStreamCreate(&stream);
+    if (err != hipSuccess) {
+      std::fprintf(stderr, "hipStreamCreate failed: %s\n", hipGetErrorString(err));
+      status = 1;
+      break;
+    }
+
+    declaresHostcall<<<1, 1, 0, stream>>>(0);
+
+    // A launch that never happened would leave no listener to shut down, quietly turning this
+    // into a test of nothing.
+    err = hipGetLastError();
+    if (err != hipSuccess) {
+      std::fprintf(stderr, "kernel launch failed: %s\n", hipGetErrorString(err));
+      status = 1;
+      break;
+    }
+
+    // Destroying the stream retires the last queue holding a hostcall buffer, so the listener is
+    // torn down here, possibly before it ever ran.
+    err = hipStreamDestroy(stream);
+    if (err != hipSuccess) {
+      std::fprintf(stderr, "hipStreamDestroy failed: %s\n", hipGetErrorString(err));
+      status = 1;
+      break;
+    }
+  }
+
+  stopSpinners.store(true, std::memory_order_relaxed);
+  for (auto& spinner : spinners) {
+    spinner.join();
+  }
+
+  armExitWatchdog();
+  return status;
+}


### PR DESCRIPTION
## Motivation

Processes that use HIP `printf` (or any other hostcall service) can hang forever
during static destruction at process exit, or crash in library teardown. The
failure needs no application error: it is a race in the ROCclr hostcall listener
shutdown handshake that is exposed whenever the listener thread is slow to be
scheduled, for example when several processes are pinned to the same core.

This was originally reported as a Kokkos unit test that intermittently took the
full 30s timeout instead of ~1s when four copies ran concurrently under
`OMP_PROC_BIND=close`. OpenMP is not at fault; it only supplies the CPU
oversubscription that makes the race likely.

## Technical Details

The static `Init` object that stops the runtime finalizing while a hostcall
listener thread is still running tracked a single non-atomic `volatile State`.
Three writers raced on that one word and the loser's update was silently lost:

- the listener thread wrote `kInit` at the top of `consumePackets()`,
- `HostcallListener::terminate()` wrote `kExit` before waiting for the thread,
- `~Init()` wrote `kDestroy` and then spun, unbounded, waiting for `kExit`.

`Thread::start()` only marks the thread RUNNABLE and returns, so the listener
may not reach `consumePackets()` for a long time on a loaded machine. Two
distinct lost updates follow:

1. `terminate()` stores `kExit`, then the late listener stores `kInit` over it
   and immediately returns on the doorbell. Nothing is running any more, but the
   state says `kInit`, so `~Init()` sets `kDestroy` and spins forever with no
   thread left to answer it. **The process hangs at exit.**
2. The listener has not stored `kInit` by the time `~Init()` runs, so the state
   is still `kDefault` and `~Init()` does not wait at all. The listener then runs
   concurrently with library teardown, which is **the crash this handshake exists
   to prevent** (SWDEV-450636).

This PR replaces the state word with a count of listener threads that are live
right now, plus a separate shutdown flag:

- `initSignal()` raises the count **before** `thread_.start()`, so a listener is
  accounted for from before it is able to run rather than from whenever it
  happens to be scheduled. This closes (2).
- `consumePackets()` lowers the count from an RAII guard on every exit path, and
  only ever reads the shutdown flag.
- `~Init()` sets the flag and waits for the count to reach zero.

Each location now writes a variable no other location writes, so no update can
be lost and (1) cannot occur. Counting live threads rather than recording a
state is also correct when listeners are started and stopped repeatedly, and
when a new listener overlaps one that is still winding down; neither case could
be expressed by the single state word.

The wait is now bounded. A running listener observes the flag within one
doorbell timeout, and a five second deadline backstops a wedged thread by
continuing teardown with a warning, which is what the runtime did before the
handshake existed and is preferable to hanging forever.

**Performance:** the fast path is unchanged. The only added work is one relaxed
increment per listener creation, which happens once per listener rather than
once per dispatch. Kernels that use no hostcall service create no listener and
run no new code.

**Scope:** the `FIXME_lmoriche` termination handshake in `terminate()` is left
alone. A real join would require `amd::Thread` to stop creating threads
`PTHREAD_CREATE_DETACHED`, which affects every rocclr thread.

**Provenance:** introduced in 6.2 by `21a5b16faa` (the unbounded spin) and
`24bb38acb8` (the `kExit` store before the wait). The fix does not depend on the
`listenerTerminating` guard added by `07a607c278`, so it applies unchanged to
release branches that predate it.

**Alternatives considered and rejected:**

- *Moving the `kExit` store below the wait loop in `terminate()`.* Necessary but
  not sufficient: it leaves the data race and the unbounded spin in place, and it
  relies on `listenerTerminating` to stop a new listener starting in the window,
  a guard that does not exist on 7.2.4 and earlier.
- *Promoting `kDefault` to `kInit` with a compare-exchange.* After the first
  listener exits the state is `kExit`, so a second listener's CAS fails, and
  `~Init()` then concludes nothing is running while a listener is live,
  reintroducing SWDEV-450636.

## Issue Tracking

JIRA ID: ROCM-29126

## Test Plan

Tested on gfx942.

1. **Targeted HIP reproducer**, three variants, all launching a `printf` kernel
   so a hostcall buffer and listener are created: stream destroyed before exit
   (listener terminated), stream left alive at exit (listener still running), and
   eight repeated stream create/destroy cycles. Six processes pinned to a single
   core with `taskset -c 0,96`, 24-36 runs of each variant.
2. **Control** for the crash: the same "stream alive at exit" variant launching a
   kernel with no hostcall service, so no listener is ever created. Confirms the
   crash is attributable to the listener and not to leaving a stream alive.
3. **Original Kokkos reproducer**: four concurrent
   `Kokkos_CoreUnitTest_KokkosP` under `OMP_PROC_BIND=close`, `OMP_PLACES=cores`,
   `OMP_NUM_THREADS=8`, 30s timeout, 64 runs before and after.
4. **Fault injection** (scaffolding, not included in this PR): a build that
   stalls the listener at its entry point for a configurable delay, which is
   exactly the window the scheduler opens by itself under contention. This makes
   the failure deterministic in a single unpinned process with no concurrency,
   so the fix can be shown to close the specific race rather than merely making
   it less likely.

## Test Result

All figures below were measured on this branch's merge base, `dfd3f592c6`, with
the only difference between "before" and "after" being this commit.

Targeted reproducer, six processes pinned to one core:

| Scenario | Before | After |
| --- | --- | --- |
| Stream destroyed before exit | 13/24 hung until killed at 30s | 0/36 |
| Repeated create/destroy cycles | 14/24 hung until killed at 30s | 0/36 |
| Listener alive at exit | 7/24 SIGSEGV | 0/36 |
| Stream destroyed, unpinned | (not reproducible unpinned) | 0/36 |

Original Kokkos reproducer, four concurrent processes: **26/64 runs timed out at
30s before, 64/64 clean after.** The hang rate is sensitive to background load,
so a smaller earlier sample on the same build gave 1/24; the fixed build has not
produced a single timeout in any sample.

The control that attributes the crash to the listener was measured as a matched
pair on the earlier base `5bc651a826`, same build and conditions, 48 runs each:
**14/48 SIGSEGV with a `printf` kernel (listener created) versus 0/48 with a
kernel using no hostcall service (no listener).**

Fault injection, single unpinned process, no contention:

- Unpatched: hangs at every injected delay of 1s or more (1s, 2s, 3s, 5s all
  hang until killed).
- Patched: always exits cleanly, with wall time scaling exactly by the injected
  delay.
- Patched with a 20s stall: correctly trips the five second backstop, printing
  the warning and exiting cleanly after 7.3s rather than waiting 22s.

No new compiler warnings. Both the `USE_NEW_HOSTCALL_IMPL` and legacy
`consumePackets()` paths were updated; the legacy path is compiled but was not
exercised at runtime by these tests.

Note this branch is rebased on top of #9643, which also touches
`devhostcall.cpp` (the listener thread now takes the default stack). The two
changes do not overlap textually, and the failures above were re-confirmed to
still be present on `develop` with #9643 included.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
