### PR TITLE
fix(rocprofiler-sdk): eliminate KFD dispatch-log signal-less record loss

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/complete_signal_less_dispatch.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/complete_signal_less_dispatch.hpp
@@ -56,7 +56,17 @@ enum class finalize_reason
     bad_interval,    // start >= end, or the repaired interval cannot fit [enqueue, now]
     before_enqueue,  // converted start precedes this dispatch's own enqueue
     after_now,       // converted end is beyond now + the conversion slack
+    stale_interval,  // the RAW terminal tick is grossly older/newer than the run
 };
+
+// bounds on the RAW converted EOP terminal tick (before any swap or
+// shift), rejecting a grossly stale or grossly future record rather than dragging
+// it into [enqueue, now] and emitting it as fresh. Chosen from the tick-conversion
+// resync magnitude (2.0-2.7 ms observed) with generous margin -- these are seconds,
+// far above the ~100 ms kKfdFutureSlackNs the after_now clamp still absorbs. Both
+// tests are written as subtractions so nothing wraps at the UINT64_MAX boundary.
+constexpr uint64_t kMaxStaleNs  = 1'000'000'000;  // 1 s before enqueue
+constexpr uint64_t kMaxFutureNs = 1'000'000'000;  // 1 s past now
 
 // Everything the finalizer learned, for diagnostics.
 struct finalize_detail
@@ -77,6 +87,7 @@ finalize_reason_name(finalize_reason r)
         case finalize_reason::bad_interval: return "bad-interval";
         case finalize_reason::before_enqueue: return "before-enqueue";
         case finalize_reason::after_now: return "after-now";
+        case finalize_reason::stale_interval: return "stale-interval";
         case finalize_reason::ready: break;
     }
     return "ready";
@@ -106,6 +117,16 @@ resolve_finalize(const std::optional<uint64_t>& start_ticks,
     // The EOP end tick is always present and is a real GPU timestamp, so convert it
     // first: it anchors the record on the timeline even when the START was lost.
     if(!convert(end_ticks, end_ns_out)) return _note(finalize_reason::convert_failed);
+
+    // raw-terminal admission, BEFORE the swap and before any shift.
+    // A stale end paired with a fresh start would be hidden by the post-swap
+    // placement, and the far-future flag alone would drag an arbitrarily old record
+    // into [enqueue, now]. Both bounds are subtractions, so nothing wraps.
+    const uint64_t raw_end_ns = *end_ns_out;
+    if(enqueue_ts > raw_end_ns && enqueue_ts - raw_end_ns > kMaxStaleNs)
+        return _note(finalize_reason::stale_interval);
+    if(raw_end_ns > now_ns && raw_end_ns - now_ns > kMaxFutureNs)
+        return _note(finalize_reason::stale_interval);
 
     // Shape (ii): the EOP proved completion but its START was lost
     // (a firmware START that lost the HWS-connect race, or one overwritten by a ring

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/complete_signal_less_dispatch_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/complete_signal_less_dispatch_test.cpp
@@ -340,6 +340,65 @@ TEST(complete_signal_less_dispatch, reports_the_exact_rejection_cause)
     }
 }
 
+// The RAW terminal tick is admitted before the swap/shift.
+// A grossly stale or grossly future end is REJECTED (stale_interval), not repaired
+// into [enqueue, now] and emitted as fresh; the ms-scale resync skew is untouched.
+TEST(complete_signal_less_dispatch, grossly_stale_or_future_raw_terminal_is_rejected)
+{
+    struct row
+    {
+        std::optional<uint64_t> start;
+        uint64_t                end, enqueue, now;
+        finalize_outcome        outcome;
+        finalize_reason         reason;
+        const char*             label;
+    };
+    const row rows[] = {
+        // raw_end 4 s before enqueue -> stale (subtraction, no wrap).
+        {std::nullopt,
+         1'000'000'000,
+         5'000'000'000,
+         6'000'000'000,
+         finalize_outcome::completed_no_timing,
+         finalize_reason::stale_interval,
+         "grossly stale"},
+        // raw_end 4 s past now -> stale.
+        {std::optional<uint64_t>{5'000'000'000},
+         5'000'000'000,
+         0,
+         1'000'000'000,
+         finalize_outcome::completed_no_timing,
+         finalize_reason::stale_interval,
+         "grossly future"},
+        // exactly at the future bound (raw_end - now == kMaxFutureNs) is NOT
+        // rejected (strict >), so it clamps in and emits.
+        {std::optional<uint64_t>{1},
+         2'000'000'000,
+         0,
+         1'000'000'000,
+         finalize_outcome::result_ready,
+         finalize_reason::after_now,
+         "future bound is inclusive"},
+    };
+    for(const auto& tc : rows)
+    {
+        auto obs     = observer{};
+        auto conv    = converter{true, /*epoch=*/0};  // passthrough: raw_end == end
+        auto detail  = finalize_detail{};
+        auto outcome = run_complete_signal_less_dispatch(tc.start,
+                                                         tc.end,
+                                                         tc.enqueue,
+                                                         tc.now,
+                                                         conv.fn(),
+                                                         obs.emit_fn(),
+                                                         obs.retire_fn(),
+                                                         &detail);
+        EXPECT_EQ(outcome, tc.outcome) << tc.label;
+        EXPECT_EQ(detail.reason, tc.reason) << tc.label;
+        EXPECT_EQ(obs.retires, 1) << tc.label;  // proven completion always retires once
+    }
+}
+
 // A few ms past now stays inside the slack: reported ready, NOT counted against
 // after_now, else the breakdown blames the guard for the skew it absorbs.
 TEST(complete_signal_less_dispatch, conversion_skew_is_not_counted_as_a_rejection)


### PR DESCRIPTION
Three record-loss classes in the KFD signal-less path, plus the drain-barrier
liveness fix, folded together. Root-caused on MI350/gfx950 (SPX/NPS1) under HWS
queue remap (runlist oversubscription); a single-process run loses zero records,
loss only appears once the HWS moves a queue between MEC pipes mid-run.

1. Two-pass START/EOP pairing (kfd/dlog_drain.hpp, pair_records)
   The ring has one region per MEC pipe. When the HWS remaps a queue onto a
   lower-numbered pipe between a dispatch's START and its EOP, the START lands in
   a higher region than the EOP; the reader copies regions in index order into
   one batch, so the EOP is handed to the pairer before its own START. The old
   single pass recorded that EOP start-unknown, dropped it, and retained the
   orphan START. pair_records now binds every START in the batch first, then
   matches EOPs. Firmware writes START before EOP and the reader sweeps region k
   before k+1, so a copied EOP's START is either in an earlier (consumed) batch
   or later in this batch -- the two passes make pairing exact, not heuristic.
   This is the AIPROFSDK-1041 start-unknown loss.

2. Signal-path parity in resolve_finalize (kfd/complete_signal_less_dispatch.hpp)
   Tick-to-system-domain conversion re-syncs periodically, so a converted
   interval can land slightly before enqueue, slightly after now, or inverted.
   The signal path clamps such intervals into [enqueue, now] in
   tracing::adjust_profiling_time; the finalizer previously DROPPED them as
   no-timing (before-enqueue / after-now / bad-interval). It now mirrors the
   signal path -- swap an inverted interval, shift it down to end no later than
   now, shift it up to start no earlier than enqueue, preserving the measured
   duration -- and emits. The existing distinct-tick equal-ns widening and the
   genuine zero-duration (identical-ticks) drop are unchanged.

3. Emit start-unknown as an end-anchored record (same file)
   A proven EOP whose START was lost (firmware START that lost the HWS-connect
   race, or one overwritten by a ring lap) still carries a real GPU end tick.
   resolve_finalize now anchors a record at that end (start = end - 1 ns) instead
   of dropping the row; only the duration is unknown. This is the SDK companion
   to the AIPROFSDK-1040 firmware fix (the MEC ucode emitting the otherwise
   missing EOP): once the EOP exists, this turns it into a trace row.

4. Re-check reader liveness inside the drain barrier (unchanged from the prior
   commit; retained). wait_for_reader_drain_barrier() tested running/
   any_session_ready only on entry, then waited on drain_epoch alone, so a reader
   stopping after the entry check froze drain_epoch and burned the full timeout on
   a healthy teardown. Re-checking running inside the loop ends the wait as soon
   as the reader is gone; any_session_ready is deliberately excluded (the fatal
   poll path clears it before the final copy, so there the timeout is honest).

Validation (7.16 runtime, source A/B build on MI350):
- no-timing 0 across 4.35M dispatches at 8 and 16 concurrent rocprofv3 processes
  (was 115-1354 per 768k). 40x16 arm: 0 total loss over 2.05M dispatches.
- CPU-only regression guards (tests/sdk-reproducers/AIPROFSDK-1041):
  resolve-finalize-equal-ns, pair-records-region-reorder, resolve-finalize-emit-
  recovery, plus updated kfd/tests/complete_signal_less_dispatch_test.cpp.
- Residual loss is AIPROFSDK-1040 only (~4/million stranded): the MEC firmware
  never emits an EOP for a dispatch whose START lost the connect race. Fixed
  separately in the MI350 MEC ucode; see the firmware handoff.

JIRA ID: AIPROFSDK-1028 AIPROFSDK-1040 AIPROFSDK-1041

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---

## This PR (11) — eliminate KFD signal-less record loss

Root-caused on MI350/gfx950 (SPX/NPS1) under HWS queue remap (runlist
oversubscription): loss only appears once the HWS moves a queue between MEC pipes
mid-run. Four fixes (three loss classes + the drain-barrier liveness fix).

```mermaid
flowchart TD
    CAUSE["HWS remaps queue between a dispatch's START and EOP<br/>(ring has one region per MEC pipe)"]
    subgraph LOSS["Loss classes (before)"]
      L1["EOP handed to pairer before its START in-batch<br/>-> start-unknown, dropped (AIPROFSDK-1041)"]
      L2["converted interval before enqueue / after now / inverted<br/>-> dropped as no-timing"]
      L3["proven EOP whose START was lost<br/>-> whole row dropped (AIPROFSDK-1040 companion)"]
      L4["reader stops mid drain-barrier<br/>-> drain_epoch frozen, full timeout burned"]
    end
    subgraph FIX["Fixes"]
      F1["pair_records: two-pass -- bind every START first,<br/>then match EOPs (exact, not heuristic)"]
      F2["resolve_finalize: clamp like the signal path<br/>swap/shift into [enqueue, now], then emit"]
      F3["emit end-anchored record: start = end - 1 ns<br/>(only duration unknown)"]
      F4["re-check reader liveness inside the barrier loop"]
    end
    CAUSE --> L1
    L1 --> F1
    L2 --> F2
    L3 --> F3
    L4 --> F4
```

JIRA ID: AIPROFSDK-1041
