### PR TITLE
fix(rccl): MI350/MI300 1-node Direct algo region Channel Count increased 64->256

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1220,7 +1220,27 @@ static ncclResult_t ncclTopoGetNchannels(struct ncclComm* comm, int g /*local gp
 }
 
 NCCL_PARAM(MinP2pNChannels, "MIN_P2P_NCHANNELS", 1);
-NCCL_PARAM(MaxP2pNChannels, "MAX_P2P_NCHANNELS", MAXCHANNELS);
+NCCL_PARAM(MaxP2pNChannels, "MAX_P2P_NCHANNELS", -2);
+
+int ncclMaxP2pNchannels() {
+  int maxP2pNchannels = MAXCHANNELS;
+  if (ncclParamMaxP2pNChannels() != -2) maxP2pNchannels = (int)ncclParamMaxP2pNChannels();
+  maxP2pNchannels = std::min(maxP2pNchannels, (int)MAXCHANNELS);
+  if (maxP2pNchannels < 1) {
+    INFO(NCCL_GRAPH | NCCL_ENV, "User asked for a maximum of %d P2P channels, setting it to 1", maxP2pNchannels);
+    maxP2pNchannels = 1;
+  }
+  return maxP2pNchannels;
+}
+
+int ncclP2pChannelsUpperBound(bool* userOptedHigherOut) {
+  int64_t userMaxP2pParam = ncclParamMaxP2pNChannels();
+  int defaultMax = 4 * CHANNEL_LIMIT;
+  bool userOptedHigher = (userMaxP2pParam != -2 && userMaxP2pParam > defaultMax);
+  if (userOptedHigherOut != nullptr) *userOptedHigherOut = userOptedHigher;
+  return userOptedHigher ? std::min((int)userMaxP2pParam, (int)MAXCHANNELS) : defaultMax;
+}
+
 // When enabled, caps p2pnChannels to 16 on gfx950 (MI350) for large-scale jobs
 // (nNodes >= 16) to reduce P2P CU usage. Disabled by default.
 NCCL_PARAM(P2pCuReduceScaleEnable, "P2P_CU_REDUCE_SCALE_ENABLE", 0);
@@ -1250,11 +1270,11 @@ ncclResult_t ncclTopoComputeP2pChannelsPerPeer(struct ncclComm* comm) {
 ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   /* here we already honor comm->max/minCTAs for p2pnChannels. */
   if (comm->sharedRes->owner != comm) {
-    comm->p2pnChannels = std::min(comm->nChannels, (int)ncclParamMaxP2pNChannels());
+    comm->p2pnChannels = std::min(comm->nChannels, ncclMaxP2pNchannels());
     comm->p2pnChannels =
       std::min(std::max(comm->p2pnChannels, (int)ncclParamMinP2pNChannels()), comm->sharedRes->tpP2pNChannels);
   } else {
-    comm->p2pnChannels = std::min(comm->nChannels, (int)ncclParamMaxP2pNChannels());
+    comm->p2pnChannels = std::min(comm->nChannels, ncclMaxP2pNchannels());
     comm->p2pnChannels = std::max(comm->p2pnChannels, (int)ncclParamMinP2pNChannels());
   }
 
@@ -1293,11 +1313,10 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     // (=64), treat it as an opt-in to the extended upper bound (up to MAXCHANNELS).
     // Otherwise keep the historical 64 cap and per-arch multi-node caps below.
     {
-      int userMaxP2p = (int)ncclParamMaxP2pNChannels();
-      int defaultMax = 4 * CHANNEL_LIMIT;
-      int upper = (userMaxP2p > defaultMax) ? std::min(userMaxP2p, (int)MAXCHANNELS) : defaultMax;
+      bool userOptedHigher = false;
+      int upper = ncclP2pChannelsUpperBound(&userOptedHigher);
       comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), upper);
-      if (upper == defaultMax) {
+      if (!userOptedHigher) {
         // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS
         // Capping the comm->p2pnChannels to 32 for send/recv based collectives on multi-node MI350 (2 and 4 nodes)
         if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) &&

--- a/projects/rccl/src/include/graph.h
+++ b/projects/rccl/src/include/graph.h
@@ -38,6 +38,11 @@ void ncclTopoFree(struct ncclTopoSystem* system);
 ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* comm);
 ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm);
 ncclResult_t ncclTopoComputeP2pChannelsPerPeer(struct ncclComm* comm);
+// Resolved NCCL_MAX_P2P_NCHANNELS (MAXCHANNELS when unset, else clamped user value).
+int ncclMaxP2pNchannels();
+// Topology upper bound for p2pnChannels: 64 unless the user explicitly set
+// NCCL_MAX_P2P_NCHANNELS above 64, in which case up to MAXCHANNELS applies.
+int ncclP2pChannelsUpperBound(bool* userOptedHigherOut);
 ncclResult_t ncclTopoGetNvbGpus(struct ncclTopoSystem* system, int rank, int* nranks, int** ranks);
 ncclResult_t ncclTopoPathAllNVLink(struct ncclTopoSystem* system, int* allNvLink);
 ncclResult_t ncclTopoPathAllDirectNVLink(struct ncclTopoSystem* system, bool* allNvlinkConnected);

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -463,6 +463,7 @@ if(BUILD_TESTS)
       LL128RegVariantKernel_test.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp
+      P2pMaxNchannelsTests.cpp
       TopoNicFusionTests.cpp
       NetSocketTests.cpp
       PluginCompatV11_test.cpp

--- a/projects/rccl/test/P2pMaxNchannelsTests.cpp
+++ b/projects/rccl/test/P2pMaxNchannelsTests.cpp
@@ -24,6 +24,7 @@
 #include "device.h"
 #include "graph.h"
 #include "graph/topo.h"
+#include "nccl.h"
 
 namespace RcclUnitTesting
 {
@@ -33,67 +34,80 @@ namespace
 
 constexpr int kDefaultP2pUpper = 4 * CHANNEL_LIMIT;  // 64
 
+// Minimal stand-in communicator for ncclTopoComputeP2pChannels(). ncclComm is
+// several MB (channels[MAXCHANNELS] plus planner.wipPlan.channels[MAXCHANNELS]),
+// so heap-allocate it: stack-allocating inside the isolated-test thread was
+// tripping SIGSEGV. Mirrors MockComm in TopoEnvPolicyTests / NetDevsPolicyP2pNetTests.
 struct P2pChannelsComm
 {
-    ncclComm            comm{};
-    ncclTopoSystem      topo{};
-    ncclSharedResources sharedRes{};
+    ncclComm*            comm     = nullptr;
+    ncclTopoSystem*      topo     = nullptr;
+    ncclSharedResources* sharedRes = nullptr;
 
-    void initSingleNode(const char* gcn, int nRanks, int nChannels, int seedP2pPerPeer)
+    P2pChannelsComm()
+    {
+        comm      = new ncclComm();
+        topo      = new ncclTopoSystem();
+        sharedRes = new ncclSharedResources();
+    }
+
+    ~P2pChannelsComm()
+    {
+        delete sharedRes;
+        delete topo;
+        delete comm;
+    }
+
+    P2pChannelsComm(const P2pChannelsComm&)            = delete;
+    P2pChannelsComm& operator=(const P2pChannelsComm&) = delete;
+
+    void initCommon(const char* gcn, int nRanks, int nNodes, int localGpus, int nChannels,
+                    int seedP2pPerPeer)
     {
         ncclTopoNode gpuNode{};
-        memset(&comm, 0, sizeof(comm));
-        memset(&topo, 0, sizeof(topo));
-        memset(&sharedRes, 0, sizeof(sharedRes));
+        memset(comm, 0, sizeof(*comm));
+        memset(topo, 0, sizeof(*topo));
+        memset(sharedRes, 0, sizeof(*sharedRes));
         memset(&gpuNode, 0, sizeof(gpuNode));
+
+        for(int c = 0; c < MAXCHANNELS; c++) comm->channels[c].id = -1;
 
         strncpy(gpuNode.gpu.gcn, gcn, GCN_ARCH_NAME_LEN - 1);
         gpuNode.gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
 
-        topo.nodes[GPU].count = nRanks;
-        topo.nRanks           = nRanks;
-        topo.type             = RCCL_TOPO_XGMI_ALL;
-        topo.nodes[GPU].nodes[0] = gpuNode;
+        topo->nodes[GPU].count      = localGpus;
+        topo->nRanks                = nRanks;
+        topo->type                  = RCCL_TOPO_XGMI_ALL;
+        topo->nodes[GPU].nodes[0]   = gpuNode;
+        topo->nodes[CPU].count      = 1;
+        topo->nodes[CPU].nodes[0].cpu.vendor = NCCL_TOPO_CPU_VENDOR_AMD;
+        topo->nodes[CPU].nodes[0].cpu.arch   = NCCL_TOPO_CPU_ARCH_X86;
 
-        comm.topo                = &topo;
-        comm.sharedRes           = &sharedRes;
-        sharedRes.owner            = &comm;
-        comm.nRanks                = nRanks;
-        comm.nNodes                = 1;
-        comm.nChannels             = nChannels;
-        comm.p2pnChannelsPerPeer   = seedP2pPerPeer;
+        comm->topo                      = topo;
+        comm->sharedRes                 = sharedRes;
+        sharedRes->owner                = comm;
+        comm->nRanks                    = nRanks;
+        comm->nNodes                    = nNodes;
+        comm->nChannels                 = nChannels;
+        comm->p2pnChannelsPerPeer       = seedP2pPerPeer;
+        comm->config.nChannelsPerNetPeer = NCCL_CONFIG_UNDEF_INT;
+    }
+
+    void initSingleNode(const char* gcn, int nRanks, int nChannels, int seedP2pPerPeer)
+    {
+        initCommon(gcn, nRanks, /*nNodes=*/1, /*localGpus=*/nRanks, nChannels, seedP2pPerPeer);
     }
 
     void initMultiNode(const char* gcn, int nNodes, int nRanks, int localGpus, int nChannels,
                        int seedP2pPerPeer)
     {
-        ncclTopoNode gpuNode{};
-        memset(&comm, 0, sizeof(comm));
-        memset(&topo, 0, sizeof(topo));
-        memset(&sharedRes, 0, sizeof(sharedRes));
-        memset(&gpuNode, 0, sizeof(gpuNode));
-
-        strncpy(gpuNode.gpu.gcn, gcn, GCN_ARCH_NAME_LEN - 1);
-        gpuNode.gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
-
-        topo.nodes[GPU].count = localGpus;
-        topo.nRanks           = nRanks;
-        topo.type             = RCCL_TOPO_XGMI_ALL;
-        topo.nodes[GPU].nodes[0] = gpuNode;
-
-        comm.topo                = &topo;
-        comm.sharedRes           = &sharedRes;
-        sharedRes.owner            = &comm;
-        comm.nRanks                = nRanks;
-        comm.nNodes                = nNodes;
-        comm.nChannels             = nChannels;
-        comm.p2pnChannelsPerPeer   = seedP2pPerPeer;
+        initCommon(gcn, nRanks, nNodes, localGpus, nChannels, seedP2pPerPeer);
     }
 
     ncclResult_t computeP2pChannels(int* outP2pChannels)
     {
-        ncclResult_t res = ncclTopoComputeP2pChannels(&comm);
-        if(res == ncclSuccess) *outP2pChannels = comm.p2pnChannels;
+        ncclResult_t res = ncclTopoComputeP2pChannels(comm);
+        if(res == ncclSuccess) *outP2pChannels = comm->p2pnChannels;
         return res;
     }
 };

--- a/projects/rccl/test/P2pMaxNchannelsTests.cpp
+++ b/projects/rccl/test/P2pMaxNchannelsTests.cpp
@@ -1,0 +1,290 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for NCCL_MAX_P2P_NCHANNELS resolution and the p2pnChannels
+// upper-bound logic in src/graph/paths.cc (ncclMaxP2pNchannels,
+// ncclP2pChannelsUpperBound, ncclTopoComputeP2pChannels).
+//
+// Each case runs in an isolated process so ncclParamMaxP2pNChannels()'s cached
+// parse is fresh per env value (same pattern as TopoEnvPolicyTests).
+//
+// Target: rccl-UnitTestsFixturesDebug (internal symbols are hidden in Release).
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include "checks.h"
+#include "comm.h"
+#include "common/ProcessIsolatedTestRunner.hpp"
+#include "device.h"
+#include "graph.h"
+#include "graph/topo.h"
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+constexpr int kDefaultP2pUpper = 4 * CHANNEL_LIMIT;  // 64
+
+struct P2pChannelsComm
+{
+    ncclComm            comm{};
+    ncclTopoSystem      topo{};
+    ncclSharedResources sharedRes{};
+
+    void initSingleNode(const char* gcn, int nRanks, int nChannels, int seedP2pPerPeer)
+    {
+        ncclTopoNode gpuNode{};
+        memset(&comm, 0, sizeof(comm));
+        memset(&topo, 0, sizeof(topo));
+        memset(&sharedRes, 0, sizeof(sharedRes));
+        memset(&gpuNode, 0, sizeof(gpuNode));
+
+        strncpy(gpuNode.gpu.gcn, gcn, GCN_ARCH_NAME_LEN - 1);
+        gpuNode.gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
+
+        topo.nodes[GPU].count = nRanks;
+        topo.nRanks           = nRanks;
+        topo.type             = RCCL_TOPO_XGMI_ALL;
+        topo.nodes[GPU].nodes[0] = gpuNode;
+
+        comm.topo                = &topo;
+        comm.sharedRes           = &sharedRes;
+        sharedRes.owner            = &comm;
+        comm.nRanks                = nRanks;
+        comm.nNodes                = 1;
+        comm.nChannels             = nChannels;
+        comm.p2pnChannelsPerPeer   = seedP2pPerPeer;
+    }
+
+    void initMultiNode(const char* gcn, int nNodes, int nRanks, int localGpus, int nChannels,
+                       int seedP2pPerPeer)
+    {
+        ncclTopoNode gpuNode{};
+        memset(&comm, 0, sizeof(comm));
+        memset(&topo, 0, sizeof(topo));
+        memset(&sharedRes, 0, sizeof(sharedRes));
+        memset(&gpuNode, 0, sizeof(gpuNode));
+
+        strncpy(gpuNode.gpu.gcn, gcn, GCN_ARCH_NAME_LEN - 1);
+        gpuNode.gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
+
+        topo.nodes[GPU].count = localGpus;
+        topo.nRanks           = nRanks;
+        topo.type             = RCCL_TOPO_XGMI_ALL;
+        topo.nodes[GPU].nodes[0] = gpuNode;
+
+        comm.topo                = &topo;
+        comm.sharedRes           = &sharedRes;
+        sharedRes.owner            = &comm;
+        comm.nRanks                = nRanks;
+        comm.nNodes                = nNodes;
+        comm.nChannels             = nChannels;
+        comm.p2pnChannelsPerPeer   = seedP2pPerPeer;
+    }
+
+    ncclResult_t computeP2pChannels(int* outP2pChannels)
+    {
+        ncclResult_t res = ncclTopoComputeP2pChannels(&comm);
+        if(res == ncclSuccess) *outP2pChannels = comm.p2pnChannels;
+        return res;
+    }
+};
+
+void checkMaxP2pResolver(int expected)
+{
+    EXPECT_EQ(ncclMaxP2pNchannels(), expected);
+}
+
+void checkUpperBound(int expectedUpper, bool expectedOptedHigher)
+{
+    bool optedHigher = !expectedOptedHigher;
+    EXPECT_EQ(ncclP2pChannelsUpperBound(&optedHigher), expectedUpper);
+    EXPECT_EQ(optedHigher, expectedOptedHigher);
+    EXPECT_EQ(ncclP2pChannelsUpperBound(nullptr), expectedUpper);
+}
+
+void checkSingleNodeCompute(const char* gcn, int expectedP2pChannels)
+{
+    P2pChannelsComm fixture;
+    // Seed values large enough that only the upper-bound policy (not topology)
+    // determines the outcome: nChannels=256, per-peer seed=128 -> doubled to 256
+    // before the cap is applied.
+    fixture.initSingleNode(gcn, /*nRanks=*/8, /*nChannels=*/256, /*seedP2pPerPeer=*/128);
+    int p2pnChannels = -1;
+    ASSERT_EQ(fixture.computeP2pChannels(&p2pnChannels), ncclSuccess);
+    EXPECT_EQ(p2pnChannels, expectedP2pChannels) << "arch=" << gcn;
+}
+
+}  // namespace
+
+// --- ncclMaxP2pNchannels / ncclP2pChannelsUpperBound (param layer) ---------
+
+TEST(P2pMaxNchannelsParamTests, UnsetEnv_ResolvesToMaxChannelsAndDefaultUpper)
+{
+    RUN_ISOLATED_TEST(
+        "UnsetEnv_ResolvesToMaxChannelsAndDefaultUpper",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            checkMaxP2pResolver(MAXCHANNELS);
+            checkUpperBound(kDefaultP2pUpper, /*expectedOptedHigher=*/false);
+        });
+}
+
+TEST(P2pMaxNchannelsParamTests, Explicit64_Uses64_NoExtendedOptIn)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "Explicit64_Uses64_NoExtendedOptIn",
+        []()
+        {
+            checkMaxP2pResolver(64);
+            checkUpperBound(kDefaultP2pUpper, /*expectedOptedHigher=*/false);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "64"}});
+}
+
+TEST(P2pMaxNchannelsParamTests, Explicit32_Uses32_NoExtendedOptIn)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "Explicit32_Uses32_NoExtendedOptIn",
+        []()
+        {
+            checkMaxP2pResolver(32);
+            checkUpperBound(kDefaultP2pUpper, /*expectedOptedHigher=*/false);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "32"}});
+}
+
+TEST(P2pMaxNchannelsParamTests, Explicit128_OptsIntoExtendedUpper)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "Explicit128_OptsIntoExtendedUpper",
+        []()
+        {
+            checkMaxP2pResolver(128);
+            checkUpperBound(128, /*expectedOptedHigher=*/true);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "128"}});
+}
+
+TEST(P2pMaxNchannelsParamTests, Explicit256_OptsIntoExtendedUpper)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "Explicit256_OptsIntoExtendedUpper",
+        []()
+        {
+            checkMaxP2pResolver(std::min(256, MAXCHANNELS));
+            checkUpperBound(std::min(256, MAXCHANNELS), /*expectedOptedHigher=*/true);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "256"}});
+}
+
+TEST(P2pMaxNchannelsParamTests, ExplicitAboveMaxChannels_ClampsToMaxChannels)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "ExplicitAboveMaxChannels_ClampsToMaxChannels",
+        []()
+        {
+            checkMaxP2pResolver(MAXCHANNELS);
+            checkUpperBound(MAXCHANNELS, /*expectedOptedHigher=*/true);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "512"}});
+}
+
+// --- ncclTopoComputeP2pChannels integration (single-node MI3xx arches) ------
+
+class P2pMaxNchannelsSingleNodeTest : public ::testing::TestWithParam<const char*>
+{
+};
+
+TEST_P(P2pMaxNchannelsSingleNodeTest, UnsetEnv_CapsP2pPoolAt64)
+{
+    const char* gcn = GetParam();
+    RUN_ISOLATED_TEST(
+        std::string("UnsetEnv_CapsP2pPoolAt64_") + gcn,
+        [gcn]() {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            checkSingleNodeCompute(gcn, kDefaultP2pUpper);
+        });
+}
+
+TEST_P(P2pMaxNchannelsSingleNodeTest, Explicit256_AllowsExtendedPool)
+{
+    const char* gcn = GetParam();
+    RUN_ISOLATED_TEST_WITH_ENV(
+        std::string("Explicit256_AllowsExtendedPool_") + gcn,
+        [gcn]() { checkSingleNodeCompute(gcn, std::min(256, MAXCHANNELS)); },
+        {{"NCCL_MAX_P2P_NCHANNELS", "256"}});
+}
+
+TEST_P(P2pMaxNchannelsSingleNodeTest, Explicit64_StaysAt64)
+{
+    const char* gcn = GetParam();
+    RUN_ISOLATED_TEST_WITH_ENV(
+        std::string("Explicit64_StaysAt64_") + gcn,
+        [gcn]() { checkSingleNodeCompute(gcn, 64); },
+        {{"NCCL_MAX_P2P_NCHANNELS", "64"}});
+}
+
+INSTANTIATE_TEST_SUITE_P(Mi3xxSingleNode, P2pMaxNchannelsSingleNodeTest,
+                         ::testing::Values("gfx942", "gfx950", "gfx1250"));
+
+// --- Multi-node MI350 caps apply only without extended opt-in ---------------
+
+TEST(P2pMaxNchannelsMultiNodeTests, Gfx950_2Node16Rank_UnsetEnv_CapsAt32)
+{
+    RUN_ISOLATED_TEST(
+        "Gfx950_2Node16Rank_UnsetEnv_CapsAt32",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            P2pChannelsComm fixture;
+            fixture.initMultiNode("gfx950", /*nNodes=*/2, /*nRanks=*/16, /*localGpus=*/8,
+                                  /*nChannels=*/128, /*seedP2pPerPeer=*/64);
+            int p2pnChannels = -1;
+            ASSERT_EQ(fixture.computeP2pChannels(&p2pnChannels), ncclSuccess);
+            EXPECT_EQ(p2pnChannels, 32);
+        });
+}
+
+TEST(P2pMaxNchannelsMultiNodeTests, Gfx950_2Node16Rank_Explicit256_Skips32Cap)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "Gfx950_2Node16Rank_Explicit256_Skips32Cap",
+        []()
+        {
+            P2pChannelsComm fixture;
+            fixture.initMultiNode("gfx950", /*nNodes=*/2, /*nRanks=*/16, /*localGpus=*/8,
+                                  /*nChannels=*/256, /*seedP2pPerPeer=*/128);
+            int p2pnChannels = -1;
+            ASSERT_EQ(fixture.computeP2pChannels(&p2pnChannels), ncclSuccess);
+            EXPECT_EQ(p2pnChannels, std::min(256, MAXCHANNELS));
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "256"}});
+}
+
+TEST(P2pMaxNchannelsMultiNodeTests, Gfx950_2Node8Rank_HalfSub_UnsetEnv_CapsAt16)
+{
+    RUN_ISOLATED_TEST(
+        "Gfx950_2Node8Rank_HalfSub_UnsetEnv_CapsAt16",
+        []()
+        {
+            ::unsetenv("NCCL_MAX_P2P_NCHANNELS");
+            P2pChannelsComm fixture;
+            fixture.initMultiNode("gfx950", /*nNodes=*/2, /*nRanks=*/8, /*localGpus=*/4,
+                                  /*nChannels=*/64, /*seedP2pPerPeer=*/32);
+            int p2pnChannels = -1;
+            ASSERT_EQ(fixture.computeP2pChannels(&p2pnChannels), ncclSuccess);
+            EXPECT_EQ(p2pnChannels, 16);
+        });
+}
+
+}  // namespace RcclUnitTesting

--- a/projects/rccl/test/test_categories_fixtures_debug.yaml
+++ b/projects/rccl/test/test_categories_fixtures_debug.yaml
@@ -34,6 +34,7 @@ test_categories:
       - "NetDevsPolicyP2pNetTests.*"
       - "TopoTest.*"
       - "TopoNicFusionTests.*"
+      - "P2pMaxNchannels.*"
     exclude_windows:
       - "*"
     labels:


### PR DESCRIPTION
## Motivation

Merge of gfx1250 code (#8945 ) introduced change to channel count calculation that caused change in single node channel count on MI350 to jump from 64 to 256 in Direct algo region.

## Technical Details

Overriding the channel count beyond the default max is allowed as an "extended range" to support gfx1250 capabilities. However, default for `NCCL_P2P_MAX_NCHANNELS` was changed to `MAXCHANNELS` (256), which prevents differentiating between user-set and user-unset state.

The fix sets default to -2, and uses helper function to maintain new default of `MAXCHANNELS`, then updates logic to differentiate the set case from unset case, maintaining the original default max of `4 * CHANNEL_LIMIT` (64).

## Issue Tracking

JIRA ID : AICOMRCCL-2094

## Test Plan

Tests added to rcclUnitTestFixturesDebug, ran by CI.

## Test Result

TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
