### PR TITLE
ci(rccl): capture host-test coverage in host-unit-tests workflow

### DIFF
--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -29,6 +29,12 @@ jobs:
     name: Host unit tests (CPU-only)
     runs-on: ubuntu-24.04
     container:
+      # The `-full` variant ships the complete ROCm LLVM toolchain under
+      # /opt/rocm/llvm/bin. Ubuntu 22.04's apt llvm package is version 15, which
+      # is too old to consume the coverage data the AMD compilers emit; the
+      # `-full` image lets the coverage tooling (llvm-profdata/llvm-cov) match
+      # the compiler that built the tests. This is why `deps` no longer
+      # apt-installs llvm.
       image: rocm/dev-ubuntu-22.04:7.14.0-full
     env:
       ROCM_PATH: /opt/rocm
@@ -47,8 +53,10 @@ jobs:
         # Dependency list lives in run_host_tests.sh (single source of truth).
         run: bash projects/rccl/test/host/run_host_tests.sh deps
 
-      - name: Put ROCm LLVM on PATH
-        run: echo "/opt/rocm/llvm/bin" >> "$GITHUB_PATH"
+      - name: Put ROCm on PATH
+        run: |
+          echo "/opt/rocm/llvm/bin" >> "$GITHUB_PATH"
+          echo "/opt/rocm/bin" >> "$GITHUB_PATH"
 
       # Every pipeline command lives in run_host_tests.sh (single source of truth,
       # runnable identically in CI and locally). Each phase is its own step so a
@@ -71,19 +79,20 @@ jobs:
       # Assemble the coverage profiles the run phase produced into per-binary
       # reports plus an overall line/branch union (the CI coverage metric). Runs
       # even if the suite failed so partial coverage is still captured.
-      - name: Coverage
-        if: always()
+      - name: Assemble coverage reports
+        if: ${{ !cancelled() }}
         run: bash projects/rccl/test/host/run_host_tests.sh coverage
 
       - name: Upload results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: host-unit-test-results
           path: |
             projects/rccl/test/host/host_tests.log
-            projects/rccl/test/host/host_tests.xml
+            projects/rccl/test/host/host_tests*.xml
             projects/rccl/test/host/build/coverage/**/coverage.txt
+            projects/rccl/test/host/build/coverage/**/coverage.lcov
             projects/rccl/test/host/build/coverage/**/html/**
             projects/rccl/test/host/build/coverage/overall/combined.lcov
             projects/rccl/test/host/build/coverage/overall/summary.txt

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Run host tests
         run: bash projects/rccl/test/host/run_host_tests.sh run
 
+      # Assemble the coverage profiles the run phase produced into per-binary
+      # reports plus an overall line/branch union (the CI coverage metric). Runs
+      # even if the suite failed so partial coverage is still captured.
+      - name: Coverage
+        if: always()
+        run: bash projects/rccl/test/host/run_host_tests.sh coverage
+
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -76,3 +83,7 @@ jobs:
           path: |
             projects/rccl/test/host/host_tests.log
             projects/rccl/test/host/host_tests.xml
+            projects/rccl/test/host/build/coverage/**/coverage.txt
+            projects/rccl/test/host/build/coverage/**/html/**
+            projects/rccl/test/host/build/coverage/overall/combined.lcov
+            projects/rccl/test/host/build/coverage/overall/summary.txt

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
     name: Host unit tests (CPU-only)
     runs-on: ubuntu-24.04
     container:
-      image: rocm/dev-ubuntu-22.04:7.2
+      image: rocm/dev-ubuntu-22.04:7.14.0-full
     env:
       ROCM_PATH: /opt/rocm
       # Pin a valid arch so RCCL's configure never probes for a GPU (none on CI).
@@ -47,8 +47,8 @@ jobs:
         # Dependency list lives in run_host_tests.sh (single source of truth).
         run: bash projects/rccl/test/host/run_host_tests.sh deps
 
-      - name: Put ROCm on PATH
-        run: echo "/opt/rocm/bin" >> "$GITHUB_PATH"
+      - name: Put ROCm LLVM on PATH
+        run: echo "/opt/rocm/llvm/bin" >> "$GITHUB_PATH"
 
       # Every pipeline command lives in run_host_tests.sh (single source of truth,
       # runnable identically in CI and locally). Each phase is its own step so a

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -86,7 +86,7 @@ do_deps() {
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev lcov llvm
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
 }
 
 do_rccl_configure() {

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -265,14 +265,19 @@ do_coverage() {
     llvm-profdata merge -sparse "$dir"/*.profraw -o "$dir/merged.profdata" \
       || { echo "    error: llvm-profdata failed for $name" >&2; rc=1; continue; }
 
+    # Filter /test/ and nvtx here too so the per-binary text + HTML reports carry
+    # the same denominator as the lcov export below (and the overall summary that
+    # unions those tracefiles); otherwise the numbers next to each other mislead.
     llvm-cov report "$exe" \
       -instr-profile="$dir/merged.profdata" \
+      --ignore-filename-regex='(/test/|nvtx)' \
       --show-branch-summary --show-region-summary \
       > "$dir/coverage.txt" \
       || { echo "    error: llvm-cov report failed for $name" >&2; rc=1; continue; }
 
     llvm-cov show "$exe" \
       -instr-profile="$dir/merged.profdata" \
+      --ignore-filename-regex='(/test/|nvtx)' \
       -format=html -output-dir="$dir/html" \
       --show-branches=count \
       || { echo "    error: llvm-cov show failed for $name" >&2; rc=1; continue; }
@@ -352,8 +357,9 @@ do_coverage() {
       >/dev/null 2>&1; then
       echo "    overall html report: $odir/html/index.html"
     else
+      # A genhtml rendering hiccup should not redden a job whose tests all
+      # passed and whose tracefiles were all written -- warn but leave rc.
       echo "    warning: genhtml failed -- overall html report not generated" >&2
-      rc=1
     fi
   fi
   echo "    overall tracefile:   $odir/combined.lcov"

--- a/projects/rccl/test/host/run_host_tests.sh
+++ b/projects/rccl/test/host/run_host_tests.sh
@@ -83,7 +83,7 @@ do_deps() {
   [ "$(id -u)" -eq 0 ] || sudo="sudo"
   $sudo apt-get update
   $sudo apt-get install -y cmake git python3 python3-venv build-essential rocm-cmake \
-    moreutils libgtest-dev libgmock-dev libfmt-dev lcov llvm
+    moreutils libgtest-dev libgmock-dev libfmt-dev lcov
 }
 
 do_rccl_configure() {


### PR DESCRIPTION
JIRA ID : AICOMRCCL-1687

Adds coverage capture to the RCCL host-unit-tests GitHub Actions workflow.

Stacked on #10401 (which adds the coverage support to
`run_host_tests.sh`); base will retarget to develop once #10401 merges.

What changed
- New `Coverage` step runs `run_host_tests.sh coverage` after the host test
  suite. Uses `if: always()` so coverage is assembled even when the suite
  fails. The `deps` step already installs lcov (added in #10401).
- The `host-unit-test-results` upload artifact now also captures:
  - per-binary text reports (`build/coverage/**/coverage.txt`)
  - per-binary + overall HTML reports (`build/coverage/**/html/**`)
  - the overall unioned tracefile (`build/coverage/overall/combined.lcov`)
  - the overall line/function/branch summary (`build/coverage/overall/summary.txt`)

Why
Makes the host-only coverage metric (and browsable reports) available as CI
artifacts on every PR that touches projects/rccl.

Testing
- YAML validated.
- Coverage phase exercised locally via `run_host_tests.sh coverage`.