### PR TITLE
[AICOMRCCL-1179] rccl: graceful-skip UBR_MultiSegment tests and add single-node validation harness

### DIFF
--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -208,6 +208,16 @@ protected:
         return (!mseg || std::string(mseg) != "0");
     }
 
+    // Mirror DeviceApiTests (PR #9599): when cuMem / symmetric windows are
+    // unavailable (e.g. an older driver where the runtime disables cuMem),
+    // registration is rejected with ncclInvalidUsage. Treat that as an
+    // unsupported configuration and skip, so CI reports a skip rather than a
+    // spurious failure. Any other non-success code remains a real error.
+    static bool isUnsupportedRegistration(ncclResult_t rc)
+    {
+        return rc == ncclInvalidUsage;
+    }
+
     bool isWinEnabled()
     {
         const char* win = getenv("NCCL_WIN_ENABLE");
@@ -804,7 +814,10 @@ TEST_F(UBR_MultiSegment, Generic)
     size_t count   = halfSize / sizeof(T);
 
     void* regHandle = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &regHandle));
+    ncclResult_t regResult = ncclCommRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &regHandle);
+    if (isUnsupportedRegistration(regResult))
+        GTEST_SKIP() << "Multi-segment registration is unsupported on this configuration (cuMem/symmetric disabled).";
+    ASSERT_MPI_EQ(ncclSuccess, regResult);
     auto regCleanup = makeScopeGuard([&]() {
         if (regHandle) HIP_EXPECT(ncclCommDeregister(getActiveCommunicator(), regHandle));
     });
@@ -875,7 +888,10 @@ TEST_F(UBR_MultiSegment, Generic)
      size_t count   = halfSize / sizeof(T);
  
      void* regHandle = nullptr;
-     ASSERT_MPI_EQ(ncclSuccess, ncclCommRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &regHandle));
+     ncclResult_t regResult = ncclCommRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &regHandle);
+     if (isUnsupportedRegistration(regResult))
+         GTEST_SKIP() << "Multi-segment registration is unsupported on this configuration (cuMem/symmetric disabled).";
+     ASSERT_MPI_EQ(ncclSuccess, regResult);
      auto regCleanup = makeScopeGuard([&]() {
          if (regHandle) HIP_EXPECT(ncclCommDeregister(getActiveCommunicator(), regHandle));
      });
@@ -960,7 +976,10 @@ TEST_F(UBR_MultiSegment, Generic)
      size_t count   = halfSize / sizeof(T);
  
      ncclWindow_t win = nullptr;
-     ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+     ncclResult_t winResult = ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC);
+     if (isUnsupportedRegistration(winResult))
+         GTEST_SKIP() << "Multi-segment symmetric window registration is unsupported on this configuration (cuMem/symmetric disabled).";
+     ASSERT_MPI_EQ(ncclSuccess, winResult);
      auto winCleanup = makeScopeGuard([&]() {
          if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
      });
@@ -1143,7 +1162,10 @@ TEST_F(UBR_MultiSegment, Symmetric_Elastic_Lsa)
      size_t count   = halfSize / sizeof(T);
  
      ncclWindow_t win = nullptr;
-     ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+     ncclResult_t winResult = ncclCommWindowRegister(getActiveCommunicator(), buf.vaBase, buf.totalSize, &win, NCCL_WIN_COLL_SYMMETRIC);
+     if (isUnsupportedRegistration(winResult))
+         GTEST_SKIP() << "Multi-segment symmetric window registration is unsupported on this configuration (cuMem/symmetric disabled).";
+     ASSERT_MPI_EQ(ncclSuccess, winResult);
      auto winCleanup = makeScopeGuard([&]() {
          if (win) HIP_EXPECT(ncclCommWindowDeregister(getActiveCommunicator(), win));
      });


### PR DESCRIPTION
## Motivation

Validate RCCL symmetric window and multi-segment buffer registration on older driver/kernel configurations, and make the UBR_MultiSegment MPI tests report unsupported configurations as skips instead of hard failures. This closes out the validation work for AICOMRCCL-1179.

## Technical Details

- projects/rccl/test/RegistrationMPITests.cpp: add an isUnsupportedRegistration() helper and convert four hard assertions in the UBR_MultiSegment cases (Generic, Generic_Reuse, Symmetric_Lsa, Symmetric_Elastic_Lsa) to GTEST_SKIP when the registration call returns ncclInvalidUsage. This mirrors the graceful-skip pattern already used in DeviceApiTests (https://github.com/ROCm/rocm-systems/pull/9599).
- projects/rccl/contrib/multiseg_validation/: reproducible single-node validation harness (build/run script, a getHostName link shim, and instructions). It compiles only the MPI test objects against a prebuilt librccl.so to avoid a full device-code rebuild.

## Issue Tracking

JIRA ID : AICOMRCCL-1179

## Test Plan

Single-node MI300X, ROCm 7.14 container. Built the MPI registration tests and ran UBR_MultiSegment at -np 2 with NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT,REG. Steps are documented in projects/rccl/contrib/multiseg_validation/INSTRUCTIONS.txt.

## Test Result

At -np 2: 4 PASS (Generic, Generic_Reuse, Symmetric_Lsa, Symmetric_Elastic_Lsa), 2 SKIP (Symmetric_LsaGin needs GIN / 2+ nodes; Symmetric_Elastic_Gating needs NCCL_ELASTIC_BUFFER_REGISTER=0), 0 FAIL.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
