### PR TITLE
ci(rccl): add nightly coco-based RCCL perf/coverage testing workflow

### DIFF
--- a/.github/actions/checkout-coco-harness/action.yml
+++ b/.github/actions/checkout-coco-harness/action.yml
@@ -1,0 +1,45 @@
+name: 'Checkout coco harness'
+description: >-
+  Mint a short-lived GitHub App token scoped to the coco harness repository
+  (ROCm/tRCCL) and check it out at the given ref. Shared by the nightly
+  caller's setup job and the reusable run launcher so the token's scope and
+  the checkout out App version can't drift apart between them.
+
+inputs:
+  ref:
+    description: 'Git ref (commit, tag, or branch) to check out.'
+    required: true
+  path:
+    description: 'Checkout path, relative to the workspace.'
+    required: true
+  app-id:
+    description: 'GitHub App ID used to mint the checkout token.'
+    required: true
+  app-private-key:
+    description: 'Private key for app-id.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # github.token is scoped to this repository, so it cannot read another org
+    # repo. This cross-org-repo checkout pattern is also used elsewhere in
+    # this repo (e.g. docs-pr-preview.yml, rocm_ci_caller.yml) to mint a
+    # short-lived App token; here it's scoped down to just the harness repo.
+    # The App must be installed there with contents:read.
+    - name: Generate a token for the coco harness repository
+      id: coco_token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: tRCCL
+
+    - name: Checkout the coco harness
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        repository: ROCm/tRCCL
+        ref: ${{ inputs.ref }}
+        path: ${{ inputs.path }}
+        token: ${{ steps.coco_token.outputs.token }}

--- a/.github/workflows/rccl-coco-nightly.yml
+++ b/.github/workflows/rccl-coco-nightly.yml
@@ -1,0 +1,177 @@
+name: RCCL coco nightly
+
+# Nightly coco launches on the ruby cluster.
+#
+# One workflow per trigger type: this file owns the nightly schedule only.
+# Other trigger types get their own callers later; every caller fans out into
+# the shared launcher, rccl-coco-run.yml, which holds the run steps and no
+# trigger-specific logic.
+#
+# Process:
+#   1. `setup` runs on the cluster runner, checks out the coco harness at the
+#      requested ref, and resolves it to one exact commit. The runner label
+#      below names a pool of machines, not a single fixed host, so pinning to
+#      a commit here -- rather than letting each fan-out job below re-resolve
+#      a floating ref on whichever machine it happens to land on -- is what
+#      guarantees `perf` and `coverage` run the identical commit.
+#   2. `perf` and `coverage` each call rccl-coco-run.yml with that pinned
+#      commit and their own job. Neither depends on the other, so a failure or
+#      re-run of one never touches the other's status, log, or artifact.
+#
+# These jobs run only against the refs configured below, never against a pull
+# request: this workflow has no pull_request trigger, and workflow_dispatch
+# requires write access to this repository, so a fork cannot reach it.
+#
+# SCHEDULING: cron here is UTC and does not observe DST, so a fixed entry
+# drifts an hour across the year. 04:00 UTC is 22:00 CST in winter and 23:00
+# CDT in summer -- both comfortably after the 21:00 CST maintenance window in
+# which the runner's node may be restarted. Do not move this earlier than
+# 03:00 UTC: that is 21:00 CST in winter and would land inside the restart
+# window.
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 22:00 CST / 23:00 CDT -- after the 21:00 CST maintenance restart
+  # Manual dispatch exists so this workflow can be exercised without waiting
+  # for the cron, and so a missed night can be re-driven by hand. It
+  # deliberately offers no job selector: what runs nightly is the point of
+  # the file.
+  workflow_dispatch:
+    inputs:
+      coco_ref:
+        description: 'ROCm/tRCCL ref for the coco harness.'
+        type: string
+        required: false
+        default: 'main'
+      rocm_systems_ref:
+        description: 'rocm-systems ref to test.'
+        type: string
+        required: false
+        default: 'develop'
+      dry_run:
+        description: 'Resolve stacks and submissions without building or running anything.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Runs on the cluster runner itself (rather than a generic CPU runner) so the
+  # commit it resolves below is checked out from the same pool perf and
+  # coverage will run on, then hands that commit to both.
+  setup:
+    name: Setup
+    runs-on: ruby-linux-slurm-scale-runner
+    outputs:
+      coco_ref: ${{ steps.resolve.outputs.coco_ref }}
+      rocm_systems_ref: ${{ steps.resolve.outputs.rocm_systems_ref }}
+      coco_args: ${{ steps.resolve.outputs.coco_args }}
+      # `scheduled` is what the nightly trend queries in the coco database
+      # select on. A manual dispatch must not be recorded as one, or a
+      # hand-driven test lands in the nightly series as though it were that
+      # night's data point.
+      trigger_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+    steps:
+      # A local composite action reference (below) has to resolve from a
+      # checkout already on disk; this job otherwise has no other reason to
+      # check out this repo.
+      - name: Checkout rocm-systems
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Checkout the coco harness
+        uses: ./.github/actions/checkout-coco-harness
+        with:
+          ref: ${{ inputs.coco_ref || 'main' }}
+          path: _coco
+          app-id: ${{ secrets.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Resolve run parameters
+        id: resolve
+        working-directory: _coco
+        env:
+          # A scheduled run has no inputs context, so these fall back to the
+          # same values the dispatch inputs default to.
+          ROCM_SYSTEMS_REF: ${{ inputs.rocm_systems_ref || 'develop' }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          # Pin to the exact commit just checked out, rather than passing the
+          # ref (e.g. "main") through unresolved -- see the note at the top of
+          # this file on why that matters with a multi-machine runner pool.
+          coco_sha="$(git rev-parse HEAD)"
+
+          # -vv because the only record of a failed unattended run is this
+          # log. --prune-build and --skip-failed-builds so one job failing to
+          # build doesn't cost the other its nightly data point.
+          args='-vv --prune-build --skip-failed-builds'
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            args="${args} --dry-run"
+          fi
+          {
+            echo "coco_ref=${coco_sha}"
+            echo "rocm_systems_ref=${ROCM_SYSTEMS_REF}"
+            echo "coco_args=${args}"
+          } >> "${GITHUB_OUTPUT}"
+
+      # This runner is persistent and keeps its workspace between runs.
+      - name: Clean up harness checkout
+        if: always()
+        run: rm -rf _coco
+
+  # The fan-out. Two independent jobs so each gets its own status, log,
+  # artifact and re-run button.
+  #
+  # They are not ordered against each other. Both submit work to the cluster,
+  # which owns the nodes and queues rather than cancelling, so contention
+  # resolves there instead of here. Add `needs: perf` to coverage if they
+  # should go back to running one after the other.
+  perf:
+    name: 'Perf (ruby64-rccl-perf-nightly)'
+    needs: setup
+    uses: ./.github/workflows/rccl-coco-run.yml
+    permissions:
+      contents: read
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      RCCL_COCO_DB_URL: ${{ secrets.RCCL_COCO_DB_URL }}
+    with:
+      job: ruby64-rccl-perf-nightly
+      runs_on: ruby-linux-slurm-scale-runner
+      coco_ref: ${{ needs.setup.outputs.coco_ref }}
+      rocm_systems_ref: ${{ needs.setup.outputs.rocm_systems_ref }}
+      trigger_kind: ${{ needs.setup.outputs.trigger_kind }}
+      coco_args: ${{ needs.setup.outputs.coco_args }}
+      # A full nightly run of this job is expected to take upward of six
+      # hours (multi-node sweep across several software stacks). This budget
+      # is set with several hours of margin above that so a slow but healthy
+      # run is not killed by the platform default before it can finish; tune
+      # down once real run times are in hand.
+      timeout_minutes: 720
+      concurrency_group: rccl-coco-nightly-perf
+
+  coverage:
+    name: 'Coverage (ruby64-rccl-coverage-nightly)'
+    needs: setup
+    uses: ./.github/workflows/rccl-coco-run.yml
+    permissions:
+      contents: read
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      RCCL_COCO_DB_URL: ${{ secrets.RCCL_COCO_DB_URL }}
+    with:
+      job: ruby64-rccl-coverage-nightly
+      runs_on: ruby-linux-slurm-scale-runner
+      coco_ref: ${{ needs.setup.outputs.coco_ref }}
+      rocm_systems_ref: ${{ needs.setup.outputs.rocm_systems_ref }}
+      trigger_kind: ${{ needs.setup.outputs.trigger_kind }}
+      coco_args: ${{ needs.setup.outputs.coco_args }}
+      # Many unit-test lanes on an instrumented build; instrumented gtest is
+      # substantially slower than release, so this also expects an upward-of-
+      # six-hour run. Same margin as perf; tune down once real times are in
+      # hand.
+      timeout_minutes: 720
+      concurrency_group: rccl-coco-nightly-coverage

--- a/.github/workflows/rccl-coco-nightly.yml
+++ b/.github/workflows/rccl-coco-nightly.yml
@@ -30,7 +30,7 @@ name: RCCL coco nightly
 # window.
 on:
   schedule:
-    - cron: '0 4 * * *'  # 22:00 CST / 23:00 CDT -- after the 21:00 CST maintenance restart
+    - cron: '0 4 * * 0-4'  # 22:00 CST / 23:00 CDT -- after the 21:00 CST maintenance restart
   # Manual dispatch exists so this workflow can be exercised without waiting
   # for the cron, and so a missed night can be re-driven by hand. It
   # deliberately offers no job selector: what runs nightly is the point of
@@ -42,11 +42,6 @@ on:
         type: string
         required: false
         default: 'main'
-      rocm_systems_ref:
-        description: 'rocm-systems ref to test.'
-        type: string
-        required: false
-        default: 'develop'
       dry_run:
         description: 'Resolve stacks and submissions without building or running anything.'
         type: boolean
@@ -65,7 +60,6 @@ jobs:
     runs-on: ruby-linux-slurm-scale-runner
     outputs:
       coco_ref: ${{ steps.resolve.outputs.coco_ref }}
-      rocm_systems_ref: ${{ steps.resolve.outputs.rocm_systems_ref }}
       coco_args: ${{ steps.resolve.outputs.coco_args }}
       # `scheduled` is what the nightly trend queries in the coco database
       # select on. A manual dispatch must not be recorded as one, or a
@@ -73,11 +67,11 @@ jobs:
       # night's data point.
       trigger_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
     steps:
-      # A local composite action reference (below) has to resolve from a
-      # checkout already on disk; this job otherwise has no other reason to
-      # check out this repo.
+      # Limit the checkout to the composite action's own directory.
       - name: Checkout rocm-systems
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: .github/actions/checkout-coco-harness
 
       - name: Checkout the coco harness
         uses: ./.github/actions/checkout-coco-harness
@@ -91,9 +85,8 @@ jobs:
         id: resolve
         working-directory: _coco
         env:
-          # A scheduled run has no inputs context, so these fall back to the
-          # same values the dispatch inputs default to.
-          ROCM_SYSTEMS_REF: ${{ inputs.rocm_systems_ref || 'develop' }}
+          # A scheduled run has no inputs context, so this falls back to the
+          # same value the dispatch input defaults to.
           DRY_RUN: ${{ inputs.dry_run || false }}
         run: |
           set -euo pipefail
@@ -111,7 +104,6 @@ jobs:
           fi
           {
             echo "coco_ref=${coco_sha}"
-            echo "rocm_systems_ref=${ROCM_SYSTEMS_REF}"
             echo "coco_args=${args}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -141,7 +133,6 @@ jobs:
       job: ruby64-rccl-perf-nightly
       runs_on: ruby-linux-slurm-scale-runner
       coco_ref: ${{ needs.setup.outputs.coco_ref }}
-      rocm_systems_ref: ${{ needs.setup.outputs.rocm_systems_ref }}
       trigger_kind: ${{ needs.setup.outputs.trigger_kind }}
       coco_args: ${{ needs.setup.outputs.coco_args }}
       # A full nightly run of this job is expected to take upward of six
@@ -166,7 +157,6 @@ jobs:
       job: ruby64-rccl-coverage-nightly
       runs_on: ruby-linux-slurm-scale-runner
       coco_ref: ${{ needs.setup.outputs.coco_ref }}
-      rocm_systems_ref: ${{ needs.setup.outputs.rocm_systems_ref }}
       trigger_kind: ${{ needs.setup.outputs.trigger_kind }}
       coco_args: ${{ needs.setup.outputs.coco_args }}
       # Many unit-test lanes on an instrumented build; instrumented gtest is

--- a/.github/workflows/rccl-coco-run.yml
+++ b/.github/workflows/rccl-coco-run.yml
@@ -1,0 +1,213 @@
+name: RCCL coco run
+
+# Reusable launcher for the coco harness (ROCm/tRCCL). One call runs one coco
+# job to completion and reports its exit status. It holds no trigger-specific
+# logic: each trigger type gets its own caller workflow in this repo, and every
+# caller fans out into this file.
+#
+# `runs_on` (where this job executes) and `job` (which coco job to run) are a
+# matched pair chosen by the caller: each job is bound internally to the
+# machine it expects, with no way to override that from here, so a job meant
+# for the ruby cluster must always be paired with a ruby runner label.
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: 'Runner label to run on.'
+        type: string
+        required: true
+      job:
+        description: 'coco job key to run.'
+        type: string
+        required: true
+      concurrency_group:
+        description: 'Concurrency group, set by the caller so each job serialises independently.'
+        type: string
+        required: true
+      coco_ref:
+        description: 'ROCm/tRCCL git ref (commit, tag, or branch) to check out the harness at.'
+        type: string
+        required: false
+        default: 'main'
+      rocm_systems_ref:
+        description: 'rocm-systems git ref to check out as the sources under test.'
+        type: string
+        required: false
+        default: 'develop'
+      trigger_kind:
+        description: 'coco --trigger-kind, recorded against the run. No default: every caller must state its own, so a caller that forgets to wire this through fails loudly instead of silently mislabeling its run.'
+        type: string
+        required: true
+      coco_args:
+        description: 'Additional coco flags, word-split verbatim (e.g. "-vv --prune-build").'
+        type: string
+        required: false
+        default: ''
+      timeout_minutes:
+        description: 'Job timeout in minutes.'
+        type: number
+        required: false
+        default: 600
+    # Declared explicitly rather than taking `secrets: inherit` from the caller,
+    # so this workflow's credential requirements are visible in its own contract.
+    secrets:
+      APP_ID:
+        description: 'GitHub App ID, used to mint a read token for the coco harness repository.'
+        required: true
+      APP_PRIVATE_KEY:
+        description: 'Private key for APP_ID.'
+        required: true
+      RCCL_COCO_DB_URL:
+        description: 'coco database URL for result ingest. Omit to run without publishing.'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  coco:
+    name: ${{ inputs.job }}
+    # A reusable workflow can be invoked by full reference (owner/repo/path@ref)
+    # from any repository, not just this one -- workflow_call has no built-in
+    # allow-list of callers. github.repository reflects the caller's repository
+    # in that case, so this refuses to run anywhere except this repo, which
+    # keeps a fork or any outside repository from pointing at this file to run
+    # on these self-hosted runners. The relative-path call from this repo's own
+    # nightly caller always satisfies this.
+    if: github.repository == 'ROCm/rocm-systems'
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    # The group is per-input so each caller can serialise its own jobs
+    # independently. cancel-in-progress is never true here, not just by
+    # default: killing this job would not cancel the cluster allocation coco
+    # submitted, so cancelling it would orphan an allocation that keeps
+    # holding cluster nodes. There's no legitimate reason for a caller of
+    # this workflow to override that.
+    concurrency:
+      group: ${{ inputs.concurrency_group }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      LOG_FILE: ${{ github.workspace }}/coco-${{ inputs.job }}-${{ github.run_id }}.log
+      # coco is installed into a throwaway venv and always invoked by absolute
+      # path. This runner is persistent, so installing into the interpreter
+      # setup-python puts on PATH would leak between runs; and an *activated*
+      # venv is worse than useless here -- rccl-suite.yml documents SLURM
+      # compute-node builds failing because an exported VIRTUAL_ENV/PATH made
+      # cmake's find_package(Python3) pick a runner-only interpreter. Never
+      # activate this; just call its entry point directly.
+      COCO_VENV: ${{ github.workspace }}/_coco/venv
+    steps:
+      # The sources under test. coco builds RCCL from this checkout, so the ref
+      # chosen here is what the run actually measures.
+      - name: Checkout rocm-systems
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.rocm_systems_ref }}
+
+      # The harness itself, cloned rather than vendored so a run can pin any
+      # coco ref without touching this repo. Mints its own scoped token; see
+      # .github/actions/checkout-coco-harness.
+      - name: Checkout the coco harness
+        uses: ./.github/actions/checkout-coco-harness
+        with:
+          ref: ${{ inputs.coco_ref }}
+          path: _coco/tRCCL
+          app-id: ${{ secrets.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: _coco/tRCCL/pyproject.toml
+
+      - name: Install coco
+        working-directory: _coco/tRCCL
+        run: |
+          set -euo pipefail
+          python3 -m venv "${COCO_VENV}"
+          "${COCO_VENV}/bin/python3" -m pip install --upgrade pip
+          "${COCO_VENV}/bin/python3" -m pip install -e ".[dev]"
+          # Exercise the exact entry point the launch step calls, so a
+          # packaging problem surfaces here rather than after the cluster queue.
+          "${COCO_VENV}/bin/coco" --help > /dev/null
+          echo "==> coco installed from $(git rev-parse HEAD)"
+
+      - name: Launch coco
+        id: launch
+        working-directory: _coco/tRCCL
+        env:
+          JOB: ${{ inputs.job }}
+          TRIGGER_KIND: ${{ inputs.trigger_kind }}
+          COCO_ARGS: ${{ inputs.coco_args }}
+          COCO_DB_URL: ${{ secrets.RCCL_COCO_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${COCO_DB_URL:-}" ]]; then
+            echo "::warning::RCCL_COCO_DB_URL is empty; this run will not publish results to the coco database."
+          fi
+          # COCO_ARGS is deliberately word-split: it carries a whole flag list
+          # composed by the caller, not a single argument.
+          echo "==> coco run --job ${JOB} --trigger-kind ${TRIGGER_KIND} ${COCO_ARGS}"
+          # Straight to the file, not teed through the console: at -vv this
+          # can run for hours and risks the platform's per-job log-size limit
+          # and a slow-to-render live log. The tail below and the uploaded
+          # artifact are how this becomes visible instead.
+          "${COCO_VENV}/bin/coco" run \
+            --job "${JOB}" \
+            --trigger-kind "${TRIGGER_KIND}" \
+            ${COCO_ARGS} > "${LOG_FILE}" 2>&1
+
+      - name: Upload coco log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coco-${{ inputs.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.LOG_FILE }}
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Run summary
+        if: always()
+        env:
+          JOB: ${{ inputs.job }}
+          TRIGGER_KIND: ${{ inputs.trigger_kind }}
+          COCO_REF: ${{ inputs.coco_ref }}
+          ROCM_SYSTEMS_REF: ${{ inputs.rocm_systems_ref }}
+          COCO_ARGS: ${{ inputs.coco_args }}
+          LAUNCH_OUTCOME: ${{ steps.launch.outcome }}
+        run: |
+          {
+            echo "### ${JOB}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| outcome | \`${LAUNCH_OUTCOME}\` |"
+            echo "| trigger kind | \`${TRIGGER_KIND}\` |"
+            echo "| coco ref | \`${COCO_REF}\` |"
+            echo "| rocm-systems ref | \`${ROCM_SYSTEMS_REF}\` |"
+            echo "| extra flags | \`${COCO_ARGS:-(none)}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          # Only dumped on a non-success outcome: a healthy nightly run's -vv
+          # log is long, and there's no reason to pay to render/store 200
+          # lines of it in the summary every single night. The full file is
+          # always in the uploaded artifact regardless of outcome.
+          if [[ "${LAUNCH_OUTCOME}" != "success" && -s "${LOG_FILE}" ]]; then
+            echo "::group::coco output (tail)"
+            tail -n 200 "${LOG_FILE}"
+            echo "::endgroup::"
+          fi
+
+      # This runner is persistent and keeps its workspace between runs.
+      - name: Clean up harness checkout
+        if: always()
+        run: |
+          rm -rf "${{ github.workspace }}/_coco"
+          rm -f "${LOG_FILE}"

--- a/.github/workflows/rccl-coco-run.yml
+++ b/.github/workflows/rccl-coco-run.yml
@@ -29,11 +29,6 @@ on:
         type: string
         required: false
         default: 'main'
-      rocm_systems_ref:
-        description: 'rocm-systems git ref to check out as the sources under test.'
-        type: string
-        required: false
-        default: 'develop'
       trigger_kind:
         description: 'coco --trigger-kind, recorded against the run. No default: every caller must state its own, so a caller that forgets to wire this through fails loudly instead of silently mislabeling its run.'
         type: string
@@ -93,21 +88,14 @@ jobs:
         shell: bash
     env:
       LOG_FILE: ${{ github.workspace }}/coco-${{ inputs.job }}-${{ github.run_id }}.log
-      # coco is installed into a throwaway venv and always invoked by absolute
-      # path. This runner is persistent, so installing into the interpreter
-      # setup-python puts on PATH would leak between runs; and an *activated*
-      # venv is worse than useless here -- rccl-suite.yml documents SLURM
-      # compute-node builds failing because an exported VIRTUAL_ENV/PATH made
-      # cmake's find_package(Python3) pick a runner-only interpreter. Never
-      # activate this; just call its entry point directly.
-      COCO_VENV: ${{ github.workspace }}/_coco/venv
+      # Unique per run + attempt.
+      COCO_DIR: ${{ github.workspace }}/_coco-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      # The sources under test. coco builds RCCL from this checkout, so the ref
-      # chosen here is what the run actually measures.
+      # Limit the checkout to the composite action's own directory.
       - name: Checkout rocm-systems
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.rocm_systems_ref }}
+          sparse-checkout: .github/actions/checkout-coco-harness
 
       # The harness itself, cloned rather than vendored so a run can pin any
       # coco ref without touching this repo. Mints its own scoped token; see
@@ -116,7 +104,7 @@ jobs:
         uses: ./.github/actions/checkout-coco-harness
         with:
           ref: ${{ inputs.coco_ref }}
-          path: _coco/tRCCL
+          path: ${{ env.COCO_DIR }}/tRCCL
           app-id: ${{ secrets.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -125,12 +113,15 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: _coco/tRCCL/pyproject.toml
+          cache-dependency-path: ${{ env.COCO_DIR }}/tRCCL/pyproject.toml
 
       - name: Install coco
-        working-directory: _coco/tRCCL
+        working-directory: ${{ env.COCO_DIR }}/tRCCL
+        env:
+          COCO_VENV: ${{ env.COCO_DIR }}/venv
         run: |
           set -euo pipefail
+          # Never activated; invoked by absolute path.
           python3 -m venv "${COCO_VENV}"
           "${COCO_VENV}/bin/python3" -m pip install --upgrade pip
           "${COCO_VENV}/bin/python3" -m pip install -e ".[dev]"
@@ -141,14 +132,20 @@ jobs:
 
       - name: Launch coco
         id: launch
-        working-directory: _coco/tRCCL
+        working-directory: ${{ env.COCO_DIR }}/tRCCL
         env:
           JOB: ${{ inputs.job }}
           TRIGGER_KIND: ${{ inputs.trigger_kind }}
           COCO_ARGS: ${{ inputs.coco_args }}
           COCO_DB_URL: ${{ secrets.RCCL_COCO_DB_URL }}
+          COCO_VENV: ${{ env.COCO_DIR }}/venv
         run: |
           set -euo pipefail
+          # Strip login-node Python from the environment before coco submits
+          # the compute-node SLURM job.
+          unset VIRTUAL_ENV PYTHONHOME pythonLocation Python_ROOT_DIR Python3_ROOT_DIR
+          PATH="$(printf '%s' "${PATH}" | tr ':' '\n' | grep -vE '/_work/_tool/Python/' | paste -sd: -)"
+          export PATH
           if [[ -z "${COCO_DB_URL:-}" ]]; then
             echo "::warning::RCCL_COCO_DB_URL is empty; this run will not publish results to the coco database."
           fi
@@ -179,7 +176,6 @@ jobs:
           JOB: ${{ inputs.job }}
           TRIGGER_KIND: ${{ inputs.trigger_kind }}
           COCO_REF: ${{ inputs.coco_ref }}
-          ROCM_SYSTEMS_REF: ${{ inputs.rocm_systems_ref }}
           COCO_ARGS: ${{ inputs.coco_args }}
           LAUNCH_OUTCOME: ${{ steps.launch.outcome }}
         run: |
@@ -191,7 +187,6 @@ jobs:
             echo "| outcome | \`${LAUNCH_OUTCOME}\` |"
             echo "| trigger kind | \`${TRIGGER_KIND}\` |"
             echo "| coco ref | \`${COCO_REF}\` |"
-            echo "| rocm-systems ref | \`${ROCM_SYSTEMS_REF}\` |"
             echo "| extra flags | \`${COCO_ARGS:-(none)}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -205,9 +200,8 @@ jobs:
             echo "::endgroup::"
           fi
 
-      # This runner is persistent and keeps its workspace between runs.
       - name: Clean up harness checkout
         if: always()
         run: |
-          rm -rf "${{ github.workspace }}/_coco"
+          rm -rf "${COCO_DIR}"
           rm -f "${LOG_FILE}"


### PR DESCRIPTION
## Motivation

Add automated nightly RCCL testing (performance + coverage) on the SLURM-backed
`ruby-linux-slurm-scale-runner` pool, orchestrated through the private `coco` harness in
ROCm/tRCCL. Runs fire on a nightly schedule and are available via manual dispatch; there is no
`pull_request` trigger, since these self-hosted runners must never be reachable from forks/PRs.

## Technical Details

- `.github/workflows/rccl-coco-nightly.yml`: schedule (04:00 UTC) + `workflow_dispatch` entry
  point. A `setup` job pins one `coco` harness commit so both fan-out jobs build the identical
  harness across the runner pool, then fans out to independent `perf` and `coverage` jobs.
- `.github/workflows/rccl-coco-run.yml`: reusable `workflow_call` launcher — checks out
  rocm-systems + the pinned coco harness, installs `coco` into an isolated venv (pip-cached),
  runs it, uploads the log as a 14-day artifact, and writes a job summary (full log tail only on
  failure). Repository-gated (`if: github.repository == 'ROCm/rocm-systems'`) so forks/mirrors
  can't invoke it against self-hosted runners.
- `.github/actions/checkout-coco-harness/action.yml`: local composite action factoring out the
  GitHub App token mint + tRCCL checkout, shared by both workflows so token scoping can't drift.

## Issue Tracking

JIRA ID : AICOMRCCL-1673

## Test Plan

This workflow intentionally has no `pull_request` trigger (self-hosted-runner security gate), so
it cannot go green on this PR's own CI. Validated locally instead:

- `actionlint` clean (one pre-existing-pattern false positive: this repo has no `actionlint.yaml`
  declaring self-hosted labels, so the literal `ruby-linux-slurm-scale-runner` label reads as
  "unknown" — every other workflow avoids this only by referencing the label through an
  expression, which is invisible to actionlint's static checker)
- `act -l` confirms the job graph/trigger wiring matches intent: `setup` fans out to `perf` +
  `coverage`; the reusable workflow parses as a single `workflow_call` job keyed by `inputs.job`
- All 4 pinned action SHAs verified against their claimed version tags via the GitHub API —
  caught and fixed one stale/mismatched pin (`create-github-app-token` was pinned to a v2.1.4
  commit mislabeled as v3.2.0; repinned to the real v3.2.0 commit)
- Every step's bash (run-parameter resolution, coco install/launch, summary generation) executed
  against a stand-in local `coco` CLI package, across both trigger paths and both outcome branches
- Confirmed no tRCCL internal paths/structure leak into the workflow YAML

## Test Result

All static/dry-run checks pass. Real end-to-end validation (the actual `coco` CLI, actual SLURM
submission) requires a manual `workflow_dispatch` after merge — planned as an immediate
follow-up with `dry_run: true` first.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.