### PR TITLE
test(rccl): gin device tests for sdma

### DIFF
--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
@@ -420,15 +420,17 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
       auto** handles = (::sdma_anvil::SdmaQueueDeviceHandle**)loadConst(&rsCtx->queueHandles);
       int nr = ctx.nRanks;
       int numCh = loadConst(&rsCtx->numChannels);
+      if (handles != nullptr) {
 #pragma unroll 1
-      for (int p = coop.thread_rank(); p < nr; p += coop.size()) {
-        uint64_t peerMask = ((1ULL << numCh) - 1) << (p * numCh);
-        if ((dirty & peerMask) == 0) continue;
-        for (int ch = 0; ch < numCh; ++ch) {
-          uint64_t bit = 1ULL << (p * numCh + ch);
-          if ((dirty & bit) == 0) continue;
-          auto* h = loadConst(handles + p * numCh + ch);
-          if (h != nullptr) ::sdma_anvil::quiet(*h);
+        for (int p = coop.thread_rank(); p < nr; p += coop.size()) {
+          uint64_t peerMask = ((1ULL << numCh) - 1) << (p * numCh);
+          if ((dirty & peerMask) == 0) continue;
+          for (int ch = 0; ch < numCh; ++ch) {
+            uint64_t bit = 1ULL << (p * numCh + ch);
+            if ((dirty & bit) == 0) continue;
+            auto* h = loadConst(handles + p * numCh + ch);
+            if (h != nullptr) ::sdma_anvil::quiet(*h);
+          }
         }
       }
       coop.sync();

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -577,12 +577,6 @@ if(BUILD_TESTS)
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-    # GinAlltoAllEligibilityTests.cpp calls ncclAllToAllGinSdmaEligible() only
-    # when ENABLE_ROCSHMEM_GIN is defined (otherwise it GTEST_SKIPs). Match librccl.
-    if(ENABLE_ROCSHMEM_GIN)
-      target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE ENABLE_ROCSHMEM_GIN)
-    endif()
-
     # PluginCompatV10_test.cpp / PluginCompatV11_test.cpp resolve their in-process
     # mock plugin symbols via dlsym(dlopen(NULL), ...), which only sees the
     # executable's dynamic symbols.

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -524,6 +524,7 @@ if(BUILD_TESTS)
       DdaFabricEligibilityTests.cpp
       CeAllReduceEligibilityTests.cpp
       CeAlltoAllvEligibilityTests.cpp
+      GinAlltoAllEligibilityTests.cpp
       EnqueueTests.cpp
       LL128RegVariantKernel_test.cpp
       IpcsocketTests.cpp
@@ -575,6 +576,12 @@ if(BUILD_TESTS)
     # so they can build the path.
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
+    # GinAlltoAllEligibilityTests.cpp calls ncclAllToAllGinSdmaEligible() only
+    # when ENABLE_ROCSHMEM_GIN is defined (otherwise it GTEST_SKIPs). Match librccl.
+    if(ENABLE_ROCSHMEM_GIN)
+      target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE ENABLE_ROCSHMEM_GIN)
+    endif()
 
     # PluginCompatV10_test.cpp / PluginCompatV11_test.cpp resolve their in-process
     # mock plugin symbols via dlsym(dlopen(NULL), ...), which only sees the

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -64,6 +64,19 @@ if(BUILD_TESTS)
     add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)
   endif()
 
+  # add_rocshmem_targets() exports these with PARENT_SCOPE from src/, so re-derive them here.
+  if(ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN)
+    if(NOT ROCSHMEM_INSTALL_DIR)
+      set(ROCSHMEM_INSTALL_DIR "${CMAKE_SOURCE_DIR}/ext/rocshmem")
+    endif()
+    if(NOT ROCSHMEM_INCLUDE_DIR)
+      set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INSTALL_DIR}/include")
+    endif()
+    if(NOT ROCSHMEM_LIBRARY)
+      set(ROCSHMEM_LIBRARY "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a")
+    endif()
+  endif()
+
   find_package(hsa-runtime64 PATHS /opt/rocm )
   if(${hsa-runtime64_FOUND})
     message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
@@ -440,6 +453,9 @@ if(BUILD_TESTS)
     endif()
 
     target_compile_definitions(rccl-UnitTestsGinAnvilPlugin PRIVATE ENABLE_ROCSHMEM_GIN)
+
+    # No rccl link below, so the implicit ordering after hipify has to be explicit.
+    add_dependencies(rccl-UnitTestsGinAnvilPlugin hipify_all)
   endif()
   endif()
 
@@ -798,9 +814,18 @@ if(BUILD_TESTS)
     endif()
   endif()
 
+  # Targets wired up with the sdma stub headers below; everything else opts out.
+  set(RCCL_ANVIL_SDMA_STUB_TARGETS rccl-UnitTestsFixtures rccl-UnitTestsGinAnvilPlugin)
+
   foreach(test_executable IN LISTS RCCL_TEST_EXECUTABLES)
     target_include_directories(${test_executable} PRIVATE ${RCCL_COMMON_INCLUDE_DIRS})
     target_compile_definitions(${test_executable} PRIVATE ${RCCL_COMMON_COMPILE_DEFS})
+
+    # RCCL_COMMON_COMPILE_DEFS inherits ENABLE_ROCSHMEM_GIN from rccl's COMPILE_DEFINITIONS,
+    # which defaults NCCL_GIN_ANVIL_SDMA_ENABLE to 1 and pulls in rocSHMEM's sdma headers.
+    if(ENABLE_ROCSHMEM_GIN AND NOT "${test_executable}" IN_LIST RCCL_ANVIL_SDMA_STUB_TARGETS)
+      target_compile_definitions(${test_executable} PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+    endif()
     if(ENABLE_DEVICE_LINKER)
       # Mirror the rccl library define so device-linker-specific test expectations compile in.
       target_compile_definitions(${test_executable} PRIVATE RCCL_DEVICE_LINKER)
@@ -847,7 +872,8 @@ if(BUILD_TESTS)
 
     # Link the GIN device backend library and device-link its rdc code (-fgpu-rdc
     # --hip-link --offload-arch=... -rdynamic) so GIN device tests can run.
-    if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_INSTALL_DIR AND "${test_executable}" STREQUAL "rccl-UnitTestsMPI")
+    # GDA only. SDMA host code already lives in librccl.so and its device code is header-only.
+    if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_LIBRARY AND "${test_executable}" STREQUAL "rccl-UnitTestsMPI")
       set(_ROCSHMEM_OFFLOAD_FLAGS "")
       foreach(_g IN LISTS GPU_TARGETS)
         if(_g)
@@ -863,14 +889,36 @@ if(BUILD_TESTS)
       if(NOT _ROCSHMEM_DRM_AMDGPU)
         set(_ROCSHMEM_DRM_AMDGPU drm_amdgpu)
       endif()
-      # Enable the GIN device backend in the test kernels so ncclGinCall has a
-      # dispatch case for the corresponding runtime GIN type.
+      # Enable the rocshmem-gda GIN backend in the test kernels so ncclGinCall
+      # has a dispatch case for it.
       target_compile_definitions(${test_executable} PRIVATE NCCL_GIN_ROCSHMEM_GDA_ENABLE=1)
+
+      # Enable anvil-sdma only for the TU that launches its kernels; the rocSHMEM
+      # sdma headers are on that TU's include path alone.
+      set(_ANVIL_SDMA_INCLUDES "")
+      if(ROCSHMEM_SOURCE_DIR)
+        list(APPEND _ANVIL_SDMA_INCLUDES ${ROCSHMEM_SOURCE_DIR}/src ${ROCSHMEM_SOURCE_DIR}/include)
+      endif()
+      if(ROCSHMEM_INCLUDE_DIR)
+        list(APPEND _ANVIL_SDMA_INCLUDES ${ROCSHMEM_INCLUDE_DIR})
+      endif()
+      # -U first because the target opted out with =0, and a second -D warns under -Wmacro-redefined.
+      set_source_files_properties(transport/GinDeviceMPITests.cpp PROPERTIES
+          COMPILE_OPTIONS "-UNCCL_GIN_ANVIL_SDMA_ENABLE;-DNCCL_GIN_ANVIL_SDMA_ENABLE=1"
+          INCLUDE_DIRECTORIES "${_ANVIL_SDMA_INCLUDES}")
       target_compile_options(${test_executable} PRIVATE -fgpu-rdc)
+      if(TARGET rocshmem_static)
+        add_dependencies(${test_executable} rocshmem_static)
+      endif()
       target_link_libraries(${test_executable} PRIVATE
-          ${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a
+          ${ROCSHMEM_LIBRARY}
           ibverbs hsa-runtime64 hsakmt numa ${_ROCSHMEM_DRM} ${_ROCSHMEM_DRM_AMDGPU})
-      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic)
+      # ROCm < 7.14 emits cooperative_groups::this_cluster() as a non-inline stub, so -fgpu-rdc device TUs collide; keep one copy. Fixed (inline) in 7.14.
+      set(_ROCSHMEM_DEVLINK_EXTRA "")
+      if(ROCM_VERSION VERSION_LESS "71400")
+        set(_ROCSHMEM_DEVLINK_EXTRA "SHELL:-Xoffload-linker --allow-multiple-definition")
+      endif()
+      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic ${_ROCSHMEM_DEVLINK_EXTRA})
     endif()
 
     # librccl.so built with ENABLE_ROCSHMEM_GIN but without host librocshmem
@@ -906,7 +954,9 @@ if(BUILD_TESTS)
   endforeach()
 
   # Suite H: shadow rocSHMEM sdma headers with no-op test stubs (higher-priority include path).
-  if(ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS))
+  # Gated on ENABLE_ROCSHMEM_GIN because that is what now turns on NCCL_GIN_ANVIL_SDMA_ENABLE,
+  # and these are the only two test targets that define it.
+  if(ENABLE_ROCSHMEM_GIN)
     if(ROCSHMEM_SOURCE_DIR)
       target_include_directories(rccl-UnitTestsFixtures PRIVATE ${ROCSHMEM_SOURCE_DIR}/src)
     else()
@@ -914,6 +964,10 @@ if(BUILD_TESTS)
     endif()
     target_include_directories(rccl-UnitTestsFixtures BEFORE PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/device)
+    if(TARGET rccl-UnitTestsGinAnvilPlugin)
+      target_include_directories(rccl-UnitTestsGinAnvilPlugin BEFORE PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/device)
+    endif()
   endif()
 
   # Create install-time test file for distribution

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -64,6 +64,19 @@ if(BUILD_TESTS)
     add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)
   endif()
 
+  # add_rocshmem_targets() exports these with PARENT_SCOPE from src/, so re-derive them here.
+  if(ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN)
+    if(NOT ROCSHMEM_INSTALL_DIR)
+      set(ROCSHMEM_INSTALL_DIR "${CMAKE_SOURCE_DIR}/ext/rocshmem")
+    endif()
+    if(NOT ROCSHMEM_INCLUDE_DIR)
+      set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INSTALL_DIR}/include")
+    endif()
+    if(NOT ROCSHMEM_LIBRARY)
+      set(ROCSHMEM_LIBRARY "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a")
+    endif()
+  endif()
+
   find_package(hsa-runtime64 PATHS /opt/rocm )
   if(${hsa-runtime64_FOUND})
     message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
@@ -434,6 +447,9 @@ if(BUILD_TESTS)
     endif()
 
     target_compile_definitions(rccl-UnitTestsGinAnvilPlugin PRIVATE ENABLE_ROCSHMEM_GIN)
+
+    # No rccl link below, so the implicit ordering after hipify has to be explicit.
+    add_dependencies(rccl-UnitTestsGinAnvilPlugin hipify_all)
   endif()
   endif()
 
@@ -792,9 +808,18 @@ if(BUILD_TESTS)
     endif()
   endif()
 
+  # Targets wired up with the sdma stub headers below; everything else opts out.
+  set(RCCL_ANVIL_SDMA_STUB_TARGETS rccl-UnitTestsFixtures rccl-UnitTestsGinAnvilPlugin)
+
   foreach(test_executable IN LISTS RCCL_TEST_EXECUTABLES)
     target_include_directories(${test_executable} PRIVATE ${RCCL_COMMON_INCLUDE_DIRS})
     target_compile_definitions(${test_executable} PRIVATE ${RCCL_COMMON_COMPILE_DEFS})
+
+    # RCCL_COMMON_COMPILE_DEFS inherits ENABLE_ROCSHMEM_GIN from rccl's COMPILE_DEFINITIONS,
+    # which defaults NCCL_GIN_ANVIL_SDMA_ENABLE to 1 and pulls in rocSHMEM's sdma headers.
+    if(ENABLE_ROCSHMEM_GIN AND NOT "${test_executable}" IN_LIST RCCL_ANVIL_SDMA_STUB_TARGETS)
+      target_compile_definitions(${test_executable} PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+    endif()
     if(ENABLE_DEVICE_LINKER)
       # Mirror the rccl library define so device-linker-specific test expectations compile in.
       target_compile_definitions(${test_executable} PRIVATE RCCL_DEVICE_LINKER)
@@ -841,7 +866,8 @@ if(BUILD_TESTS)
 
     # Link the GIN device backend library and device-link its rdc code (-fgpu-rdc
     # --hip-link --offload-arch=... -rdynamic) so GIN device tests can run.
-    if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_INSTALL_DIR AND "${test_executable}" STREQUAL "rccl-UnitTestsMPI")
+    # GDA only. SDMA host code already lives in librccl.so and its device code is header-only.
+    if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_LIBRARY AND "${test_executable}" STREQUAL "rccl-UnitTestsMPI")
       set(_ROCSHMEM_OFFLOAD_FLAGS "")
       foreach(_g IN LISTS GPU_TARGETS)
         if(_g)
@@ -857,14 +883,36 @@ if(BUILD_TESTS)
       if(NOT _ROCSHMEM_DRM_AMDGPU)
         set(_ROCSHMEM_DRM_AMDGPU drm_amdgpu)
       endif()
-      # Enable the GIN device backend in the test kernels so ncclGinCall has a
-      # dispatch case for the corresponding runtime GIN type.
+      # Enable the rocshmem-gda GIN backend in the test kernels so ncclGinCall
+      # has a dispatch case for it.
       target_compile_definitions(${test_executable} PRIVATE NCCL_GIN_ROCSHMEM_GDA_ENABLE=1)
+
+      # Enable anvil-sdma only for the TU that launches its kernels; the rocSHMEM
+      # sdma headers are on that TU's include path alone.
+      set(_ANVIL_SDMA_INCLUDES "")
+      if(ROCSHMEM_SOURCE_DIR)
+        list(APPEND _ANVIL_SDMA_INCLUDES ${ROCSHMEM_SOURCE_DIR}/src ${ROCSHMEM_SOURCE_DIR}/include)
+      endif()
+      if(ROCSHMEM_INCLUDE_DIR)
+        list(APPEND _ANVIL_SDMA_INCLUDES ${ROCSHMEM_INCLUDE_DIR})
+      endif()
+      # -U first because the target opted out with =0, and a second -D warns under -Wmacro-redefined.
+      set_source_files_properties(transport/GinDeviceMPITests.cpp PROPERTIES
+          COMPILE_OPTIONS "-UNCCL_GIN_ANVIL_SDMA_ENABLE;-DNCCL_GIN_ANVIL_SDMA_ENABLE=1"
+          INCLUDE_DIRECTORIES "${_ANVIL_SDMA_INCLUDES}")
       target_compile_options(${test_executable} PRIVATE -fgpu-rdc)
+      if(TARGET rocshmem_static)
+        add_dependencies(${test_executable} rocshmem_static)
+      endif()
       target_link_libraries(${test_executable} PRIVATE
-          ${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a
+          ${ROCSHMEM_LIBRARY}
           ibverbs hsa-runtime64 hsakmt numa ${_ROCSHMEM_DRM} ${_ROCSHMEM_DRM_AMDGPU})
-      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic)
+      # ROCm < 7.14 emits cooperative_groups::this_cluster() as a non-inline stub, so -fgpu-rdc device TUs collide; keep one copy. Fixed (inline) in 7.14.
+      set(_ROCSHMEM_DEVLINK_EXTRA "")
+      if(ROCM_VERSION VERSION_LESS "71400")
+        set(_ROCSHMEM_DEVLINK_EXTRA "SHELL:-Xoffload-linker --allow-multiple-definition")
+      endif()
+      target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic ${_ROCSHMEM_DEVLINK_EXTRA})
     endif()
 
     # librccl.so built with ENABLE_ROCSHMEM_GIN but without host librocshmem
@@ -900,7 +948,9 @@ if(BUILD_TESTS)
   endforeach()
 
   # Suite H: shadow rocSHMEM sdma headers with no-op test stubs (higher-priority include path).
-  if(ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS))
+  # Gated on ENABLE_ROCSHMEM_GIN because that is what now turns on NCCL_GIN_ANVIL_SDMA_ENABLE,
+  # and these are the only two test targets that define it.
+  if(ENABLE_ROCSHMEM_GIN)
     if(ROCSHMEM_SOURCE_DIR)
       target_include_directories(rccl-UnitTestsFixtures PRIVATE ${ROCSHMEM_SOURCE_DIR}/src)
     else()
@@ -908,6 +958,10 @@ if(BUILD_TESTS)
     endif()
     target_include_directories(rccl-UnitTestsFixtures BEFORE PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/device)
+    if(TARGET rccl-UnitTestsGinAnvilPlugin)
+      target_include_directories(rccl-UnitTestsGinAnvilPlugin BEFORE PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/device)
+    endif()
   endif()
 
   # Create install-time test file for distribution

--- a/projects/rccl/test/DevRuntimeTestsStubs.cc
+++ b/projects/rccl/test/DevRuntimeTestsStubs.cc
@@ -22,6 +22,9 @@
 #include "cudawrap.h"
 #include "dev_runtime_internal.h"
 #include "gin/gin_host.h"
+#ifdef ENABLE_ROCSHMEM_GIN
+#include "gin/gin_host_anvil_sdma.h"
+#endif
 #include "rma/rma_proxy.h"
 #include "nccl_device/core_tmp.h"
 #include "nccl_device/lsa_barrier.h"
@@ -178,6 +181,11 @@ ncclResult_t ncclGinRegister(struct ncclComm*, void*, size_t, void*[NCCL_GIN_MAX
   return ncclSuccess;
 }
 ncclResult_t ncclGinDeregister(struct ncclComm*, void*[NCCL_GIN_MAX_CONNECTIONS]) { return ncclSuccess; }
+#ifdef ENABLE_ROCSHMEM_GIN
+ncclResult_t ncclGinAnvilBindResourceWindowSignals(struct ncclComm*, void*, size_t, int, int) {
+  return ncclSuccess;
+}
+#endif
 
 // ---------------------------------------------------------------------------
 // RMA proxy.

--- a/projects/rccl/test/GinAlltoAllEligibilityTests.cpp
+++ b/projects/rccl/test/GinAlltoAllEligibilityTests.cpp
@@ -22,6 +22,8 @@ namespace
 // Stand-in ncclComm that passes every ncclAllToAllGinSdmaEligible() gate up to the
 // window lookup, so each test below spoils one earlier field. bigSize must stay
 // non-zero or ncclTeamLsa() runs real device-runtime init here and crashes.
+// Purpose-built like DdaIpcMockComm: common/MockComm.hpp builds topology and
+// arch state that no eligibility gate reads.
 struct GinAlltoAllMockComm
 {
     ncclComm            comm{};
@@ -57,12 +59,16 @@ bool envEquals(const char* name, const char* value)
 
 } // namespace
 
-// Every assertion here is EXPECT_FALSE, because the one path to a true verdict
-// runs through registered ncclDevrWindows and ncclDevrWindowSorted is private to
-// dev_runtime.cc. That leaves the 16 B alignment gate and the eligible case to
-// the MPI tests in transport/GinDeviceMPITests.cpp. It also means no single test
-// can prove *which* gate rejected -- except BuffersNotRegistered, which is the
-// one case where deleting the gate under test flips the verdict to true.
+// These tests document the gate list. They do not detect a deleted gate. The mock
+// registers no window, so every case below is rejected by the window lookup, which
+// runs after the gate it targets: delete the nNodes check and MultiNode still gets
+// false, and still passes. BuffersNotRegistered is the exception, because there the
+// window lookup is the gate under test, so removing it flips the verdict to true.
+//
+// The baseline cannot be true while ncclDevrWindowSorted is defined in
+// dev_runtime.cc rather than the header, so the mock cannot populate winSorted.
+// The 16 B alignment gate and the eligible case stay with the MPI tests in
+// transport/GinDeviceMPITests.cpp.
 class GinAlltoAllEligibilityTest : public ::testing::Test
 {
 protected:

--- a/projects/rccl/test/GinAlltoAllEligibilityTests.cpp
+++ b/projects/rccl/test/GinAlltoAllEligibilityTests.cpp
@@ -1,0 +1,193 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <cstdlib>
+#include <cstring>
+
+#include "algorithms/gin/gin_alltoall.h"
+#include "comm.h"
+#include "gtest/gtest.h"
+
+namespace RcclUnitTesting
+{
+
+#if defined(ENABLE_ROCSHMEM_GIN)
+
+namespace
+{
+
+// Stand-in ncclComm that passes every ncclAllToAllGinSdmaEligible() gate up to the
+// window lookup, so each test below spoils one earlier field. bigSize must stay
+// non-zero or ncclTeamLsa() runs real device-runtime init here and crashes.
+struct GinAlltoAllMockComm
+{
+    ncclComm            comm{};
+    ncclSharedResources sharedRes{};
+    char                bootstrapPlaceholder{0};
+
+    GinAlltoAllMockComm()
+    {
+        std::memset(&comm, 0, sizeof(comm));
+        comm.bootstrap        = &bootstrapPlaceholder;
+        comm.nNodes           = 1;
+        comm.nRanks           = 8;
+        comm.rank             = 0;
+        comm.symmetricSupport = true;
+        comm.globalGinSupport = NCCL_GIN_CONNECTION_FULL;
+
+        comm.devrState.bigSize = 1;
+        comm.devrState.lsaSize = comm.nRanks;
+        comm.devrState.lsaSelf = comm.rank;
+
+        sharedRes.ginState.ginType = (ncclGinType_t)NCCL_NET_DEVICE_GIN_ANVIL_SDMA;
+        comm.sharedRes             = &sharedRes;
+    }
+
+    ncclComm* get() { return &comm; }
+};
+
+bool envEquals(const char* name, const char* value)
+{
+    const char* env = std::getenv(name);
+    return env != nullptr && std::strcmp(env, value) == 0;
+}
+
+} // namespace
+
+// Every assertion here is EXPECT_FALSE, because the one path to a true verdict
+// runs through registered ncclDevrWindows and ncclDevrWindowSorted is private to
+// dev_runtime.cc. That leaves the 16 B alignment gate and the eligible case to
+// the MPI tests in transport/GinDeviceMPITests.cpp. It also means no single test
+// can prove *which* gate rejected -- except BuffersNotRegistered, which is the
+// one case where deleting the gate under test flips the verdict to true.
+class GinAlltoAllEligibilityTest : public ::testing::Test
+{
+protected:
+    GinAlltoAllMockComm mockComm_;
+    void*               sendbuff_{reinterpret_cast<void*>(0x1000)};
+    void*               recvbuff_{reinterpret_cast<void*>(0x2000)};
+    // 8 MiB per peer of float32, i.e. the NCCL_GIN_A2A_SDMA_MIN_BYTES default, so
+    // neither the minimum-size nor the 16 B alignment gate can be what rejects.
+    static constexpr size_t kBytesPerPeer = 8ull * 1024 * 1024;
+    static constexpr size_t kCount        = kBytesPerPeer / sizeof(float);
+
+    bool eligible(size_t count)
+    {
+        return ncclAllToAllGinSdmaEligible(mockComm_.get(), sendbuff_, recvbuff_, count, ncclFloat32);
+    }
+};
+
+TEST_F(GinAlltoAllEligibilityTest, NullComm)
+{
+    EXPECT_FALSE(ncclAllToAllGinSdmaEligible(nullptr, sendbuff_, recvbuff_, kCount, ncclFloat32));
+}
+
+TEST_F(GinAlltoAllEligibilityTest, MissingBootstrap)
+{
+    mockComm_.comm.bootstrap = nullptr;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+TEST_F(GinAlltoAllEligibilityTest, ZeroCount)
+{
+    EXPECT_FALSE(eligible(0));
+}
+
+// The path is scaleup-only: anything spanning nodes has to fall back.
+TEST_F(GinAlltoAllEligibilityTest, MultiNode)
+{
+    mockComm_.comm.nNodes = 2;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// markSdmaDirty packs (peer, channel) into a 64-bit mask, which caps the path at
+// kGinA2AMaxRanks (16) in gin_alltoall_sdma.cu.
+TEST_F(GinAlltoAllEligibilityTest, TooManyRanks)
+{
+    mockComm_.comm.nRanks            = 32;
+    mockComm_.comm.devrState.lsaSize = mockComm_.comm.nRanks;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+TEST_F(GinAlltoAllEligibilityTest, NoSymmetricSupport)
+{
+    mockComm_.comm.symmetricSupport = false;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// Partial GIN connectivity is not enough; every peer has to be reachable.
+TEST_F(GinAlltoAllEligibilityTest, PartialGinConnectivity)
+{
+    mockComm_.comm.globalGinSupport = NCCL_GIN_CONNECTION_NONE;
+    EXPECT_FALSE(eligible(kCount));
+
+    mockComm_.comm.globalGinSupport = NCCL_GIN_CONNECTION_RAIL;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// A comm whose LSA team covers only part of the world cannot reach every peer
+// with stores, so the alltoall has to fall back even on one node.
+TEST_F(GinAlltoAllEligibilityTest, LsaTeamSmallerThanComm)
+{
+    mockComm_.comm.devrState.lsaSize = mockComm_.comm.nRanks / 2;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// The path runs on the comm's shared GIN backend, so a comm brought up on any
+// other backend must not be claimed.
+TEST_F(GinAlltoAllEligibilityTest, WrongGinBackend)
+{
+    mockComm_.sharedRes.ginState.ginType = (ncclGinType_t)NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA;
+    EXPECT_FALSE(eligible(kCount));
+
+    mockComm_.sharedRes.ginState.ginType = (ncclGinType_t)NCCL_NET_DEVICE_GIN_PROXY;
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// The kernel puts straight into symmetric windows, so unregistered buffers are
+// rejected. This is the mock's default state: every gate above passes, and the
+// empty window registry is the only reason the verdict is false.
+TEST_F(GinAlltoAllEligibilityTest, BuffersNotRegistered)
+{
+    ASSERT_EQ(mockComm_.comm.devrState.winSortedCount, 0);
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// NCCL_GIN_A2A_ENABLE is an NCCL_PARAM, so it is read once per process and cannot
+// be flipped from inside the binary. The test_runner config gives this filter a
+// run of its own with the kill switch thrown; see
+// tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json.
+TEST_F(GinAlltoAllEligibilityTest, A2ADisabledByParam)
+{
+    if (!envEquals("NCCL_GIN_A2A_ENABLE", "0")) {
+        GTEST_SKIP() << "needs NCCL_GIN_A2A_ENABLE=0 in the environment";
+    }
+    EXPECT_FALSE(eligible(kCount));
+}
+
+// Same deal: the config pins NCCL_GIN_A2A_MIN_BYTES above the size this test asks
+// for, so the floor is what rejects.
+TEST_F(GinAlltoAllEligibilityTest, BelowMinBytesParam)
+{
+    const char* env = std::getenv("NCCL_GIN_A2A_MIN_BYTES");
+    if (env == nullptr) {
+        GTEST_SKIP() << "needs NCCL_GIN_A2A_MIN_BYTES set above " << kBytesPerPeer;
+    }
+    ASSERT_GT(std::strtoull(env, nullptr, 0), kBytesPerPeer)
+        << "config must pin the floor above the per-peer size under test";
+    EXPECT_FALSE(eligible(kCount));
+}
+
+#endif // ENABLE_ROCSHMEM_GIN
+
+#if !defined(ENABLE_ROCSHMEM_GIN)
+TEST(GinAlltoAllEligibilityTest, SkippedWithoutGinBuild)
+{
+    GTEST_SKIP() << "GIN AllToAll eligibility tests require ENABLE_ROCSHMEM_GIN";
+}
+#endif
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -187,6 +187,9 @@ if(BUILD_TESTS)
     # init.cc), so hipify keeps its name -- no _tmp suffix.
     target_compile_definitions(${_init_tgt} PRIVATE ${RCCL_COMMON_COMPILE_DEFS}
       INIT_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/init.cc")
+    if(ENABLE_ROCSHMEM_GIN)
+      target_compile_definitions(${_init_tgt} PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+    endif()
     if(_variant STREQUAL "-uncached")
       target_compile_definitions(${_init_tgt} PRIVATE HIP_HOST_UNCACHED_MEMORY HIP_UNCACHED_MEMORY)
     endif()

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -46,6 +46,13 @@ if(BUILD_TESTS)
     ${RCCL_COMMON_INCLUDE_DIRS})
   target_compile_definitions(rccl-UnitTestsMicro PRIVATE ${RCCL_COMMON_COMPILE_DEFS})
 
+  # Mirrors the opt-out in test/CMakeLists.txt, whose loop does not reach this target.
+  # Inheriting ENABLE_ROCSHMEM_GIN defaults NCCL_GIN_ANVIL_SDMA_ENABLE to 1, which pulls
+  # in rocSHMEM's sdma device headers.
+  if(ENABLE_ROCSHMEM_GIN)
+    target_compile_definitions(rccl-UnitTestsMicro PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+  endif()
+
   # Apply HIP's *compile* usage requirements (headers, device intrinsics/codegen,
   # compile defs) WITHOUT linking the HIP runtime. $<COMPILE_ONLY:hip::host> would
   # express this in one line but requires CMake >= 3.27; pulling the interface

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -182,6 +182,9 @@ if(BUILD_TESTS)
     # init.cc), so hipify keeps its name -- no _tmp suffix.
     target_compile_definitions(${_init_tgt} PRIVATE ${RCCL_COMMON_COMPILE_DEFS}
       INIT_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/init.cc")
+    if(ENABLE_ROCSHMEM_GIN)
+      target_compile_definitions(${_init_tgt} PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+    endif()
     if(_variant STREQUAL "-uncached")
       target_compile_definitions(${_init_tgt} PRIVATE HIP_HOST_UNCACHED_MEMORY HIP_UNCACHED_MEMORY)
     endif()

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -43,6 +43,13 @@ if(BUILD_TESTS)
     ${RCCL_COMMON_INCLUDE_DIRS})
   target_compile_definitions(rccl-UnitTestsMicro PRIVATE ${RCCL_COMMON_COMPILE_DEFS})
 
+  # Mirrors the opt-out in test/CMakeLists.txt, whose loop does not reach this target.
+  # Inheriting ENABLE_ROCSHMEM_GIN defaults NCCL_GIN_ANVIL_SDMA_ENABLE to 1, which pulls
+  # in rocSHMEM's sdma device headers.
+  if(ENABLE_ROCSHMEM_GIN)
+    target_compile_definitions(rccl-UnitTestsMicro PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+  endif()
+
   # Apply HIP's *compile* usage requirements (headers, device intrinsics/codegen,
   # compile defs) WITHOUT linking the HIP runtime. $<COMPILE_ONLY:hip::host> would
   # express this in one line but requires CMake >= 3.27; pulling the interface

--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -47,6 +47,7 @@ bool ncclDdaUseFabricPath(struct ncclComm* comm) { return false; }
 ncclResult_t ncclDevrFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclDevrFindWindow(struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin) { ::abort(); }
 bool ncclDevrIsOneLsaTeam(struct ncclComm* comm) { ::abort(); }
+ncclResult_t ncclGinA2AFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclGinFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclGinHostFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) { ::abort(); }

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -11,6 +11,7 @@
 #include "MPITestBase.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
+#include "comm.h"
 
 #include "nccl_device.h"
 
@@ -39,19 +40,29 @@ std::string ginEnvDisabledReason() {
   return "";
 }
 
-// GIN type requested for this run (2=proxy, 4=rocshmem-gda); 0 if unset.
+// GIN type requested for this run (proxy / rocshmem-gda / anvil-sdma), 0 if unset.
 int requestedGinType() {
   const char* t = std::getenv("NCCL_GIN_TYPE");
   return t ? std::atoi(t) : 0;
 }
 
+// Valid NCCL_GIN_TYPE values, derived from the enum so the numbers stay correct
+// if the type numbering ever changes.
+std::string ginTypeUsage() {
+  return "required NCCL_GIN_TYPE=" +
+         std::to_string(NCCL_NET_DEVICE_GIN_PROXY) + " [proxy], " +
+         std::to_string(NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA) + " [rocshmem-gda] or " +
+         std::to_string(NCCL_NET_DEVICE_GIN_ANVIL_SDMA) + " [anvil-sdma]";
+}
+
 std::string ginTypeReason() {
   const char* ginType = std::getenv("NCCL_GIN_TYPE");
   if (!ginType)
-    return "GIN type not set (required NCCL_GIN_TYPE=2 [proxy] or 4 [rocshmem-gda])";
+    return "GIN type not set (" + ginTypeUsage() + ")";
   int t = requestedGinType();
-  if (t != 2 && t != 4)
-    return std::string("Invalid GIN type: ") + ginType + " (required NCCL_GIN_TYPE=2 [proxy] or 4 [rocshmem-gda])";
+  if (t != NCCL_NET_DEVICE_GIN_PROXY && t != NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA &&
+      t != NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    return std::string("Invalid GIN type: ") + ginType + " (" + ginTypeUsage() + ")";
   return "";
 }
 
@@ -93,6 +104,8 @@ std::string intranetReason() {
   int worldSize = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
   if (nodeLocalRanks() != worldSize) return "";
+  // anvil-sdma works single-node without intranet mode
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) return "";
   const char* intra = std::getenv("RCCL_ENABLE_INTRANET");
   if (!intra || std::strcmp(intra, "1") != 0)
     return "Intranet mode required for single-node run (RCCL_ENABLE_INTRANET=1)";
@@ -108,21 +121,56 @@ std::string crossNodeReason() {
   return "";
 }
 
+// anvil-SDMA is a single-node backend. Skip (rather than fail/hang) if it is
+// accidentally launched with ranks spanning more than one physical node.
+std::string anvilSingleNodeReason() {
+  if (requestedGinType() != NCCL_NET_DEVICE_GIN_ANVIL_SDMA) return "";
+  int worldSize = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+  if (nodeLocalRanks() != worldSize)
+    return "anvil-SDMA is a single-node backend; skipping multi-node run";
+  return "";
+}
+
 // First failing prerequisite, or "" if all met.
 std::string ginProxyTestSkipReason() {
-  for (auto check : {ginEnvDisabledReason, ginTypeReason, cuMemReason, intranetReason}) {
+  for (auto check : {ginEnvDisabledReason, ginTypeReason, cuMemReason, intranetReason,
+                     anvilSingleNodeReason}) {
     if (auto reason = check(); !reason.empty()) return reason;
   }
   return "";
 }
 
-// rocSHMEM-GDA (type 4)/SDMA (type 5) implements only INDEXED signals; VA signals are
+// rocSHMEM-GDA and SDMA implement only INDEXED signals; VA signals are
 // unsupported (Put/PutValue address the signal via indexedSignal.signalId).
 std::string vaSignalTestSkipReason() {
-  if (requestedGinType() == 4)
-    return "VA signals not supported by rocSHMEM-GDA (NCCL_GIN_TYPE=4)";
-  if (requestedGinType() == 5)
-    return "VA signals not supported by SDMA (NCCL_GIN_TYPE=5)";
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
+    return "VA signals not supported by rocSHMEM-GDA (NCCL_GIN_TYPE=" +
+           std::to_string(NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA) + ")";
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    return "VA signals not supported by SDMA (NCCL_GIN_TYPE=" +
+           std::to_string(NCCL_NET_DEVICE_GIN_ANVIL_SDMA) + ")";
+  return "";
+}
+
+// The GIN-SDMA alltoall exists only on the SDMA backend.
+std::string sdmaInternalA2AEnvSkipReason() {
+  if (requestedGinType() != NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    return "GIN-SDMA alltoall requires NCCL_GIN_TYPE=" +
+           std::to_string(NCCL_NET_DEVICE_GIN_ANVIL_SDMA);
+  if (const char* e = std::getenv("NCCL_GIN_A2A_ENABLE"); e && std::strcmp(e, "0") == 0)
+    return "GIN-SDMA alltoall disabled (NCCL_GIN_A2A_ENABLE=0)";
+  return "";
+}
+
+// Comm-side preconditions from ncclAllToAllGinSdmaEligible; skip rather than fail.
+std::string sdmaInternalA2ACommSkipReason(ncclComm_t comm) {
+  if (comm->nNodes != 1)
+    return "GIN-SDMA alltoall is scaleup-only (requires nNodes=1)";
+  if (!comm->symmetricSupport)
+    return "GIN-SDMA alltoall requires symmetric memory support";
+  if (comm->globalGinSupport != NCCL_GIN_CONNECTION_FULL)
+    return "GIN-SDMA alltoall requires full GIN connectivity";
   return "";
 }
 
@@ -1043,9 +1091,21 @@ TEST_F(GinMPIDeviceTests, Signal_NoPayload) {
   constexpr ncclGinSignal_t kSigIdx = 1;
   constexpr int             kPeer   = 1;  // rank 0 -> rank 1
 
-  // No buffers, no windows: gin.signal is a zero-byte put. The runtime's
-  // own signal pool is the only memory touched by the GFD; it's allocated
-  // and registered by ncclDevCommCreate based on ginSignalCount.
+  // anvil-sdma binds signal routes only when >=1 window is registered
+  // (dev_runtime.cc gates on winSortedCount>0). Proxy backends need no window.
+  void*            scratchBuf   = nullptr;
+  ncclWindow_t     scratchWin   = nullptr;
+  constexpr size_t kScratchBytes = 4 * 1024;
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
+                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
+  }
+  auto scratchCleanup = makeScopeGuard([&]() {
+    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
+    if (scratchBuf) (void)ncclMemFree(scratchBuf);
+  });
+
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
   reqs.ginSignalCount      = 2;
@@ -1106,6 +1166,21 @@ TEST_F(GinMPIDeviceTests, Signal_HighIdNoOverflow) {
   constexpr ncclGinSignal_t kSigIdx          = 65536;  // > 0xFFFF
   constexpr uint32_t        kSignalPoolCount = 65537;
   constexpr int             kPeer            = 1;       // rank 0 -> rank 1
+
+  // anvil-sdma needs >=1 window for signal routes to bind (see
+  // Signal_NoPayload). Proxy backends keep the no-window path.
+  void*            scratchBuf   = nullptr;
+  ncclWindow_t     scratchWin   = nullptr;
+  constexpr size_t kScratchBytes = 4 * 1024;
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
+                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
+  }
+  auto scratchCleanup = makeScopeGuard([&]() {
+    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
+    if (scratchBuf) (void)ncclMemFree(scratchBuf);
+  });
 
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
@@ -2598,41 +2673,47 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
   reqs.ginSignalCount      = 1;
-  ncclDevComm devComm{};
-  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
-  auto devCommCleanup = makeScopeGuard([&]() {
-    (void)ncclDevCommDestroy(comm, &devComm);
-  });
 
   // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
   const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
   constexpr int kCTAs          = 1;   // == railGinBarrierCount
   constexpr int kThreadsPerCTA = 512; // matches the production example launch
 
+  // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate
+  // activates GIN: some backends resolve a buffer's address at registration,
+  // which only succeeds pre-activation.
+  const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
+
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, maxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, maxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dSend, maxBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dRecv, maxBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
   for (size_t count : counts) {
     SCOPED_TRACE(::testing::Message() << "count=" << count);
 
     const size_t totalElements = count * static_cast<size_t>(nRanks);
     const size_t sizeBytes     = totalElements * sizeof(float);
-
-    void* dSend = nullptr;
-    void* dRecv = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
-    auto memCleanup = makeScopeGuard([&]() {
-      if (dSend) (void)ncclMemFree(dSend);
-      if (dRecv) (void)ncclMemFree(dRecv);
-    });
-
-    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
-    auto winCleanup = makeScopeGuard([&]() {
-      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
-      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
-    });
 
     // Per-source/per-dest pattern: every byte of every slice has a unique
     // expected value, so a misrouted slice surfaces as a mismatch.
@@ -2772,40 +2853,46 @@ TEST_F(GinMPIDeviceTests, AlltoallHybrid_Reference) {
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.barrierCount        = 1;
   reqs.ginSignalCount      = 1;
+
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+  constexpr int kCTAs          = 1;
+  constexpr int kThreadsPerCTA = 512;
+
+  // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate
+  // activates GIN: some backends resolve a buffer's address at registration,
+  // which only succeeds pre-activation.
+  const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
+
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, maxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, maxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dSend, maxBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dRecv, maxBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
     (void)ncclDevCommDestroy(comm, &devComm);
   });
 
-  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
-  constexpr int kCTAs          = 1;
-  constexpr int kThreadsPerCTA = 512;
-
   for (size_t count : counts) {
     SCOPED_TRACE(::testing::Message() << "count=" << count);
 
     const size_t totalElements = count * static_cast<size_t>(nRanks);
     const size_t sizeBytes     = totalElements * sizeof(float);
-
-    void* dSend = nullptr;
-    void* dRecv = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
-    auto memCleanup = makeScopeGuard([&]() {
-      if (dSend) (void)ncclMemFree(dSend);
-      if (dRecv) (void)ncclMemFree(dRecv);
-    });
-
-    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
-    auto winCleanup = makeScopeGuard([&]() {
-      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
-      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
-    });
 
     // Same deterministic pattern as Alltoall_PureReference.
     std::vector<float> hostSend(totalElements, 0.0f);
@@ -3183,6 +3270,101 @@ TEST_F(GinMPIDeviceTests, DevComm_PerInstanceGinResourcesRemainUsable) {
   secondLive = false;
   ASSERT_MPI_EQ(ncclSuccess, secondDestroyResult);
   MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ncclAlltoAll dispatches to ncclAllToAllGinSdma when eligible.
+TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (auto reason = sdmaInternalA2AEnvSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  if (auto reason = sdmaInternalA2ACommSkipReason(comm); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // Same sizes as Alltoall_PureReference so the two are directly comparable.
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+
+  // No ncclDevCommCreate here: the path lazily builds its own private devComm.
+  const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
+
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, maxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, maxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  // Registered once at the largest size and reused across the sweep.
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dSend, maxBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dRecv, maxBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
+  for (size_t count : counts) {
+    SCOPED_TRACE(::testing::Message() << "count=" << count);
+
+    const size_t totalElements = count * static_cast<size_t>(nRanks);
+    const size_t sizeBytes     = totalElements * sizeof(float);
+
+    // Same deterministic pattern as Alltoall_PureReference.
+    std::vector<float> hostSend(totalElements, 0.0f);
+    std::vector<float> hostRecv(totalElements, 0.0f);
+    for (int dst = 0; dst < nRanks; dst++) {
+      for (size_t i = 0; i < count; i++) {
+        hostSend[static_cast<size_t>(dst) * count + i] =
+            static_cast<float>(rank * 1000 + dst * 100 + static_cast<int>(i));
+      }
+    }
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dSend, hostSend.data(), sizeBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dRecv, hostRecv.data(), sizeBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAlltoAll(dSend, dRecv, count, ncclFloat, comm, stream));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    // Set by ncclGinA2AInitOnce, so a silent fallback fails here instead of passing.
+    ASSERT_MPI_TRUE(comm->ginA2AState.initialized);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_EQ(hipSuccess,
+        hipMemcpy(hostRecv.data(), dRecv, sizeBytes, hipMemcpyDeviceToHost));
+    for (int src = 0; src < nRanks; src++) {
+      for (size_t i = 0; i < count; i++) {
+        const float expected =
+            static_cast<float>(src * 1000 + rank * 100 + static_cast<int>(i));
+        const float got = hostRecv[static_cast<size_t>(src) * count + i];
+        ASSERT_EQ(expected, got)
+            << "rank=" << rank << " src=" << src << " i=" << i;
+      }
+    }
+  }
 }
 
 // Producer: one block per GIN context. Block b uses ginContext=b, puts into
@@ -3915,7 +4097,7 @@ TEST_F(GinMPIDeviceTests, Alltoall_CrossNode) {
 
 // =====================================================================
 // Coverage for the new NCCL 2.29.7 GIN device-API features. All run on the
-// device-API NCCL_GIN_TYPE=2 path with cross-node placement (2 ranks on 2
+// device-API GIN proxy path with cross-node placement (2 ranks on 2
 // nodes). Tests for features that depend on topology/library support that
 // may be unavailable skip gracefully rather than fail.
 // =====================================================================
@@ -3936,7 +4118,7 @@ TEST_F(GinMPIDeviceTests, Properties_NLsaTeams) {
   ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
   ASSERT_EQ(ncclSuccess, ncclCommQueryProperties(comm, &props));
 
-  // Backend type must match the requested NCCL_GIN_TYPE (2=proxy, 4=rocshmem-gda).
+  // Backend type must match the requested NCCL_GIN_TYPE (proxy / rocshmem-gda / anvil-sdma).
   EXPECT_EQ(requestedGinType(), (int)props.ginType);
 
   // nLsaTeams = nRanks / lsaSize: >= 1 and must evenly divide nRanks.
@@ -5002,8 +5184,11 @@ std::string intraNodeSymReason() {
 // symmetric-memory RS kernel (RailA2A_LsaLD) eligible, so this drives the
 // production kernel path -- not a hand-written reference kernel.
 TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
-  if (requestedGinType() == 4)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
     GTEST_SKIP() << "Skipping symmetric ReduceScatter (RailA2A_LsaLD) for rocSHMEM-GDA";
+  // anvil-sdma is single-node. Symmetric ReduceScatter is a multi-node test.
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    GTEST_SKIP() << "Symmetric ReduceScatter not supported for anvil-sdma: single-node backend";
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
@@ -5091,8 +5276,11 @@ TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
 // Same as ReduceScatter_Symmetric but exercises ncclAvg, which drives the
 // FuncSumPostDiv post-divide path on the symmetric RS kernel (RailA2A_LsaLD).
 TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric_Avg) {
-  if (requestedGinType() == 4)
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA)
     GTEST_SKIP() << "Skipping symmetric ReduceScatter (RailA2A_LsaLD) for rocSHMEM-GDA";
+  // anvil-sdma is single-node. Symmetric ReduceScatter is a multi-node test.
+  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA)
+    GTEST_SKIP() << "Symmetric ReduceScatter not supported for anvil-sdma: single-node backend";
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2615,24 +2615,20 @@ TEST_F(GinMPIDeviceTests, SymPtr_PutAndPutValue) {
 
 // Reference single-node alltoall: every rank puts its slice for every peer
 // into that peer's recvbuf via gin.put + SignalInc, then waits on its own
-// signal cell for nRanks increments. Ported one-for-one from
-// examples/06_device_api/02_gin_alltoall_pure/main.cu so a regression in
-// put + signal + barrier + flush composed under realistic load surfaces here.
-__global__ void alltoallPureKernel(
+// signal cell for nRanks increments. Mirrors ginAlltoAllBody (device impl 3) in
+// rccl-tests/src/alltoall.cu, minus its trailing release sync, so a regression
+// in put + signal + barrier + flush composed under load surfaces here.
+// Body shared by the two reference kernels below. bar is whichever session the
+// caller built, so the identical put + signal + flush composition runs under
+// both the generic barrier and the dedicated world-team GIN barrier.
+template <typename BarT>
+__device__ void alltoallPureBody(
+    ncclGin& gin, BarT& bar, unsigned int signalIndex, uint64_t signalValue,
     ncclWindow_t sendwin, size_t sendoffset,
     ncclWindow_t recvwin, size_t recvoffset,
     size_t count, struct ncclDevComm devComm) {
-  constexpr int ginContext = 0;
-  unsigned int signalIndex = blockIdx.x;
-  ncclGin gin{devComm, ginContext};
-  // Capture current signal cell so a count-sweep that reuses the same
-  // kernel/devComm doesn't conflate increments from past iterations.
-  uint64_t signalValue = gin.readSignal(signalIndex);
-
   // Cross-rank sync ensures every rank's sendbuf is registered before any
   // peer reads from it via gin.put below.
-  ncclBarrierSession<ncclCoopCta> bar{
-      ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x};
   bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -2656,38 +2652,55 @@ __global__ void alltoallPureKernel(
   gin.flush(ncclCoopCta());
 }
 
-// Single-node 2-8 ranks; count sweep {1, 1024, 1<<16}. Bit-for-bit verifies
-// the deterministic sendbuf[i] = rank*1000 + dst*100 + i pattern landed on
-// the right peer slot. The 1<<16 case (256 KiB / direction / peer) saturates
-// ring credit to exercise the postGfd credit-wait path.
-TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
-  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
-    GTEST_SKIP() << reason;
+// Generic session, provisioned from reqs.barrierCount. This is the rccl-tests
+// composition.
+__global__ void alltoallPureKernel(
+    ncclWindow_t sendwin, size_t sendoffset,
+    ncclWindow_t recvwin, size_t recvoffset,
+    size_t count, struct ncclDevComm devComm) {
+  unsigned int signalIndex = blockIdx.x;
+  ncclGin gin{devComm, /*ginContext=*/0};
+  // Capture current signal cell so a count-sweep that reuses the same
+  // kernel/devComm doesn't conflate increments from past iterations.
+  uint64_t signalValue = gin.readSignal(signalIndex);
 
-  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
-    GTEST_SKIP() << "Requires 2-8 ranks";
+  ncclBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x};
+  alltoallPureBody(gin, bar, signalIndex, signalValue,
+      sendwin, sendoffset, recvwin, recvoffset, count, devComm);
+}
 
-  ASSERT_EQ(ncclSuccess, createTestCommunicator());
-  ncclComm_t  comm   = getActiveCommunicator();
-  hipStream_t stream = getActiveStream();
+// Same collective on the dedicated world GIN pool, provisioned from
+// reqs.worldGinBarrierCount. This is the composition in
+// examples/06_device_api/02_alltoall_gin/c/main.cu.
+__global__ void alltoallWorldGinKernel(
+    ncclWindow_t sendwin, size_t sendoffset,
+    ncclWindow_t recvwin, size_t recvoffset,
+    size_t count, struct ncclDevComm devComm) {
+  unsigned int signalIndex = blockIdx.x;
+  ncclGin gin{devComm, /*ginContext=*/0};
+  uint64_t signalValue = gin.readSignal(signalIndex);
 
-  int rank = -1, nRanks = -1;
-  ncclCommUserRank(comm, &rank);
-  ncclCommCount(comm, &nRanks);
-  ASSERT_GE(nRanks, 2);
-  ASSERT_LE(nRanks, 8);
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, blockIdx.x};
+  alltoallPureBody(gin, bar, signalIndex, signalValue,
+      sendwin, sendoffset, recvwin, recvoffset, count, devComm);
+}
 
-  // The world-team ncclBarrierSession sizes its hybrid LSA+rail-GIN barriers from
-  // reqs.barrierCount (not lsa/railGinBarrierCount), and 0 hangs the rail arm.
-  // ginSignalCount=1 covers the kernel's own signalIndex=0.
-  ncclDevCommRequirements reqs = defaultGinReqs();
-  reqs.barrierCount        = 1;
-  reqs.ginSignalCount      = 1;
+// One CTA keeps barrier index 0 the only index in play; 512 threads is the
+// rccl-tests production launch shape.
+constexpr int kAlltoallRefCTAs    = 1;
+constexpr int kAlltoallRefThreads = 512;
 
-  // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
+// Count sweep shared by the two alltoall reference tests: 1 (alignment/tail
+// edges), 1024 (medium), 65536 (saturating). Only reqs and the kernel differ
+// between them, so each caller supplies those. launch receives the registered
+// windows, the current count and the devComm. Asserts, so callers wrap this in
+// ASSERT_NO_FATAL_FAILURE.
+template <typename LaunchT>
+void runAlltoallReferenceSweep(ncclComm_t comm, hipStream_t stream, int rank, int nRanks,
+                               const ncclDevCommRequirements& reqs, LaunchT&& launch) {
   const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
-  constexpr int kCTAs          = 1;   // == barrierCount
-  constexpr int kThreadsPerCTA = 512; // matches the production example launch
 
   // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate
   // activates GIN: some backends resolve a buffer's address at registration,
@@ -2742,10 +2755,7 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    alltoallPureKernel<<<kCTAs, kThreadsPerCTA, 0, stream>>>(
-        sendWin, /*sendoffset=*/0,
-        recvWin, /*recvoffset=*/0,
-        count, devComm);
+    launch(sendWin, recvWin, count, devComm);
     ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -2763,6 +2773,79 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
       }
     }
   }
+}
+
+// Single-node 2-8 ranks. Bit-for-bit verifies the deterministic
+// sendbuf[i] = rank*1000 + dst*100 + i pattern landed on the right peer slot.
+// The 1<<16 case (256 KiB / direction / peer) saturates ring credit to
+// exercise the postGfd credit-wait path.
+TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // ncclBarrierSession(ncclTeamTagWorld) draws on the three hybrid pools, all
+  // sized by reqs.barrierCount rather than lsa/railGinBarrierCount, so leaving
+  // it 0 hangs the GIN arm. ginSignalCount=1 covers the kernel's signalIndex=0.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.barrierCount   = 1;
+  reqs.ginSignalCount = 1;
+
+  ASSERT_NO_FATAL_FAILURE(runAlltoallReferenceSweep(comm, stream, rank, nRanks, reqs,
+      [&](ncclWindow_t sendWin, ncclWindow_t recvWin, size_t count, ncclDevComm& devComm) {
+        alltoallPureKernel<<<kAlltoallRefCTAs, kAlltoallRefThreads, 0, stream>>>(
+            sendWin, /*sendoffset=*/0,
+            recvWin, /*recvoffset=*/0,
+            count, devComm);
+      }));
+}
+
+// Same collective and same verification as Alltoall_PureReference, on the
+// dedicated world GIN barrier pool instead of the generic one. Keeps the
+// ncclTeamTagWorld constructor and worldGinBarrierCount covered, which the
+// generic session never touches.
+TEST_F(GinMPIDeviceTests, Alltoall_WorldGinBarrierReference) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // worldGinBarrierCount allocates the world pool that the ncclTeamTagWorld
+  // constructor binds to, so no manual barrier requirement is needed.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.worldGinBarrierCount = 1;
+  reqs.ginSignalCount       = 1;
+
+  ASSERT_NO_FATAL_FAILURE(runAlltoallReferenceSweep(comm, stream, rank, nRanks, reqs,
+      [&](ncclWindow_t sendWin, ncclWindow_t recvWin, size_t count, ncclDevComm& devComm) {
+        alltoallWorldGinKernel<<<kAlltoallRefCTAs, kAlltoallRefThreads, 0, stream>>>(
+            sendWin, /*sendoffset=*/0,
+            recvWin, /*recvoffset=*/0,
+            count, devComm);
+      }));
 }
 
 // Hybrid alltoall: LSA stores for intra-node peers + gin.put for cross-node

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1956,7 +1956,7 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
 
   constexpr int kIters = 16;
 
-  // Only barrierCount provisions the two pools consumed by the generic
+  // Only barrierCount provisions the three pools consumed by the generic
   // world-team session. Keeping every specialized count at zero ensures an
   // accidental constructor or requirement-routing regression cannot be masked.
   ncclDevCommRequirements reqs = defaultGinReqs();
@@ -1969,7 +1969,8 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
 
   ASSERT_MPI_EQ(1, devComm.hybridLsaBarrier.nBarriers);
   ASSERT_MPI_EQ(0, devComm.lsaBarrier.nBarriers);
-  ASSERT_MPI_EQ(ncclTeamRail(comm).nRanks, devComm.ginSignalCount);
+  // barrierCount sizes both outer GIN arms: one cell per source rank of the rail team and of the world team.
+  ASSERT_MPI_EQ(ncclTeamRail(comm).nRanks + ncclTeamWorld(comm).nRanks, devComm.ginSignalCount);
 
   MPI_Barrier(MPI_COMM_WORLD);
 

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2623,9 +2623,8 @@ __global__ void alltoallPureKernel(
 
   // Cross-rank sync ensures every rank's sendbuf is registered before any
   // peer reads from it via gin.put below.
-  ncclGinBarrierSession<ncclCoopCta> bar{
-      ncclCoopCta(), gin, ncclTeamWorld(devComm),
-      devComm.railGinBarrier, blockIdx.x};
+  ncclBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x};
   bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -2670,15 +2669,16 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
   ASSERT_GE(nRanks, 2);
   ASSERT_LE(nRanks, 8);
 
-  // ginSignalCount=1 covers signalIndex=0; railGinBarrierCount=1 matches
-  // our single-CTA launch.
+  // The world-team ncclBarrierSession sizes its hybrid LSA+rail-GIN barriers from
+  // reqs.barrierCount (not lsa/railGinBarrierCount), and 0 hangs the rail arm.
+  // ginSignalCount=1 covers the kernel's own signalIndex=0.
   ncclDevCommRequirements reqs = defaultGinReqs();
-  reqs.railGinBarrierCount = 1;
+  reqs.barrierCount        = 1;
   reqs.ginSignalCount      = 1;
 
   // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
   const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
-  constexpr int kCTAs          = 1;   // == railGinBarrierCount
+  constexpr int kCTAs          = 1;   // == barrierCount
   constexpr int kThreadsPerCTA = 512; // matches the production example launch
 
   // Register windows ONCE (largest count) and reuse, BEFORE ncclDevCommCreate

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -163,7 +163,8 @@ std::string sdmaInternalA2AEnvSkipReason() {
   return "";
 }
 
-// Comm-side preconditions from ncclAllToAllGinSdmaEligible; skip rather than fail.
+// Comm-side subset of ncclAllToAllGinSdmaEligible in gin_alltoall_sdma.cu, which is
+// the source of truth. Skipping keeps an ineligible setup from failing opaquely.
 std::string sdmaInternalA2ACommSkipReason(ncclComm_t comm) {
   if (comm->nNodes != 1)
     return "GIN-SDMA alltoall is scaleup-only (requires nNodes=1)";
@@ -3297,8 +3298,12 @@ TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
   ASSERT_GE(nRanks, 2);
   ASSERT_LE(nRanks, 8);
 
-  // Same sizes as Alltoall_PureReference so the two are directly comparable.
-  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+  // Per-peer bytes select the kernel inside ncclAllToAllGinSdma: below
+  // NCCL_GIN_A2A_SDMA_MIN_BYTES (default 8 MiB) it runs ncclGinA2AKernel<false>,
+  // at or above it runs ncclGinA2AKernel<true>.
+  const std::vector<size_t> counts = {
+      1, 1024, size_t{1} << 16,            // 4 B / 4 KiB / 256 KiB per peer -> LSA
+      (size_t{8} << 20) / sizeof(float)};  // 8 MiB per peer -> SDMA engine
 
   // No ncclDevCommCreate here: the path lazily builds its own private devComm.
   const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
@@ -3349,7 +3354,8 @@ TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
         ncclAlltoAll(dSend, dRecv, count, ncclFloat, comm, stream));
     ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
-    // Set by ncclGinA2AInitOnce, so a silent fallback fails here instead of passing.
+    // Set by ncclGinA2AInitOnce and sticky for the comm's lifetime: this catches a
+    // fallback on the first dispatch, but cannot tell the LSA and SDMA tiers apart.
     ASSERT_MPI_TRUE(comm->ginA2AState.initialized);
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -160,6 +160,12 @@ std::string sdmaInternalA2AEnvSkipReason() {
            std::to_string(NCCL_NET_DEVICE_GIN_ANVIL_SDMA);
   if (const char* e = std::getenv("NCCL_GIN_A2A_ENABLE"); e && std::strcmp(e, "0") == 0)
     return "GIN-SDMA alltoall disabled (NCCL_GIN_A2A_ENABLE=0)";
+  // The count sweep needs both thresholds at their defaults: a raised floor drops
+  // the smallest count, a raised SDMA cutoff keeps the largest on the LSA kernel.
+  if (std::getenv("NCCL_GIN_A2A_MIN_BYTES"))
+    return "count sweep assumes the default NCCL_GIN_A2A_MIN_BYTES";
+  if (std::getenv("NCCL_GIN_A2A_SDMA_MIN_BYTES"))
+    return "SDMA tier coverage assumes the default NCCL_GIN_A2A_SDMA_MIN_BYTES";
   return "";
 }
 
@@ -181,6 +187,28 @@ ncclDevCommRequirements defaultGinReqs() {
   r.ginConnectionType = NCCL_GIN_CONNECTION_FULL;
   return r;
 }
+
+// No-ops on backends other than anvil-sdma. acquire() asserts, so callers wrap
+// it in ASSERT_NO_FATAL_FAILURE.
+struct SdmaScratchWindow {
+  ncclComm_t   comm = nullptr;
+  void*        buf  = nullptr;
+  ncclWindow_t win  = nullptr;
+
+  ~SdmaScratchWindow() {
+    if (win) (void)ncclCommWindowDeregister(comm, win);
+    if (buf) (void)ncclMemFree(buf);
+  }
+
+  void acquire(ncclComm_t c) {
+    if (requestedGinType() != NCCL_NET_DEVICE_GIN_ANVIL_SDMA) return;
+    constexpr size_t kBytes = 4 * 1024;
+    comm = c;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&buf, kBytes));
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(c, buf, kBytes, &win, NCCL_WIN_COLL_SYMMETRIC));
+  }
+};
 
 // Bounded stream drain: poll with a deadline so a device-side hang becomes a
 // reported timeout instead of an infinite hipStreamSynchronize. Returns the
@@ -1094,18 +1122,8 @@ TEST_F(GinMPIDeviceTests, Signal_NoPayload) {
 
   // anvil-sdma binds signal routes only when >=1 window is registered
   // (dev_runtime.cc gates on winSortedCount>0). Proxy backends need no window.
-  void*            scratchBuf   = nullptr;
-  ncclWindow_t     scratchWin   = nullptr;
-  constexpr size_t kScratchBytes = 4 * 1024;
-  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
-                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
-  }
-  auto scratchCleanup = makeScopeGuard([&]() {
-    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
-    if (scratchBuf) (void)ncclMemFree(scratchBuf);
-  });
+  SdmaScratchWindow scratch;
+  ASSERT_NO_FATAL_FAILURE(scratch.acquire(comm));
 
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
@@ -1168,20 +1186,10 @@ TEST_F(GinMPIDeviceTests, Signal_HighIdNoOverflow) {
   constexpr uint32_t        kSignalPoolCount = 65537;
   constexpr int             kPeer            = 1;       // rank 0 -> rank 1
 
-  // anvil-sdma needs >=1 window for signal routes to bind (see
-  // Signal_NoPayload). Proxy backends keep the no-window path.
-  void*            scratchBuf   = nullptr;
-  ncclWindow_t     scratchWin   = nullptr;
-  constexpr size_t kScratchBytes = 4 * 1024;
-  if (requestedGinType() == NCCL_NET_DEVICE_GIN_ANVIL_SDMA) {
-    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&scratchBuf, kScratchBytes));
-    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowRegister(comm, scratchBuf, kScratchBytes,
-                                                      &scratchWin, NCCL_WIN_COLL_SYMMETRIC));
-  }
-  auto scratchCleanup = makeScopeGuard([&]() {
-    if (scratchWin) (void)ncclCommWindowDeregister(comm, scratchWin);
-    if (scratchBuf) (void)ncclMemFree(scratchBuf);
-  });
+  // anvil-sdma needs >=1 window for signal routes to bind (see Signal_NoPayload).
+  // Proxy backends keep the no-window path.
+  SdmaScratchWindow scratch;
+  ASSERT_NO_FATAL_FAILURE(scratch.acquire(comm));
 
   ncclDevCommRequirements reqs = defaultGinReqs();
   reqs.railGinBarrierCount = 1;
@@ -3298,12 +3306,12 @@ TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
   ASSERT_GE(nRanks, 2);
   ASSERT_LE(nRanks, 8);
 
-  // Per-peer bytes select the kernel inside ncclAllToAllGinSdma: below
-  // NCCL_GIN_A2A_SDMA_MIN_BYTES (default 8 MiB) it runs ncclGinA2AKernel<false>,
-  // at or above it runs ncclGinA2AKernel<true>.
+  // Mirrors the NCCL_GIN_A2A_SDMA_MIN_BYTES default (enforced by the env skip).
+  // Below it ncclAllToAllGinSdma runs ncclGinA2AKernel<false>, at or above <true>.
+  constexpr size_t kSdmaMinBytesPerPeer = size_t{8} << 20;
   const std::vector<size_t> counts = {
-      1, 1024, size_t{1} << 16,            // 4 B / 4 KiB / 256 KiB per peer -> LSA
-      (size_t{8} << 20) / sizeof(float)};  // 8 MiB per peer -> SDMA engine
+      1, 1024, size_t{1} << 16,               // 4 B / 4 KiB / 256 KiB per peer -> LSA
+      kSdmaMinBytesPerPeer / sizeof(float)};  // 8 MiB per peer -> SDMA engine
 
   // No ncclDevCommCreate here: the path lazily builds its own private devComm.
   const size_t maxBytes = counts.back() * static_cast<size_t>(nRanks) * sizeof(float);
@@ -3328,7 +3336,8 @@ TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
     if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
   });
 
-  for (size_t count : counts) {
+  for (size_t idx = 0; idx < counts.size(); idx++) {
+    const size_t count = counts[idx];
     SCOPED_TRACE(::testing::Message() << "count=" << count);
 
     const size_t totalElements = count * static_cast<size_t>(nRanks);
@@ -3354,9 +3363,11 @@ TEST_F(GinMPIDeviceTests, Alltoall_SdmaInternal) {
         ncclAlltoAll(dSend, dRecv, count, ncclFloat, comm, stream));
     ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
 
-    // Set by ncclGinA2AInitOnce and sticky for the comm's lifetime: this catches a
-    // fallback on the first dispatch, but cannot tell the LSA and SDMA tiers apart.
-    ASSERT_MPI_TRUE(comm->ginA2AState.initialized);
+    // Set by ncclGinA2AInitOnce and sticky for the comm's lifetime, so the first
+    // dispatch is the only one that can fail this. Checking it here reports a
+    // fallback before the sweep reaches the larger sizes, but it cannot tell the
+    // LSA and SDMA tiers apart.
+    if (idx == 0) ASSERT_MPI_TRUE(comm->ginA2AState.initialized);
 
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -140,7 +140,10 @@
           "name": "AlltoallHybrid_Reference", "description": "GIN hybrid (LSA + GIN) alltoall reference (2 ranks/node)", "test_filter": "GinMPIDeviceTests.AlltoallHybrid_Reference",
           "num_ranks": 4, "num_gpus": 2
         },
-        { "name": "Alltoall_SdmaInternal",    "description": "GIN-SDMA alltoall via ncclAlltoAll (SDMA only)",       "test_filter": "GinMPIDeviceTests.Alltoall_SdmaInternal" },
+        {
+          "name": "Alltoall_SdmaInternal", "description": "GIN-SDMA alltoall via ncclAlltoAll (SDMA only, 8 ranks)", "test_filter": "GinMPIDeviceTests.Alltoall_SdmaInternal",
+          "num_ranks": 8, "num_gpus": 8
+        },
         { "name": "MultiContext_AllFourRoute","description": "GIN multi-context, all four routes",                    "test_filter": "GinMPIDeviceTests.MultiContext_AllFourRoute" },
         {
           "name": "MultiContext_NonPowerOf2", "description": "GIN multi-context with non-power-of-2 context count (NCONNECTIONS=3, NCONTEXTS=3)", "test_filter": "GinMPIDeviceTests.MultiContext_NonPowerOf2",

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -136,6 +136,7 @@
         { "name": "SignalAdd_AndShadow",      "description": "GIN device signal-add and shadow counter",              "test_filter": "GinMPIDeviceTests.SignalAdd_AndShadow" },
         { "name": "SymPtr_PutAndPutValue",    "description": "GIN symmetric-pointer put and put-value",               "test_filter": "GinMPIDeviceTests.SymPtr_PutAndPutValue" },
         { "name": "Alltoall_PureReference",   "description": "GIN pure-reference alltoall kernel",                    "test_filter": "GinMPIDeviceTests.Alltoall_PureReference" },
+        { "name": "Alltoall_WorldGinBarrier", "description": "GIN alltoall on the world-team GIN barrier pool",       "test_filter": "GinMPIDeviceTests.Alltoall_WorldGinBarrierReference" },
         {
           "name": "AlltoallHybrid_Reference", "description": "GIN hybrid (LSA + GIN) alltoall reference (2 ranks/node)", "test_filter": "GinMPIDeviceTests.AlltoallHybrid_Reference",
           "num_ranks": 4, "num_gpus": 2

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -1,0 +1,236 @@
+{
+  "system_configurations": {
+    "name": "RCCL-GIN-rocSHMEM-Backends-MI300X-Mellanox-IB",
+    "description": "GIN rocSHMEM backends (GDA and SDMA) on MI300X over Mellanox IB. alltoall_perf (D3/D4) plus the full GinMPIDeviceTests suite run one-mpirun-per-test."
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH:-/opt/shared/ompi}"
+  },
+  "env_variables": {
+    "NCCL_SOCKET_IFNAME": "eth0,eth1",
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+    "NCCL_DEBUG": "INFO"
+  },
+  "build_configuration": {
+    "install_flags": [
+      "-l",
+      "--debug",
+      "-t",
+      "--enable-mpi-tests",
+      "--enable-code-coverage",
+      "--rocshmem-gin",
+      "--prefix",
+      "${WORKDIR}/install"
+    ],
+    "parallel_jobs": 64
+  },
+  "rccl_tests_build_configuration": {
+    "enabled": true,
+    "source_dir": "${RCCL_TESTS_DIR:-${WORKDIR}/../rccl-tests}",
+    "build_command": "make clean && cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=ON -DENABLE_DEVICE_API=ON -DENABLE_ROCSHMEM_GIN=ON -DGPU_TARGETS=gfx942 -DRCCL_DIR=${WORKDIR}/install/lib/cmake/rccl -DRCCL_SOURCE_DIR=${WORKDIR} && cmake --build build -j$(nproc)"
+  },
+  "test_configurations": {
+    "default": {
+      "env_variables": {},
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      }
+    },
+
+    "gin_perf_base": {
+      "is_gtest": false,
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+      "num_ranks": 16,
+      "num_nodes": 2,
+      "num_gpus": 8,
+      "timeout": 600,
+      "command_args": "-b 1 -e 1G -f 2 -g 1",
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1"
+      }
+    },
+    "gin_perf_gda": {
+      "extends": "gin_perf_base",
+      "env_variables": {
+        "NCCL_GIN_TYPE": "5"
+      },
+      "tests": [
+        { "name": "GIN_GDA_D3", "description": "GDA alltoall, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_GDA_D4", "description": "GDA alltoall, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+    "gin_perf_gda_1node": {
+      "extends": "gin_perf_base",
+      "description": "Single-node GDA alltoall (num_nodes=1, 8 ranks): same params as the multi-node GDA perf but all ranks packed on one node.",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "5"
+      },
+      "tests": [
+        { "name": "GIN_GDA_1N_D3", "description": "GDA alltoall single-node, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_GDA_1N_D4", "description": "GDA alltoall single-node, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+    "gin_perf_sdma": {
+      "extends": "gin_perf_base",
+      "description": "SDMA is a single-node backend: all ranks are packed onto one node (num_nodes=1, 8 ranks).",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "6"
+      },
+      "tests": [
+        { "name": "GIN_SDMA_D3", "description": "SDMA alltoall, GinAlltoAllKernel, pure-GIN (-R 2 -D 3)", "command_args": "-R 2 -D 3" },
+        { "name": "GIN_SDMA_D4", "description": "SDMA alltoall, HybridAlltoAllKernel, LSA+GIN (-R 2 -D 4)", "command_args": "-R 2 -D 4" }
+      ]
+    },
+    "gin_perf_sdma_internal": {
+      "extends": "gin_perf_base",
+      "description": "Collectives on the GIN-SDMA path. Single node, 8 ranks.",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "command_args": "-b 1 -e 4G -f 2 -g 1",
+      "env_variables": {
+        "NCCL_GIN_TYPE": "6"
+      },
+      "tests": [
+        { "name": "GIN_SDMA_INTERNAL", "description": "GIN-SDMA alltoall via ncclAlltoAll (-R 2)", "command_args": "-R 2" }
+      ]
+    },
+
+    "gin_devmpi_common": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none",
+        "NCCL_DMABUF_ENABLE": "1"
+      },
+      "tests": [
+        { "name": "Put_BasicAndOffsets",      "description": "GIN device put with base + offset variants",            "test_filter": "GinMPIDeviceTests.Put_BasicAndOffsets" },
+        { "name": "Put_CrossNode",            "description": "GIN device put crossing the IB fabric",                 "test_filter": "GinMPIDeviceTests.Put_CrossNode" },
+        { "name": "PutValue_Inline",          "description": "GIN device inline put-value",                           "test_filter": "GinMPIDeviceTests.PutValue_Inline" },
+        { "name": "Signal_NoPayload",         "description": "GIN device signal, no payload",                         "test_filter": "GinMPIDeviceTests.Signal_NoPayload" },
+        { "name": "Signal_HighIdNoOverflow",  "description": "GIN device signal with high id, no overflow",           "test_filter": "GinMPIDeviceTests.Signal_HighIdNoOverflow" },
+        { "name": "WaitCounter_Local",        "description": "GIN device wait-counter, local",                        "test_filter": "GinMPIDeviceTests.WaitCounter_Local" },
+        { "name": "WaitCounterAndSignal",     "description": "GIN device wait-counter combined with signal",          "test_filter": "GinMPIDeviceTests.WaitCounterAndSignal" },
+        { "name": "Barrier_TwoRanks",         "description": "GIN device two-rank barrier",                           "test_filter": "GinMPIDeviceTests.Barrier_TwoRanks" },
+        {
+          "name": "BarrierSession_LsaOnly", "description": "ncclBarrierSession LSA-only (2 ranks/node, non-trivial LSA team)", "test_filter": "GinMPIDeviceTests.BarrierSession_LsaOnly",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        {
+          "name": "BarrierSession_Hybrid", "description": "ncclBarrierSession hybrid inner-LSA + outer rail-GIN (2 ranks/node)", "test_filter": "GinMPIDeviceTests.BarrierSession_Hybrid",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        { "name": "SignalAdd_AndShadow",      "description": "GIN device signal-add and shadow counter",              "test_filter": "GinMPIDeviceTests.SignalAdd_AndShadow" },
+        { "name": "SymPtr_PutAndPutValue",    "description": "GIN symmetric-pointer put and put-value",               "test_filter": "GinMPIDeviceTests.SymPtr_PutAndPutValue" },
+        { "name": "Alltoall_PureReference",   "description": "GIN pure-reference alltoall kernel",                    "test_filter": "GinMPIDeviceTests.Alltoall_PureReference" },
+        {
+          "name": "AlltoallHybrid_Reference", "description": "GIN hybrid (LSA + GIN) alltoall reference (2 ranks/node)", "test_filter": "GinMPIDeviceTests.AlltoallHybrid_Reference",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        { "name": "Alltoall_SdmaInternal",    "description": "GIN-SDMA alltoall via ncclAlltoAll (SDMA only)",       "test_filter": "GinMPIDeviceTests.Alltoall_SdmaInternal" },
+        { "name": "MultiContext_AllFourRoute","description": "GIN multi-context, all four routes",                    "test_filter": "GinMPIDeviceTests.MultiContext_AllFourRoute" },
+        {
+          "name": "MultiContext_NonPowerOf2", "description": "GIN multi-context with non-power-of-2 context count (NCONNECTIONS=3, NCONTEXTS=3)", "test_filter": "GinMPIDeviceTests.MultiContext_NonPowerOf2",
+          "env_variables": { "NCCL_GIN_NCONNECTIONS": "3", "NCCL_GIN_NCONTEXTS": "3" }
+        },
+        { "name": "LargeBuffer_Sweep",        "description": "GIN large-buffer size sweep",                           "test_filter": "GinMPIDeviceTests.LargeBuffer_Sweep", "timeout": 300 },
+        {
+          "name": "Disable_Error", "description": "Negative: devCommCreate must reject GIN when NCCL_GIN_ENABLE=0", "test_filter": "GinMPIDeviceTests.Disable_Error",
+          "env_variables": { "NCCL_GIN_ENABLE": "0" }
+        },
+        {
+          "name": "Invalid_SignalPool", "description": "Negative: oversized signal pool rejected at devCommCreate", "test_filter": "GinMPIDeviceTests.Invalid_SignalPool",
+          "env_variables": { "NCCL_GIN_SIGNAL_POOL_SIZE": "0x40000000" }
+        },
+        {
+          "name": "Invalid_CounterPool", "description": "Negative: oversized counter pool rejected at devCommCreate", "test_filter": "GinMPIDeviceTests.Invalid_CounterPool",
+          "env_variables": { "NCCL_GIN_COUNTER_POOL_SIZE": "0x40000000" }
+        },
+        { "name": "Teardown_NoLeaks",         "description": "GIN teardown leaves no leaks",                          "test_filter": "GinMPIDeviceTests.Teardown_NoLeaks" },
+        { "name": "Init_Destroy_Stress",      "description": "GIN init/destroy stress loop",                          "test_filter": "GinMPIDeviceTests.Init_Destroy_Stress", "timeout": 300 },
+        { "name": "Alltoall_CrossNode",       "description": "GIN cross-node alltoall (self-skips unless >=16 ranks)", "test_filter": "GinMPIDeviceTests.Alltoall_CrossNode" },
+        { "name": "Properties_NLsaTeams",     "description": "GIN properties: number of LSA teams",                   "test_filter": "GinMPIDeviceTests.Properties_NLsaTeams" },
+        { "name": "MultiContext_Exclusive",   "description": "GIN multi-context exclusive contexts",                  "test_filter": "GinMPIDeviceTests.MultiContext_Exclusive" },
+        { "name": "VASignal_Put",             "description": "GIN VA-signal put",                                     "test_filter": "GinMPIDeviceTests.VASignal_Put" },
+        {
+          "name": "RailConnection_Create", "description": "GIN rail connection create; rail-only mode (NCCL_CROSS_NIC=0)", "test_filter": "GinMPIDeviceTests.RailConnection_Create",
+          "env_variables": { "NCCL_CROSS_NIC": "0" }
+        },
+        {
+          "name": "ReduceScatter_Symmetric", "description": "Symmetric-memory ReduceScatter sum (2 ranks/node)", "test_filter": "GinMPIDeviceTests.ReduceScatter_Symmetric",
+          "num_ranks": 4, "num_gpus": 2
+        },
+        {
+          "name": "ReduceScatter_Symmetric_Avg", "description": "Symmetric-memory ReduceScatter avg (2 ranks/node)", "test_filter": "GinMPIDeviceTests.ReduceScatter_Symmetric_Avg",
+          "num_ranks": 4, "num_gpus": 2
+        }
+      ]
+    },
+    "gin_devmpi_gda": {
+      "extends": "gin_devmpi_common",
+      "env_variables": {
+        "NCCL_GIN_TYPE": "5"
+      }
+    },
+    "gin_devmpi_sdma": {
+      "extends": "gin_devmpi_common",
+      "description": "SDMA is a single-node backend: every GinMPIDeviceTests case runs on a single node (num_nodes=1). Cross-node cases (Put_CrossNode/Alltoall_CrossNode/ReduceScatter_Symmetric*) self-skip.",
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "6"
+      }
+    }
+  },
+  "test_suites": [
+    {
+      "name": "GIN alltoall - GDA",
+      "description": "alltoall_perf (D3/D4) on the GDA backend, 2 nodes x 8 GPUs",
+      "config": "gin_perf_gda",
+      "enabled": true
+    },
+    {
+      "name": "GIN alltoall - GDA (single node)",
+      "description": "alltoall_perf (D3/D4) on the GDA backend, single node x 8 GPUs",
+      "config": "gin_perf_gda_1node",
+      "enabled": true
+    },
+    {
+      "name": "GIN alltoall - SDMA",
+      "description": "alltoall_perf (D3/D4) on the SDMA backend, single node x 8 GPUs",
+      "config": "gin_perf_sdma",
+      "enabled": true
+    },
+    {
+      "name": "GIN collectives - SDMA (internal, single node)",
+      "description": "Collectives dispatched through the public NCCL API onto the GIN-SDMA path, single node x 8 GPUs",
+      "config": "gin_perf_sdma_internal",
+      "enabled": true
+    },
+    {
+      "name": "GIN Device MPI Tests - GDA",
+      "description": "Every GinMPIDeviceTests case, one mpirun per test, on the GDA backend",
+      "config": "gin_devmpi_gda",
+      "enabled": true
+    },
+    {
+      "name": "GIN Device MPI Tests - SDMA (single node)",
+      "description": "Every GinMPIDeviceTests case, one mpirun per test, on the SDMA backend (single node)",
+      "config": "gin_devmpi_sdma",
+      "enabled": true
+    }
+  ]
+
+}

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -45,8 +45,8 @@
       "num_ranks": 16,
       "num_nodes": 2,
       "num_gpus": 8,
-      "timeout": 600,
-      "command_args": "-b 1 -e 1G -f 2 -g 1",
+      "timeout": 1200,
+      "command_args": "-b 1 -e 512M -f 2 -g 1",
       "env_variables": {
         "NCCL_GIN_ENABLE": "1",
         "NCCL_CUMEM_ENABLE": "1"

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -195,6 +195,28 @@
       "env_variables": {
         "NCCL_GIN_TYPE": "6"
       }
+    },
+
+    "gin_a2a_eligibility": {
+      "extends": "default",
+      "description": "Host-only ncclAllToAllGinSdmaEligible unit tests, single process, no GPU.",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "tests": [
+        { "name": "A2A_Eligibility_Gates", "description": "All comm-state eligibility gates at default params", "test_filter": "GinAlltoAllEligibilityTest.*" },
+        {
+          "name": "A2A_Eligibility_Disabled", "description": "Negative: NCCL_GIN_A2A_ENABLE=0 makes the path ineligible", "test_filter": "GinAlltoAllEligibilityTest.A2ADisabledByParam",
+          "env_variables": { "NCCL_GIN_A2A_ENABLE": "0" }
+        },
+        {
+          "name": "A2A_Eligibility_MinBytes", "description": "Negative: 64 MiB floor rejects the 8 MiB/peer call", "test_filter": "GinAlltoAllEligibilityTest.BelowMinBytesParam",
+          "env_variables": { "NCCL_GIN_A2A_MIN_BYTES": "67108864" }
+        }
+      ]
     }
   },
   "test_suites": [
@@ -232,6 +254,12 @@
       "name": "GIN Device MPI Tests - SDMA (single node)",
       "description": "Every GinMPIDeviceTests case, one mpirun per test, on the SDMA backend (single node)",
       "config": "gin_devmpi_sdma",
+      "enabled": true
+    },
+    {
+      "name": "GIN alltoall eligibility (host-only)",
+      "description": "Host-only eligibility unit tests for the GIN-SDMA alltoall path",
+      "config": "gin_a2a_eligibility",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -635,10 +635,18 @@ class TestExecutor:
         rocm_path = self._rocm_root()
         mpi_path = self.paths.get("mpi_path", "")
 
-        install_flags = list(self.build_config.get("install_flags", []))
+        # Expand env vars / ~ (e.g. ${WORKDIR}, ${ROCM_SYSTEMS:-...}) so build
+        # paths need not be hardcoded. Mirrors build_rccl_tests(); a no-op for
+        # flags/options that contain no ${VAR} references.
+        def _expand(p):
+            return os.path.expanduser(expand_env_vars(str(p)))
+
+        install_flags = [_expand(f) for f in self.build_config.get("install_flags", [])]
         cmake_options = self.build_config.get("cmake_options", "")
         if isinstance(cmake_options, dict):
-            cmake_options = " ".join(f"-D{k}={v}" for k, v in cmake_options.items())
+            cmake_options = " ".join(f"-D{k}={_expand(v)}" for k, v in cmake_options.items())
+        else:
+            cmake_options = _expand(cmake_options)
         build_env_vars = self.build_config.get("env_variables", {})
         parallel_jobs = self.build_config.get("parallel_jobs")
 


### PR DESCRIPTION
## Motivation

Extend the existing GIN device MPI tests to cover the anvil-SDMA backend.

## Technical Details

Enable SDMA dispatch in the test kernels and skip paths that don't apply to the backend.

## Issue Tracking

JIRA ID: AICOMRCCL-1475

## Test Plan

Run the existing `GinMPIDeviceTests` suite to confirm the existing tests are compatible with the GIN SDMA anvil backend

## Test Result

- `Alltoall_SdmaInternal` passes
- All existing tests pass for GIN type `NCCL_NET_DEVICE_GIN_ANVIL_SDMA`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
