### PR TITLE
fix(rocshmem): fix fabric handle probe when compiler is not hipcc

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -110,8 +110,6 @@ rocm_setup_version(VERSION ${VERSION_STRING})
 # Try to find AMD SMI library
 find_package(amd_smi QUIET)
 
-find_package(hip QUIET)
-
 set(HAVE_AMDSMI_GPU_FABRIC_INFO FALSE)
 
 if(TARGET amd_smi)

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -110,6 +110,8 @@ rocm_setup_version(VERSION ${VERSION_STRING})
 # Try to find AMD SMI library
 find_package(amd_smi QUIET)
 
+find_package(hip QUIET)
+
 set(HAVE_AMDSMI_GPU_FABRIC_INFO FALSE)
 
 if(TARGET amd_smi)
@@ -123,9 +125,16 @@ if(TARGET amd_smi)
   check_library_exists(amd_smi amdsmi_get_gpu_fabric_info "" HAVE_AMDSMI_FABRIC_FUNC)
   cmake_pop_check_state()
 
-  # Check if HIP runtime has hipMemFabricHandle_t
+  find_path(_hip_include_dir
+    hip/hip_runtime_api.h
+    HINTS "${ROCM_PATH}/include" "${CMAKE_PREFIX_PATH}/include" /opt/rocm/include
+    NO_DEFAULT_PATH
+  )
   cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_INCLUDES ${HIP_INCLUDE_DIRS})
+  if(_hip_include_dir)
+    set(CMAKE_REQUIRED_INCLUDES ${_hip_include_dir})
+  endif()
+  set(CMAKE_REQUIRED_DEFINITIONS -D__HIP_PLATFORM_AMD__)
   check_cxx_source_compiles("
     #include <hip/hip_runtime_api.h>
     int main() {

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -127,7 +127,7 @@ if(TARGET amd_smi)
 
   find_path(_hip_include_dir
     hip/hip_runtime_api.h
-    HINTS "${ROCM_PATH}" ${CMAKE_PREFIX_PATH} /opt/rocm
+    HINTS "${ROCM_PATH}"
     PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -127,7 +127,8 @@ if(TARGET amd_smi)
 
   find_path(_hip_include_dir
     hip/hip_runtime_api.h
-    HINTS "${ROCM_PATH}/include" "${CMAKE_PREFIX_PATH}/include" /opt/rocm/include
+    HINTS "${ROCM_PATH}" ${CMAKE_PREFIX_PATH} /opt/rocm
+    PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
   cmake_push_check_state(RESET)


### PR DESCRIPTION
The capability probe for hipMemFabricHandle_t failed silently in any build where CMAKE_CXX_COMPILER is set to clang++ or amdclang++ (e.g. ROCm packaging builds via TheRock toolchain files), causing HAVE_AMDSMI_GPU_FABRIC_INFO to always be FALSE and disabling VMM fabric heap and pod-based IPC admission.

Two independent defects:

1. HIP_INCLUDE_DIRS was empty at probe time because find_package(hip) was called 181 lines later. On some ROCm versions (e.g. 7.14) the hip cmake config never populates HIP_INCLUDE_DIRS at all, and the hip::host target's INTERFACE_INCLUDE_DIRECTORIES may contain unexpanded generator expressions that check_cxx_source_compiles cannot evaluate. Fix: use find_path to locate hip/hip_runtime_api.h directly from the filesystem, with an early find_package(hip QUIET) to seed ROCM_PATH if needed.

2. hip/hip_runtime_api.h hard-errors unless __HIP_PLATFORM_AMD__ is defined. cmake_push_check_state(RESET) clears CMAKE_REQUIRED_DEFINITIONS, and hipcc's implicit injection is not available when the compiler is amdclang++. Fix: set CMAKE_REQUIRED_DEFINITIONS to -D__HIP_PLATFORM_AMD__ explicitly.


## Issue Tracking

JIRA ID: AIROCSHMEM-493

## Test Plan

Verified with amdclang++ and hipcc on ROCm 7.2.1 and ROCm 7.14.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
