### PR TITLE
[rocjitsu] Translate gfx1250 lane-banked and kernarg-supplied indirect calls

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -1957,16 +1957,67 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
   // that bounded set avoids repeatedly scanning every fact
   // to recover information that changes only when the corresponding vector does.
   std::vector<std::bitset<REGISTER_SET_MAX_SGPRS>> entry_pairs(blocks.size());
-  std::deque<size_t> worklist;
+
+  // Visit blocks in reverse postorder. The least fixed point of this monotone
+  // join does not depend on the visit order, but the order decides how many
+  // times it is recomputed. A recovered indirect call gives its shared callee
+  // block one predecessor per call site -- thousands of them on a large device
+  // library -- and popping in block-index order then re-evaluates that
+  // O(predecessors x pairs) join once for every predecessor that happens to be
+  // processed after it. Reverse postorder evaluates a predecessor before its
+  // successors wherever the graph is acyclic, so a block is normally recomputed
+  // only for its back edges. On the largest hipTensor object this is the
+  // difference between 84.8M block visits and 558k, and between 264 s and 0.7 s
+  // per round.
+  //
+  // The order is a pure function of the block graph: roots are tried in
+  // ascending block index, successors in their stored order, and the root loop
+  // covers every block, so blocks unreachable from any earlier root still
+  // receive a position and are still seeded onto the worklist below.
+  std::vector<size_t> rpo_order;
+  rpo_order.reserve(blocks.size());
+  {
+    std::vector<uint8_t> visited(blocks.size(), 0);
+    std::vector<std::pair<size_t, size_t>> stack;
+    for (size_t root = 0; root < blocks.size(); ++root) {
+      if (visited[root])
+        continue;
+      visited[root] = 1;
+      stack.emplace_back(root, 0);
+      while (!stack.empty()) {
+        const size_t node = stack.back().first;
+        size_t &next_successor = stack.back().second;
+        if (next_successor < blocks[node].successors.size()) {
+          const size_t successor = blocks[node].successors[next_successor++];
+          if (successor < blocks.size() && !visited[successor]) {
+            visited[successor] = 1;
+            stack.emplace_back(successor, 0);
+          }
+          continue;
+        }
+        rpo_order.push_back(node);
+        stack.pop_back();
+      }
+    }
+  }
+  std::ranges::reverse(rpo_order);
+  std::vector<size_t> rpo_position(blocks.size(), 0);
+  for (size_t position = 0; position < rpo_order.size(); ++position)
+    rpo_position[rpo_order[position]] = position;
+
+  // Keyed by reverse-postorder position so the lowest position is always popped
+  // next. Positions are unique, so this is a total order and the pop sequence is
+  // fully determined by the block graph.
+  std::set<size_t> worklist;
   std::vector<bool> on_worklist(blocks.size(), false);
   for (size_t block_index = 0; block_index < blocks.size(); ++block_index) {
-    worklist.push_back(block_index);
+    worklist.insert(rpo_position[block_index]);
     on_worklist[block_index] = true;
   }
 
   while (!worklist.empty()) {
-    const size_t block_index = worklist.front();
-    worklist.pop_front();
+    const size_t block_index = rpo_order[*worklist.begin()];
+    worklist.erase(worklist.begin());
     on_worklist[block_index] = false;
 
     LatticeFacts new_entry;
@@ -2052,7 +2103,7 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
     for (size_t successor : blocks[block_index].successors) {
       if (on_worklist[successor])
         continue;
-      worklist.push_back(successor);
+      worklist.insert(rpo_position[successor]);
       on_worklist[successor] = true;
     }
   }
@@ -2244,11 +2295,17 @@ constexpr size_t kRetainedAnalysisUnitBytes = 64;
 // budget. Exhaustion remains fail-closed, so a still larger object loses recovery rather than
 // memory.
 //
-// 1<<24 is a ceiling, not a headroom guess. At 1<<26 the largest hipTensor object in the corpus
-// (8.3 MB) does finish -- but in 552 s and 2.6 GB, against a 30 s per-object budget, and this runs
-// at code-object load time. Refusing that object costs one unrecovered transfer; admitting it would
-// stall the loader for nine minutes. The bound is set where recovery still pays for itself.
-constexpr size_t kMaxRetainedAnalysisUnits = size_t{1} << 24;
+// Sized to admit the objects real workloads dispatch rather than to leave headroom. hipTensor's
+// scale_contraction and trinary_scale_contraction tests dispatch 4.65 MB and 4.70 MB objects that
+// 1<<24 still refused; at this bound they translate in 7.6 s and 1.06 GB, against a 30 s and
+// 4096 MiB per-object budget.
+//
+// Raising it does NOT expose the loader to the multi-minute translations some very large objects
+// take. Those are pre-existing and not governed by this constant: the 8.3 MB hipTensor object costs
+// 510 s / 2.4 GB on unmodified develop at 1<<20, 541 s at 1<<24 and 552 s at 1<<26 -- about 6%
+// across a 64x change in the bound, because the time is spent outside lane recovery almost
+// entirely. Exhaustion stays fail-closed: an object that outgrows this loses recovery, not memory.
+constexpr size_t kMaxRetainedAnalysisUnits = size_t{1} << 26;
 constexpr size_t kMaxCalleeSummaryVariantsPerTarget = 8;
 constexpr size_t kCalleeSummaryCacheEntryUnits =
     1 + (sizeof(CalleeSummaryCacheKey) + sizeof(std::optional<CalleeSummary>) + 3 * sizeof(void *) -

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.cpp
@@ -180,6 +180,16 @@ enum class ScalarSop2Op {
 struct PcValue {
   int64_t offset = 0;
   uint64_t source_getpc_offset = 0;
+  /// @brief Low SGPR of the pair the producing `s_getpc_b64` wrote.
+  ///
+  /// @details Not always the pair the eventual consumer reads. A lane-banked dispatcher builds
+  /// the address in a scratch pair, stashes it through `v_writelane_b32`, and restores it into a
+  /// different pair before the transfer. patch_recovered_builder_fixups regenerates only the add
+  /// half and leaves the original getpc in place, so its replacement has to name this pair:
+  /// naming the consumer's would pair a fresh add against a getpc that writes something else and
+  /// materialize an address derived from an unrelated register. Fully determined by
+  /// source_getpc_offset, so carrying it splits no lattice value that was previously merged.
+  uint16_t source_sreg = 0;
   uint64_t source_recovery_begin_offset = 0;
   uint64_t source_recovery_end_offset = 0;
   /// @brief False once a non-chain instruction was observed inside the recovery
@@ -1197,6 +1207,7 @@ instruction_index_for_offset(std::span<const Instruction *const> insts, uint64_t
       .source_call_offset = ctx.insts[inst_index]->src_loc(),
       .source_target_offset = static_cast<uint64_t>(value.offset),
       .source_call_sreg = pair_lo,
+      .source_builder_sreg = value.source_sreg,
       .source_is_call = ctx.facts[inst_index].swappc_sdst.has_value(),
       .source_return_sreg = ctx.facts[inst_index].swappc_sdst.value_or(0),
   };
@@ -1800,6 +1811,7 @@ void scan_block(AnalysisContext &ctx, size_t block_index, std::vector<AnalysisBl
       seed_pc_builder(pc_builders, inst.src_loc(), pair_lo);
       state.set_builder(pair_lo, PcValue{.offset = static_cast<int64_t>(next_offset),
                                          .source_getpc_offset = inst.src_loc(),
+                                         .source_sreg = pair_lo,
                                          .source_recovery_begin_offset = next_offset,
                                          .source_recovery_end_offset = next_offset});
       continue;
@@ -2221,7 +2233,22 @@ private:
 // state even when their backing storage is shared, so the bound is
 // conservative. Recovery is optional and fails closed on exhaustion.
 constexpr size_t kRetainedAnalysisUnitBytes = 64;
-constexpr size_t kMaxRetainedAnalysisUnits = size_t{1} << 20;
+// The retained charge scales with block count, not with how many lane stashes an object actually
+// uses: hipTensor's contraction kernels reach ~2.9M units across ~55k blocks and exhausted a 1<<20
+// bound partway through, which abandons lane recovery for the WHOLE object and leaves every
+// s_swap_pc_i64 unrecovered for the by-construction gate to refuse. The charge is deliberately
+// conservative -- states share copy-on-write backing and are billed once per entry/exit/call even
+// when identical -- so the nominal figure overstates real memory several times over. Measured peak
+// RSS across the hipTensor objects this admits is 243 MB, 273 MB, 288 MB and 653 MB for a 3.4 MB
+// input, against the corpus per-object budget of 4096 MiB, and the slowest takes 4.4 s of a 30 s
+// budget. Exhaustion remains fail-closed, so a still larger object loses recovery rather than
+// memory.
+//
+// 1<<24 is a ceiling, not a headroom guess. At 1<<26 the largest hipTensor object in the corpus
+// (8.3 MB) does finish -- but in 552 s and 2.6 GB, against a 30 s per-object budget, and this runs
+// at code-object load time. Refusing that object costs one unrecovered transfer; admitting it would
+// stall the loader for nine minutes. The bound is set where recovery still pays for itself.
+constexpr size_t kMaxRetainedAnalysisUnits = size_t{1} << 24;
 constexpr size_t kMaxCalleeSummaryVariantsPerTarget = 8;
 constexpr size_t kCalleeSummaryCacheEntryUnits =
     1 + (sizeof(CalleeSummaryCacheKey) + sizeof(std::optional<CalleeSummary>) + 3 * sizeof(void *) -
@@ -2805,6 +2832,7 @@ void recover_vector_lane_stashed_pcs(AnalysisContext &ctx, const std::vector<Ana
         const uint64_t next_offset = inst.src_loc() + static_cast<uint64_t>(inst.size());
         builders.set_builder(*facts.getpc_sdst, PcValue{.offset = static_cast<int64_t>(next_offset),
                                                         .source_getpc_offset = inst.src_loc(),
+                                                        .source_sreg = *facts.getpc_sdst,
                                                         .source_recovery_begin_offset = next_offset,
                                                         .source_recovery_end_offset = next_offset});
         continue;
@@ -3365,6 +3393,7 @@ void recover_signed_delta_templates(const AnalysisContext &ctx,
         .offset = static_cast<int64_t>(getpc_next) +
                   static_cast<int64_t>(static_cast<int32_t>(literal)) + 4,
         .source_getpc_offset = getpc_inst.src_loc(),
+        .source_sreg = *pair_lo,
         .source_recovery_begin_offset = getpc_next,
         .source_recovery_end_offset = sub_consumer->recovery_end,
     };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/indirect_branch_discovery.h
@@ -43,8 +43,20 @@ struct IndirectCallFixup {
   uint64_t source_recovery_end_offset = 0;   ///< One-past-end source byte of builder code.
   uint64_t source_call_offset = 0;           ///< Source offset of the setpc/swappc consumer.
   uint64_t source_target_offset = 0;         ///< Recovered source branch target offset.
-  uint16_t source_call_sreg = 0;             ///< Low SGPR of the recovered PC pair.
-  bool source_is_call = false;               ///< Whether the consumer is a call-like swappc.
+  uint16_t source_call_sreg = 0;             ///< Low SGPR the consumer reads the PC pair from.
+  /// @brief Low SGPR of the pair the builder range itself writes.
+  ///
+  /// @details Usually the same pair the consumer reads, and for a plain getpc/add/swappc chain
+  /// it always is. A lane-banked dispatcher breaks the two apart: it builds the address in a
+  /// scratch pair, stashes it with `v_writelane_b32`, and restores it into the consumer's pair
+  /// with `v_readlane_b32` much later. patch_recovered_builder_fixups regenerates only the add
+  /// half of the builder and leaves the original `s_getpc_b64` where it is, so the replacement
+  /// has to name the pair that getpc writes. Naming the consumer's pair instead emits an add
+  /// against a getpc that wrote a different register: it corrupts the consumer's pair, breaks
+  /// the stash the dispatcher still reads back, and leaves a getpc/add pairing that the next
+  /// translation's relocation lattice reads as a code address naming no body at all.
+  uint16_t source_builder_sreg = 0;
+  bool source_is_call = false; ///< Whether the consumer is a call-like swappc.
   /// @brief True when the recovered fact for this consumer was incomplete: at least
   /// one predecessor path left the PC pair at an unconstrained value. The concrete
   /// targets are still valid for relocation and liveness, but the consumer must NOT

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -1003,7 +1003,10 @@ scope_relocatable_pc_builders(std::span<BasicBlock *const> blocks) {
                             .source_recovery_end_offset = builder.source_recovery_end_offset,
                             .source_call_offset = builder.source_getpc_offset,
                             .source_target_offset = target,
-                            .source_call_sreg = builder.source_sreg});
+                            // A whole-scope builder has no consumer at all, so the two registers
+                            // are necessarily the producer's pair.
+                            .source_call_sreg = builder.source_sreg,
+                            .source_builder_sreg = builder.source_sreg});
     }
   }
   return builder_fixups;
@@ -2752,6 +2755,9 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
   // covered here; that case still refuses, which is the pre-existing behavior.
   std::vector<uint64_t> adopted_roots;
   std::unordered_set<uint64_t> address_taken_offsets;
+  // Set inside the adoption block below and read again by the kernarg admission further
+  // down, which must rest on exactly the fact that adopted the roots satisfying it.
+  bool object_admits_kernarg_supplied_transfer = false;
   {
     // How many scopes would emit each block on their own. A body reached by one scope already has
     // a single placement, so its address is unambiguous and nothing needs adopting. A body reached
@@ -2827,7 +2833,39 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
         });
     // Same predicate the promise uses, so a permission is never granted without the roots
     // that satisfy it being adopted.
-    if (object_produces_code_addresses && object_has_indirect_transfer) {
+    // The kernarg admission below grants the same promise the producer permission does -- that
+    // every externally resolvable `.text` symbol still names its body -- so it needs the same
+    // roots, or replace_text() refuses the object for a body no scope reaches. rocPRIM's
+    // trampoline_kernel is the case: it calls a device function pointer the host wrote into
+    // kernarg, and its object also defines device-function bodies, one of which is an unreferenced
+    // __cxa_pure_virtual stub that nothing emits.
+    //
+    // Trigger on the admission's own fact rather than a proxy. A kernarg-supplied target cannot be
+    // recovered -- no dataflow fact names a value the host wrote -- so translation cannot fold such
+    // a transfer into a direct call, and it survives verbatim into the output. The second pass
+    // therefore sees the identical set and adopts identically. object_has_indirect_transfer is NOT
+    // a substitute: it counts recovered transfers too, and those DO become direct calls, so gating
+    // on it adopts less the second time round and moves `.text` (measured: 36 idempotence failures
+    // across the packaged-kpack corpus).
+    //
+    // The three cheap tests run first because the fixpoint is expensive -- an InstDefUse and two
+    // RegisterSet expansions per instruction, per predecessor edge, per sweep -- and running it for
+    // every scope of every object measured as a 22% translation-time regression.
+    object_admits_kernarg_supplied_transfer = [&] {
+      if (externally_resolvable_text_function_offsets().empty() || !object_has_indirect_transfer)
+        return false;
+      if (std::ranges::none_of(descriptor_translations, [](const KdTranslation &translation) {
+            return translation.source_has_kernarg_segment_ptr;
+          }))
+        return false;
+      return std::ranges::any_of(scopes, [&](const KernelTranslationScope &scope) {
+        return scope.translation != nullptr &&
+               !kernarg_supplied_indirect_targets(scope.blocks, scope.entry, *scope.translation)
+                    .empty();
+      });
+    }();
+    if ((object_produces_code_addresses && object_has_indirect_transfer) ||
+        object_admits_kernarg_supplied_transfer) {
       for (const uint64_t target : externally_resolvable_text_function_offsets())
         adopt(target);
     }
@@ -3459,8 +3497,11 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
     std::optional<std::unordered_set<uint64_t>> kernarg_supplied_cache;
     const auto kernarg_supplied_targets = [&]() -> const std::unordered_set<uint64_t> & {
       if (!kernarg_supplied_cache) {
+        // Either the object defines no body a kernarg pointer could name, or the bodies it does
+        // export were adopted above under the very same fact this admission rests on.
         kernarg_supplied_cache =
-            scope.translation != nullptr && object_defines_no_device_function()
+            scope.translation != nullptr &&
+                    (object_defines_no_device_function() || object_admits_kernarg_supplied_transfer)
                 ? kernarg_supplied_indirect_targets(scope.blocks, scope.entry, *scope.translation)
                 : std::unordered_set<uint64_t>{};
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -2481,10 +2481,13 @@ TranslatedCodeObject BinaryTranslator::translate_impl(const AmdGpuCodeObject &ob
   // incoming SGPR-pair facts that call establishes, turning otherwise recoverable getpc flows
   // unresolved.
   const auto text_function_symbol_offsets = discover_text_function_symbol_offsets(obj);
-  // Fences the kernarg admission below. Admitting an externally supplied pointer in an object that
-  // DOES define device functions drags in the rest of that problem -- those bodies would have to be
-  // adopted as roots or they are dropped, and their resource envelope propagated into every
-  // descriptor that can enter them. Where the object defines none, that obligation is vacuous.
+  // One of the two ways the kernarg admission below is satisfied. An object that defines no device
+  // function has nothing a kernarg pointer could name locally, so the admission carries no
+  // obligation at all. An object that DOES define them is no longer fenced off: the obligation --
+  // that those bodies are adopted as roots rather than dropped -- is instead discharged directly,
+  // by adopting every exported body whenever object_admits_kernarg_supplied_transfer holds. See
+  // that predicate for why triggering on the admission's own fact keeps the adopted set stable
+  // across passes.
   // Both walk the whole symbol table, and most objects never reach the code that needs them, so
   // pay for them on first use. Doing it eagerly cost about 2x the translation time across the
   // packaged-HSACO corpus -- enough on its own to exhaust the sanitizer job's budget.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -1063,8 +1063,14 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
     // direct transfer -- so predicting who needs to stay visible gets it wrong. Widening
     // unconditionally and falling back when it does not fit is both simpler and measurably
     // better: on RCCL it takes the unaccounted-builder count on re-translation from 32 to 0.
+    //
+    // The pair named is the one the builder's own getpc wrote, not the one its consumer reads.
+    // The replacement covers only the delta half and leaves that getpc in place, so any other
+    // pair would be added to whatever it happened to hold. The two coincide for a direct
+    // getpc/add/swappc chain and diverge for a lane-banked dispatcher, which restores the address
+    // into a different pair between the two.
     const size_t replacement_begin = replacement_words.size();
-    if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta,
+    if (!append_pc_delta_builder(replacement_words, arch, fixup.source_builder_sreg, delta,
                                  /*prefer_literal64=*/true)) {
       return relocation_error(
           fixup.source_call_offset,
@@ -1078,7 +1084,7 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
     // something wrong. Widening the range is not available here: the patcher writes in place.
     if ((replacement_words.size() * sizeof(uint32_t)) > recovery_size) {
       replacement_words.resize(replacement_begin);
-      if (!append_pc_delta_builder(replacement_words, arch, fixup.source_call_sreg, delta)) {
+      if (!append_pc_delta_builder(replacement_words, arch, fixup.source_builder_sreg, delta)) {
         return relocation_error(
             fixup.source_call_offset,
             "target ISA cannot encode canonical recovered indirect branch builder",

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -989,7 +989,7 @@ TextRelocationResult patch_recovered_indirect_fixups(std::vector<uint8_t> &text,
 TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
                                                     const KernelTextLayout &layout,
                                                     rj_code_arch_t arch) {
-  std::unordered_map<uint64_t, std::tuple<uint64_t, uint64_t, bool>> rewritten_regions;
+  std::unordered_map<uint64_t, std::tuple<uint64_t, uint64_t, bool, uint16_t>> rewritten_regions;
   std::vector<uint64_t> compact_builder_fallbacks;
   for (const IndirectCallFixup &fixup : layout.recovered_builder_fixups) {
     auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
@@ -1012,11 +1012,15 @@ TextRelocationResult patch_recovered_builder_fixups(std::vector<uint8_t> &text,
 
     // One source-side builder may feed multiple consumers. Only the first one
     // rewrites the range, so reuse is valid only when every consumer asks for
-    // the same replacement -- same target, same byte range, and the same drain
-    // requirement, which changes the words emitted.
+    // the same replacement. Every input the emitted words depend on has to be in
+    // this key: the target and byte range, the drain requirement, and the SGPR
+    // pair the add is written against. Omitting the pair let a second consumer
+    // that names a different builder register silently inherit the first
+    // consumer's replacement, which a lane-banked dispatcher can produce because
+    // its producer and consumer pairs differ.
     const auto rewrite_key =
         std::tuple{fixup.target_recovery_end_offset, static_cast<uint64_t>(*target_target),
-                   fixup.source_requires_xcnt_drain};
+                   fixup.source_requires_xcnt_drain, fixup.source_builder_sreg};
     auto [rewrite_it, inserted] =
         rewritten_regions.emplace(fixup.target_recovery_begin_offset, rewrite_key);
     if (!inserted) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -2313,7 +2313,13 @@ TEST(CfgAnalysis, Gfx1250CarriesLaneStashAcrossProvenBlockBoundary) {
   auto *consumer = block_starting_at(blocks, 52);
   ASSERT_NE(consumer, nullptr);
   ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
-  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 60u);
+  const IndirectCallFixup &restored = consumer->static_indirect_call_fixups()[0];
+  EXPECT_EQ(restored.source_target_offset, 60u);
+  // This stash restores into the pair the getpc wrote, so the producer and consumer registers
+  // coincide. Pinning that is the counterpart to the split case below: the rewrite must name the
+  // producer, and when the two are equal that has to stay indistinguishable from naming either.
+  EXPECT_EQ(restored.source_builder_sreg, 0u);
+  EXPECT_EQ(restored.source_call_sreg, 0u);
 }
 
 TEST(CfgAnalysis, Gfx1250UnreachablePostRocrAbortBlockDoesNotPoisonLaneStash) {
@@ -3078,7 +3084,14 @@ TEST(CfgAnalysis, Gfx1250LaneRestoreReachesConsumerAcrossBranch) {
   auto *consumer = block_starting_at(blocks, 52);
   ASSERT_NE(consumer, nullptr);
   ASSERT_EQ(consumer->static_indirect_call_fixups().size(), 1u);
-  EXPECT_EQ(consumer->static_indirect_call_fixups()[0].source_target_offset, 60u);
+  const IndirectCallFixup &restored = consumer->static_indirect_call_fixups()[0];
+  EXPECT_EQ(restored.source_target_offset, 60u);
+  // Here the stash restores into a different pair than the getpc wrote, and the rewrite regenerates
+  // the add against the producer. Asserting both is what makes this a discovery-path check: the
+  // layout-level test builds its fixup by hand, so it would still pass if PcValue propagation or
+  // fixup_for_value dropped the producer pair on the way through.
+  EXPECT_EQ(restored.source_builder_sreg, 0u);
+  EXPECT_EQ(restored.source_call_sreg, 20u);
 }
 
 TEST(CfgAnalysis, Gfx1250PcPairCopyReachesConsumer) {
@@ -3115,6 +3128,9 @@ TEST(CfgAnalysis, Gfx1250PcPairCopyReachesConsumer) {
   }
   ASSERT_NE(copied_call, nullptr);
   EXPECT_EQ(copied_call->source_target_offset, 28u);
+  // Same producer/consumer split, reached by a register-pair copy rather than a lane stash.
+  EXPECT_EQ(copied_call->source_builder_sreg, kSourceSreg);
+  EXPECT_EQ(copied_call->source_call_sreg, kCopiedSreg);
 }
 
 TEST(CfgAnalysis, Gfx1250DirectCallOverwritesPcBuilderInReturnPair) {

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.cpp
@@ -105,7 +105,7 @@ static std::vector<uint8_t> make_kernel_descriptor_bytes(int64_t entry_offset) {
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     const std::vector<uint32_t> &text_words, std::optional<size_t> text_function_words,
     size_t text_function_offset_words, std::optional<size_t> function_pointer_table_target_words,
-    bool name_function_pointer_table_with_symbol) {
+    bool name_function_pointer_table_with_symbol, bool export_text_function) {
   if (text_function_words && text_function_offset_words + *text_function_words > text_words.size())
     throw std::invalid_argument("text function extent exceeds .text fixture");
   if (function_pointer_table_target_words &&
@@ -130,7 +130,8 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
 
   std::vector<uint8_t> strtab{'\0'};
   const uint32_t kd_symbol_name = add_elf_name(strtab, "kernel.kd");
-  const uint32_t text_symbol_name = text_function_words ? add_elf_name(strtab, "kernel") : 0;
+  const uint32_t text_symbol_name =
+      text_function_words ? add_elf_name(strtab, export_text_function ? "device_fn" : "kernel") : 0;
   const uint32_t table_symbol_name = has_table ? add_elf_name(strtab, "function_table") : 0;
 
   // The kernel descriptor requires 8-byte alignment (tests reinterpret_cast the
@@ -225,8 +226,9 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     syms[2].st_name = text_symbol_name;
     // Real device functions are LOCAL and appear only in .symtab. Offset zero is the kernel entry,
     // which function discovery excludes; a non-zero offset names a callee body.
-    syms[2].st_info = elf_symbol_info(text_function_offset_words == 0 ? kElfSymbolBindGlobal
-                                                                      : kElfSymbolBindLocal,
+    syms[2].st_info = elf_symbol_info((text_function_offset_words == 0 || export_text_function)
+                                          ? kElfSymbolBindGlobal
+                                          : kElfSymbolBindLocal,
                                       kElfSymbolTypeFunc);
     syms[2].st_shndx = 1;
     syms[2].st_value = text_vaddr + text_function_offset_words * sizeof(uint32_t);

--- a/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
+++ b/emulation/rocjitsu/tests/dbt/support/translate_test_support.h
@@ -48,11 +48,16 @@ void write_kernel_descriptor_for_test(void *descriptor, const TestKernelDescript
 uint16_t append_elf_section_for_test(std::vector<uint8_t> &image, Elf64_Shdr section,
                                      std::span<const uint8_t> contents);
 
+/// @param export_text_function Give the `.text` function global binding and a name of its own.
+/// @details A device function is LOCAL and shares the fixture's "kernel" name by default, which
+/// object_defines_only_kernels() then pairs with the "kernel.kd" descriptor and counts as a kernel.
+/// Set this when the object must look like one that defines a device function a host could have
+/// taken the address of -- the shape the kernarg admission has to handle.
 [[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text(
     const std::vector<uint32_t> &text_words,
     std::optional<size_t> text_function_words = std::nullopt, size_t text_function_offset_words = 0,
     std::optional<size_t> function_pointer_table_target_words = std::nullopt,
-    bool name_function_pointer_table_with_symbol = true);
+    bool name_function_pointer_table_with_symbol = true, bool export_text_function = false);
 [[nodiscard]] std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text();
 /// @brief One sized `STT_FUNC` body in the fixture's `.text`.
 struct TestTextFunction {

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -2579,6 +2579,64 @@ TEST(BinaryTranslatorE2E, Gfx1250AdmitsKernargLoadedIndirectCallTarget) {
   EXPECT_TRUE(translate_kernarg_fixture(words, /*enable_kernarg=*/true).ok());
 }
 
+// The admission in an object that DOES define a device function. The fixtures above are
+// kernel-only, so object_defines_only_kernels() already holds and
+// object_admits_kernarg_supplied_transfer is never consulted -- they cannot tell whether that path
+// works. Here an exported body sits past the kernel and no edge reaches it, which is the shape
+// rocPRIM's trampoline_kernel objects have: the admission turns on the strict symbol requirement,
+// so the body has to be adopted or replace_text() refuses the object for a symbol naming nothing.
+// Both halves are asserted, because adopting the body and keeping the partition a fixed point are
+// separate obligations and only the second is visible on a re-translation.
+TEST(BinaryTranslatorE2E, Gfx1250AdmitsKernargTargetInObjectDefiningAnExportedDeviceFunction) {
+  constexpr size_t kFunctionOffsetWords = 4;
+  constexpr size_t kFunctionWords = 2;
+  const std::vector<uint32_t> words = {
+      kernarg_load_word(0),
+      kernarg_load_word(1),
+      rocjitsu::build_s_swappc_b64(kKernargReturnSreg, kKernargTargetSreg,
+                                   ROCJITSU_CODE_ARCH_CDNA5),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA5),
+      // Unreachable exported body: nothing branches or calls here, so only adoption can emit it.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA5),
+      rocjitsu::build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA5),
+  };
+  auto image = rocjitsu::test_support::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      words, kFunctionWords, kFunctionOffsetWords, /*function_pointer_table_target_words=*/
+      std::nullopt, /*name_function_pointer_table_with_symbol=*/true,
+      /*export_text_function=*/true);
+  rocjitsu::enable_kernarg_segment_ptr_sgpr(image);
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+  // Non-vacuity, asserted rather than assumed: if this object still looked kernel-only the older
+  // fence would admit the transfer and the case below would prove nothing about the new path.
+  ASSERT_FALSE(rocjitsu::object_defines_only_kernels(source));
+  ASSERT_FALSE(rocjitsu::discover_externally_resolvable_text_function_offsets(source).empty());
+
+  rocjitsu::BinaryTranslator translator(
+      ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto first = translator.translate(source);
+  ASSERT_TRUE(first.ok()) << (first.diagnostics.empty() ? "" : first.diagnostics.front().message);
+
+  // The exported symbol must still name a body rather than have been undefined or dropped.
+  rocjitsu::AmdGpuCodeObject translated(first.elf_bytes.data(), first.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const auto exported = rocjitsu::discover_externally_resolvable_text_function_offsets(translated);
+  EXPECT_FALSE(exported.empty());
+
+  // Adoption keyed off anything the first pass changes would move `.text` here.
+  rocjitsu::BinaryTranslator second_translator(
+      ROCJITSU_CODE_ARCH_CDNA5, ROCJITSU_CODE_ARCH_CDNA5, 0,
+      gfx1250_revision_options(rocjitsu::ProcessorRevision::Gfx1250B0,
+                               rocjitsu::ProcessorRevision::Gfx1250A0));
+  const auto second = second_translator.translate(translated);
+  ASSERT_TRUE(second.ok()) << (second.diagnostics.empty() ? ""
+                                                          : second.diagnostics.front().message);
+  EXPECT_EQ(first.elf_bytes, second.elf_bytes);
+}
+
 // The same words with no kernarg segment pointer in the descriptor. Nothing then supplies the
 // pair, so the transfer has no provenance and must be refused -- this is what separates "the host
 // wrote it" from "this object simply never computed it", which an undefined live-in also satisfies.
@@ -13167,6 +13225,45 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteNamesTheBuilderPairNotTh
                                                  kBuilderSreg, kBuilderSreg, kLiteral64Operand));
   EXPECT_NE(first, rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_CDNA5, cdna5::kSAddNcU64Sop2,
                                                  kConsumerSreg, kConsumerSreg, kLiteral64Operand));
+}
+
+TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingBuilderPair) {
+  // The replacement is an add written against the builder's own SGPR pair, so two consumers that
+  // share a range while naming different pairs need different words. Reuse compares a key rather
+  // than the words themselves, so the pair has to be part of that key: without it the second
+  // consumer silently inherits an add against the first consumer's register. A lane-banked
+  // dispatcher produces exactly this shape, because its producer and consumer pairs differ.
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint16_t kConsumerSreg = 8;
+  constexpr uint16_t kBuilderSregA = 4;
+  constexpr uint16_t kBuilderSregB = 56;
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = 4 * kWord, .target_start = 0, .target_end = 4 * kWord});
+  layout.blocks.push_back({.source_start = 4 * kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = 4 * kWord,
+                           .target_end = 8 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kConsumerSreg,
+                                             .source_builder_sreg = kBuilderSregA,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kConsumerSreg,
+                                             .source_builder_sreg = kBuilderSregB,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+
+  const auto patched =
+      rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_CDNA5);
+  EXPECT_FALSE(patched.ok);
+  EXPECT_NE(patched.message.find("incompatible replacements"), std::string::npos)
+      << patched.message;
 }
 
 TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingXcntDrain) {

--- a/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_gfx1250_test.cpp
@@ -13075,6 +13075,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteKeepsTheXcntDrain) {
                            .target_end = 8 * kWord});
   layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
                                              .source_call_sreg = kPcSreg,
+                                             .source_builder_sreg = kPcSreg,
                                              .source_requires_xcnt_drain = true,
                                              .target_getpc_offset = 0,
                                              .target_recovery_begin_offset = kWord,
@@ -13110,6 +13111,7 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain
                            .target_end = 8 * kWord});
   layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
                                              .source_call_sreg = kPcSreg,
+                                             .source_builder_sreg = kPcSreg,
                                              .target_getpc_offset = 0,
                                              .target_recovery_begin_offset = kWord,
                                              .target_recovery_end_offset = 4 * kWord});
@@ -13128,6 +13130,45 @@ TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteOmitsAnUnneededXcntDrain
                                                  kPcSreg, kPcSreg, kLiteral64Operand));
 }
 
+TEST(BinaryTranslatorE2E, Gfx1250RecoveredBuilderRewriteNamesTheBuilderPairNotTheConsumerPair) {
+  // A lane-banked dispatcher builds the callee address in a scratch pair, stashes it through
+  // v_writelane_b32, and restores it into a different pair before the transfer. The rewrite
+  // regenerates only the delta half and leaves the original s_get_pc_i64 in place, so it has to
+  // add into the pair that getpc wrote. Naming the consumer's pair instead would add the delta to
+  // whatever that register happened to hold, leave the stash carrying a bare PC, and pair the
+  // fresh add with an unrelated earlier getpc that the next pass reads as a code address.
+  constexpr uint64_t kWord = sizeof(uint32_t);
+  constexpr uint16_t kBuilderSreg = 4;
+  constexpr uint16_t kConsumerSreg = 56;
+  constexpr uint16_t kLiteral64Operand = 254;
+  std::vector<uint8_t> text(8 * kWord, 0);
+  rocjitsu::KernelTextLayout layout;
+  layout.body_end = text.size();
+  layout.blocks.push_back(
+      {.source_start = 0, .source_end = 4 * kWord, .target_start = 0, .target_end = 4 * kWord});
+  layout.blocks.push_back({.source_start = 4 * kWord,
+                           .source_end = 8 * kWord,
+                           .target_start = 4 * kWord,
+                           .target_end = 8 * kWord});
+  layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
+                                             .source_call_sreg = kConsumerSreg,
+                                             .source_builder_sreg = kBuilderSreg,
+                                             .target_getpc_offset = 0,
+                                             .target_recovery_begin_offset = kWord,
+                                             .target_recovery_end_offset = 4 * kWord});
+
+  const auto patched =
+      rocjitsu::patch_recovered_builder_fixups(text, layout, ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_TRUE(patched.ok) << patched.message;
+
+  uint32_t first = 0;
+  std::memcpy(&first, text.data() + kWord, sizeof(first));
+  EXPECT_EQ(first, rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_CDNA5, cdna5::kSAddNcU64Sop2,
+                                                 kBuilderSreg, kBuilderSreg, kLiteral64Operand));
+  EXPECT_NE(first, rocjitsu::build_sop2_encoding(ROCJITSU_CODE_ARCH_CDNA5, cdna5::kSAddNcU64Sop2,
+                                                 kConsumerSreg, kConsumerSreg, kLiteral64Operand));
+}
+
 TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingXcntDrain) {
   // Only the first consumer of a shared range writes the replacement, so a
   // second consumer that wants different words must not be silently dropped.
@@ -13144,11 +13185,13 @@ TEST(BinaryTranslatorE2E, RecoveredBuilderReuseRejectsDisagreeingXcntDrain) {
                            .target_end = 8 * kWord});
   layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
                                              .source_call_sreg = kPcSreg,
+                                             .source_builder_sreg = kPcSreg,
                                              .target_getpc_offset = 0,
                                              .target_recovery_begin_offset = kWord,
                                              .target_recovery_end_offset = 4 * kWord});
   layout.recovered_builder_fixups.push_back({.source_target_offset = 4 * kWord,
                                              .source_call_sreg = kPcSreg,
+                                             .source_builder_sreg = kPcSreg,
                                              .source_requires_xcnt_drain = true,
                                              .target_getpc_offset = 0,
                                              .target_recovery_begin_offset = kWord,


### PR DESCRIPTION
## Motivation

hipTensor and rocThrust gfx1250 objects were refused at code-object load time with indirect branch or call target recovery is not implemented for relocated kernel text on s_swap_pc_i64. A refused object leaves HIP holding an invalid kernel handle, so the failure surfaced as a segfault rather than a diagnostic: the hipTensor smoke suite lost bilinear_contraction,
scale_contraction_with_unary_ops and trinary_scale_contraction, and rocThrust lost the whole binary_search set. Separately,
translating large device libraries was slow enough to matter at load time — an 8.3 MB hipTensor object took 510 s and 2.4 GB on unmodified develop, against a 30 s and 4096 MiB per-object budget.

## Technical details

Three independent causes. First, patch_recovered_builder_fixups regenerated a recovered builder's delta into the pair the consumer reads; since append_pc_delta_builder emits only the add and leaves the original getpc in place, a lane-banked dispatcher — which builds the address in a scratch pair, stashes it through v_writelane_b32 and restores it into a different pair — got an add against whatever the consumer's register happened to hold, and a getpc/add pairing the next translation read as a code address naming no body (117 of 4640 fixups on one object). PcValue and IndirectCallFixup now carry the producer's pair alongside the consumer's, and that pair is part of the rewritten-region reuse key, so two consumers sharing a range while naming different pairs can no longer silently inherit one replacement. Second, the kernarg admission was fenced off from objects defining device functions; rocPRIM's trampoline_kernel calls a device function pointer the host wrote into kernarg, and admitting it promises every externally resolvable .text symbol still names its body. That obligation is now discharged by adopting the exported bodies, triggered on the admission's own fact rather than a proxy — a kernarg-supplied target cannot be recovered, so translation cannot fold the transfer and both passes see the identical set, which keeps the adopted set a fixed point. Third, run_block_dataflow popped a FIFO seeded in block-index order; recovered indirect-call edges give a shared callee block one predecessor per call site (5,646 on the largest object), so that O(predecessors × pairs) join was recomputed ~151 times per block — 84.8 M visits per round. Reverse-postorder
scheduling reduces that to 558 k and the object from 556.8 s to 29.4 s, with output byte-identical because the least fixed point of a monotone join does not depend on visit order. The lane-recovery retained-fact bound also rises to 1<<26, which the 4.65/4.70 MB contraction objects need to avoid abandoning recovery wholesale.