### PR TITLE
fix(rocprofiler-systems): Fix `.clang-tidy` to include only source directory

### DIFF
--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -2,3 +2,5 @@
 Checks: "-*,\
 misc-const-correctness,\
 "
+
+HeaderFilterRegex: "/rocprofiler-systems/source/"


### PR DESCRIPTION
## Motivation

Focus `clang-tidy` checks on the `projects/rocprofiler-systems/source/` folder.

## Technical Details

Add `HeaderFilterRegex` to `.clang-tidy` file.

## Issue Tracking

JIRA ID: AIPROFSYST-496

## Test Plan

- Verify that script only report warnings on diff.
- Verify that it doesn't report unwanted header files.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
