### PR TITLE
chore(amdsmi): add agent developer-tooling skills and helpers

### DIFF
--- a/projects/amdsmi/.claude/skills/amdsmi-ci-logs/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-ci-logs/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: amdsmi-ci-logs
+description: "Use when a GitHub Actions run or job for an amd-smi / rocm-systems PR failed and the web UI shows truncated output, when you need the full failing log, or when you need CI artifacts (test reports, packages). Triggers: an actions/runs/<id>/job/<id> URL, 'where are the logs', 'output is truncated', 'where are the artifacts', a red check on a PR."
+---
+
+# CI Logs — amd-smi (GitHub Actions)
+
+Get the **full** log and artifacts for a rocm-systems Actions run when the web UI
+truncates output. The failing assertion and the uploaded test reports live in the
+raw log / artifacts, not the truncated job view.
+
+**Not** the internal Gerrit/Zuul CI (`gerrit.core.linux.amd.com`) — that's a
+separate system.
+
+## When to Use
+
+- A pasted `.../actions/runs/<RUN_ID>/job/<JOB_ID>` URL
+- "The unit-test output is truncated / cut off"
+- "Where do I see if there are artifacts?"
+- A red check on a PR and you need the failing step's full text
+
+## From a URL or run id
+
+A job URL encodes both ids: `.../actions/runs/<RUN_ID>/job/<JOB_ID>?pr=<PR>`.
+
+```bash
+REPO=ROCm/rocm-systems
+gh run view <RUN_ID> --repo $REPO                 # summary: jobs, conclusion, artifacts
+gh run view <RUN_ID> --repo $REPO --log-failed    # only failed steps (fastest triage)
+gh run view --repo $REPO --job <JOB_ID> --log     # one job, full log
+```
+
+Logs can be large — redirect to a file and grep, don't dump inline:
+
+```bash
+gh run view <RUN_ID> --repo $REPO --log > "${TMPDIR:-/tmp}/ci-<RUN_ID>.log"
+grep -nE 'FAILED|Error|assert' "${TMPDIR:-/tmp}/ci-<RUN_ID>.log"
+```
+
+## Artifacts (test reports, packages)
+
+Artifacts are **not** in the job log view — download them:
+
+```bash
+gh run view <RUN_ID> --repo $REPO                          # lists artifact names
+gh run download <RUN_ID> --repo $REPO -D "${TMPDIR:-/tmp}/ci-<RUN_ID>"
+gh run download <RUN_ID> --repo $REPO -n <name> -D <dir>   # one named artifact
+```
+
+## From a PR number (no URL yet)
+
+```bash
+gh pr checks <PR#> --repo $REPO                   # checks + run links
+BR=$(gh pr view <PR#> --repo $REPO --json headRefName -q .headRefName)
+gh run list --repo $REPO --branch "$BR" --limit 10
+```
+
+## Helper
+
+`gh-ci-logs.sh <run-id|run-url|job-url> [--failed] [-r owner/repo] [-o outdir]`
+parses the id(s), writes the summary, full log, and artifacts under
+`$TMPDIR/ci-<run-id>/`, and prints that directory. Repo defaults to
+`ROCm/rocm-systems` (override with `-r` or `GH_CI_REPO`).
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Reading the truncated web/job view | `--log` / `--log-failed` gives the full text |
+| Looking for test reports in the log | They're **artifacts** — `gh run download` |
+| Dumping a huge log inline | Redirect to `$TMPDIR`, then `grep` |
+| Guessing which run belongs to a PR | `gh pr checks <PR#>` links the exact run |
+| Using this for internal Gerrit/Zuul CI | Wrong CI — different system, different tooling |

--- a/projects/amdsmi/.claude/skills/amdsmi-ci-logs/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-ci-logs/SKILL.md
@@ -30,7 +30,12 @@ gh run view <RUN_ID> --repo $REPO --log-failed    # only failed steps (fastest t
 gh run view --repo $REPO --job <JOB_ID> --log     # one job, full log
 ```
 
-Logs can be large — redirect to a file and grep, don't dump inline:
+`--log-failed` only filters at the **run** level. Combined with `--job` it is
+silently ignored and you get the whole job log.
+
+A rocm-systems run is big (a failed-only run log can exceed 80k lines), so
+redirect to a file and grep. Never `head -n` a run log for triage: the amdsmi
+failure is usually far below the first screenful of some other project's output.
 
 ```bash
 gh run view <RUN_ID> --repo $REPO --log > "${TMPDIR:-/tmp}/ci-<RUN_ID>.log"
@@ -60,13 +65,16 @@ gh run list --repo $REPO --branch "$BR" --limit 10
 `gh-ci-logs.sh <run-id|run-url|job-url> [--failed] [-r owner/repo] [-o outdir]`
 parses the id(s), writes the summary, full log, and artifacts under
 `$TMPDIR/ci-<run-id>/`, and prints that directory. Repo defaults to
-`ROCm/rocm-systems` (override with `-r` or `GH_CI_REPO`).
+`ROCm/rocm-systems` (override with `-r` or `GH_CI_REPO`). It exits non-zero if
+the run can't be read, so a 404 never lands in the log file as if it were output.
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
 | Reading the truncated web/job view | `--log` / `--log-failed` gives the full text |
+| `head -200` on a run log to triage | The amdsmi failure is often tens of thousands of lines in — `grep` instead |
+| Expecting `--log-failed` to filter a single job | It only filters at run level; job logs come back whole |
 | Looking for test reports in the log | They're **artifacts** — `gh run download` |
 | Dumping a huge log inline | Redirect to `$TMPDIR`, then `grep` |
 | Guessing which run belongs to a PR | `gh pr checks <PR#>` links the exact run |

--- a/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Fetch full GitHub Actions logs + artifacts for a run or job.
+# The web UI truncates output and hides artifacts; this pulls the raw log,
+# the failing steps, and any uploaded artifacts into one directory.
+#
+# Usage:
+#   gh-ci-logs.sh <run-id | run-url | job-url> [-r owner/repo] [-o outdir] [--failed]
+#
+# Examples:
+#   gh-ci-logs.sh 31407615392
+#   gh-ci-logs.sh https://github.com/ROCm/rocm-systems/actions/runs/31407615392/job/93517652084 --failed
+#
+# Repo defaults to ROCm/rocm-systems (override with -r or GH_CI_REPO).
+set -uo pipefail
+
+REPO="${GH_CI_REPO:-ROCm/rocm-systems}"
+OUTDIR=""
+LOG_FLAG="--log"
+ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r|--repo)  REPO="$2"; shift 2;;
+    -o|--out)   OUTDIR="$2"; shift 2;;
+    --failed)   LOG_FLAG="--log-failed"; shift;;
+    -h|--help)  tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "unknown flag: $1" >&2; exit 2;;
+    *)  ARG="$1"; shift;;
+  esac
+done
+
+[[ -n "$ARG" ]] || { echo "error: need a run id, run URL, or job URL" >&2; exit 2; }
+command -v gh >/dev/null || { echo "error: gh CLI not found" >&2; exit 2; }
+
+# Parse run id (and optional job id) from a URL or bare id.
+RUN_ID=""; JOB_ID=""
+if [[ "$ARG" =~ /actions/runs/([0-9]+)(/job/([0-9]+))? ]]; then
+  RUN_ID="${BASH_REMATCH[1]}"; JOB_ID="${BASH_REMATCH[3]:-}"
+elif [[ "$ARG" =~ ^[0-9]+$ ]]; then
+  RUN_ID="$ARG"
+else
+  echo "error: could not parse a run id from '$ARG'" >&2; exit 2
+fi
+
+OUTDIR="${OUTDIR:-${TMPDIR:-/tmp}/ci-${RUN_ID}}"
+mkdir -p "$OUTDIR"
+echo "repo=$REPO run=$RUN_ID job=${JOB_ID:-<all>} out=$OUTDIR" >&2
+
+# Run summary: jobs, conclusion, artifact names.
+gh run view "$RUN_ID" --repo "$REPO" > "$OUTDIR/summary.txt" 2>&1 || true
+
+# Full log — a single job if one was given, else the whole run.
+if [[ -n "$JOB_ID" ]]; then
+  gh run view --repo "$REPO" --job "$JOB_ID" "$LOG_FLAG" > "$OUTDIR/job-${JOB_ID}.log" 2>&1 || true
+else
+  gh run view "$RUN_ID" --repo "$REPO" "$LOG_FLAG" > "$OUTDIR/run.log" 2>&1 || true
+fi
+
+# Artifacts (test reports, packages) — hidden behind the run summary page.
+if gh run download "$RUN_ID" --repo "$REPO" -D "$OUTDIR/artifacts" 2>/dev/null; then
+  echo "artifacts -> $OUTDIR/artifacts" >&2
+else
+  echo "no downloadable artifacts (or none retained)" >&2
+fi
+
+echo "$OUTDIR"

--- a/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-ci-logs/gh-ci-logs.sh
@@ -17,11 +17,12 @@ REPO="${GH_CI_REPO:-ROCm/rocm-systems}"
 OUTDIR=""
 LOG_FLAG="--log"
 ARG=""
+need_val() { [[ $# -ge 2 ]] || { echo "error: $1 needs a value" >&2; exit 2; }; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -r|--repo)  REPO="$2"; shift 2;;
-    -o|--out)   OUTDIR="$2"; shift 2;;
+    -r|--repo)  need_val "$@"; REPO="$2"; shift 2;;
+    -o|--out)   need_val "$@"; OUTDIR="$2"; shift 2;;
     --failed)   LOG_FLAG="--log-failed"; shift;;
     -h|--help)  tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
     -*) echo "unknown flag: $1" >&2; exit 2;;
@@ -47,14 +48,34 @@ mkdir -p "$OUTDIR"
 echo "repo=$REPO run=$RUN_ID job=${JOB_ID:-<all>} out=$OUTDIR" >&2
 
 # Run summary: jobs, conclusion, artifact names.
-gh run view "$RUN_ID" --repo "$REPO" > "$OUTDIR/summary.txt" 2>&1 || true
+# Keep stderr out of the output files so a failed call never looks like a log.
+if ! gh run view "$RUN_ID" --repo "$REPO" > "$OUTDIR/summary.txt" 2> "$OUTDIR/gh.err"; then
+  echo "error: cannot read run $RUN_ID in $REPO" >&2
+  cat "$OUTDIR/gh.err" >&2
+  rm -f "$OUTDIR/summary.txt" "$OUTDIR/gh.err"
+  exit 1
+fi
+
+# gh ignores --log-failed when a single job is selected, so don't claim otherwise.
+if [[ -n "$JOB_ID" && "$LOG_FLAG" == "--log-failed" ]]; then
+  echo "note: --failed does not apply to a single job; writing the full job log" >&2
+fi
 
 # Full log — a single job if one was given, else the whole run.
 if [[ -n "$JOB_ID" ]]; then
-  gh run view --repo "$REPO" --job "$JOB_ID" "$LOG_FLAG" > "$OUTDIR/job-${JOB_ID}.log" 2>&1 || true
+  LOG_FILE="$OUTDIR/job-${JOB_ID}.log"
+  gh run view --repo "$REPO" --job "$JOB_ID" --log > "$LOG_FILE" 2> "$OUTDIR/gh.err"
 else
-  gh run view "$RUN_ID" --repo "$REPO" "$LOG_FLAG" > "$OUTDIR/run.log" 2>&1 || true
+  LOG_FILE="$OUTDIR/run.log"
+  gh run view "$RUN_ID" --repo "$REPO" "$LOG_FLAG" > "$LOG_FILE" 2> "$OUTDIR/gh.err"
 fi
+
+if [[ ! -s "$LOG_FILE" ]]; then
+  echo "warning: no log retrieved (expired or still running)" >&2
+  cat "$OUTDIR/gh.err" >&2
+  rm -f "$LOG_FILE"
+fi
+rm -f "$OUTDIR/gh.err"
 
 # Artifacts (test reports, packages) — hidden behind the run summary page.
 if gh run download "$RUN_ID" --repo "$REPO" -D "$OUTDIR/artifacts" 2>/dev/null; then

--- a/projects/amdsmi/.claude/skills/amdsmi-test-runner/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-test-runner/SKILL.md
@@ -43,19 +43,16 @@ source ../../tests/amd_smi_test/detect_asic_filter.sh
 
 ## Python Tests
 
-### Unit Tests
+### Unit / Integration / CLI
+
+Run the suite files directly (each `sys.exit(0/1)`):
 
 ```bash
-cd tests/python_unittest
-python3 -m pytest -v
+cd tests/python
+python3 unit_tests.py -v
+python3 integration_test.py -v
+python3 cli_unit_test.py -v
 ```
-
-<!-- ### CLI Tests
-
-```bash
-cd amdsmi_cli
-python3 -m pytest -v
-``` -->
 
 ### Import Verification
 
@@ -76,15 +73,19 @@ Tests must work in **both** install contexts:
 |---------|--------------|
 | System install (RPM/DEB) | Default after `amdsmi-build-install` |
 
-## Running All Tests (One-Shot)
+## Running All Tests to Logs (One-Shot)
+
+`run-all-tests.sh` (this skill's directory) runs the C++ GTest, Python unit,
+integration, and CLI suites, tees each to a timestamped log dir, and prints a
+pass/fail summary. It derives the project root, so run it from anywhere in the tree:
 
 ```bash
-cd build/tests && \
-source ../../tests/amd_smi_test/amdsmitst.exclude && \
-source ../../tests/amd_smi_test/detect_asic_filter.sh && \
-./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" && \
-cd ../../tests/python_unittest && python3 -m pytest -v
+.claude/skills/amdsmi-test-runner/run-all-tests.sh          # logs under $TMPDIR/amdsmi-tests-<stamp>/
+.claude/skills/amdsmi-test-runner/run-all-tests.sh -o ./ci-logs
 ```
+
+Each suite's full output is in `<logdir>/<suite>.log`; the exit code is non-zero
+if any suite failed.
 
 ## Output
 

--- a/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Run all amd-smi test suites (C++ GTest, Python unit/integration/CLI) and tee
+# each to a timestamped log dir. Exits non-zero if any suite fails.
+# Derives the project root from git; no hard-coded users or paths.
+#
+# Usage: run-all-tests.sh [-o outdir] [--no-cpp] [--no-python]
+set -uo pipefail
+
+OUTDIR=""
+RUN_CPP=1
+RUN_PY=1
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--out)    OUTDIR="$2"; shift 2;;
+    --no-cpp)    RUN_CPP=0; shift;;
+    --no-python) RUN_PY=0; shift;;
+    -h|--help)   tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+# Project root: the dir holding tests/ and build/ (handles the monorepo layout).
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+[[ -d "$ROOT/projects/amdsmi" ]] && ROOT="$ROOT/projects/amdsmi"
+[[ -d "$ROOT/tests" ]] || { echo "error: no tests/ under $ROOT" >&2; exit 2; }
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+OUTDIR="${OUTDIR:-${TMPDIR:-/tmp}/amdsmi-tests-${STAMP}}"
+mkdir -p "$OUTDIR"
+echo "logs -> $OUTDIR" >&2
+
+declare -a NAMES RCS
+
+# C++ GTest with the skip blacklist + ASIC filter.
+if [[ "$RUN_CPP" == 1 ]]; then
+  if [[ -x "$ROOT/build/tests/amdsmitst" ]]; then
+    echo "=== C++ GTest ===" >&2
+    ( cd "$ROOT/build/tests" \
+      && source "$ROOT/tests/amd_smi_test/amdsmitst.exclude" \
+      && source "$ROOT/tests/amd_smi_test/detect_asic_filter.sh" \
+      && ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE:-}" ) 2>&1 | tee "$OUTDIR/cpp-gtest.log"
+    NAMES+=("C++ GTest"); RCS+=("${PIPESTATUS[0]}")
+  else
+    echo "skip C++: build/tests/amdsmitst not found (build with -DBUILD_TESTS=ON)" >&2
+  fi
+fi
+
+# Python suites — run the file runners directly (each sys.exit(0/1)).
+if [[ "$RUN_PY" == 1 ]]; then
+  for pair in "Python unit:unit_tests.py" \
+              "Python integration:integration_test.py" \
+              "Python CLI:cli_unit_test.py"; do
+    name="${pair%%:*}"; file="${pair##*:}"
+    if [[ -f "$ROOT/tests/python/$file" ]]; then
+      echo "=== $name ===" >&2
+      log="$(echo "$name" | tr ' A-Z' '-a-z').log"
+      ( cd "$ROOT/tests/python" && python3 "$file" -v ) 2>&1 | tee "$OUTDIR/$log"
+      NAMES+=("$name"); RCS+=("${PIPESTATUS[0]}")
+    else
+      echo "skip $name: tests/python/$file not found" >&2
+    fi
+  done
+fi
+
+# Summary.
+echo
+echo "===== SUMMARY ($OUTDIR) ====="
+fail=0
+for i in "${!NAMES[@]}"; do
+  if [[ "${RCS[$i]}" == 0 ]]; then status=PASS; else status=FAIL; fail=1; fi
+  printf '  %-20s %s (rc=%s)\n' "${NAMES[$i]}" "$status" "${RCS[$i]}"
+done
+[[ ${#NAMES[@]} -eq 0 ]] && { echo "  (no suites ran)"; exit 2; }
+exit $fail

--- a/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-test-runner/run-all-tests.sh
@@ -9,9 +9,10 @@ set -uo pipefail
 OUTDIR=""
 RUN_CPP=1
 RUN_PY=1
+need_val() { [[ $# -ge 2 ]] || { echo "error: $1 needs a value" >&2; exit 2; }; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -o|--out)    OUTDIR="$2"; shift 2;;
+    -o|--out)    need_val "$@"; OUTDIR="$2"; shift 2;;
     --no-cpp)    RUN_CPP=0; shift;;
     --no-python) RUN_PY=0; shift;;
     -h|--help)   tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
@@ -29,7 +30,8 @@ OUTDIR="${OUTDIR:-${TMPDIR:-/tmp}/amdsmi-tests-${STAMP}}"
 mkdir -p "$OUTDIR"
 echo "logs -> $OUTDIR" >&2
 
-declare -a NAMES RCS
+NAMES=()
+RCS=()
 
 # C++ GTest with the skip blacklist + ASIC filter.
 if [[ "$RUN_CPP" == 1 ]]; then
@@ -65,10 +67,10 @@ fi
 # Summary.
 echo
 echo "===== SUMMARY ($OUTDIR) ====="
+[[ ${#NAMES[@]} -eq 0 ]] && { echo "  (no suites ran)"; exit 2; }
 fail=0
 for i in "${!NAMES[@]}"; do
   if [[ "${RCS[$i]}" == 0 ]]; then status=PASS; else status=FAIL; fail=1; fi
   printf '  %-20s %s (rc=%s)\n' "${NAMES[$i]}" "$status" "${RCS[$i]}"
 done
-[[ ${#NAMES[@]} -eq 0 ]] && { echo "  (no suites ran)"; exit 2; }
 exit $fail

--- a/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/SKILL.md
@@ -98,6 +98,20 @@ git worktree add "${WORKTREE}" -b "${BRANCH}" origin/develop
 cd "${WORKTREE}/projects/amdsmi"
 ```
 
+### Shortcut: `new-worktree.sh`
+
+`new-worktree.sh` (this skill's directory) scripts Steps 0–2 — it derives the main
+checkout, applies the `rocm-systems-<name>` convention, creates the worktree, and
+prints the `cd` target. It hard-codes no user or path, so any rocm-systems checkout
+can use it:
+
+```bash
+.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh -p 10091                       # rocm-systems-pr10091 from the PR head
+.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh apu-fix -b users/me/apu-fix    # new branch off origin/develop
+```
+
+Still confirm consent (Step 1) before running it.
+
 **Sandbox fallback:** If `git worktree add` fails with a permission error, tell the user and work in the current directory instead.
 
 ## Step 3: Project Setup

--- a/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Create an amd-smi worktree following the rocm-systems-<name> sibling convention.
+# Derives the parent and base from git; no hard-coded users or paths, so any
+# rocm-systems checkout can use it.
+#
+# Usage:
+#   new-worktree.sh <name> [-b branch] [--base origin/develop]   # new/existing branch off base
+#   new-worktree.sh -p <PR#> [-b branch]                          # names it rocm-systems-pr<PR#>
+#
+# Examples:
+#   new-worktree.sh -p 10091
+#   new-worktree.sh apu-metric-schema -b users/me/apu-metric-schema
+#
+# Prints a `cd <path>` line on stdout; run `eval "$(new-worktree.sh ...)"` to jump in.
+set -uo pipefail
+
+BASE="origin/develop"
+PR=""; NAME=""; BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--pr)     PR="$2"; shift 2;;
+    -b|--branch) BRANCH="$2"; shift 2;;
+    --base)      BASE="$2"; shift 2;;
+    -h|--help)   tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "unknown flag: $1" >&2; exit 2;;
+    *)  NAME="$1"; shift;;
+  esac
+done
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || { echo "error: not inside a git repo" >&2; exit 2; }
+
+# Derive the *main* checkout even when invoked from inside a linked worktree.
+MAIN_CHECKOUT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+PARENT=$(dirname "$MAIN_CHECKOUT")
+
+# Worktree directory name from the tiered convention.
+if [[ -n "$PR" ]]; then
+  DIRNAME="rocm-systems-pr${PR}"
+elif [[ -n "$NAME" ]]; then
+  DIRNAME="rocm-systems-${NAME}"
+else
+  echo "error: pass a <name> or -p <PR#>" >&2; exit 2
+fi
+WORKTREE="${PARENT}/${DIRNAME}"
+[[ -e "$WORKTREE" ]] && { echo "error: $WORKTREE already exists" >&2; exit 1; }
+
+cd "$MAIN_CHECKOUT"
+
+if [[ -n "$PR" ]]; then
+  BRANCH="${BRANCH:-pr-${PR}}"
+  git fetch origin "pull/${PR}/head:${BRANCH}" 2>/dev/null \
+    || git fetch origin "${BRANCH}:${BRANCH}"
+  git worktree add "$WORKTREE" "$BRANCH"
+elif [[ -n "$BRANCH" ]]; then
+  git fetch origin "${BASE#origin/}" 2>/dev/null || true
+  git worktree add "$WORKTREE" -b "$BRANCH" "$BASE"
+else
+  git worktree add "$WORKTREE" "$BASE"
+fi
+
+# amd-smi work happens under projects/amdsmi in the monorepo layout.
+DEST="$WORKTREE"
+[[ -d "$WORKTREE/projects/amdsmi" ]] && DEST="$WORKTREE/projects/amdsmi"
+
+echo "created: $WORKTREE" >&2
+echo "branch:  $(git -C "$WORKTREE" branch --show-current 2>/dev/null || echo '(detached)')" >&2
+echo "cd $DEST"

--- a/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
+++ b/projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/new-worktree.sh
@@ -16,12 +16,13 @@ set -uo pipefail
 
 BASE="origin/develop"
 PR=""; NAME=""; BRANCH=""
+need_val() { [[ $# -ge 2 ]] || { echo "error: $1 needs a value" >&2; exit 2; }; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -p|--pr)     PR="$2"; shift 2;;
-    -b|--branch) BRANCH="$2"; shift 2;;
-    --base)      BASE="$2"; shift 2;;
+    -p|--pr)     need_val "$@"; PR="$2"; shift 2;;
+    -b|--branch) need_val "$@"; BRANCH="$2"; shift 2;;
+    --base)      need_val "$@"; BASE="$2"; shift 2;;
     -h|--help)   tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'; exit 0;;
     -*) echo "unknown flag: $1" >&2; exit 2;;
     *)  NAME="$1"; shift;;

--- a/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-architecture
 description: "Architecture review subagent. Checks design patterns, API consistency, layering, cascade integrity. Use when: architecture review, design check, API cascade."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory, search/usages
-model: "Claude Opus 4.6"
+model: "Claude Opus 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-build.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-build.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-build
 description: "Build system review subagent. Checks CMake, packaging, install targets, dependencies. Use when: build review, CMake check, packaging, RPM/DEB."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory, execute/runInTerminal
-model: "Claude Sonnet 4.6"
+model: "Claude Sonnet 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-docs.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-docs.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-docs
 description: "Documentation review subagent. Checks docs, comments, help text, docstrings. Use when: documentation review, docs check, help text."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory
-model: "Claude Sonnet 4.6"
+model: "Claude Sonnet 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-performance.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-performance.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-performance
 description: "Performance review subagent. Checks efficiency, scaling, resource usage, hot paths. Use when: performance review, optimization check."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory
-model: "Claude Sonnet 4.6"
+model: "Claude Sonnet 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-security
 description: "Security review subagent. Checks vulnerabilities, secrets, input validation, unsafe patterns. Use when: security review, vulnerability check."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory
-model: "Claude Opus 4.6"
+model: "Claude Opus 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-skeptic
 description: "Skeptic review subagent. Questions necessity, challenges scope, finds simpler alternatives, resists premature abstraction. Also runs as rebuttal reviewer in thorough mode. Use when: skeptic review, scope check, simplification, rebuttal."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory, search/usages
-model: "Claude Opus 4.6"
+model: "Claude Opus 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-spec.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-spec.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-spec
 description: "Spec-conformance review subagent. Checks the diff against its originating spec/issue/PRD — missing requirements, scope creep, implemented-but-wrong. Use when: spec conformance, requirement coverage, scope creep vs spec."
 tools: read/readFile, search/textSearch, search/fileSearch, search/listDirectory, search/usages, execute/runInTerminal, atlassian/*
-model: "Claude Opus 4.6"
+model: "Claude Opus 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-style
 description: "Style review subagent. Checks formatting, naming, pre-commit compliance. Use when: style review, formatting check, naming conventions."
 tools: execute/runInTerminal, read/readFile, search/textSearch, search/fileSearch, search/listDirectory
-model: "Claude Sonnet 4.6"
+model: "Claude Sonnet 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
@@ -2,7 +2,7 @@
 name: amdsmi-review-tests
 description: "Test review subagent. Checks test coverage, quality, missing tests. Use when: test review, coverage check, test quality."
 tools: execute/runInTerminal, read/readFile, search/textSearch, search/fileSearch, search/listDirectory
-model: "Claude Sonnet 4.6"
+model: "Claude Sonnet 5"
 user-invocable: false
 ---
 

--- a/projects/amdsmi/.github/prompts/amdsmi-review-branch.prompt.md
+++ b/projects/amdsmi/.github/prompts/amdsmi-review-branch.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Review the current local branch using the AMD-SMI Review Agent"
 agent: "AMD-SMI Review Agent"
-argument-hint: "[review-type ...] — style, tests, docs, architecture, security, performance, build, skeptic (or blank for comprehensive). Add 'fast' to skip rebuttal. Add 'no-build' to skip build step. Add 'inherit' to use the orchestrator's model for subagents instead of the default (Sonnet 4.6)."
+argument-hint: "[review-type ...] — style, tests, docs, architecture, security, performance, build, skeptic (or blank for comprehensive). Add 'fast' to skip rebuttal. Add 'no-build' to skip build step. Add 'inherit' to use the orchestrator's model for subagents instead of the default (Sonnet 5)."
 tools: [execute, read, edit, search, agent, todo]
 ---
 
@@ -13,7 +13,7 @@ Review the current local branch using the AMD-SMI Review Agent.
 - Valid types: `style`, `tests`, `docs`, `architecture`, `security`, `performance`, `build`, `skeptic`
 - Special modifier: `fast` — skips the rebuttal round (comprehensive mode only)
 - Special modifier: `no-build` — skips the build & install step
-- Special modifier: `inherit` — makes all subagents inherit the orchestrator's model (the model you selected in the VS Code model picker) instead of their default (Sonnet 4.6)
+- Special modifier: `inherit` — makes all subagents inherit the orchestrator's model (the model you selected in the VS Code model picker) instead of their default (Sonnet 5)
 - If no types specified, perform a **comprehensive** review (all subagents, with rebuttal)
 
 ## Process

--- a/projects/amdsmi/.github/prompts/amdsmi-review-pr.prompt.md
+++ b/projects/amdsmi/.github/prompts/amdsmi-review-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Review a GitHub pull request using the AMD-SMI Review Agent"
 agent: "AMD-SMI Review Agent"
-argument-hint: "<PR_NUMBER> [review-type ...] — e.g. 1234 style tests (or just the number for comprehensive). Add 'fast' to skip rebuttal. Add 'no-build' to skip build step. Add 'inherit' to use the orchestrator's model for subagents instead of the default (Sonnet 4.6)."
+argument-hint: "<PR_NUMBER> [review-type ...] — e.g. 1234 style tests (or just the number for comprehensive). Add 'fast' to skip rebuttal. Add 'no-build' to skip build step. Add 'inherit' to use the orchestrator's model for subagents instead of the default (Sonnet 5)."
 tools: [execute, read, edit, search, agent, web, todo]
 ---
 
@@ -14,7 +14,7 @@ Review a GitHub pull request using the AMD-SMI Review Agent.
 - Remaining: optional review types: `style`, `tests`, `docs`, `architecture`, `security`, `performance`, `build`, `skeptic`
 - Special modifier: `fast` — skips the rebuttal round (comprehensive mode only)
 - Special modifier: `no-build` — skips the build & install step
-- Special modifier: `inherit` — makes all subagents inherit the orchestrator's model (the model you selected in the VS Code model picker) instead of their default (Sonnet 4.6)
+- Special modifier: `inherit` — makes all subagents inherit the orchestrator's model (the model you selected in the VS Code model picker) instead of their default (Sonnet 5)
 - If no types specified, perform a **comprehensive** review (all subagents, with rebuttal)
 
 ## Process


### PR DESCRIPTION
## Motivation

Agent sessions kept re-deriving the same workflows by hand: fetching full CI logs when the GitHub web UI truncates them, creating worktrees that follow the rocm-systems naming convention, and running the full test suite with saved logs. This captures them as reusable agent skills plus helper scripts so any developer or agent gets the same behavior.

## Technical Details

**New skill: CI logs** (`projects/amdsmi/.claude/skills/amdsmi-ci-logs/`):
- `SKILL.md` documents pulling complete GitHub Actions logs and artifacts for a run or job
- `gh-ci-logs.sh` resolves a run/job id from a run-id, run URL, or job URL and saves the summary, raw log, and artifacts under `$TMPDIR`

**Worktree skill** (`projects/amdsmi/.claude/skills/amdsmi-using-git-worktrees/`):
- `new-worktree.sh` creates a `rocm-systems-<name>` worktree, deriving the parent checkout and base ref from git with no hard-coded users or paths
- `SKILL.md` documents the shortcut

**Test-runner skill** (`projects/amdsmi/.claude/skills/amdsmi-test-runner/`):
- `run-all-tests.sh` runs the C++ GTest and Python unit/integration/CLI suites, tees each to a timestamped log dir, and exits non-zero on any failure
- `SKILL.md` updated to the current `tests/python/` layout and references the one-shot runner

Docs/tooling only, no library source, wrapper, or CLI behavior changes.

## Issue Tracking

JIRA ID: AILITOOLS-278

## Test Plan

- `bash -n` on all three scripts
- `--help` smoke test on each script
- `pre-commit run --config projects/amdsmi/.pre-commit-config.yaml --files <changed files>`

## Test Result

- `bash -n`: clean on all three scripts
- `--help`: prints usage for each
- pre-commit: codespell, trailing-whitespace, end-of-file-fixer, mixed-line-ending all Passed (clang-format / ruff / gersemi skipped, no matching files)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
