### PR TITLE
[CLR] Avoid locking get func

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -618,6 +618,8 @@ hipError_t StatCO::RegisterManagedVar(Var* var) {
 // ================================================================================================
 void StatCO::ResizeForDevices(size_t device_count) {
   std::scoped_lock lock(sclock_);
+  managedVarsDevicePtrInitialized_ = std::make_unique<std::atomic<bool>[]>(device_count);
+  managedVarsDevicePtrInitializedSize_ = device_count;
   for (const auto& it : vars_) {
     it.second->ResizeDVar(device_count);
   }
@@ -633,10 +635,16 @@ void StatCO::ResizeForDevices(size_t device_count) {
 
 // ================================================================================================
 hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
+  // Fast lock free path
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitializedSize_ &&
+      managedVarsDevicePtrInitialized_[deviceId].load(std::memory_order_acquire)) {
+    return hipSuccess;
+  }
+
   std::scoped_lock lock(sclock_);
   hipError_t err = hipSuccess;
-  if (managedVarsDevicePtrInitalized_.find(deviceId) == managedVarsDevicePtrInitalized_.end() ||
-      !managedVarsDevicePtrInitalized_[deviceId]) {
+  // Re-check under the lock in case another thread initialized this device while we waited.
+  if (!managedVarsDevicePtrInitialized_[deviceId].load(std::memory_order_relaxed)) {
     for (auto& vecIter : managedVars_) {
       for (auto& var : vecIter.second) {
         // Lazy load
@@ -658,7 +666,7 @@ hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
                          mem->getSize(), hipMemcpyHostToDevice, *stream);
       }
     }
-    managedVarsDevicePtrInitalized_[deviceId] = true;
+    managedVarsDevicePtrInitialized_[deviceId].store(true, std::memory_order_release);
   }
   return err;
 }

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -619,6 +619,11 @@ hipError_t StatCO::RegisterManagedVar(Var* var) {
 void StatCO::ResizeForDevices(size_t device_count) {
   std::scoped_lock lock(sclock_);
   managedVarsDevicePtrInitialized_ = std::make_unique<std::atomic<bool>[]>(device_count);
+  // Explicitly initialize each per-device flag to false before it can be read by
+  // the lock-free fast path in InitManagedVarDevicePtr.
+  for (size_t i = 0; i < device_count; ++i) {
+    managedVarsDevicePtrInitialized_[i].store(false, std::memory_order_relaxed);
+  }
   managedVarsDevicePtrInitializedSize_ = device_count;
   for (const auto& it : vars_) {
     it.second->ResizeDVar(device_count);

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -534,14 +534,17 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
 
   // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
-  if (module != nullptr) {
+  if (module == nullptr) {
+    return hipErrorInvalidDeviceFunction;
+  }
+
+  // Only take sclock_ when the module has not been loaded yet. Once loaded the
+  // fast path avoids the lock entirely.
+  if (*(module) == nullptr) {
     std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
      IHIP_RETURN_ONFAIL(DigestFatBinary(module_to_hostModule_[module], *module));
     }
-  } else {
-    // Module was nullptr
-    return hipErrorInvalidDeviceFunction;
   }
 
   return it->second->GetStatFunc(hfunc, deviceId);

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -9,7 +9,9 @@
 
 #include "hip_global.hpp"
 
+#include <atomic>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -208,7 +210,9 @@ class StatCO : public CodeObject {
   //! Reverse mapping of vars
   std::unordered_map<FatBinaryInfo**, std::vector<const void*> > module_to_hostVars_;
   //! Tracks managed var initialization per device
-  std::unordered_map<int, bool> managedVarsDevicePtrInitalized_;
+  std::unique_ptr<std::atomic<bool>[]> managedVarsDevicePtrInitialized_;
+  //! Number of entries in managedVarsDevicePtrInitialized_
+  size_t managedVarsDevicePtrInitializedSize_ = 0;
 };
 
 };  // namespace hip


### PR DESCRIPTION
## Motivation

Avoid locking when calling StaticCo's `GetFunc` and `InitManagedVarDevicePtr`

8GPU kernel sumbissions currently seralize with these two functions as they are under lock.

MI300X kernel no-op submissions moves from `1,189,897 kernels/sec` to `1,598,125 kenels/sec` giving a `34.3% change` in submission speed.

## Technical Details

Undo change in #1107 that causes lock always to be aquired. Adds `InitManagedVarDevicePtr` as a boolean atomic allowing for fast checkes to verify that managed memory has been initalised. 

## Issue Tracking

JIRA ID: ROCM-27455

## Test Plan

No additional testing needed

## Test Result

Tests pass locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
