### PR TITLE
[RCCL][GRAPH] Support graphStreamOrdering config and add graph capture window MPI tests

### DIFF
--- a/projects/rccl/docs/userguide/source/api/types.rst
+++ b/projects/rccl/docs/userguide/source/api/types.rst
@@ -284,19 +284,26 @@ ncclConfig_t
 
   (since 2.30)
 
-  Per-communicator override of :ref:`NCCL_GRAPH_STREAM_ORDERING`. ``1`` keeps
+  Per-communicator setting, honored unless
+  :ref:`NCCL_GRAPH_STREAM_ORDERING` is set to ``0`` or ``1``. ``1`` keeps
   NCCL's default capture-time serialization of communication kernels. ``0``
   disables it for this communicator—kernels are placed on the capture stream
   and the application must guarantee correct ordering (see
   :ref:`NCCL_GRAPH_STREAM_ORDERING`).
 
   Defaults to ``NCCL_CONFIG_UNDEF_INT`` (inherits
-  :ref:`NCCL_GRAPH_STREAM_ORDERING`). ``0`` or ``1`` overrides the env var
-  for this communicator.
+  :ref:`NCCL_GRAPH_STREAM_ORDERING`). Setting that environment variable to
+  ``0`` or ``1`` overrides this field.
 
   ``graphStreamOrdering=0`` requires ``graphUsageMode`` ``0`` or ``1``
-  (mixing **off**). Combining it with ``graphUsageMode=2`` is **not
-  supported**; see :ref:`NCCL_GRAPH_STREAM_ORDERING`.
+  (mixing **off**). If it is combined with ``graphUsageMode=2``, NCCL emits a
+  warning and forces ``graphStreamOrdering`` to ``1``; communicator creation
+  still succeeds. See :ref:`NCCL_GRAPH_STREAM_ORDERING`. NCCL enforces this
+  compatibility fallback within a single communicator only. Communicators
+  created by ``ncclCommSplit`` with ``splitShare`` share one internal
+  serialization event with their parent, so ordering ``0`` on one and
+  ``graphUsageMode=2`` on another that shares those resources is equally
+  unsupported and is **not** diagnosed.
 
   **Mixed values on one GPU:** A communicator set to ``1`` still receives
   NCCL's internal serialization for its own kernels, but NCCL does **not**

--- a/projects/rccl/docs/userguide/source/env.rst
+++ b/projects/rccl/docs/userguide/source/env.rst
@@ -1494,12 +1494,14 @@ CUDA graph capture.
 .. warning::
 
    ``NCCL_GRAPH_STREAM_ORDERING=0`` together with **graph mixing** (communicator
-   ``graphUsageMode=2``; see :ref:`ncclconfig`) is **not supported**. If stream
-   ordering is disabled for a communicator, **graph mixing must be off**—use
-   ``graphUsageMode`` ``0`` or ``1`` (and note that :ref:`NCCL_GRAPH_MIXING_SUPPORT`
-   ``1`` forces ``graphUsageMode=2`` at init, overriding an explicit lower mode).
-   Workloads that require mixing must keep the default ``1``. The same rule applies
-   to per-communicator :c:macro:`graphStreamOrdering` ``0``.
+   ``graphUsageMode=2``; see :ref:`ncclconfig`) is **not supported**. NCCL emits
+   a warning, forces ``graphStreamOrdering`` to ``1``, and continues communicator
+   creation successfully. If stream ordering is disabled for a communicator,
+   **graph mixing must be off**—use ``graphUsageMode`` ``0`` or ``1`` (and note
+   that :ref:`NCCL_GRAPH_MIXING_SUPPORT` ``1`` forces ``graphUsageMode=2`` at init,
+   overriding an explicit lower mode). Workloads that require mixing must keep the
+   default ``1``. The same rule applies to per-communicator
+   :c:macro:`graphStreamOrdering` ``0``.
 
 When set to 1 (default), NCCL guarantees that communication kernels are executed
 in a serialized and deterministic order across graphs and communicators that share
@@ -1511,12 +1513,20 @@ The application is responsible for ensuring correct ordering of communication
 kernels.
 
 The same bypass can be selected per communicator with the
-:c:macro:`graphStreamOrdering` field in :ref:`ncclconfig`. When that
-field is ``0`` or ``1``, it overrides ``NCCL_GRAPH_STREAM_ORDERING`` for that
-communicator. Communicators on the same GPU may still set this option
+:c:macro:`graphStreamOrdering` field in :ref:`ncclconfig`. That field takes
+effect unless ``NCCL_GRAPH_STREAM_ORDERING`` is set to ``0`` or ``1``, which
+overrides the field on every communicator; any other value of the environment
+variable is ignored and leaves the field in
+effect. Communicators on the same GPU may still set this option
 differently; NCCL does not order them with respect to each other in that case,
 so the application's obligations below apply whenever the bypass is in effect
 for a communicator—see :c:macro:`graphStreamOrdering` for details.
+
+Communicators created by ``ncclCommSplit`` with ``splitShare`` share one
+internal serialization event with their parent. Ordering ``0`` on one such
+communicator must not be combined with ``graphUsageMode=2`` on another that
+shares those resources: the mixing guarantee depends on that shared event, and
+NCCL does not detect the conflict across communicators.
 
 .. admonition:: Application responsibilities
 

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -2075,7 +2075,13 @@ ncclResult_t scheduleCeCollTaskToPlan(struct ncclComm* comm, struct ncclKernelPl
   plan->ceCollArgs->func = task->func;
   plan->ceCollArgs->sendWin = task->sendWin;
   plan->ceCollArgs->recvWin = task->recvWin;
+  plan->ceCollArgs->useDda = task->useDda;
+  plan->ceCollArgs->ddaPeerBases = task->ddaPeerBases;
+  plan->ceCollArgs->ddaUserRecvBuff = task->ddaUserRecvBuff;
+  plan->ceCollArgs->ddaCopyBackBytes = task->ddaCopyBackBytes;
+  plan->ceCollArgs->redOp = task->opHost;
   plan->ceCollArgs->collApiEventHandle = task->collApiEventHandle;
+  plan->ceCollArgs->sizes = (task->func == ncclFuncAlltoAllv) ? task->sizes : nullptr;
 
   if (comm->rank == 0) {
     if (!ncclDevrIsOneLsaTeam(comm)) {

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -1985,7 +1985,13 @@ ncclResult_t scheduleCeCollTaskToPlan(struct ncclComm* comm, struct ncclKernelPl
   plan->ceCollArgs->func = task->func;
   plan->ceCollArgs->sendWin = task->sendWin;
   plan->ceCollArgs->recvWin = task->recvWin;
+  plan->ceCollArgs->useDda = task->useDda;
+  plan->ceCollArgs->ddaPeerBases = task->ddaPeerBases;
+  plan->ceCollArgs->ddaUserRecvBuff = task->ddaUserRecvBuff;
+  plan->ceCollArgs->ddaCopyBackBytes = task->ddaCopyBackBytes;
+  plan->ceCollArgs->redOp = task->opHost;
   plan->ceCollArgs->collApiEventHandle = task->collApiEventHandle;
+  plan->ceCollArgs->sizes = (task->func == ncclFuncAlltoAllv) ? task->sizes : nullptr;
 
   if (comm->rank == 0) {
     if (!ncclDevrIsOneLsaTeam(comm)) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1995,6 +1995,11 @@ enum ncclImplicitOrder {
   ncclImplicitOrderSerial,
   ncclImplicitOrderLaunch
 };
+
+// When true, NCCL applies internal capture-time serialization of communication kernels (captureStream path).
+static bool ncclGraphStreamOrderingSerialize(struct ncclComm* comm) {
+  return comm->config.graphStreamOrdering != 0;
+}
 } // namespace
 
 static ncclResult_t getImplicitOrder(enum ncclImplicitOrder* mode, bool capturing, int driver = -1) {
@@ -2049,36 +2054,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
           nPlans += 1;
         }
       } else if (!ncclIntruQueueEmpty(&planner->collCeTaskQueue)) {
-        struct ncclTaskColl* task = ncclIntruQueueHead(&planner->collCeTaskQueue);
-        plan->isCeColl = true;
-        plan->ceCollArgs = ncclMemoryStackAlloc<struct ncclCeCollArgs>(&comm->memScoped);
-        plan->ceCollArgs->rootRank = task->root;
-        plan->ceCollArgs->datatype = task->datatype;
-        plan->ceCollArgs->nElts = task->count;
-        plan->ceCollArgs->eltSize = ncclTypeSize(task->datatype);
-        plan->ceCollArgs->sendBuff = (uint8_t*)task->sendbuff;
-        plan->ceCollArgs->recvBuff = (uint8_t*)task->recvbuff;
-        plan->ceCollArgs->func = task->func;
-        plan->ceCollArgs->sendWin = task->sendWin;
-        plan->ceCollArgs->recvWin = task->recvWin;
-        plan->ceCollArgs->useDda = task->useDda;
-        plan->ceCollArgs->ddaPeerBases = task->ddaPeerBases;
-        plan->ceCollArgs->ddaUserRecvBuff = task->ddaUserRecvBuff;
-        plan->ceCollArgs->ddaCopyBackBytes = task->ddaCopyBackBytes;
-        plan->ceCollArgs->datatype = task->datatype;
-        plan->ceCollArgs->redOp = task->opHost;
-        plan->ceCollArgs->collApiEventHandle = task->collApiEventHandle;
-        plan->ceCollArgs->sizes = (task->func == ncclFuncAlltoAllv) ? task->sizes : nullptr;
-
-        if (comm->rank == 0) {
-          const char* nvlsSync = comm->nvlsSupport ? "; CE synchronization with NVLS" : "";
-          INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s", ncclFuncToString(task->func),
-               task->count * ncclTypeSize(task->datatype), nvlsSync);
-        }
-
-        ncclIntruQueueEnqueue(&planner->planQueue, plan);
-        ncclIntruQueueDequeue(&planner->collCeTaskQueue);
-        ncclMemoryPoolFree(&comm->memPool_ncclTaskColl, task);
+        NCCLCHECKGOTO(scheduleCeCollTaskToPlan(comm, plan), result, failure);
         nPlans += 1;
       } else {
         if (!ncclIntruQueueEmpty(&planner->collSymTaskQueue)) {
@@ -2123,9 +2099,28 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
     cudaStream_t launchStream = planner->streams->stream;
     cudaStream_t deviceStream, launchOrder;
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
-    NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
-                                          &deviceStream),
-                  result, failure);
+    bool useLaunchStream = capturing && !ncclGraphStreamOrderingSerialize(comm);
+
+    if (useLaunchStream) {
+      // GRAPH_STREAM_ORDERING=0: run kernels on the graph origin (launchStream) without a
+      // secondary captureStream. Serialize graph launches by waiting on serialEvent via
+      // hipEventWaitExternal, which HIP allows on the origin stream during capture.
+      struct ncclStrongStream* ss = &comm->sharedRes->deviceStream;
+      bool firstCapture = !COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed);
+      COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
+      if (firstCapture) {
+        // Bootstrap: signal serialEvent on the live stream so the first graph's ExternalWait
+        // node can fire immediately. This keeps graph structure identical across all
+        // captures (ExternalWait always present), so hipGraphExecUpdate succeeds.
+        CUDACHECKGOTO(cudaEventRecord(ss->serialEvent, ss->liveStream), result, failure);
+      }
+      CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, ss->serialEvent, hipEventWaitExternal), result, failure);
+      deviceStream = launchStream;
+    } else {
+      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
+                                            &deviceStream),
+                    result, failure);
+    }
 
     if (persistent || planner->numStreams != 1) {
       // userStream[0] waits on each userStream[i]...
@@ -2133,8 +2128,10 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
         CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
       }
-      // userStream[0] waits on deviceStream
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
+      // userStream[0] waits on deviceStream (skip when same to avoid a self-loop in the graph)
+      if (deviceStream != launchStream) {
+        NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
+      }
     } else if (comm->lastStreamTag != 0 &&
                comm->lastStreamTag != ncclStreamTag(launchStream)) {
       // Stream changed. Wait on doneEvent, recorded by ncclLaunchKernel on the previous launch
@@ -2152,10 +2149,16 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       // required if this is a graph capture, non-captured cannot be concurrent because that would violate
       // deterministic program order of launches.
       bool concurrent = capturing;
-      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent,
-                                            &launchOrder),
-                    result, failure);
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, launchOrder, comm->sharedRes->scratchEvent), result, failure);
+      if (useLaunchStream) {
+        launchOrder = planner->capturingGraph.origin;
+      } else {
+        NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                              &launchOrder),
+                      result, failure);
+      }
+      if (launchOrder != launchStream) {
+        NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, launchOrder, comm->sharedRes->scratchEvent), result, failure);
+      }
     }
 
     if (!persistent && comm->sharedRes->persistentRefs)
@@ -2405,6 +2408,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     ncclIntruQueueConstruct(&planner->planQueue);
 
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
+    bool useLaunchStream = capturing && !ncclGraphStreamOrderingSerialize(comm);
     cudaStream_t launchStream = planner->streams->stream; // First user stream gets launch
     cudaStream_t deviceStream, launchOrder;
     cudaEvent_t finishedEvent = comm->sharedRes->scratchEvent;
@@ -2425,18 +2429,21 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
 
     if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
       CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
-      // deviceStream waits on userStream[0]
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream,
-                                                   /*concurrent=*/false, &deviceStream));
 
-      // We know that deviceStream is strictly behind the launchStream because launchStream
-      // synced with it before kernel launch. This allows us to to see deviceStream waiting
-      // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
-      // be handled specially so as not to create graphs with a blowup in the number of edges.
-      // So we could do this:
-      //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
-      // But instead we do:
-      NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+      if (!useLaunchStream) {
+        // deviceStream waits on userStream[0]
+        NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream,
+                                                     /*concurrent=*/false, &deviceStream));
+
+        // We know that deviceStream is strictly behind the launchStream because launchStream
+        // synced with it before kernel launch. This allows us to to see deviceStream waiting
+        // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
+        // be handled specially so as not to create graphs with a blowup in the number of edges.
+        // So we could do this:
+        //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
+        // But instead we do:
+        NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+      }
 
       // Each userStream[i] waits on userStream[0]
       for (struct ncclCudaStreamList* l = planner->streams->next; l != nullptr; l = l->next) {
@@ -2449,13 +2456,31 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       // As in ncclLaunchPrepare, strong stream can be non-concurrent when non-captured.
       bool concurrent = capturing;
       // Incorporate launch event into per-device (context) launch order.
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent,
-                                                   &launchOrder));
+      // NOTE: launchOrder cannot be eliminated even when NCCL_GRAPH_STREAM_ORDERING=0.
+      // comm->sharedRes->launchEvent is filled by CUDA via CU_LAUNCH_ATTRIBUTE_LAUNCH_COMPLETION_EVENT
+      // when cuLaunchKernelEx returns. Users cannot query a stream for the launch event of its last
+      // kernel, so this ordering dependency can never be delegated to the user's stream.
+      if (useLaunchStream) {
+        launchOrder = planner->capturingGraph.origin;
+      } else {
+        NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                                     &launchOrder));
+      }
       // If we don't have launch events (requires CUDA 12.3) then just use completion event (serialize execution).
       CUDACHECK(cudaStreamWaitEvent(
         launchOrder, implicitOrder == ncclImplicitOrderLaunch ? comm->sharedRes->launchEvent : finishedEvent));
-      // Release launchOrder as acquired in ncclLaunchPrepare()
-      NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->context->launchOrder, concurrent));
+      if (!useLaunchStream) {
+        // Release launchOrder as acquired in ncclLaunchPrepare()
+        NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->context->launchOrder, concurrent));
+      }
+    }
+    if (!useLaunchStream) {
+      if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
+        NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false));
+      }
+    } else {
+      NCCLCHECK(ncclCudaGraphRecordEvent(planner->capturingGraph, comm->sharedRes->deviceStream.serialEvent,
+                                         launchStream));
     }
   }
   return ncclSuccess;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1913,6 +1913,11 @@ enum ncclImplicitOrder {
   ncclImplicitOrderSerial,
   ncclImplicitOrderLaunch
 };
+
+// When true, NCCL applies internal capture-time serialization of communication kernels (captureStream path).
+static bool ncclGraphStreamOrderingSerialize(struct ncclComm* comm) {
+  return comm->config.graphStreamOrdering != 0;
+}
 } // namespace
 
 static ncclResult_t getImplicitOrder(enum ncclImplicitOrder* mode, bool capturing, int driver = -1) {
@@ -1967,36 +1972,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
           nPlans += 1;
         }
       } else if (!ncclIntruQueueEmpty(&planner->collCeTaskQueue)) {
-        struct ncclTaskColl* task = ncclIntruQueueHead(&planner->collCeTaskQueue);
-        plan->isCeColl = true;
-        plan->ceCollArgs = ncclMemoryStackAlloc<struct ncclCeCollArgs>(&comm->memScoped);
-        plan->ceCollArgs->rootRank = task->root;
-        plan->ceCollArgs->datatype = task->datatype;
-        plan->ceCollArgs->nElts = task->count;
-        plan->ceCollArgs->eltSize = ncclTypeSize(task->datatype);
-        plan->ceCollArgs->sendBuff = (uint8_t*)task->sendbuff;
-        plan->ceCollArgs->recvBuff = (uint8_t*)task->recvbuff;
-        plan->ceCollArgs->func = task->func;
-        plan->ceCollArgs->sendWin = task->sendWin;
-        plan->ceCollArgs->recvWin = task->recvWin;
-        plan->ceCollArgs->useDda = task->useDda;
-        plan->ceCollArgs->ddaPeerBases = task->ddaPeerBases;
-        plan->ceCollArgs->ddaUserRecvBuff = task->ddaUserRecvBuff;
-        plan->ceCollArgs->ddaCopyBackBytes = task->ddaCopyBackBytes;
-        plan->ceCollArgs->datatype = task->datatype;
-        plan->ceCollArgs->redOp = task->opHost;
-        plan->ceCollArgs->collApiEventHandle = task->collApiEventHandle;
-        plan->ceCollArgs->sizes = (task->func == ncclFuncAlltoAllv) ? task->sizes : nullptr;
-
-        if (comm->rank == 0) {
-          const char* nvlsSync = comm->nvlsSupport ? "; CE synchronization with NVLS" : "";
-          INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s", ncclFuncToString(task->func),
-               task->count * ncclTypeSize(task->datatype), nvlsSync);
-        }
-
-        ncclIntruQueueEnqueue(&planner->planQueue, plan);
-        ncclIntruQueueDequeue(&planner->collCeTaskQueue);
-        ncclMemoryPoolFree(&comm->memPool_ncclTaskColl, task);
+        NCCLCHECKGOTO(scheduleCeCollTaskToPlan(comm, plan), result, failure);
         nPlans += 1;
       } else {
         if (!ncclIntruQueueEmpty(&planner->collSymTaskQueue)) {
@@ -2041,9 +2017,28 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
     cudaStream_t launchStream = planner->streams->stream;
     cudaStream_t deviceStream, launchOrder;
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
-    NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
-                                          &deviceStream),
-                  result, failure);
+    bool useLaunchStream = capturing && !ncclGraphStreamOrderingSerialize(comm);
+
+    if (useLaunchStream) {
+      // GRAPH_STREAM_ORDERING=0: run kernels on the graph origin (launchStream) without a
+      // secondary captureStream. Serialize graph launches by waiting on serialEvent via
+      // hipEventWaitExternal, which HIP allows on the origin stream during capture.
+      struct ncclStrongStream* ss = &comm->sharedRes->deviceStream;
+      bool firstCapture = !COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed);
+      COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
+      if (firstCapture) {
+        // Bootstrap: signal serialEvent on the live stream so the first graph's ExternalWait
+        // node can fire immediately. This keeps graph structure identical across all
+        // captures (ExternalWait always present), so hipGraphExecUpdate succeeds.
+        CUDACHECKGOTO(cudaEventRecord(ss->serialEvent, ss->liveStream), result, failure);
+      }
+      CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, ss->serialEvent, hipEventWaitExternal), result, failure);
+      deviceStream = launchStream;
+    } else {
+      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
+                                            &deviceStream),
+                    result, failure);
+    }
 
     if (persistent || planner->numStreams != 1) {
       // userStream[0] waits on each userStream[i]...
@@ -2051,8 +2046,10 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
         CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
       }
-      // userStream[0] waits on deviceStream
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
+      // userStream[0] waits on deviceStream (skip when same to avoid a self-loop in the graph)
+      if (deviceStream != launchStream) {
+        NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
+      }
     } else if (comm->lastStreamValid && comm->lastStream != launchStream) {
       // Stream changed from last call. The new launchStream has no implicit edge to the
       // previous kernel's completion; install a direct event-based dependency on doneEvent.
@@ -2074,10 +2071,16 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       // required if this is a graph capture, non-captured cannot be concurrent because that would violate
       // deterministic program order of launches.
       bool concurrent = capturing;
-      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent,
-                                            &launchOrder),
-                    result, failure);
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, launchOrder, comm->sharedRes->scratchEvent), result, failure);
+      if (useLaunchStream) {
+        launchOrder = planner->capturingGraph.origin;
+      } else {
+        NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                              &launchOrder),
+                      result, failure);
+      }
+      if (launchOrder != launchStream) {
+        NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, launchOrder, comm->sharedRes->scratchEvent), result, failure);
+      }
     }
 
     if (!persistent && comm->sharedRes->persistentRefs)
@@ -2316,6 +2319,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     ncclIntruQueueConstruct(&planner->planQueue);
 
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
+    bool useLaunchStream = capturing && !ncclGraphStreamOrderingSerialize(comm);
     cudaStream_t launchStream = planner->streams->stream; // First user stream gets launch
     cudaStream_t deviceStream, launchOrder;
     cudaEvent_t finishedEvent = comm->sharedRes->scratchEvent;
@@ -2336,18 +2340,21 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
 
     if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
       CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
-      // deviceStream waits on userStream[0]
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream,
-                                                   /*concurrent=*/false, &deviceStream));
 
-      // We know that deviceStream is strictly behind the launchStream because launchStream
-      // synced with it before kernel launch. This allows us to to see deviceStream waiting
-      // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
-      // be handled specially so as not to create graphs with a blowup in the number of edges.
-      // So we could do this:
-      //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
-      // But instead we do:
-      NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+      if (!useLaunchStream) {
+        // deviceStream waits on userStream[0]
+        NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream,
+                                                     /*concurrent=*/false, &deviceStream));
+
+        // We know that deviceStream is strictly behind the launchStream because launchStream
+        // synced with it before kernel launch. This allows us to to see deviceStream waiting
+        // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
+        // be handled specially so as not to create graphs with a blowup in the number of edges.
+        // So we could do this:
+        //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
+        // But instead we do:
+        NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+      }
 
       // Each userStream[i] waits on userStream[0]
       for (struct ncclCudaStreamList* l = planner->streams->next; l != nullptr; l = l->next) {
@@ -2360,13 +2367,31 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       // As in ncclLaunchPrepare, strong stream can be non-concurrent when non-captured.
       bool concurrent = capturing;
       // Incorporate launch event into per-device (context) launch order.
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent,
-                                                   &launchOrder));
+      // NOTE: launchOrder cannot be eliminated even when NCCL_GRAPH_STREAM_ORDERING=0.
+      // comm->sharedRes->launchEvent is filled by CUDA via CU_LAUNCH_ATTRIBUTE_LAUNCH_COMPLETION_EVENT
+      // when cuLaunchKernelEx returns. Users cannot query a stream for the launch event of its last
+      // kernel, so this ordering dependency can never be delegated to the user's stream.
+      if (useLaunchStream) {
+        launchOrder = planner->capturingGraph.origin;
+      } else {
+        NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                                     &launchOrder));
+      }
       // If we don't have launch events (requires CUDA 12.3) then just use completion event (serialize execution).
       CUDACHECK(cudaStreamWaitEvent(
         launchOrder, implicitOrder == ncclImplicitOrderLaunch ? comm->sharedRes->launchEvent : finishedEvent));
-      // Release launchOrder as acquired in ncclLaunchPrepare()
-      NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->context->launchOrder, concurrent));
+      if (!useLaunchStream) {
+        // Release launchOrder as acquired in ncclLaunchPrepare()
+        NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->context->launchOrder, concurrent));
+      }
+    }
+    if (!useLaunchStream) {
+      if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
+        NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false));
+      }
+    } else {
+      NCCLCHECK(ncclCudaGraphRecordEvent(planner->capturingGraph, comm->sharedRes->deviceStream.serialEvent,
+                                         launchStream));
     }
   }
   return ncclSuccess;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2106,19 +2106,22 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       // secondary captureStream. Serialize graph launches by waiting on serialEvent via
       // hipEventWaitExternal, which HIP allows on the origin stream during capture.
       struct ncclStrongStream* ss = &comm->sharedRes->deviceStream;
-      bool firstCapture = !COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed);
-      COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
-      if (firstCapture) {
+      if (!COMPILER_ATOMIC_LOAD(&ss->graphOriginCaptured, std::memory_order_relaxed)) {
         // Bootstrap: signal serialEvent on the live stream so the first graph's ExternalWait
-        // node can fire immediately. This keeps graph structure identical across all
-        // captures (ExternalWait always present), so hipGraphExecUpdate succeeds.
+        // node can fire immediately. The wait stays unconditional, so graph structure is identical
+        // across all captures (ExternalWait always present) and hipGraphExecUpdate succeeds.
+        // Latch after the record so a failed record is retried instead of suppressed for good.
         CUDACHECKGOTO(cudaEventRecord(ss->serialEvent, ss->liveStream), result, failure);
+        COMPILER_ATOMIC_STORE(&ss->graphOriginCaptured, true, std::memory_order_relaxed);
       }
+      // everCaptured still has to be set: ncclStrongStream{Acquire,Release} read it to interlock
+      // non-captured work with graphs when a comm sharing this sharedRes uses graphUsageMode=2.
+      COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
       CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, ss->serialEvent, hipEventWaitExternal), result, failure);
       deviceStream = launchStream;
     } else {
-      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
-                                            &deviceStream),
+      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream,
+                                            /*concurrent=*/false, &deviceStream),
                     result, failure);
     }
 
@@ -2475,9 +2478,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       }
     }
     if (!useLaunchStream) {
-      if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
-        NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false));
-      }
+      NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false));
     } else {
       NCCLCHECK(ncclCudaGraphRecordEvent(planner->capturingGraph, comm->sharedRes->deviceStream.serialEvent,
                                          launchStream));

--- a/projects/rccl/src/include/strongstream.h
+++ b/projects/rccl/src/include/strongstream.h
@@ -120,6 +120,10 @@ struct ncclStrongStream {
 #if ROCM_VERSION >= 60100
   // This stream ever appeared in a graph capture.
   bool everCaptured;
+  // serialEvent has been recorded at least once for the graph-origin path used when
+  // graphStreamOrdering=0. Separate from everCaptured, which is also set by captures that never
+  // record serialEvent (graphUsageMode != 2) and is shared with splitShare children.
+  bool graphOriginCaptured;
   std::mutex mutex;
   struct ncclStrongStreamCapture* captureHead;
   // The event used to establish order between graphs and streams. During acquire

--- a/projects/rccl/src/misc/strongstream.cc
+++ b/projects/rccl/src/misc/strongstream.cc
@@ -108,6 +108,7 @@ ncclResult_t ncclStrongStreamConstruct(struct ncclStrongStream* ss) {
   CUDACHECK(cudaStreamCreateWithFlags(&ss->liveStream, cudaStreamNonBlocking));
 #if ROCM_VERSION >= 60100
   ss->everCaptured = false;
+  ss->graphOriginCaptured = false;
   ss->captureHead = nullptr;
   CUDACHECK(cudaEventCreateWithFlags(&ss->serialEvent, cudaEventDisableTiming));
 #endif

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -1429,4 +1429,187 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     ASSERT_MPI_EQ(ncclSuccess, ncclCommDestroy(splitComm));
 }
 
+/**
+ * @class GraphStreamOrderingConfigMPITest
+ * @brief Validates NCCL 2.30 graphStreamOrdering config parsing and compatibility
+ *        rules (see NCCL_GRAPH_STREAM_ORDERING in env.rst).
+ */
+class GraphStreamOrderingConfigMPITest : public ConfigCommMPITestBase
+{
+protected:
+    int configured_graph_stream_ordering_ = NCCL_CONFIG_UNDEF_INT;
+    int configured_graph_usage_mode_      = NCCL_CONFIG_UNDEF_INT;
+
+    void applyConfig(ncclConfig_t& config) override
+    {
+        config.graphStreamOrdering = configured_graph_stream_ordering_;
+        config.graphUsageMode      = configured_graph_usage_mode_;
+    }
+
+    std::string configLabel() const override
+    {
+        return "graphStreamOrdering=" + std::to_string(configured_graph_stream_ordering_)
+             + " graphUsageMode=" + std::to_string(configured_graph_usage_mode_);
+    }
+
+    static const char* graphStreamOrderingEnv()
+    {
+        return std::getenv("NCCL_GRAPH_STREAM_ORDERING");
+    }
+
+    static bool isGraphStreamOrderingEnvUnset()
+    {
+        return graphStreamOrderingEnv() == nullptr;
+    }
+
+    static bool isGraphStreamOrderingEnvSetAndValid()
+    {
+        const char* env = graphStreamOrderingEnv();
+        if(env == nullptr)
+        {
+            return false;
+        }
+        return std::string(env) == "0" || std::string(env) == "1";
+    }
+
+    static bool isGraphStreamOrderingEnvUnsetOrZero()
+    {
+        const char* env = graphStreamOrderingEnv();
+        if(env == nullptr)
+        {
+            return true;
+        }
+        return std::string(env) == "0";
+    }
+};
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering
+ * @brief ncclConfig_t graphStreamOrdering is stored on comm->config when env is unset.
+ *
+ * NCCL 2.30.7 upstream applies NCCL_GRAPH_STREAM_ORDERING after ncclConfig_t in
+ * envConfigOverride(), so this test requires the env var to be absent.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, ConfigOverrideAppliesGraphStreamOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvUnset())
+        << "NCCL_GRAPH_STREAM_ORDERING must not be set; upstream NCCL envConfigOverride() overrides "
+           "explicit ncclConfig_t graphStreamOrdering.";
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 0);
+    ASSERT_MPI_EQ(comm->config.graphUsageMode, 1);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering
+ * @brief graphStreamOrdering=0 with graphUsageMode=2 is unsupported and falls back to 1.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, IncompatibleMixingFallsBackToEnabledOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 2;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 1);
+    ASSERT_MPI_EQ(comm->config.graphUsageMode, 2);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering
+ * @brief NCCL_GRAPH_STREAM_ORDERING overrides ncclConfig_t graphStreamOrdering at init.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, EnvOverrideAppliesGraphStreamOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvSetAndValid())
+        << "NCCL_GRAPH_STREAM_ORDERING must be set to 0 or 1";
+
+    const int expected = std::atoi(graphStreamOrderingEnv());
+
+    // Set config to the opposite value; upstream NCCL envConfigOverride() must win.
+    configured_graph_stream_ordering_ = (expected == 0) ? 1 : 0;
+    configured_graph_usage_mode_        = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, expected);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke
+ * @brief Smoke test: graphStreamOrdering=0 with graphUsageMode=1 can capture and replay AllReduce.
+ *
+ * Requires effective ordering 0. Skips when NCCL_GRAPH_STREAM_ORDERING is set to 1,
+ * because upstream NCCL envConfigOverride() would override config graphStreamOrdering=0.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, DisabledOrderingGraphCaptureSmoke)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvUnsetOrZero())
+        << "NCCL_GRAPH_STREAM_ORDERING must be unset or 0; value 1 overrides config "
+           "graphStreamOrdering=0 in upstream NCCL.";
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 0);
+
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sendBuf, sizeof(float)));
+    auto sendGuard = makeDeviceBufferAutoGuard(sendBuf);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&recvBuf, sizeof(float)));
+    auto recvGuard = makeDeviceBufferAutoGuard(recvBuf);
+
+    const float sendVal = static_cast<float>(getTestMpiRank() + 1.0f);
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(sendBuf, &sendVal, sizeof(float), hipMemcpyHostToDevice));
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, 1, ncclFloat, ncclSum, comm, getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+    ASSERT_MPI_NE(nullptr, graph);
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    auto graphCleanup = makeScopeGuard([&]() {
+        if(graphExec) (void)hipGraphExecDestroy(graphExec);
+        if(graph) (void)hipGraphDestroy(graph);
+    });
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    float result = 0.0f;
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&result, recvBuf, sizeof(float), hipMemcpyDeviceToHost));
+
+    const int worldSize = MPIEnvironment::world_size;
+    const float expected = static_cast<float>(worldSize * (worldSize + 1) / 2);
+    ASSERT_NEAR(result, expected, 1e-3f);
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -937,4 +937,187 @@ TEST_F(GinRmaContextMPITest, RmaAndGinFinalizeWithSplitComm)
     ASSERT_MPI_EQ(ncclSuccess, ncclCommDestroy(splitComm));
 }
 
+/**
+ * @class GraphStreamOrderingConfigMPITest
+ * @brief Validates NCCL 2.30 graphStreamOrdering config parsing and compatibility
+ *        rules (see NCCL_GRAPH_STREAM_ORDERING in env.rst).
+ */
+class GraphStreamOrderingConfigMPITest : public ConfigCommMPITestBase
+{
+protected:
+    int configured_graph_stream_ordering_ = NCCL_CONFIG_UNDEF_INT;
+    int configured_graph_usage_mode_      = NCCL_CONFIG_UNDEF_INT;
+
+    void applyConfig(ncclConfig_t& config) override
+    {
+        config.graphStreamOrdering = configured_graph_stream_ordering_;
+        config.graphUsageMode      = configured_graph_usage_mode_;
+    }
+
+    std::string configLabel() const override
+    {
+        return "graphStreamOrdering=" + std::to_string(configured_graph_stream_ordering_)
+             + " graphUsageMode=" + std::to_string(configured_graph_usage_mode_);
+    }
+
+    static const char* graphStreamOrderingEnv()
+    {
+        return std::getenv("NCCL_GRAPH_STREAM_ORDERING");
+    }
+
+    static bool isGraphStreamOrderingEnvUnset()
+    {
+        return graphStreamOrderingEnv() == nullptr;
+    }
+
+    static bool isGraphStreamOrderingEnvSetAndValid()
+    {
+        const char* env = graphStreamOrderingEnv();
+        if(env == nullptr)
+        {
+            return false;
+        }
+        return std::string(env) == "0" || std::string(env) == "1";
+    }
+
+    static bool isGraphStreamOrderingEnvUnsetOrZero()
+    {
+        const char* env = graphStreamOrderingEnv();
+        if(env == nullptr)
+        {
+            return true;
+        }
+        return std::string(env) == "0";
+    }
+};
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering
+ * @brief ncclConfig_t graphStreamOrdering is stored on comm->config when env is unset.
+ *
+ * NCCL 2.30.7 upstream applies NCCL_GRAPH_STREAM_ORDERING after ncclConfig_t in
+ * envConfigOverride(), so this test requires the env var to be absent.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, ConfigOverrideAppliesGraphStreamOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvUnset())
+        << "NCCL_GRAPH_STREAM_ORDERING must not be set; upstream NCCL envConfigOverride() overrides "
+           "explicit ncclConfig_t graphStreamOrdering.";
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 0);
+    ASSERT_MPI_EQ(comm->config.graphUsageMode, 1);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering
+ * @brief graphStreamOrdering=0 with graphUsageMode=2 is unsupported and falls back to 1.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, IncompatibleMixingFallsBackToEnabledOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 2;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 1);
+    ASSERT_MPI_EQ(comm->config.graphUsageMode, 2);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering
+ * @brief NCCL_GRAPH_STREAM_ORDERING overrides ncclConfig_t graphStreamOrdering at init.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, EnvOverrideAppliesGraphStreamOrdering)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvSetAndValid())
+        << "NCCL_GRAPH_STREAM_ORDERING must be set to 0 or 1";
+
+    const int expected = std::atoi(graphStreamOrderingEnv());
+
+    // Set config to the opposite value; upstream NCCL envConfigOverride() must win.
+    configured_graph_stream_ordering_ = (expected == 0) ? 1 : 0;
+    configured_graph_usage_mode_        = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, expected);
+}
+
+/**
+ * @test GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke
+ * @brief Smoke test: graphStreamOrdering=0 with graphUsageMode=1 can capture and replay AllReduce.
+ *
+ * Requires effective ordering 0. Skips when NCCL_GRAPH_STREAM_ORDERING is set to 1,
+ * because upstream NCCL envConfigOverride() would override config graphStreamOrdering=0.
+ */
+TEST_F(GraphStreamOrderingConfigMPITest, DisabledOrderingGraphCaptureSmoke)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
+
+    ASSERT_TRUE(isGraphStreamOrderingEnvUnsetOrZero())
+        << "NCCL_GRAPH_STREAM_ORDERING must be unset or 0; value 1 overrides config "
+           "graphStreamOrdering=0 in upstream NCCL.";
+
+    configured_graph_stream_ordering_ = 0;
+    configured_graph_usage_mode_      = 1;
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_EQ(comm->config.graphStreamOrdering, 0);
+
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&sendBuf, sizeof(float)));
+    auto sendGuard = makeDeviceBufferAutoGuard(sendBuf);
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&recvBuf, sizeof(float)));
+    auto recvGuard = makeDeviceBufferAutoGuard(recvBuf);
+
+    const float sendVal = static_cast<float>(getTestMpiRank() + 1.0f);
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(sendBuf, &sendVal, sizeof(float), hipMemcpyHostToDevice));
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, 1, ncclFloat, ncclSum, comm, getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+    ASSERT_MPI_NE(nullptr, graph);
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    auto graphCleanup = makeScopeGuard([&]() {
+        if(graphExec) (void)hipGraphExecDestroy(graphExec);
+        if(graph) (void)hipGraphDestroy(graph);
+    });
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    float result = 0.0f;
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&result, recvBuf, sizeof(float), hipMemcpyDeviceToHost));
+
+    const int worldSize = MPIEnvironment::world_size;
+    const float expected = static_cast<float>(worldSize * (worldSize + 1) / 2);
+    ASSERT_NEAR(result, expected, 1e-3f);
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -1452,34 +1452,10 @@ protected:
              + " graphUsageMode=" + std::to_string(configured_graph_usage_mode_);
     }
 
-    static const char* graphStreamOrderingEnv()
+    static int graphStreamOrderingEnv()
     {
-        return std::getenv("NCCL_GRAPH_STREAM_ORDERING");
-    }
-
-    static bool isGraphStreamOrderingEnvUnset()
-    {
-        return graphStreamOrderingEnv() == nullptr;
-    }
-
-    static bool isGraphStreamOrderingEnvSetAndValid()
-    {
-        const char* env = graphStreamOrderingEnv();
-        if(env == nullptr)
-        {
-            return false;
-        }
-        return std::string(env) == "0" || std::string(env) == "1";
-    }
-
-    static bool isGraphStreamOrderingEnvUnsetOrZero()
-    {
-        const char* env = graphStreamOrderingEnv();
-        if(env == nullptr)
-        {
-            return true;
-        }
-        return std::string(env) == "0";
+        return MPIHelpers::getEnvParam<int>("NCCL_GRAPH_STREAM_ORDERING",
+                                            NCCL_CONFIG_UNDEF_INT);
     }
 };
 
@@ -1494,9 +1470,11 @@ TEST_F(GraphStreamOrderingConfigMPITest, ConfigOverrideAppliesGraphStreamOrderin
 {
     ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
 
-    ASSERT_TRUE(isGraphStreamOrderingEnvUnset())
-        << "NCCL_GRAPH_STREAM_ORDERING must not be set; upstream NCCL envConfigOverride() overrides "
-           "explicit ncclConfig_t graphStreamOrdering.";
+    if(graphStreamOrderingEnv() != NCCL_CONFIG_UNDEF_INT)
+    {
+        GTEST_SKIP() << "NCCL_GRAPH_STREAM_ORDERING must not be set; upstream NCCL "
+                        "envConfigOverride() overrides explicit ncclConfig_t graphStreamOrdering.";
+    }
 
     configured_graph_stream_ordering_ = 0;
     configured_graph_usage_mode_      = 1;
@@ -1517,6 +1495,14 @@ TEST_F(GraphStreamOrderingConfigMPITest, IncompatibleMixingFallsBackToEnabledOrd
 {
     ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
 
+    const int graphStreamOrdering = graphStreamOrderingEnv();
+    if(graphStreamOrdering != NCCL_CONFIG_UNDEF_INT && graphStreamOrdering != 0)
+    {
+        GTEST_SKIP() << "NCCL_GRAPH_STREAM_ORDERING must be unset or 0; value 1 sets "
+                        "graphStreamOrdering=1 before the incompatible-mixing fallback, which "
+                        "would then not be exercised.";
+    }
+
     configured_graph_stream_ordering_ = 0;
     configured_graph_usage_mode_      = 2;
 
@@ -1536,14 +1522,15 @@ TEST_F(GraphStreamOrderingConfigMPITest, EnvOverrideAppliesGraphStreamOrdering)
 {
     ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
 
-    ASSERT_TRUE(isGraphStreamOrderingEnvSetAndValid())
-        << "NCCL_GRAPH_STREAM_ORDERING must be set to 0 or 1";
-
-    const int expected = std::atoi(graphStreamOrderingEnv());
+    const int expected = graphStreamOrderingEnv();
+    if(expected != 0 && expected != 1)
+    {
+        GTEST_SKIP() << "NCCL_GRAPH_STREAM_ORDERING must be set to 0 or 1";
+    }
 
     // Set config to the opposite value; upstream NCCL envConfigOverride() must win.
     configured_graph_stream_ordering_ = (expected == 0) ? 1 : 0;
-    configured_graph_usage_mode_        = 1;
+    configured_graph_usage_mode_      = 1;
 
     ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
@@ -1554,7 +1541,12 @@ TEST_F(GraphStreamOrderingConfigMPITest, EnvOverrideAppliesGraphStreamOrdering)
 
 /**
  * @test GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke
- * @brief Smoke test: graphStreamOrdering=0 with graphUsageMode=1 can capture and replay AllReduce.
+ * @brief graphStreamOrdering=0 with graphUsageMode=1 captures and replays AllReduce.
+ *
+ * Captures the same collective into two graphs and replays both, so the first/subsequent
+ * capture split of the origin-stream path is covered rather than just the single-capture
+ * case. Both graphs are launched on one stream with a host sync between them, so the
+ * cross-graph serialEvent dependency is not itself exercised.
  *
  * Requires effective ordering 0. Skips when NCCL_GRAPH_STREAM_ORDERING is set to 1,
  * because upstream NCCL envConfigOverride() would override config graphStreamOrdering=0.
@@ -1563,9 +1555,12 @@ TEST_F(GraphStreamOrderingConfigMPITest, DisabledOrderingGraphCaptureSmoke)
 {
     ASSERT_MPI_TRUE(validateTestPrerequisites(kMinProcessesForMPI));
 
-    ASSERT_TRUE(isGraphStreamOrderingEnvUnsetOrZero())
-        << "NCCL_GRAPH_STREAM_ORDERING must be unset or 0; value 1 overrides config "
-           "graphStreamOrdering=0 in upstream NCCL.";
+    const int graphStreamOrdering = graphStreamOrderingEnv();
+    if(graphStreamOrdering != NCCL_CONFIG_UNDEF_INT && graphStreamOrdering != 0)
+    {
+        GTEST_SKIP() << "NCCL_GRAPH_STREAM_ORDERING must be unset or 0; value 1 overrides config "
+                        "graphStreamOrdering=0 in upstream NCCL.";
+    }
 
     configured_graph_stream_ordering_ = 0;
     configured_graph_usage_mode_      = 1;
@@ -1586,30 +1581,69 @@ TEST_F(GraphStreamOrderingConfigMPITest, DisabledOrderingGraphCaptureSmoke)
     const float sendVal = static_cast<float>(getTestMpiRank() + 1.0f);
     ASSERT_MPI_EQ(hipSuccess, hipMemcpy(sendBuf, &sendVal, sizeof(float), hipMemcpyHostToDevice));
 
-    hipGraph_t graph = nullptr;
-    hipGraphExec_t graphExec = nullptr;
+    constexpr int  kGraphs             = 2;
+    hipGraph_t     graphs[kGraphs]     = {};
+    hipGraphExec_t graphExecs[kGraphs] = {};
 
-    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
-    ASSERT_MPI_EQ(ncclSuccess,
-                  ncclAllReduce(sendBuf, recvBuf, 1, ncclFloat, ncclSum, comm, getActiveStream()));
-    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
-    ASSERT_MPI_NE(nullptr, graph);
-
-    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
     auto graphCleanup = makeScopeGuard([&]() {
-        if(graphExec) (void)hipGraphExecDestroy(graphExec);
-        if(graph) (void)hipGraphDestroy(graph);
+        for(int i = 0; i < kGraphs; ++i)
+        {
+            if(graphExecs[i]) (void)hipGraphExecDestroy(graphExecs[i]);
+            if(graphs[i]) (void)hipGraphDestroy(graphs[i]);
+        }
     });
 
-    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
-    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+    bool captureActive = false;
+    auto captureCleanup = makeScopeGuard([&]() {
+        if(captureActive)
+        {
+            hipGraph_t abandonedGraph = nullptr;
+            if(hipStreamEndCapture(getActiveStream(), &abandonedGraph) == hipSuccess &&
+               abandonedGraph)
+                (void)hipGraphDestroy(abandonedGraph);
+        }
+    });
 
-    float result = 0.0f;
-    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&result, recvBuf, sizeof(float), hipMemcpyDeviceToHost));
+    // Capture twice so both halves of the origin-stream path run: the first capture bootstraps
+    // serialEvent on the live stream, the second must take the already-bootstrapped path.
+    for(int i = 0; i < kGraphs; ++i)
+    {
+        const hipError_t captureBeginStatus =
+            hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal);
+        captureActive = (captureBeginStatus == hipSuccess);
+        ASSERT_MPI_EQ(hipSuccess, captureBeginStatus);
+        ASSERT_MPI_EQ(ncclSuccess,
+                      ncclAllReduce(sendBuf, recvBuf, 1, ncclFloat, ncclSum, comm, getActiveStream()));
+        const hipError_t captureEndStatus = hipStreamEndCapture(getActiveStream(), &graphs[i]);
+        if(captureEndStatus == hipSuccess) captureActive = false;
+        ASSERT_MPI_EQ(hipSuccess, captureEndStatus);
+        ASSERT_MPI_NE(nullptr, graphs[i]);
+        ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExecs[i], graphs[i], nullptr, nullptr, 0));
+    }
 
-    const int worldSize = MPIEnvironment::world_size;
-    const float expected = static_cast<float>(worldSize * (worldSize + 1) / 2);
-    ASSERT_NEAR(result, expected, 1e-3f);
+#if ROCM_VERSION >= 60100
+    // graphStreamOrdering=0 must launch directly on the graph origin instead of acquiring
+    // deviceStream.captureStream. This assertion fails if the enqueue.cc feature is reverted.
+    ASSERT_MPI_TRUE(comm->sharedRes->deviceStream.captureHead == nullptr);
+#endif
+
+    const int   worldSize = MPIEnvironment::world_size;
+    const float expected  = static_cast<float>(worldSize * (worldSize + 1) / 2);
+
+    for(int i = 0; i < kGraphs; ++i)
+    {
+        ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, sizeof(float)));
+        ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExecs[i], getActiveStream()));
+        ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        float result = 0.0f;
+        ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&result, recvBuf, sizeof(float), hipMemcpyDeviceToHost));
+
+        // EXPECT_NEAR reports the values; the fatal check must be MPI-aware so one mismatching
+        // rank cannot leave the others waiting in the next iteration's collective asserts.
+        EXPECT_NEAR(result, expected, 1e-3f) << "graph " << i;
+        ASSERT_MPI_TRUE(result >= expected - 1e-3f && result <= expected + 1e-3f);
+    }
 }
 
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -11,6 +11,7 @@
  * This file contains tests for:
  * 1. User Buffer Registration (UBR) - explicit buffer registration via ncclCommRegister
  * 2. Graph Capture Registration - automatic buffer registration during HIP graph capture
+ * 3. Symmetric window registration during HIP graph capture (NCCL 2.30.7)
  *
  * REQUIRED Environment Variables:
  *   NCCL_DEBUG=INFO              Enable debug logging
@@ -2298,6 +2299,105 @@ TEST_F(GraphCapture_AllReduce, MultiNode)
     bool resultValid = verifyAllReduceResult<T>(recvBuf, count, nRanks);
     ASSERT_TRUE(resultValid);
     TEST_INFO("AllReduce graph test completed successfully");
+}
+
+// ============================================================================
+// Graph Capture + Symmetric Window Registration
+// ============================================================================
+
+/**
+ * @brief Exercises ncclCommWindowRegister during HIP graph capture.
+ *
+ * NCCL 2.30.7 added support for symmetric window registration while a stream
+ * is capturing. RCCL mirrors this by running host-side registration work in
+ * relaxed capture mode (dev_runtime.cc). This test registers symmetric windows
+ * inside capture, issues a captured AllReduce on those buffers, and verifies
+ * correctness after graph replay.
+ *
+ * Requires NCCL_CUMEM_ENABLE=1 and NCCL_WIN_ENABLE!=0.
+ */
+class GraphCapture_WindowRegister : public RegistrationTestBase {};
+
+TEST_F(GraphCapture_WindowRegister, SymmetricAllReduce)
+{
+    if(!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT))
+    {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+
+    using T = RegTestConfig::DefaultType;
+    const size_t count = RegTestConfig::MEDIUM_COUNT;
+
+    int rank = 0;
+    int nRanks = 0;
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t bufSize = count * sizeof(T);
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, bufSize));
+
+    auto bufCleanup = makeScopeGuard([&]() {
+        if (sendBuf) (void)ncclMemFree(sendBuf);
+        if (recvBuf) (void)ncclMemFree(recvBuf);
+    });
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+    ncclWindow_t sendWin = nullptr;
+    ncclWindow_t recvWin = nullptr;
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(getActiveCommunicator(), sendBuf, bufSize, &sendWin,
+                                         NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(getActiveCommunicator(), recvBuf, bufSize, &recvWin,
+                                         NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum,
+                                getActiveCommunicator(), getActiveStream()));
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+    ASSERT_MPI_NE(nullptr, graph);
+
+    size_t numNodes = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numNodes));
+    ASSERT_MPI_GT(numNodes, 0u);
+    TEST_INFO("GraphCapture_WindowRegister captured graph with %zu nodes", numNodes);
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+    auto graphCleanup = makeScopeGuard([&]() {
+        if (graphExec) (void)hipGraphExecDestroy(graphExec);
+        if (graph) (void)hipGraphDestroy(graph);
+    });
+
+    ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, bufSize));
+    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_TRUE(verifyAllReduceResult<T>(recvBuf, count, nRanks));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), sendWin));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWin));
+    sendWin = nullptr;
+    recvWin = nullptr;
+
+    TEST_INFO("GraphCapture_WindowRegister symmetric AllReduce completed successfully");
 }
 
 // ============================================================================

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -30,9 +30,11 @@
 #include "MPIHelpers.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
+#include "comm.h"
 #include <cstdlib>
 #include <regex>
 #include <sstream>
+#include <string>
 
 #ifdef MPI_TESTS_ENABLED
 
@@ -125,6 +127,22 @@ public:
         return hasPattern("RCCL DIRECT ALLGATHER has been disabled") ||
                hasPattern("RCCL DIRECT ALLGATHER disabled") ||
                hasPattern("Direct AllGather disabled");
+    }
+
+    bool usedSymmetricCollective(const std::string& collective) const
+    {
+        return hasPattern(collective + " [Symmetric]:");
+    }
+
+    bool usedLegacyCollective(const std::string& collective) const
+    {
+        const std::regex re(collective + ": [^\\n]*-> Algo ");
+        return std::regex_search(m_content, re);
+    }
+
+    bool usedNonSymmetricWindowRegistration() const
+    {
+        return hasPattern("windowRegisterNonSym:");
     }
 
     std::string getSummary() const
@@ -2310,94 +2328,234 @@ TEST_F(GraphCapture_AllReduce, MultiNode)
  *
  * NCCL 2.30.7 added support for symmetric window registration while a stream
  * is capturing. RCCL mirrors this by running host-side registration work in
- * relaxed capture mode (dev_runtime.cc). This test registers symmetric windows
- * inside capture, issues a captured AllReduce on those buffers, and verifies
- * correctness after graph replay.
+ * relaxed capture mode (dev_runtime.cc). These tests register symmetric windows
+ * inside capture, issue each symmetric-kernel-capable collective on those
+ * buffers, and verify correctness after graph replay. The same tests run on
+ * single- and multi-node configurations and validate the selected symmetric or
+ * legacy-fallback scheduler path.
  *
  * Requires NCCL_CUMEM_ENABLE=1 and NCCL_WIN_ENABLE!=0.
  */
-class GraphCapture_WindowRegister : public RegistrationTestBase {};
+class GraphCapture_WindowRegister : public RegistrationTestBase
+{
+protected:
+    enum class Collective
+    {
+        AllReduce,
+        AllGather,
+        ReduceScatter
+    };
+
+    static const char* collectiveName(Collective collective)
+    {
+        switch(collective)
+        {
+        case Collective::AllReduce:     return "AllReduce";
+        case Collective::AllGather:     return "AllGather";
+        case Collective::ReduceScatter: return "ReduceScatter";
+        }
+        return "Unknown";
+    }
+
+    void runSymmetricCollective(Collective collective)
+    {
+        if(!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT))
+        {
+            GTEST_SKIP() << "Requires 2+ ranks";
+        }
+
+        ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+        ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+        ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+
+        using T = RegTestConfig::DefaultType;
+        const size_t count = RegTestConfig::MEDIUM_COUNT;
+
+        int rank = 0;
+        int nRanks = 0;
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        size_t sendCount = count;
+        size_t recvCount = count;
+        if(collective == Collective::AllGather)
+        {
+            recvCount *= static_cast<size_t>(nRanks);
+        }
+        else if(collective == Collective::ReduceScatter)
+        {
+            sendCount *= static_cast<size_t>(nRanks);
+        }
+
+        const size_t sendBytes = sendCount * sizeof(T);
+        const size_t recvBytes = recvCount * sizeof(T);
+        void* sendBuf = nullptr;
+        void* recvBuf = nullptr;
+
+        ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, sendBytes));
+        ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, recvBytes));
+
+        auto bufCleanup = makeScopeGuard([&]() {
+            if(sendBuf) (void)ncclMemFree(sendBuf);
+            if(recvBuf) (void)ncclMemFree(recvBuf);
+        });
+
+        initSendBuffer<T>(sendBuf, sendCount, rank);
+
+        hipGraph_t graph = nullptr;
+        hipGraphExec_t graphExec = nullptr;
+        ncclWindow_t sendWin = nullptr;
+        ncclWindow_t recvWin = nullptr;
+
+        ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), sendBuf, sendBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), recvBuf, recvBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+        ASSERT_MPI_NE(sendWin, nullptr);
+        ASSERT_MPI_NE(recvWin, nullptr);
+
+        switch(collective)
+        {
+        case Collective::AllReduce:
+            ASSERT_MPI_EQ(ncclSuccess, ncclAllReduce(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum, getActiveCommunicator(), getActiveStream()));
+            break;
+        case Collective::AllGather:
+            ASSERT_MPI_EQ(ncclSuccess, ncclAllGather(sendBuf, recvBuf, count, getNcclDataType<T>(), getActiveCommunicator(), getActiveStream()));
+            break;
+        case Collective::ReduceScatter:
+            ASSERT_MPI_EQ(ncclSuccess, ncclReduceScatter(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum, getActiveCommunicator(), getActiveStream()));
+            break;
+        }
+
+        ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+        ASSERT_MPI_NE(nullptr, graph);
+
+        size_t numGraphNodes = 0;
+        ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numGraphNodes));
+        ASSERT_MPI_GT(numGraphNodes, 0u);
+        TEST_INFO("GraphCapture_WindowRegister %s captured graph with %zu nodes", collectiveName(collective), numGraphNodes);
+
+        ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+        auto graphCleanup = makeScopeGuard([&]() {
+            if(graphExec) (void)hipGraphExecDestroy(graphExec);
+            if(graph) (void)hipGraphDestroy(graph);
+        });
+        auto windowCleanup = makeScopeGuard([&]() {
+            if(sendWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), sendWin);
+            if(recvWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), recvWin);
+        });
+
+        constexpr int kGraphLaunches = 2;
+        for(int launch = 0; launch < kGraphLaunches; ++launch)
+        {
+            ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, recvBytes));
+            ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+            ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+            bool resultValid = false;
+            switch(collective)
+            {
+            case Collective::AllReduce:
+                resultValid = verifyAllReduceResult<T>(recvBuf, count, nRanks);
+                break;
+            case Collective::AllGather:
+                resultValid = verifyAllGatherResult<T>(recvBuf, count, nRanks);
+                break;
+            case Collective::ReduceScatter:
+                resultValid = verifyReduceScatterResult<T>(recvBuf, count, nRanks);
+                break;
+            }
+            ASSERT_MPI_TRUE(resultValid);
+        }
+
+        ncclComm* comm = getActiveCommunicator();
+        const bool ginKernelsEnabled =
+            MPIHelpers::getEnvParam<int>("NCCL_SYM_GIN_KERNELS_ENABLE", 1) != 0;
+        const bool symmetricRuntimeAvailable =
+            comm->symmetricSupport && comm->isAllDirectNvlink;
+
+        bool expectSymmetric = symmetricRuntimeAvailable;
+        if(comm->nNodes > 1)
+        {
+            switch(collective)
+            {
+            case Collective::AllReduce:
+                // No AllReduce kernel is present in kernelMask_Gin.
+                expectSymmetric = false;
+                break;
+            case Collective::AllGather:
+                // The multi-node AllGather kernel requires LSA store multimem.
+                expectSymmetric = symmetricRuntimeAvailable && ginKernelsEnabled &&
+                                  comm->symkState.hasLsaMultimem;
+                break;
+            case Collective::ReduceScatter:
+                // RailA2A_LsaLD does not require LSA multimem.
+                expectSymmetric = symmetricRuntimeAvailable && ginKernelsEnabled;
+                break;
+            }
+        }
+
+        const REGLogChecker checker = getLogChecker();
+        const bool sawSymmetric = checker.usedSymmetricCollective(collectiveName(collective));
+        const bool sawLegacy = checker.usedLegacyCollective(collectiveName(collective));
+        TEST_INFO("%s path: nNodes=%d symmetricSupport=%d isAllDirectNvlink=%d "
+                  "hasLsaMultimem=%d expected=%s observedSymmetric=%d observedLegacy=%d",
+                  collectiveName(collective), comm->nNodes, comm->symmetricSupport,
+                  static_cast<int>(comm->isAllDirectNvlink),
+                  static_cast<int>(comm->symkState.hasLsaMultimem),
+                  expectSymmetric ? "symmetric" : "legacy", static_cast<int>(sawSymmetric),
+                  static_cast<int>(sawLegacy));
+
+        // Both markers come from NCCL_TUNING on communicator rank 0. Seeing
+        // neither means that subsystem is off (or this rank is not rank 0), so
+        // there is nothing to compare against and only correctness is checked.
+        // Non-fatal: only rank 0 reaches this branch, and the collective
+        // assertions that follow must still be executed by every rank.
+        const bool pathMarkerPresent = sawSymmetric || sawLegacy;
+        if(pathMarkerPresent)
+        {
+            EXPECT_EQ(expectSymmetric, sawSymmetric)
+                << collectiveName(collective) << ": expected the "
+                << (expectSymmetric ? "symmetric" : "legacy fallback") << " path";
+            if(!comm->symmetricSupport)
+            {
+                EXPECT_TRUE(checker.usedNonSymmetricWindowRegistration())
+                    << "symmetricSupport is off, so registration must report windowRegisterNonSym";
+            }
+        }
+        else
+        {
+            TEST_INFO("No TUNING path marker for %s; run with NCCL_DEBUG=INFO, "
+                      "NCCL_DEBUG_SUBSYS including TUNING and RCCL_MPI_LOG_ALL_RANKS=1 to also "
+                      "assert the scheduler path",
+                      collectiveName(collective));
+        }
+
+        ASSERT_MPI_EQ(ncclSuccess,ncclCommWindowDeregister(getActiveCommunicator(), sendWin));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWin));
+        sendWin = nullptr;
+        recvWin = nullptr;
+
+        TEST_INFO("GraphCapture_WindowRegister %s completed via %s path",
+                  collectiveName(collective), expectSymmetric ? "symmetric" : "legacy fallback");
+    }
+};
 
 TEST_F(GraphCapture_WindowRegister, SymmetricAllReduce)
 {
-    if(!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT))
-    {
-        GTEST_SKIP() << "Requires 2+ ranks";
-    }
-    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    runSymmetricCollective(Collective::AllReduce);
+}
 
-    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
-    ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+TEST_F(GraphCapture_WindowRegister, SymmetricAllGather)
+{
+    runSymmetricCollective(Collective::AllGather);
+}
 
-    using T = RegTestConfig::DefaultType;
-    const size_t count = RegTestConfig::MEDIUM_COUNT;
-
-    int rank = 0;
-    int nRanks = 0;
-    ncclCommUserRank(getActiveCommunicator(), &rank);
-    ncclCommCount(getActiveCommunicator(), &nRanks);
-
-    const size_t bufSize = count * sizeof(T);
-    void* sendBuf = nullptr;
-    void* recvBuf = nullptr;
-
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, bufSize));
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, bufSize));
-
-    auto bufCleanup = makeScopeGuard([&]() {
-        if (sendBuf) (void)ncclMemFree(sendBuf);
-        if (recvBuf) (void)ncclMemFree(recvBuf);
-    });
-
-    initSendBuffer<T>(sendBuf, count, rank);
-
-    hipGraph_t graph = nullptr;
-    hipGraphExec_t graphExec = nullptr;
-    ncclWindow_t sendWin = nullptr;
-    ncclWindow_t recvWin = nullptr;
-
-    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
-
-    ASSERT_MPI_EQ(ncclSuccess,
-                  ncclCommWindowRegister(getActiveCommunicator(), sendBuf, bufSize, &sendWin,
-                                         NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_EQ(ncclSuccess,
-                  ncclCommWindowRegister(getActiveCommunicator(), recvBuf, bufSize, &recvWin,
-                                         NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_NE(sendWin, nullptr);
-    ASSERT_MPI_NE(recvWin, nullptr);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-                  ncclAllReduce(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum,
-                                getActiveCommunicator(), getActiveStream()));
-
-    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
-    ASSERT_MPI_NE(nullptr, graph);
-
-    size_t numNodes = 0;
-    ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numNodes));
-    ASSERT_MPI_GT(numNodes, 0u);
-    TEST_INFO("GraphCapture_WindowRegister captured graph with %zu nodes", numNodes);
-
-    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
-
-    auto graphCleanup = makeScopeGuard([&]() {
-        if (graphExec) (void)hipGraphExecDestroy(graphExec);
-        if (graph) (void)hipGraphDestroy(graph);
-    });
-
-    ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, bufSize));
-    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
-
-    ASSERT_TRUE(verifyAllReduceResult<T>(recvBuf, count, nRanks));
-
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), sendWin));
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWin));
-    sendWin = nullptr;
-    recvWin = nullptr;
-
-    TEST_INFO("GraphCapture_WindowRegister symmetric AllReduce completed successfully");
+TEST_F(GraphCapture_WindowRegister, SymmetricReduceScatter)
+{
+    runSymmetricCollective(Collective::ReduceScatter);
 }
 
 // ============================================================================

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -11,6 +11,7 @@
  * This file contains tests for:
  * 1. User Buffer Registration (UBR) - explicit buffer registration via ncclCommRegister
  * 2. Graph Capture Registration - automatic buffer registration during HIP graph capture
+ * 3. Symmetric window registration during HIP graph capture (NCCL 2.30.7)
  *
  * REQUIRED Environment Variables:
  *   NCCL_DEBUG=INFO              Enable debug logging
@@ -2289,6 +2290,105 @@ TEST_F(GraphCapture_AllReduce, MultiNode)
     bool resultValid = verifyAllReduceResult<T>(recvBuf, count, nRanks);
     ASSERT_TRUE(resultValid);
     TEST_INFO("AllReduce graph test completed successfully");
+}
+
+// ============================================================================
+// Graph Capture + Symmetric Window Registration
+// ============================================================================
+
+/**
+ * @brief Exercises ncclCommWindowRegister during HIP graph capture.
+ *
+ * NCCL 2.30.7 added support for symmetric window registration while a stream
+ * is capturing. RCCL mirrors this by running host-side registration work in
+ * relaxed capture mode (dev_runtime.cc). This test registers symmetric windows
+ * inside capture, issues a captured AllReduce on those buffers, and verifies
+ * correctness after graph replay.
+ *
+ * Requires NCCL_CUMEM_ENABLE=1 and NCCL_WIN_ENABLE!=0.
+ */
+class GraphCapture_WindowRegister : public RegistrationTestBase {};
+
+TEST_F(GraphCapture_WindowRegister, SymmetricAllReduce)
+{
+    if(!validateTestPrerequisites(RegTestConfig::MIN_RANKS_DEFAULT))
+    {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+
+    using T = RegTestConfig::DefaultType;
+    const size_t count = RegTestConfig::MEDIUM_COUNT;
+
+    int rank = 0;
+    int nRanks = 0;
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t bufSize = count * sizeof(T);
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, bufSize));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, bufSize));
+
+    auto bufCleanup = makeScopeGuard([&]() {
+        if (sendBuf) (void)ncclMemFree(sendBuf);
+        if (recvBuf) (void)ncclMemFree(recvBuf);
+    });
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    hipGraph_t graph = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+    ncclWindow_t sendWin = nullptr;
+    ncclWindow_t recvWin = nullptr;
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(getActiveCommunicator(), sendBuf, bufSize, &sendWin,
+                                         NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(getActiveCommunicator(), recvBuf, bufSize, &recvWin,
+                                         NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum,
+                                getActiveCommunicator(), getActiveStream()));
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+    ASSERT_MPI_NE(nullptr, graph);
+
+    size_t numNodes = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numNodes));
+    ASSERT_MPI_GT(numNodes, 0u);
+    TEST_INFO("GraphCapture_WindowRegister captured graph with %zu nodes", numNodes);
+
+    ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+    auto graphCleanup = makeScopeGuard([&]() {
+        if (graphExec) (void)hipGraphExecDestroy(graphExec);
+        if (graph) (void)hipGraphDestroy(graph);
+    });
+
+    ASSERT_MPI_EQ(hipSuccess, hipMemset(recvBuf, 0, bufSize));
+    ASSERT_MPI_EQ(hipSuccess, hipGraphLaunch(graphExec, getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_TRUE(verifyAllReduceResult<T>(recvBuf, count, nRanks));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), sendWin));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWin));
+    sendWin = nullptr;
+    recvWin = nullptr;
+
+    TEST_INFO("GraphCapture_WindowRegister symmetric AllReduce completed successfully");
 }
 
 // ============================================================================

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -2364,18 +2364,21 @@ protected:
             GTEST_SKIP() << "Requires 2+ ranks";
         }
 
+        MPIHelpers::TestLogAssertionContext logCtx(
+            MPIHelpers::makePerRankStderrAssertionOptions(getTestMpiRank()));
+
         ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
-        ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
-        ASSERT_TRUE(isWinEnabled()) << "NCCL_WIN_ENABLE must not be set to 0";
+        ASSERT_MPI_TRUE(isCuMemEnabled());
+        ASSERT_MPI_TRUE(isWinEnabled());
 
         using T = RegTestConfig::DefaultType;
         const size_t count = RegTestConfig::MEDIUM_COUNT;
 
         int rank = 0;
         int nRanks = 0;
-        ncclCommUserRank(getActiveCommunicator(), &rank);
-        ncclCommCount(getActiveCommunicator(), &nRanks);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommUserRank(getActiveCommunicator(), &rank));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommCount(getActiveCommunicator(), &nRanks));
 
         size_t sendCount = count;
         size_t recvCount = count;
@@ -2394,21 +2397,45 @@ protected:
         void* recvBuf = nullptr;
 
         ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&sendBuf, sendBytes));
+        auto sendBufGuard = makeHipMemBufferAutoGuard(sendBuf);
         ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&recvBuf, recvBytes));
+        auto recvBufGuard = makeHipMemBufferAutoGuard(recvBuf);
 
-        auto bufCleanup = makeScopeGuard([&]() {
-            if(sendBuf) (void)ncclMemFree(sendBuf);
-            if(recvBuf) (void)ncclMemFree(recvBuf);
-        });
-
-        initSendBuffer<T>(sendBuf, sendCount, rank);
+        ASSERT_MPI_EQ(
+            hipSuccess,
+            initializeBufferWithPattern<T>(
+                sendBuf,
+                sendCount,
+                [rank](size_t) { return static_cast<T>(static_cast<float>(rank + 1)); }));
 
         hipGraph_t graph = nullptr;
         hipGraphExec_t graphExec = nullptr;
         ncclWindow_t sendWin = nullptr;
         ncclWindow_t recvWin = nullptr;
 
-        ASSERT_MPI_EQ(hipSuccess, hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal));
+        bool captureActive = false;
+
+        auto windowCleanup = makeScopeGuard([&]() {
+            if(sendWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), sendWin);
+            if(recvWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), recvWin);
+        });
+
+        // Declared after windowCleanup so it unwinds first: an early return before
+        // hipStreamEndCapture must leave the stream idle, because the deregisters above cannot
+        // be issued into a capturing stream.
+        auto captureCleanup = makeScopeGuard([&]() {
+            if(captureActive)
+            {
+                hipGraph_t abandonedGraph = nullptr;
+                if(hipStreamEndCapture(getActiveStream(), &abandonedGraph) == hipSuccess && abandonedGraph)
+                    (void)hipGraphDestroy(abandonedGraph);
+            }
+        });
+
+        const hipError_t captureBeginStatus =
+            hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal);
+        captureActive = (captureBeginStatus == hipSuccess);
+        ASSERT_MPI_EQ(hipSuccess, captureBeginStatus);
 
         ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), sendBuf, sendBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
         ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), recvBuf, recvBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
@@ -2428,8 +2455,16 @@ protected:
             break;
         }
 
-        ASSERT_MPI_EQ(hipSuccess, hipStreamEndCapture(getActiveStream(), &graph));
+        const hipError_t captureEndStatus = hipStreamEndCapture(getActiveStream(), &graph);
+        if(captureEndStatus == hipSuccess) captureActive = false;
+        ASSERT_MPI_EQ(hipSuccess, captureEndStatus);
         ASSERT_MPI_NE(nullptr, graph);
+
+        // Guard the graph as soon as it exists; graphExec is null-checked until instantiated.
+        auto graphCleanup = makeScopeGuard([&]() {
+            if(graphExec) (void)hipGraphExecDestroy(graphExec);
+            if(graph) (void)hipGraphDestroy(graph);
+        });
 
         size_t numGraphNodes = 0;
         ASSERT_MPI_EQ(hipSuccess, hipGraphGetNodes(graph, nullptr, &numGraphNodes));
@@ -2437,15 +2472,6 @@ protected:
         TEST_INFO("GraphCapture_WindowRegister %s captured graph with %zu nodes", collectiveName(collective), numGraphNodes);
 
         ASSERT_MPI_EQ(hipSuccess, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
-
-        auto graphCleanup = makeScopeGuard([&]() {
-            if(graphExec) (void)hipGraphExecDestroy(graphExec);
-            if(graph) (void)hipGraphDestroy(graph);
-        });
-        auto windowCleanup = makeScopeGuard([&]() {
-            if(sendWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), sendWin);
-            if(recvWin) (void)ncclCommWindowDeregister(getActiveCommunicator(), recvWin);
-        });
 
         constexpr int kGraphLaunches = 2;
         for(int launch = 0; launch < kGraphLaunches; ++launch)
@@ -2477,7 +2503,7 @@ protected:
             comm->symmetricSupport && comm->isAllDirectNvlink;
 
         bool expectSymmetric = symmetricRuntimeAvailable;
-        if(comm->nNodes > 1)
+        if(comm->devrState.lsaSize < comm->nRanks)
         {
             switch(collective)
             {
@@ -2497,13 +2523,13 @@ protected:
             }
         }
 
-        const REGLogChecker checker = getLogChecker();
+        const REGLogChecker checker(logCtx.readPerRankStderrLog());
         const bool sawSymmetric = checker.usedSymmetricCollective(collectiveName(collective));
         const bool sawLegacy = checker.usedLegacyCollective(collectiveName(collective));
-        TEST_INFO("%s path: nNodes=%d symmetricSupport=%d isAllDirectNvlink=%d "
+        TEST_INFO("%s path: nNodes=%d lsaSize=%d nRanks=%d symmetricSupport=%d isAllDirectNvlink=%d "
                   "hasLsaMultimem=%d expected=%s observedSymmetric=%d observedLegacy=%d",
-                  collectiveName(collective), comm->nNodes, comm->symmetricSupport,
-                  static_cast<int>(comm->isAllDirectNvlink),
+                  collectiveName(collective), comm->nNodes, comm->devrState.lsaSize, comm->nRanks,
+                  comm->symmetricSupport, static_cast<int>(comm->isAllDirectNvlink),
                   static_cast<int>(comm->symkState.hasLsaMultimem),
                   expectSymmetric ? "symmetric" : "legacy", static_cast<int>(sawSymmetric),
                   static_cast<int>(sawLegacy));
@@ -2533,10 +2559,15 @@ protected:
                       collectiveName(collective));
         }
 
-        ASSERT_MPI_EQ(ncclSuccess,ncclCommWindowDeregister(getActiveCommunicator(), sendWin));
-        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWin));
+        // Hand each window off before deregistering it: ASSERT_MPI_EQ returns on every rank when
+        // any one rank fails, so a rank that already succeeded must not leave the handle set for
+        // windowCleanup to deregister a second time.
+        ncclWindow_t sendWinToRelease = sendWin;
         sendWin = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), sendWinToRelease));
+        ncclWindow_t recvWinToRelease = recvWin;
         recvWin = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(getActiveCommunicator(), recvWinToRelease));
 
         TEST_INFO("GraphCapture_WindowRegister %s completed via %s path",
                   collectiveName(collective), expectSymmetric ? "symmetric" : "legacy fallback");

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1899,7 +1899,7 @@
       "timeout": 300,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
-        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_DEBUG_SUBSYS": "REG,INIT,TUNING",
         "NCCL_GRAPH_REGISTER": "1",
         "NCCL_LEGACY_CUDA_REGISTER": "1",
         "NCCL_LOCAL_REGISTER": "1",
@@ -1915,6 +1915,30 @@
           "name": "GraphCapture_AllReduce_MultiNode",
           "description": "AllReduce graph capture with buffer registration on multi-node",
           "test_filter": "GraphCapture_AllReduce.MultiNode"
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllReduce_MultiNode",
+          "description": "Graph-captured symmetric AllReduce on two nodes; expects legacy fallback (no multi-node AllReduce symmetric kernel)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllGather_MultiNode",
+          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback on gfx950 (no LSA multimem)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricReduceScatter_MultiNode",
+          "description": "Graph-captured symmetric ReduceScatter on two nodes; uses GIN RailA2A when available, otherwise fallback",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricReduceScatter",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
         }
       ]
     },
@@ -1929,6 +1953,7 @@
       "timeout": 180,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "INIT,TUNING",
         "NCCL_CUMEM_ENABLE": "1"
       },
       "tests": [
@@ -2006,6 +2031,16 @@
           "name": "SymWin_GraphCapture_SymmetricAllReduce",
           "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
           "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllGather",
+          "description": "Symmetric window registration during HIP graph capture with captured AllGather replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricReduceScatter",
+          "description": "Symmetric window registration during HIP graph capture with captured ReduceScatter replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricReduceScatter"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1315,6 +1315,37 @@
           "name": "CommMPITests_GinRmaFinalizeWithSplitComm",
           "description": "RMA and GIN hold separate contexts that a shared split child inherits and finalizes without a NULL access",
           "test_filter": "GinRmaContextMPITest.RmaAndGinFinalizeWithSplitComm"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_ConfigOverride",
+          "description": "ncclConfig_t graphStreamOrdering stored on comm when NCCL_GRAPH_STREAM_ORDERING is unset",
+          "test_filter": "GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_IncompatibleMixingFallback",
+          "description": "graphStreamOrdering=0 with graphUsageMode=2 falls back to ordering=1",
+          "test_filter": "GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_Zero",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=0 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "0"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_One",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=1 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "1"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_DisabledOrderingGraphCaptureSmoke",
+          "description": "graphStreamOrdering=0 with graphUsageMode=1 captures and replays AllReduce",
+          "test_filter": "GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke"
         }
       ]
     },
@@ -1970,6 +2001,11 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllReduce",
+          "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1235,6 +1235,37 @@
           "name": "CommMPITests_GinRmaFinalizeWithSplitComm",
           "description": "RMA and GIN hold separate contexts that a shared split child inherits and finalizes without a NULL access",
           "test_filter": "GinRmaContextMPITest.RmaAndGinFinalizeWithSplitComm"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_ConfigOverride",
+          "description": "ncclConfig_t graphStreamOrdering stored on comm when NCCL_GRAPH_STREAM_ORDERING is unset",
+          "test_filter": "GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_IncompatibleMixingFallback",
+          "description": "graphStreamOrdering=0 with graphUsageMode=2 falls back to ordering=1",
+          "test_filter": "GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_Zero",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=0 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "0"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_One",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=1 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "1"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_DisabledOrderingGraphCaptureSmoke",
+          "description": "graphStreamOrdering=0 with graphUsageMode=1 captures and replays AllReduce",
+          "test_filter": "GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke"
         }
       ]
     },
@@ -1890,6 +1921,11 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllReduce",
+          "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1926,7 +1926,7 @@
         },
         {
           "name": "GraphCapture_WindowRegister_SymmetricAllGather_MultiNode",
-          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback on gfx950 (no LSA multimem)",
+          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback when LSA store multimem is unavailable",
           "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather",
           "env_variables": {
             "NCCL_CUMEM_ENABLE": "1"
@@ -1954,7 +1954,8 @@
       "env_variables": {
         "NCCL_DEBUG": "INFO",
         "NCCL_DEBUG_SUBSYS": "INIT,TUNING",
-        "NCCL_CUMEM_ENABLE": "1"
+        "NCCL_CUMEM_ENABLE": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -1577,6 +1577,37 @@
             "NCCL_MIN_CTAS": "0",
             "NCCL_MAX_CTAS": "0"
           }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_ConfigOverride",
+          "description": "ncclConfig_t graphStreamOrdering stored on comm when NCCL_GRAPH_STREAM_ORDERING is unset",
+          "test_filter": "GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_IncompatibleMixingFallback",
+          "description": "graphStreamOrdering=0 with graphUsageMode=2 falls back to ordering=1",
+          "test_filter": "GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_Zero",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=0 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "0"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_One",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=1 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "1"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_DisabledOrderingGraphCaptureSmoke",
+          "description": "graphStreamOrdering=0 with graphUsageMode=1 captures and replays AllReduce",
+          "test_filter": "GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke"
         }
       ]
     },
@@ -2181,6 +2212,11 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllReduce",
+          "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2111,7 +2111,7 @@
       "timeout": 300,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
-        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_DEBUG_SUBSYS": "REG,INIT,TUNING",
         "NCCL_GRAPH_REGISTER": "1",
         "NCCL_LEGACY_CUDA_REGISTER": "1",
         "NCCL_LOCAL_REGISTER": "1",
@@ -2127,6 +2127,30 @@
           "name": "GraphCapture_AllReduce_MultiNode",
           "description": "AllReduce graph capture with buffer registration on multi-node",
           "test_filter": "GraphCapture_AllReduce.MultiNode"
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllReduce_MultiNode",
+          "description": "Graph-captured symmetric AllReduce on two nodes; expects legacy fallback (no multi-node AllReduce symmetric kernel)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllGather_MultiNode",
+          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback on gfx950 (no LSA multimem)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricReduceScatter_MultiNode",
+          "description": "Graph-captured symmetric ReduceScatter on two nodes; uses GIN RailA2A when available, otherwise fallback",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricReduceScatter",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
         }
       ]
     },
@@ -2140,6 +2164,7 @@
       "timeout": 180,
       "env_variables": {
         "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "INIT,TUNING",
         "NCCL_CUMEM_ENABLE": "1"
       },
       "tests": [
@@ -2217,6 +2242,16 @@
           "name": "SymWin_GraphCapture_SymmetricAllReduce",
           "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
           "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllGather",
+          "description": "Symmetric window registration during HIP graph capture with captured AllGather replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricReduceScatter",
+          "description": "Symmetric window registration during HIP graph capture with captured ReduceScatter replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricReduceScatter"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -1572,6 +1572,37 @@
             "NCCL_MIN_CTAS": "0",
             "NCCL_MAX_CTAS": "0"
           }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_ConfigOverride",
+          "description": "ncclConfig_t graphStreamOrdering stored on comm when NCCL_GRAPH_STREAM_ORDERING is unset",
+          "test_filter": "GraphStreamOrderingConfigMPITest.ConfigOverrideAppliesGraphStreamOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_IncompatibleMixingFallback",
+          "description": "graphStreamOrdering=0 with graphUsageMode=2 falls back to ordering=1",
+          "test_filter": "GraphStreamOrderingConfigMPITest.IncompatibleMixingFallsBackToEnabledOrdering"
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_Zero",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=0 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "0"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_EnvOverride_One",
+          "description": "NCCL_GRAPH_STREAM_ORDERING=1 overrides ncclConfig_t at init",
+          "test_filter": "GraphStreamOrderingConfigMPITest.EnvOverrideAppliesGraphStreamOrdering",
+          "env_variables": {
+            "NCCL_GRAPH_STREAM_ORDERING": "1"
+          }
+        },
+        {
+          "name": "CommMPITests_GraphStreamOrdering_DisabledOrderingGraphCaptureSmoke",
+          "description": "graphStreamOrdering=0 with graphUsageMode=1 captures and replays AllReduce",
+          "test_filter": "GraphStreamOrderingConfigMPITest.DisabledOrderingGraphCaptureSmoke"
         }
       ]
     },
@@ -2176,6 +2207,11 @@
           "name": "SymWin_WindowLifecycle_Repeated",
           "description": "Repeated register/deregister cycles",
           "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        },
+        {
+          "name": "SymWin_GraphCapture_SymmetricAllReduce",
+          "description": "Symmetric window registration during HIP graph capture with captured AllReduce replay",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -2165,7 +2165,8 @@
       "env_variables": {
         "NCCL_DEBUG": "INFO",
         "NCCL_DEBUG_SUBSYS": "INIT,TUNING",
-        "NCCL_CUMEM_ENABLE": "1"
+        "NCCL_CUMEM_ENABLE": "1",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -2105,7 +2105,7 @@
       "env_variables": {
         "NCCL_MNNVL_ENABLE": "1",
         "NCCL_DEBUG": "INFO",
-        "NCCL_DEBUG_SUBSYS": "REG",
+        "NCCL_DEBUG_SUBSYS": "REG,INIT,TUNING",
         "NCCL_GRAPH_REGISTER": "1",
         "NCCL_LEGACY_CUDA_REGISTER": "1",
         "NCCL_LOCAL_REGISTER": "1",
@@ -2121,6 +2121,30 @@
           "name": "GraphCapture_AllReduce_MultiNode",
           "description": "AllReduce graph capture with buffer registration on multi-node",
           "test_filter": "GraphCapture_AllReduce.MultiNode"
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllReduce_MultiNode",
+          "description": "Graph-captured symmetric AllReduce on two nodes; expects legacy fallback (no multi-node AllReduce symmetric kernel)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllReduce",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricAllGather_MultiNode",
+          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback on gfx950 (no LSA multimem)",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GraphCapture_WindowRegister_SymmetricReduceScatter_MultiNode",
+          "description": "Graph-captured symmetric ReduceScatter on two nodes; uses GIN RailA2A when available, otherwise fallback",
+          "test_filter": "GraphCapture_WindowRegister.SymmetricReduceScatter",
+          "env_variables": {
+            "NCCL_CUMEM_ENABLE": "1"
+          }
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -2132,7 +2132,7 @@
         },
         {
           "name": "GraphCapture_WindowRegister_SymmetricAllGather_MultiNode",
-          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback on gfx950 (no LSA multimem)",
+          "description": "Graph-captured symmetric AllGather on two nodes; expects fallback when LSA store multimem is unavailable",
           "test_filter": "GraphCapture_WindowRegister.SymmetricAllGather",
           "env_variables": {
             "NCCL_CUMEM_ENABLE": "1"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Bring RCCL in line with NCCL 2.30.7 for graph stream ordering and add MPI coverage for symmetric window registration during HIP graph capture.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
**_enqueue.cc:_** Port graphStreamOrdering launch logic (captureStream vs user-stream / useLaunchStream path).
**_ce_coll.cc:_**    Align CE collective scheduling with upstream scheduleCeCollTaskToPlan().
**_Tests:_**           GraphStreamOrderingConfigMPITest (4 cases) and GraphCapture_WindowRegister.SymmetricAllReduce.
**_Test runner:_** Wire new tests into mi300x_mellanox_ib.json and mi355x_thor2_roce.json.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: AICOMRCCL-1284

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
* Run newly added test cases: `GraphStreamOrderingConfigMPITest (4 cases)` and `GraphCapture_WindowRegister.SymmetricAllReduce`.
* CI

## Test Result

<!-- Briefly summarize test outcomes. -->
PASS

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
