### PR TITLE
fix(rocprofiler-compute): consolidate membw-analysis gate

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -178,6 +178,7 @@ class OmniAnalyze_Base:
             sys_info=sys_info,
             profiling_config=profiling_config,
             arch=arch,
+            membw_analysis=getattr(self.get_args(), "membw_analysis", False),
         )
         self._arch_configs[arch] = ac
         return self._arch_configs

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/tui_utils.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/tui_utils.py
@@ -148,9 +148,6 @@ def process_panels_to_dataframes(
     decimal_precision = getattr(args, "decimal", 2) if args else 2
 
     for panel_id, panel in arch_configs.panel_configs.items():
-        if panel_id == 3000 and not args.membw_analysis:
-            continue
-
         if panel_id in config.HIDDEN_SECTIONS:
             continue
 

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -53,6 +53,7 @@ def build_dfs(
     sys_info: pd.Series,
     profiling_config: dict[str, Any],
     arch: Optional[str] = None,
+    membw_analysis: bool = False,
 ) -> None:
     """Build a dataframe template for each table in each panel. Analyze-mode
     filter_metrics overrides profile-mode filter_blocks; tables that fail the
@@ -91,6 +92,9 @@ def build_dfs(
     )
 
     for panel_id, panel in arch_configs.panel_configs.items():
+        if panel_id == 3000 and not membw_analysis:
+            continue
+
         for data_source in panel["data source"]:
             for table_type, data_config in data_source.items():
                 table_id = data_config["id"]

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -886,11 +886,6 @@ def show_all(
     )
 
     for panel_id, panel in arch_configs.panel_configs.items():
-        # NOTE: Experimental Feature Toggle
-        # HARD GATE: Block 30 (panel 3000) requires membw_analysis flag
-        if panel_id == 3000 and not args.membw_analysis:
-            continue
-
         # Skip panels that don't support baseline comparison
         if len(args.path) > 1 and panel_id in config.HIDDEN_SECTIONS:
             continue

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -961,11 +961,6 @@ def show_all(
     )
 
     for panel_id, panel in arch_configs.panel_configs.items():
-        # NOTE: Experimental Feature Toggle
-        # HARD GATE: Block 30 (panel 3000) requires membw_analysis flag
-        if panel_id == 3000 and not args.membw_analysis:
-            continue
-
         # Skip panels that don't support baseline comparison
         if len(args.path) > 1 and panel_id in config.HIDDEN_SECTIONS:
             continue

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_tui/utils/test_tui_utils.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_tui/utils/test_tui_utils.py
@@ -161,25 +161,30 @@ class TestProcessPanelsToDataframes:
         ],
     )
     def test_membw_analysis_panel_gate(self, membw_analysis: bool) -> None:
-        """Panel 3000 is included only when memory bandwidth analysis is enabled."""
+        """Panel 3000 is included only when present in arch_configs."""
         mock_args = MagicMock()
         mock_args.decimal = 2
         mock_args.membw_analysis = membw_analysis
 
-        mock_arch_configs = MagicMock()
-        mock_arch_configs.panel_configs = {
-            3000: {
-                "title": "Memory Bandwidth Analysis",
-                "data source": [
-                    {
-                        "metric_table": {
-                            "id": 3013,
-                            "title": "EA Interface",
+        panel_configs = (
+            {
+                3000: {
+                    "title": "Memory Bandwidth Analysis",
+                    "data source": [
+                        {
+                            "metric_table": {
+                                "id": 3013,
+                                "title": "EA Interface",
+                            }
                         }
-                    }
-                ],
+                    ],
+                }
             }
-        }
+            if membw_analysis
+            else {}
+        )
+        mock_arch_configs = MagicMock()
+        mock_arch_configs.panel_configs = panel_configs
         metric_dataframe = pd.DataFrame({
             "Metric": ["EA read request fraction - HBM"],
             "Avg": [50.0],

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -294,6 +294,76 @@ class TestBuildDfs:
         assert ac.metric_counters["Kept"] == ["COUNTER_KEPT"]
         assert ac.dfs_expressions[201] == ["AVG(COUNTER_KEPT)"]
 
+    def test_membw_gate_excludes_panel_3000_by_default(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(ac, filter_metrics=None, sys_info=_sys_info(), profiling_config={})
+
+        assert 1 in ac.dfs
+        assert 3001 not in ac.dfs
+
+    def test_membw_gate_includes_panel_3000_when_enabled(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(
+            ac,
+            filter_metrics=None,
+            sys_info=_sys_info(),
+            profiling_config={},
+            membw_analysis=True,
+        )
+
+        assert 3001 in ac.dfs
+        assert list(ac.dfs[3001]["Metric"]) == ["BW"]
+
+    def test_membw_gate_overrides_filter_targeting_panel_3000(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                200,
+                _metric_panel(
+                    200,
+                    201,
+                    metrics={"M1": {"value": "AVG(COUNTER_A)"}},
+                ),
+            ),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(
+            ac,
+            filter_metrics=["30"],
+            sys_info=_sys_info(),
+            profiling_config={},
+            membw_analysis=False,
+        )
+
+        assert 3001 not in ac.dfs
+
 
 # =============================================================================
 # expand_placeholder_ranges

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -314,6 +314,76 @@ class TestBuildDfs:
         assert ac.metric_counters["Kept"] == ["COUNTER_KEPT"]
         assert ac.dfs_expressions[201] == ["AVG(COUNTER_KEPT)"]
 
+    def test_membw_gate_excludes_panel_3000_by_default(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(ac, filter_metrics=None, sys_info=_sys_info(), profiling_config={})
+
+        assert 1 in ac.dfs
+        assert 3001 not in ac.dfs
+
+    def test_membw_gate_includes_panel_3000_when_enabled(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(
+            ac,
+            filter_metrics=None,
+            sys_info=_sys_info(),
+            profiling_config={},
+            membw_analysis=True,
+        )
+
+        assert 3001 in ac.dfs
+        assert list(ac.dfs[3001]["Metric"]) == ["BW"]
+
+    def test_membw_gate_overrides_filter_targeting_panel_3000(self):
+        ac = _make_arch_config([
+            (0, _raw_csv_panel(0, 1, "kernel_top.csv")),
+            (
+                200,
+                _metric_panel(
+                    200,
+                    201,
+                    metrics={"M1": {"value": "AVG(COUNTER_A)"}},
+                ),
+            ),
+            (
+                3000,
+                _metric_panel(
+                    3000,
+                    3001,
+                    metrics={"BW": {"value": "AVG(COUNTER_BW)"}},
+                ),
+            ),
+        ])
+        build_dfs(
+            ac,
+            filter_metrics=["30"],
+            sys_info=_sys_info(),
+            profiling_config={},
+            membw_analysis=False,
+        )
+
+        assert 3001 not in ac.dfs
+
 
 # =============================================================================
 # expand_placeholder_ranges

--- a/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
@@ -306,7 +306,7 @@ def test_show_all_membw_analysis_panel_gate(
     monkeypatch: pytest.MonkeyPatch,
     membw_analysis: bool,
 ) -> None:
-    """Panel 3000 is rendered only when memory bandwidth analysis is enabled."""
+    """Panel 3000 is rendered only when present in arch_configs."""
     args = argparse.Namespace(
         decimal=2,
         filter_metrics=None,
@@ -327,15 +327,18 @@ def test_show_all_membw_analysis_panel_gate(
         "title": "EA Interface",
         "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
     }
-    arch_configs = SimpleNamespace(
-        panel_configs={
+    panel_configs = (
+        {
             3000: {
                 "id": 3000,
                 "title": "Memory Bandwidth Analysis",
                 "data source": [{"metric_table": table_config}],
             }
         }
+        if membw_analysis
+        else {}
     )
+    arch_configs = SimpleNamespace(panel_configs=panel_configs)
     runs = {
         "fixture": SimpleNamespace(
             dfs={3013: metric_dataframe},

--- a/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
@@ -310,7 +310,7 @@ def test_show_all_membw_analysis_panel_gate(
     monkeypatch: pytest.MonkeyPatch,
     membw_analysis: bool,
 ) -> None:
-    """Panel 3000 is rendered only when memory bandwidth analysis is enabled."""
+    """Panel 3000 is rendered only when present in arch_configs."""
     args = argparse.Namespace(
         decimal=2,
         filter_metrics=None,
@@ -331,15 +331,18 @@ def test_show_all_membw_analysis_panel_gate(
         "title": "EA Interface",
         "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
     }
-    arch_configs = SimpleNamespace(
-        panel_configs={
+    panel_configs = (
+        {
             3000: {
                 "id": 3000,
                 "title": "Memory Bandwidth Analysis",
                 "data source": [{"metric_table": table_config}],
             }
         }
+        if membw_analysis
+        else {}
     )
+    arch_configs = SimpleNamespace(panel_configs=panel_configs)
     runs = {
         "fixture": SimpleNamespace(
             dfs={3013: metric_dataframe},


### PR DESCRIPTION
## Motivation

The `--membw-analysis flag` is currently checked in 5 separate places across the codebase. This is a mechanical cleanup with no functional changes: it simplifies the architecture before new code is added on top of it.

## Technical Details

Move the gate into data loading: Add a membw_analysis check in `build_dfs` (`src/utils/parser.py`) so that panel 3000 is never loaded when the flag is not set. This follows the same pattern already used for `profile_panel_filter` and `filter_metrics` in the same function.

## Issue Tracking

JIRA ID: AIPROFCOMP-790

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
