### PR TITLE
feat(rocr): env-gated HSA_NPI_SET_RESOURCE_LIMITS on gfx9.4+/gfx12

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -315,6 +315,9 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Fill queue properties
   void GetInfoProperties(uint8_t value[8]) const;
 
+  /// @brief Overwrite shader COMPUTE_RESOURCE_LIMITS via PM4 (HSA_NPI_SET_RESOURCE_LIMITS).
+  void SetResourceLimits(uint32_t limit);
+
   // AQL packet ring buffer
   void* ring_buf_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_pm4.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_pm4.h
@@ -56,6 +56,8 @@
 #define PM4_HDR_IT_OPCODE_WAIT_REG_MEM                    0x3CU
 #define PM4_HDR_IT_OPCODE_COPY_DATA                       0x40U
 #define PM4_HDR_IT_OPCODE_DMA_DATA                        0x50U
+// drivers/gpu/drm/amd/amdkfd/kfd_pm4_opcodes.h
+#define PM4_HDR_IT_OPCODE_SET_SH_REG                      0x76U
 
 #define PM4_HDR_SHADER_TYPE(x)                            (((x) & 0x1U) << 1)
 #define PM4_HDR_IT_OPCODE(x)                              (((x) & 0xFFU) << 8)
@@ -141,6 +143,12 @@
 #define PM4_WRITE_DATA_DW2_DST_MEM_ADDR_LO(x)          (((x) & 0xFFFFFFFCU) << 0)
 #define PM4_WRITE_DATA_DW3_DST_MEM_ADDR_HI(x)          (((x) & 0xFFFFFFFFU) << 0)
 #define PM4_WRITE_DATA_DW4_DATA(x)                     (((x) & 0xFFFFFFFFU) << 0)
+
+#define PM4_SET_SH_REG_DW1(x)                          (((x) & 0xFFFFFFFFU) << 0)
+#   define PM4_SET_SH_REG_DW1_REG_OFFSET(x)            (((x) & 0xFFFFU) << 0)
+#   define PM4_SET_SH_REG_DW1_VMID_SHIFT(x)            (((x) & 0x1FU) << 23)
+#   define PM4_SET_SH_REG_DW1_INDEX(x)                 (((x) & 0xFU) << 28)
+#define PM4_SET_SH_REG_DW2_DATA(x)                     (((x) & 0xFFFFFFFFU) << 0)
 
 // clang-format on
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -344,6 +344,10 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
   active_ = true;
 
+  if (core::Runtime::runtime_singleton_->flag().debug_set_resource_limits()) {
+    SetResourceLimits(core::Runtime::runtime_singleton_->flag().debug_set_resource_limits());
+  }
+
   PM4IBGuard.Dismiss();
   RingGuard.Dismiss();
   QueueGuard.Dismiss();
@@ -1582,6 +1586,70 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
   }
   memcpy(cu_mask, &cu_mask_[0], sizeof(uint32_t) * user_dword_count);
   return HSA_STATUS_SUCCESS;
+}
+
+void AqlQueue::SetResourceLimits(uint32_t limit) {
+  // Instrumentation tag so we can grep the logs to confirm the chosen
+  // value and exactly what was programmed. This path is only reached when
+  // HSA_NPI_SET_RESOURCE_LIMITS is set to a non-zero value.
+  static const char* kTag = "[HSA_NPI_SET_RESOURCE_LIMITS]";
+  auto isa = agent_->supported_isas()[0];
+  const std::string isa_name = isa->GetProcessorName();
+
+  fprintf(stderr, "%s chosen=%u target_isa=%s (gfx%d.%d.%d)\n", kTag, limit,
+          isa_name.c_str(), isa->GetMajorVersion(), isa->GetMinorVersion(),
+          isa->GetStepping());
+
+  // COMPUTE_RESOURCE_LIMITS.WAVES_PER_SH is a 10-bit field (0..1023).
+  if (limit > 1023) {
+    fprintf(stderr, "%s ERROR invalid limit=%u (valid range 0..1023) - NOT programmed\n",
+            kTag, limit);
+    return;
+  }
+
+  // Supported on gfx9.4+ and the gfx12 family. The CP SH-register offset for
+  // COMPUTE_RESOURCE_LIMITS is a stable CP ABI (0x0215) across these gens; see
+  // the derivation note at COMPUTE_RESOURCE_LIMITS_OFFSET below.
+  const bool supported = (isa->GetMajorVersion() == 9 && isa->GetMinorVersion() >= 4) ||
+                         (isa->GetMajorVersion() == 12);
+  if (!supported) {
+    fprintf(stderr, "%s ERROR resource limits not supported on %s - NOT programmed\n",
+            kTag, isa_name.c_str());
+    return;
+  }
+
+  const uint32_t sh_reg_pkt_size_dw = 3;
+  uint32_t sh_reg_pkt[sh_reg_pkt_size_dw] = {};
+
+  /*
+   * COMPUTE_RESOURCE_LIMITS SET_SH_REG offset = 0x0215.
+   *
+   * A SET_SH_REG packet takes the register's offset within the CP SH-register
+   * aperture, i.e. (CP_absolute_reg_addr - PACKET3_SET_SH_REG_START), where
+   * PACKET3_SET_SH_REG_START = 0x2c00. This offset is a stable CP microcode ABI,
+   * not the GRBM number: on gfx12.5 the asic_reg header renumbers the compute
+   * block (regCOMPUTE_RESOURCE_LIMITS = 0x1bb5, gc_12_1_0) so it cannot be used
+   * directly; the CP SH offset is still 0x0215.
+   *
+   * Validated on gfx12.5 silicon: capping WAVES_PER_SH via this packet throttles
+   * wave occupancy inversely with the cap (wall time scales ~1/cap), with no
+   * neighbouring SH register clobbered and no GPU faults.
+   */
+  const uint32_t COMPUTE_RESOURCE_LIMITS_OFFSET = 0x0215;
+
+  sh_reg_pkt[0] = PM4_HDR(PM4_HDR_IT_OPCODE_SET_SH_REG, sh_reg_pkt_size_dw, isa->GetMajorVersion());
+  sh_reg_pkt[1] = PM4_SET_SH_REG_DW1_REG_OFFSET(COMPUTE_RESOURCE_LIMITS_OFFSET);
+  sh_reg_pkt[2] = PM4_SET_SH_REG_DW2_DATA(limit);
+
+  fprintf(stderr,
+          "%s programming COMPUTE_RESOURCE_LIMITS: WAVES_PER_SH=%u reg_value=0x%08x "
+          "set_sh_reg_offset=0x%04x pkt=[0x%08x 0x%08x 0x%08x]\n",
+          kTag, limit & 0x3ff, limit, COMPUTE_RESOURCE_LIMITS_OFFSET,
+          sh_reg_pkt[0], sh_reg_pkt[1], sh_reg_pkt[2]);
+
+  ExecutePM4(sh_reg_pkt, sh_reg_pkt_size_dw * sizeof(uint32_t));
+
+  fprintf(stderr, "%s enqueued SET_SH_REG on %s (limit=%u)\n", kTag, isa_name.c_str(), limit);
 }
 
 void AqlQueue::SetProfiling(bool enabled) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -346,6 +346,11 @@ class Flag {
 
     core_dump_pattern_ = os::GetEnvVar("HSA_COREDUMP_PATTERN");
 
+    // Overwrite the shader COMPUTE_RESOURCE_LIMITS (WAVES_PER_SH) via a PM4
+    // packet at queue init. Valid values are 0..1023. 0/unset = disabled.
+    var = os::GetEnvVar("HSA_NPI_SET_RESOURCE_LIMITS");
+    debug_set_resource_limits_ = var.empty() ? 0 : atoi(var.c_str());
+
     // This enables generation of lightweight gpu coredumps (Scratch & CWSR).
     var = os::GetEnvVar("HSA_ENABLE_LIGHTWEIGHT_COREDUMP");
     lightweight_core_dump_enable_ = (var == "1");
@@ -529,6 +534,10 @@ class Flag {
                                          return core_dump_pattern_; }
 
   [[nodiscard]]
+  uint32_t debug_set_resource_limits() const {
+                                        return debug_set_resource_limits_; }
+
+  [[nodiscard]]
   bool lightweight_core_dump_enable() const {
     return lightweight_core_dump_enable_;
   }
@@ -637,6 +646,8 @@ class Flag {
   bool core_dump_disable_ = false;
   bool enable_core_dump_progress_ = false;
   std::string core_dump_pattern_;
+
+  uint32_t debug_set_resource_limits_ = 0;
   bool lightweight_core_dump_enable_ = false;
 
   uint32_t cp_queues_limit_;


### PR DESCRIPTION
Program COMPUTE_RESOURCE_LIMITS.WAVES_PER_SH (0..1023) at queue init via a PM4 SET_SH_REG packet when HSA_NPI_SET_RESOURCE_LIMITS is set. Dormant by default.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
