### PR TITLE
test(rccl): produce per-binary and unioned host-test coverage reports

### DIFF
--- a/projects/rccl/.gitignore
+++ b/projects/rccl/.gitignore
@@ -25,7 +25,6 @@ tags
 *.swp
 .cache/
 *.log
-*.profraw
 
 # Visual Studio Code
 .vscode

--- a/projects/rccl/.gitignore
+++ b/projects/rccl/.gitignore
@@ -24,6 +24,8 @@ junits/
 tags
 *.swp
 .cache/
+*.log
+*.profraw
 
 # Visual Studio Code
 .vscode

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -622,27 +622,6 @@ target_compile_definitions(rccl-HostUnitTests PRIVATE
   $<$<BOOL:${HIP_FABRIC_API}>:HIP_FABRIC_API>
 )
 
-# llvm source-based coverage (host-only build: no -Xarch_device split needed
-# because --offload-host-only never runs the amdgcn device pass; see the
-# CMAKE_CXX_FLAGS_INIT above). On by default so the binary always produces a
-# profile; disable with -DHOST_UT_COVERAGE=OFF.
-#
-# RCCL_TEST_CODE_COVERAGE is what makes process-isolated tests flush their
-# counters in the forked child (test/common/ProcessIsolatedTestRunner.cpp).
-# Without it those tests run but contribute nothing to the profile, so it is
-# tied to the same switch rather than exposed separately.
-# rccl-source-wrappers must be instrumented too: mem_manager.cc reaches the
-# binary through that static library, so instrumenting only the executable
-# silently drops it from the report -- the profile still looks healthy, it just
-# has no record of that file at all.
-option(HOST_UT_COVERAGE "Build rccl-HostUnitTests with llvm source-based coverage" ON)
-if(HOST_UT_COVERAGE)
-  target_compile_options(rccl-HostUnitTests PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  target_link_options(rccl-HostUnitTests PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  target_compile_definitions(rccl-HostUnitTests PRIVATE RCCL_TEST_CODE_COVERAGE=1)
-  target_compile_options(rccl-source-wrappers PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-endif()
-
 target_link_options(rccl-HostUnitTests PRIVATE -no-hip-rt -no-pie)
 
 target_link_libraries(rccl-HostUnitTests PRIVATE
@@ -703,17 +682,6 @@ target_link_libraries(rccl-UnitTestsMicro PRIVATE
   Threads::Threads
   fmt::fmt-header-only
 )
-
-# llvm source-based coverage (host-only build: no -Xarch_device split needed
-# because --offload-host-only never runs the amdgcn device pass).
-# On by default; disable with -DMICRO_COVERAGE=OFF.
-option(MICRO_COVERAGE "Build the host-only test binaries with llvm source-based coverage" ON)
-if(MICRO_COVERAGE)
-  foreach(_cov_tgt rccl-UnitTestsMicro rccl-HostUnitTests rccl-source-wrappers)
-    target_compile_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-    target_link_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  endforeach()
-endif()
 
 # --- Standalone init micro-test binaries --------------------------------
 # rccl-UnitTestsMicroInit(+-uncached): host-only microtests for src/init.cc,
@@ -780,13 +748,7 @@ foreach(_variant "" "-uncached")
     Threads::Threads
     fmt::fmt-header-only
   )
-
-  if(MICRO_COVERAGE)
-    target_compile_options(${_init_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-    target_link_options(${_init_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  endif()
 endforeach()
-
 
 # ---------------------------------------------------------------------------
 # rccl-UnitTestsMicroEnqueue (standalone mode) -- see the in-build block for the
@@ -868,14 +830,41 @@ foreach(_enq_variant "" "-devlinker")
     Threads::Threads
     fmt::fmt-header-only
   )
-
-  if(MICRO_COVERAGE)
-    target_compile_options(${_enq_tgt} PRIVATE
-      -fprofile-instr-generate -fcoverage-mapping)
-    target_link_options(${_enq_tgt} PRIVATE
-      -fprofile-instr-generate -fcoverage-mapping)
-  endif()
 endforeach()
+
+# --- Coverage (all host-only test binaries) -----------------------------
+# Single switch for the whole standalone build: llvm source-based coverage is
+# either on for every host-only test binary or off for all of them. Host-only
+# build, so no -Xarch_device split is needed -- --offload-host-only never runs
+# the amdgcn device pass (see CMAKE_CXX_FLAGS_INIT above). On by default so the
+# binaries always produce a profile; disable with -DHOST_TEST_COVERAGE=OFF.
+#
+# Applied uniformly, per target:
+#  - the -fprofile-instr-generate/-fcoverage-mapping instrumentation flags;
+#  - RCCL_TEST_CODE_COVERAGE=1, which is what makes process-isolated tests flush
+#    their counters in the forked child (common/ProcessIsolatedTestRunner.cpp).
+#    Without it those tests run but contribute nothing to the profile;
+#  - libdl, which the RCCL_TEST_CODE_COVERAGE dlsym() path in that runner needs
+#    (empty where libdl is folded into libc, glibc >= 2.34).
+# rccl-source-wrappers is a static library reached by rccl-HostUnitTests, so it
+# only takes the instrumentation flags -- mem_manager.cc reaches the binary
+# through it and otherwise disappears from the report entirely.
+option(HOST_TEST_COVERAGE "Build the host-only test binaries with llvm source-based coverage" ON)
+if(HOST_TEST_COVERAGE)
+  foreach(_cov_tgt
+      rccl-HostUnitTests
+      rccl-UnitTestsMicro
+      rccl-UnitTestsMicroInit
+      rccl-UnitTestsMicroInit-uncached
+      rccl-UnitTestsMicroEnqueue
+      rccl-UnitTestsMicroEnqueue-devlinker)
+    target_compile_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_link_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_compile_definitions(${_cov_tgt} PRIVATE RCCL_TEST_CODE_COVERAGE=1)
+    target_link_libraries(${_cov_tgt} PRIVATE ${CMAKE_DL_LIBS})
+  endforeach()
+  target_compile_options(rccl-source-wrappers PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+endif()
 
 # NOTE: the standalone project intentionally does not register these binaries
 # with CTest (matching test/host from #9320); run them directly, e.g.

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -707,10 +707,12 @@ target_link_libraries(rccl-UnitTestsMicro PRIVATE
 # llvm source-based coverage (host-only build: no -Xarch_device split needed
 # because --offload-host-only never runs the amdgcn device pass).
 # On by default; disable with -DMICRO_COVERAGE=OFF.
-option(MICRO_COVERAGE "Build rccl-UnitTestsMicro with llvm source-based coverage" ON)
+option(MICRO_COVERAGE "Build the host-only test binaries with llvm source-based coverage" ON)
 if(MICRO_COVERAGE)
-  target_compile_options(rccl-UnitTestsMicro PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  target_link_options(rccl-UnitTestsMicro PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  foreach(_cov_tgt rccl-UnitTestsMicro rccl-HostUnitTests rccl-source-wrappers)
+    target_compile_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_link_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  endforeach()
 endif()
 
 # --- Standalone init micro-test binaries --------------------------------

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -417,6 +417,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_compile_options(-Wno-tautological-constant-out-of-range-compare)
 
+# Wrapper around add_executable() that also records the target in
+# HOST_TEST_BINARIES, so the coverage block at the end of this file instruments
+# every host-only test binary without a separately-maintained list. A macro
+# (not a function) so list(APPEND) mutates the caller's variable. Use this
+# instead of add_executable() for every test binary in the standalone build.
+macro(add_test_executable _name)
+  list(APPEND HOST_TEST_BINARIES ${_name})
+  add_executable(${_name} ${ARGN})
+endmacro()
+
 find_package(Threads REQUIRED)
 include(FetchContent)
 
@@ -583,7 +593,7 @@ target_link_libraries(rccl-source-wrappers PRIVATE
 )
 
 # --- Main test executable ---
-add_executable(rccl-HostUnitTests
+add_test_executable(rccl-HostUnitTests
   main.cpp
   ${RCCL_TEST_DIR}/BitOpsTests.cpp
   ${RCCL_TEST_DIR}/IommuPassthrough_test.cpp
@@ -646,7 +656,7 @@ target_link_libraries(rccl-HostUnitTests PRIVATE
 # DEVCOMM_V22907_CC_PATH) and
 # satisfies every HIP/nccl symbol from fakes/ rather than librccl.so or the
 # HIP runtime.
-add_executable(rccl-UnitTestsMicro ${RCCL_MICRO_TEST_SOURCES})
+add_test_executable(rccl-UnitTestsMicro ${RCCL_MICRO_TEST_SOURCES})
 
 target_compile_options(rccl-UnitTestsMicro PRIVATE
   -Wno-unused-parameter -Wno-unused-variable)
@@ -715,7 +725,7 @@ set(TEST_MICRO_INIT_SOURCE_FILES
 # with different -D (see the in-build block above for the full rationale).
 foreach(_variant "" "-uncached")
   set(_init_tgt "rccl-UnitTestsMicroInit${_variant}")
-  add_executable(${_init_tgt} ${TEST_MICRO_INIT_SOURCE_FILES})
+  add_test_executable(${_init_tgt} ${TEST_MICRO_INIT_SOURCE_FILES})
 
   target_compile_options(${_init_tgt} PRIVATE
     -Wno-unused-parameter -Wno-unused-variable -ffunction-sections)
@@ -797,7 +807,7 @@ set(TEST_MICRO_ENQUEUE_SOURCE_FILES
 # the shipping arm would go untested by that workflow entirely.
 foreach(_enq_variant "" "-devlinker")
   set(_enq_tgt "rccl-UnitTestsMicroEnqueue${_enq_variant}")
-  add_executable(${_enq_tgt} ${TEST_MICRO_ENQUEUE_SOURCE_FILES})
+  add_test_executable(${_enq_tgt} ${TEST_MICRO_ENQUEUE_SOURCE_FILES})
 
   target_compile_options(${_enq_tgt} PRIVATE
     -Wno-unused-parameter -Wno-unused-variable -ffunction-sections)
@@ -851,13 +861,9 @@ endforeach()
 # through it and otherwise disappears from the report entirely.
 option(HOST_TEST_COVERAGE "Build the host-only test binaries with llvm source-based coverage" ON)
 if(HOST_TEST_COVERAGE)
-  foreach(_cov_tgt
-      rccl-HostUnitTests
-      rccl-UnitTestsMicro
-      rccl-UnitTestsMicroInit
-      rccl-UnitTestsMicroInit-uncached
-      rccl-UnitTestsMicroEnqueue
-      rccl-UnitTestsMicroEnqueue-devlinker)
+  # HOST_TEST_BINARIES is populated by add_test_executable() above, so new test
+  # binaries are instrumented automatically.
+  foreach(_cov_tgt ${HOST_TEST_BINARIES})
     target_compile_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
     target_link_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
     target_compile_definitions(${_cov_tgt} PRIVATE RCCL_TEST_CODE_COVERAGE=1)

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -545,10 +545,12 @@ target_link_libraries(rccl-UnitTestsMicro PRIVATE
 # llvm source-based coverage (host-only build: no -Xarch_device split needed
 # because --offload-host-only never runs the amdgcn device pass).
 # On by default; disable with -DMICRO_COVERAGE=OFF.
-option(MICRO_COVERAGE "Build rccl-UnitTestsMicro with llvm source-based coverage" ON)
+option(MICRO_COVERAGE "Build the host-only test binaries with llvm source-based coverage" ON)
 if(MICRO_COVERAGE)
-  target_compile_options(rccl-UnitTestsMicro PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-  target_link_options(rccl-UnitTestsMicro PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  foreach(_cov_tgt rccl-UnitTestsMicro rccl-HostUnitTests rccl-source-wrappers)
+    target_compile_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+    target_link_options(${_cov_tgt} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+  endforeach()
 endif()
 
 # --- Standalone init micro-test binaries --------------------------------

--- a/projects/rccl/test/host/MICROTEST_README.md
+++ b/projects/rccl/test/host/MICROTEST_README.md
@@ -532,5 +532,5 @@ cmake --build build -j"$(nproc)"
 ./build/rccl-HostUnitTests
 ```
 
-Disable coverage instrumentation for the standalone micro-test with
-`-DMICRO_COVERAGE=OFF`.
+Disable coverage instrumentation for the standalone host-only test binaries
+with `-DHOST_TEST_COVERAGE=OFF`.

--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -437,9 +437,13 @@ hipError_t hipMalloc(void** p, size_t) { if (p) *p = nullptr; return hipErrorInv
 hipError_t hipMemcpy(void*, const void*, size_t, hipMemcpyKind) { return hipErrorInvalidValue; }
 hipError_t hipMemset(void*, int, size_t) { return hipErrorInvalidValue; }
 hipError_t hipDeviceSynchronize(void) { return hipErrorInvalidValue; }
-// init.cc's hipGetDeviceProperties call binds to hipGetDevicePropertiesR0600
-// after hipify; the ROCm header remaps the unversioned name to this symbol.
-hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int device)
+// We define hipGetDevicePropertiesR0600, the versioned public HIP ABI symbol,
+// rather than the unversioned hipGetDeviceProperties. Callers write
+// hipGetDeviceProperties in source, but the HIP header (post rocm-systems
+// #10358) provides a `static inline hipGetDeviceProperties` wrapper that
+// delegates to hipGetDevicePropertiesR0600, so every call site inlines down to
+// a reference to that R0600 symbol -- which is what our fake must supply.
+hipError_t hipGetDevicePropertiesR0600(hipDeviceProp_t* prop, int device)
 {
     return g_hipGetDeviceProperties(prop, device);
 }

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -267,6 +267,7 @@ do_coverage() {
     # lcov diagnostics are legible.
     llvm-cov export "$exe" \
       -instr-profile="$dir/merged.profdata" \
+      --ignore-filename-regex='(/test/|nvtx)' \
       -format=lcov > "$dir/coverage.lcov"
 
     echo "    $name text report: $dir/coverage.txt"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -151,21 +151,30 @@ do_host_tests() {
   )
 
   : > "$LOG_FILE"   # truncate; each binary appends below
-  local rc=0 entry name xml
+  local rc=0 entry exe name xml profdir
   for entry in "${binaries[@]}"; do
     name="${entry%%:*}"
     xml="${entry#*:}"
-    if [ ! -x "$BUILD_DIR/$name" ]; then
-      echo "ERROR: expected binary not built: $BUILD_DIR/$name" | tee -a "$LOG_FILE"
+    exe="$BUILD_DIR/$name"
+    if [ ! -x "$exe" ]; then
+      echo "ERROR: expected binary not built: $exe" | tee -a "$LOG_FILE"
       rc=1
       continue
     fi
     echo "----- $name -----" | tee -a "$LOG_FILE"
+    # Direct this binary's llvm profiles into its OWN subdir so `coverage` finds
+    # them at $COVERAGE_DIR/<binary>/. Without this, instrumented binaries write
+    # default.profraw into the CWD and coverage sees nothing. %p (PID) + %m
+    # (module hash) keep the process-isolated forks' files distinct; the runner
+    # inherits this value (it sets LLVM_PROFILE_FILE with overwrite=0).
+    profdir="$COVERAGE_DIR/$name"
+    mkdir -p "$profdir"
+    export LLVM_PROFILE_FILE="$profdir/$name-%p-%m.profraw"
     # Shuffle every binary here, not just the micro ones: the init microtests share ~40 mutable
     # file-scope globals reset only in the fixture TearDown, and the older suites were audited to be
     # order-independent too. gtest prints the seed, so a failure stays reproducible; clear
     # HOST_TEST_SHUFFLE to run in declaration order while bisecting.
-    "$BUILD_DIR/$name" \
+    "$exe" \
       --gtest_filter="$GTEST_FILTER" \
       --gtest_output="xml:$xml" \
       ${HOST_TEST_SHUFFLE_ARGS[@]+"${HOST_TEST_SHUFFLE_ARGS[@]}"} \
@@ -210,18 +219,19 @@ do_guards() {
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
 
-  local test_bins
-  mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
-  if [ "${#test_bins[@]}" -eq 0 ]; then
-    echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
-    exit 1
-  fi
-
-  local exe name dir
+  local exe name dir rc=0
   local tracefiles=()
-  for exe in "${test_bins[@]}"; do
-    name="$(basename "$exe")"
-    dir="$COVERAGE_DIR/$name"
+  # Each binary's profraw lives in its own $COVERAGE_DIR/<name>/ subdir, written
+  # by the `run` phase. Iterate those so coverage tracks exactly what ran.
+  for dir in "$COVERAGE_DIR"/*/; do
+    name="$(basename "$dir")"
+    [ "$name" = overall ] && continue
+    exe="$BUILD_DIR/$name"
+    if [ ! -x "$exe" ]; then
+      echo "error: expected binary not built: $exe -- run the build phase first" >&2
+      rc=1
+      continue
+    fi
     if ! compgen -G "$dir/*.profraw" >/dev/null; then
       echo "    skip $name -- no profraw (run the 'run' phase first)" >&2
       continue
@@ -260,7 +270,7 @@ do_coverage() {
   # --- Overall union across all binaries (the CI metric) -------------------
   if ! command -v lcov >/dev/null 2>&1; then
     echo "    note: lcov not installed -- skipping overall union report (run the 'deps' phase)" >&2
-    return 0
+    return "$rc"
   fi
 
   local odir="$COVERAGE_DIR/overall"
@@ -299,6 +309,7 @@ do_coverage() {
   fi
   echo "    overall tracefile:   $odir/combined.lcov"
   echo "    overall summary:     $odir/summary.txt"
+  return "$rc"
 }
 
 # The `run` phase aggregates every check the host-test pipeline executes: the

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -26,7 +26,7 @@
 #   run             run the suite (timestamped log + JUnit XML). Always emits
 #                   llvm source-based coverage profiles (*.profraw) into
 #                   <BUILD_DIR>/coverage (requires the host tests to be built
-#                   with -DMICRO_COVERAGE=ON, the default)
+#                   with -DHOST_TEST_COVERAGE=ON, the default)
 #   coverage        turn the per-binary *.profraw profiles from `run` into
 #                   reports: a per-binary text/HTML report + lcov tracefile
 #                   (clean, no hash mismatch), plus an overall line/branch union

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -14,9 +14,8 @@
 #   (default phase: all)
 #
 # Phases:
-#   deps            install the host-test build/runtime dependencies via apt
-#                   (cmake, toolchain, gtest/fmt, moreutils, python3-venv). CI
-#                   runs this as its own step; not part of `all`.
+#   deps            install the host-test build/runtime dependencies via apt.
+#                   CI runs this as its own step; not part of `all`.
 #   rccl-configure  configure the RCCL tree (root) -- pins GPU_TARGETS so CMake
 #                   never probes for a GPU; BUILD_TESTS=OFF (we only need hipify)
 #   hipify          build the hipify_all target -> stages build/hipify/src, the
@@ -238,8 +237,12 @@ do_coverage() {
 
   local exe name dir rc=0
   local tracefiles=()
+  local skipped=()
   # Each binary's profraw lives in its own $COVERAGE_DIR/<name>/ subdir, written
   # by the `run` phase. Iterate those so coverage tracks exactly what ran.
+  # nullglob so an empty/absent $COVERAGE_DIR yields zero iterations rather than
+  # one pass with `dir` set to the literal glob pattern.
+  shopt -s nullglob
   for dir in "$COVERAGE_DIR"/*/; do
     name="$(basename "$dir")"
     [ "$name" = overall ] && continue
@@ -251,21 +254,28 @@ do_coverage() {
     fi
     if ! compgen -G "$dir/*.profraw" >/dev/null; then
       echo "    skip $name -- no profraw (run the 'run' phase first)" >&2
+      skipped+=("$name")
       continue
     fi
 
     # Per-binary: merge its own profraw and report against its own object only.
-    llvm-profdata merge -sparse "$dir"/*.profraw -o "$dir/merged.profdata"
+    # Guard each llvm invocation: under `set -e` one bad binary would otherwise
+    # abort the whole phase mid-loop and discard the rc already accumulated.
+    # Degrade instead -- mark the phase failed and move on to the next binary.
+    llvm-profdata merge -sparse "$dir"/*.profraw -o "$dir/merged.profdata" \
+      || { echo "    error: llvm-profdata failed for $name" >&2; rc=1; continue; }
 
     llvm-cov report "$exe" \
       -instr-profile="$dir/merged.profdata" \
       --show-branch-summary --show-region-summary \
-      > "$dir/coverage.txt"
+      > "$dir/coverage.txt" \
+      || { echo "    error: llvm-cov report failed for $name" >&2; rc=1; continue; }
 
     llvm-cov show "$exe" \
       -instr-profile="$dir/merged.profdata" \
       -format=html -output-dir="$dir/html" \
-      --show-branches=count
+      --show-branches=count \
+      || { echo "    error: llvm-cov show failed for $name" >&2; rc=1; continue; }
 
     # Per-binary lcov tracefile -- the hash-agnostic, line/branch-keyed form that
     # can be unioned across binaries. Tag it with the binary name so genhtml and
@@ -273,7 +283,8 @@ do_coverage() {
     llvm-cov export "$exe" \
       -instr-profile="$dir/merged.profdata" \
       --ignore-filename-regex='(/test/|nvtx)' \
-      -format=lcov > "$dir/coverage.lcov"
+      -format=lcov > "$dir/coverage.lcov" \
+      || { echo "    error: llvm-cov export failed for $name" >&2; rc=1; continue; }
 
     echo "    $name text report: $dir/coverage.txt"
     echo "    $name html report: $dir/html/index.html"
@@ -281,7 +292,10 @@ do_coverage() {
   done
 
   if [ "${#tracefiles[@]}" -eq 0 ]; then
-    echo "error: no .profraw files found under $COVERAGE_DIR -- run the 'run' phase first" >&2
+    echo "error: no .profraw files found under $COVERAGE_DIR --" >&2
+    echo "       run the 'run' phase first. If you did, the tests were built" >&2
+    echo "       with -DHOST_TEST_COVERAGE=OFF, which produces no profiles" >&2
+    echo "       (coverage is on by default; drop that flag to re-enable it)" >&2
     exit 1
   fi
 
@@ -321,6 +335,16 @@ do_coverage() {
   # Machine-readable-ish overall summary (line + branch %) and a browsable HTML.
   lcov "${lcov_args[@]}" --summary "$odir/combined.lcov" \
     2>&1 | tee "$odir/summary.txt"
+
+  # Record how many binaries actually contributed a tracefile vs. how many were
+  # skipped for missing profraw, so a partial-coverage run is auditable from the
+  # summary rather than silently reading as a source regression on a dashboard.
+  {
+    echo "tracefiles unioned: ${#tracefiles[@]}"
+    if [ "${#skipped[@]}" -gt 0 ]; then
+      echo "binaries skipped (no profraw): ${#skipped[@]} -- ${skipped[*]}"
+    fi
+  } | tee -a "$odir/summary.txt"
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
     [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors "inconsistent,unsupported,corrupt,format")
@@ -357,6 +381,15 @@ case "$PHASE" in
   guards)         do_guards ;;
   run)            do_run "$@" ;;
   coverage)       do_coverage ;;
-  all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@"; do_coverage ;;
+  all)
+    do_rccl_configure; do_hipify; do_configure; do_build
+    # Keep the run's exit status but still generate coverage: the profraw files
+    # are already on disk, and a failing suite is exactly the run that most
+    # wants a report. `set -e` would otherwise abort before do_coverage.
+    run_rc=0
+    do_run "$@" || run_rc=$?
+    do_coverage
+    exit "$run_rc"
+    ;;
   *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|coverage|all] [extra gtest args]" >&2; exit 2 ;;
 esac

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -324,9 +324,13 @@ do_coverage() {
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
     [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors "inconsistent,unsupported,corrupt,format")
-    genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
-      >/dev/null 2>&1 || true
-    echo "    overall html report: $odir/html/index.html"
+    if genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
+      >/dev/null 2>&1; then
+      echo "    overall html report: $odir/html/index.html"
+    else
+      echo "    warning: genhtml failed -- overall html report not generated" >&2
+      rc=1
+    fi
   fi
   echo "    overall tracefile:   $odir/combined.lcov"
   echo "    overall summary:     $odir/summary.txt"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -219,6 +219,18 @@ do_guards() {
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
 
+  # Prefer the toolchain's own llvm tools: versions match the build clang by construction.
+  if [ -d "$ROCM_PATH/llvm/bin" ]; then
+    PATH="$ROCM_PATH/llvm/bin:$PATH"
+  fi
+  local tool
+  for tool in llvm-profdata llvm-cov; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "error: $tool not found -- coverage needs the LLVM that built the tests" >&2
+      exit 1
+    fi
+  done
+
   local exe name dir rc=0
   local tracefiles=()
   # Each binary's profraw lives in its own $COVERAGE_DIR/<name>/ subdir, written

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -10,7 +10,7 @@
 # `all` runs the whole pipeline end to end.
 #
 # Usage:
-#   run_host_tests.sh [deps|rccl-configure|hipify|configure|build|guards|run|all] [extra gtest args]
+#   run_host_tests.sh [deps|rccl-configure|hipify|configure|build|guards|run|coverage|all] [extra gtest args]
 #   (default phase: all)
 #
 # Phases:
@@ -24,6 +24,9 @@
 #   configure       configure test/host
 #   build           build all host binaries (default target)
 #   run             run every host binary (timestamped log + per-binary JUnit XML)
+#   coverage        run every host-test binary under llvm profiling and emit
+#                   text + HTML source-based coverage reports (requires the
+#                   host tests to be built with -DMICRO_COVERAGE=ON, the default)
 #   all             rccl-configure -> hipify -> configure -> build -> run
 #
 # Knobs (environment variables, all optional):
@@ -38,6 +41,7 @@
 #                                                   when bisecting a failure. Deliberately NOT named
 #                                                   GTEST_SHUFFLE: gtest owns that name and reads an
 #                                                   empty value as TRUE, so clearing it would shuffle)
+#   COVERAGE_DIR  coverage output dir (coverage)   (default: <BUILD_DIR>/coverage)
 # Any args after the phase are forwarded to the test binary, e.g.:
 #   run_host_tests.sh run --gtest_filter='BitOps*' --gtest_repeat=5
 #
@@ -58,6 +62,7 @@ HOST_TEST_SHUFFLE="${HOST_TEST_SHUFFLE---gtest_shuffle}"  # `-` not `:-`: an exp
 read -ra HOST_TEST_SHUFFLE_ARGS <<< "$HOST_TEST_SHUFFLE"
 LOG_FILE="${LOG_FILE:-$SCRIPT_DIR/host_tests.log}"
 XML_FILE="${XML_FILE:-$SCRIPT_DIR/host_tests.xml}"
+COVERAGE_DIR="${COVERAGE_DIR:-$BUILD_DIR/coverage}"
 JOBS="$(nproc 2>/dev/null || echo 4)"
 
 PHASE="${1:-all}"
@@ -170,6 +175,54 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
+# Run every host-test binary under llvm source-based coverage and emit both a
+# text summary and a browsable HTML report. Requires the host tests to have been
+# built with -DMICRO_COVERAGE=ON (the default), which instruments every host-only
+# test binary with -fprofile-instr-generate -fcoverage-mapping.
+do_coverage() {
+  echo "==> Coverage  (out: $COVERAGE_DIR)"
+  mkdir -p "$COVERAGE_DIR"
+  rm -f "$COVERAGE_DIR"/*.profraw
+
+  local test_bins
+  mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
+  if [ "${#test_bins[@]}" -eq 0 ]; then
+    echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
+    exit 1
+  fi
+
+  local exe
+  for exe in "${test_bins[@]}"; do
+    LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw" "$exe"
+  done
+
+  llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
+    -o "$COVERAGE_DIR/merged.profdata"
+
+  # -object args for every binary beyond the first (llvm-cov takes the first
+  # positional binary, then -object for each additional one).
+  local object_args=()
+  local bin
+  for bin in "${test_bins[@]:1}"; do
+    object_args+=(-object "$bin")
+  done
+
+  llvm-cov report \
+    "${test_bins[0]}" "${object_args[@]}" \
+    -instr-profile="$COVERAGE_DIR/merged.profdata" \
+    --show-branch-summary --show-region-summary \
+    > "$COVERAGE_DIR/coverage.txt"
+
+  llvm-cov show \
+    "${test_bins[0]}" "${object_args[@]}" \
+    -instr-profile="$COVERAGE_DIR/merged.profdata" \
+    -format=html -output-dir="$COVERAGE_DIR/html" \
+    --show-branches=count
+
+  echo "    text report: $COVERAGE_DIR/coverage.txt"
+  echo "    html report: $COVERAGE_DIR/html/index.html"
+}
+
 # The `run` phase aggregates every check the host-test pipeline executes: the
 # gtest suite plus any CPU-only guards. The host-test workflow invokes `run`
 # (and `all` ends with it), so adding a future check here makes both CI and
@@ -189,6 +242,7 @@ case "$PHASE" in
   build)          do_build ;;
   guards)         do_guards ;;
   run)            do_run "$@" ;;
+  coverage)       do_coverage ;;
   all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@" ;;
-  *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|all] [extra gtest args]" >&2; exit 2 ;;
+  *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|coverage|all] [extra gtest args]" >&2; exit 2 ;;
 esac

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -23,11 +23,14 @@
 #                   prerequisite the host tests compile against
 #   configure       configure test/host
 #   build           build all host binaries (default target)
-#   run             run every host binary (timestamped log + per-binary JUnit XML)
-#   coverage        run every host-test binary under llvm profiling and emit
-#                   text + HTML source-based coverage reports (requires the
-#                   host tests to be built with -DMICRO_COVERAGE=ON, the default)
-#   all             rccl-configure -> hipify -> configure -> build -> run
+#   run             run the suite (timestamped log + JUnit XML). Always emits
+#                   llvm source-based coverage profiles (*.profraw) into
+#                   COVERAGE_DIR (requires the host tests to be built with
+#                   -DMICRO_COVERAGE=ON, the default)
+#   coverage        assemble the *.profraw profiles produced by `run` into a
+#                   merged profile and emit text + HTML coverage reports
+#                   (does not run any binaries -- run the `run` phase first)
+#   all             rccl-configure -> hipify -> configure -> build -> run -> coverage
 #
 # Knobs (environment variables, all optional):
 #   ROCM_PATH     ROCm install prefix              (default: /opt/rocm)
@@ -105,6 +108,15 @@ do_build() {
 
 do_host_tests() {
   echo "==> Run  (filter: $GTEST_FILTER)"
+
+  # Always emit source-based coverage profiles: instrumented binaries (built with
+  # -DMICRO_COVERAGE=ON, the default) write a .profraw into COVERAGE_DIR via
+  # LLVM_PROFILE_FILE. The `coverage` phase later merges these into reports
+  # without re-running anything. Start from a clean profraw set each run.
+  mkdir -p "$COVERAGE_DIR"
+  rm -f "$COVERAGE_DIR"/*.profraw
+  export LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw"
+
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
   # (pipefail) so a failure still fails CI.
@@ -175,14 +187,19 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
-# Run every host-test binary under llvm source-based coverage and emit both a
-# text summary and a browsable HTML report. Requires the host tests to have been
-# built with -DMICRO_COVERAGE=ON (the default), which instruments every host-only
-# test binary with -fprofile-instr-generate -fcoverage-mapping.
+# Assemble the coverage profiles produced by the `run` phase into a merged
+# profile and emit both a text summary and a browsable HTML report. Does NOT run
+# any binaries -- the .profraw files are produced by `run` (see do_host_tests).
+# Requires the host tests to have been built with -DMICRO_COVERAGE=ON (the
+# default), which instruments every host-only test binary with
+# -fprofile-instr-generate -fcoverage-mapping.
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
-  mkdir -p "$COVERAGE_DIR"
-  rm -f "$COVERAGE_DIR"/*.profraw
+
+  if ! compgen -G "$COVERAGE_DIR/*.profraw" >/dev/null; then
+    echo "error: no .profraw files in $COVERAGE_DIR -- run the 'run' phase first" >&2
+    exit 1
+  fi
 
   local test_bins
   mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
@@ -190,11 +207,6 @@ do_coverage() {
     echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
     exit 1
   fi
-
-  local exe
-  for exe in "${test_bins[@]}"; do
-    LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw" "$exe"
-  done
 
   llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
     -o "$COVERAGE_DIR/merged.profdata"
@@ -243,6 +255,6 @@ case "$PHASE" in
   guards)         do_guards ;;
   run)            do_run "$@" ;;
   coverage)       do_coverage ;;
-  all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@" ;;
+  all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@"; do_coverage ;;
   *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|coverage|all] [extra gtest args]" >&2; exit 2 ;;
 esac

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -84,7 +84,7 @@ do_deps() {
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov llvm
 }
 
 do_rccl_configure() {

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -25,8 +25,8 @@
 #   build           build all host binaries (default target)
 #   run             run the suite (timestamped log + JUnit XML). Always emits
 #                   llvm source-based coverage profiles (*.profraw) into
-#                   COVERAGE_DIR (requires the host tests to be built with
-#                   -DMICRO_COVERAGE=ON, the default)
+#                   <BUILD_DIR>/coverage (requires the host tests to be built
+#                   with -DMICRO_COVERAGE=ON, the default)
 #   coverage        turn the per-binary *.profraw profiles from `run` into
 #                   reports: a per-binary text/HTML report + lcov tracefile
 #                   (clean, no hash mismatch), plus an overall line/branch union
@@ -45,7 +45,6 @@
 #                                                   when bisecting a failure. Deliberately NOT named
 #                                                   GTEST_SHUFFLE: gtest owns that name and reads an
 #                                                   empty value as TRUE, so clearing it would shuffle)
-#   COVERAGE_DIR  coverage output dir (coverage)   (default: <BUILD_DIR>/coverage)
 # Any args after the phase are forwarded to the test binary, e.g.:
 #   run_host_tests.sh run --gtest_filter='BitOps*' --gtest_repeat=5
 #
@@ -66,7 +65,11 @@ HOST_TEST_SHUFFLE="${HOST_TEST_SHUFFLE---gtest_shuffle}"  # `-` not `:-`: an exp
 read -ra HOST_TEST_SHUFFLE_ARGS <<< "$HOST_TEST_SHUFFLE"
 LOG_FILE="${LOG_FILE:-$SCRIPT_DIR/host_tests.log}"
 XML_FILE="${XML_FILE:-$SCRIPT_DIR/host_tests.xml}"
-COVERAGE_DIR="${COVERAGE_DIR:-$BUILD_DIR/coverage}"
+# Coverage output always lives in a dedicated subdir we own under BUILD_DIR.
+# Deliberately NOT a user knob: the `run` phase wipes this dir, and an
+# arbitrary user-supplied path (e.g. '/', '.', or a source dir) would then
+# recursively delete unrelated files.
+COVERAGE_DIR="$BUILD_DIR/coverage"
 JOBS="$(nproc 2>/dev/null || echo 4)"
 
 PHASE="${1:-all}"
@@ -122,6 +125,8 @@ do_host_tests() {
   # Keeping profiles isolated lets `coverage` emit a clean per-binary report and
   # a clean per-binary lcov tracefile; the tracefiles are then unioned at the
   # line/branch level into one overall report (hash-agnostic). Start clean.
+  # COVERAGE_DIR is always <BUILD_DIR>/coverage, a dedicated subdir we own; the
+  # ${VAR:?} guard is belt-and-suspenders against an empty BUILD_DIR. Start clean.
   mkdir -p "$COVERAGE_DIR"
   rm -rf "${COVERAGE_DIR:?}"/*
 

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -27,9 +27,10 @@
 #                   llvm source-based coverage profiles (*.profraw) into
 #                   COVERAGE_DIR (requires the host tests to be built with
 #                   -DMICRO_COVERAGE=ON, the default)
-#   coverage        assemble the *.profraw profiles produced by `run` into a
-#                   merged profile and emit text + HTML coverage reports
-#                   (does not run any binaries -- run the `run` phase first)
+#   coverage        turn the per-binary *.profraw profiles from `run` into
+#                   reports: a per-binary text/HTML report + lcov tracefile
+#                   (clean, no hash mismatch), plus an overall line/branch union
+#                   across all binaries via lcov (the CI metric).
 #   all             rccl-configure -> hipify -> configure -> build -> run -> coverage
 #
 # Knobs (environment variables, all optional):
@@ -72,16 +73,18 @@ PHASE="${1:-all}"
 [ $# -gt 0 ] && shift || true   # remaining args ($@) are forwarded to the binary
 
 # Install everything the host-test pipeline needs that the base ROCm dev image
-# lacks: cmake + host toolchain, gtest/fmt, moreutils (ts), and python3-venv
-# (the guards phase creates a venv + pip-installs pytest). Uses sudo when not
-# already root so it works both in the root CI container and locally.
+# lacks: cmake + host toolchain, gtest/fmt, moreutils (ts), python3-venv (the
+# guards phase creates a venv + pip-installs pytest), and lcov/genhtml (the
+# coverage phase merges per-binary lcov tracefiles into one overall report).
+# Uses sudo when not already root so it works both in the root CI container and
+# locally.
 do_deps() {
   echo "==> Install host-test dependencies (apt)"
   local sudo=""
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
 }
 
 do_rccl_configure() {
@@ -109,13 +112,18 @@ do_build() {
 do_host_tests() {
   echo "==> Run  (filter: $GTEST_FILTER)"
 
-  # Always emit source-based coverage profiles: instrumented binaries (built with
-  # -DMICRO_COVERAGE=ON, the default) write a .profraw into COVERAGE_DIR via
-  # LLVM_PROFILE_FILE. The `coverage` phase later merges these into reports
-  # without re-running anything. Start from a clean profraw set each run.
+  # Always emit source-based coverage profiles: instrumented binaries write
+  # .profraw files that the `coverage` phase turns into reports without
+  # re-running anything.
+  #
+  # Each binary writes into its OWN profraw subdir ($COVERAGE_DIR/<binary>/).
+  # The host-test binaries compile some of the same source under different
+  # #defines, so a shared function has a different coverage-mapping hash in each.
+  # Keeping profiles isolated lets `coverage` emit a clean per-binary report and
+  # a clean per-binary lcov tracefile; the tracefiles are then unioned at the
+  # line/branch level into one overall report (hash-agnostic). Start clean.
   mkdir -p "$COVERAGE_DIR"
-  rm -f "$COVERAGE_DIR"/*.profraw
-  export LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw"
+  rm -rf "$COVERAGE_DIR"/*
 
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
@@ -187,19 +195,20 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
-# Assemble the coverage profiles produced by the `run` phase into a merged
-# profile and emit both a text summary and a browsable HTML report. Does NOT run
-# any binaries -- the .profraw files are produced by `run` (see do_host_tests).
-# Requires the host tests to have been built with -DMICRO_COVERAGE=ON (the
-# default), which instruments every host-only test binary with
-# -fprofile-instr-generate -fcoverage-mapping.
+# Turn the per-binary profraw sets produced by the `run` phase into coverage
+# reports. Two levels of output:
+#
+#   1. Per binary ($COVERAGE_DIR/<binary>/): a text + HTML report and an lcov
+#      tracefile, each built against ONLY that binary's own profile so llvm-cov
+#      never warns about "mismatched data". This is what the inner dev loop wants
+#      (focused on one binary / one file under test).
+#
+#   2. Overall ($COVERAGE_DIR/overall/): the per-binary lcov tracefiles unioned
+#      at the line/branch level via `lcov`. A line/branch counts as covered if
+#      ANY binary covered it, so source that is exercised in different binaries
+#      under different #defines is credited correctly.
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
-
-  if ! compgen -G "$COVERAGE_DIR/*.profraw" >/dev/null; then
-    echo "error: no .profraw files in $COVERAGE_DIR -- run the 'run' phase first" >&2
-    exit 1
-  fi
 
   local test_bins
   mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
@@ -208,31 +217,88 @@ do_coverage() {
     exit 1
   fi
 
-  llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
-    -o "$COVERAGE_DIR/merged.profdata"
+  local exe name dir
+  local tracefiles=()
+  for exe in "${test_bins[@]}"; do
+    name="$(basename "$exe")"
+    dir="$COVERAGE_DIR/$name"
+    if ! compgen -G "$dir/*.profraw" >/dev/null; then
+      echo "    skip $name -- no profraw (run the 'run' phase first)" >&2
+      continue
+    fi
 
-  # -object args for every binary beyond the first (llvm-cov takes the first
-  # positional binary, then -object for each additional one).
-  local object_args=()
-  local bin
-  for bin in "${test_bins[@]:1}"; do
-    object_args+=(-object "$bin")
+    # Per-binary: merge its own profraw and report against its own object only.
+    llvm-profdata merge -sparse "$dir"/*.profraw -o "$dir/merged.profdata"
+
+    llvm-cov report "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      --show-branch-summary --show-region-summary \
+      > "$dir/coverage.txt"
+
+    llvm-cov show "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      -format=html -output-dir="$dir/html" \
+      --show-branches=count
+
+    # Per-binary lcov tracefile -- the hash-agnostic, line/branch-keyed form that
+    # can be unioned across binaries. Tag it with the binary name so genhtml and
+    # lcov diagnostics are legible.
+    llvm-cov export "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      -format=lcov > "$dir/coverage.lcov"
+
+    echo "    $name text report: $dir/coverage.txt"
+    echo "    $name html report: $dir/html/index.html"
+    tracefiles+=("$dir/coverage.lcov")
   done
 
-  llvm-cov report \
-    "${test_bins[0]}" "${object_args[@]}" \
-    -instr-profile="$COVERAGE_DIR/merged.profdata" \
-    --show-branch-summary --show-region-summary \
-    > "$COVERAGE_DIR/coverage.txt"
+  if [ "${#tracefiles[@]}" -eq 0 ]; then
+    echo "error: no .profraw files found under $COVERAGE_DIR -- run the 'run' phase first" >&2
+    exit 1
+  fi
 
-  llvm-cov show \
-    "${test_bins[0]}" "${object_args[@]}" \
-    -instr-profile="$COVERAGE_DIR/merged.profdata" \
-    -format=html -output-dir="$COVERAGE_DIR/html" \
-    --show-branches=count
+  # --- Overall union across all binaries (the CI metric) -------------------
+  if ! command -v lcov >/dev/null 2>&1; then
+    echo "    note: lcov not installed -- skipping overall union report (run the 'deps' phase)" >&2
+    return 0
+  fi
 
-  echo "    text report: $COVERAGE_DIR/coverage.txt"
-  echo "    html report: $COVERAGE_DIR/html/index.html"
+  local odir="$COVERAGE_DIR/overall"
+  mkdir -p "$odir"
+
+  # Common lcov flags. lcov 2.x enforces strict consistency checks that reject
+  # llvm-cov's tracefiles (e.g. "line is hit but no branches evaluated"); disable
+  # them and tolerate the format quirks. lcov 1.x has neither the checks nor the
+  # error categories, so only pass these on >= 2.
+  local lcov_args=(--rc branch_coverage=1)
+  local lcov_major
+  lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
+  if [ "${lcov_major:-0}" -ge 2 ]; then
+    lcov_args+=(--rc check_data_consistency=0
+               --ignore-errors inconsistent,unsupported,corrupt,format)
+  fi
+
+  # lcov merges tracefiles by taking the union per line/branch: a line/branch is
+  # covered if ANY input covered it.
+  local add_args=()
+  local tf
+  for tf in "${tracefiles[@]}"; do
+    add_args+=(--add-tracefile "$tf")
+  done
+  lcov "${lcov_args[@]}" "${add_args[@]}" -o "$odir/combined.lcov"
+
+  # Machine-readable-ish overall summary (line + branch %) and a browsable HTML.
+  lcov "${lcov_args[@]}" --summary "$odir/combined.lcov" \
+    2>&1 | tee "$odir/summary.txt"
+  if command -v genhtml >/dev/null 2>&1; then
+    local genhtml_args=(--branch-coverage)
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors inconsistent,unsupported,corrupt,format)
+    genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
+      >/dev/null 2>&1 || true
+    echo "    overall html report: $odir/html/index.html"
+  fi
+  echo "    overall tracefile:   $odir/combined.lcov"
+  echo "    overall summary:     $odir/summary.txt"
 }
 
 # The `run` phase aggregates every check the host-test pipeline executes: the

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -280,12 +280,15 @@ do_coverage() {
   # llvm-cov's tracefiles (e.g. "line is hit but no branches evaluated"); disable
   # them and tolerate the format quirks. lcov 1.x has neither the checks nor the
   # error categories, so only pass these on >= 2.
-  local lcov_args=(--rc branch_coverage=1)
+  local lcov_args=()
   local lcov_major
   lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
   if [ "${lcov_major:-0}" -ge 2 ]; then
-    lcov_args+=(--rc check_data_consistency=0
+    lcov_args+=(--rc branch_coverage=1
+                --rc check_data_consistency=0
                 --ignore-errors "inconsistent,unsupported,corrupt,format")
+  else
+    lcov_args+=(--rc lcov_branch_coverage=1)
   fi
 
   # lcov merges tracefiles by taking the union per line/branch: a line/branch is

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -274,8 +274,8 @@ do_coverage() {
   local lcov_major
   lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
   if [ "${lcov_major:-0}" -ge 2 ]; then
-    lcov_args+=("--rc check_data_consistency=0"
-                "--ignore-errors inconsistent,unsupported,corrupt,format")
+    lcov_args+=(--rc check_data_consistency=0
+                --ignore-errors "inconsistent,unsupported,corrupt,format")
   fi
 
   # lcov merges tracefiles by taking the union per line/branch: a line/branch is
@@ -292,7 +292,7 @@ do_coverage() {
     2>&1 | tee "$odir/summary.txt"
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
-    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=("--ignore-errors inconsistent,unsupported,corrupt,format")
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors "inconsistent,unsupported,corrupt,format")
     genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
       >/dev/null 2>&1 || true
     echo "    overall html report: $odir/html/index.html"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -123,7 +123,7 @@ do_host_tests() {
   # a clean per-binary lcov tracefile; the tracefiles are then unioned at the
   # line/branch level into one overall report (hash-agnostic). Start clean.
   mkdir -p "$COVERAGE_DIR"
-  rm -rf "$COVERAGE_DIR"/*
+  rm -rf "${COVERAGE_DIR:?}"/*
 
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
@@ -274,8 +274,8 @@ do_coverage() {
   local lcov_major
   lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
   if [ "${lcov_major:-0}" -ge 2 ]; then
-    lcov_args+=(--rc check_data_consistency=0
-               --ignore-errors inconsistent,unsupported,corrupt,format)
+    lcov_args+=("--rc check_data_consistency=0"
+                "--ignore-errors inconsistent,unsupported,corrupt,format")
   fi
 
   # lcov merges tracefiles by taking the union per line/branch: a line/branch is
@@ -292,7 +292,7 @@ do_coverage() {
     2>&1 | tee "$odir/summary.txt"
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
-    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors inconsistent,unsupported,corrupt,format)
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=("--ignore-errors inconsistent,unsupported,corrupt,format")
     genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
       >/dev/null 2>&1 || true
     echo "    overall html report: $odir/html/index.html"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -26,9 +26,10 @@
 #                   llvm source-based coverage profiles (*.profraw) into
 #                   COVERAGE_DIR (requires the host tests to be built with
 #                   -DMICRO_COVERAGE=ON, the default)
-#   coverage        assemble the *.profraw profiles produced by `run` into a
-#                   merged profile and emit text + HTML coverage reports
-#                   (does not run any binaries -- run the `run` phase first)
+#   coverage        turn the per-binary *.profraw profiles from `run` into
+#                   reports: a per-binary text/HTML report + lcov tracefile
+#                   (clean, no hash mismatch), plus an overall line/branch union
+#                   across all binaries via lcov (the CI metric).
 #   all             rccl-configure -> hipify -> configure -> build -> run -> coverage
 #
 # Knobs (environment variables, all optional):
@@ -71,16 +72,18 @@ PHASE="${1:-all}"
 [ $# -gt 0 ] && shift || true   # remaining args ($@) are forwarded to the binary
 
 # Install everything the host-test pipeline needs that the base ROCm dev image
-# lacks: cmake + host toolchain, gtest/fmt, moreutils (ts), and python3-venv
-# (the guards phase creates a venv + pip-installs pytest). Uses sudo when not
-# already root so it works both in the root CI container and locally.
+# lacks: cmake + host toolchain, gtest/fmt, moreutils (ts), python3-venv (the
+# guards phase creates a venv + pip-installs pytest), and lcov/genhtml (the
+# coverage phase merges per-binary lcov tracefiles into one overall report).
+# Uses sudo when not already root so it works both in the root CI container and
+# locally.
 do_deps() {
   echo "==> Install host-test dependencies (apt)"
   local sudo=""
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
 }
 
 do_rccl_configure() {
@@ -108,13 +111,18 @@ do_build() {
 do_host_tests() {
   echo "==> Run  (filter: $GTEST_FILTER)"
 
-  # Always emit source-based coverage profiles: instrumented binaries (built with
-  # -DMICRO_COVERAGE=ON, the default) write a .profraw into COVERAGE_DIR via
-  # LLVM_PROFILE_FILE. The `coverage` phase later merges these into reports
-  # without re-running anything. Start from a clean profraw set each run.
+  # Always emit source-based coverage profiles: instrumented binaries write
+  # .profraw files that the `coverage` phase turns into reports without
+  # re-running anything.
+  #
+  # Each binary writes into its OWN profraw subdir ($COVERAGE_DIR/<binary>/).
+  # The host-test binaries compile some of the same source under different
+  # #defines, so a shared function has a different coverage-mapping hash in each.
+  # Keeping profiles isolated lets `coverage` emit a clean per-binary report and
+  # a clean per-binary lcov tracefile; the tracefiles are then unioned at the
+  # line/branch level into one overall report (hash-agnostic). Start clean.
   mkdir -p "$COVERAGE_DIR"
-  rm -f "$COVERAGE_DIR"/*.profraw
-  export LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw"
+  rm -rf "$COVERAGE_DIR"/*
 
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
@@ -181,19 +189,20 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
-# Assemble the coverage profiles produced by the `run` phase into a merged
-# profile and emit both a text summary and a browsable HTML report. Does NOT run
-# any binaries -- the .profraw files are produced by `run` (see do_host_tests).
-# Requires the host tests to have been built with -DMICRO_COVERAGE=ON (the
-# default), which instruments every host-only test binary with
-# -fprofile-instr-generate -fcoverage-mapping.
+# Turn the per-binary profraw sets produced by the `run` phase into coverage
+# reports. Two levels of output:
+#
+#   1. Per binary ($COVERAGE_DIR/<binary>/): a text + HTML report and an lcov
+#      tracefile, each built against ONLY that binary's own profile so llvm-cov
+#      never warns about "mismatched data". This is what the inner dev loop wants
+#      (focused on one binary / one file under test).
+#
+#   2. Overall ($COVERAGE_DIR/overall/): the per-binary lcov tracefiles unioned
+#      at the line/branch level via `lcov`. A line/branch counts as covered if
+#      ANY binary covered it, so source that is exercised in different binaries
+#      under different #defines is credited correctly.
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
-
-  if ! compgen -G "$COVERAGE_DIR/*.profraw" >/dev/null; then
-    echo "error: no .profraw files in $COVERAGE_DIR -- run the 'run' phase first" >&2
-    exit 1
-  fi
 
   local test_bins
   mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
@@ -202,31 +211,88 @@ do_coverage() {
     exit 1
   fi
 
-  llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
-    -o "$COVERAGE_DIR/merged.profdata"
+  local exe name dir
+  local tracefiles=()
+  for exe in "${test_bins[@]}"; do
+    name="$(basename "$exe")"
+    dir="$COVERAGE_DIR/$name"
+    if ! compgen -G "$dir/*.profraw" >/dev/null; then
+      echo "    skip $name -- no profraw (run the 'run' phase first)" >&2
+      continue
+    fi
 
-  # -object args for every binary beyond the first (llvm-cov takes the first
-  # positional binary, then -object for each additional one).
-  local object_args=()
-  local bin
-  for bin in "${test_bins[@]:1}"; do
-    object_args+=(-object "$bin")
+    # Per-binary: merge its own profraw and report against its own object only.
+    llvm-profdata merge -sparse "$dir"/*.profraw -o "$dir/merged.profdata"
+
+    llvm-cov report "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      --show-branch-summary --show-region-summary \
+      > "$dir/coverage.txt"
+
+    llvm-cov show "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      -format=html -output-dir="$dir/html" \
+      --show-branches=count
+
+    # Per-binary lcov tracefile -- the hash-agnostic, line/branch-keyed form that
+    # can be unioned across binaries. Tag it with the binary name so genhtml and
+    # lcov diagnostics are legible.
+    llvm-cov export "$exe" \
+      -instr-profile="$dir/merged.profdata" \
+      -format=lcov > "$dir/coverage.lcov"
+
+    echo "    $name text report: $dir/coverage.txt"
+    echo "    $name html report: $dir/html/index.html"
+    tracefiles+=("$dir/coverage.lcov")
   done
 
-  llvm-cov report \
-    "${test_bins[0]}" "${object_args[@]}" \
-    -instr-profile="$COVERAGE_DIR/merged.profdata" \
-    --show-branch-summary --show-region-summary \
-    > "$COVERAGE_DIR/coverage.txt"
+  if [ "${#tracefiles[@]}" -eq 0 ]; then
+    echo "error: no .profraw files found under $COVERAGE_DIR -- run the 'run' phase first" >&2
+    exit 1
+  fi
 
-  llvm-cov show \
-    "${test_bins[0]}" "${object_args[@]}" \
-    -instr-profile="$COVERAGE_DIR/merged.profdata" \
-    -format=html -output-dir="$COVERAGE_DIR/html" \
-    --show-branches=count
+  # --- Overall union across all binaries (the CI metric) -------------------
+  if ! command -v lcov >/dev/null 2>&1; then
+    echo "    note: lcov not installed -- skipping overall union report (run the 'deps' phase)" >&2
+    return 0
+  fi
 
-  echo "    text report: $COVERAGE_DIR/coverage.txt"
-  echo "    html report: $COVERAGE_DIR/html/index.html"
+  local odir="$COVERAGE_DIR/overall"
+  mkdir -p "$odir"
+
+  # Common lcov flags. lcov 2.x enforces strict consistency checks that reject
+  # llvm-cov's tracefiles (e.g. "line is hit but no branches evaluated"); disable
+  # them and tolerate the format quirks. lcov 1.x has neither the checks nor the
+  # error categories, so only pass these on >= 2.
+  local lcov_args=(--rc branch_coverage=1)
+  local lcov_major
+  lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
+  if [ "${lcov_major:-0}" -ge 2 ]; then
+    lcov_args+=(--rc check_data_consistency=0
+               --ignore-errors inconsistent,unsupported,corrupt,format)
+  fi
+
+  # lcov merges tracefiles by taking the union per line/branch: a line/branch is
+  # covered if ANY input covered it.
+  local add_args=()
+  local tf
+  for tf in "${tracefiles[@]}"; do
+    add_args+=(--add-tracefile "$tf")
+  done
+  lcov "${lcov_args[@]}" "${add_args[@]}" -o "$odir/combined.lcov"
+
+  # Machine-readable-ish overall summary (line + branch %) and a browsable HTML.
+  lcov "${lcov_args[@]}" --summary "$odir/combined.lcov" \
+    2>&1 | tee "$odir/summary.txt"
+  if command -v genhtml >/dev/null 2>&1; then
+    local genhtml_args=(--branch-coverage)
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors inconsistent,unsupported,corrupt,format)
+    genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
+      >/dev/null 2>&1 || true
+    echo "    overall html report: $odir/html/index.html"
+  fi
+  echo "    overall tracefile:   $odir/combined.lcov"
+  echo "    overall summary:     $odir/summary.txt"
 }
 
 # The `run` phase aggregates every check the host-test pipeline executes: the

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -160,11 +160,19 @@ do_host_tests() {
   fi
 
   : > "$LOG_FILE"   # truncate; each binary appends below
-  local rc=0 exe name xml
+  local rc=0 exe name xml profdir
   for exe in "${binaries[@]}"; do
     name="$(basename "$exe")"
     xml="$(xml_for_binary "$name")"
     echo "----- $name -----" | tee -a "$LOG_FILE"
+    # Direct this binary's llvm profiles into its OWN subdir so `coverage` finds
+    # them at $COVERAGE_DIR/<binary>/. Without this, instrumented binaries write
+    # default.profraw into the CWD and coverage sees nothing. %p (PID) + %m
+    # (module hash) keep the process-isolated forks' files distinct; the runner
+    # inherits this value (it sets LLVM_PROFILE_FILE with overwrite=0).
+    profdir="$COVERAGE_DIR/$name"
+    mkdir -p "$profdir"
+    export LLVM_PROFILE_FILE="$profdir/$name-%p-%m.profraw"
     # Shuffle every binary here, not just the micro ones: the init microtests share ~40 mutable
     # file-scope globals reset only in the fixture TearDown, and the older suites were audited to be
     # order-independent too. gtest prints the seed, so a failure stays reproducible; clear

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -122,7 +122,7 @@ do_host_tests() {
   # a clean per-binary lcov tracefile; the tracefiles are then unioned at the
   # line/branch level into one overall report (hash-agnostic). Start clean.
   mkdir -p "$COVERAGE_DIR"
-  rm -rf "$COVERAGE_DIR"/*
+  rm -rf "${COVERAGE_DIR:?}"/*
 
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
@@ -268,8 +268,8 @@ do_coverage() {
   local lcov_major
   lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
   if [ "${lcov_major:-0}" -ge 2 ]; then
-    lcov_args+=(--rc check_data_consistency=0
-               --ignore-errors inconsistent,unsupported,corrupt,format)
+    lcov_args+=("--rc check_data_consistency=0"
+                "--ignore-errors inconsistent,unsupported,corrupt,format")
   fi
 
   # lcov merges tracefiles by taking the union per line/branch: a line/branch is
@@ -286,7 +286,7 @@ do_coverage() {
     2>&1 | tee "$odir/summary.txt"
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
-    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors inconsistent,unsupported,corrupt,format)
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=("--ignore-errors inconsistent,unsupported,corrupt,format")
     genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
       >/dev/null 2>&1 || true
     echo "    overall html report: $odir/html/index.html"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -83,7 +83,7 @@ do_deps() {
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov llvm
 }
 
 do_rccl_configure() {

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -22,11 +22,14 @@
 #                   prerequisite the host tests compile against
 #   configure       configure test/host
 #   build           build all host binaries (default target)
-#   run             run every host binary (timestamped log + per-binary JUnit XML)
-#   coverage        run every host-test binary under llvm profiling and emit
-#                   text + HTML source-based coverage reports (requires the
-#                   host tests to be built with -DMICRO_COVERAGE=ON, the default)
-#   all             rccl-configure -> hipify -> configure -> build -> run
+#   run             run the suite (timestamped log + JUnit XML). Always emits
+#                   llvm source-based coverage profiles (*.profraw) into
+#                   COVERAGE_DIR (requires the host tests to be built with
+#                   -DMICRO_COVERAGE=ON, the default)
+#   coverage        assemble the *.profraw profiles produced by `run` into a
+#                   merged profile and emit text + HTML coverage reports
+#                   (does not run any binaries -- run the `run` phase first)
+#   all             rccl-configure -> hipify -> configure -> build -> run -> coverage
 #
 # Knobs (environment variables, all optional):
 #   ROCM_PATH     ROCm install prefix              (default: /opt/rocm)
@@ -104,6 +107,15 @@ do_build() {
 
 do_host_tests() {
   echo "==> Run  (filter: $GTEST_FILTER)"
+
+  # Always emit source-based coverage profiles: instrumented binaries (built with
+  # -DMICRO_COVERAGE=ON, the default) write a .profraw into COVERAGE_DIR via
+  # LLVM_PROFILE_FILE. The `coverage` phase later merges these into reports
+  # without re-running anything. Start from a clean profraw set each run.
+  mkdir -p "$COVERAGE_DIR"
+  rm -f "$COVERAGE_DIR"/*.profraw
+  export LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw"
+
   # Prepend a real-UTC timestamp to each line via `ts` (moreutils) when available,
   # tee the full stdout+stderr to LOG_FILE, and preserve each binary's exit code
   # (pipefail) so a failure still fails CI.
@@ -169,14 +181,19 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
-# Run every host-test binary under llvm source-based coverage and emit both a
-# text summary and a browsable HTML report. Requires the host tests to have been
-# built with -DMICRO_COVERAGE=ON (the default), which instruments every host-only
-# test binary with -fprofile-instr-generate -fcoverage-mapping.
+# Assemble the coverage profiles produced by the `run` phase into a merged
+# profile and emit both a text summary and a browsable HTML report. Does NOT run
+# any binaries -- the .profraw files are produced by `run` (see do_host_tests).
+# Requires the host tests to have been built with -DMICRO_COVERAGE=ON (the
+# default), which instruments every host-only test binary with
+# -fprofile-instr-generate -fcoverage-mapping.
 do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
-  mkdir -p "$COVERAGE_DIR"
-  rm -f "$COVERAGE_DIR"/*.profraw
+
+  if ! compgen -G "$COVERAGE_DIR/*.profraw" >/dev/null; then
+    echo "error: no .profraw files in $COVERAGE_DIR -- run the 'run' phase first" >&2
+    exit 1
+  fi
 
   local test_bins
   mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
@@ -184,11 +201,6 @@ do_coverage() {
     echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
     exit 1
   fi
-
-  local exe
-  for exe in "${test_bins[@]}"; do
-    LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw" "$exe"
-  done
 
   llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
     -o "$COVERAGE_DIR/merged.profdata"
@@ -237,6 +249,6 @@ case "$PHASE" in
   guards)         do_guards ;;
   run)            do_run "$@" ;;
   coverage)       do_coverage ;;
-  all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@" ;;
+  all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@"; do_coverage ;;
   *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|coverage|all] [extra gtest args]" >&2; exit 2 ;;
 esac

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -108,6 +108,24 @@ do_build() {
   cmake --build "$BUILD_DIR" -j"$JOBS"
 }
 
+get_test_binaries() {
+  find "$BUILD_DIR" -maxdepth 1 -type f -executable | sort
+}
+
+# Map a binary name to its JUnit XML path. rccl-HostUnitTests keeps host_tests.xml
+# for backward compatibility (it is the only report CI uploads)
+xml_for_binary() {
+  local name="$1"
+  if [ "$name" = "rccl-HostUnitTests" ]; then
+    echo "$XML_FILE"
+    return
+  fi
+  # rccl-UnitTestsMicroInit-uncached -> host_tests_micro_init_uncached.xml, etc.
+  local slug
+  slug="$(echo "$name" | sed -e 's/^rccl-UnitTests//' -e 's/\([A-Z]\)/_\L\1/g' -e 's/^_//' -e 's/-/_/g')"
+  echo "$SCRIPT_DIR/host_tests_${slug}.xml"
+}
+
 do_host_tests() {
   echo "==> Run  (filter: $GTEST_FILTER)"
 
@@ -134,32 +152,24 @@ do_host_tests() {
     stamp=(cat)
   fi
 
-  # Every host binary the build produces. Each writes its own JUnit XML
-  # (host_tests*.xml, all uploaded) and appends to the single console LOG_FILE.
-  # rccl-HostUnitTests keeps host_tests.xml for backward compatibility.
-  local -a binaries=(
-    "rccl-HostUnitTests:$XML_FILE"
-    "rccl-UnitTestsMicro:$SCRIPT_DIR/host_tests_micro.xml"
-    "rccl-UnitTestsMicroInit:$SCRIPT_DIR/host_tests_micro_init.xml"
-    "rccl-UnitTestsMicroInit-uncached:$SCRIPT_DIR/host_tests_micro_init_uncached.xml"
-  )
+  local -a binaries
+  mapfile -t binaries < <(get_test_binaries)
+  if [ "${#binaries[@]}" -eq 0 ]; then
+    echo "ERROR: no host-test binaries found in $BUILD_DIR -- run the build phase first" | tee -a "$LOG_FILE"
+    return 1
+  fi
 
   : > "$LOG_FILE"   # truncate; each binary appends below
-  local rc=0 entry name xml
-  for entry in "${binaries[@]}"; do
-    name="${entry%%:*}"
-    xml="${entry#*:}"
-    if [ ! -x "$BUILD_DIR/$name" ]; then
-      echo "ERROR: expected binary not built: $BUILD_DIR/$name" | tee -a "$LOG_FILE"
-      rc=1
-      continue
-    fi
+  local rc=0 exe name xml
+  for exe in "${binaries[@]}"; do
+    name="$(basename "$exe")"
+    xml="$(xml_for_binary "$name")"
     echo "----- $name -----" | tee -a "$LOG_FILE"
     # Shuffle every binary here, not just the micro ones: the init microtests share ~40 mutable
     # file-scope globals reset only in the fixture TearDown, and the older suites were audited to be
     # order-independent too. gtest prints the seed, so a failure stays reproducible; clear
     # HOST_TEST_SHUFFLE to run in declaration order while bisecting.
-    "$BUILD_DIR/$name" \
+    "$exe" \
       --gtest_filter="$GTEST_FILTER" \
       --gtest_output="xml:$xml" \
       ${HOST_TEST_SHUFFLE_ARGS[@]+"${HOST_TEST_SHUFFLE_ARGS[@]}"} \
@@ -205,7 +215,7 @@ do_coverage() {
   echo "==> Coverage  (out: $COVERAGE_DIR)"
 
   local test_bins
-  mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
+  mapfile -t test_bins < <(get_test_binaries)
   if [ "${#test_bins[@]}" -eq 0 ]; then
     echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
     exit 1

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -9,7 +9,7 @@
 # `all` runs the whole pipeline end to end.
 #
 # Usage:
-#   run_host_tests.sh [deps|rccl-configure|hipify|configure|build|guards|run|all] [extra gtest args]
+#   run_host_tests.sh [deps|rccl-configure|hipify|configure|build|guards|run|coverage|all] [extra gtest args]
 #   (default phase: all)
 #
 # Phases:
@@ -23,6 +23,9 @@
 #   configure       configure test/host
 #   build           build all host binaries (default target)
 #   run             run every host binary (timestamped log + per-binary JUnit XML)
+#   coverage        run every host-test binary under llvm profiling and emit
+#                   text + HTML source-based coverage reports (requires the
+#                   host tests to be built with -DMICRO_COVERAGE=ON, the default)
 #   all             rccl-configure -> hipify -> configure -> build -> run
 #
 # Knobs (environment variables, all optional):
@@ -37,6 +40,7 @@
 #                                                   when bisecting a failure. Deliberately NOT named
 #                                                   GTEST_SHUFFLE: gtest owns that name and reads an
 #                                                   empty value as TRUE, so clearing it would shuffle)
+#   COVERAGE_DIR  coverage output dir (coverage)   (default: <BUILD_DIR>/coverage)
 # Any args after the phase are forwarded to the test binary, e.g.:
 #   run_host_tests.sh run --gtest_filter='BitOps*' --gtest_repeat=5
 #
@@ -57,6 +61,7 @@ HOST_TEST_SHUFFLE="${HOST_TEST_SHUFFLE---gtest_shuffle}"  # `-` not `:-`: an exp
 read -ra HOST_TEST_SHUFFLE_ARGS <<< "$HOST_TEST_SHUFFLE"
 LOG_FILE="${LOG_FILE:-$SCRIPT_DIR/host_tests.log}"
 XML_FILE="${XML_FILE:-$SCRIPT_DIR/host_tests.xml}"
+COVERAGE_DIR="${COVERAGE_DIR:-$BUILD_DIR/coverage}"
 JOBS="$(nproc 2>/dev/null || echo 4)"
 
 PHASE="${1:-all}"
@@ -164,6 +169,54 @@ do_guards() {
   "$venv/bin/python" -m pytest "$gd/tests" -v
 }
 
+# Run every host-test binary under llvm source-based coverage and emit both a
+# text summary and a browsable HTML report. Requires the host tests to have been
+# built with -DMICRO_COVERAGE=ON (the default), which instruments every host-only
+# test binary with -fprofile-instr-generate -fcoverage-mapping.
+do_coverage() {
+  echo "==> Coverage  (out: $COVERAGE_DIR)"
+  mkdir -p "$COVERAGE_DIR"
+  rm -f "$COVERAGE_DIR"/*.profraw
+
+  local test_bins
+  mapfile -t test_bins < <(find "$BUILD_DIR" -maxdepth 1 -type f -executable)
+  if [ "${#test_bins[@]}" -eq 0 ]; then
+    echo "error: no test binaries found in $BUILD_DIR -- run the build phase first" >&2
+    exit 1
+  fi
+
+  local exe
+  for exe in "${test_bins[@]}"; do
+    LLVM_PROFILE_FILE="$COVERAGE_DIR/%m-%p.profraw" "$exe"
+  done
+
+  llvm-profdata merge -sparse "$COVERAGE_DIR"/*.profraw \
+    -o "$COVERAGE_DIR/merged.profdata"
+
+  # -object args for every binary beyond the first (llvm-cov takes the first
+  # positional binary, then -object for each additional one).
+  local object_args=()
+  local bin
+  for bin in "${test_bins[@]:1}"; do
+    object_args+=(-object "$bin")
+  done
+
+  llvm-cov report \
+    "${test_bins[0]}" "${object_args[@]}" \
+    -instr-profile="$COVERAGE_DIR/merged.profdata" \
+    --show-branch-summary --show-region-summary \
+    > "$COVERAGE_DIR/coverage.txt"
+
+  llvm-cov show \
+    "${test_bins[0]}" "${object_args[@]}" \
+    -instr-profile="$COVERAGE_DIR/merged.profdata" \
+    -format=html -output-dir="$COVERAGE_DIR/html" \
+    --show-branches=count
+
+  echo "    text report: $COVERAGE_DIR/coverage.txt"
+  echo "    html report: $COVERAGE_DIR/html/index.html"
+}
+
 # The `run` phase aggregates every check the host-test pipeline executes: the
 # gtest suite plus any CPU-only guards. The host-test workflow invokes `run`
 # (and `all` ends with it), so adding a future check here makes both CI and
@@ -183,6 +236,7 @@ case "$PHASE" in
   build)          do_build ;;
   guards)         do_guards ;;
   run)            do_run "$@" ;;
+  coverage)       do_coverage ;;
   all)            do_rccl_configure; do_hipify; do_configure; do_build; do_run "$@" ;;
-  *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|all] [extra gtest args]" >&2; exit 2 ;;
+  *) echo "usage: $0 [deps|rccl-configure|hipify|configure|build|run|guards|coverage|all] [extra gtest args]" >&2; exit 2 ;;
 esac

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -268,8 +268,8 @@ do_coverage() {
   local lcov_major
   lcov_major="$(lcov --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
   if [ "${lcov_major:-0}" -ge 2 ]; then
-    lcov_args+=("--rc check_data_consistency=0"
-                "--ignore-errors inconsistent,unsupported,corrupt,format")
+    lcov_args+=(--rc check_data_consistency=0
+                --ignore-errors "inconsistent,unsupported,corrupt,format")
   fi
 
   # lcov merges tracefiles by taking the union per line/branch: a line/branch is
@@ -286,7 +286,7 @@ do_coverage() {
     2>&1 | tee "$odir/summary.txt"
   if command -v genhtml >/dev/null 2>&1; then
     local genhtml_args=(--branch-coverage)
-    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=("--ignore-errors inconsistent,unsupported,corrupt,format")
+    [ "${lcov_major:-0}" -ge 2 ] && genhtml_args+=(--ignore-errors "inconsistent,unsupported,corrupt,format")
     genhtml "${genhtml_args[@]}" "$odir/combined.lcov" -o "$odir/html" \
       >/dev/null 2>&1 || true
     echo "    overall html report: $odir/html/index.html"


### PR DESCRIPTION
JIRA ID : AICOMRCCL-1687

Improves the host-only coverage pipeline in test/host/run_host_tests.sh.

What changed
- `all` now runs the `coverage` phase, so a single `run_host_tests.sh all`
  builds, runs, and reports coverage end to end.
- The `run` phase always emits llvm source-based coverage profiles, writing
  each test binary's `.profraw` into its own per-binary subdir under
  `build/coverage/<binary>/`. Keeping profiles isolated avoids llvm-cov
  "mismatched data" warnings that occur when the same source is compiled into
  multiple binaries under different `#defines`.
- The `coverage` phase no longer re-runs binaries. It now emits two levels of
  output:
  - Per binary: a clean text + HTML report and an lcov tracefile, built against
    only that binary's own profile (inner dev loop).
  - Overall: the per-binary lcov tracefiles unioned at the line/branch level via
    `lcov`, giving one overall line/function/branch metric where a line/branch
    counts as covered if any binary covered it. This is the CI metric
    (`build/coverage/overall/summary.txt`).
- `deps` now installs `lcov` (provides `genhtml`); the union step is skipped
  with a note if lcov is absent. Strict lcov 2.x consistency checks that reject
  llvm-cov tracefiles are suppressed, gated on the detected lcov major version.
- Fixed several shellcheck warnings (SC2044, SC2054) and an array-quoting bug
  that passed combined "option value" strings to lcov as single arguments.

Why
Different host-test binaries compile overlapping source under different compile
definitions, so a single merged llvm profile is ill-defined and warns. Per-binary
reports serve local development; an lcov line/branch union gives a meaningful
overall coverage number for CI.

Testing
- `test/host/run_host_tests.sh all` — builds, runs, and produces coverage.
- `test/host/run_host_tests.sh coverage` — verified clean per-binary reports and
  the overall union (union count exceeds each binary individually).
- `bash -n` and shellcheck clean.