### PR TITLE
test(rccl): add ext-mixed plugin tests and docs for single-object plugins

### DIFF
--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -63,6 +63,26 @@ jobs:
       therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
+  # ext-plugins suite on ruby: builds RCCL + rccl-tests + the example plugins,
+  # then runs test/ext-plugins pytest (mixed/tuner/profiler/...). Non-gating for
+  # now so a new suite cannot block merges while it is validated on the runner.
+  ext-plugins:
+    name: ext-plugins
+    uses: ./.github/workflows/rccl-suite.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      suite: ext-plugins
+      runs_on: '["ruby-linux-slurm-scale-runner"]'
+      partition: interactive
+      timeout_minutes: 120
+      non_gating: true
+      artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
+      artifact_run_id: ${{ inputs.artifact_run_id || '' }}
+      therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
+      amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
+
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
   # non_gating keeps test failures from blocking; build/infra failures gate via
   # gin-build-gate below. AICOMRCCL-1478: enable full gating once GIN lands in develop.

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -63,9 +63,10 @@ jobs:
       therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
-  # ext-plugins suite on ruby: builds RCCL + rccl-tests + the example plugins,
-  # then runs test/ext-plugins pytest (mixed/tuner/profiler/...). Non-gating for
-  # now so a new suite cannot block merges while it is validated on the runner.
+  # ext-plugins suite on ruby: builds RCCL, a UCX-enabled OpenMPI, rccl-tests and
+  # the tuner example plugin, then runs test/ext-plugins pytest for the mixed and
+  # CSV-tuner suites. Non-gating for now so a new suite cannot block merges while
+  # it is validated on the runner.
   ext-plugins:
     name: ext-plugins
     uses: ./.github/workflows/rccl-suite.yml
@@ -76,7 +77,7 @@ jobs:
       suite: ext-plugins
       runs_on: '["ruby-linux-slurm-scale-runner"]'
       partition: interactive
-      timeout_minutes: 120
+      timeout_minutes: 240
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -77,7 +77,7 @@ jobs:
       suite: ext-plugins
       runs_on: '["ruby-linux-slurm-scale-runner"]'
       partition: interactive
-      timeout_minutes: 240
+      timeout_minutes: 300
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -60,6 +60,7 @@ jobs:
       timeout_minutes: 240
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
+      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
       therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
@@ -67,8 +68,8 @@ jobs:
   # the tuner example plugin, then runs test/ext-plugins pytest for the mixed and
   # CSV-tuner suites. Non-gating for now so a new suite cannot block merges while
   # it is validated on the runner.
-  ext-plugins:
-    name: ext-plugins
+  rccl-ext-plugins:
+    name: rccl-ext-plugins
     uses: ./.github/workflows/rccl-suite.yml
     permissions:
       contents: read
@@ -81,7 +82,8 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
+      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
+      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
@@ -103,6 +105,7 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
+      # TheRock pinned ref committed 2026-08-26; bump when refreshing artifacts.
       therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -63,6 +63,26 @@ jobs:
       therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
+  # ext-plugins suite on ruby: builds RCCL + rccl-tests + the example plugins,
+  # then runs test/ext-plugins pytest (mixed/tuner/profiler/...). Non-gating for
+  # now so a new suite cannot block merges while it is validated on the runner.
+  ext-plugins:
+    name: ext-plugins
+    uses: ./.github/workflows/rccl-suite.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      suite: ext-plugins
+      runs_on: '["ruby-linux-slurm-scale-runner"]'
+      partition: interactive
+      timeout_minutes: 120
+      non_gating: true
+      artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
+      artifact_run_id: ${{ inputs.artifact_run_id || '' }}
+      therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
+      amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
+
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
   # non_gating keeps test failures from blocking; build/infra failures gate via
   # gin-build-gate below. AICOMRCCL-1478: enable full gating once GIN lands in develop.

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -63,9 +63,10 @@ jobs:
       therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
-  # ext-plugins suite on ruby: builds RCCL + rccl-tests + the example plugins,
-  # then runs test/ext-plugins pytest (mixed/tuner/profiler/...). Non-gating for
-  # now so a new suite cannot block merges while it is validated on the runner.
+  # ext-plugins suite on ruby: builds RCCL, a UCX-enabled OpenMPI, rccl-tests and
+  # the tuner example plugin, then runs test/ext-plugins pytest for the mixed and
+  # CSV-tuner suites. Non-gating for now so a new suite cannot block merges while
+  # it is validated on the runner.
   ext-plugins:
     name: ext-plugins
     uses: ./.github/workflows/rccl-suite.yml
@@ -76,7 +77,7 @@ jobs:
       suite: ext-plugins
       runs_on: '["ruby-linux-slurm-scale-runner"]'
       partition: interactive
-      timeout_minutes: 120
+      timeout_minutes: 240
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}

--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -80,6 +80,7 @@ on:
         options:
           - device-api
           - gin
+          - ext-plugins
       runs_on:
         description: 'Runner label(s) as a JSON array string.'
         type: string

--- a/projects/rccl/plugins/mixed/README.md
+++ b/projects/rccl/plugins/mixed/README.md
@@ -1,4 +1,57 @@
-# NCCL Mixed Plugin Documentation
+# RCCL Mixed Plugin
 
-The NCCL mixed plugin API is a combination of Net and Tuner plugin APIs. It demonstrates how
-different plugins can be combined into a single library.
+The mixed plugin demonstrates that a **single shared object can export more than one
+RCCL plugin type**. The example combines the network (net) and tuner plugin APIs in one
+library, but the same approach applies to other plugin types (for example, the profiler).
+
+This is useful when a vendor ships a network stack together with a matching tuner or
+profiler and wants to distribute and version them as one artifact instead of several
+separate `.so` files.
+
+## What the example contains
+
+`example/plugin.c` exports two versioned plugin symbols from one source file:
+
+- `ncclNetPlugin_v12` &mdash; the network plugin.
+- `ncclTunerPlugin_v6` &mdash; the tuner plugin.
+
+## Building
+
+```shell
+cd example
+make            # produces libnccl-mixed.so
+make test       # builds, then checks both plugin symbols are exported
+```
+
+You can also inspect the exported symbols directly:
+
+```shell
+nm -D libnccl-mixed.so | grep -E "NetPlugin|TunerPlugin"
+```
+
+## Using it at runtime
+
+Point RCCL at the mixed library through the network plugin variable, and leave the
+dedicated tuner/profiler variables unset so RCCL reuses the same object for them:
+
+```shell
+export NCCL_NET_PLUGIN=/path/to/libnccl-mixed.so
+unset NCCL_TUNER_PLUGIN
+unset NCCL_PROFILER_PLUGIN
+```
+
+With `NCCL_DEBUG=INFO` and `NCCL_DEBUG_SUBSYS=INIT,NET,TUNING`, the log shows both the
+net plugin and the tuner plugin being loaded from the same object:
+
+```text
+NET/Plugin: Loaded net plugin Plugin (v12)
+Successfully loaded external network plugin /path/to/libnccl-mixed.so
+TUNER/Plugin: Using Plugin (v6)
+```
+
+The example net plugin advertises zero devices, so a `Failed to initialize NET plugin`
+message is expected; it does not affect the tuner reuse being demonstrated.
+
+## Further reading
+
+- Automated tests: `test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py`

--- a/projects/rccl/plugins/tuner/example/plugin.c
+++ b/projects/rccl/plugins/tuner/example/plugin.c
@@ -439,7 +439,12 @@ __hidden ncclResult_t pluginGetCollInfo(void* context, ncclFunc_t collType, size
       }
     } else {
       if (ctx->logFunction) {
-        ctx->logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__,
+        // TRACE, like the other per-config diagnostics above: this fires once
+        // per config per collective, so at INFO a config file that matches
+        // nothing turned a single test into tens of MB of log (a 30-config file
+        // over a size sweep produced 265k of these lines / 57 MB). The
+        // per-callback outcome is still reported at INFO below.
+        ctx->logFunction(NCCL_LOG_TRACE, NCCL_TUNING, __FILE__, __LINE__,
                          "TUNER/ExamplePlugin: Config does not match - collType match=%d, size match=%d, nodes match=%d, ranks match=%d, pipeOps match=%d, regBuff match=%d",
                          config->collType == collType,
                          (nBytes >= config->minBytes && nBytes <= config->maxBytes),

--- a/projects/rccl/plugins/tuner/example/plugin.c
+++ b/projects/rccl/plugins/tuner/example/plugin.c
@@ -367,9 +367,6 @@ __hidden ncclResult_t pluginGetCollInfo(void* context, ncclFunc_t collType, size
                      collTypeToString(collType), nBytes, numPipeOps, regBuff, ctx->numConfigs);
   }
 
-  // Cast the collCostTable pointer to a 2D array to fix the segmentation fault
-  float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
-
   // Look for matching configuration
   for (int i = 0; i < ctx->numConfigs; i++) {
     TuningConfig* config = &ctx->configs[i];

--- a/projects/rccl/test/ext-plugins/README.md
+++ b/projects/rccl/test/ext-plugins/README.md
@@ -10,6 +10,8 @@ This directory contains automated tests for RCCL (ROCm Communication Collectives
 
 3. **Inspector Plugin**: Validates the inspector plugin that produces structured JSONL output for collective operations. Tests cover schema correctness, per-rank output files, timing source validation, and verbose event trace fields across single-node and multi-node configurations.
 
+4. **Mixed Plugin**: Validates that a single shared object can export multiple plugin types. It builds `plugins/mixed/example/libnccl-mixed.so` (net + tuner), checks that both plugin symbols are exported, and runs a collective to confirm RCCL loads both the net and tuner plugins from the same object (`ext-mixed`, marker `ext_mixed`).
+
 The tests are written in Python using the pytest framework, making it easy to run, maintain, and extend the test coverage.
 
 ## Directory Structure

--- a/projects/rccl/test/ext-plugins/assets/csv_confs/singlenode_config.conf
+++ b/projects/rccl/test/ext-plugins/assets/csv_confs/singlenode_config.conf
@@ -14,13 +14,15 @@ broadcast,65537,16777216,ring,ll128,4,1,8,-1,-1
 # Large broadcast: ring/simple (16M to 128M)
 broadcast,16777217,134217728,ring,simple,6,1,8,-1,-1
 
-# Single-node allgather configuration for 8 ranks, 1 node - use ring algorithm (supported for allgather) - 8B-128M
+# Single-node allgather configuration for 4 ranks, 1 node - use ring algorithm (supported for allgather) - 8B-128M
+# 4 and not 8 ranks: RCCL bypasses the tuner for allgather when nRanks % 8 == 0
+# (Direct AllGather), so the allgather tuner tests run at 4 ranks.
 # Small allgather: ring/ll (8 bytes to 64K)
-allgather,8,65536,ring,ll,2,1,8,-1,-1
+allgather,8,65536,ring,ll,2,1,4,-1,-1
 # Medium allgather: ring/ll128 (64K to 16M)
-allgather,65537,16777216,ring,ll128,4,1,8,-1,-1
+allgather,65537,16777216,ring,ll128,4,1,4,-1,-1
 # Large allgather: ring/simple (16M to 128M)
-allgather,16777217,134217728,ring,simple,6,1,8,-1,-1
+allgather,16777217,134217728,ring,simple,6,1,4,-1,-1
 
 # Single-node reduce configuration for 8 ranks, 1 node - use ring algorithm (supported for reduce) - 8B-128M
 # Small reduce: ring/ll (8 bytes to 64K)

--- a/projects/rccl/test/ext-plugins/assets/csv_confs/singlenode_config.conf
+++ b/projects/rccl/test/ext-plugins/assets/csv_confs/singlenode_config.conf
@@ -32,10 +32,12 @@ reduce,65537,16777216,ring,ll128,4,1,8,-1,-1
 # Large reduce: ring/simple (16M to 128M)
 reduce,16777217,134217728,ring,simple,6,1,8,-1,-1
 
-# Single-node reducescatter configuration for 8 ranks, 1 node - use ring algorithm (supported for reducescatter) - 8B-128M
+# Single-node reducescatter configuration for 4 ranks, 1 node - use ring algorithm (supported for reducescatter) - 8B-128M
+# 4 and not 8 ranks: RCCL bypasses the tuner for reducescatter when nRanks % 8 == 0
+# (Direct ReduceScatter), so the reducescatter tuner tests run at 4 ranks.
 # Small reducescatter: ring/ll (8 bytes to 64K)
-reducescatter,8,65536,ring,ll,2,1,8,-1,-1
+reducescatter,8,65536,ring,ll,2,1,4,-1,-1
 # Medium reducescatter: ring/ll128 (64K to 16M)
-reducescatter,65537,16777216,ring,ll128,4,1,8,-1,-1
+reducescatter,65537,16777216,ring,ll128,4,1,4,-1,-1
 # Large reducescatter: ring/simple (16M to 128M)
-reducescatter,16777217,134217728,ring,simple,6,1,8,-1,-1
+reducescatter,16777217,134217728,ring,simple,6,1,4,-1,-1

--- a/projects/rccl/test/ext-plugins/pytest.ini
+++ b/projects/rccl/test/ext-plugins/pytest.ini
@@ -5,6 +5,7 @@ markers =
     ext_profiler: marks tests related to Profiler Plugin
     ext_inspector: marks tests related to Inspector Plugin
     inspector_regression: marks NCCL inspector teardown/UAF regression tests (issue #2000)
+    ext_mixed: marks tests related to the Mixed Plugin (multiple plugin types in one shared object)
     allreduce: marks tests related to AllReduce collective
     broadcast: marks tests related to Broadcast collective
     reduce: marks tests related to Reduce collective

--- a/projects/rccl/test/ext-plugins/requirements.txt
+++ b/projects/rccl/test/ext-plugins/requirements.txt
@@ -1,2 +1,3 @@
 # Testing dependencies
 pytest
+pytest-timeout

--- a/projects/rccl/test/ext-plugins/tests/conftest.py
+++ b/projects/rccl/test/ext-plugins/tests/conftest.py
@@ -37,8 +37,23 @@ UNSUPPORTED_ALGO_PROTO_CONFIG = os.path.join(WORKDIR, "assets/csv_confs/unsuppor
 SINGLENODE_CONFIG = os.path.join(WORKDIR, "assets/csv_confs/singlenode_config.conf")
 MULTINODE_CONFIG = os.path.join(WORKDIR, "assets/csv_confs/multinode_config.conf")
 
-LOGDIR = os.path.join(WORKDIR, "logs")
+# The tuner tests write the full rccl-tests stdout (RCCL debug logging included)
+# to LOGDIR. On the Ruby CI runner the repo lives on a shared NFS mount where
+# that write is the dominant cost of the suite: the same broadcast run takes 5.9s
+# with the log on node-local disk and 865s with it on NFS. RCCL_EXT_PLUGINS_LOGDIR
+# lets the runner point the logs at node-local scratch; it must not be tied to a
+# particular user, since the CI job and a developer run as different users.
+LOGDIR = os.environ.get("RCCL_EXT_PLUGINS_LOGDIR") or os.path.join(WORKDIR, "logs")
 os.makedirs(LOGDIR, exist_ok=True)
+
+# rccl-tests sweep shared by every CSV tuner test. Those tests assert on the
+# tuner plugin's log output, not on bandwidth, so the sweep only has to cross
+# each size band the CSV configs declare (8B-64K, 64K-16M, 16M-128M). Stepping
+# by 8 spans all three in 9 sizes, and a single measured iteration is enough for
+# RCCL to consult the tuner. The previous "-f 2" sweep with the default 20
+# iterations ran ~525 collectives per test, and since the plugin logs a line per
+# config per call that produced hundreds of MB of debug output per suite run.
+TUNER_PERF_ARGS = ["-b", "8", "-e", "128M", "-f", "8", "-g", "1", "-n", "1", "-w", "1"]
 
 PROFILER_DUMP_DIR = os.path.join(WORKDIR, "profiler_dumps")
 INSPECTOR_DUMP_DIR = os.path.join(WORKDIR, "inspector_dumps")
@@ -184,6 +199,7 @@ def paths():
         SINGLENODE_CONFIG=SINGLENODE_CONFIG,
         MULTINODE_CONFIG=MULTINODE_CONFIG,
         LOGDIR=LOGDIR,
+        TUNER_PERF_ARGS=TUNER_PERF_ARGS,
         PROFILER_DUMP_DIR=PROFILER_DUMP_DIR,
         INSPECTOR_DUMP_DIR=INSPECTOR_DUMP_DIR,
         # Helper Functions for Ext-Tuner

--- a/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
@@ -126,7 +126,10 @@ def test_mixed_runtime_load(paths):
     """RCCL must load both net and tuner from the single mixed shared object.
 
     The plugin loader is a per-process property, so this runs the collective in a
-    single multi-GPU process (all_reduce_perf -g 2); no MPI launcher is required.
+    single multi-GPU process (all_reduce_perf -g 2). rccl-tests may be built with
+    MPI (USE_MPI=ON), in which case the binary calls MPI_Init and must be launched
+    via mpirun; when an OpenMPI is available it is run through `mpirun -np 1`,
+    otherwise (a non-MPI binary) it is run bare.
     """
     so_path = _build_mixed_plugin()
 
@@ -152,19 +155,36 @@ def test_mixed_runtime_load(paths):
         }
     )
 
-    args = [perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "2", "-n", "5", "-w", "2"]
+    perf_args = [perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "2", "-n", "5", "-w", "2"]
+
+    # A USE_MPI=ON rccl-tests binary calls MPI_Init and hangs if launched bare
+    # under OpenMPI 5.x (PMIx/PRTE). When an OpenMPI is available, launch the one
+    # process via `mpirun -np 1` so MPI initializes cleanly; the loader is still
+    # per-process, so a single rank with -g 2 exercises the reuse path just as a
+    # bare run would. mpirun forwards this env (NCCL_NET_PLUGIN etc.) to the rank.
+    mpirun = os.path.join(paths.OMPI_INSTALL_DIR, "bin", "mpirun")
+    if os.path.exists(mpirun):
+        env["PATH"] = f"{paths.OMPI_INSTALL_DIR}/bin:{env.get('PATH', '')}"
+        env["LD_LIBRARY_PATH"] = f"{paths.OMPI_INSTALL_DIR}/lib:{env['LD_LIBRARY_PATH']}"
+        args = [mpirun, "-np", "1"] + perf_args
+    else:
+        args = perf_args
 
     log_dir = os.path.join(paths.LOGDIR, "mixed_plugin_test_logs")
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "test_mixed_runtime_load.log")
     with open(log_file, "w") as logfile:
-        run = subprocess.run(
-            args,
-            env=env,
-            stdout=logfile,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-        )
+        try:
+            run = subprocess.run(
+                args,
+                env=env,
+                stdout=logfile,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"Mixed plugin collective run timed out after 300s, see {log_file}")
 
     with open(log_file) as logfile:
         log = logfile.read()

--- a/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
@@ -1,0 +1,195 @@
+# *************************************************************************
+#  * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#  *
+#  * See LICENSE.txt for license information
+#  ************************************************************************
+"""
+Tests for the RCCL "mixed" plugin, which demonstrates the NCCL feature
+"plugin system supports multiple plugin types from a single shared object".
+
+A single libnccl-mixed.so exports both a net plugin (ncclNetPlugin_vXX) and a
+tuner plugin (ncclTunerPlugin_vXX). When RCCL is pointed at this object via
+NCCL_NET_PLUGIN and no dedicated tuner plugin is configured, RCCL must:
+  1. load the net plugin from the object, and
+  2. re-use the SAME object for the tuner plugin (via ncclGetNetPluginLib),
+     instead of falling back to the built-in CSV tuner.
+
+There are two tests:
+  * test_mixed_symbols_exported - static, no GPU/MPI: builds the object and
+    checks both plugin symbols are exported (pytest port of plugins/mixed/example/test.sh).
+  * test_mixed_runtime_load - runtime: runs a real collective and asserts from
+    the RCCL debug log that net AND tuner were served from the single object.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+
+import pytest
+
+# Single owner of the mixed-example paths for this suite. Repo-relative from this
+# file at test/ext-plugins/tests/ext-mixed/ (four levels up to the repo root).
+MIXED_EXAMPLE_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "..", "plugins", "mixed", "example"
+    )
+)
+MIXED_SO = os.path.join(MIXED_EXAMPLE_DIR, "libnccl-mixed.so")
+INCLUDE_DIR = os.path.abspath(
+    os.path.join(MIXED_EXAMPLE_DIR, "..", "..", "..", "src", "include", "plugin")
+)
+
+# Built once per test session; both tests share the same artifact.
+_built_so = None
+
+
+def _expected_symbol(header, macro):
+    """Read the expected plugin symbol name from a plugin header (as test.sh does)."""
+    path = os.path.join(INCLUDE_DIR, header)
+    with open(path) as f:
+        for line in f:
+            if macro in line:
+                # e.g. '#define NCCL_NET_PLUGIN_SYMBOL ncclNetPlugin_v12'
+                token = line.split()[2]
+                return token.strip().strip('"')
+    return None
+
+
+def _build_mixed_plugin():
+    """Build libnccl-mixed.so from source once. Returns the .so path or skips."""
+    global _built_so
+    if _built_so is not None:
+        return _built_so
+
+    cc = os.environ.get("CC", "cc")
+    if shutil.which("make") is None or shutil.which(cc) is None:
+        pytest.skip(f"make/{cc} not available to build the mixed plugin")
+
+    build = subprocess.run(
+        ["make", "default"],
+        cwd=MIXED_EXAMPLE_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert (
+        build.returncode == 0
+    ), f"Failed to build mixed plugin:\nstdout:\n{build.stdout}\nstderr:\n{build.stderr}"
+    assert os.path.exists(MIXED_SO), f"Mixed plugin not produced at {MIXED_SO}"
+    _built_so = MIXED_SO
+    return MIXED_SO
+
+
+@pytest.mark.ext_mixed
+def test_mixed_symbols_exported():
+    """The single shared object must export both a net and a tuner plugin symbol."""
+    if shutil.which("nm") is None:
+        pytest.skip("nm not available to inspect exported symbols")
+    so_path = _build_mixed_plugin()
+
+    net_sym = _expected_symbol("nccl_net.h", "NCCL_NET_PLUGIN_SYMBOL")
+    tuner_sym = _expected_symbol("nccl_tuner.h", "NCCL_TUNER_PLUGIN_SYMBOL")
+    assert (
+        net_sym and tuner_sym
+    ), "Could not resolve expected plugin symbols from headers"
+
+    nm = subprocess.run(["nm", "-D", so_path], capture_output=True, text=True)
+    assert nm.returncode == 0, f"nm failed on {so_path}: {nm.stderr}"
+    exported = nm.stdout
+
+    assert re.search(
+        rf"\b{re.escape(net_sym)}\b", exported
+    ), f"Net plugin symbol {net_sym} not exported by {so_path}\n{exported}"
+    assert re.search(
+        rf"\b{re.escape(tuner_sym)}\b", exported
+    ), f"Tuner plugin symbol {tuner_sym} not exported by {so_path}\n{exported}"
+
+
+def _gpu_count():
+    """Best-effort count of ROCm GPUs; returns None if it cannot be determined."""
+    rocminfo = shutil.which("rocminfo")
+    if rocminfo is None:
+        return None
+    try:
+        out = subprocess.run(
+            [rocminfo], capture_output=True, text=True, timeout=30
+        ).stdout
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return sum(1 for line in out.splitlines() if re.search(r"Device Type:\s*GPU", line))
+
+
+@pytest.mark.ext_mixed
+@pytest.mark.allreduce
+def test_mixed_runtime_load(paths):
+    """RCCL must load both net and tuner from the single mixed shared object.
+
+    The plugin loader is a per-process property, so this runs the collective in a
+    single multi-GPU process (all_reduce_perf -g 2); no MPI launcher is required.
+    """
+    so_path = _build_mixed_plugin()
+
+    perf_bin = os.path.join(paths.RCCL_TESTS_DIR, "build", "all_reduce_perf")
+    if not os.path.exists(perf_bin):
+        pytest.skip(f"rccl-tests all_reduce_perf not found at: {perf_bin}")
+
+    ngpu = _gpu_count()
+    if ngpu is not None and ngpu < 2:
+        pytest.skip(f"need >=2 GPUs for the mixed runtime test, found {ngpu}")
+
+    env = os.environ.copy()
+    # Ensure the reuse path is exercised: no dedicated tuner/profiler plugin.
+    env.pop("NCCL_TUNER_PLUGIN", None)
+    env.pop("NCCL_PROFILER_PLUGIN", None)
+    env.update(
+        {
+            "LD_LIBRARY_PATH": f"{paths.RCCL_INSTALL_DIR}:{env.get('LD_LIBRARY_PATH', '')}",
+            "HSA_NO_SCRATCH_RECLAIM": "1",
+            "NCCL_NET_PLUGIN": so_path,
+            "NCCL_DEBUG": "INFO",
+            "NCCL_DEBUG_SUBSYS": "INIT,NET,TUNING",
+        }
+    )
+
+    args = [perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "2", "-n", "5", "-w", "2"]
+
+    log_dir = os.path.join(paths.LOGDIR, "mixed_plugin_test_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, "test_mixed_runtime_load.log")
+    with open(log_file, "w") as logfile:
+        run = subprocess.run(
+            args,
+            env=env,
+            stdout=logfile,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+
+    with open(log_file) as logfile:
+        log = logfile.read()
+
+    assert run.returncode == 0, f"Mixed plugin collective run failed, see {log_file}"
+
+    # 1) net plugin came from the mixed object specifically: require the object
+    #    path on the "Successfully loaded external network plugin" line.
+    assert re.search(
+        r"Successfully loaded external network plugin\b.*libnccl-mixed\.so", log
+    ), f"Net plugin was not loaded from the mixed object, see {log_file}"
+
+    # 2) tuner was served from the SAME object (reuse via ncclGetNetPluginLib):
+    #    a tuner is in use, but NOT via a dedicated tuner .so and NOT the built-in CSV.
+    assert (
+        "TUNER/Plugin: Using " in log
+    ), f"No external tuner was loaded, see {log_file}"
+    assert (
+        "Successfully loaded external tuner plugin" not in log
+    ), f"A dedicated tuner plugin was loaded instead of reusing the mixed object, see {log_file}"
+    assert (
+        "Using built-in CSV tuner" not in log
+    ), f"RCCL fell back to the built-in CSV tuner instead of the mixed object, see {log_file}"
+
+    # 3) collective correctness
+    assert (
+        "Out of bounds values" in log and "OK" in log
+    ), f"Collective did not validate correctly, see {log_file}"

--- a/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py
@@ -125,11 +125,12 @@ def _gpu_count():
 def test_mixed_runtime_load(paths):
     """RCCL must load both net and tuner from the single mixed shared object.
 
-    The plugin loader is a per-process property, so this runs the collective in a
-    single multi-GPU process (all_reduce_perf -g 2). rccl-tests may be built with
-    MPI (USE_MPI=ON), in which case the binary calls MPI_Init and must be launched
-    via mpirun; when an OpenMPI is available it is run through `mpirun -np 1`,
-    otherwise (a non-MPI binary) it is run bare.
+    Each process loads the plugins independently, so a 2-rank all_reduce exercises
+    the reuse path. rccl-tests may be built with MPI (USE_MPI=ON): that binary
+    calls MPI_Init and hangs if launched bare under OpenMPI 5.x (PMIx/PRTE), so
+    when an OpenMPI is available it is launched via `mpirun -np 2` with one GPU per
+    rank (-g 1), matching the device-api suite. Without OpenMPI (a non-MPI binary)
+    it runs bare in one process with two GPUs (-g 2) for the same 2-rank collective.
     """
     so_path = _build_mixed_plugin()
 
@@ -155,20 +156,20 @@ def test_mixed_runtime_load(paths):
         }
     )
 
-    perf_args = [perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "2", "-n", "5", "-w", "2"]
-
     # A USE_MPI=ON rccl-tests binary calls MPI_Init and hangs if launched bare
-    # under OpenMPI 5.x (PMIx/PRTE). When an OpenMPI is available, launch the one
-    # process via `mpirun -np 1` so MPI initializes cleanly; the loader is still
-    # per-process, so a single rank with -g 2 exercises the reuse path just as a
-    # bare run would. mpirun forwards this env (NCCL_NET_PLUGIN etc.) to the rank.
+    # under OpenMPI 5.x (PMIx/PRTE). When an OpenMPI is available, launch it via
+    # `mpirun -np 2` with one GPU per rank (-g 1), matching the device-api suite;
+    # mpirun forwards this env (NCCL_NET_PLUGIN etc.) to the ranks. Without an
+    # OpenMPI (a non-MPI binary), run bare in one process with two GPUs (-g 2) for
+    # the same 2-rank collective.
     mpirun = os.path.join(paths.OMPI_INSTALL_DIR, "bin", "mpirun")
     if os.path.exists(mpirun):
         env["PATH"] = f"{paths.OMPI_INSTALL_DIR}/bin:{env.get('PATH', '')}"
         env["LD_LIBRARY_PATH"] = f"{paths.OMPI_INSTALL_DIR}/lib:{env['LD_LIBRARY_PATH']}"
-        args = [mpirun, "-np", "1"] + perf_args
+        args = [mpirun, "-np", "2", "-x", "LD_LIBRARY_PATH",
+                perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "1", "-n", "5", "-w", "2"]
     else:
-        args = perf_args
+        args = [perf_bin, "-b", "8", "-e", "1M", "-f", "4", "-g", "2", "-n", "5", "-w", "2"]
 
     log_dir = os.path.join(paths.LOGDIR, "mixed_plugin_test_logs")
     os.makedirs(log_dir, exist_ok=True)

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_allgather.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_allgather.py
@@ -8,6 +8,17 @@ import os
 import subprocess
 import pytest
 
+# RCCL only routes AllGather through the tuner when the rank count is not a
+# multiple of 8. rcclUseAllGatherDirect() gates Direct AllGather on
+# `comm->nRanks % 8`, so at 8 ranks on a single node RCCL picks a specialized
+# AllGather that never calls the plugin's pluginGetCollInfo(). Measured on
+# MI350X: 8 ranks yields zero tuner callbacks for any config, size range or
+# value of RCCL_DIRECT_ALLGATHER_DISABLE / _THRESHOLD, while 4 ranks exercises
+# the tuner normally. The AllGather tuner tests therefore run at 4 ranks -- at 8
+# they cannot observe the plugin at all, so "no config applied" would hold
+# vacuously rather than because the plugin decided so.
+ALLGATHER_TUNER_RANKS = "4"
+
 @pytest.mark.ext_tuner
 @pytest.mark.allgather
 def test_valid_config_with_wildcards(paths):
@@ -29,10 +40,7 @@ def test_valid_config_with_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -85,10 +93,7 @@ def test_valid_config_without_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -124,7 +129,10 @@ def test_valid_config_without_wildcards(paths):
 @pytest.mark.ext_tuner
 @pytest.mark.allgather
 def test_no_matching_config(paths):
-    """Test CSV plugin behavior with no matching configurations"""
+    """Test CSV plugin behavior with no matching configurations
+
+    Runs at 4 ranks: see ALLGATHER_TUNER_RANKS.
+    """
 
     env = os.environ.copy()
     env.update({
@@ -138,14 +146,11 @@ def test_no_matching_config(paths):
     })
 
     args = [
-        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", "8",
+        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", ALLGATHER_TUNER_RANKS,
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -198,10 +203,7 @@ def test_incorrect_values_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -255,10 +257,7 @@ def test_unsupported_algo_proto_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "64",
-        "-e", "1M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -294,7 +293,11 @@ def test_unsupported_algo_proto_config(paths):
 @pytest.mark.ext_tuner
 @pytest.mark.allgather
 def test_singlenode_config(paths):
-    """Test CSV plugin with single-node configuration"""
+    """Test CSV plugin with single-node configuration
+
+    Runs at 4 ranks: see ALLGATHER_TUNER_RANKS. The allgather rows of
+    singlenode_config.conf are pinned to nodes=1,ranks=4 to match.
+    """
 
     env = os.environ.copy()
     env.update({
@@ -308,14 +311,11 @@ def test_singlenode_config(paths):
     })
 
     args = [
-        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", "8",
+        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", ALLGATHER_TUNER_RANKS,
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")
@@ -403,10 +403,7 @@ def test_multinode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_gather_perf",
-        "-b", "8",      
-        "-e", "128M",      
-        "-f", "2",       
-        "-g", "1",        
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allgather_log_dir = os.path.join(paths.LOGDIR, "allgather_csv_plugin_test_logs")

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_allreduce.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_allreduce.py
@@ -42,10 +42,7 @@ def test_valid_config_with_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -98,10 +95,7 @@ def test_valid_config_without_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -156,10 +150,7 @@ def test_no_matching_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -212,10 +203,7 @@ def test_incorrect_values_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -269,10 +257,7 @@ def test_unsupported_algo_proto_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -327,10 +312,7 @@ def test_singlenode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")
@@ -407,10 +389,7 @@ def test_multinode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/all_reduce_perf",
-        "-b", "8",       
-        "-e", "128M",      
-        "-f", "2",        
-        "-g", "1",        
+        *paths.TUNER_PERF_ARGS,
     ]
 
     allreduce_log_dir = os.path.join(paths.LOGDIR, "allreduce_csv_plugin_test_logs")

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_broadcast.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_broadcast.py
@@ -29,10 +29,7 @@ def test_valid_config_with_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -85,10 +82,7 @@ def test_valid_config_without_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -142,10 +136,7 @@ def test_no_matching_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -198,10 +189,7 @@ def test_incorrect_values_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -255,10 +243,7 @@ def test_unsupported_algo_proto_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -312,10 +297,7 @@ def test_singlenode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")
@@ -392,10 +374,7 @@ def test_multinode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/broadcast_perf",
-        "-b", "8",       
-        "-e", "128M",      
-        "-f", "2",        
-        "-g", "1",      
+        *paths.TUNER_PERF_ARGS,
     ]
 
     broadcast_log_dir = os.path.join(paths.LOGDIR, "broadcast_csv_plugin_test_logs")

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reduce.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reduce.py
@@ -29,10 +29,7 @@ def test_valid_config_with_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -85,10 +82,7 @@ def test_valid_config_without_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -142,10 +136,7 @@ def test_no_matching_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -198,10 +189,7 @@ def test_incorrect_values_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -255,10 +243,7 @@ def test_unsupported_algo_proto_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -312,10 +297,7 @@ def test_singlenode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")
@@ -392,10 +374,7 @@ def test_multinode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_perf",
-        "-b", "8",       # 64 bytes start (faster than 1 byte)
-        "-e", "128M",      # 64MB end (much smaller than 16GB)
-        "-f", "2",        # factor 4 (fewer size steps)
-        "-g", "1",        # gap 1
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reduce_log_dir = os.path.join(paths.LOGDIR, "reduce_csv_plugin_test_logs")

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reducescatter.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reducescatter.py
@@ -29,10 +29,7 @@ def test_valid_config_with_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -85,10 +82,7 @@ def test_valid_config_without_wildcards(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -142,10 +136,7 @@ def test_no_matching_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -198,10 +189,7 @@ def test_incorrect_values_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -255,10 +243,7 @@ def test_unsupported_algo_proto_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -312,10 +297,7 @@ def test_singlenode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",
-        "-e", "128M",
-        "-f", "2",
-        "-g", "1",
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")
@@ -392,10 +374,7 @@ def test_multinode_config(paths):
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
-        "-b", "8",       
-        "-e", "128M",      
-        "-f", "2",       
-        "-g", "1",       
+        *paths.TUNER_PERF_ARGS,
     ]
 
     reducescatter_log_dir = os.path.join(paths.LOGDIR, "reducescatter_csv_plugin_test_logs")

--- a/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reducescatter.py
+++ b/projects/rccl/test/ext-plugins/tests/ext-tuner/test_reducescatter.py
@@ -8,6 +8,16 @@ import os
 import subprocess
 import pytest
 
+# Like AllGather, RCCL only routes ReduceScatter through the tuner when the rank
+# count is not a multiple of 8: rcclUseReduceScatterDirect() gates Direct
+# ReduceScatter on `comm->nRanks % 8`, so at 8 ranks on a single node RCCL picks
+# a specialized ReduceScatter that never calls pluginGetCollInfo(). Measured on
+# MI350X: 8 ranks yields zero tuner callbacks, while 4 ranks exercises the tuner
+# normally. These tests therefore run at 4 ranks -- at 8 they cannot observe the
+# plugin at all, so "no config applied" would hold vacuously rather than because
+# the plugin decided so.
+REDUCESCATTER_TUNER_RANKS = "4"
+
 @pytest.mark.ext_tuner
 @pytest.mark.reducescatter
 def test_valid_config_with_wildcards(paths):
@@ -118,7 +128,10 @@ def test_valid_config_without_wildcards(paths):
 @pytest.mark.ext_tuner
 @pytest.mark.reducescatter
 def test_no_matching_config(paths):
-    """Test CSV plugin behavior with no matching configurations"""
+    """Test CSV plugin behavior with no matching configurations
+
+    Runs at 4 ranks: see REDUCESCATTER_TUNER_RANKS.
+    """
 
     env = os.environ.copy()
     env.update({
@@ -132,7 +145,7 @@ def test_no_matching_config(paths):
     })
 
     args = [
-        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", "8",
+        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", REDUCESCATTER_TUNER_RANKS,
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",
@@ -279,7 +292,11 @@ def test_unsupported_algo_proto_config(paths):
 @pytest.mark.ext_tuner
 @pytest.mark.reducescatter
 def test_singlenode_config(paths):
-    """Test CSV plugin with single-node configuration"""
+    """Test CSV plugin with single-node configuration
+
+    Runs at 4 ranks: see REDUCESCATTER_TUNER_RANKS. The reducescatter rows of
+    singlenode_config.conf are pinned to nodes=1,ranks=4 to match.
+    """
 
     env = os.environ.copy()
     env.update({
@@ -293,7 +310,7 @@ def test_singlenode_config(paths):
     })
 
     args = [
-        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", "8",
+        f"{paths.OMPI_INSTALL_DIR}/bin/mpirun", "-np", REDUCESCATTER_TUNER_RANKS,
         "--mca", "pml", "ucx",
         "--mca", "btl", "^vader,openib",
         f"{paths.RCCL_TESTS_DIR}/build/reduce_scatter_perf",

--- a/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
+++ b/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
@@ -14,7 +14,10 @@
 #   UCX_VERSION            UCX version (default: 1.17.0)
 #   OMPI_MAJOR_MINOR       OpenMPI major.minor (default: 5.0)
 #   OMPI_VERSION           OpenMPI patch version (default: 5.0.9)
-#   RCCL_BUILD_JOBS        Parallel build jobs (default: $(nproc))
+#   OMPI_UCX_BUILD_JOBS    Parallel build jobs for these builds. UCX and OpenMPI
+#                          are light C compiles (not memory-heavy like RCCL's C++),
+#                          so this defaults higher than the RCCL cap:
+#                          min(nproc, 64). Overridable via this env var.
 #   RCCL_DEVICE_API_WORKDIR / WORKDIR   Workspace root (for .ci-out output)
 
 set -euxo pipefail
@@ -22,7 +25,12 @@ set -euxo pipefail
 UCX_VERSION="${UCX_VERSION:-1.17.0}"
 OMPI_MAJOR_MINOR="${OMPI_MAJOR_MINOR:-5.0}"
 OMPI_VERSION="${OMPI_VERSION:-5.0.9}"
-build_jobs="${RCCL_BUILD_JOBS:-$(nproc)}"
+if [[ -n "${OMPI_UCX_BUILD_JOBS:-}" ]]; then
+  build_jobs="${OMPI_UCX_BUILD_JOBS}"
+else
+  _np="$(nproc)"
+  build_jobs=$(( _np < 64 ? _np : 64 ))
+fi
 
 WORKDIR="${RCCL_DEVICE_API_WORKDIR:-${WORKDIR:-}}"
 if [[ -z "${WORKDIR}" ]]; then

--- a/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
+++ b/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Build a UCX-enabled OpenMPI for the ext-plugins suite, ISOLATED from the shared
+# build-ompi.sh used by gin/device-api. The ext-tuner tests launch mpirun with
+# `--mca pml ucx`, which the shared OpenMPI (built without UCX) does not provide.
+#
+# Everything here lives under its own cache subtree and install paths
+# (${CACHE_DIR}/ext-plugins/...), so it never collides with or changes the
+# gin/device-api OpenMPI. Builds are cached and rebuilt only when missing.
+# Writes .ci-out/ompi-ucx.env with MPI_HOME plus the UCX runtime lib path.
+#
+# Environment:
+#   ROCM_PATH              ROCm tree to build against (REQUIRED only on a rebuild)
+#   RCCL_DEVICE_API_CACHE  Persistent cache root (default: /apps/rccl-ci)
+#   UCX_VERSION            UCX version (default: 1.17.0)
+#   OMPI_MAJOR_MINOR       OpenMPI major.minor (default: 5.0)
+#   OMPI_VERSION           OpenMPI patch version (default: 5.0.9)
+#   RCCL_BUILD_JOBS        Parallel build jobs (default: $(nproc))
+#   RCCL_DEVICE_API_WORKDIR / WORKDIR   Workspace root (for .ci-out output)
+
+set -euxo pipefail
+
+UCX_VERSION="${UCX_VERSION:-1.17.0}"
+OMPI_MAJOR_MINOR="${OMPI_MAJOR_MINOR:-5.0}"
+OMPI_VERSION="${OMPI_VERSION:-5.0.9}"
+build_jobs="${RCCL_BUILD_JOBS:-$(nproc)}"
+
+WORKDIR="${RCCL_DEVICE_API_WORKDIR:-${WORKDIR:-}}"
+if [[ -z "${WORKDIR}" ]]; then
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  WORKDIR="$(cd "${script_dir}/../../../.." && pwd)"
+fi
+
+CACHE_DIR="${RCCL_DEVICE_API_CACHE:-/apps/rccl-ci}"
+# Isolated subtree: nothing here is shared with the gin/device-api OpenMPI.
+ext_cache="${CACHE_DIR}/ext-plugins"
+downloads="${CACHE_DIR}/downloads"
+if ! mkdir -p "${ext_cache}/ucx" "${ext_cache}/ompi" "${downloads}"; then
+  echo "ERROR: cannot create cache dirs under ${CACHE_DIR} (is /apps writable?)" >&2
+  exit 1
+fi
+
+env_out="${WORKDIR}/.ci-out/ompi-ucx.env"
+mkdir -p "${WORKDIR}/.ci-out"
+
+UCX_INSTALL_DIR="${ext_cache}/ucx/install/${UCX_VERSION}"
+# Install dir tagged with the UCX version so a UCX bump forces an OpenMPI rebuild
+# and can never be confused with the shared (non-UCX) OpenMPI cache.
+OMPI_INSTALL_DIR="${ext_cache}/ompi/install/${OMPI_VERSION}-ucx${UCX_VERSION}"
+
+ucx_cached()  { [[ -f "${UCX_INSTALL_DIR}/lib/libucp.so" ]]; }
+ompi_cached() {
+  [[ -x "${OMPI_INSTALL_DIR}/bin/mpirun" ]] \
+    && [[ -f "${OMPI_INSTALL_DIR}/lib/libmpi.so" ]] \
+    && [[ -f "${OMPI_INSTALL_DIR}/lib/openmpi/mca_pml_ucx.so" ]]
+}
+
+do_build_ucx() {
+  echo "==> Building UCX ${UCX_VERSION} into ${UCX_INSTALL_DIR}"
+  rm -rf "${UCX_INSTALL_DIR}"; mkdir -p "${UCX_INSTALL_DIR}"
+  local src="${ext_cache}/ucx/src-${UCX_VERSION}.$$"
+  rm -rf "${src}"; mkdir -p "${src}"
+  local tar="${downloads}/ucx-${UCX_VERSION}.tar.gz"
+  [[ -f "${tar}" ]] || wget -q -O "${tar}" \
+    "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz"
+  tar -zxf "${tar}" -C "${src}" --strip-components=1
+  (
+    cd "${src}"
+    # Plain UCX is enough: MPI only uses it for its own bootstrap transport, RCCL
+    # drives the GPU collectives itself. Keep the dependency surface minimal.
+    ./configure --prefix="${UCX_INSTALL_DIR}" \
+        --without-java \
+        --disable-doxygen-doc \
+        --enable-optimizations
+    make -j"${build_jobs}"
+    make install
+  )
+  rm -rf "${src}"
+}
+
+do_build_ompi() {
+  : "${ROCM_PATH:?build-ompi-ucx.sh: ROCM_PATH must be set (source .ci-out/rocm.env first)}"
+  if [[ ! -x "${ROCM_PATH}/bin/hipcc" ]]; then
+    echo "ERROR: ROCM_PATH=${ROCM_PATH} has no bin/hipcc" >&2
+    exit 1
+  fi
+  echo "==> Building OpenMPI ${OMPI_VERSION} (--with-ucx=${UCX_INSTALL_DIR}) into ${OMPI_INSTALL_DIR}"
+  rm -rf "${OMPI_INSTALL_DIR}"; mkdir -p "${OMPI_INSTALL_DIR}"
+  local src="${ext_cache}/ompi/src-${OMPI_VERSION}.$$"
+  rm -rf "${src}"; mkdir -p "${src}"
+  local tar="${downloads}/openmpi-${OMPI_VERSION}.tar.gz"
+  [[ -f "${tar}" ]] || wget -q -O "${tar}" \
+    "https://download.open-mpi.org/release/open-mpi/v${OMPI_MAJOR_MINOR}/openmpi-${OMPI_VERSION}.tar.gz"
+  tar -zxf "${tar}" -C "${src}" --strip-components=1
+  (
+    cd "${src}"
+    ./configure --prefix="${OMPI_INSTALL_DIR}" \
+        --with-rocm="${ROCM_PATH}" \
+        --with-ucx="${UCX_INSTALL_DIR}" \
+        --disable-oshmem \
+        --disable-mpi-fortran \
+        --enable-orterun-prefix-by-default
+    make -j"${build_jobs}"
+    make install
+  )
+  rm -rf "${src}"
+  printf 'ompi=%s\nucx=%s\nbuilt_with_rocm=%s\n' \
+    "${OMPI_VERSION}" "${UCX_VERSION}" "${ROCM_PATH}" > "${OMPI_INSTALL_DIR}/.stamp"
+}
+
+# UCX first (OpenMPI links it), each guarded by a per-version lock so parallel
+# jobs serialize into the same install path; the inner re-check lets the loser
+# reuse what the winner produced.
+if ucx_cached; then
+  echo "==> Reusing cached UCX ${UCX_VERSION} at ${UCX_INSTALL_DIR}"
+else
+  exec {lock_fd}>"${downloads}/.lock-ucx-${UCX_VERSION}"
+  flock "${lock_fd}"
+  if ucx_cached; then
+    echo "==> Reusing cached UCX ${UCX_VERSION} at ${UCX_INSTALL_DIR}"
+  else
+    do_build_ucx
+  fi
+  flock -u "${lock_fd}"
+fi
+
+if ompi_cached; then
+  echo "==> Reusing cached UCX-enabled OpenMPI ${OMPI_VERSION} at ${OMPI_INSTALL_DIR}"
+else
+  exec {lock_fd}>"${downloads}/.lock-ompi-ucx-${OMPI_VERSION}-${UCX_VERSION}"
+  flock "${lock_fd}"
+  if ompi_cached; then
+    echo "==> Reusing cached UCX-enabled OpenMPI ${OMPI_VERSION} at ${OMPI_INSTALL_DIR}"
+  else
+    do_build_ompi
+  fi
+  flock -u "${lock_fd}"
+fi
+
+{
+  printf 'export MPI_HOME=%q\n' "${OMPI_INSTALL_DIR}"
+  printf 'export UCX_HOME=%q\n' "${UCX_INSTALL_DIR}"
+  # UCX runtime libs must be resolvable when mpirun selects `--mca pml ucx`.
+  printf 'export LD_LIBRARY_PATH=%q:%q:${LD_LIBRARY_PATH:-}\n' \
+    "${OMPI_INSTALL_DIR}/lib" "${UCX_INSTALL_DIR}/lib"
+} > "${env_out}"
+echo "==> Wrote ${env_out}"

--- a/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
+++ b/projects/rccl/tools/ci/lib/build-ompi-ucx.sh
@@ -57,9 +57,13 @@ OMPI_INSTALL_DIR="${ext_cache}/ompi/install/${OMPI_VERSION}-ucx${UCX_VERSION}"
 
 ucx_cached()  { [[ -f "${UCX_INSTALL_DIR}/lib/libucp.so" ]]; }
 ompi_cached() {
+  # OpenMPI 5.x links the UCX pml component into libmpi rather than shipping a
+  # standalone lib/openmpi/mca_pml_ucx.so, so a file check for that component
+  # never succeeds and would rebuild OpenMPI on every job. Gate on the .stamp
+  # written only after a successful `--with-ucx` build + install instead.
   [[ -x "${OMPI_INSTALL_DIR}/bin/mpirun" ]] \
     && [[ -f "${OMPI_INSTALL_DIR}/lib/libmpi.so" ]] \
-    && [[ -f "${OMPI_INSTALL_DIR}/lib/openmpi/mca_pml_ucx.so" ]]
+    && [[ -f "${OMPI_INSTALL_DIR}/.stamp" ]]
 }
 
 do_build_ucx() {

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -233,7 +233,11 @@ python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requir
 
 # conftest.py resolves assets/logs from the current working directory.
 cd "${ext_dir}"
-python3 -m pytest -v -rs --color=no -m "ext_mixed or ext_tuner"
+# Safety net: cap any single test at 10 min (pytest-timeout, signal method so it
+# interrupts a blocked subprocess). A hung test then fails fast instead of eating
+# the whole SLURM allocation, and the remaining tests still run.
+python3 -m pytest -v -rs --color=no --timeout=600 --timeout-method=signal \
+  -m "ext_mixed or ext_tuner"
 _pt "test:end"
 } > "${test_out}" 2> "${test_err}" || test_rc=$?
 echo "==> test phase logs: ${test_out} / ${test_err}"

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -13,16 +13,17 @@
 # On one multi-GPU node:
 #   1. consume ROCm (provisioned on the head node) via .ci-out/rocm.env
 #   2. projects/rccl  install.sh              build RCCL from PR sources
-#   3. projects/rccl-tests                    build all_reduce_perf (no MPI)
-#   4. test/ext-plugins                       run pytest -m ext_mixed
+#   3. lib/build-ompi-ucx.sh                  build a UCX-enabled OpenMPI (isolated)
+#   4. projects/rccl-tests                    build the *_perf binaries (with MPI)
+#   5. plugins/tuner/example                  build + install libnccl-tuner-example.so
+#   6. test/ext-plugins                       run pytest -m "ext_mixed or ext_tuner"
 #
-# Scope: only the mixed-plugin tests (the pytest port of
-# plugins/mixed/example/test.sh plus the new runtime check). They build their
-# own libnccl-mixed.so from in-tree headers and drive all_reduce_perf in a
-# single multi-GPU process, so they need no OpenMPI and no prebuilt example
-# plugins. The tuner/profiler/inspector suites need a full OpenMPI + every
-# *_perf binary (and cuda.h for the profiler/inspector examples); wiring those
-# in is a separate, heavier follow-up.
+# Scope: the mixed-plugin tests (the pytest port of plugins/mixed/example/test.sh
+# plus the new runtime check) and the CSV tuner tests. The tuner tests launch
+# mpirun with `--mca pml ucx`, so this suite uses its OWN UCX-enabled OpenMPI via
+# build-ompi-ucx.sh, kept fully isolated from the gin/device-api OpenMPI. The
+# profiler/inspector suites additionally need cuda.h for their example .so and
+# are left as a follow-up.
 #
 # Required env (from the workflow via `sbatch --export=ALL,...`):
 #   RCCL_DEVICE_API_WORKDIR   GHA workspace (rocm-systems root)
@@ -94,7 +95,7 @@ build_rc=0
 source "${ci_dir}/lib/ensure-python-yaml.sh"
 
 # 1) RCCL from the PR sources.
-echo "==> [1/3] build RCCL (targets=${gpu_targets})"
+echo "==> [1/5] build RCCL (targets=${gpu_targets})"
 rccl_src="${workdir}/projects/rccl"
 rm -rf "${rccl_prefix}"
 (
@@ -120,32 +121,68 @@ fi
 rccl_cmake_dir="$(dirname "${rccl_cfg}")"
 echo "    in-tree RCCL cmake config: ${rccl_cmake_dir}"
 
-# 2) rccl-tests: only all_reduce_perf is needed, run as a single multi-GPU
-# process (no MPI launcher), so build without MPI to keep it light.
-echo "==> [2/3] build rccl-tests (all_reduce_perf, no MPI)"
+# 2) UCX-enabled OpenMPI, isolated from the gin/device-api OpenMPI. The tuner
+# tests launch `mpirun --mca pml ucx`, which the shared build lacks.
+echo "==> [2/5] build UCX-enabled OpenMPI (isolated)"
+"${ci_dir}/lib/build-ompi-ucx.sh"
+set -a
+# shellcheck source=/dev/null
+source "${workdir}/.ci-out/ompi-ucx.env"
+set +a
+export PATH="${MPI_HOME}/bin:${PATH}"
+if [[ ! -x "${MPI_HOME}/bin/mpirun" ]]; then
+  echo "ERROR: no mpirun under ${MPI_HOME}/bin" >&2
+  exit 1
+fi
+
+# 3) rccl-tests WITH MPI: the tuner tests drive several collectives via mpirun,
+# so build all the *_perf binaries. Use -k so one failing target does not sink
+# the rest; the required binaries are checked explicitly below.
+echo "==> [3/5] build rccl-tests (*_perf, USE_MPI=ON)"
 rccl_tests_build="${rccl_tests_src}/build"
 rm -rf "${rccl_tests_build}"; mkdir -p "${rccl_tests_build}"
 (
   cd "${rccl_tests_build}"
-  cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=OFF \
+  cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=ON \
     -DRCCL_DIR="${rccl_cmake_dir}" \
-    -DCMAKE_PREFIX_PATH="${rccl_prefix}" \
+    -DCMAKE_PREFIX_PATH="${rccl_prefix};${MPI_HOME}" \
     -DGPU_TARGETS="${gpu_targets}" \
     ..
-  make -j"${build_jobs}" all_reduce_perf
+  make -j"${build_jobs}" -k || true
 )
-if [[ ! -x "${rccl_tests_build}/all_reduce_perf" ]]; then
-  echo "ERROR: all_reduce_perf not built under ${rccl_tests_build}" >&2
+missing=""
+for b in all_reduce_perf all_gather_perf broadcast_perf reduce_perf reduce_scatter_perf; do
+  [[ -x "${rccl_tests_build}/${b}" ]] || missing="${missing} ${b}"
+done
+if [[ -n "${missing}" ]]; then
+  echo "ERROR: rccl-tests missing perf binaries:${missing}" >&2
   ls -la "${rccl_tests_build}" 2>/dev/null >&2 || true
   exit 1
 fi
 
-# 3) Hand the install/test locations to the run stage. RCCL_INSTALL_DIR is used
-# by the mixed runtime test for LD_LIBRARY_PATH (librccl.so); RCCL_TESTS_DIR is
-# where it finds build/all_reduce_perf.
+# 4) CSV tuner example plugin. Installed where conftest.py expects it
+# (RCCL_INSTALL_DIR/plugins/tuner/example); its presence is also what makes
+# conftest run (not skip) the ext_tuner tests.
+echo "==> [4/5] build + install libnccl-tuner-example.so"
+tuner_src="${rccl_src}/plugins/tuner/example"
+tuner_dst="${rccl_install_dir}/plugins/tuner/example"
+make -C "${tuner_src}" -j"${build_jobs}" default
+tuner_so="$(find "${tuner_src}" -name libnccl-tuner-example.so -type f 2>/dev/null | head -n1)"
+if [[ -z "${tuner_so}" ]]; then
+  echo "ERROR: libnccl-tuner-example.so not produced under ${tuner_src}" >&2
+  exit 1
+fi
+mkdir -p "${tuner_dst}"
+cp -f "${tuner_so}" "${tuner_dst}/libnccl-tuner-example.so"
+echo "    installed -> ${tuner_dst}/libnccl-tuner-example.so"
+
+# 5) Hand the install/test locations to the run stage. RCCL_INSTALL_DIR is the
+# librccl.so dir and the plugin root; OMPI_INSTALL_DIR/UCX come from ompi-ucx.env
+# and are re-sourced there so the runtime LD_LIBRARY_PATH resolves UCX.
 {
   printf 'export RCCL_INSTALL_DIR=%q\n' "${rccl_install_dir}"
   printf 'export RCCL_TESTS_DIR=%q\n'   "${rccl_tests_src}"
+  printf 'export OMPI_INSTALL_DIR=%q\n' "${MPI_HOME}"
 } > "${workdir}/.ci-out/ext-plugins.env"
 ) > "${build_out}" 2> "${build_err}" || build_rc=$?
 echo "==> build phase logs: ${build_out} / ${build_err}"
@@ -163,13 +200,16 @@ fi
 # instead, which the workflow turns into a red (non-gating) result. ---
 test_rc=0
 {
-echo "==> [3/3] run ext-plugins pytest (-m ext_mixed)"
+echo "==> [5/5] run ext-plugins pytest (-m 'ext_mixed or ext_tuner')"
 set -a
+# shellcheck source=/dev/null
+source "${workdir}/.ci-out/ompi-ucx.env"
 # shellcheck source=/dev/null
 source "${workdir}/.ci-out/ext-plugins.env"
 set +a
 echo "    RCCL_INSTALL_DIR=${RCCL_INSTALL_DIR}"
 echo "    RCCL_TESTS_DIR=${RCCL_TESTS_DIR}"
+echo "    OMPI_INSTALL_DIR=${OMPI_INSTALL_DIR}"
 
 ext_dir="${workdir}/projects/rccl/test/ext-plugins"
 venv_dir="${workdir}/.ci-out/ext-plugins-venv"
@@ -180,7 +220,7 @@ python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requir
 
 # conftest.py resolves assets/logs from the current working directory.
 cd "${ext_dir}"
-python3 -m pytest -v -rs --color=no -m ext_mixed
+python3 -m pytest -v -rs --color=no -m "ext_mixed or ext_tuner"
 } > "${test_out}" 2> "${test_err}" || test_rc=$?
 echo "==> test phase logs: ${test_out} / ${test_err}"
 if [[ "${test_rc}" -ne 0 ]]; then

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -214,6 +214,10 @@ _tt0=$(date +%s)
 _pt(){ echo "PHASE_TS $1 epoch=$(date +%s) iso=$(date -Is) elapsed=$(( $(date +%s) - _tt0 ))s"; }
 _pt "test:start"
 echo "==> [5/5] run ext-plugins pytest (-m 'ext_mixed or ext_tuner')"
+# UCX mpirun registers RDMA memory via ibv_reg_mr; SLURM jobs submitted from the
+# GHA runner often inherit RLIMIT_MEMLOCK=8192 kB. Raise it for pytest/mpirun.
+ulimit -l unlimited 2>/dev/null || echo "WARN: could not raise RLIMIT_MEMLOCK (ulimit -l)"
+echo "==> RLIMIT_MEMLOCK (ulimit -l) = $(ulimit -l)"
 set -a
 # shellcheck source=/dev/null
 source "${workdir}/.ci-out/ompi-ucx.env"

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=rccl-ext-plugins
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --partition=interactive
+#SBATCH --exclusive
+#SBATCH --time=02:00:00
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+#
+# Compute-node orchestrator for the RCCL ext-plugins CI suite, invoked from
+# .github/workflows/rccl-suite.yml (suite=ext-plugins) via submit_slurm_job.py.
+# On one multi-GPU node:
+#   1. consume ROCm (provisioned on the head node) via .ci-out/rocm.env
+#   2. projects/rccl  install.sh              build RCCL from PR sources
+#   3. projects/rccl-tests                    build all_reduce_perf (no MPI)
+#   4. plugins/{tuner,profiler,inspector}     build the example plugins and
+#      install their .so where the pytest harness (conftest.py) expects them
+#   5. test/ext-plugins                       run pytest (mixed/tuner/profiler/...)
+#
+# The mixed-plugin tests build their own libnccl-mixed.so from in-tree headers,
+# so they run even if the prebuilt example .so's above fail to build (those
+# suites simply skip on the missing .so, per conftest.py).
+#
+# Required env (from the workflow via `sbatch --export=ALL,...`):
+#   RCCL_DEVICE_API_WORKDIR   GHA workspace (rocm-systems root)
+# Optional env:
+#   RCCL_AMDGPU_TARGETS       GPU arch (default: gfx950)
+
+set -euo pipefail
+
+echo "=== sbatch ext-plugins on $(hostname) ==="
+date -Is
+env | grep -E '^SLURM_' | sort || true
+echo
+
+workdir="${RCCL_DEVICE_API_WORKDIR:?RCCL_DEVICE_API_WORKDIR must be exported from the workflow}"
+cd "${workdir}"
+
+ci_dir="${workdir}/projects/rccl/tools/ci"
+gpu_targets="${RCCL_AMDGPU_TARGETS:-gfx950}"
+
+# Phase-split logs into build-%j and test-%j (SLURM_SUBMIT_DIR = the *-logs dir).
+logs_dir="${SLURM_SUBMIT_DIR:-$(pwd)}"
+jid="${SLURM_JOB_ID:-local}"
+build_out="${logs_dir}/build-${jid}.out"; build_err="${logs_dir}/build-${jid}.err"
+test_out="${logs_dir}/test-${jid}.out";   test_err="${logs_dir}/test-${jid}.err"
+
+# Cap parallelism (nodes report nproc=384; -j384 thrashes the C++ compile).
+if [[ -z "${RCCL_BUILD_JOBS:-}" ]]; then
+  nproc_count="$(nproc)"
+  RCCL_BUILD_JOBS=$(( nproc_count < 32 ? nproc_count : 32 ))
+fi
+export RCCL_BUILD_JOBS
+build_jobs="${RCCL_BUILD_JOBS}"
+
+# ROCm floor (provisioned on the head node from TheRock artifacts). Sourced at
+# top level so BOTH the build and test phases inherit ROCM_PATH/PATH/lib paths;
+# the runtime pytest (all_reduce_perf) needs the ROCm runtime libraries too.
+rocm_env="${workdir}/.ci-out/rocm.env"
+if [[ ! -f "${rocm_env}" ]]; then
+  echo "ERROR: ${rocm_env} not found. The workflow must run 'Provision ROCm" >&2
+  echo "       from TheRock artifacts' on the head node before sbatch." >&2
+  exit 1
+fi
+set -a
+# shellcheck source=/dev/null
+source "${rocm_env}"
+set +a
+if [[ ! -x "${ROCM_PATH:-}/bin/hipcc" ]]; then
+  echo "ERROR: ROCM_PATH='${ROCM_PATH:-}' (from rocm.env) has no bin/hipcc" >&2
+  exit 1
+fi
+echo "    ROCM_PATH=${ROCM_PATH} ROCM_RELEASE=${ROCM_RELEASE:-<unset>}"
+export HIP_PATH="${ROCM_PATH}"
+export PATH="${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}"
+export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+export CMAKE_PREFIX_PATH="${ROCM_PATH}/lib/cmake:${ROCM_PATH}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+
+rccl_prefix="${workdir}/.ci-out/rccl-install"
+# conftest.py reads RCCL_INSTALL_DIR both as the librccl.so dir (LD_LIBRARY_PATH)
+# and as the plugin root (RCCL_INSTALL_DIR/plugins/...), so it points at lib/.
+rccl_install_dir="${rccl_prefix}/lib"
+rccl_tests_src="${workdir}/projects/rccl-tests"
+
+# --- build phase -> build-%j.{out,err}. Runs in a subshell so any failure (a
+# hard `exit` or a set -e abort) is caught below and skips the test phase. ---
+build_rc=0
+(
+# Ensure `import yaml` works for the RCCL build (some cmake steps need it).
+# shellcheck source=/dev/null
+source "${ci_dir}/lib/ensure-python-yaml.sh"
+
+# 1) RCCL from the PR sources.
+echo "==> [1/4] build RCCL (targets=${gpu_targets})"
+rccl_src="${workdir}/projects/rccl"
+rm -rf "${rccl_prefix}"
+(
+  cd "${rccl_src}"
+  ./install.sh -j "${build_jobs}" \
+    --amdgpu_targets="${gpu_targets}" \
+    --prefix="${rccl_prefix}" \
+    --no_clean
+)
+if [[ ! -f "${rccl_install_dir}/librccl.so" && ! -f "${rccl_install_dir}/librccl.so.1" ]]; then
+  echo "ERROR: no librccl.so under ${rccl_install_dir}" >&2
+  ls -la "${rccl_install_dir}" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# Locate the in-tree RCCL CMake package config so rccl-tests links THIS build
+# rather than any RCCL under the ROCm floor (same pin the gin suite uses).
+rccl_cfg="$(ls "${rccl_prefix}"/lib*/cmake/rccl/*[Cc]onfig.cmake 2>/dev/null | head -n1)"
+if [[ -z "${rccl_cfg}" ]]; then
+  echo "ERROR: no RCCL cmake config under ${rccl_prefix}/lib*/cmake/rccl" >&2
+  exit 1
+fi
+rccl_cmake_dir="$(dirname "${rccl_cfg}")"
+echo "    in-tree RCCL cmake config: ${rccl_cmake_dir}"
+
+# 2) rccl-tests: only all_reduce_perf is needed, run as a single multi-GPU
+# process (no MPI launcher), so build without MPI to keep it light.
+echo "==> [2/4] build rccl-tests (all_reduce_perf, no MPI)"
+rccl_tests_build="${rccl_tests_src}/build"
+rm -rf "${rccl_tests_build}"; mkdir -p "${rccl_tests_build}"
+(
+  cd "${rccl_tests_build}"
+  cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=OFF \
+    -DRCCL_DIR="${rccl_cmake_dir}" \
+    -DCMAKE_PREFIX_PATH="${rccl_prefix}" \
+    -DGPU_TARGETS="${gpu_targets}" \
+    ..
+  make -j"${build_jobs}" all_reduce_perf
+)
+if [[ ! -x "${rccl_tests_build}/all_reduce_perf" ]]; then
+  echo "ERROR: all_reduce_perf not built under ${rccl_tests_build}" >&2
+  ls -la "${rccl_tests_build}" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# 3) Example plugins. Build each and install the produced .so where conftest.py
+# looks for it. Best-effort: a plugin that fails to build only makes its own
+# suite skip (missing .so), it does not fail the whole run. The mixed tests do
+# not depend on these; they build libnccl-mixed.so from source at test time.
+echo "==> [3/4] build + install example plugins"
+plugins_dir="${rccl_src}/plugins"
+install_plugin() {
+  # $1 = source subdir under plugins/, $2 = expected .so name,
+  # $3 = install subdir under ${rccl_install_dir}/plugins/, $@4.. = make args
+  local src="${plugins_dir}/$1" so_name="$2" dst="${rccl_install_dir}/plugins/$3"
+  shift 3
+  echo "    -- ${so_name} (from plugins/$(basename "${src}"))"
+  if ! make -C "${src}" -j"${build_jobs}" "$@"; then
+    echo "    WARNING: build failed for ${so_name}; its tests will skip." >&2
+    return 0
+  fi
+  local produced
+  produced="$(find "${src}" -name "${so_name}" -type f 2>/dev/null | head -n1)"
+  if [[ -z "${produced}" ]]; then
+    echo "    WARNING: ${so_name} not produced; its tests will skip." >&2
+    return 0
+  fi
+  mkdir -p "${dst}"
+  cp -f "${produced}" "${dst}/${so_name}"
+  echo "       installed -> ${dst}/${so_name}"
+}
+
+install_plugin "tuner/example"      "libnccl-tuner-example.so"     "tuner/example"    default
+install_plugin "profiler/example"   "librccl-profiler-example.so"  "profiler/example" build
+# The inspector Makefile checks CUDA_HOME; point it at the ROCm floor. Still
+# best-effort (extra deps), so a failure just skips the inspector tests.
+CUDA_HOME="${ROCM_PATH}" install_plugin "profiler/inspector" "librccl-profiler-inspector.so" "profiler/inspector"
+
+# 4) Hand the install/test locations to the run stage.
+{
+  printf 'export RCCL_INSTALL_DIR=%q\n' "${rccl_install_dir}"
+  printf 'export RCCL_TESTS_DIR=%q\n'   "${rccl_tests_src}"
+} > "${workdir}/.ci-out/ext-plugins.env"
+) > "${build_out}" 2> "${build_err}" || build_rc=$?
+echo "==> build phase logs: ${build_out} / ${build_err}"
+
+# Skip the test phase if the build failed (testing a broken build is pointless).
+if [[ "${build_rc}" -ne 0 ]]; then
+  echo "ERROR: build phase failed (rc=${build_rc}); skipping ext-plugins tests." >&2
+  echo "----- last 60 lines of ${build_err} -----" >&2
+  tail -n 60 "${build_err}" >&2 || true
+  exit "${build_rc}"
+fi
+
+# --- test phase -> test-%j.{out,err}. Don't fail the sbatch on test failures
+# (that would look like a build/infra failure); drop a `tests-failed` sentinel
+# instead, which the workflow turns into a red (non-gating) result. ---
+test_rc=0
+{
+echo "==> [4/4] run ext-plugins pytest"
+set -a
+# shellcheck source=/dev/null
+source "${workdir}/.ci-out/ext-plugins.env"
+set +a
+echo "    RCCL_INSTALL_DIR=${RCCL_INSTALL_DIR}"
+echo "    RCCL_TESTS_DIR=${RCCL_TESTS_DIR}"
+
+ext_dir="${workdir}/projects/rccl/test/ext-plugins"
+venv_dir="${workdir}/.ci-out/ext-plugins-venv"
+python3 -m venv --system-site-packages "${venv_dir}"
+# shellcheck source=/dev/null
+source "${venv_dir}/bin/activate"
+python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requirements.txt"
+
+# conftest.py resolves assets/logs from the current working directory.
+cd "${ext_dir}"
+python3 -m pytest -v -rs --color=no
+} > "${test_out}" 2> "${test_err}" || test_rc=$?
+echo "==> test phase logs: ${test_out} / ${test_err}"
+if [[ "${test_rc}" -ne 0 ]]; then
+  echo "ext-plugins tests failed (rc=${test_rc}); non-gating (sentinel written)." >&2
+  # Capture pytest's short summary into the sentinel so the workflow can show
+  # exactly which tests failed, not just a red check.
+  sed -n '/=* short test summary info =*/,$p' "${test_out}" > "${logs_dir}/tests-failed" 2>/dev/null || true
+  [[ -s "${logs_dir}/tests-failed" ]] \
+    || echo "ext-plugins tests failed (rc=${test_rc}); see the test log group." > "${logs_dir}/tests-failed"
+fi

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #SBATCH --job-name=rccl-ext-plugins
 #SBATCH --nodes=1
-#SBATCH --ntasks=1
+#SBATCH --ntasks=8
 #SBATCH --partition=interactive
 #SBATCH --exclusive
 #SBATCH --time=04:00:00

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -14,13 +14,15 @@
 #   1. consume ROCm (provisioned on the head node) via .ci-out/rocm.env
 #   2. projects/rccl  install.sh              build RCCL from PR sources
 #   3. projects/rccl-tests                    build all_reduce_perf (no MPI)
-#   4. plugins/{tuner,profiler,inspector}     build the example plugins and
-#      install their .so where the pytest harness (conftest.py) expects them
-#   5. test/ext-plugins                       run pytest (mixed/tuner/profiler/...)
+#   4. test/ext-plugins                       run pytest -m ext_mixed
 #
-# The mixed-plugin tests build their own libnccl-mixed.so from in-tree headers,
-# so they run even if the prebuilt example .so's above fail to build (those
-# suites simply skip on the missing .so, per conftest.py).
+# Scope: only the mixed-plugin tests (the pytest port of
+# plugins/mixed/example/test.sh plus the new runtime check). They build their
+# own libnccl-mixed.so from in-tree headers and drive all_reduce_perf in a
+# single multi-GPU process, so they need no OpenMPI and no prebuilt example
+# plugins. The tuner/profiler/inspector suites need a full OpenMPI + every
+# *_perf binary (and cuda.h for the profiler/inspector examples); wiring those
+# in is a separate, heavier follow-up.
 #
 # Required env (from the workflow via `sbatch --export=ALL,...`):
 #   RCCL_DEVICE_API_WORKDIR   GHA workspace (rocm-systems root)
@@ -92,7 +94,7 @@ build_rc=0
 source "${ci_dir}/lib/ensure-python-yaml.sh"
 
 # 1) RCCL from the PR sources.
-echo "==> [1/4] build RCCL (targets=${gpu_targets})"
+echo "==> [1/3] build RCCL (targets=${gpu_targets})"
 rccl_src="${workdir}/projects/rccl"
 rm -rf "${rccl_prefix}"
 (
@@ -120,7 +122,7 @@ echo "    in-tree RCCL cmake config: ${rccl_cmake_dir}"
 
 # 2) rccl-tests: only all_reduce_perf is needed, run as a single multi-GPU
 # process (no MPI launcher), so build without MPI to keep it light.
-echo "==> [2/4] build rccl-tests (all_reduce_perf, no MPI)"
+echo "==> [2/3] build rccl-tests (all_reduce_perf, no MPI)"
 rccl_tests_build="${rccl_tests_src}/build"
 rm -rf "${rccl_tests_build}"; mkdir -p "${rccl_tests_build}"
 (
@@ -138,40 +140,9 @@ if [[ ! -x "${rccl_tests_build}/all_reduce_perf" ]]; then
   exit 1
 fi
 
-# 3) Example plugins. Build each and install the produced .so where conftest.py
-# looks for it. Best-effort: a plugin that fails to build only makes its own
-# suite skip (missing .so), it does not fail the whole run. The mixed tests do
-# not depend on these; they build libnccl-mixed.so from source at test time.
-echo "==> [3/4] build + install example plugins"
-plugins_dir="${rccl_src}/plugins"
-install_plugin() {
-  # $1 = source subdir under plugins/, $2 = expected .so name,
-  # $3 = install subdir under ${rccl_install_dir}/plugins/, $@4.. = make args
-  local src="${plugins_dir}/$1" so_name="$2" dst="${rccl_install_dir}/plugins/$3"
-  shift 3
-  echo "    -- ${so_name} (from plugins/$(basename "${src}"))"
-  if ! make -C "${src}" -j"${build_jobs}" "$@"; then
-    echo "    WARNING: build failed for ${so_name}; its tests will skip." >&2
-    return 0
-  fi
-  local produced
-  produced="$(find "${src}" -name "${so_name}" -type f 2>/dev/null | head -n1)"
-  if [[ -z "${produced}" ]]; then
-    echo "    WARNING: ${so_name} not produced; its tests will skip." >&2
-    return 0
-  fi
-  mkdir -p "${dst}"
-  cp -f "${produced}" "${dst}/${so_name}"
-  echo "       installed -> ${dst}/${so_name}"
-}
-
-install_plugin "tuner/example"      "libnccl-tuner-example.so"     "tuner/example"    default
-install_plugin "profiler/example"   "librccl-profiler-example.so"  "profiler/example" build
-# The inspector Makefile checks CUDA_HOME; point it at the ROCm floor. Still
-# best-effort (extra deps), so a failure just skips the inspector tests.
-CUDA_HOME="${ROCM_PATH}" install_plugin "profiler/inspector" "librccl-profiler-inspector.so" "profiler/inspector"
-
-# 4) Hand the install/test locations to the run stage.
+# 3) Hand the install/test locations to the run stage. RCCL_INSTALL_DIR is used
+# by the mixed runtime test for LD_LIBRARY_PATH (librccl.so); RCCL_TESTS_DIR is
+# where it finds build/all_reduce_perf.
 {
   printf 'export RCCL_INSTALL_DIR=%q\n' "${rccl_install_dir}"
   printf 'export RCCL_TESTS_DIR=%q\n'   "${rccl_tests_src}"
@@ -192,7 +163,7 @@ fi
 # instead, which the workflow turns into a red (non-gating) result. ---
 test_rc=0
 {
-echo "==> [4/4] run ext-plugins pytest"
+echo "==> [3/3] run ext-plugins pytest (-m ext_mixed)"
 set -a
 # shellcheck source=/dev/null
 source "${workdir}/.ci-out/ext-plugins.env"
@@ -209,7 +180,7 @@ python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requir
 
 # conftest.py resolves assets/logs from the current working directory.
 cd "${ext_dir}"
-python3 -m pytest -v -rs --color=no
+python3 -m pytest -v -rs --color=no -m ext_mixed
 } > "${test_out}" 2> "${test_err}" || test_rc=$?
 echo "==> test phase logs: ${test_out} / ${test_err}"
 if [[ "${test_rc}" -ne 0 ]]; then

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -4,7 +4,7 @@
 #SBATCH --ntasks=1
 #SBATCH --partition=interactive
 #SBATCH --exclusive
-#SBATCH --time=02:00:00
+#SBATCH --time=04:00:00
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
 #

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -237,12 +237,31 @@ python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requir
 
 # conftest.py resolves assets/logs from the current working directory.
 cd "${ext_dir}"
+
+# Each tuner test captures the whole rccl-tests stdout, RCCL debug logging
+# included. ${workdir} lives on the shared NFS mount the GHA runner uses, and
+# writing those logs there is what dominates the suite runtime: the same
+# broadcast run takes 5.9s with its 57 MB log on node-local disk and 865s with it
+# on that NFS. Keep the logs node-local (world-writable /tmp, so this works for
+# any user the job runs as) and copy them back afterwards for artifact upload.
+export RCCL_EXT_PLUGINS_LOGDIR="${SLURM_TMPDIR:-/tmp}/rccl-ext-plugins-logs-${jid}"
+rm -rf "${RCCL_EXT_PLUGINS_LOGDIR}"
+mkdir -p "${RCCL_EXT_PLUGINS_LOGDIR}"
+echo "    RCCL_EXT_PLUGINS_LOGDIR=${RCCL_EXT_PLUGINS_LOGDIR}"
+
 # Safety net: cap any single test at 10 min (pytest-timeout, signal method so it
 # interrupts a blocked subprocess). A hung test then fails fast instead of eating
 # the whole SLURM allocation, and the remaining tests still run.
+pytest_rc=0
 python3 -m pytest -v -rs --color=no --timeout=600 --timeout-method=signal \
-  -m "ext_mixed or ext_tuner"
+  -m "ext_mixed or ext_tuner" || pytest_rc=$?
+
+mkdir -p "${ext_dir}/logs"
+cp -r "${RCCL_EXT_PLUGINS_LOGDIR}/." "${ext_dir}/logs/" 2>/dev/null || true
+echo "==> test logs copied to ${ext_dir}/logs ($(du -sh "${ext_dir}/logs" 2>/dev/null | cut -f1))"
 _pt "test:end"
+# Make pytest's status the status of this block so the sentinel logic below runs.
+(exit "${pytest_rc}")
 } > "${test_out}" 2> "${test_err}" || test_rc=$?
 echo "==> test phase logs: ${test_out} / ${test_err}"
 if [[ "${test_rc}" -ne 0 ]]; then

--- a/projects/rccl/tools/ci/lib/ext-plugins.sbatch
+++ b/projects/rccl/tools/ci/lib/ext-plugins.sbatch
@@ -94,7 +94,13 @@ build_rc=0
 # shellcheck source=/dev/null
 source "${ci_dir}/lib/ensure-python-yaml.sh"
 
+# Per-phase wall-clock marks. Embedded in the build log so the CI job can report
+# exactly how long each build step took (independent of when logs are dumped).
+_bt0=$(date +%s)
+_pt(){ echo "PHASE_TS $1 epoch=$(date +%s) iso=$(date -Is) elapsed=$(( $(date +%s) - _bt0 ))s"; }
+
 # 1) RCCL from the PR sources.
+_pt "build:rccl:start"
 echo "==> [1/5] build RCCL (targets=${gpu_targets})"
 rccl_src="${workdir}/projects/rccl"
 rm -rf "${rccl_prefix}"
@@ -123,6 +129,7 @@ echo "    in-tree RCCL cmake config: ${rccl_cmake_dir}"
 
 # 2) UCX-enabled OpenMPI, isolated from the gin/device-api OpenMPI. The tuner
 # tests launch `mpirun --mca pml ucx`, which the shared build lacks.
+_pt "build:ompi-ucx:start"
 echo "==> [2/5] build UCX-enabled OpenMPI (isolated)"
 "${ci_dir}/lib/build-ompi-ucx.sh"
 set -a
@@ -138,6 +145,7 @@ fi
 # 3) rccl-tests WITH MPI: the tuner tests drive several collectives via mpirun,
 # so build all the *_perf binaries. Use -k so one failing target does not sink
 # the rest; the required binaries are checked explicitly below.
+_pt "build:rccl-tests:start"
 echo "==> [3/5] build rccl-tests (*_perf, USE_MPI=ON)"
 rccl_tests_build="${rccl_tests_src}/build"
 rm -rf "${rccl_tests_build}"; mkdir -p "${rccl_tests_build}"
@@ -163,6 +171,7 @@ fi
 # 4) CSV tuner example plugin. Installed where conftest.py expects it
 # (RCCL_INSTALL_DIR/plugins/tuner/example); its presence is also what makes
 # conftest run (not skip) the ext_tuner tests.
+_pt "build:tuner-so:start"
 echo "==> [4/5] build + install libnccl-tuner-example.so"
 tuner_src="${rccl_src}/plugins/tuner/example"
 tuner_dst="${rccl_install_dir}/plugins/tuner/example"
@@ -184,6 +193,7 @@ echo "    installed -> ${tuner_dst}/libnccl-tuner-example.so"
   printf 'export RCCL_TESTS_DIR=%q\n'   "${rccl_tests_src}"
   printf 'export OMPI_INSTALL_DIR=%q\n' "${MPI_HOME}"
 } > "${workdir}/.ci-out/ext-plugins.env"
+_pt "build:end"
 ) > "${build_out}" 2> "${build_err}" || build_rc=$?
 echo "==> build phase logs: ${build_out} / ${build_err}"
 
@@ -200,6 +210,9 @@ fi
 # instead, which the workflow turns into a red (non-gating) result. ---
 test_rc=0
 {
+_tt0=$(date +%s)
+_pt(){ echo "PHASE_TS $1 epoch=$(date +%s) iso=$(date -Is) elapsed=$(( $(date +%s) - _tt0 ))s"; }
+_pt "test:start"
 echo "==> [5/5] run ext-plugins pytest (-m 'ext_mixed or ext_tuner')"
 set -a
 # shellcheck source=/dev/null
@@ -221,6 +234,7 @@ python3 -m pip install --quiet --disable-pip-version-check -r "${ext_dir}/requir
 # conftest.py resolves assets/logs from the current working directory.
 cd "${ext_dir}"
 python3 -m pytest -v -rs --color=no -m "ext_mixed or ext_tuner"
+_pt "test:end"
 } > "${test_out}" 2> "${test_err}" || test_rc=$?
 echo "==> test phase logs: ${test_out} / ${test_err}"
 if [[ "${test_rc}" -ne 0 ]]; then


### PR DESCRIPTION
## Motivation

RCCL supports loading multiple plugin types from a single shared object (for example net + tuner in one `.so`), matching the NCCL plugin system. This PR adds automated tests and end-user docs so the feature is validated and documented.

## Technical Details

- New pytest suite `test/ext-plugins/tests/ext-mixed/test_mixed_plugin.py`:
  - `test_mixed_symbols_exported`: builds `plugins/mixed/example/libnccl-mixed.so` and checks it exports both the net and tuner plugin symbols (pytest port of the existing `test.sh`).
  - `test_mixed_runtime_load`: runs an all_reduce and asserts from the RCCL debug log that net and tuner are served from the same object (reuse via `ncclGetNetPluginLib`), not the built-in CSV tuner.
- Register the `ext_mixed` marker in `pytest.ini` and add paths/skip logic in `conftest.py`.
- Expand `plugins/mixed/README.md` with build, runtime, and verification instructions.

## Issue Tracking

JIRA ID : AICOMRCCL-1881

## Test Plan

- Static: `cd plugins/mixed/example && make test`
- Runtime: `pytest test/ext-plugins/tests/ext-mixed/` on a node with >=2 AMD GPUs
- Environment: MI300X (gfx942), ROCm 7.0.2, RCCL 2.30.4

## Test Result

Static symbol check (`make test`):

```
PLUGIN-NET:        Expecting symbol "ncclNetPlugin_v12"   [SUCCESS]
PLUGIN-TUNER:      Expecting symbol "ncclTunerPlugin_v6" [SUCCESS]
```

pytest:

```
tests/ext-mixed/test_mixed_plugin.py::test_mixed_symbols_exported PASSED [ 50%]
tests/ext-mixed/test_mixed_plugin.py::test_mixed_runtime_load PASSED     [100%]
2 passed in 5.20s
```

Decisive runtime evidence (net and tuner loaded from one `.so`):

```
NCCL INFO NET/Plugin: Loaded net plugin Plugin (v12)
NCCL INFO Successfully loaded external network plugin .../plugins/mixed/example/libnccl-mixed.so
NCCL INFO TUNER/Plugin: Could not find: libnccl-tuner.so
NCCL INFO TUNER/Plugin: Using Plugin (v6)
```

The collective validated correctly (`Out of bounds values : 0 OK`).

### Full ext-plugins suite (this cluster)

Verified on MI300X (gfx942), ROCm 7.0.2, RCCL 2.30.4:


The 3 passing tests are the two new `ext_mixed` tests plus the `ext_tuner` config-parser thread-safety test. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.