### PR TITLE
[rocjitsu] Dispatch operand validation by type

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -11410,7 +11410,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
             if uses_packed_16bit_sources
             else ''
         )
-        selector_validation = ''
+        selector_validation_cases = []
         for selector in sorted(
             self.isa_spec.opnd_selectors, key=lambda item: item.operand_type
         ):
@@ -11438,11 +11438,19 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 f'(encoding_value >= {lo} && encoding_value <= {hi})'
                 for lo, hi in intervals
             )
-            selector_validation += (
-                f'  if (opr_type == OperandType::{operand_type} && '
-                f'!({valid_expr}))\n'
-                f'    defer_encoding_error(EncodingError::{error});\n'
+            selector_validation_cases.append(
+                f'  case OperandType::{operand_type}:\n'
+                f'    if (!({valid_expr}))\n'
+                f'      defer_encoding_error(EncodingError::{error});\n'
+                f'    break;\n'
             )
+        selector_validation = (
+            '  switch (opr_type) {\n'
+            + ''.join(selector_validation_cases)
+            + '  default:\n'
+            + '    break;\n'
+            + '  }\n'
+        )
         packed_16bit_ctor_impl = []
         if uses_packed_16bit_sources:
             packed_16bit_ctor_impl.append(
@@ -11492,12 +11500,9 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                 cgen.Line(
                     'Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,\n'
                     '                 uint16_t literal16_display_value, bool has_literal16_display)\n'
-                    f'    : {operand_base_init}(size_bits, opr_type, encoding_value)'
-                    f'{execution_backend_ctor_init},\n'
-                    '      literal16_display_value_(literal16_display_value),\n'
-                    '      has_literal16_display_(has_literal16_display) {\n'
-                    f'{selector_validation}'
-                    '  is_vgpr_ = is_vgpr_operand_type(opr_type);\n'
+                    '    : Operand(size_bits, opr_type, encoding_value) {\n'
+                    '  literal16_display_value_ = literal16_display_value;\n'
+                    '  has_literal16_display_ = has_literal16_display;\n'
                     '}'
                 ),
                 cgen.Line(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2173,8 +2173,8 @@ def test_generated_operand_validates_scalar_register_selector_intervals(
             (amdgpu_generated_root / arch / 'operand.cpp').read_text().split()
         )
         assert (
-            'opr_type==OperandType::OPR_SREG&&'
-            '!((encoding_value>=0&&encoding_value<=123)||'
+            'caseOperandType::OPR_SREG:'
+            'if(!((encoding_value>=0&&encoding_value<=123)||'
             '(encoding_value>=125&&encoding_value<=125))' in operand
         )
         assert (
@@ -2189,12 +2189,12 @@ def test_generated_operand_validates_scalar_register_selector_variants(
     gfx1250_operand = ''.join(
         (gfx1250_generated_root / 'operand.cpp').read_text().split()
     )
-    assert 'opr_type==OperandType::OPR_SREG_M0&&' in gfx1250_operand
+    assert 'caseOperandType::OPR_SREG_M0:' in gfx1250_operand
 
     rdna4_operand = ''.join((rdna4_generated_root / 'operand.cpp').read_text().split())
     assert (
-        'opr_type==OperandType::OPR_SREG_LITERAL&&'
-        '!((encoding_value>=0&&encoding_value<=124)||'
+        'caseOperandType::OPR_SREG_LITERAL:'
+        'if(!((encoding_value>=0&&encoding_value<=124)||'
         '(encoding_value>=255&&encoding_value<=255))' in rdna4_operand
     )
 
@@ -2207,13 +2207,13 @@ def test_generated_operand_validates_scalar_selector_families(
     )
 
     assert (
-        'opr_type==OperandType::OPR_SDST&&'
-        '!((encoding_value>=0&&encoding_value<=124)||'
+        'caseOperandType::OPR_SDST:'
+        'if(!((encoding_value>=0&&encoding_value<=124)||'
         '(encoding_value>=126&&encoding_value<=127))' in operand
     )
     assert (
-        'opr_type==OperandType::OPR_SSRC_NOLIT&&'
-        '!((encoding_value>=0&&encoding_value<=124)||'
+        'caseOperandType::OPR_SSRC_NOLIT:'
+        'if(!((encoding_value>=0&&encoding_value<=124)||'
         '(encoding_value>=126&&encoding_value<=208)||'
         '(encoding_value>=235&&encoding_value<=248)||'
         '(encoding_value>=251&&encoding_value<=253))' in operand
@@ -2232,7 +2232,7 @@ def test_generated_operand_validates_barrier_id_selectors(
         (rdna4_generated_root, 194),
     ):
         operand = ''.join((root / 'operand.cpp').read_text().split())
-        assert 'opr_type==OperandType::OPR_SSRC_BARRIER_ID&&' in operand
+        assert 'caseOperandType::OPR_SSRC_BARRIER_ID:' in operand
         assert '(encoding_value>=125&&encoding_value<=125)' in operand
         assert '(encoding_value>=128&&encoding_value<=159)' in operand
         assert f'(encoding_value>=193&&encoding_value<={negative_max})' in operand
@@ -2261,9 +2261,9 @@ def test_generated_operand_validates_direct_selector_namespaces(
     gfx1250_operand = ''.join(
         (gfx1250_generated_root / 'operand.cpp').read_text().split()
     )
-    assert 'opr_type==OperandType::OPR_SRC&&' in gfx1250_operand
+    assert 'caseOperandType::OPR_SRC:' in gfx1250_operand
     assert '(encoding_value>=209&&encoding_value<=229)' not in gfx1250_operand
-    assert 'opr_type==OperandType::OPR_SRC_VGPR_OR_INLINE&&' in gfx1250_operand
+    assert 'caseOperandType::OPR_SRC_VGPR_OR_INLINE:' in gfx1250_operand
     assert '(encoding_value>=128&&encoding_value<=208)' in gfx1250_operand
     assert '(encoding_value>=240&&encoding_value<=248)' in gfx1250_operand
     assert '(encoding_value>=256&&encoding_value<=511)' in gfx1250_operand
@@ -2272,8 +2272,8 @@ def test_generated_operand_validates_direct_selector_namespaces(
         (amdgpu_generated_root / 'cdna1' / 'operand.cpp').read_text().split()
     )
     assert (
-        'opr_type==OperandType::OPR_SMEM_OFFSET&&'
-        '!((encoding_value>=0&&encoding_value<=124))' in cdna1_operand
+        'caseOperandType::OPR_SMEM_OFFSET:'
+        'if(!((encoding_value>=0&&encoding_value<=124))' in cdna1_operand
     )
 
 
@@ -2324,7 +2324,7 @@ def test_gfx1250_generated_operand_validates_lane_selectors(
 
     assert 'OPR_SSRC_LANESEL_POS_INT_MAX = 191' in operand_types
     assert '#include "util/except.h"' not in operand
-    assert 'opr_type == OperandType::OPR_SSRC_LANESEL' in operand
+    assert 'case OperandType::OPR_SSRC_LANESEL:' in operand
     assert 'EncodingError::InvalidLaneSelector' in operand
 
 
@@ -2333,7 +2333,7 @@ def test_gfx1250_generated_operand_rejects_invalid_exec_selector(
 ):
     operand = (gfx1250_generated_root / 'operand.cpp').read_text()
     assert '#include "util/except.h"' not in operand
-    assert 'opr_type == OperandType::OPR_EXEC' in operand
+    assert 'case OperandType::OPR_EXEC:' in operand
     assert '(encoding_value >= 126 && encoding_value <= 126)' in operand
     assert 'EncodingError::InvalidExecSelector' in operand
 
@@ -3346,7 +3346,7 @@ def test_gfx1250_generated_operand_rejects_reserved_scalar_source_selectors(
 ):
     operand = (gfx1250_generated_root / 'operand.cpp').read_text()
 
-    assert 'opr_type == OperandType::OPR_SSRC' in operand
+    assert 'case OperandType::OPR_SSRC:' in operand
     assert '(encoding_value >= 209 && encoding_value <= 229)' not in operand
     assert 'EncodingError::InvalidScalarSourceSelector' in operand
 
@@ -4289,9 +4289,10 @@ def test_generated_operands_validate_vgpr_source_selectors(
     amdgpu_generated_root: Path,
 ):
     validation = (
-        'if (opr_type == OperandType::OPR_SRC_VGPR && '
-        '!((encoding_value >= 256 && encoding_value <= 511)))\n'
-        '    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);'
+        'case OperandType::OPR_SRC_VGPR:\n'
+        '    if (!((encoding_value >= 256 && encoding_value <= 511)))\n'
+        '      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);\n'
+        '    break;'
     )
     for arch in (
         'cdna1',
@@ -4307,6 +4308,31 @@ def test_generated_operands_validate_vgpr_source_selectors(
     ):
         operand = (amdgpu_generated_root / arch / 'operand.cpp').read_text()
         assert validation in operand
+
+
+def test_generated_operand_validation_switch_is_shared_by_constructors(
+    amdgpu_generated_root: Path,
+):
+    literal16_constructor = (
+        'Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,\n'
+        '                 uint16_t literal16_display_value, bool has_literal16_display)\n'
+        '    : Operand(size_bits, opr_type, encoding_value) {'
+    )
+    for arch in (
+        'cdna1',
+        'cdna2',
+        'cdna3',
+        'cdna4',
+        'cdna5',
+        'rdna1',
+        'rdna2',
+        'rdna3',
+        'rdna3_5',
+        'rdna4',
+    ):
+        operand = (amdgpu_generated_root / arch / 'operand.cpp').read_text()
+        assert operand.count('switch (opr_type) {') == 1
+        assert literal16_constructor in operand
 
 
 def test_cdna4_mfma_f8f6f4_accepts_standalone_and_prefixed_encodings(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/operand.cpp
@@ -27,188 +27,146 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 768 && encoding_value <= 1023)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 15) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ACCVGPR:
+    if (!((encoding_value >= 768 && encoding_value <= 1023)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PARAM:
+    if (!((encoding_value >= 0 && encoding_value <= 2)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 254) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NOVCC:
+    if (!((encoding_value >= 0 && encoding_value <= 105) ||
+          (encoding_value >= 108 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 9) ||
+          (encoding_value >= 12 && encoding_value <= 15) ||
+          (encoding_value >= 32 && encoding_value <= 63)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 254 && encoding_value <= 254) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 768 && encoding_value <= 1023)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 15) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/operand.cpp
@@ -27,172 +27,132 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ACCVGPR:
+    if (!((encoding_value >= 512 && encoding_value <= 767)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NOVCC:
+    if (!((encoding_value >= 0 && encoding_value <= 105) ||
+          (encoding_value >= 108 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/operand.cpp
@@ -27,172 +27,132 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ACCVGPR:
+    if (!((encoding_value >= 512 && encoding_value <= 767)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NOVCC:
+    if (!((encoding_value >= 0 && encoding_value <= 105) ||
+          (encoding_value >= 108 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/operand.cpp
@@ -27,176 +27,136 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ACCVGPR:
+    if (!((encoding_value >= 512 && encoding_value <= 767)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_GPUMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NOVCC:
+    if (!((encoding_value >= 0 && encoding_value <= 105) ||
+          (encoding_value >= 108 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLIT:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 126 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ACCVGPR && !((encoding_value >= 512 && encoding_value <= 767)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                            (encoding_value >= 126 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NOVCC &&
-      !((encoding_value >= 0 && encoding_value <= 105) ||
-        (encoding_value >= 108 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 124) ||
-                                             (encoding_value >= 126 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLIT &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 126 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/operand.cpp
@@ -64,78 +64,121 @@ Operand::Operand(int size_bits, OperandType opr_type, int encoding_value, bool p
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
       packed_16bit_source_(packed_16bit_source), packed_16bit_dst_(packed_16bit_dst) {
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SGPR && !((encoding_value >= 0 && encoding_value <= 105)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET_NOK &&
-      !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 230 && encoding_value <= 231) ||
-                                            (encoding_value >= 235 && encoding_value <= 236) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOINLINE &&
-      !((encoding_value >= 0 && encoding_value <= 127) ||
-        (encoding_value >= 254 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 230 && encoding_value <= 231) ||
-        (encoding_value >= 235 && encoding_value <= 236) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 253 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0 && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 230 && encoding_value <= 231) ||
-                                             (encoding_value >= 235 && encoding_value <= 236) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_BARRIER_ID &&
-      !((encoding_value >= 125 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 159) ||
-        (encoding_value >= 193 && encoding_value <= 196)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_GPUMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 105)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET_NOK:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 230 && encoding_value <= 231) ||
+          (encoding_value >= 235 && encoding_value <= 236) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOINLINE:
+    if (!((encoding_value >= 0 && encoding_value <= 127) ||
+          (encoding_value >= 254 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 230 && encoding_value <= 231) ||
+          (encoding_value >= 235 && encoding_value <= 236) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR_OR_INLINE:
+    if (!((encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 230 && encoding_value <= 231) ||
+          (encoding_value >= 235 && encoding_value <= 236) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_BARRIER_ID:
+    if (!((encoding_value >= 125 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 159) ||
+          (encoding_value >= 193 && encoding_value <= 196)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
@@ -146,83 +189,9 @@ Operand::Operand(int size_bits, OperandType opr_type, unsigned short encoding_va
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SGPR && !((encoding_value >= 0 && encoding_value <= 105)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET_NOK &&
-      !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 230 && encoding_value <= 231) ||
-                                            (encoding_value >= 235 && encoding_value <= 236) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOINLINE &&
-      !((encoding_value >= 0 && encoding_value <= 127) ||
-        (encoding_value >= 254 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 230 && encoding_value <= 231) ||
-        (encoding_value >= 235 && encoding_value <= 236) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 253 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0 && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 230 && encoding_value <= 231) ||
-                                             (encoding_value >= 235 && encoding_value <= 236) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_BARRIER_ID &&
-      !((encoding_value >= 125 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 159) ||
-        (encoding_value >= 193 && encoding_value <= 196)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/operand.cpp
@@ -27,178 +27,144 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SIMM8 && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123) ||
-                                             (encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NONULL && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 20) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PARAM:
+    if (!((encoding_value >= 0 && encoding_value <= 2)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SIMM8:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123) ||
+          (encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0_INL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NONULL:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 9) ||
+          (encoding_value >= 12 && encoding_value <= 16) ||
+          (encoding_value >= 20 && encoding_value <= 20) ||
+          (encoding_value >= 32 && encoding_value <= 63)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 254 && encoding_value <= 254) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SIMM8 && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123) ||
-                                             (encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NONULL && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 20) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/operand.cpp
@@ -27,172 +27,139 @@ std::string reg_name(const char *prefix, int reg_num, int size_bits) {
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value)
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123) ||
-                                             (encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NONULL && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 20) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PARAM:
+    if (!((encoding_value >= 0 && encoding_value <= 2)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_SIMPLE:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 123) ||
+          (encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0_INL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_NONULL:
+    if (!((encoding_value >= 0 && encoding_value <= 123)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_NOLDS:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 248) ||
+          (encoding_value >= 251 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 9) ||
+          (encoding_value >= 12 && encoding_value <= 16) ||
+          (encoding_value >= 20 && encoding_value <= 20) ||
+          (encoding_value >= 32 && encoding_value <= 63)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR_OR_LDS:
+    if (!((encoding_value >= 254 && encoding_value <= 254) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PARAM && !((encoding_value >= 0 && encoding_value <= 2)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 248) ||
-                                            (encoding_value >= 251 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_SIMPLE &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 123) ||
-                                             (encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_NONULL && !((encoding_value >= 0 && encoding_value <= 123)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 248) ||
-                                             (encoding_value >= 251 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_NOLDS &&
-      !((encoding_value >= 0 && encoding_value <= 208) ||
-        (encoding_value >= 235 && encoding_value <= 248) ||
-        (encoding_value >= 251 && encoding_value <= 253) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 9) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 20) ||
-                                            (encoding_value >= 32 && encoding_value <= 63)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR_OR_LDS &&
-      !((encoding_value >= 254 && encoding_value <= 254) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/operand.cpp
@@ -64,67 +64,109 @@ Operand::Operand(int size_bits, OperandType opr_type, int encoding_value, bool p
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
       packed_16bit_source_(packed_16bit_source), packed_16bit_dst_(packed_16bit_dst) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_NULL && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_NULL:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR_OR_INLINE:
+    if (!((encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0_INL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 8) ||
+          (encoding_value >= 12 && encoding_value <= 16) ||
+          (encoding_value >= 20 && encoding_value <= 22)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
@@ -135,72 +177,9 @@ Operand::Operand(int size_bits, OperandType opr_type, unsigned short encoding_va
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_NULL && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -64,67 +64,109 @@ Operand::Operand(int size_bits, OperandType opr_type, int encoding_value, bool p
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
       packed_16bit_source_(packed_16bit_source), packed_16bit_dst_(packed_16bit_dst) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_NULL && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_FLAT_SCRATCH:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_NULL:
+    if (!((encoding_value >= 124 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR_OR_INLINE:
+    if (!((encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0_INL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 8) ||
+          (encoding_value >= 12 && encoding_value <= 16) ||
+          (encoding_value >= 20 && encoding_value <= 22)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
@@ -135,72 +177,9 @@ Operand::Operand(int size_bits, OperandType opr_type, unsigned short encoding_va
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_FLAT_SCRATCH && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_NULL && !((encoding_value >= 124 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0_INL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/operand.cpp
@@ -64,74 +64,118 @@ Operand::Operand(int size_bits, OperandType opr_type, int encoding_value, bool p
     : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
       execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
       packed_16bit_source_(packed_16bit_source), packed_16bit_dst_(packed_16bit_dst) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET_NOK &&
-      !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_LITERAL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0 && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_BARRIER_ID &&
-      !((encoding_value >= 125 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 159) ||
-        (encoding_value >= 193 && encoding_value <= 194)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
+  switch (opr_type) {
+  case OperandType::OPR_ATTR:
+    if (!((encoding_value >= 0 && encoding_value <= 32)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_DSMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 126)))
+      defer_encoding_error(EncodingError::InvalidExecSelector);
+    break;
+  case OperandType::OPR_GPUMEM:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_PC:
+    if (!((encoding_value >= 0 && encoding_value <= 0)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST:
+    if (!((encoding_value >= 0 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_EXEC:
+    if (!((encoding_value >= 126 && encoding_value <= 127)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SDST_M0:
+    if (!((encoding_value >= 125 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SMEM_OFFSET_NOK:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR:
+    if (!((encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
+    break;
+  case OperandType::OPR_SRC_VGPR_OR_INLINE:
+    if (!((encoding_value >= 128 && encoding_value <= 208) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 256 && encoding_value <= 511)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_SREG:
+    if (!((encoding_value >= 0 && encoding_value <= 124)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_LITERAL:
+    if (!((encoding_value >= 0 && encoding_value <= 124) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SREG_M0:
+    if (!((encoding_value >= 0 && encoding_value <= 125)))
+      defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
+    break;
+  case OperandType::OPR_SSRC:
+    if (!((encoding_value >= 0 && encoding_value <= 208) ||
+          (encoding_value >= 235 && encoding_value <= 238) ||
+          (encoding_value >= 240 && encoding_value <= 248) ||
+          (encoding_value >= 253 && encoding_value <= 253) ||
+          (encoding_value >= 255 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_BARRIER_ID:
+    if (!((encoding_value >= 125 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 159) ||
+          (encoding_value >= 193 && encoding_value <= 194)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_SSRC_LANESEL:
+    if (!((encoding_value >= 0 && encoding_value <= 125) ||
+          (encoding_value >= 128 && encoding_value <= 191)))
+      defer_encoding_error(EncodingError::InvalidLaneSelector);
+    break;
+  case OperandType::OPR_SSRC_SPECIAL_SCC:
+    if (!((encoding_value >= 253 && encoding_value <= 253)))
+      defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
+    break;
+  case OperandType::OPR_TGT:
+    if (!((encoding_value >= 0 && encoding_value <= 8) ||
+          (encoding_value >= 12 && encoding_value <= 16) ||
+          (encoding_value >= 20 && encoding_value <= 22)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VCC:
+    if (!((encoding_value >= 106 && encoding_value <= 106)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  case OperandType::OPR_VGPR:
+    if (!((encoding_value >= 0 && encoding_value <= 255)))
+      defer_encoding_error(EncodingError::InvalidSelector);
+    break;
+  default:
+    break;
+  }
   is_vgpr_ = is_vgpr_operand_type(opr_type);
 }
 
@@ -142,79 +186,9 @@ Operand::Operand(int size_bits, OperandType opr_type, unsigned short encoding_va
 
 Operand::Operand(int size_bits, OperandType opr_type, int encoding_value,
                  uint16_t literal16_display_value, bool has_literal16_display)
-    : IsaOperand<Isa>(size_bits, opr_type, encoding_value),
-      execution_backend_(static_cast<const ExecutionBackend *>(current_isa_operand_backend())),
-      literal16_display_value_(literal16_display_value),
-      has_literal16_display_(has_literal16_display) {
-  if (opr_type == OperandType::OPR_ATTR && !((encoding_value >= 0 && encoding_value <= 32)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_DSMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_EXEC && !((encoding_value >= 126 && encoding_value <= 126)))
-    defer_encoding_error(EncodingError::InvalidExecSelector);
-  if (opr_type == OperandType::OPR_GPUMEM && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_PC && !((encoding_value >= 0 && encoding_value <= 0)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST && !((encoding_value >= 0 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_EXEC && !((encoding_value >= 126 && encoding_value <= 127)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SDST_M0 && !((encoding_value >= 125 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SMEM_OFFSET_NOK &&
-      !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                            (encoding_value >= 235 && encoding_value <= 238) ||
-                                            (encoding_value >= 240 && encoding_value <= 248) ||
-                                            (encoding_value >= 253 && encoding_value <= 253) ||
-                                            (encoding_value >= 255 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR && !((encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidVgprSourceSelector);
-  if (opr_type == OperandType::OPR_SRC_VGPR_OR_INLINE &&
-      !((encoding_value >= 128 && encoding_value <= 208) ||
-        (encoding_value >= 240 && encoding_value <= 248) ||
-        (encoding_value >= 256 && encoding_value <= 511)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_SREG && !((encoding_value >= 0 && encoding_value <= 124)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_LITERAL &&
-      !((encoding_value >= 0 && encoding_value <= 124) ||
-        (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SREG_M0 && !((encoding_value >= 0 && encoding_value <= 125)))
-    defer_encoding_error(EncodingError::InvalidScalarRegisterSelector);
-  if (opr_type == OperandType::OPR_SSRC && !((encoding_value >= 0 && encoding_value <= 208) ||
-                                             (encoding_value >= 235 && encoding_value <= 238) ||
-                                             (encoding_value >= 240 && encoding_value <= 248) ||
-                                             (encoding_value >= 253 && encoding_value <= 253) ||
-                                             (encoding_value >= 255 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_BARRIER_ID &&
-      !((encoding_value >= 125 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 159) ||
-        (encoding_value >= 193 && encoding_value <= 194)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_SSRC_LANESEL &&
-      !((encoding_value >= 0 && encoding_value <= 125) ||
-        (encoding_value >= 128 && encoding_value <= 191)))
-    defer_encoding_error(EncodingError::InvalidLaneSelector);
-  if (opr_type == OperandType::OPR_SSRC_SPECIAL_SCC &&
-      !((encoding_value >= 253 && encoding_value <= 253)))
-    defer_encoding_error(EncodingError::InvalidScalarSourceSelector);
-  if (opr_type == OperandType::OPR_TGT && !((encoding_value >= 0 && encoding_value <= 8) ||
-                                            (encoding_value >= 12 && encoding_value <= 16) ||
-                                            (encoding_value >= 20 && encoding_value <= 22)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VCC && !((encoding_value >= 106 && encoding_value <= 106)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  if (opr_type == OperandType::OPR_VGPR && !((encoding_value >= 0 && encoding_value <= 255)))
-    defer_encoding_error(EncodingError::InvalidSelector);
-  is_vgpr_ = is_vgpr_operand_type(opr_type);
+    : Operand(size_bits, opr_type, encoding_value) {
+  literal16_display_value_ = literal16_display_value;
+  has_literal16_display_ = has_literal16_display;
 }
 
 Operand::Operand(int size_bits, OperandType opr_type, uint64_t literal64_value, bool is_literal64)


### PR DESCRIPTION
Generated operand constructors validated each encoding by walking every operand-type predicate. Operand construction is the largest decoder hot-path cost, and common operand types appeared late in that linear chain.

Emit a switch over OperandType so construction evaluates only the matching selector ranges while preserving deferred diagnostics. Delegate the literal16 constructor to the primary constructor so each generated translation unit contains one validation switch, regenerate all ten AMDGPU models, and extend the generator profile gates for the shared structure.

On the pinned large-object benchmark, median valid-decode throughput improves 25.1%, cycles fall 19.7%, and instructions fall 35.6% across nine alternating CPU-pinned pairs with identical corpus results and checksums.