### PR TITLE
test(rccl): CE graph-barrier tests for #9334

### DIFF
--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -140,6 +140,17 @@ TEST_F(CeInternalMPITest, InitSetsWindowPointers)
     EXPECT_NE(ceComm->ceColl.ceSyncWin, nullptr);
 }
 
+// INIT-01b: ncclCeInit allocates ceSeqNumDev and seeds GRAPH_SYNC_VALUE in slot [1].
+TEST_F(CeInternalMPITest, InitAllocatesCeSeqNumDev)
+{
+    ASSERT_NE(ceComm->ceColl.ceSeqNumDev, nullptr);
+    uint32_t graphSlot = 0;
+    ASSERT_EQ(hipMemcpy(&graphSlot, ceComm->ceColl.ceSeqNumDev + 1, sizeof(uint32_t),
+                        hipMemcpyDeviceToHost),
+              hipSuccess);
+    EXPECT_EQ(graphSlot, kCeGraphSyncValue);
+}
+
 // INIT-02: ncclCeFinalize sets sync-window pointers back to null.
 TEST_F(CeInternalMPITest, FiniNullsPointers)
 {
@@ -148,6 +159,7 @@ TEST_F(CeInternalMPITest, FiniNullsPointers)
     EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
     EXPECT_EQ(ceComm->ceColl.baseUCSymComplPtr, nullptr);
     EXPECT_EQ(ceComm->ceColl.ceSyncWin, nullptr);
+    EXPECT_EQ(ceComm->ceColl.ceSeqNumDev, nullptr);
 }
 
 // INIT-03: Calling ncclCeFinalize twice is safe (idempotent).
@@ -156,6 +168,17 @@ TEST_F(CeInternalMPITest, DoubleFiniIsSafe)
     EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
     EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
     EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.ceSeqNumDev, nullptr);
+}
+
+// INIT-03b: Double finalize must not double-free ceSeqNumDev.
+TEST_F(CeInternalMPITest, InitFiniIdempotentCeSeqNumDev)
+{
+    ASSERT_NE(ceComm->ceColl.ceSeqNumDev, nullptr);
+    EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ceComm->ceColl.ceSeqNumDev, nullptr);
+    EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ceComm->ceColl.ceSeqNumDev, nullptr);
 }
 
 // INIT-04: Two comms have independent CE state; advancing one must not affect the other.
@@ -451,6 +474,170 @@ TEST_F(CeInternalMPITest, SeqNumWrapAroundCollective)
     }
 }
 
+// SYNC-06: Under simulated graph capture, batchParams holds waits only (no fused writes).
+TEST_F(CeInternalMPITest, PrepUCSyncCaptureOpCount)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    const int nRanks = ceComm->nRanks;
+    CeSimulatedCaptureGuard capture(ceComm);
+    auto [batch, opIdx] = callPrepUCSync();
+
+    EXPECT_EQ(opIdx, static_cast<size_t>(nRanks - 1))
+        << "capture path should place only peer waits in batchParams";
+
+    int writeOps = 0;
+    int waitOps  = 0;
+    for(size_t i = 0; i < opIdx; ++i)
+    {
+        if(batch[i].operation == hipStreamMemOpWriteValue32)
+            ++writeOps;
+        if(batch[i].operation == hipStreamMemOpWaitValue32)
+        {
+            ++waitOps;
+            EXPECT_EQ(batch[i].waitValue.value, kCeGraphSyncValue)
+                << "capture waits must use GRAPH_SYNC_VALUE";
+        }
+    }
+    EXPECT_EQ(writeOps, 0) << "peer writes must be issued outside batchParams during capture";
+    EXPECT_EQ(waitOps, nRanks - 1);
+}
+
+// SYNC-07: Non-capture path keeps fused WRITE+WAIT in one batch (latency regression guard).
+TEST_F(CeInternalMPITest, PrepUCSyncNonCaptureStillFused)
+{
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    const int    nRanks     = ceComm->nRanks;
+    const uint32_t seqBefore = ceComm->ceColl.ceSeqNum + 1;
+    auto [batch, opIdx]      = callPrepUCSync();
+
+    EXPECT_EQ(opIdx, static_cast<size_t>(2 * (nRanks - 1)));
+
+    int writeOps = 0;
+    int waitOps  = 0;
+    for(size_t i = 0; i < opIdx; ++i)
+    {
+        if(batch[i].operation == hipStreamMemOpWriteValue32)
+        {
+            ++writeOps;
+            EXPECT_EQ(batch[i].writeValue.value, seqBefore);
+        }
+        if(batch[i].operation == hipStreamMemOpWaitValue32)
+        {
+            ++waitOps;
+            EXPECT_EQ(batch[i].waitValue.value, seqBefore);
+        }
+    }
+    EXPECT_EQ(writeOps, nRanks - 1);
+    EXPECT_EQ(waitOps, nRanks - 1);
+}
+
+// ===========================================================================
+// CeInternal_MemOpSync – capture-time wait/reset batch split
+// ===========================================================================
+
+// MEMOP-01: Capture-time ncclMemOpSync zeros the active ready array after the barrier.
+TEST_F(CeInternalMPITest, MemOpSyncCaptureResetsFlags)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    const int nRanks = ceComm->nRanks;
+    ASSERT_EQ(hipMemset(ceComm->ceColl.baseUCSymReadyPtr, 0xAB,
+                        static_cast<size_t>(nRanks) * sizeof(uint32_t)),
+              hipSuccess);
+
+    CeSimulatedCaptureGuard capture(ceComm);
+    const bool useCompleteBefore = ceComm->ceColl.useCompletePtr;
+    ASSERT_EQ(ncclMemOpSync(ceComm, getActiveStream(), nullptr), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+
+    const auto ready = ceReadUcReadyFlags(ceComm);
+    ASSERT_EQ(ready.size(), static_cast<size_t>(nRanks));
+    for(int i = 0; i < nRanks; ++i)
+        EXPECT_EQ(ready[static_cast<size_t>(i)], 0u) << "ready slot " << i << " not reset";
+
+    EXPECT_EQ(ceComm->ceColl.useCompletePtr, !useCompleteBefore);
+}
+
+// MEMOP-02: Capture reset covers all nRanks slots (not lsaSize only).
+TEST_F(CeInternalMPITest, MemOpSyncCaptureResetCoversAllRanks)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    const int nRanks = ceComm->nRanks;
+    for(int i = 0; i < nRanks; ++i)
+    {
+        const uint32_t pattern = static_cast<uint32_t>(0x1000 + i);
+        ASSERT_EQ(hipMemcpy(static_cast<uint32_t*>(ceComm->ceColl.baseUCSymReadyPtr) + i,
+                            &pattern, sizeof(uint32_t), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    CeSimulatedCaptureGuard capture(ceComm);
+    ASSERT_EQ(ncclMemOpSync(ceComm, getActiveStream(), nullptr), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+
+    const auto ready = ceReadUcReadyFlags(ceComm);
+    for(int i = 0; i < nRanks; ++i)
+        EXPECT_EQ(ready[static_cast<size_t>(i)], 0u) << "rank slot " << i;
+}
+
+// ===========================================================================
+// CeInternal_DevRuntime – graph-safe window registration during capture
+// ===========================================================================
+
+// DEVR-01: Symmetric window registration during HIP capture completes successfully.
+TEST_F(CeInternalMPITest, SymBufAllocDuringCaptureRestoresCaptureMode)
+{
+    hipGraph_t graph = nullptr;
+    ASSERT_EQ(hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal), hipSuccess);
+
+    RCCLTestHelpers::SymBuf extraSym;
+    ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(getActiveCommunicator(), 4096, extraSym),
+              ncclSuccess)
+        << "window registration during capture should succeed";
+
+    ASSERT_EQ(hipStreamEndCapture(getActiveStream(), &graph), hipSuccess);
+    ASSERT_NE(graph, nullptr);
+    SCOPE_EXIT((void)hipGraphDestroy(graph));
+
+    hipGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0), hipSuccess);
+    SCOPE_EXIT(if(graphExec) (void)hipGraphExecDestroy(graphExec));
+
+    ASSERT_EQ(hipGraphLaunch(graphExec, getActiveStream()), hipSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+}
+
+// DEVR-02: Comm teardown after capture with CE init must not hang (devr finalize path).
+TEST_F(CeInternalMPITest, CommTeardownAfterCaptureWithCeInit)
+{
+    hipGraph_t graph = nullptr;
+    ASSERT_EQ(hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal), hipSuccess);
+
+    RCCLTestHelpers::SymBuf extraSym;
+    ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(getActiveCommunicator(), 4096, extraSym),
+              ncclSuccess);
+
+    ASSERT_EQ(hipStreamEndCapture(getActiveStream(), &graph), hipSuccess);
+    SCOPE_EXIT((void)hipGraphDestroy(graph));
+
+    ASSERT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.ceSeqNumDev, nullptr);
+}
+
 // ===========================================================================
 // CeInternal_Launch – ncclCeLaunchBatchOps with zero and real ops
 // ===========================================================================
@@ -575,6 +762,151 @@ TEST_F(CeInternalMPITest, LaunchFourOpsNullStreamSucceeds)
             << "op " << i << " produced wrong data on the null stream";
     }
     // srcGuards, dstGuards, and params freed automatically on scope exit.
+}
+
+// LAUNCH-04: Odd intra-batch sync count under capture appends an extra ncclMemOpSync so
+//            useCompletePtr returns to its pre-launch value (graph replay safety).
+TEST_F(CeInternalMPITest, LaunchBatchOpsEvenSyncCountRestoresUseCompletePtr)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    using namespace RCCLTestGuards;
+    constexpr int    kOps   = 16; // one mid-loop sync + even-count padding → restored toggle
+    constexpr size_t kBytes = sizeof(float);
+
+    std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
+    for(int i = 0; i < kOps; ++i)
+    {
+        void* p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        srcGuards[i].set(p);
+        p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        dstGuards[i].set(p);
+
+        const float pattern = static_cast<float>(i + 1);
+        ASSERT_EQ(hipMemcpy(srcGuards[i].get(), &pattern, sizeof(float), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i]  = static_cast<float*>(srcGuards[i].get());
+        params.dsts[i]  = static_cast<float*>(dstGuards[i].get());
+        params.sizes[i] = kBytes;
+    }
+    params.numOps         = kOps;
+    params.intraBatchSync = true;
+
+    const bool useCompleteBefore = ceComm->ceColl.useCompletePtr;
+    CeSimulatedCaptureGuard capture(ceComm);
+    ncclCeCollArgs          collArgs{};
+    ASSERT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream(), &collArgs), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    EXPECT_EQ(ceComm->ceColl.useCompletePtr, useCompleteBefore)
+        << "even sync count (with padding) must restore useCompletePtr for replay";
+}
+
+// LAUNCH-05: When padding is not needed the internal sync count is already even.
+TEST_F(CeInternalMPITest, LaunchBatchOpsEvenInternalSyncCountRestoresUseCompletePtr)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    using namespace RCCLTestGuards;
+    constexpr int    kOps   = 24; // two mid-loop syncs, no padding
+    constexpr size_t kBytes = sizeof(float);
+
+    std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
+    for(int i = 0; i < kOps; ++i)
+    {
+        void* p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        srcGuards[i].set(p);
+        p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        dstGuards[i].set(p);
+        const float pattern = static_cast<float>(i + 1);
+        ASSERT_EQ(hipMemcpy(srcGuards[i].get(), &pattern, sizeof(float), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i]  = static_cast<float*>(srcGuards[i].get());
+        params.dsts[i]  = static_cast<float*>(dstGuards[i].get());
+        params.sizes[i] = kBytes;
+    }
+    params.numOps         = kOps;
+    params.intraBatchSync = true;
+
+    const bool useCompleteBefore = ceComm->ceColl.useCompletePtr;
+    CeSimulatedCaptureGuard capture(ceComm);
+    ncclCeCollArgs          collArgs{};
+    ASSERT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream(), &collArgs), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    EXPECT_EQ(ceComm->ceColl.useCompletePtr, useCompleteBefore);
+}
+
+// LAUNCH-06: Odd internal sync count without padding leaves useCompletePtr flipped.
+TEST_F(CeInternalMPITest, LaunchBatchOpsOddSyncCountWithoutPaddingFlipsUseCompletePtr)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    ceSkipIfNvls(ceComm);
+    requireMinRanks(2);
+
+    using namespace RCCLTestGuards;
+    constexpr int    kOps   = 8; // one mid-loop sync, padding not appended
+    constexpr size_t kBytes = sizeof(float);
+
+    std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
+    for(int i = 0; i < kOps; ++i)
+    {
+        void* p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        srcGuards[i].set(p);
+        p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        dstGuards[i].set(p);
+        const float pattern = static_cast<float>(i + 1);
+        ASSERT_EQ(hipMemcpy(srcGuards[i].get(), &pattern, sizeof(float), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i]  = static_cast<float*>(srcGuards[i].get());
+        params.dsts[i]  = static_cast<float*>(dstGuards[i].get());
+        params.sizes[i] = kBytes;
+    }
+    params.numOps         = kOps;
+    params.intraBatchSync = true;
+
+    const bool useCompleteBefore = ceComm->ceColl.useCompletePtr;
+    CeSimulatedCaptureGuard capture(ceComm);
+    ncclCeCollArgs          collArgs{};
+    ASSERT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream(), &collArgs), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    EXPECT_NE(ceComm->ceColl.useCompletePtr, useCompleteBefore)
+        << "single mid-loop sync must flip useCompletePtr when padding is not applied";
 }
 
 // ===========================================================================

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -550,9 +550,14 @@ TEST_F(CeInternalMPITest, MemOpSyncCaptureResetsFlags)
     requireMinRanks(2);
 
     const int nRanks = ceComm->nRanks;
-    ASSERT_EQ(hipMemset(ceComm->ceColl.baseUCSymReadyPtr, 0xAB,
-                        static_cast<size_t>(nRanks) * sizeof(uint32_t)),
+    // Warmup AllGather may leave useCompletePtr true; reset targets the active array.
+    ceComm->ceColl.useCompletePtr = false;
+    ASSERT_EQ(ceResetUcSyncWindowOnStream(ceComm, getActiveStream()), hipSuccess);
+    ASSERT_EQ(hipMemsetAsync(ceComm->ceColl.baseUCSymReadyPtr, 0xAB,
+                             static_cast<size_t>(nRanks) * sizeof(uint32_t), getActiveStream()),
               hipSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    MPI_Barrier(MPI_COMM_WORLD);
 
     CeSimulatedCaptureGuard capture(ceComm);
     const bool useCompleteBefore = ceComm->ceColl.useCompletePtr;
@@ -576,13 +581,9 @@ TEST_F(CeInternalMPITest, MemOpSyncCaptureResetCoversAllRanks)
     requireMinRanks(2);
 
     const int nRanks = ceComm->nRanks;
-    for(int i = 0; i < nRanks; ++i)
-    {
-        const uint32_t pattern = static_cast<uint32_t>(0x1000 + i);
-        ASSERT_EQ(hipMemcpy(static_cast<uint32_t*>(ceComm->ceColl.baseUCSymReadyPtr) + i,
-                            &pattern, sizeof(uint32_t), hipMemcpyHostToDevice),
-                  hipSuccess);
-    }
+    ceComm->ceColl.useCompletePtr = false;
+    ASSERT_EQ(ceWriteUcReadyPatternsOnStream(ceComm, getActiveStream()), hipSuccess);
+    MPI_Barrier(MPI_COMM_WORLD);
 
     CeSimulatedCaptureGuard capture(ceComm);
     ASSERT_EQ(ncclMemOpSync(ceComm, getActiveStream(), nullptr), ncclSuccess);
@@ -861,8 +862,9 @@ TEST_F(CeInternalMPITest, LaunchBatchOpsEvenInternalSyncCountRestoresUseComplete
     EXPECT_EQ(ceComm->ceColl.useCompletePtr, useCompleteBefore);
 }
 
-// LAUNCH-06: Odd internal sync count without padding leaves useCompletePtr flipped.
-TEST_F(CeInternalMPITest, LaunchBatchOpsOddSyncCountWithoutPaddingFlipsUseCompletePtr)
+// LAUNCH-06: One mid-loop sync (odd) still gets a padding ncclMemOpSync under capture,
+//            restoring useCompletePtr.  numOps=9 → sync at op 8 + padding sync.
+TEST_F(CeInternalMPITest, LaunchBatchOpsOddMidLoopSyncCountGetsPaddingRestoresUseCompletePtr)
 {
     if(!ceSimulatedCaptureSupported())
         GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
@@ -870,7 +872,7 @@ TEST_F(CeInternalMPITest, LaunchBatchOpsOddSyncCountWithoutPaddingFlipsUseComple
     requireMinRanks(2);
 
     using namespace RCCLTestGuards;
-    constexpr int    kOps   = 8; // one mid-loop sync, padding not appended
+    constexpr int    kOps   = 9; // one mid-loop sync; padding makes total sync count even
     constexpr size_t kBytes = sizeof(float);
 
     std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
@@ -905,8 +907,8 @@ TEST_F(CeInternalMPITest, LaunchBatchOpsOddSyncCountWithoutPaddingFlipsUseComple
     ncclCeCollArgs          collArgs{};
     ASSERT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream(), &collArgs), ncclSuccess);
     ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
-    EXPECT_NE(ceComm->ceColl.useCompletePtr, useCompleteBefore)
-        << "single mid-loop sync must flip useCompletePtr when padding is not applied";
+    EXPECT_EQ(ceComm->ceColl.useCompletePtr, useCompleteBefore)
+        << "odd mid-loop sync count must be padded to restore useCompletePtr for replay";
 }
 
 // ===========================================================================

--- a/projects/rccl/test/ce/CeMPITests.cpp
+++ b/projects/rccl/test/ce/CeMPITests.cpp
@@ -19,6 +19,10 @@
 #include <hip/hip_runtime.h>
 #include <string>
 
+#include <ce_coll.h>
+#include <comm.h>
+#include <dev_runtime.h>
+
 #ifdef MPI_TESTS_ENABLED
 
 using namespace MPITestConstants;
@@ -816,6 +820,258 @@ TEST_F(CeMPI_Stress, InterleavedCEAllGatherAndSMAllReduce)
     }
 
     assertCEPathTaken("CeMPI_Stress/InterleavedCEAllGatherAndSMAllReduce");
+}
+
+// ===========================================================================
+// CeMPI_GraphBarrier – CE UC barrier replay (direct CE API; bypasses enqueue graph guard)
+// ===========================================================================
+
+namespace CeGraphBarrierHelpers
+{
+constexpr int kGraphReplayIters = 20;
+
+inline bool warmupCeInit(ncclComm_t comm, hipStream_t stream)
+{
+    auto* ceComm = static_cast<ncclComm*>(comm);
+    constexpr size_t kElem = 4;
+    SymBuf           sendSym, recvSym;
+    if(ncclSymBufAlloc(comm, kElem * sizeof(float), sendSym) != ncclSuccess)
+        return false;
+    if(ncclSymBufAlloc(comm, kElem * static_cast<size_t>(ceComm->nRanks) * sizeof(float),
+                       recvSym) != ncclSuccess)
+        return false;
+    if(ncclAllGather(sendSym.ptr, recvSym.ptr, kElem, ncclFloat32, comm, stream) != ncclSuccess)
+        return false;
+    if(hipStreamSynchronize(stream) != hipSuccess)
+        return false;
+    return ceComm->ceColl.baseUCSymReadyPtr != nullptr;
+}
+
+inline ncclResult_t runCeAllGatherDirect(ncclComm* comm, void* send, void* recv, size_t count,
+                                         hipStream_t stream)
+{
+    struct ncclDevrWindow* sendWin = nullptr;
+    struct ncclDevrWindow* recvWin = nullptr;
+    ncclResult_t           ret     = ncclDevrFindWindow(comm, send, &sendWin);
+    if(ret != ncclSuccess)
+        return ret;
+    ret = ncclDevrFindWindow(comm, recv, &recvWin);
+    if(ret != ncclSuccess)
+        return ret;
+
+    ncclCeCollArgs args{};
+    args.func      = ncclFuncAllGather;
+    args.datatype  = ncclFloat32;
+    args.nElts     = count;
+    args.eltSize   = sizeof(float);
+    args.sendBuff  = static_cast<uint8_t*>(send);
+    args.recvBuff  = static_cast<uint8_t*>(recv);
+    args.sendWin   = sendWin;
+    args.recvWin   = recvWin;
+    return ncclCeAllGather(comm, &args, stream);
+}
+} // namespace CeGraphBarrierHelpers
+
+using namespace CeGraphBarrierHelpers;
+
+class CeMPI_GraphBarrier : public CeMPITest
+{};
+
+// CE-MPI-GRAPH-01: Repeated ncclCeAllGather under simulated capture (replay semantics).
+TEST_F(CeMPI_GraphBarrier, AllGatherDirectCaptureReplay)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    auto* ceComm = static_cast<ncclComm*>(getActiveCommunicator());
+    ceSkipIfNvls(ceComm);
+    if(!warmupCeInit(getActiveCommunicator(), getActiveStream()))
+        GTEST_SKIP() << "CE not available on this system";
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    SymBuf       sendSym, recvSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), recvSym));
+    fillRankScalar(sendSym.ptr, count, rank);
+
+    for(int iter = 0; iter < kGraphReplayIters; ++iter)
+    {
+        CeSimulatedCaptureGuard capture(ceComm);
+        ASSERT_EQ(runCeAllGatherDirect(ceComm, sendSym.ptr, recvSym.ptr, count, getActiveStream()),
+                  ncclSuccess)
+            << "ncclCeAllGather failed at replay iter " << iter;
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+        ASSERT_TRUE(ceVerifyBlockPatternFloat(recvSym.ptr, count * static_cast<size_t>(nRanks), count))
+            << "data wrong at replay iter " << iter;
+    }
+}
+
+// CE-MPI-GRAPH-02: HIP graph capture/instantiate/launch of ncclCeAllGather (20 replays).
+TEST_F(CeMPI_GraphBarrier, AllGatherHipGraphCaptureReplay)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    auto* ceComm = static_cast<ncclComm*>(getActiveCommunicator());
+    ceSkipIfNvls(ceComm);
+    if(!warmupCeInit(getActiveCommunicator(), getActiveStream()))
+        GTEST_SKIP() << "CE not available on this system";
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    SymBuf       sendSym, recvSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), recvSym));
+    fillRankScalar(sendSym.ptr, count, rank);
+
+    hipGraph_t     graph     = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal), hipSuccess);
+    {
+        CeSimulatedCaptureGuard capture(ceComm);
+        ASSERT_EQ(runCeAllGatherDirect(ceComm, sendSym.ptr, recvSym.ptr, count, getActiveStream()),
+                  ncclSuccess);
+    }
+    ASSERT_EQ(hipStreamEndCapture(getActiveStream(), &graph), hipSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0), hipSuccess);
+    SCOPE_EXIT(
+        if(graphExec) (void)hipGraphExecDestroy(graphExec);
+        if(graph) (void)hipGraphDestroy(graph););
+
+    for(int iter = 0; iter < kGraphReplayIters; ++iter)
+    {
+        ASSERT_EQ(hipGraphLaunch(graphExec, getActiveStream()), hipSuccess)
+            << "graph launch failed at iter " << iter;
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+        ASSERT_TRUE(ceVerifyBlockPatternFloat(recvSym.ptr, count * static_cast<size_t>(nRanks), count))
+            << "data wrong after graph replay iter " << iter;
+    }
+}
+
+// CE-MPI-GRAPH-03: Alternate captured replay with eager direct CE AllGather (mixing).
+TEST_F(CeMPI_GraphBarrier, GraphMixingCaptureAndEagerCeAllGather)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    MPIHelpers::MpiEnvGuard mixingGuard("NCCL_GRAPH_MIXING_SUPPORT", "1");
+
+    ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    auto* ceComm = static_cast<ncclComm*>(getActiveCommunicator());
+    ceSkipIfNvls(ceComm);
+    if(!warmupCeInit(getActiveCommunicator(), getActiveStream()))
+        GTEST_SKIP() << "CE not available on this system";
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    SymBuf       sendSym, recvSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), recvSym));
+    fillRankScalar(sendSym.ptr, count, rank);
+
+    hipGraph_t     graph     = nullptr;
+    hipGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(hipStreamBeginCapture(getActiveStream(), hipStreamCaptureModeThreadLocal), hipSuccess);
+    {
+        CeSimulatedCaptureGuard capture(ceComm);
+        ASSERT_EQ(runCeAllGatherDirect(ceComm, sendSym.ptr, recvSym.ptr, count, getActiveStream()),
+                  ncclSuccess);
+    }
+    ASSERT_EQ(hipStreamEndCapture(getActiveStream(), &graph), hipSuccess);
+    ASSERT_EQ(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0), hipSuccess);
+    SCOPE_EXIT(
+        if(graphExec) (void)hipGraphExecDestroy(graphExec);
+        if(graph) (void)hipGraphDestroy(graph););
+
+    for(int iter = 0; iter < kInterleavedIters; ++iter)
+    {
+        ASSERT_EQ(hipGraphLaunch(graphExec, getActiveStream()), hipSuccess)
+            << "captured launch failed at iter " << iter;
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+        ASSERT_TRUE(ceVerifyBlockPatternFloat(recvSym.ptr, count * static_cast<size_t>(nRanks), count));
+
+        ASSERT_EQ(runCeAllGatherDirect(ceComm, sendSym.ptr, recvSym.ptr, count, getActiveStream()),
+                  ncclSuccess)
+            << "eager CE AllGather failed at iter " << iter;
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+        ASSERT_TRUE(ceVerifyBlockPatternFloat(recvSym.ptr, count * static_cast<size_t>(nRanks), count));
+    }
+}
+
+// CE-MPI-GRAPH-04: Two communicators with independent capture/replay CE state.
+TEST_F(CeMPI_GraphBarrier, IndependentCommsCaptureReplay)
+{
+    if(!ceSimulatedCaptureSupported())
+        GTEST_SKIP() << "Simulated capture requires ROCm >= 6.1 graph support";
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    auto* ceComm1 = static_cast<ncclComm*>(getActiveCommunicator());
+    if(!warmupCeInit(getActiveCommunicator(), getActiveStream()))
+        GTEST_SKIP() << "CE not available on comm1";
+    ceSkipIfNvls(ceComm1);
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    ncclUniqueId uid{};
+    if(rank == 0)
+        ASSERT_EQ(ncclGetUniqueId(&uid), ncclSuccess);
+    MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+    ncclComm_t comm2 = nullptr;
+    ASSERT_EQ(ncclCommInitRank(&comm2, nRanks, uid, rank), ncclSuccess);
+    RCCLTestGuards::NcclCommAutoGuard comm2Guard(comm2);
+    auto* ceComm2 = static_cast<ncclComm*>(comm2);
+    if(!warmupCeInit(comm2, getActiveStream()))
+        GTEST_SKIP() << "CE not available on comm2";
+
+    const size_t count = kSmallCount;
+    SymBuf       s1, r1, s2, r2;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), s1));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), r1));
+    ASSERT_EQ(ncclSuccess, ncclSymBufAlloc(comm2, count * sizeof(float), s2));
+    ASSERT_EQ(ncclSuccess,
+              ncclSymBufAlloc(comm2, count * static_cast<size_t>(nRanks) * sizeof(float), r2));
+    fillRankScalar(s1.ptr, count, rank);
+    fillRankScalar(s2.ptr, count, rank);
+
+    const uint32_t seqComm1Before = ceComm1->ceColl.ceSeqNum;
+    for(int iter = 0; iter < 5; ++iter)
+    {
+        CeSimulatedCaptureGuard capture2(ceComm2);
+        ASSERT_EQ(runCeAllGatherDirect(ceComm2, s2.ptr, r2.ptr, count, getActiveStream()), ncclSuccess)
+            << "comm2 replay iter " << iter;
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    }
+
+    CeSimulatedCaptureGuard capture1(ceComm1);
+    ASSERT_EQ(runCeAllGatherDirect(ceComm1, s1.ptr, r1.ptr, count, getActiveStream()), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+    EXPECT_GE(ceComm1->ceColl.ceSeqNum, seqComm1Before)
+        << "comm1 CE seq should advance independently of comm2 replay";
+    ASSERT_TRUE(ceVerifyBlockPatternFloat(r1.ptr, count * static_cast<size_t>(nRanks), count));
 }
 
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/ce/CeTestHelpers.hpp
+++ b/projects/rccl/test/ce/CeTestHelpers.hpp
@@ -82,6 +82,35 @@ inline std::vector<uint32_t> ceReadUcCompleteFlags(const ncclComm* comm)
     return host;
 }
 
+// Reset UC ready/complete flag arrays on the same stream used by ncclMemOpSync.
+// Default-stream hipMemset/hipMemcpy races with batch memops on the test stream.
+inline hipError_t ceResetUcSyncWindowOnStream(ncclComm* comm, hipStream_t stream)
+{
+    const size_t nBytes = static_cast<size_t>(comm->nRanks) * sizeof(uint32_t);
+    hipError_t   err    = hipMemsetAsync(comm->ceColl.baseUCSymReadyPtr, 0, nBytes, stream);
+    if(err != hipSuccess)
+        return err;
+    err = hipMemsetAsync(comm->ceColl.baseUCSymComplPtr, 0, nBytes, stream);
+    if(err != hipSuccess)
+        return err;
+    return hipStreamSynchronize(stream);
+}
+
+// Seed distinct per-rank patterns into the ready array on stream.
+inline hipError_t ceWriteUcReadyPatternsOnStream(ncclComm* comm, hipStream_t stream)
+{
+    auto* readyPtrs = reinterpret_cast<uint32_t*>(comm->ceColl.baseUCSymReadyPtr);
+    for(int i = 0; i < comm->nRanks; ++i)
+    {
+        const uint32_t pattern = static_cast<uint32_t>(0x1000 + i);
+        hipError_t err =
+            hipMemcpyAsync(&readyPtrs[i], &pattern, sizeof(uint32_t), hipMemcpyHostToDevice, stream);
+        if(err != hipSuccess)
+            return err;
+    }
+    return hipStreamSynchronize(stream);
+}
+
 #else
 
 inline bool ceSimulatedCaptureSupported() { return false; }

--- a/projects/rccl/test/ce/CeTestHelpers.hpp
+++ b/projects/rccl/test/ce/CeTestHelpers.hpp
@@ -15,8 +15,80 @@
 #include "MPIHelpers.hpp"
 
 #include <hip/hip_runtime.h>
+#include <gtest/gtest.h>
+#include <climits>
+#include <cstdint>
 #include <cstdlib>
 #include <string>
+#include <vector>
+
+struct ncclComm;
+
+// Mirrors ce_coll.cc GRAPH_SYNC_VALUE (not exported).
+inline constexpr uint32_t kCeGraphSyncValue = 1;
+
+#if ROCM_VERSION >= 60100
+#include <comm.h>
+
+// RAII: mark comm->planner.capturingGraph valid for white-box CE graph-path tests.
+class CeSimulatedCaptureGuard
+{
+public:
+    explicit CeSimulatedCaptureGuard(ncclComm* comm) : comm_(comm)
+    {
+        saved_ = comm_->planner.capturingGraph;
+        comm_->planner.capturingGraph.graphId = 0;
+    }
+
+    ~CeSimulatedCaptureGuard() { comm_->planner.capturingGraph = saved_; }
+
+    CeSimulatedCaptureGuard(const CeSimulatedCaptureGuard&)            = delete;
+    CeSimulatedCaptureGuard& operator=(const CeSimulatedCaptureGuard&) = delete;
+
+private:
+    ncclComm*       comm_;
+    ncclCudaGraph   saved_;
+};
+
+inline bool ceSimulatedCaptureSupported() { return true; }
+
+inline void ceSkipIfNvls(const ncclComm* comm)
+{
+    if(comm != nullptr && comm->nvlsSupport)
+        GTEST_SKIP() << "UC-only test; nvlsSupport MC path not covered here";
+}
+
+inline std::vector<uint32_t> ceReadUcReadyFlags(const ncclComm* comm)
+{
+    std::vector<uint32_t> host(static_cast<size_t>(comm->nRanks));
+    if(comm->ceColl.baseUCSymReadyPtr != nullptr)
+    {
+        EXPECT_EQ(hipMemcpy(host.data(), comm->ceColl.baseUCSymReadyPtr,
+                            host.size() * sizeof(uint32_t), hipMemcpyDeviceToHost),
+                  hipSuccess);
+    }
+    return host;
+}
+
+inline std::vector<uint32_t> ceReadUcCompleteFlags(const ncclComm* comm)
+{
+    std::vector<uint32_t> host(static_cast<size_t>(comm->nRanks));
+    if(comm->ceColl.baseUCSymComplPtr != nullptr)
+    {
+        EXPECT_EQ(hipMemcpy(host.data(), comm->ceColl.baseUCSymComplPtr,
+                            host.size() * sizeof(uint32_t), hipMemcpyDeviceToHost),
+                  hipSuccess);
+    }
+    return host;
+}
+
+#else
+
+inline bool ceSimulatedCaptureSupported() { return false; }
+
+inline void ceSkipIfNvls(const ncclComm*) {}
+
+#endif
 
 // Returns true when compiled with CE batch API support (CE_BATCH_ASYNC_SUPPORTED).
 // Gated at build time via check_symbol_exists(hipMemcpyBatchAsync); no runtime query needed.


### PR DESCRIPTION
## Summary

Adds automated test coverage for #9334 on a **separate branch** (`users/abreslow/ce-graph-barrier-tests`) — this PR does not modify `users/mustafabar/CE_support_sync`.

- White-box tests in `CeInternalMPITests.cpp` for capture-path `ncclPrepUCSync`, split wait/reset batches in `ncclMemOpSync`, even intra-batch sync padding in `ncclCeLaunchBatchOps`, `ceSeqNumDev` lifecycle, and graph-safe window registration during capture.
- End-to-end MPI tests in `CeMPITests.cpp` (`CeMPI_GraphBarrier`) exercising direct `ncclCeAllGather` replay under simulated and HIP graph capture, graph mixing, and multi-comm isolation.
- Shared helpers in `CeTestHelpers.hpp` (`CeSimulatedCaptureGuard`, flag readers, etc.).

## Test plan

- [x] `mpirun -np 2 ./CeInternalMPITests --gtest_filter='CeInternal*:MemOpSync*:LaunchBatchOps*:SymBuf*:CommTeardown*:Init*CeSeq*'`
- [x] `mpirun -np 2 ./CeMPITests --gtest_filter='CeMPI_GraphBarrier.*'`
- [x] Requires CE dispatch env (`NCCL_CTA_POLICY=2`, `NCCL_LOCAL_REGISTER=0`, `NCCL_CUMEM_ENABLE=1`) and UC path (`nvlsSupport=false`)

Stacked on #9334 — merge after the fix lands or review together.


Made with [Cursor](https://cursor.com)