### PR TITLE
fix(amdsmi): [AILITOOLS-304] default the processor index to an invalid value

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -64,6 +64,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `amd-smi ras --afid --folder --json` emitting nothing when no CPER files are readable**.  
   - When every `.cper` file in the folder was skipped (e.g. rejected as a symlink), the JSON path printed empty output, so consumers feeding stdout to `json.loads` failed with `Expecting value: line 1 column 1 (char 0)`. It now emits `[]` for that case, matching the `--cper --json` contract.
 
+- **Fixed an uninitialized processor index that let the CPU and Core APIs read an unrelated CPU socket**.  
+  - Passing a GPU, NIC, or switch handle to a CPU or Core API could return another socket's telemetry with `AMDSMI_STATUS_SUCCESS`. Such handles are now rejected. Calls that pass a CPU or Core handle are unaffected.
+
 - **Fixed `amd-smi static --vram` reporting `GDDR7` for LPDDR5 unified memory on APUs (e.g. gfx117x)**.  
   - `AMDSMI_VRAM_TYPE__MAX` aliases the highest real memory type (`LPDDR5`), so a genuine LPDDR5 reading was matched by the `__MAX` special case and mislabeled `GDDR7`. It is now correctly reported as `LPDDR5`.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -25,6 +25,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - For `mclk` and `fclk` ONLY, which expose a discrete DPM table, the requested `max` is now rounded down to the nearest selectable clock level, so the enforced limit never exceeds the requested value.
   - `sclk` supports a continuous frequency range, so its requested `max` is honored exactly (e.g. `600` enforces a limit of 600MHz) and is not snapped.
 
+- **Fixed an uninitialized processor index that let the CPU and Core APIs read an unrelated CPU socket**.  
+  - Passing a GPU, NIC, or switch handle to a CPU or Core API could return another socket's telemetry with `AMDSMI_STATUS_SUCCESS`. Such handles are now rejected. Calls that pass a CPU or Core handle are unaffected.
+
 ### Upcoming Changes
 
 - **UUIDs will be replaced by CUIDs in an upcoming version**.  

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_processor.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_processor.h
@@ -24,7 +24,7 @@ class AMDSmiProcessor {
 
  private:
   amdsmi_processor_type_t processor_type_;
-  // Unset reads as "-1" under %d, which narrows to an out-of-range socket.
+  // Out-of-range sentinel so the CPU and Core APIs can reject an unset index.
   uint32_t pindex_{UINT32_MAX};
   std::string processor_identifier_;
 };

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_processor.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_processor.h
@@ -4,6 +4,7 @@
 #ifndef AMD_SMI_INCLUDE_AMD_SMI_PROCESSOR_H_
 #define AMD_SMI_INCLUDE_AMD_SMI_PROCESSOR_H_
 
+#include <cstdint>
 #include <string>
 
 #include "amd_smi/amdsmi.h"
@@ -23,7 +24,8 @@ class AMDSmiProcessor {
 
  private:
   amdsmi_processor_type_t processor_type_;
-  uint32_t pindex_;
+  // Unset reads as "-1" under %d, which narrows to an out-of-range socket.
+  uint32_t pindex_{UINT32_MAX};
   std::string processor_identifier_;
 };
 }  // namespace amd::smi

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/processor_index_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/processor_index_test.cc
@@ -1,0 +1,94 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Processor index defaults. Only the CPU socket and core constructors pass an
+// index. The CPU/Core APIs reuse that index as an ESMI socket or core number.
+// An unset index must therefore stay an obvious out-of-range selection.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "amd_smi/impl/amd_smi_processor.h"
+
+namespace {
+
+using amd::smi::AMDSmiProcessor;
+
+// ESMI limits from e_smi.h. Both are counts, so the last valid index is one below.
+constexpr uint32_t kMaxSockets = 8;           // MAX_SOCKET
+constexpr uint32_t kMaxCoresPerSocket = 512;  // CPU_MAX_CORES_PER_SOCKET
+constexpr uint32_t kMaxCoresInSystem = kMaxSockets * kMaxCoresPerSocket;
+constexpr uint32_t kLastCoreInSocket = kMaxCoresPerSocket - 1;
+constexpr uint32_t kLastCoreInSystem = kMaxCoresInSystem - 1;
+
+// Spelled out rather than read from the header, so changing the sentinel fails here.
+constexpr uint32_t kUnsetIndex = UINT32_MAX;
+constexpr uint32_t kUnsetIndexLowByte = 255;
+
+// Arbitrary in-range values. They only have to survive the round trip.
+constexpr uint32_t kSampleSocketIndex = 3;
+constexpr uint32_t kSampleCoreIndex = 191;
+
+TEST(SystemUnit, ProcessorIndexUnsetDefaultsToInvalid) {
+  AMDSmiProcessor gpu(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
+  EXPECT_EQ(gpu.get_processor_index(), kUnsetIndex)
+      << "pindex_ lost its default initializer in amd_smi_processor.h. GPU, NIC and\n"
+         "switch processors never pass an index, so they would hold indeterminate\n"
+         "values again. Fix the initializer, not this expectation. See AILITOOLS-304.";
+}
+
+TEST(SystemUnit, ProcessorIndexIdentifierCtorDefaultsToInvalid) {
+  AMDSmiProcessor by_id(std::string("0000:0c:00.0"));
+  EXPECT_EQ(by_id.get_processor_index(), kUnsetIndex)
+      << "The identifier constructor sets neither the type nor the index, so it\n"
+         "depends entirely on the default initializer. See AILITOOLS-304.";
+}
+
+TEST(SystemUnit, ProcessorIndexPreservedWhenProvided) {
+  AMDSmiProcessor socket(AMDSMI_PROCESSOR_TYPE_AMD_CPU, kSampleSocketIndex);
+  EXPECT_EQ(socket.get_processor_index(), kSampleSocketIndex)
+      << "CPU sockets must keep the index they were built with. Any other value\n"
+         "means every CPU API would target the wrong socket.";
+
+  AMDSmiProcessor core(AMDSMI_PROCESSOR_TYPE_AMD_CPU_CORE, kSampleCoreIndex);
+  EXPECT_EQ(core.get_processor_index(), kSampleCoreIndex)
+      << "CPU cores must keep the index they were built with.";
+}
+
+// ESMI allows CPU_MAX_CORES_PER_SOCKET (512) cores across MAX_SOCKET (8)
+// sockets, so the index has to hold values well beyond a single byte. amd-smi
+// assigns per-socket core indices today, so the system-wide ceiling is headroom
+// rather than a value it currently builds.
+TEST(SystemUnit, ProcessorIndexHoldsFullEsmiCoreRange) {
+  AMDSmiProcessor last_in_socket(AMDSMI_PROCESSOR_TYPE_AMD_CPU_CORE, kLastCoreInSocket);
+  EXPECT_EQ(last_in_socket.get_processor_index(), kLastCoreInSocket)
+      << "Core " << kLastCoreInSocket << " is the last of " << kMaxCoresPerSocket
+      << " cores ESMI allows on one socket. Narrowing pindex_ to uint8_t would\n"
+         "fold it onto core "
+      << (kLastCoreInSocket & 0xFFu) << ".";
+
+  AMDSmiProcessor last_in_system(AMDSMI_PROCESSOR_TYPE_AMD_CPU_CORE, kLastCoreInSystem);
+  EXPECT_EQ(last_in_system.get_processor_index(), kLastCoreInSystem)
+      << "Core " << kLastCoreInSystem
+      << " is the highest index ESMI can address: " << kMaxCoresPerSocket << " cores on each of "
+      << kMaxSockets << " sockets.";
+}
+
+// The CPU/Core APIs narrow the index to uint8_t before passing it to ESMI.
+// A low byte inside the socket range selects a real socket and returns its
+// data. The previous uninitialized value did this non-deterministically.
+TEST(SystemUnit, ProcessorIndexSentinelSurvivesUint8Narrowing) {
+  AMDSmiProcessor gpu(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
+  const uint32_t narrowed = static_cast<uint8_t>(gpu.get_processor_index());
+  EXPECT_EQ(narrowed, kUnsetIndexLowByte)
+      << "The sentinel's low byte must stay outside the range of " << kMaxSockets
+      << " sockets. UINT32_MAX narrows to " << kUnsetIndexLowByte
+      << " and is rejected. A tidier\n"
+         "looking value such as 0x100 narrows to 0 and would silently select socket\n"
+         "0. Change the sentinel in amd_smi_processor.h, not this expectation.\n"
+         "See AILITOOLS-304.";
+}
+
+}  // namespace


### PR DESCRIPTION
## Motivation

The CPU and Core APIs reuse `AMDSmiProcessor::pindex_` as the ESMI socket or
core number, and only the CPU socket and core constructors set it. GPU, BRCM
NIC, BRCM switch, and AMD NIC processors all use the type-only constructor, so
a handle from any of them carried an indeterminate value into ESMI.

When that value happened to land in range, the call did not fail. It returned
another socket's real telemetry with `AMDSMI_STATUS_SUCCESS`. On an MI300A the
result sat within a few milliwatts of the true socket reading, so the wrong
data was indistinguishable from correct data:

    cpu[0]=47469  cpu[1]=40653  cpu[2]=33785  cpu[3]=38066
    gpu[0] info='0'     socket_power=OK 47477   <-- socket 0's data, SUCCESS
    gpu[1] info='0'     socket_power=OK 47473
    gpu[2] info='32678' socket_power=INVAL
    gpu[3] info='32678' socket_power=INVAL

Because the value was indeterminate, the same binary reported different
results between runs.

## Technical Details

**Library** (`include/amd_smi/impl/amd_smi_processor.h`):
- Give `pindex_` a `UINT32_MAX` default initializer, so an unset index reaches
  ESMI out of range and is rejected instead of being silently answered
- Add the `<cstdint>` include the sentinel relies on

**Tests** (`tests/amd_smi_test/unit/system/processor_index_test.cc`):
- New `SystemUnit.ProcessorIndex*` suite covering the unset default for both
  the type-only and identifier constructors, index preservation when one is
  supplied, the ESMI core range, and the sentinel surviving the `uint8_t`
  narrowing the CPU/Core APIs perform

**Changelog** (`CHANGELOG.md`):
- Entry under ROCm 10.0.0 -> Resolved Issues

## Issue Tracking

JIRA ID : AILITOOLS-304

## Test Plan

- `amdsmitst --gtest_filter='SystemUnit.ProcessorIndex*'`
- Same suite with the initializer reverted, to confirm the tests track the fix
- `pre-commit run --config projects/amdsmi/.pre-commit-config.yaml` over the diff
- Python CPU integration suite on an MI300A system, before and after

## Test Result

- `SystemUnit.ProcessorIndex*`: 5/5 pass
- Reverting the initializer fails 3 of the 5 while
  `ProcessorIndexPreservedWhenProvided` still passes, so the tests track the
  initializer rather than something incidental
- All pre-commit hooks pass

**Expect the Python CPU test failure count to rise.** This change converts
silently-wrong successes into correct errors, so calls that previously passed
on another socket's data now fail as they should. Observed on an MI300A test
system, single samples, not CI runs:

| build | CPU test failures |
|---|---|
| merge-base `a6e711c7da` | 3 |
| this branch, before the initializer | 3 |
| this branch, with the initializer | 15 |

Older develop builds of the same suite produced 14. The count moved with
unrelated commits that shifted object layout and therefore changed which
garbage `pindex_` read, which is the underlying symptom rather than a separate
problem. With the initializer in place the count is stable.

The additional failures are pre-existing defects this change makes visible, not
regressions introduced by it.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
