### PR TITLE
fix(rocprofiler-systems): Scope child sampler shutdown

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -137,10 +137,7 @@ postfork_child()
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;
-    // all_threads=true: the pre-fork threads no longer exist in this child, but their
-    // sampler objects were inherited with the address space, so release all of them.
-    // Every other caller must use the default (own slot only) -- see sampling.hpp.
-    rocprofsys::sampling::shutdown(/*all_threads=*/true);
+    rocprofsys::sampling::postfork_child_release_samplers();
     rocprofsys::categories::shutdown();
     state::thread::set(state::thread::Disabled);
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -137,7 +137,10 @@ postfork_child()
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;
-    rocprofsys::sampling::shutdown();
+    // all_threads=true: the pre-fork threads no longer exist in this child, but their
+    // sampler objects were inherited with the address space, so release all of them.
+    // Every other caller must use the default (own slot only) -- see sampling.hpp.
+    rocprofsys::sampling::shutdown(/*all_threads=*/true);
     rocprofsys::categories::shutdown();
     state::thread::set(state::thread::Disabled);
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -34,10 +34,13 @@
 
 namespace rocprofsys
 {
-// NOTE: sampling::setup() and sampling::shutdown() used to be forward-declared here.
-// shutdown() now takes a defaulted `all_threads` argument, and a local re-declaration
-// without that default makes the call below ambiguous. Both come from
-// library/sampling.hpp, which is already included above.
+namespace sampling
+{
+std::set<int>
+setup();
+std::set<int>
+shutdown();
+}  // namespace sampling
 
 namespace component
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -34,13 +34,10 @@
 
 namespace rocprofsys
 {
-namespace sampling
-{
-std::set<int>
-setup();
-std::set<int>
-shutdown();
-}  // namespace sampling
+// NOTE: sampling::setup() and sampling::shutdown() used to be forward-declared here.
+// shutdown() now takes a defaulted `all_threads` argument, and a local re-declaration
+// without that default makes the call below ambiguous. Both come from
+// library/sampling.hpp, which is already included above.
 
 namespace component
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1091,10 +1091,15 @@ void
 postfork_child_release_samplers() noexcept
 {
     // release() rather than reset(): deliberately skips ~sampler_t() after fork().
-    auto* _samplers = sampler_instances::get();
-    if(!_samplers) return;
-    for(auto& itr : *_samplers)
+    auto* samplers = sampler_instances::get();
+    if(!samplers)
+    {
+        return;
+    }
+    for(auto& itr : *samplers)
+    {
         (void) itr.release();
+    }
 }
 
 std::set<int>
@@ -1102,9 +1107,9 @@ shutdown()
 {
     // Prefer the ID captured in thread_info: the thread-local backing get_id() may
     // already have been destroyed when shutdown() runs from a thread-local destructor.
-    const auto& _info = thread_info::get();
-    const auto  _tid  = (_info && _info->index_data) ? _info->index_data->sequent_value
-                                                     : threading::get_id();
+    const auto& info = thread_info::get();
+    const auto  tid  = (info && info->index_data) ? info->index_data->sequent_value
+                                                  : threading::get_id();
 
     if(is_child_process())
     {
@@ -1112,20 +1117,22 @@ shutdown()
         // destructor of every exiting thread, and is_child_process() stays true for the
         // child's whole lifetime, so releasing the whole array would destroy samplers
         // belonging to threads still inside configure().
-        auto* _samplers = sampler_instances::get();
-        if(_samplers)
+        auto* samplers = sampler_instances::get();
+        if(samplers)
         {
             // Validate the signed thread ID before converting it and indexing sampler
             // storage. This runs during thread teardown, so avoid throwing accessors.
-            if(_tid >= 0 && static_cast<size_t>(_tid) < _samplers->size())
-                (void) (*_samplers)[static_cast<size_t>(_tid)].release();
+            if(tid >= 0 && static_cast<size_t>(tid) < samplers->size())
+            {
+                (void) (*samplers)[static_cast<size_t>(tid)].release();
+            }
         }
         return std::set<int>{};
     }
 
-    auto _v = configure(false, _tid);
+    auto configured_signals = configure(false, tid);
     if(utility::get_thread_index() == 0) stop_duration_thread();
-    return _v;
+    return configured_signals;
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1088,18 +1088,24 @@ setup()
 }
 
 void
-postfork_child_release_samplers()
+postfork_child_release_samplers() noexcept
 {
     // release() rather than reset(): deliberately skips ~sampler_t() after fork().
     auto* _samplers = sampler_instances::get();
     if(!_samplers) return;
     for(auto& itr : *_samplers)
-        itr.release();
+        (void) itr.release();
 }
 
 std::set<int>
 shutdown()
 {
+    // Prefer the ID captured in thread_info: the thread-local backing get_id() may
+    // already have been destroyed when shutdown() runs from a thread-local destructor.
+    const auto& _info = thread_info::get();
+    const auto  _tid  = (_info && _info->index_data) ? _info->index_data->sequent_value
+                                                     : threading::get_id();
+
     if(is_child_process())
     {
         // Only this thread's sampler may be released here: shutdown() runs from the
@@ -1109,18 +1115,15 @@ shutdown()
         auto* _samplers = sampler_instances::get();
         if(_samplers)
         {
-            // get_id() returns -1 when the id manager is gone, and offset
-            // (rocprof-sys-internal) thread ids count downward, so the id can be
-            // negative. Bounds-check before at(), which throws -- and an exception
-            // escaping a thread destructor terminates the process.
-            const auto _tid = threading::get_id();
+            // Validate the signed thread ID before converting it and indexing sampler
+            // storage. This runs during thread teardown, so avoid throwing accessors.
             if(_tid >= 0 && static_cast<size_t>(_tid) < _samplers->size())
-                _samplers->at(static_cast<size_t>(_tid)).release();
+                (void) (*_samplers)[static_cast<size_t>(_tid)].release();
         }
         return std::set<int>{};
     }
 
-    auto _v = configure(false);
+    auto _v = configure(false, _tid);
     if(utility::get_thread_index() == 0) stop_duration_thread();
     return _v;
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1087,29 +1087,35 @@ setup()
     return configure(true);
 }
 
+void
+postfork_child_release_samplers()
+{
+    // release() rather than reset(): deliberately skips ~sampler_t() after fork().
+    auto* _samplers = sampler_instances::get();
+    if(!_samplers) return;
+    for(auto& itr : *_samplers)
+        itr.release();
+}
+
 std::set<int>
-shutdown(bool all_threads)
+shutdown()
 {
     if(is_child_process())
     {
+        // Only this thread's sampler may be released here: shutdown() runs from the
+        // destructor of every exiting thread, and is_child_process() stays true for the
+        // child's whole lifetime, so releasing the whole array would destroy samplers
+        // belonging to threads still inside configure().
         auto* _samplers = sampler_instances::get();
         if(_samplers)
         {
-            if(all_threads)
-            {
-                for(auto& itr : *_samplers)
-                    itr.release();
-            }
-            else
-            {
-                // stable_vector::at() throws when out of range and this runs from a
-                // thread destructor, where an escaping exception would terminate the
-                // process. The pthread gotcha bounds-checks against
-                // utility::get_thread_index(), which is a different counter from
-                // threading::get_id(), so verify the index explicitly here.
-                const auto _tid = static_cast<size_t>(threading::get_id());
-                if(_tid < sampler_instances::size()) _samplers->at(_tid).release();
-            }
+            // get_id() returns -1 when the id manager is gone, and offset
+            // (rocprof-sys-internal) thread ids count downward, so the id can be
+            // negative. Bounds-check before at(), which throws -- and an exception
+            // escaping a thread destructor terminates the process.
+            const auto _tid = threading::get_id();
+            if(_tid >= 0 && static_cast<size_t>(_tid) < _samplers->size())
+                _samplers->at(static_cast<size_t>(_tid)).release();
         }
         return std::set<int>{};
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1088,12 +1088,29 @@ setup()
 }
 
 std::set<int>
-shutdown()
+shutdown(bool all_threads)
 {
     if(is_child_process())
     {
-        for(auto& itr : *sampler_instances::get())
-            itr.release();
+        auto* _samplers = sampler_instances::get();
+        if(_samplers)
+        {
+            if(all_threads)
+            {
+                for(auto& itr : *_samplers)
+                    itr.release();
+            }
+            else
+            {
+                // stable_vector::at() throws when out of range and this runs from a
+                // thread destructor, where an escaping exception would terminate the
+                // process. The pthread gotcha bounds-checks against
+                // utility::get_thread_index(), which is a different counter from
+                // threading::get_id(), so verify the index explicitly here.
+                const auto _tid = static_cast<size_t>(threading::get_id());
+                if(_tid < sampler_instances::size()) _samplers->at(_tid).release();
+            }
+        }
         return std::set<int>{};
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
@@ -31,9 +31,9 @@ get_signal_types(std::int64_t _tid);
 std::set<int>
 setup();
 
-/// Deactivates sampling for the calling thread. Returns the thread's configured signal
-/// types; every current caller discards it. In a child process this releases only the
-/// calling thread's sampler -- see postfork_child_release_samplers() for the bulk case.
+/// Deactivates sampling for the calling thread. In a child process, releases only the
+/// calling thread's sampler and returns an empty set; otherwise returns the configured
+/// signal types. Every current caller discards the return value.
 std::set<int>
 shutdown();
 
@@ -56,12 +56,14 @@ postfork_parent_reinit();
 void
 postfork_child_cleanup();
 
-/// Releases the sampler slot of *every* thread. Fork-child only: the pre-fork threads do
-/// not exist in the child, but their sampler objects were inherited with the address
-/// space. Calling this from a live multi-threaded process destroys samplers belonging to
-/// threads still inside configure(), which then dereference null.
+/// Releases ownership of every inherited sampler slot without running destructors.
+/// Fork-child only: the pre-fork threads no longer exist in the child. Calling this from
+/// a live multi-threaded process clears sampler slots belonging to threads still inside
+/// configure(), which can then observe a null sampler.
+/// @note Exceptions must not escape the pthread_atfork() child handler; failures
+/// terminate.
 void
-postfork_child_release_samplers();
+postfork_child_release_samplers() noexcept;
 
 void
 prefork_lock_pmc_sampler();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
@@ -32,7 +32,7 @@ std::set<int>
 setup();
 
 std::set<int>
-shutdown();
+shutdown(bool all_threads = false);
 
 void
 block_samples();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
@@ -31,8 +31,11 @@ get_signal_types(std::int64_t _tid);
 std::set<int>
 setup();
 
+/// Deactivates sampling for the calling thread. Returns the thread's configured signal
+/// types; every current caller discards it. In a child process this releases only the
+/// calling thread's sampler -- see postfork_child_release_samplers() for the bulk case.
 std::set<int>
-shutdown(bool all_threads = false);
+shutdown();
 
 void
 block_samples();
@@ -52,6 +55,13 @@ postfork_parent_reinit();
 
 void
 postfork_child_cleanup();
+
+/// Releases the sampler slot of *every* thread. Fork-child only: the pre-fork threads do
+/// not exist in the child, but their sampler objects were inherited with the address
+/// space. Calling this from a live multi-threaded process destroys samplers belonging to
+/// threads still inside configure(), which then dereference null.
+void
+postfork_child_release_samplers();
 
 void
 prefork_lock_pmc_sampler();


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix a `rocprof-sys-sample` crash seen when profiling TransferBench through a Python launcher. The direct TransferBench binary path works, but the Python parent/child path can crash while child threads are setting up sampling.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
`sampling::shutdown()` used the same child-process path for two different cases: normal sampled thread exit and post-fork cleanup. In a forked child, an exiting thread could release every sampler slot, including slots owned by other live threads still inside `sampling::configure()`.

This PR separates the two cleanup paths:
- normal thread-exit shutdown releases only the current thread's sampler slot
- `postfork_child()` calls `postfork_child_release_samplers()` to release all inherited sampler slots after fork
- `sampling::shutdown()` derives the sampler index from the persistent `thread_info` record, avoiding a thread-local destruction-order dependency during teardown
- the child thread-exit path validates and bounds-checks the index before accessing sampler storage
- `sampling::shutdown()` keeps its existing signature

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID - AIPROFSYST-437

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Validated the reported TransferBench Python parent/child reproduction on an MI300X system using the latest PR commit. Also validated a fork-without-exec workload to cover the `postfork_child()` cleanup path. Repeated both affected paths in a local 2-GPU container.

## Test Result

<!-- Briefly summarize test outcomes. -->
MI300X TransferBench Python launcher:
- 5/5 runs completed successfully
- exit code: 0
- crash count: 0
- aggregate GPU bandwidth: 2688.511–2694.895 GB/s

MI300X fork-without-exec validation:
- 8 threads: 3/3 runs completed, crash=0, child rc=0
- 64 threads: 3/3 runs completed, crash=0, child rc=0

Local 2-GPU validation:
- build completed: 29/29 targets
- thread-exit path: 3/3 runs completed without crashes
- aggregate GPU bandwidth: 184.730–185.610 GB/s
- postfork path with 8 and 32 threads completed without crashes
- child exit code: 0

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

