### PR TITLE
Cherry-pick: fix(hip-tests): Disable swap tests on gfx1250

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -799,6 +799,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Functional) {
  * hipMemcpyFlagExtOpSwap across generated per-side allocation types, copy counts, and sizes.
  */
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Swap) {
+  skipMemcpyBatchAsyncIfAnyGfx1250();
+
   const size_t count = GENERATE(2, 3, 8);
   const size_t size_in_bytes = GENERATE(as<size_t>{}, 1, 63, 4096);
   const LinearAllocs allocTypeA =

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync_p2p.cc
@@ -22,6 +22,8 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Swap) {
     HIP_SKIP_TEST("Skipping because fewer than 2 devices are available");
   }
 
+  skipMemcpyBatchAsyncIfAnyGfx1250();
+
   const int device_for_a = 0;
   const int device_for_b = 1;
   int can_access_peer_a_to_b = 0;

--- a/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpyBatchAsync_common.hh
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -16,6 +17,20 @@
 #include <hip_test_process.hh>
 #include <resource_guards.hh>
 #include <utils.hh>
+
+#if HT_AMD
+inline void skipMemcpyBatchAsyncIfAnyGfx1250() {
+  const int device_count = HipTest::getDeviceCount();
+  for (int dev = 0; dev < device_count; ++dev) {
+    hipDeviceProp_t props{};
+    HIP_CHECK(hipGetDeviceProperties(&props, dev));
+    const std::string arch(props.gcnArchName);
+    if (arch.find("gfx1250") != std::string::npos) {
+      HIP_SKIP_TEST("ROCM-29275: not supported on gfx1250");
+    }
+  }
+}
+#endif
 
 // Copy `data` from the host into `buffer`, picking the copy kind from the buffer's allocation type
 // so device and host buffers can be filled through one call.


### PR DESCRIPTION
## Motivation

Swap tests are not being skipped properly on gfx1250 due to a bug in hip-tests framework. This only happens with multi-arch builds.

## Technical Details

Skip the tests by querying the device property `gcnArchName` instead.

Cherry-pick of:  https://github.com/ROCm/rocm-systems/pull/10399

## Issue Tracking

Jira ID : ROCM-29275

## Test Plan

Test locally on MI450 with multi-arch TheRock build:

```
cmake .. -GNinja \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DCMAKE_INSTALL_PREFIX=$PWD/install \
    -DTHEROCK_ENABLE_ALL=OFF \
    -DTHEROCK_ENABLE_HIP_RUNTIME=ON \
    -DTHEROCK_ENABLE_OCL_RUNTIME=ON \
    -DTHEROCK_ENABLE_CORE_RUNTIME=ON \
    -DTHEROCK_BUILD_TESTING=ON \
    -DTHEROCK_ENABLE_CORE_HIPTESTS=ON \
    -DTHEROCK_DIST_AMDGPU_FAMILIES="gfx950;gfx1250" \
    -DTHEROCK_AMDGPU_TARGETS="gfx950;gfx1250" \
    -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME="gfx950;gfx1250" \
    -DTHEROCK_TEST_AMDGPU_TARGETS="gfx950;gfx1250" \
    -Damd-llvm_BUILD_TYPE=Release
```

## Test Result

Tests are skipped:

```
    Start 897: Unit_hipMemcpyBatchAsync_Swap
1/3 Test #897: Unit_hipMemcpyBatchAsync_Swap ..................................***Skipped   0.06 sec
    Start 904: Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect
2/3 Test #904: Unit_hipMemcpyBatchAsync_MixedAttributes_DefaultSwapIndirect ...***Skipped   0.06 sec
    Start 906: Unit_hipMemcpyBatchAsync_P2P_Swap
3/3 Test #906: Unit_hipMemcpyBatchAsync_P2P_Swap ..............................***Skipped   0.06 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
