### PR TITLE
fix(rocshmem/gda) Find libverbs and libmlx5  with the .so.1 

### DIFF
--- a/projects/rocshmem/src/gda/ibv_wrapper.cpp
+++ b/projects/rocshmem/src/gda/ibv_wrapper.cpp
@@ -41,16 +41,10 @@ IBVWrapper ibv;
 IBVWrapper::IBVWrapper() {
   int err;
 
-  ibv_handle = dlopen("libibverbs.so", RTLD_NOW);
-
+  ibv_handle = dlopen("libibverbs.so.1", RTLD_NOW);
   if (!ibv_handle) {
-    // Try hard-coded PATH
-    ibv_handle = dlopen("/usr/lib/x86_64-linux-gnu/libibverbs.so", RTLD_NOW);
-
-    if (!ibv_handle) {
-      LOG_WARN("Could not open libibverbs. Disabled.");
-      return;
-    }
+    LOG_WARN("Could not open libibverbs. Disabled.");
+    return;
   }
 
   err = init_function_table();

--- a/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -32,9 +32,9 @@ namespace rocshmem {
 
 void* GDABackend::mlx5_dv_dlopen() {
   void* dv_handle{nullptr};
-  dv_handle = dlopen("libmlx5.so", RTLD_LAZY);
+  dv_handle = dlopen("libmlx5.so.1", RTLD_LAZY);
   if (!dv_handle) {
-    LOG_TRACE("Could not open libmlx5.so. Returning");
+    LOG_TRACE("Could not open libmlx5.so.1. Returning");
   }
   return dv_handle;
 }


### PR DESCRIPTION
The .so-only variant is part of the dev package. This is a packaging convention in linux distributions.

## Motivation

On many distros, libxyz.so is not available when zyx-dev is not installed. Notably, libverbs.so and libmlx5.so are not always present, meanwhile libverbs.so.1 and libmlx5.so.1 are installed from non-dev packages. 

## Technical Details

dlopen the .so.1 instead, it is always installed even when dev packages are not installed

## Issue Tracking

JIRA ID: AIROCSHMEM-492

## Test Plan

Built on Banff/mlx5, built on tensorwave/ainic (without dev packages) 

## Test Result

Compiles and run as intended.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
