### PR TITLE
Use LDS DMA for cooperative_groups::memcpy_async on gfx9

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups_memcpy.h
@@ -162,6 +162,73 @@ __CG_STATIC_QUALIFIER__ void dispatch_async_memcpy(const TyGroup& group, TyElem*
 }
 #endif
 
+#if __has_builtin(__builtin_amdgcn_load_to_lds)
+// LDS DMA does not write to the per-lane address it is handed: the destination is a wave uniform
+// base and the hardware adds lane_id * 4. So the copy has to be partitioned by rank stride, which
+// puts consecutive lanes on consecutive dwords, rather than by the contiguous per-thread chunks
+// dispatch_async_memcpy uses. That also requires the group's ranks to be contiguous within a wave,
+// which holds for a thread_block but not for a tile or a coalesced group, and it restricts the
+// transfer to a dword: narrower transfers keep the four byte lane stride and cannot pack.
+template <typename TyGroup> struct can_group_use_lds_dma : public std::false_type {};
+template <> struct can_group_use_lds_dma<cooperative_groups::thread_block>
+    : public std::true_type {};
+
+template <class TyGroup, typename TyElem,
+          typename std::enable_if<!details::can_group_use_lds_dma<TyGroup>{}, bool>::type = true>
+__CG_STATIC_QUALIFIER__ bool dispatch_lds_dma_memcpy(const TyGroup&, TyElem* __restrict__,
+                                                     const TyElem* __restrict__, const size_t) {
+  return false;
+}
+
+template <class TyGroup, typename TyElem,
+          typename std::enable_if<details::can_group_use_lds_dma<TyGroup>{}, bool>::type = true>
+__CG_STATIC_QUALIFIER__ bool dispatch_lds_dma_memcpy(const TyGroup& group,
+                                                     TyElem* __restrict__ dst,
+                                                     const TyElem* __restrict__ src,
+                                                     const size_t count) {
+  if (count == 0) {
+    return true;
+  }
+
+  // LDS DMA only moves global -> LDS.
+  if (!__builtin_amdgcn_is_shared((const __attribute__((address_space(0))) void*)dst) ||
+      __builtin_amdgcn_is_shared((const __attribute__((address_space(0))) void*)src)) {
+    return false;
+  }
+
+  // Callers reach this only for element types aligned to at least a dword, so every dword
+  // transfer below is naturally aligned.
+  char* c_dst = (char*)dst;
+  const char* c_src = (const char*)src;
+
+  const size_t ndwords = count / 4;
+  const unsigned int num_threads = group.num_threads();
+  const unsigned int rank = group.thread_rank();
+  const unsigned int lane = __builtin_amdgcn_mbcnt_hi(~0u, __builtin_amdgcn_mbcnt_lo(~0u, 0u));
+  const unsigned int wave_first_rank = rank - lane;
+
+  // base_idx is uniform across the wave, so it can be handed to the hardware as the destination
+  // base while each lane supplies its own source address.
+  for (size_t base_idx = wave_first_rank; base_idx < ndwords; base_idx += num_threads) {
+    const size_t idx = base_idx + lane;
+    if (idx < ndwords) {
+      __builtin_amdgcn_load_to_lds((__attribute__((address_space(1))) int*)(c_src + idx * 4),
+                                   (__attribute__((address_space(3))) int*)(c_dst + base_idx * 4),
+                                   4 /* size */, 0 /* offset */, 0 /* cache policy */);
+    }
+  }
+
+  // At most three bytes cannot fill a dword, so one thread stores them without LDS DMA.
+  if (rank == 0) {
+    for (size_t i = ndwords * 4; i < count; i++) {
+      c_dst[i] = c_src[i];
+    }
+  }
+
+  return true;
+}
+#endif
+
 // Traditional Copy used when memcpy_async builtins are unavailable or not invocable on the target.
 // Partition the memory into segments which each thread copies a portion of, similar to the
 // accelerated copy.
@@ -198,12 +265,20 @@ __CG_STATIC_QUALIFIER__ void memcpy_async_bytes(const TyGroup& group, TyElem* __
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_global_store_async_from_lds_b128) &&
       __builtin_amdgcn_is_invocable(__builtin_amdgcn_global_load_async_to_lds_b128)) {
     details::dispatch_async_memcpy(group, dst, src, count);
-  } else {
-    traditional_memcpy_bytes(group, dst, src, count);
+    return;
   }
-#else
-  traditional_memcpy_bytes(group, dst, src, count);
 #endif
+#if __has_builtin(__builtin_amdgcn_load_to_lds)
+  // Targets without the async builtins can still move global->LDS without staging the data
+  // through the VGPRs, which the traditional copy below cannot avoid. LDS DMA transfers a dword
+  // per lane, so it is only used for element types that guarantee dword alignment; Hint is a
+  // constant, which keeps the unused path out of the generated code.
+  if ((Hint % 4) == 0 && __builtin_amdgcn_is_invocable(__builtin_amdgcn_load_to_lds) &&
+      details::dispatch_lds_dma_memcpy(group, dst, src, count)) {
+    return;
+  }
+#endif
+  traditional_memcpy_bytes(group, dst, src, count);
 }
 }  // namespace details
 

--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -73,6 +73,7 @@ set(AMD_TEST_SRC
     fp6_ocp.cc
     fp4_ocp.cc
     memcpy_async.cc
+    memcpy_async_lds_dma_test.cc
     bfloat16_atomic_test.cc
     fp16_atomic_test.cc
 )

--- a/projects/hip-tests/catch/unit/deviceLib/memcpy_async_lds_dma_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/memcpy_async_lds_dma_test.cc
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Correctness coverage for cooperative_groups::memcpy_async across the paths the
+// implementation can select. The element type decides whether the accelerated path is
+// eligible: only types aligned to at least a dword can use it, so int-typed copies
+// exercise the accelerated path where the target provides one while char-typed copies
+// exercise the traditional fallback. LDS -> global is covered as well because only the
+// global -> LDS direction has an LDS DMA path.
+//
+// Block sizes include partial waves and non-multiples of either wave size on purpose.
+// Where the copy is performed by LDS DMA the destination base is wave uniform and the
+// hardware supplies the per-lane offset, so the partitioning depends on how ranks map
+// onto lanes and those sizes are what stress it.
+//
+// This is a correctness test, not a path test: it is expected to pass regardless of
+// which path the target selects.
+
+#include <hip_test_common.hh>
+
+#include <hip/hip_cooperative_groups.h>
+#include <hip/cooperative_groups/memcpy_async.h>
+
+#include <vector>
+
+namespace cg = cooperative_groups;
+
+namespace {
+
+constexpr int kSharedCap = 8192;
+
+template <typename T>
+__global__ void globalToLds(const T* in, T* out, int bytes) {
+  __shared__ __align__(16) unsigned char raw[kSharedCap];
+  cg::thread_block block = cg::this_thread_block();
+
+  for (int i = block.thread_rank(); i < kSharedCap; i += block.num_threads()) raw[i] = 0;
+  block.sync();
+
+  cg::memcpy_async(block, reinterpret_cast<T*>(raw), in, static_cast<size_t>(bytes));
+  block.sync();  // memcpy_async is asynchronous; the barrier is what makes raw readable
+
+  unsigned char* o = reinterpret_cast<unsigned char*>(out);
+  for (int i = block.thread_rank(); i < bytes; i += block.num_threads()) o[i] = raw[i];
+}
+
+template <typename T>
+__global__ void ldsToGlobal(const T* in, T* out, int bytes) {
+  __shared__ __align__(16) unsigned char raw[kSharedCap];
+  cg::thread_block block = cg::this_thread_block();
+
+  const unsigned char* i8 = reinterpret_cast<const unsigned char*>(in);
+  for (int i = block.thread_rank(); i < bytes; i += block.num_threads()) raw[i] = i8[i];
+  block.sync();
+
+  cg::memcpy_async(block, out, reinterpret_cast<T*>(raw), static_cast<size_t>(bytes));
+  block.sync();
+}
+
+// whole waves, partial waves, and non-multiples of either wave size
+constexpr int kThreads[] = {32, 64, 65, 100, 128, 129, 192, 200, 256, 320, 512, 1024};
+// dword multiples, ragged tails, counts below the group size, and large copies
+constexpr int kBytes[] = {4,   8,    12,   64,   100,  255,  256,  257, 258,
+                          259, 1024, 1025, 1027, 2048, 4095, 4096, 8188};
+
+template <typename T>
+void runCase(const char* tag, int threads, int bytes, const std::vector<unsigned char>& ref,
+             unsigned char* d_in, unsigned char* d_out, bool ldsToGlobalDir) {
+  HIP_CHECK(hipMemset(d_out, 0xAB, kSharedCap));
+
+  if (ldsToGlobalDir) {
+    ldsToGlobal<T><<<1, threads>>>(reinterpret_cast<const T*>(d_in), reinterpret_cast<T*>(d_out),
+                                   bytes);
+  } else {
+    globalToLds<T><<<1, threads>>>(reinterpret_cast<const T*>(d_in), reinterpret_cast<T*>(d_out),
+                                   bytes);
+  }
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  std::vector<unsigned char> got(bytes, 0xAB);
+  HIP_CHECK(hipMemcpy(got.data(), d_out, bytes, hipMemcpyDeviceToHost));
+
+  // Compare the whole buffer and assert once per case, so each case contributes an assertion
+  // without emitting one per byte.
+  int mismatch = -1;
+  for (int i = 0; i < bytes; i++) {
+    if (got[i] != ref[i]) {
+      mismatch = i;
+      break;
+    }
+  }
+
+  if (mismatch >= 0) {
+    INFO(tag << " threads: " << threads << " bytes: " << bytes << " first mismatch at index: "
+             << mismatch << " got: " << static_cast<unsigned>(got[mismatch])
+             << " expected: " << static_cast<unsigned>(ref[mismatch]));
+  }
+  REQUIRE(mismatch == -1);
+}
+
+}  // namespace
+
+TEST_CASE("Unit_device_memcpy_async_paths") {
+  unsigned char *d_in = nullptr, *d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_in, kSharedCap));
+  HIP_CHECK(hipMalloc(&d_out, kSharedCap));
+
+  std::vector<unsigned char> ref(kSharedCap);
+  for (size_t i = 0; i < ref.size(); i++) ref[i] = static_cast<unsigned char>(i * 7 + 3);
+  HIP_CHECK(hipMemcpy(d_in, ref.data(), kSharedCap, hipMemcpyHostToDevice));
+
+  SECTION("global to lds, dword aligned elements") {
+    for (int t : kThreads)
+      for (int b : kBytes) runCase<int>("int g2l", t, b, ref, d_in, d_out, false);
+  }
+
+  SECTION("global to lds, byte elements") {
+    for (int t : kThreads)
+      for (int b : kBytes) runCase<unsigned char>("char g2l", t, b, ref, d_in, d_out, false);
+  }
+
+  SECTION("lds to global, dword aligned elements") {
+    for (int t : kThreads)
+      for (int b : kBytes) runCase<int>("int l2g", t, b, ref, d_in, d_out, true);
+  }
+
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+}

--- a/projects/hip-tests/catch/unit/deviceLib/memcpy_async_lds_dma_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/memcpy_async_lds_dma_test.cc
@@ -32,6 +32,11 @@ THE SOFTWARE.
 // hardware supplies the per-lane offset, so the partitioning depends on how ranks map
 // onto lanes and those sizes are what stress it.
 //
+// Each case also checks a short guard region past the requested count. A copy that moves
+// whole dwords has to stop short of a ragged tail rather than round it up, and without a
+// guard an implementation that rounds up would still compare equal over the requested
+// range and pass silently.
+//
 // This is a correctness test, not a path test: it is expected to pass regardless of
 // which path the target selects.
 
@@ -40,6 +45,7 @@ THE SOFTWARE.
 #include <hip/hip_cooperative_groups.h>
 #include <hip/cooperative_groups/memcpy_async.h>
 
+#include <algorithm>
 #include <vector>
 
 namespace cg = cooperative_groups;
@@ -47,9 +53,12 @@ namespace cg = cooperative_groups;
 namespace {
 
 constexpr int kSharedCap = 8192;
+// Bytes checked past the requested count, so a copy that rounds the ragged tail up to a whole
+// dword is caught instead of silently passing.
+constexpr int kGuard = 8;
 
 template <typename T>
-__global__ void globalToLds(const T* in, T* out, int bytes) {
+__global__ void globalToLds(const T* in, T* out, int bytes, int readBack) {
   __shared__ __align__(16) unsigned char raw[kSharedCap];
   cg::thread_block block = cg::this_thread_block();
 
@@ -59,14 +68,22 @@ __global__ void globalToLds(const T* in, T* out, int bytes) {
   cg::memcpy_async(block, reinterpret_cast<T*>(raw), in, static_cast<size_t>(bytes));
   block.sync();  // memcpy_async is asynchronous; the barrier is what makes raw readable
 
+  // readBack extends past bytes. raw was zero filled, so anything memcpy_async wrote outside the
+  // requested range surfaces in the guard region as a non-zero byte.
   unsigned char* o = reinterpret_cast<unsigned char*>(out);
-  for (int i = block.thread_rank(); i < bytes; i += block.num_threads()) o[i] = raw[i];
+  for (int i = block.thread_rank(); i < readBack; i += block.num_threads()) o[i] = raw[i];
 }
 
 template <typename T>
 __global__ void ldsToGlobal(const T* in, T* out, int bytes) {
   __shared__ __align__(16) unsigned char raw[kSharedCap];
   cg::thread_block block = cg::this_thread_block();
+
+  // Zero the whole buffer first so the bytes past the requested count hold a known value rather
+  // than whatever was left in LDS. A copy that reads past bytes then stores zeros into the
+  // destination guard region, which differs from the 0xAB the host put there.
+  // Each rank owns the same indices in both loops, so no barrier is needed between them.
+  for (int i = block.thread_rank(); i < kSharedCap; i += block.num_threads()) raw[i] = 0;
 
   const unsigned char* i8 = reinterpret_cast<const unsigned char*>(in);
   for (int i = block.thread_rank(); i < bytes; i += block.num_threads()) raw[i] = i8[i];
@@ -87,33 +104,45 @@ void runCase(const char* tag, int threads, int bytes, const std::vector<unsigned
              unsigned char* d_in, unsigned char* d_out, bool ldsToGlobalDir) {
   HIP_CHECK(hipMemset(d_out, 0xAB, kSharedCap));
 
+  const int readBack = std::min(bytes + kGuard, kSharedCap);
+  // Past `bytes` the destination must be untouched: 0xAB from the memset for the lds -> global
+  // direction, 0 from the LDS zero fill for global -> lds.
+  const unsigned guardByte = ldsToGlobalDir ? 0xABu : 0x00u;
+
   if (ldsToGlobalDir) {
     ldsToGlobal<T><<<1, threads>>>(reinterpret_cast<const T*>(d_in), reinterpret_cast<T*>(d_out),
                                    bytes);
   } else {
     globalToLds<T><<<1, threads>>>(reinterpret_cast<const T*>(d_in), reinterpret_cast<T*>(d_out),
-                                   bytes);
+                                   bytes, readBack);
   }
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipDeviceSynchronize());
 
-  std::vector<unsigned char> got(bytes, 0xAB);
-  HIP_CHECK(hipMemcpy(got.data(), d_out, bytes, hipMemcpyDeviceToHost));
+  std::vector<unsigned char> got(readBack, 0);
+  HIP_CHECK(hipMemcpy(got.data(), d_out, readBack, hipMemcpyDeviceToHost));
 
   // Compare the whole buffer and assert once per case, so each case contributes an assertion
   // without emitting one per byte.
   int mismatch = -1;
-  for (int i = 0; i < bytes; i++) {
-    if (got[i] != ref[i]) {
+  unsigned expected = 0;
+  for (int i = 0; i < readBack; i++) {
+    expected = (i < bytes) ? ref[i] : guardByte;
+    if (got[i] != expected) {
       mismatch = i;
       break;
     }
   }
 
   if (mismatch >= 0) {
-    INFO(tag << " threads: " << threads << " bytes: " << bytes << " first mismatch at index: "
-             << mismatch << " got: " << static_cast<unsigned>(got[mismatch])
-             << " expected: " << static_cast<unsigned>(ref[mismatch]));
+    // INFO registers a message scoped to the enclosing block, so one created inside this `if` is
+    // destroyed before the REQUIRE below runs and never prints. UNSCOPED_INFO survives until the
+    // next assertion, which is the one that needs it.
+    UNSCOPED_INFO(tag << " threads: " << threads << " bytes: " << bytes
+                      << (mismatch >= bytes ? " wrote past the requested count at index: "
+                                            : " first mismatch at index: ")
+                      << mismatch << " got: " << static_cast<unsigned>(got[mismatch])
+                      << " expected: " << expected);
   }
   REQUIRE(mismatch == -1);
 }


### PR DESCRIPTION
## Motivation

`cooperative_groups::memcpy_async` only has an accelerated path when the
`global_load_async_to_lds` / `global_store_async_from_lds` builtins are invocable, which today is
gfx12.5 alone. Every other target falls through to `traditional_memcpy_bytes`, which stages the
data through the VGPRs and waits on it, so the copy is neither wide nor asynchronous.

On gfx942 that costs 1.31x on a double-buffered tiling benchmark and leaves the API slower than a
plain `__syncthreads` copy — the opposite of what a user reaching for `memcpy_async` expects.

gfx9 (and gfx10) can already move global -> LDS directly through LDS DMA, so the accelerated path
does not have to be limited to gfx12.5.

## Technical Details

The new path uses `__builtin_amdgcn_load_to_lds`, which lowers to the LDS DMA form of the vector
memory load and writes LDS without staging through the VGPRs.

That hardware addresses LDS differently from the gfx12.5 async copies. The LDS destination is a
**wave-uniform base** and the hardware adds `lane_id * 4`; the per-lane pointer handed to the
builtin is only the *source*. The contiguous per-thread chunks that `dispatch_async_memcpy` hands
out therefore do not describe what lands in LDS. The copy is instead partitioned by rank stride,
which puts consecutive lanes on consecutive dwords, and the wave-uniform base
(`thread_rank() - lane_id`, advanced by `num_threads()`) is passed as the destination so the lane
offset comes from the hardware.

Two consequences constrain where this applies:

1. Sub-dword transfers keep the four-byte lane stride and cannot produce a packed result, so only
   element types whose alignment is a multiple of 4 take this path (`Hint`, which is
   `alignof(TyElem)`, is a compile-time constant, so the unused path is not generated for other
   types). A ragged tail of at most three bytes is stored by rank 0.
2. The group's ranks must be contiguous within a wave for the lane layout to line up. That holds
   for `thread_block` but not for `thread_block_tile` or `coalesced_group`, so those keep the
   traditional copy. This is enforced by the `can_group_use_lds_dma` trait, mirroring the existing
   `can_group_do_async_copy`.

Selection order in `memcpy_async_bytes` is unchanged for existing targets:

- gfx12.5 (async builtins invocable) -> `dispatch_async_memcpy`, exactly as before.
- LDS DMA available, global -> LDS, dword-aligned element type, `thread_block` ->
  `dispatch_lds_dma_memcpy`.
- Everything else, including all LDS -> global copies -> `traditional_memcpy_bytes`.

Both new guards are compile-time (`__has_builtin` plus `__builtin_amdgcn_is_invocable`) or fold to
constants, so targets with neither mechanism, and gfx12.5, generate identical ISA.

Like the existing gfx12.5 accelerated path, the LDS DMA copy is not complete when `memcpy_async`
returns; callers synchronize with `group.sync()`, which is the usage already shown in
`memcpy_async.cc`.

## Issue Tracking

ISSUE ID : https://github.com/ROCm/rocm-systems/issues/10372

## Test Plan

Added `projects/hip-tests/catch/unit/deviceLib/memcpy_async_lds_dma_test.cc`
(`Unit_device_memcpy_async_paths`).

The existing `Unit_device_memcpy_async` is gated to gfx1250, so gfx9/gfx10 had no coverage of
`memcpy_async` at all. The new test runs on every target and is a correctness test, not a path
test: it is expected to pass regardless of which path the implementation selects.

Coverage:

- **Directions**: global -> LDS (the direction LDS DMA handles) and LDS -> global (which must stay
  on the traditional path).
- **Element types**: `int` (dword-aligned, eligible for LDS DMA) and `unsigned char` (not
  eligible, exercises the traditional fallback), so both branches are hit on the same target.
- **Block sizes**: 32, 64, 65, 100, 128, 129, 192, 200, 256, 320, 512, 1024 — whole waves, partial
  waves, and non-multiples of either wave size, which is what stresses the rank-to-lane mapping
  the LDS DMA partitioning depends on.
- **Byte counts**: 4, 8, 12, 64, 100, 255, 256, 257, 258, 259, 1024, 1025, 1027, 2048, 4095, 4096,
  8188 — dword multiples, every ragged-tail residue, counts smaller than the group size, and large
  copies.

That is 12 x 17 = 204 cases per section, 612 in total. Each case zero-fills LDS, runs the copy,
and compares the destination byte-for-byte against a host reference, reporting the first
mismatching index.

The pre-existing `Unit_device_memcpy_async` is unmodified and continues to cover the gfx12.5 path.

## Test Result

CI on this branch:

- `Test hip-tests` green on gfx94X-dcgpu, all 4 shards (the gfx942 LDS DMA path).
- `Test hip-tests (PAL)` green on gfx110X-all and gfx1151, all 4 shards.
- `Test sanity` green on gfx94X-dcgpu and gfx1151.

The remaining red checks on this PR are in components this change does not touch — `rocgdb-cpu`,
`rocprofiler-sdk`, the sles16 package-install job, the MI455 job, and the Windows ROCR `xfail`
shard. None of them compile `amd_hip_cooperative_groups_memcpy.h`, and the same jobs are red on
unrelated PRs on `develop`.

Performance motivation, measured on gfx942 with a double-buffered tiling benchmark: the previous
traditional fallback cost 1.31x relative to a plain `__syncthreads` copy.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
