### PR TITLE
rccl/gin-sdma: cap Anvil-SDMA puts at 128 MiB to fix large-message A2A hang

### DIFF
--- a/ddai-artifacts/docker/Dockerfile-rccl-gin-gda-sdma
+++ b/ddai-artifacts/docker/Dockerfile-rccl-gin-gda-sdma
@@ -1,0 +1,360 @@
+## base docker image
+#ARG ROCM_IMAGE_NAME=rocm/dev-ubuntu-24.04
+#ARG ROCM_IMAGE_TAG=latest
+#FROM "${ROCM_IMAGE_NAME}:${ROCM_IMAGE_TAG}"
+FROM ubuntu:24.04
+
+#Example build: from a github pull
+#docker build -f Dockerfile-rccl-gin-gda-sdma -t rccl-gin-gda-sdma-713 --build-arg GPU_TARGETS=gfx950  .
+#--build-arg ROCSHMEM_CACHE_BUST=N: increase N to force pull rocSHMEM and rebuilding
+#--build-arg RCCL_CACHE_BUST=N: increase N to force pull RCCL and RCCL-test and rebuilding
+#--build-arg ROCSHMEM_BRANCH=users/dondai/gin-stage2-gda-sdma-only (RCCL_BRANCH): pull and build that specific branch from github
+# Example build: from local sources, CWD in the rocm-systems pull
+#docker build -f Dockerfile-rccl-gin-gda-sdma -t rccl-gin-gda-sdma-713 --build-arg GPU_TARGETS=gfx950 --build-arg ROCSHMEM_CACHE_BUST=5 --build-arg USE_LOCAL_SRC=1  .
+
+# Example command lines:
+#docker run -it --rm --shm-size 64G   --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host   --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged  rccl-gin-gda-sdma-713 mpirun -n 8 -mca pml ob1 -mca btl ^openib -x RCCL_ROCSHMEM_ENABLE=0 -x RCCL_ROCSHMEM_THRESHOLD=$((128*1024*1024)) -x NCCL_DEBUG=VERSION -x NCCL_GIN_ENABLE=1 -x NCCL_GIN_TYPE=2 -x NCCL_DEBUG_SUBSYS=INIT,NET -x NCCL_CUMEM_ENABLE=1 -x RCCL_ENABLE_INTRANET=1  -x NCCL_DMABUF_ENABLE=1 -x NCCL_MSCCL_ENABLE=0 -x HSA_NO_SCRATCH_RECLAIM=1 rccl-tests/alltoall_perf -b 128 -e 128M -f 2 -g 1 -R 2 -D 3 -A 1
+#docker run -it --rm --shm-size 64G   --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host   --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged  rccl-gin-gda-sdma-713 mpirun -n 8 -mca pml ob1 -mca btl ^openib rocshmem/bin/rocshmem_functional_tests -a 19 -w 1 -z 256 -v $((128*1024*1024)) -noverif
+
+## creating scratch space
+ENV WORKDIR /workspace
+RUN mkdir -p ${WORKDIR}
+WORKDIR ${WORKDIR}
+ENV SRC /src
+RUN mkdir -p ${SRC}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y sudo wget curl gpg ca-certificates
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings \
+ && wget https://repo.amd.com/rocm/packages/gpg/rocm.gpg -O - | gpg --dearmor | tee /etc/apt/keyrings/amdrocm.gpg > /dev/null \
+ && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" > /etc/apt/sources.list.d/rocm.list
+RUN apt-get update \
+ && apt-get install -y amdrocm-core7.13-gfx950 amdrocm-core7.13-gfx942 amdrocm-core-dev7.13 amdrocm-developer-tools7.13 amdrocm-runtime-dev7.13 \
+ && ln -s /opt/rocm/core/.info /opt/rocm/.info
+
+## install dependencies
+RUN apt-get install -y --no-install-recommends \
+    build-essential  \
+    git \
+    make \
+    cmake \
+    ninja-build \
+    pkg-config \
+    libnuma-dev \
+    libpthread-stubs0-dev \
+    libzstd-dev \
+    lcov \
+    zip \
+    zlib1g-dev \
+    wget \
+    pkg-config \
+    unzip \
+    chrpath \
+    doxygen \
+    lshw \
+    build-essential \
+    libssl-dev \
+    curl \
+    libncursesw5-dev \
+    xz-utils \
+    liblzma-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    python3-dev \
+    python3-tk \
+    python3-yaml \
+    libfmt-dev \
+    vim \
+    less \
+    build-essential autoconf libtool flex bison pkg-config git \
+    libibverbs-dev ibverbs-utils libibumad-dev libpci-dev librdmacm-dev rdma-core infiniband-diags \
+    openmpi-bin openmpi-common libopenmpi-dev \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Newest rdma-core / libmlx5 from distro updates (base pocket can lag). RCCL GIN Anvil SDMA
+# (NCCL_GIN_TYPE=6) dlopens MLX5_1.25 symbols (mlx5dv_reg_dmabuf_mr, mlx5dv_get_data_direct_sysfs_path).
+RUN . /etc/os-release \
+ && apt-get update \
+ && ( apt-get install -y --no-install-recommends \
+        -t "${VERSION_CODENAME}-updates" \
+        rdma-core libibverbs1 libmlx5-1 librdmacm1t64 libibumad3 ibverbs-providers \
+        libibverbs-dev librdmacm-dev libibumad-dev \
+      || apt-get install -y --no-install-recommends \
+        rdma-core libibverbs1 libmlx5-1 librdmacm1t64 libibumad3 ibverbs-providers \
+        libibverbs-dev librdmacm-dev libibumad-dev ) \
+ && rm -rf /var/lib/apt/lists/*
+
+# Optional: install newer rdma-core / libmlx5 .deb files from build context (extra-rdma-debs/*.deb).
+# See extra-rdma-debs/README.md — required for Test#5 on hosts where stock noble libmlx5 lacks MLX5_1.25 symbols.
+COPY extra-rdma-debs/ /tmp/extra-rdma-debs/
+RUN set -eu; \
+  if ! ls /tmp/extra-rdma-debs/*.deb >/dev/null 2>&1; then \
+    echo "extra-rdma-debs/: no .deb files (optional; skipping)"; \
+    exit 0; \
+  fi; \
+  apt-get update; \
+  dpkg -i /tmp/extra-rdma-debs/*.deb || apt-get -fy install; \
+  rm -rf /var/lib/apt/lists/*
+
+# Stock Ubuntu 24.04 libmlx5 often lacks MLX5_1.25 exports (mlx5dv_reg_dmabuf_mr); strict verify fails (ddai-gin-build.log).
+# Default: skip. Set --build-arg RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=1 with MOFED/newer rdma-core to enforce.
+ARG RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=0
+RUN set -eu; \
+  if [ "${RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS}" != "1" ]; then \
+    echo "Skipping libmlx5 DMA-BUF symbol verify (RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS is not 1)."; \
+    exit 0; \
+  fi; \
+  ok_mr=0; ok_sys=0; \
+  for f in /lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so.1 \
+           /lib/x86_64-linux-gnu/libmlx5dv.so.1 /usr/lib/x86_64-linux-gnu/libmlx5dv.so.1; do \
+    [ -e "$f" ] || continue; \
+    rf=$(readlink -f "$f"); \
+    [ -f "$rf" ] || continue; \
+    objdump -T "$rf" 2>/dev/null | grep -q mlx5dv_reg_dmabuf_mr && ok_mr=1; \
+    objdump -T "$rf" 2>/dev/null | grep -q mlx5dv_get_data_direct_sysfs_path && ok_sys=1; \
+  done; \
+  [ "$ok_mr" -eq 1 ] && [ "$ok_sys" -eq 1 ]; \
+  echo "OK: MLX5 DMA-BUF/sysfs symbols found (RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=1)."
+
+
+## Not needed on Ubuntu 24, probably needed on Ubuntu22
+#RUN wget https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0-linux-x86_64.sh \
+#    && chmod +x cmake-3.28.0-linux-x86_64.sh \
+#    && bash ./cmake-3.28.0-linux-x86_64.sh --prefix=/usr --exclude-subdir --skip-license \
+#    && rm cmake-3.28.0-linux-x86_64.sh
+
+## Set ROCm path
+ENV ROCM_PATH=/opt/rocm
+# System OpenMPI from apt.
+# rocSHMEM MPI_ROOT, rccl-tests CMAKE_PREFIX_PATH use these.
+ENV MPI_INSTALL_PREFIX=/usr
+ENV MPI_INSTALL_DIR=/usr
+
+# We use MPI only as a launcher, any MPI will do, use system install
+## Install UCX
+#ENV UCX_INSTALL_PREFIX=/opt/ucx
+#RUN wget https://github.com/openucx/ucx/releases/download/v1.16.0/ucx-1.16.0.tar.gz \
+#    && mkdir -p ucx \
+#    && tar -zxf ucx-1.16.0.tar.gz -C ucx --strip-components=1 \
+#    && cd ucx \
+#    && mkdir build \
+#    && cd build \
+#    && ../configure --prefix=${UCX_INSTALL_PREFIX} --with-rocm=${ROCM_PATH} \
+#    && make -j16 install \
+#    && cd ../.. \
+#    && rm -rf ucx ucx-1.16.0.tar.gz
+
+## Install OpenMPI
+#ENV MPI_INSTALL_PREFIX=/opt/ompi
+#RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz \
+#    && mkdir -p ompi4 \
+#    && tar -zxf openmpi-4.1.6.tar.gz -C ompi4 --strip-components=1 \
+#    && cd ompi4 \
+#    && mkdir build \
+#    && cd build \
+#    && ../configure --prefix=${MPI_INSTALL_PREFIX} --with-ucx=${UCX_INSTALL_PREFIX} --disable-oshmem --disable-mpi-fortran --enable-orterun-prefix-by-default \
+#    && make -j16 install \
+#    && cd ../.. \
+#    && rm -rf ompi4 openmpi-4.1.6.tar.gz
+#ENV PATH="${MPI_INSTALL_PREFIX}/bin:${PATH}"
+
+# OPTIONAL: rocm-enabled IB perftest (ib_write_bw / ib_write_lat) -- a *manual*
+# network-sanity tool for validating the GDA/RDMA fabric before GIN-GDA runs. It
+# is NOT invoked by any automated GIN-GDA/GIN-SDMA test (those drive the NIC via
+# RCCL's own collective binaries), so a transient clone/build failure must never
+# abort this 57-step image build.
+#
+# The SUT is behind a proxy, and proxies commonly mishandle HTTP/2 stream
+# multiplexing; the plain full clone died mid-pack with
+#   "curl 92 HTTP/2 stream ... CANCEL (err 8)" / "fatal: early EOF".
+# Hardening: force HTTP/1.1 (sidesteps the HTTP/2 reset), shallow clone (tiny
+# pack), retry with backoff, and keep the whole block best-effort. The proxy
+# itself is already injected globally by the Docker daemon config (apt and the
+# rocSHMEM/RCCL clones in later steps go through it), so no proxy ARG is needed
+# here; forcing HTTP/1.1 is the proxy-specific part of the fix.
+RUN set -eux; \
+    ok=0; \
+    for i in 1 2 3 4 5; do \
+      rm -rf rdma-perftest; \
+      if git -c http.version=HTTP/1.1 -c http.postBuffer=524288000 \
+             clone --depth 1 https://github.com/ROCm/rdma-perftest; then ok=1; break; fi; \
+      echo "rdma-perftest clone attempt $i failed; retrying in $((i*5))s"; sleep $((i*5)); \
+    done; \
+    if [ "$ok" = 1 ]; then \
+      cd rdma-perftest \
+        && ./autogen.sh \
+        && ./configure --enable-rocm --with-rocm=/opt/rocm \
+        && make -j 8 \
+        || echo "WARNING: rdma-perftest build failed (optional tool); continuing"; \
+    else \
+      echo "WARNING: rdma-perftest clone failed after retries (optional tool); continuing"; \
+    fi
+
+## rccl repo
+ARG ROCM_REPO=https://github.com/ROCm/rocm-systems.git
+
+## AMD GPU Targets
+ARG GPU_TARGETS=gfx950
+
+# USE_LOCAL_SRC=1: use the CWD worktree instead of cloning from ROCM_REPO.
+# Build with:  docker build --build-arg USE_LOCAL_SRC=1 ...  from the repo root.
+# projects/ always exists even in a sparse checkout, so COPY never fails;
+# individual subdirs are checked in shell before use.
+ARG USE_LOCAL_SRC=0
+
+# DEBUG_BUILD=1: build all components with debug symbols (-g, Debug).
+ARG DEBUG_BUILD=0
+
+# ROCSHMEM_USE_SDMA=1 (default): rocSHMEM cmake USE_SDMA=ON. Required for GIN Anvil-SDMA
+# (NCCL_GIN_TYPE=5) exercised by docker-gin-gda-sdma-test.bash / docker-gin-gda-sdma-ruby-test.bash Test#5.
+# The Dockerfile upgrades rdma-core/libmlx5 from ${VERSION_CODENAME}-updates (when available).
+# Optional: --build-arg RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=1 fails the build unless those MLX5 symbols exist.
+# Set --build-arg ROCSHMEM_USE_SDMA=0 if you do not need Test#5 and want a slightly leaner build.
+ARG ROCSHMEM_USE_SDMA=1
+
+## building rocSHMEM
+ARG ROCSHMEM_BRANCH=users/dondai/gin-stage2-gda-sdma-only
+ARG ROCSHMEM_CACHE_BUST=1
+COPY projects/rocshmem/ /tmp/local/projects/rocshmem/
+ENV ROCSHMEM_INSTALL_DIR=${WORKDIR}/rocshmem
+RUN if [ "${USE_LOCAL_SRC}" = "1" ]; then \
+      [ -d /tmp/local/projects/rocshmem ] || { echo "ERROR: projects/rocshmem not in build context"; exit 1; }; \
+      find /tmp/local/projects/rocshmem -name CMakeCache.txt -delete && \
+      find /tmp/local/projects/rocshmem -name CMakeFiles -type d -exec rm -rf {} + 2>/dev/null; \
+      find /tmp/local/projects/rocshmem -name build -type d -exec rm -rf {} + 2>/dev/null; \
+      mkdir -p ${WORKDIR}/rocshmem/src/projects && \
+      cp -r /tmp/local/projects/rocshmem ${WORKDIR}/rocshmem/src/projects/rocshmem; \
+    else \
+      git clone --no-checkout --filter=blob:none ${ROCM_REPO} ${WORKDIR}/rocshmem/src && \
+      cd ${WORKDIR}/rocshmem/src && \
+      git sparse-checkout set --cone projects/rocshmem && \
+      git checkout ${ROCSHMEM_BRANCH}; \
+    fi
+RUN cd rocshmem/src/projects/rocshmem \
+ && mkdir -p build && cd build \
+ && ../scripts/build_configs/all_backends \
+      -DBUILD_DEBUG_TRACE_DEVICE=OFF -DBUILD_DEBUG_DEVICE=OFF -DBUILD_DEBUG_TRACE_HOST=OFF \
+      -DMPI_ROOT=${MPI_INSTALL_PREFIX} \
+      -DUSE_EXTERNAL_MPI=OFF \
+      -DGPU_TARGETS=${GPU_TARGETS} \
+      -DCMAKE_INSTALL_PREFIX=${ROCSHMEM_INSTALL_DIR} \
+      -DUSE_IPC=ON \
+      -DUSE_SDMA=ON \
+      -DBUILD_FUNCTIONAL_TESTS=OFF \
+      -DBUILD_UNIT_TESTS=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_CTESTS=OFF \
+      -DBUILD_PYTHON_TESTS=OFF \
+      -DBUILD_TOOLS=OFF \
+      $([ "${DEBUG_BUILD}" = "1" ] && echo "-DCMAKE_BUILD_TYPE=Debug")
+
+## building RCCL
+ARG RCCL_BRANCH=users/dondai/gin-stage2-gda-sdma-only
+ARG RCCL_CACHE_BUST=1
+COPY projects/rccl/      /tmp/local/projects/rccl/
+COPY projects/rccl-tests/ /tmp/local/projects/rccl-tests/
+RUN echo "RCCL_CACHE_BUST=${RCCL_CACHE_BUST}" \
+ && test -f /tmp/local/projects/rccl/src/include/gin/gin_host_rocshmem_gda.h \
+ || { echo "ERROR: gin_host_rocshmem_gda.h missing from RCCL build context"; exit 1; }
+ENV RCCL_INSTALL_PREFIX=${WORKDIR}/rccl
+# ONLY_FUNCS restricts RCCL device-kernel generation to shrink build time. This GIN image
+# needs SendRecv + AlltoAll* for its GIN work. "Broadcast" and "AllGather" are included so the
+# host baselines (broadcast_perf -D 0 / all_gather_perf -D 0) have their RING/{SIMPLE,LL,LL128}
+# device kernels across the full size range. Broadcast has no direct/copy fast path so it always
+# needs the ring kernel; AllGather works small/medium via rcclDirectAllGather but falls through
+# to the ring kernel at large sizes (~>64M) where it would otherwise fault (ncclDevFuncId
+# not found for coll:2). "AllReduce" is included so the AllReduce host baseline
+# (all_reduce_perf -D 0, gin-sdma-ar-test.bash AR-C1) has its device kernels; the GIN -D 5
+# path uses the custom kernel and does not need it. "Reduce" is included so the Reduce host
+# baseline (reduce_perf -D 0) and the GIN -D 3 devcomm/symk query for ncclFuncReduce resolve
+# via generated kernels; without it Reduce falls through to the rocshmem-GDA GIN factory and
+# aborts on undefined rocshmem symbols. Override at build time with
+# --build-arg ONLY_FUNCS="..." (empty = all).
+ARG ONLY_FUNCS="SendRecv|AlltoAllPivot|AlltoAllGda|AlltoAllvGda|Broadcast|AllGather|AllReduce|Reduce"
+# Quote the value: fine-grained ONLY_FUNCS entries contain spaces
+# (e.g. "ReduceScatter * * Sum *"); an unquoted ENV assignment would split on the
+# first space and silently drop the filter (falling back to generating all kernels).
+ENV ONLY_FUNCS="${ONLY_FUNCS}"
+RUN if [ "${USE_LOCAL_SRC}" = "1" ]; then \
+      [ -d /tmp/local/projects/rccl ]       || { echo "ERROR: projects/rccl not in build context";       exit 1; }; \
+      [ -d /tmp/local/projects/rccl-tests ] || { echo "ERROR: projects/rccl-tests not in build context"; exit 1; }; \
+      find /tmp/local/projects/rccl /tmp/local/projects/rccl-tests -name CMakeCache.txt -delete && \
+      find /tmp/local/projects/rccl /tmp/local/projects/rccl-tests -name CMakeFiles -type d -exec rm -rf {} + 2>/dev/null; \
+      find /tmp/local/projects/rccl /tmp/local/projects/rccl-tests -name build -type d -exec rm -rf {} + 2>/dev/null; \
+      mkdir -p ${WORKDIR}/rccl/src/projects && \
+      cp -r /tmp/local/projects/rccl       ${WORKDIR}/rccl/src/projects/rccl && \
+      cp -r /tmp/local/projects/rccl-tests ${WORKDIR}/rccl/src/projects/rccl-tests; \
+    else \
+      git clone --no-checkout --filter=blob:none "${ROCM_REPO}" ${WORKDIR}/rccl/src/ && \
+      cd ${WORKDIR}/rccl/src && \
+      git sparse-checkout set --cone projects/rccl && \
+      git checkout ${RCCL_BRANCH}; \
+    fi
+
+RUN cd rccl/src/projects/rccl \
+ && sed -i \
+       's/if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks\/comm->nNodes == 8) && comm->rocshmemThreshold <= 1048576)/if (comm->enableRocshmem)/' \
+       src/rccl_wrap.cc
+RUN cd rccl/src/projects/rccl \
+ && ./install.sh --amdgpu_targets=${GPU_TARGETS} --prefix=${RCCL_INSTALL_PREFIX} --no-device-linker --no_clean \
+      --cmake-options "-DENABLE_ROCSHMEM_GIN=ON -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR} -DROCSHMEM_SOURCE_DIR=${WORKDIR}/rocshmem/src/projects/rocshmem -DROCSHMEM_BUILD_DIR=${WORKDIR}/rocshmem/src/projects/rocshmem/build/include/rocshmem" \
+      $([ "${DEBUG_BUILD}" = "1" ] && echo "--debug")
+
+# Workaround: hipify renames core.h->core_tmp.h but gin headers still include ../core.h
+RUN RCCL_BUILD_DIR=$([ "${DEBUG_BUILD}" = "1" ] && echo "debug" || echo "release") \
+ && ln -sf core_tmp.h ${WORKDIR}/rccl/src/projects/rccl/build/${RCCL_BUILD_DIR}/include/nccl_device/core.h \
+ && ln -sf ../hipify/src/include/nccl_tuner.h ${WORKDIR}/rccl/src/projects/rccl/build/${RCCL_BUILD_DIR}/include/nccl_tuner.h \
+ && cp -r ${WORKDIR}/rccl/src/projects/rccl/build/${RCCL_BUILD_DIR}/include/* ${RCCL_INSTALL_PREFIX}/include/
+
+# Test-only deps for the GIN-SDMA host policy unit tests (GoogleTest). Kept in a
+# dedicated late layer so it does not invalidate the RCCL/rocSHMEM build cache.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libgtest-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+## building RCCL-Tests
+RUN if [ "${USE_LOCAL_SRC}" != "1" ]; then \
+      cd rccl/src && \
+      git sparse-checkout add --cone projects/rccl-tests && \
+      git checkout ${RCCL_BRANCH}; \
+    fi
+ARG RCCL_GIN_ALLTOALL_DEVICE_TRACE=0
+RUN mkdir rccl-tests \
+    && cd rccl-tests \
+    && cmake $([ "${DEBUG_BUILD}" = "1" ] && echo "-DCMAKE_BUILD_TYPE=Debug" || echo "-DCMAKE_BUILD_TYPE=Release") -DUSE_MPI=ON -DENABLE_DEVICE_API=ON -DENABLE_ROCSHMEM_GIN=ON -DBUILD_TESTS=ON -DBUILD_GPU_FUNCTIONAL_TESTS=ON -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR} -DROCSHMEM_SOURCE_DIR=${WORKDIR}/rocshmem/src/projects/rocshmem -DROCSHMEM_BUILD_DIR=${WORKDIR}/rocshmem/src/projects/rocshmem/build/include/rocshmem -DRCCL_SOURCE_DIR=${WORKDIR}/rccl/src/projects/rccl -DCMAKE_PREFIX_PATH="${RCCL_INSTALL_PREFIX};${MPI_INSTALL_PREFIX}" -DGPU_TARGETS=${GPU_TARGETS} $( [ "${RCCL_GIN_ALLTOALL_DEVICE_TRACE}" = "1" ] && echo '-DCMAKE_CXX_FLAGS=-DRCCL_GIN_ALLTOALL_DEVICE_TRACE=1' ) ${WORKDIR}/rccl/src/projects/rccl-tests \
+    && make -j16 \
+    # Build-time gate: the GIN-SDMA host policy unit tests (no GPU needed) must
+    # pass for the image to be considered good. GPU functional (label
+    # gpu_functional) is exercised post-build by the gin-sdma-*-test.bash gates.
+    && ctest --output-on-failure -L unit
+
+# ---------------------------------------------------------------------------
+# Build hardening (static): fail the build if GIN plumbing is missing from the
+# shipped artifacts. A prior rebuild produced a working-looking image whose GIN
+# plugins were not usable at runtime; catch that class of skew at build time.
+# GPU-level GIN bring-up is asserted post-build in docker-gin-gda-sdma-build.bash.
+# ---------------------------------------------------------------------------
+RUN set -eu; \
+    if ! command -v nm >/dev/null 2>&1; then echo "BUILD SANITY WARN: nm not found; skipping GIN symbol checks"; exit 0; fi; \
+    LIB="${RCCL_INSTALL_PREFIX}/lib/librccl.so"; \
+    EXE="${WORKDIR}/rccl-tests/alltoall_perf"; \
+    test -f "$LIB" || { echo "BUILD SANITY FAIL: $LIB missing"; exit 1; }; \
+    test -x "$EXE" || { echo "BUILD SANITY FAIL: $EXE missing"; exit 1; }; \
+    nm -DC "$LIB" 2>/dev/null | grep -q ncclGinAnvilSdmaPlugin  || { echo "BUILD SANITY FAIL: librccl.so missing GIN host plugin ncclGinAnvilSdmaPlugin"; exit 1; }; \
+    nm -DC "$LIB" 2>/dev/null | grep -q ncclGinRocshmemGdaPlugin || { echo "BUILD SANITY FAIL: librccl.so missing GIN host plugin ncclGinRocshmemGdaPlugin"; exit 1; }; \
+    nm -C  "$EXE" 2>/dev/null | grep -q "T gin_anvil_sdma_probe" || { echo "BUILD SANITY FAIL: alltoall_perf does not define gin_anvil_sdma_probe (SDMA factory not linked)"; exit 1; }; \
+    nm -C  "$EXE" 2>/dev/null | grep -q "sdma_anvil::initEndpoint" || { echo "BUILD SANITY FAIL: alltoall_perf missing sdma_anvil::initEndpoint (Anvil SDMA not linked)"; exit 1; }; \
+    echo "BUILD SANITY OK: GIN host plugins present in librccl.so; Anvil SDMA factory linked into alltoall_perf"
+
+## set environment variables
+ENV PATH="${MPI_INSTALL_PREFIX}/bin:${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${RCCL_INSTALL_PREFIX}/lib:${MPI_INSTALL_PREFIX}/lib:${ROCM_PATH}/lib:${ROCM_PATH}/core/lib/rocm_sysdeps/lib:${LD_LIBRARY_PATH:-}"
+ENV UCX_WARN_UNUSED_ENV_VARS=n
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+ENV NCCL_DEBUG=VERSION
+ENV ROCSHMEM_DEBUG_LEVEL=info:noversion
+ENV ROCSHMEM_TEST_UUID=1
+

--- a/ddai-artifacts/docs/alltoall-dda-trace-develop.md
+++ b/ddai-artifacts/docs/alltoall-dda-trace-develop.md
@@ -1,0 +1,143 @@
+# AllToAll DDA end-to-end trace (MI350 IPC vs MI450 fabric)
+
+Snapshot: `origin/develop` @ `67d45e7ccfe` (2026-08-14). Companion to
+`mi450-mi350-coexistence-develop.md`. Traces `ncclAllToAll` from the public API
+down to the device kernel for both architectures.
+
+MI450 = gfx1250 / CDNA5 (UALink/UALoE fabric). MI350 = gfx950 / CDNA4 (Infinity
+Fabric / xGMI mesh). MI300 = gfx942 / CDNA3 (also uses the IPC path).
+
+## 0. Shared entry -- `ncclAllToAll` (`projects/rccl/src/collectives.cc`)
+
+All arches enter the same function and hit one DDA gate before falling back to
+the generic ring/pivot path:
+
+```cpp
+// totalBytes = nRanks * count * typesize; per-arch 4 MiB caps (rccl_common.h)
+if (rcclDdaEnabled(comm, comm->nRanks*count*ncclTypeSize(datatype),
+                   kDdaAlltoAllGfx942ThresholdBytes,   // 4 MiB
+                   kDdaAlltoAllGfx950ThresholdBytes,   // 4 MiB
+                   kDdaAlltoAllGfx1250ThresholdBytes)) // 4 MiB
+{
+  if (IsArchMatch(comm->archName, "gfx1250")) { /* MI450 fabric tiers */ }
+  else if (ncclAllToAllDdaIpcEligible(...))   { /* MI350/MI300 IPC   */ }
+}
+// else -> info = {ncclFuncAlltoAll,...}; ncclEnqueueCheck(&info)  (generic ring/pivot)
+```
+
+`rcclDdaEnabled` (`rccl_wrap.cc`) is the shared per-arch gate: gfx1250 uses its
+own threshold; gfx942/gfx950 require `nRanks>=8`; any other arch returns false.
+AllToAll skips the `symEligible` check (no symmetric AllToAll kernel). The arch
+fork is `IsArchMatch(comm->archName, "gfx1250")`.
+
+Note: an earlier `ENABLE_ROCSHMEM` branch may take the GDA AllToAll path
+(`rcclUseAlltoAllGda` + `rocshmemThreshold`) before the DDA gate; that is the
+GIN/rocSHMEM route, separate from the DDA IPC/fabric paths traced here.
+
+## A. MI350 (gfx950) -- DDA IPC path
+
+Files: `dda_alltoall_ipc.cu`, `algorithms/alltoall/alltoall_dda.h`.
+
+1. Eligibility -- `ncclAllToAllDdaIpcEligible`: needs IPC state
+   (`ddaIpcMemHandler`, `ddaScratch`, `ddaPeerPtrsDev`, `ddaIpcBarrierState`),
+   `nNodes==1`, `nRanks==kDdaNranks` (8), dtype in {fp32,fp16,bf16}, fits
+   scratch, `count*typesize % 16 == 0`.
+2. Setup (once) -- `init.cc` -> `ncclDdaIpcCommInit` (because
+   `ncclDdaUseFabricPath` is false on gfx950): allocate VMM scratch, exchange
+   IPC mem handles over bootstrap, open peers (xGMI peer access), fill
+   `ddaPeerPtrsDev` (8 peer scratch bases), build `IpcGpuBarrier`.
+3. Host launch -- `ncclAllToAllDdaIpc` -> `...Typed<int8_t>(count*typesize)`:
+   - small (`ddaAlltoAllSingleBlockGrid`): `kStagingCopyInKernel=true` (fuse
+     send->scratch copy into the kernel).
+   - larger: host `cudaMemcpyAsync(ddaScratch, sendbuff, ...)`, staging=false.
+4. Device kernel -- `ddaAllToAllIpc<T, NRANKS=8, hasAcc=false, staging>`:
+
+```cpp
+if constexpr (kStagingCopyInKernel) { copy sendbuff -> ipcbuffs[selfRank]; barrier<true,true>(); }
+else                                { barrier<false,true>(); }
+for (idx ...) {
+#pragma unroll NRANKS
+  for (int r=0; r<NRANKS; ++r)
+    recvbuff[idx + r*idxEnd] = ipcbuffs[r][idx + selfRank*idxEnd];  // uint4 (16B) gather
+}
+barrier<true,false>();  // hold until peers finish reading
+```
+
+## B. MI450 (gfx1250) -- DDA fabric path (3 tiers)
+
+Files: `dda_alltoall_fabric.cu`, `dda_alltoall_fabric_ll.cu`,
+`dda_alltoall_fabric_ll128.cu`, `algorithms/alltoall/alltoall_dda_fabric.h`.
+
+0. Tier selection in `ncclAllToAll` (all under the 4 MiB DDA enable):
+   - `a2aBytes <= DDA_LL_THRESHOLD` (32 KiB) & LL-eligible ->
+     `ncclAllToAllDdaFabricLL` (no GPU barrier).
+   - else `<= DDA_LL128_THRESHOLD` (32 MiB) & LL128-eligible ->
+     `ncclAllToAllDdaFabricLL128`.
+   - else -> `ncclAllToAllDdaFabric` (VMM + `FabricGpuBarrier`).
+1. Eligibility -- `ncclAllToAllDdaFabricEligible`: needs
+   `ddaFabricMemHandler` + `ddaFabricBarrierState` + scratch/peer table, dtype
+   in {fp32,fp16,bf16}, fits scratch, `%16==0`, and `2 <= nRanks <=
+   kDdaMaxNranks` -- explicitly allows cross-node within an MNNVL clique.
+2. Setup (once) -- `init.cc` -> `ncclDdaFabricCommInit` (because
+   `ncclDdaUseFabricPath = MNNVL==1 && gfx1250`): VMM scratch
+   (`ddaScratchIsVmm=true`), `ncclFabricMemHandler` that exchanges + imports
+   peer memory over the UALoE fabric (`exchangeMemPtrs` / `getPeerDeviceMemPtr`
+   -> `ddaPeerPtrsDev`), `FabricGpuBarrier` + `DdaFabricBarrierState`.
+3. Host launch (VMM tier) -- `ncclAllToAllDdaFabric` -> `...Typed<int8_t>`:
+   always stages host-side (`cudaMemcpyAsync`), then dispatches a compile-time
+   specialized kernel by clique size:
+
+```cpp
+switch (nRanks) {
+  case 4:  ddaAllToAllFabric<T,4><<<grid,block>>>(...); break;  // fully unrolled
+  case 8:  ddaAllToAllFabric<T,8><<<grid,block>>>(...); break;  // fully unrolled
+  default: ddaAllToAllFabric<T,0><<<grid,block>>>(...); break;  // runtime nRanks, 8-wide unroll
+}
+```
+
+4. Device kernel -- `ddaAllToAllFabric<T, NRANKS_CT>`:
+
+```cpp
+barrier.syncOnSameBlockIdx<false,true>();          // FabricGpuBarrier
+for (idx ...) {
+#pragma unroll kUnroll                              // NRANKS_CT if >0, else 8
+  for (int r=0; r<nRanksEff; ++r)
+    recvbuff[idx + r*idxEnd] = ipcbuffs[r][idx + selfRank*idxEnd];  // uint4 gather (identical math)
+}
+barrier.syncOnSameBlockIdx<true,false>();
+```
+
+## Side-by-side
+
+| Stage | MI350 (gfx950, IPC) | MI450 (gfx1250, fabric) |
+|---|---|---|
+| Dispatch fork | `else if (ncclAllToAllDdaIpcEligible)` | `if (IsArchMatch(...,"gfx1250"))` |
+| Tiers | single kernel (+/- in-kernel staging) | LL (<=32KiB) / LL128 (<=32MiB) / VMM |
+| Eligibility | `nNodes==1`, `nRanks==8` | `2<=nRanks<=kDdaMaxNranks`, cross-node in MNNVL clique |
+| Setup | `ncclDdaIpcCommInit` -- IPC handles, xGMI peer open | `ncclDdaFabricCommInit` -- fabric handle import (VMM) |
+| Peer memory | `ipcbuffs[]` = xGMI IPC maps | `ipcbuffs[]` = fabric-imported VMM |
+| Barrier | `IpcGpuBarrier` | `FabricGpuBarrier` |
+| Staging | in-kernel (small) or `cudaMemcpyAsync` | always `cudaMemcpyAsync` |
+| Kernel | `ddaAllToAllIpc<T,8,...>` | `ddaAllToAllFabric<T,{4,8,0}>` |
+| Data movement | uint4 gather `recv[idx+r*E]=peer[r][idx+self*E]` | identical uint4 gather |
+| Fallback if ineligible | generic `ncclFuncAlltoAll` (ring/pivot) | generic `ncclFuncAlltoAll` (ring/pivot) |
+
+## Net
+
+Both arches share the entry gate (`rcclDdaEnabled`, 4 MiB), the eligibility
+shape (dtype / 16-byte / scratch fit), and the same gather kernel math. They
+diverge only in how peer memory is shared (xGMI IPC vs UALoE fabric import) and
+which barrier synchronizes ranks -- selected purely by
+`IsArchMatch(comm->archName,"gfx1250")` + `MNNVL`. MI450 additionally has the
+LL / LL128 low-latency tiers.
+
+## Code references (`origin/develop`)
+
+- `projects/rccl/src/collectives.cc` -- `ncclAllToAll` dispatch + tier selection.
+- `projects/rccl/src/rccl_wrap.cc` -- `rcclDdaEnabled` per-arch gate.
+- `projects/rccl/src/include/rccl_common.h` -- `kDdaAlltoAllGfx{942,950,1250}ThresholdBytes` (4 MiB).
+- `projects/rccl/src/dda_alltoall_ipc.cu` -- IPC eligibility + host launch.
+- `projects/rccl/src/dda_alltoall_fabric.cu` (+ `_ll.cu`, `_ll128.cu`) -- fabric tiers.
+- `projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h` -- `ddaAllToAllIpc` kernel.
+- `projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric.h` -- `ddaAllToAllFabric` kernel.
+- `projects/rccl/src/fabric_init.cu` / `init.cc` -- `ncclDdaUseFabricPath`, fabric vs IPC comm init.

--- a/ddai-artifacts/docs/fabric-heap-support-mi300-mi350-mi355.md
+++ b/ddai-artifacts/docs/fabric-heap-support-mi300-mi350-mi355.md
@@ -1,0 +1,91 @@
+# Is the fabric heap supported on MI300, MI350, MI355?
+
+Context: this branch's GIN-SDMA AllToAll design uses the VMM (cuMem) path with
+POSIX-fd IPC handles, not the "fabric heap." This note records why the fabric
+heap is not an option on these parts.
+
+## Question
+
+Is the fabric heap supported on MI300, MI350, and MI355?
+
+("Fabric heap" here = fabric-handle-based VMM memory sharing: RCCL's DDA fabric
+path via `ncclFabricMemHandler` + `FabricGpuBarrier`, and the
+`CU_MEM_HANDLE_TYPE_FABRIC` / `hipMemFabricHandle_t` allocator handle type.)
+
+## Answer
+
+**No — the fabric heap is not supported on MI300, MI350, or MI355.** It is gated
+by two independent requirements, and both fail on these parts.
+
+### 1. Hardware — no UALink/UALoE memory fabric
+
+The fabric-heap path is gated at runtime on a **UALoE/UALink scale-up fabric**,
+detected via amd-smi (`fabricInfo.fabricSupported`, logged as "UALoE-enabled
+(aka MNNVL)") and `/sys/class/drm/<card>/device/ualink/`
+(`link_type: "UALoE" | "UALLink"`).
+
+- **MI300 (gfx942 / CDNA3)** and **MI350X/MI355X (gfx950 / CDNA4)** use **AMD
+  Infinity Fabric / xGMI** for scale-up — a direct 7-link full mesh across 8
+  GPUs (153.6 GB/s bidirectional per link). They **do not implement UALink** for
+  GPU-to-GPU scale-up.
+- True UALoE (UALink-over-Ethernet) memory fabric is a **MI400 / MI455X "Helios"
+  (CDNA5)** capability (single-hop 72-GPU UALoE domain).
+- Marketing caveat: some AMD slides tag "MI350X ... UALoE72", but the platform
+  briefs and independent analysis confirm MI350/MI355 scale-up is the 8-GPU xGMI
+  mesh; the memory-fabric heap does not light up there.
+
+Consequence in RCCL: `fabricInfo.fabricSupported` returns false, so
+`ncclDdaFabricCommInit` is never selected, and the allocator's
+`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED` check fails and falls back to
+`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`.
+
+### 2. Software — ROCm does not expose fabric handles yet
+
+`HIP_FABRIC_API` (in `projects/rccl/src/CMakeLists.txt`) is only enabled if the
+ROCm build provides both `hipMemFabricHandle_t` and
+`hipMemImportFromShareableHandle`. On shipping ROCm those are absent: adding
+`CU_MEM_HANDLE_TYPE_FABRIC` / `CUmemFabricHandle` / HIP fabric handles is an
+**open feature request** (ROCm/rocm-systems #2170, Dec 2025). HIP VMM
+(`hipMemCreate` / `hipMemMap`) exists, but shareable handles are POSIX-fd only.
+RCCL keeps the hook alive but disabled: see the note in
+`projects/rccl/src/include/p2p.h` ("Preserve AMD's HIP_FABRIC_API hook in case
+it ever gets enabled").
+
+### What runs instead on these GPUs
+
+The equivalent scale-up sharing is **VMM + POSIX-fd IPC over xGMI** — exactly
+what the GIN-SDMA A2A design in this branch uses (`cuMemCreate` / `cuMemMap`
+with `NCCL_CUMEM_ENABLE=1`, shared intra-node via POSIX-fd handles). So the GIN-
+SDMA design uses VMM rather than a fabric heap in part because the fabric heap
+is simply not available on MI300 / MI350 / MI355.
+
+| Part | Scale-up | Fabric heap? | Sharing mechanism used |
+|---|---|---|---|
+| MI300 (gfx942) | Infinity Fabric / xGMI mesh | No | VMM + POSIX-fd IPC |
+| MI350X / MI355X (gfx950) | Infinity Fabric / xGMI mesh | No | VMM + POSIX-fd IPC |
+| MI400 / MI455X (Helios, CDNA5) | UALoE fabric | Yes (target) | Fabric handles + UALoE |
+
+## Code references (this branch)
+
+- `projects/rccl/src/allocator.cc` — cuMem allocator; `FABRIC` handle falls back
+  to `POSIX_FILE_DESCRIPTOR` when `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED`
+  is false.
+- `projects/rccl/src/include/alloc.h` — `cuMemCreate` / `cuMemAddressReserve` /
+  `cuMemMap` VMM allocation with an exportable `requestedHandleTypes`.
+- `projects/rccl/src/init.cc` — UALoE/MNNVL fabric detection
+  (`fabricInfo.fabricSupported`).
+- `projects/rccl/src/misc/alt_rsmi.cc` — reads
+  `/sys/class/drm/<card>/device/ualink/` (`UALoE` / `UALLink`).
+- `projects/rccl/src/fabric_init.cu` — DDA fabric path
+  (`ncclFabricMemHandler` + `FabricGpuBarrier`).
+- `projects/rccl/src/CMakeLists.txt` — `HIP_FABRIC_API` compile-time detection.
+- `projects/rccl/src/include/p2p.h` — preserved-but-disabled `HIP_FABRIC_API` hook.
+
+## References
+
+- AMD Instinct MI355X Platform brief (Infinity Fabric mesh, 7x 153.6 GB/s).
+- AMD Instinct MI350 Series product page (CDNA4, Infinity Fabric scale-up).
+- SemiAnalysis, "AMD Advancing AI: MI350X and MI400 UALoE72, MI500 UAL256."
+- ROCm CDNA5 / Helios blog (UALoE scale-up fabric on MI455X).
+- ROCm/rocm-systems issue #2170 — feature request for HIP fabric handles.
+- ROCm HIP virtual memory management docs (`hipMemCreate` / `hipMemMap`).

--- a/ddai-artifacts/docs/mi450-mi350-coexistence-develop.md
+++ b/ddai-artifacts/docs/mi450-mi350-coexistence-develop.md
@@ -1,0 +1,103 @@
+# How MI450 and MI350 co-exist in `develop`
+
+Snapshot: `origin/develop` @ `67d45e7ccfe` (synced from `upstream/develop`,
+2026-08-14). MI450 = gfx1250 / CDNA5 (UALink/UALoE fabric). MI350 = gfx950 /
+CDNA4 (Infinity Fabric / xGMI mesh). MI300 = gfx942 / CDNA3.
+
+## Summary
+
+Both architectures live in a single build. Co-existence is achieved on two
+levels:
+
+1. **Compile-time**: one multi-target fatbin with per-arch device kernels.
+2. **Runtime**: host-side `IsArchMatch(comm->archName, ...)` branching that
+   routes each arch to a different transport. There is no `#ifdef` fork on the
+   host -- both paths are always compiled in and selected per communicator.
+
+MI450 (gfx1250 + `MNNVL==1`) uses the **DDA fabric-heap** path (VMM scratch +
+fabric handles + `FabricGpuBarrier`). MI350 (gfx950) uses the **DDA IPC** path
+(xGMI peer access, single-node 8-GPU). They share the `rcclDdaEnabled`
+scaffolding and thresholds but never execute each other's transport.
+
+## 1. Compile-time: one fatbin, per-arch kernels
+
+`projects/rccl/src/device/generate.py` emits per-arch kernel variants baked into
+the fatbin, selected by the HIP loader for the running device:
+
+```python
+if "gfx950" == gfx_name:
+    return (["1", "2"], ["0"])       # MI350: unroll {1,2}, pipelining disabled
+elif "gfx1250" == gfx_name:
+    return (["8", "16", "32"], all)  # MI450: larger unrolls, Unroll 8 for FP8, 32 default
+```
+
+Device headers (`device/all_reduce.h`, `all_gather.h`, ...) guard code with
+`__gfx950__` / `__gfx1250__` macros; LL128 conditions include gfx1250.
+
+## 2. Runtime: setup + teardown gated by arch
+
+`projects/rccl/src/fabric_init.cu`:
+
+```cpp
+bool ncclDdaUseFabricPath(ncclComm* comm) {
+  return comm->MNNVL == 1 && IsArchMatch(comm->archName, "gfx1250");
+}
+```
+
+`projects/rccl/src/init.cc` (init ~2747 and fini ~528 both branch on it):
+
+```cpp
+if (ncclDdaUseFabricPath(comm)) ncclDdaFabricCommInit(comm);  // MI450: fabric heap
+else                            ncclDdaIpcCommInit(comm);     // MI350/MI300: xGMI IPC
+```
+
+So the fabric heap is only initialized on gfx1250 with a detected UALoE fabric
+(`MNNVL==1`). MI350 never satisfies the predicate and initializes the IPC path.
+
+## 3. Runtime: per-collective dispatch
+
+`rcclDdaEnabled()` (moved to `projects/rccl/src/rccl_wrap.cc`, declared in
+`rccl_common.h`) gates the DDA fast path per arch, now with a dedicated gfx1250
+threshold parameter:
+
+```cpp
+bool rcclDdaEnabled(comm, totalBytes, gfx942Default, gfx950Default, gfx1250Default) {
+  if (gfx1250)          threshold = gfx1250Default ? gfx1250Default : RCCL_DDA_THRESHOLD;
+  else if (gfx942||gfx950) { if (nRanks < 8) return false; ... per-arch default ... }
+  else return false;    // all other arches: DDA off
+  return threshold > 0 && totalBytes <= threshold;
+}
+```
+
+Each collective then branches on `ddaFabricArch = IsArchMatch(comm->archName,
+"gfx1250")`: MI450 -> `*DdaFabric{,LL,LL128}`, MI350/MI300 -> `*DdaIpc`. This is
+wired for AllReduce, AllGather, ReduceScatter, and AllToAll.
+
+## Split at a glance
+
+| | MI350 (gfx950) | MI450 (gfx1250) |
+|---|---|---|
+| Setup | `ncclDdaIpcCommInit` | `ncclDdaFabricCommInit` (fabric heap) |
+| Gate | single-node, 8 ranks | `MNNVL==1 && gfx1250` |
+| Memory sharing | VMM + POSIX-fd IPC over xGMI | VMM scratch + fabric handles + `FabricGpuBarrier` |
+| Collective kernels | `*DdaIpc*` | `*DdaFabric*` (LL / LL128 / Simple) |
+| Device codegen | unroll {1,2}, no pipelining | unroll {8,16,32}, LL128 default-on |
+| DDA threshold | per-arch default (nRanks >= 8) | `RCCL_DDA_THRESHOLD` / gfx1250Default + per-tier |
+
+## Changes vs the pre-sync snapshot (`0813205a1b9`)
+
+- `rcclDdaEnabled()` relocated to `rccl_wrap.cc` and extended with a per-arch
+  `gfx1250Default` threshold.
+- AllToAll now has the full gfx1250 fabric tier ladder (LL / LL128 / VMM),
+  matching AllReduce / ReduceScatter.
+- Teardown (`Fini`) now mirrors init: `ncclDdaFabricCommFini` vs
+  `ncclDdaIpcCommFini` by the same `ncclDdaUseFabricPath` predicate.
+
+## Code references (`origin/develop`)
+
+- `projects/rccl/src/fabric_init.cu` -- `ncclDdaUseFabricPath`,
+  `ncclDdaFabricCommInit` (VMM scratch + `ncclFabricMemHandler` + `FabricGpuBarrier`).
+- `projects/rccl/src/init.cc` -- init/fini DDA path selection.
+- `projects/rccl/src/collectives.cc` -- per-collective `ddaFabricArch` dispatch.
+- `projects/rccl/src/rccl_wrap.cc` -- `rcclDdaEnabled` (per-arch thresholds).
+- `projects/rccl/src/device/generate.py` -- per-arch unroll/pipeline codegen.

--- a/ddai-artifacts/perf-logs/mi350-gin-sdma-a2a-test.log
+++ b/ddai-artifacts/perf-logs/mi350-gin-sdma-a2a-test.log
@@ -1,0 +1,137 @@
++ return 0
++ TEST1_NCHANNELS=32
++ TEST1_MODE=ring
++ case "${TEST1_MODE}" in
++ echo '=== Test#1: A2A, 8 gpus, Host Initiated RING (channels=32) ==='
+=== Test#1: A2A, 8 gpus, Host Initiated RING (channels=32) ===
++ _a2a_host_ring 128 128M
++ sudo docker run --rm --init --ulimit memlock=-1:-1 --shm-size 64G --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host --group-add video --group-add render --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged --device /dev/infiniband/uverbs0 --device /dev/infiniband/uverbs1 --device /dev/infiniband/uverbs2 --device /dev/infiniband/uverbs3 --device /dev/infiniband/uverbs4 --device /dev/infiniband/uverbs5 --device /dev/infiniband/uverbs6 --device /dev/infiniband/uverbs7 rccl-gin-gda-sdma-713 mpirun -n 8 --allow-run-as-root -mca pml ob1 -mca btl self,vader,tcp -mca btl_vader_single_copy_mechanism none -mca hwloc_base_binding_policy none -x OMPI_ALLOW_RUN_AS_ROOT=1 -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 -x RCCL_ROCSHMEM_ENABLE=0 -x ROCSHMEM_BACKEND=ipc -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_DEBUG_LEVEL=info:noversion -x RCCL_ROCSHMEM_THRESHOLD=134217728 -x NCCL_DEBUG=VERSION -x NCCL_DEBUG_SUBSYS=INIT,NET -x RCCL_ENABLE_INTRANET=1 -x NCCL_DMABUF_ENABLE=1 -x NCCL_MSCCL_ENABLE=0 -x HSA_NO_SCRATCH_RECLAIM=1 -x NCCL_CUMEM_ENABLE=0 -x ROCSHMEM_SDMA_ENABLED=0 -x NCCL_GIN_ENABLE=0 -x NCCL_GIN_TYPE=0 -x NCCL_MIN_NCHANNELS=32 -x NCCL_MAX_NCHANNELS=32 rccl-tests/alltoall_perf -b 128 -e 128M -f 2 -g 1 -R 0 -D 0 -A 1 -V 1 -w 5 -n 20
+# rccl-tests version 2.18.3-Unknown  rccl-headers=23004 rccl-library=23004
+# Collective test starting: alltoall_perf
+# nThread 1 nGpus 1 minBytes 128 maxBytes 134217728 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0 unalign: 0
+#
+# Using devices
+#  Rank  0 Group  0 Pid     10 on cv350-rck-g03-e23-08 device  0 [0000:08:00] AMD Instinct MI350X
+#  Rank  1 Group  0 Pid     11 on cv350-rck-g03-e23-08 device  1 [0000:18:00] AMD Instinct MI350X
+#  Rank  2 Group  0 Pid     12 on cv350-rck-g03-e23-08 device  2 [0000:68:00] AMD Instinct MI350X
+#  Rank  3 Group  0 Pid     13 on cv350-rck-g03-e23-08 device  3 [0000:78:00] AMD Instinct MI350X
+#  Rank  4 Group  0 Pid     14 on cv350-rck-g03-e23-08 device  4 [0000:88:00] AMD Instinct MI350X
+#  Rank  5 Group  0 Pid     15 on cv350-rck-g03-e23-08 device  5 [0000:98:00] AMD Instinct MI350X
+#  Rank  6 Group  0 Pid     16 on cv350-rck-g03-e23-08 device  6 [0000:e8:00] AMD Instinct MI350X
+#  Rank  7 Group  0 Pid     17 on cv350-rck-g03-e23-08 device  7 [0000:f9:00] AMD Instinct MI350X
+RCCL version : 2.30.4-Unknown 
+HIP version  : 7.13.99004-3309c611
+ROCm version : 7.13.0.0-9999-3309c611
+Hostname     : cv350-rck-g03-e23-08.rck.dcgpu
+Librccl path : /workspace/rccl/lib/librccl.so.1
+#
+#                                                              out-of-place                       in-place          
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong algo      proto      nchannels 
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)                                      
+         128             4     float    none      -1    11.20    0.01    0.01       0     8.06    0.02    0.01    N/A     N/A       N/A         N/A
+         256             8     float    none      -1     7.45    0.03    0.03       0     7.32    0.03    0.03    N/A     N/A       N/A         N/A
+         512            16     float    none      -1     7.29    0.07    0.06       0     9.30    0.06    0.05    N/A     N/A       N/A         N/A
+        1024            32     float    none      -1     7.59    0.13    0.12       0     7.56    0.14    0.12    N/A     N/A       N/A         N/A
+        2048            64     float    none      -1     7.67    0.27    0.23       0     7.58    0.27    0.24    N/A     N/A       N/A         N/A
+        4096           128     float    none      -1    10.04    0.41    0.36       0     7.49    0.55    0.48    N/A     N/A       N/A         N/A
+        8192           256     float    none      -1     7.37    1.11    0.97       0     7.46    1.10    0.96    N/A     N/A       N/A         N/A
+       16384           512     float    none      -1     8.51    1.92    1.68       0     7.82    2.09    1.83    N/A     N/A       N/A         N/A
+       32768          1024     float    none      -1     8.23    3.98    3.48       0     8.20    4.00    3.50    N/A     N/A       N/A         N/A
+       65536          2048     float    none      -1     8.92    7.34    6.43       0    13.61    4.82    4.21    N/A     N/A       N/A         N/A
+      131072          4096     float    none      -1     9.37   13.98   12.23       0     9.37   13.98   12.24    N/A     N/A       N/A         N/A
+      262144          8192     float    none      -1     9.41   27.85   24.37       0     9.36   28.00   24.50    N/A     N/A       N/A         N/A
+      524288         16384     float    none      -1     9.58   54.71   47.87       0     9.52   55.10   48.21    N/A     N/A       N/A         N/A
+     1048576         32768     float    none      -1    10.66   98.33   86.04       0    10.54   99.47   87.03    N/A     N/A       N/A         N/A
+     2097152         65536     float    none      -1    14.52  144.39  126.34       0    14.24  147.31  128.90    N/A     N/A       N/A         N/A
+     4194304        131072     float    none      -1    19.85  211.31  184.89       0    19.88  211.02  184.64    N/A     N/A       N/A         N/A
+     8388608        262144     float    none      -1    37.45  223.98  195.98       0    37.44  224.07  196.06    N/A     N/A       N/A         N/A
+    16777216        524288     float    none      -1    61.38  273.32  239.16       0    62.01  270.55  236.73    N/A     N/A       N/A         N/A
+    33554432       1048576     float    none      -1   110.07  304.84  266.74       0   116.75  287.40  251.48    N/A     N/A       N/A         N/A
+    67108864       2097152     float    none      -1   204.03  328.91  287.80       0   207.30  323.73  283.26    N/A     N/A       N/A         N/A
+   134217728       4194304     float    none      -1   381.99  351.37  307.45       0   385.95  347.76  304.29    N/A     N/A       N/A         N/A
+# Out of bounds values : 0 OK
+# Avg bus bandwidth    : 84.7862 
+#
+# Collective test concluded: alltoall_perf
+#
+
++ _trace_off
++ [[ 1 == 1 ]]
++ set +x
++ return 0
++ NCCL_GIN_ANVIL_SDMA_THRESHOLD=0
++ NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=8192
++ TEST5_A2A_THRESHOLD=2097152
++ TEST5_A2A_LSA_CTAS=0
++ TEST5_A2A_LL_MAX=0
++ TEST5_A2A_LL_CTAS=0
++ TEST5_A2A_SYNC_MODE=3
++ TEST5_A2A_DEVICE_TIMING=0
++ TEST5_A2A_DEVTIME_LOOP=20
++ TEST5_A2A_DEVTIME_SKIP=5
++ TEST5_MPI_EXTRA=(-x "NCCL_GIN_ANVIL_SDMA_THRESHOLD=${NCCL_GIN_ANVIL_SDMA_THRESHOLD}" -x "NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=${NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK}" -x "NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=${TEST5_A2A_THRESHOLD}" -x "NCCL_GIN_ANVIL_A2A_LSA_CTAS=${TEST5_A2A_LSA_CTAS}" -x "NCCL_GIN_ANVIL_A2A_LL_MAX_BYTES=${TEST5_A2A_LL_MAX}" -x "NCCL_GIN_ANVIL_A2A_LL_CTAS=${TEST5_A2A_LL_CTAS}" -x "NCCL_GIN_ANVIL_A2A_SYNC_MODE=${TEST5_A2A_SYNC_MODE}" -x "NCCL_GIN_ANVIL_A2A_DEVICE_TIMING=${TEST5_A2A_DEVICE_TIMING}" -x "NCCL_GIN_ANVIL_A2A_DEVTIME_LOOP=${TEST5_A2A_DEVTIME_LOOP}" -x "NCCL_GIN_ANVIL_A2A_DEVTIME_SKIP=${TEST5_A2A_DEVTIME_SKIP}")
++ TEST5_MODE=d3
++ TEST5_D4_CTA_COUNT=8
++ TEST5_D3_CTA_COUNT=8
++ TEST5_CUDAGRAPH=0
++ TEST5_WARMUP=5
++ TEST5_ITERS=20
++ TEST5_GRAPH_ARGS=()
++ [[ 0 != 0 ]]
++ case "${TEST5_MODE}" in
++ echo '=== Test#5: A2A, 8 gpus, GIN Anvil SDMA -D 3 size-hybrid (LSA<=2097152B/peer, SDMA above; V=8, NCCL_GIN_TYPE=5, cudagraph=0, w=5, n=20) ==='
+=== Test#5: A2A, 8 gpus, GIN Anvil SDMA -D 3 size-hybrid (LSA<=2097152B/peer, SDMA above; V=8, NCCL_GIN_TYPE=5, cudagraph=0, w=5, n=20) ===
++ _a2a_gin 3 8 128 128M
++ sudo docker run --rm --init --ulimit memlock=-1:-1 --shm-size 64G --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host --group-add video --group-add render --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged --device /dev/infiniband/uverbs0 --device /dev/infiniband/uverbs1 --device /dev/infiniband/uverbs2 --device /dev/infiniband/uverbs3 --device /dev/infiniband/uverbs4 --device /dev/infiniband/uverbs5 --device /dev/infiniband/uverbs6 --device /dev/infiniband/uverbs7 rccl-gin-gda-sdma-713 mpirun -n 8 --allow-run-as-root -mca pml ob1 -mca btl self,vader,tcp -mca btl_vader_single_copy_mechanism none -mca hwloc_base_binding_policy none -x OMPI_ALLOW_RUN_AS_ROOT=1 -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 -x RCCL_ROCSHMEM_ENABLE=0 -x ROCSHMEM_BACKEND=ipc -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_DEBUG_LEVEL=info:noversion -x RCCL_ROCSHMEM_THRESHOLD=134217728 -x NCCL_DEBUG=VERSION -x NCCL_DEBUG_SUBSYS=INIT,NET -x RCCL_ENABLE_INTRANET=1 -x NCCL_DMABUF_ENABLE=1 -x NCCL_MSCCL_ENABLE=0 -x HSA_NO_SCRATCH_RECLAIM=1 -x NCCL_GIN_PLUGIN=none -x NCCL_CUMEM_ENABLE=1 -x NCCL_NET_PLUGIN=none -x ROCSHMEM_SDMA_ENABLED=0 -x NCCL_DEBUG=VERSION -x NCCL_GIN_ENABLE=1 -x NCCL_GIN_TYPE=5 -x NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS=1 -x HSA_FORCE_FINE_GRAIN_PCIE=1 -x NCCL_GIN_ANVIL_SDMA_THRESHOLD=0 -x NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=8192 -x NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=2097152 -x NCCL_GIN_ANVIL_A2A_LSA_CTAS=0 -x NCCL_GIN_ANVIL_A2A_LL_MAX_BYTES=0 -x NCCL_GIN_ANVIL_A2A_LL_CTAS=0 -x NCCL_GIN_ANVIL_A2A_SYNC_MODE=3 -x NCCL_GIN_ANVIL_A2A_DEVICE_TIMING=0 -x NCCL_GIN_ANVIL_A2A_DEVTIME_LOOP=20 -x NCCL_GIN_ANVIL_A2A_DEVTIME_SKIP=5 rccl-tests/alltoall_perf -b 128 -e 128M -f 2 -g 1 -R 2 -D 3 -A 1 -V 8 -w 5 -n 20
+# rccl-tests version 2.18.3-Unknown  rccl-headers=23004 rccl-library=23004
+# Collective test starting: alltoall_perf
+# nThread 1 nGpus 1 minBytes 128 maxBytes 134217728 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0 unalign: 0
+#
+# Using devices
+#  Rank  0 Group  0 Pid     10 on cv350-rck-g03-e23-08 device  0 [0000:08:00] AMD Instinct MI350X
+#  Rank  1 Group  0 Pid     11 on cv350-rck-g03-e23-08 device  1 [0000:18:00] AMD Instinct MI350X
+#  Rank  2 Group  0 Pid     12 on cv350-rck-g03-e23-08 device  2 [0000:68:00] AMD Instinct MI350X
+#  Rank  3 Group  0 Pid     13 on cv350-rck-g03-e23-08 device  3 [0000:78:00] AMD Instinct MI350X
+#  Rank  4 Group  0 Pid     14 on cv350-rck-g03-e23-08 device  4 [0000:88:00] AMD Instinct MI350X
+#  Rank  5 Group  0 Pid     15 on cv350-rck-g03-e23-08 device  5 [0000:98:00] AMD Instinct MI350X
+#  Rank  6 Group  0 Pid     16 on cv350-rck-g03-e23-08 device  6 [0000:e8:00] AMD Instinct MI350X
+#  Rank  7 Group  0 Pid     17 on cv350-rck-g03-e23-08 device  7 [0000:f9:00] AMD Instinct MI350X
+RCCL version : 2.30.4-Unknown 
+HIP version  : 7.13.99004-3309c611
+ROCm version : 7.13.0.0-9999-3309c611
+Hostname     : cv350-rck-g03-e23-08.rck.dcgpu
+Librccl path : /workspace/rccl/lib/librccl.so.1
+#
+#                                                              out-of-place                       in-place          
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong algo      proto      nchannels 
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)                                      
+         128             4     float    none      -1    12.02    0.01    0.01       0    12.87    0.01    0.01    N/A     N/A       N/A         N/A
+         256             8     float    none      -1    12.52    0.02    0.02       0    12.67    0.02    0.02    N/A     N/A       N/A         N/A
+         512            16     float    none      -1    13.72    0.04    0.03       0    14.36    0.04    0.03    N/A     N/A       N/A         N/A
+        1024            32     float    none      -1    16.32    0.06    0.05       0    17.37    0.06    0.05    N/A     N/A       N/A         N/A
+        2048            64     float    none      -1    23.28    0.09    0.08       0    23.79    0.09    0.08    N/A     N/A       N/A         N/A
+        4096           128     float    none      -1    23.65    0.17    0.15       0    23.34    0.18    0.15    N/A     N/A       N/A         N/A
+        8192           256     float    none      -1    23.21    0.35    0.31       0    23.47    0.35    0.31    N/A     N/A       N/A         N/A
+       16384           512     float    none      -1    23.30    0.70    0.62       0    23.38    0.70    0.61    N/A     N/A       N/A         N/A
+       32768          1024     float    none      -1    23.59    1.39    1.22       0    23.58    1.39    1.22    N/A     N/A       N/A         N/A
+       65536          2048     float    none      -1    23.87    2.75    2.40       0    23.55    2.78    2.43    N/A     N/A       N/A         N/A
+      131072          4096     float    none      -1    23.76    5.52    4.83       0    23.82    5.50    4.82    N/A     N/A       N/A         N/A
+      262144          8192     float    none      -1    24.29   10.79    9.44       0    25.78   10.17    8.90    N/A     N/A       N/A         N/A
+      524288         16384     float    none      -1    25.20   20.81   18.21       0    25.18   20.82   18.22    N/A     N/A       N/A         N/A
+     1048576         32768     float    none      -1    27.19   38.57   33.75       0    26.96   38.89   34.03    N/A     N/A       N/A         N/A
+     2097152         65536     float    none      -1    29.54   70.98   62.11       0    29.63   70.79   61.94    N/A     N/A       N/A         N/A
+     4194304        131072     float    none      -1    33.82  124.00  108.50       0    33.83  123.98  108.48    N/A     N/A       N/A         N/A
+     8388608        262144     float    none      -1    42.73  196.32  171.78       0    42.24  198.61  173.78    N/A     N/A       N/A         N/A
+    16777216        524288     float    none      -1    59.57  281.66  246.45       0    59.75  280.80  245.70    N/A     N/A       N/A         N/A
+    33554432       1048576     float    none      -1    94.02  356.87  312.26       0    97.72  343.37  300.45    N/A     N/A       N/A         N/A
+    67108864       2097152     float    none      -1   162.40  413.24  361.58       0   162.33  413.41  361.73    N/A     N/A       N/A         N/A
+   134217728       4194304     float    none      -1   299.41  448.27  392.24       0   299.37  448.34  392.30    N/A     N/A       N/A         N/A
+# Out of bounds values : 0 OK
+# Avg bus bandwidth    : 81.9354 
+#
+# Collective test concluded: alltoall_perf
+#
+
++ _trace_off
++ [[ 1 == 1 ]]
++ set +x

--- a/ddai-artifacts/perf-logs/mi355-gin-sdma-a2a-test.log
+++ b/ddai-artifacts/perf-logs/mi355-gin-sdma-a2a-test.log
@@ -1,0 +1,137 @@
++ return 0
++ TEST1_NCHANNELS=32
++ TEST1_MODE=ring
++ case "${TEST1_MODE}" in
++ echo '=== Test#1: A2A, 8 gpus, Host Initiated RING (channels=32) ==='
+=== Test#1: A2A, 8 gpus, Host Initiated RING (channels=32) ===
++ _a2a_host_ring 128 128M
++ docker run --rm --init --ulimit memlock=-1:-1 --shm-size 64G --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host --group-add video --group-add render --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged --group-add rdma rccl-gin-gda-sdma-713 mpirun -n 8 --allow-run-as-root -mca pml ob1 -mca btl self,vader,tcp -mca btl_vader_single_copy_mechanism none -mca hwloc_base_binding_policy none -x OMPI_ALLOW_RUN_AS_ROOT=1 -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 -x RCCL_ROCSHMEM_ENABLE=0 -x ROCSHMEM_BACKEND=ipc -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_DEBUG_LEVEL=info:noversion -x RCCL_ROCSHMEM_THRESHOLD=134217728 -x NCCL_DEBUG=VERSION -x NCCL_DEBUG_SUBSYS=INIT,NET -x RCCL_ENABLE_INTRANET=1 -x NCCL_DMABUF_ENABLE=1 -x NCCL_MSCCL_ENABLE=0 -x HSA_NO_SCRATCH_RECLAIM=1 -x NCCL_CUMEM_ENABLE=0 -x ROCSHMEM_SDMA_ENABLED=0 -x NCCL_GIN_ENABLE=0 -x NCCL_GIN_TYPE=0 -x NCCL_MIN_NCHANNELS=32 -x NCCL_MAX_NCHANNELS=32 rccl-tests/alltoall_perf -b 128 -e 128M -f 2 -g 1 -R 0 -D 0 -A 1 -V 1 -w 5 -n 20
+# rccl-tests version 2.18.3-Unknown  rccl-headers=23004 rccl-library=23004
+# Collective test starting: alltoall_perf
+# nThread 1 nGpus 1 minBytes 128 maxBytes 134217728 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0 unalign: 0
+#
+# Using devices
+#  Rank  0 Group  0 Pid     10 on smci355-ccs-aus-m03-17 device  0 [0000:75:00] AMD Instinct MI355X
+#  Rank  1 Group  0 Pid     11 on smci355-ccs-aus-m03-17 device  1 [0000:05:00] AMD Instinct MI355X
+#  Rank  2 Group  0 Pid     12 on smci355-ccs-aus-m03-17 device  2 [0000:65:00] AMD Instinct MI355X
+#  Rank  3 Group  0 Pid     13 on smci355-ccs-aus-m03-17 device  3 [0000:15:00] AMD Instinct MI355X
+#  Rank  4 Group  0 Pid     14 on smci355-ccs-aus-m03-17 device  4 [0000:f5:00] AMD Instinct MI355X
+#  Rank  5 Group  0 Pid     15 on smci355-ccs-aus-m03-17 device  5 [0000:85:00] AMD Instinct MI355X
+#  Rank  6 Group  0 Pid     16 on smci355-ccs-aus-m03-17 device  6 [0000:e5:00] AMD Instinct MI355X
+#  Rank  7 Group  0 Pid     17 on smci355-ccs-aus-m03-17 device  7 [0000:95:00] AMD Instinct MI355X
+RCCL version : 2.30.4-Unknown 
+HIP version  : 7.13.99004-3309c611
+ROCm version : 7.13.0.0-9999-3309c611
+Hostname     : smci355-ccs-aus-m03-17
+Librccl path : /workspace/rccl/lib/librccl.so.1
+#
+#                                                              out-of-place                       in-place          
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong algo      proto      nchannels 
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)                                      
+         128             4     float    none      -1    10.18    0.01    0.01       0     7.68    0.02    0.01    N/A     N/A       N/A         N/A
+         256             8     float    none      -1     7.56    0.03    0.03       0     7.18    0.04    0.03    N/A     N/A       N/A         N/A
+         512            16     float    none      -1     7.39    0.07    0.06       0    10.69    0.05    0.04    N/A     N/A       N/A         N/A
+        1024            32     float    none      -1     7.25    0.14    0.12       0     7.46    0.14    0.12    N/A     N/A       N/A         N/A
+        2048            64     float    none      -1     7.57    0.27    0.24       0     7.42    0.28    0.24    N/A     N/A       N/A         N/A
+        4096           128     float    none      -1    10.81    0.38    0.33       0     8.06    0.51    0.44    N/A     N/A       N/A         N/A
+        8192           256     float    none      -1     7.19    1.14    1.00       0     7.47    1.10    0.96    N/A     N/A       N/A         N/A
+       16384           512     float    none      -1    10.33    1.59    1.39       0     7.40    2.21    1.94    N/A     N/A       N/A         N/A
+       32768          1024     float    none      -1     8.11    4.04    3.54       0     7.91    4.14    3.62    N/A     N/A       N/A         N/A
+       65536          2048     float    none      -1     8.88    7.38    6.45       0    11.55    5.67    4.96    N/A     N/A       N/A         N/A
+      131072          4096     float    none      -1     9.00   14.56   12.74       0     9.17   14.29   12.50    N/A     N/A       N/A         N/A
+      262144          8192     float    none      -1     9.26   28.31   24.77       0     9.06   28.94   25.32    N/A     N/A       N/A         N/A
+      524288         16384     float    none      -1    10.76   48.72   42.63       0     9.24   56.71   49.62    N/A     N/A       N/A         N/A
+     1048576         32768     float    none      -1    10.62   98.75   86.40       0    10.15  103.33   90.41    N/A     N/A       N/A         N/A
+     2097152         65536     float    none      -1    13.96  150.22  131.44       0    13.86  151.28  132.37    N/A     N/A       N/A         N/A
+     4194304        131072     float    none      -1    19.03  220.46  192.90       0    18.88  222.20  194.43    N/A     N/A       N/A         N/A
+     8388608        262144     float    none      -1    36.47  230.03  201.27       0    35.71  234.93  205.56    N/A     N/A       N/A         N/A
+    16777216        524288     float    none      -1    58.11  288.71  252.62       0    58.98  284.46  248.90    N/A     N/A       N/A         N/A
+    33554432       1048576     float    none      -1   103.88  323.02  282.64       0   112.00  299.59  262.14    N/A     N/A       N/A         N/A
+    67108864       2097152     float    none      -1   191.93  349.66  305.95       0   195.96  342.46  299.66    N/A     N/A       N/A         N/A
+   134217728       4194304     float    none      -1   361.00  371.80  325.32       0   365.85  366.86  321.01    N/A     N/A       N/A         N/A
+# Out of bounds values : 0 OK
+# Avg bus bandwidth    : 88.7182 
+#
+# Collective test concluded: alltoall_perf
+#
+
++ _trace_off
++ [[ 1 == 1 ]]
++ set +x
++ return 0
++ NCCL_GIN_ANVIL_SDMA_THRESHOLD=0
++ NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=8192
++ TEST5_A2A_THRESHOLD=2097152
++ TEST5_A2A_LSA_CTAS=0
++ TEST5_A2A_LL_MAX=0
++ TEST5_A2A_LL_CTAS=0
++ TEST5_A2A_SYNC_MODE=3
++ TEST5_A2A_DEVICE_TIMING=0
++ TEST5_A2A_DEVTIME_LOOP=20
++ TEST5_A2A_DEVTIME_SKIP=5
++ TEST5_MPI_EXTRA=(-x "NCCL_GIN_ANVIL_SDMA_THRESHOLD=${NCCL_GIN_ANVIL_SDMA_THRESHOLD}" -x "NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=${NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK}" -x "NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=${TEST5_A2A_THRESHOLD}" -x "NCCL_GIN_ANVIL_A2A_LSA_CTAS=${TEST5_A2A_LSA_CTAS}" -x "NCCL_GIN_ANVIL_A2A_LL_MAX_BYTES=${TEST5_A2A_LL_MAX}" -x "NCCL_GIN_ANVIL_A2A_LL_CTAS=${TEST5_A2A_LL_CTAS}" -x "NCCL_GIN_ANVIL_A2A_SYNC_MODE=${TEST5_A2A_SYNC_MODE}" -x "NCCL_GIN_ANVIL_A2A_DEVICE_TIMING=${TEST5_A2A_DEVICE_TIMING}" -x "NCCL_GIN_ANVIL_A2A_DEVTIME_LOOP=${TEST5_A2A_DEVTIME_LOOP}" -x "NCCL_GIN_ANVIL_A2A_DEVTIME_SKIP=${TEST5_A2A_DEVTIME_SKIP}")
++ TEST5_MODE=d3
++ TEST5_D4_CTA_COUNT=8
++ TEST5_D3_CTA_COUNT=8
++ TEST5_CUDAGRAPH=0
++ TEST5_WARMUP=5
++ TEST5_ITERS=20
++ TEST5_GRAPH_ARGS=()
++ [[ 0 != 0 ]]
++ case "${TEST5_MODE}" in
++ echo '=== Test#5: A2A, 8 gpus, GIN Anvil SDMA -D 3 size-hybrid (LSA<=2097152B/peer, SDMA above; V=8, NCCL_GIN_TYPE=5, cudagraph=0, w=5, n=20) ==='
+=== Test#5: A2A, 8 gpus, GIN Anvil SDMA -D 3 size-hybrid (LSA<=2097152B/peer, SDMA above; V=8, NCCL_GIN_TYPE=5, cudagraph=0, w=5, n=20) ===
++ _a2a_gin 3 8 128 128M
++ docker run --rm --init --ulimit memlock=-1:-1 --shm-size 64G --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host --group-add video --group-add render --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged --group-add rdma rccl-gin-gda-sdma-713 mpirun -n 8 --allow-run-as-root -mca pml ob1 -mca btl self,vader,tcp -mca btl_vader_single_copy_mechanism none -mca hwloc_base_binding_policy none -x OMPI_ALLOW_RUN_AS_ROOT=1 -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 -x RCCL_ROCSHMEM_ENABLE=0 -x ROCSHMEM_BACKEND=ipc -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_DEBUG_LEVEL=info:noversion -x RCCL_ROCSHMEM_THRESHOLD=134217728 -x NCCL_DEBUG=VERSION -x NCCL_DEBUG_SUBSYS=INIT,NET -x RCCL_ENABLE_INTRANET=1 -x NCCL_DMABUF_ENABLE=1 -x NCCL_MSCCL_ENABLE=0 -x HSA_NO_SCRATCH_RECLAIM=1 -x NCCL_GIN_PLUGIN=none -x NCCL_CUMEM_ENABLE=1 -x NCCL_NET_PLUGIN=none -x ROCSHMEM_SDMA_ENABLED=0 -x NCCL_DEBUG=VERSION -x NCCL_GIN_ENABLE=1 -x NCCL_GIN_TYPE=5 -x NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS=1 -x HSA_FORCE_FINE_GRAIN_PCIE=1 -x NCCL_GIN_ANVIL_SDMA_THRESHOLD=0 -x NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=8192 -x NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=2097152 -x NCCL_GIN_ANVIL_A2A_LSA_CTAS=0 -x NCCL_GIN_ANVIL_A2A_LL_MAX_BYTES=0 -x NCCL_GIN_ANVIL_A2A_LL_CTAS=0 -x NCCL_GIN_ANVIL_A2A_SYNC_MODE=3 -x NCCL_GIN_ANVIL_A2A_DEVICE_TIMING=0 -x NCCL_GIN_ANVIL_A2A_DEVTIME_LOOP=20 -x NCCL_GIN_ANVIL_A2A_DEVTIME_SKIP=5 rccl-tests/alltoall_perf -b 128 -e 128M -f 2 -g 1 -R 2 -D 3 -A 1 -V 8 -w 5 -n 20
+# rccl-tests version 2.18.3-Unknown  rccl-headers=23004 rccl-library=23004
+# Collective test starting: alltoall_perf
+# nThread 1 nGpus 1 minBytes 128 maxBytes 134217728 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0 unalign: 0
+#
+# Using devices
+#  Rank  0 Group  0 Pid      9 on smci355-ccs-aus-m03-17 device  0 [0000:75:00] AMD Instinct MI355X
+#  Rank  1 Group  0 Pid     10 on smci355-ccs-aus-m03-17 device  1 [0000:05:00] AMD Instinct MI355X
+#  Rank  2 Group  0 Pid     11 on smci355-ccs-aus-m03-17 device  2 [0000:65:00] AMD Instinct MI355X
+#  Rank  3 Group  0 Pid     12 on smci355-ccs-aus-m03-17 device  3 [0000:15:00] AMD Instinct MI355X
+#  Rank  4 Group  0 Pid     13 on smci355-ccs-aus-m03-17 device  4 [0000:f5:00] AMD Instinct MI355X
+#  Rank  5 Group  0 Pid     14 on smci355-ccs-aus-m03-17 device  5 [0000:85:00] AMD Instinct MI355X
+#  Rank  6 Group  0 Pid     15 on smci355-ccs-aus-m03-17 device  6 [0000:e5:00] AMD Instinct MI355X
+#  Rank  7 Group  0 Pid     16 on smci355-ccs-aus-m03-17 device  7 [0000:95:00] AMD Instinct MI355X
+RCCL version : 2.30.4-Unknown 
+HIP version  : 7.13.99004-3309c611
+ROCm version : 7.13.0.0-9999-3309c611
+Hostname     : smci355-ccs-aus-m03-17
+Librccl path : /workspace/rccl/lib/librccl.so.1
+#
+#                                                              out-of-place                       in-place          
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong algo      proto      nchannels 
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)                                      
+         128             4     float    none      -1    11.77    0.01    0.01       0    12.24    0.01    0.01    N/A     N/A       N/A         N/A
+         256             8     float    none      -1    12.19    0.02    0.02       0    12.44    0.02    0.02    N/A     N/A       N/A         N/A
+         512            16     float    none      -1    14.21    0.04    0.03       0    13.69    0.04    0.03    N/A     N/A       N/A         N/A
+        1024            32     float    none      -1    15.97    0.06    0.06       0    17.44    0.06    0.05    N/A     N/A       N/A         N/A
+        2048            64     float    none      -1    22.11    0.09    0.08       0    23.22    0.09    0.08    N/A     N/A       N/A         N/A
+        4096           128     float    none      -1    22.32    0.18    0.16       0    22.42    0.18    0.16    N/A     N/A       N/A         N/A
+        8192           256     float    none      -1    22.37    0.37    0.32       0    22.54    0.36    0.32    N/A     N/A       N/A         N/A
+       16384           512     float    none      -1    22.47    0.73    0.64       0    22.56    0.73    0.64    N/A     N/A       N/A         N/A
+       32768          1024     float    none      -1    22.68    1.44    1.26       0    22.42    1.46    1.28    N/A     N/A       N/A         N/A
+       65536          2048     float    none      -1    22.47    2.92    2.55       0    22.37    2.93    2.56    N/A     N/A       N/A         N/A
+      131072          4096     float    none      -1    22.86    5.73    5.02       0    22.89    5.73    5.01    N/A     N/A       N/A         N/A
+      262144          8192     float    none      -1    23.39   11.21    9.81       0    24.93   10.52    9.20    N/A     N/A       N/A         N/A
+      524288         16384     float    none      -1    24.40   21.49   18.80       0    24.56   21.35   18.68    N/A     N/A       N/A         N/A
+     1048576         32768     float    none      -1    26.60   39.43   34.50       0    26.50   39.57   34.63    N/A     N/A       N/A         N/A
+     2097152         65536     float    none      -1    29.32   71.53   62.59       0    28.92   72.52   63.45    N/A     N/A       N/A         N/A
+     4194304        131072     float    none      -1    33.22  126.24  110.46       0    32.88  127.55  111.60    N/A     N/A       N/A         N/A
+     8388608        262144     float    none      -1    41.48  202.23  176.95       0    41.16  203.80  178.33    N/A     N/A       N/A         N/A
+    16777216        524288     float    none      -1    58.98  284.45  248.89       0    58.78  285.41  249.73    N/A     N/A       N/A         N/A
+    33554432       1048576     float    none      -1    92.69  362.00  316.75       0    96.73  346.90  303.54    N/A     N/A       N/A         N/A
+    67108864       2097152     float    none      -1   161.22  416.26  364.23       0   161.21  416.28  364.24    N/A     N/A       N/A         N/A
+   134217728       4194304     float    none      -1   298.52  449.60  393.40       0   298.44  449.72  393.51    N/A     N/A       N/A         N/A
+# Out of bounds values : 0 OK
+# Avg bus bandwidth    : 82.9425 
+#
+# Collective test concluded: alltoall_perf
+#
+
++ _trace_off
++ [[ 1 == 1 ]]
++ set +x

--- a/ddai-artifacts/scripts/docker-gin-gda-sdma-build.bash
+++ b/ddai-artifacts/scripts/docker-gin-gda-sdma-build.bash
@@ -1,0 +1,129 @@
+#! /usr/bin/env bash
+
+# Test#5 (GIN Anvil-SDMA, NCCL_GIN_TYPE=5) needs rocSHMEM built with USE_SDMA=ON. Default
+# ROCSHMEM_USE_SDMA=1 passes --build-arg to the Dockerfile; set ROCSHMEM_USE_SDMA=0 to opt out.
+# The Dockerfile upgrades rdma-core/libmlx5 from ${VERSION_CODENAME}-updates when available.
+# Optional CI: pass --build-arg RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=1 to fail the build unless
+# libmlx5/libmlx5dv export mlx5dv_reg_dmabuf_mr (MOFED / newer rdma-core). Default 0: stock Ubuntu 24.04
+# often lacks those symbols (ddai-gin-build.log); test scripts can skip Test#5 via MLX5 preflight.
+# Optional: export RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=1 for strict MLX5 DMA-BUF symbol check at docker build.
+# Optional GinAlltoAll trace (Test#5 debugging; both default off):
+#   RCCL_GIN_ALLTOALL_HOST_TRACE=1   — runtime host stderr launch logs (no rebuild; set when running
+#                                      docker-gin-gda-sdma-test.bash).
+#   RCCL_GIN_ALLTOALL_DEVICE_TRACE=1 — compile GPU phase/signal markers into alltoall_perf; also set
+#                                      RCCL_GIN_ALLTOALL_DEVICE_TRACE=1 at test time to poll them.
+# ROCSHMEM_USE_SDMA="${ROCSHMEM_USE_SDMA:-1}"
+
+DOCKER_NO_CACHE=${1:-0}
+DOCKER_CMD="${DOCKER_CMD:-docker}"
+DOCKERFILE="Dockerfile-rccl-gin-gda-sdma"
+# Exported so the post-build smoke gate (gin-sdma-a2a-test.bash) runs against THIS
+# just-built image rather than the harness's own default name.
+export DOCKER_IMAGE="${DOCKER_IMAGE:-rccl-gin-gda-sdma-713}"
+TARGET_GPU_ARCH="${GPU_TARGETS:-gfx950}"
+USE_LOCAL_SRC=1
+ROCSHMEM_USE_SDMA=1
+RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS="${RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS:-0}"
+# RCCL device-kernel set (ONLY_FUNCS). Includes Broadcast + AllGather + AllReduce so the host
+# baselines (broadcast_perf/all_gather_perf/all_reduce_perf -D 0) work across the full size
+# range. Set ONLY_FUNCS="" to build every collective (much slower), or override with a custom
+# pattern.
+# Fast-iteration knob: COLLECTIVE=a2a narrows the generated device-kernel set (ONLY_FUNCS)
+# AND the post-build smoke gate to just AllToAll*, so the compile and device link only cover
+# what the A2A GIN Anvil-SDMA tests exercise. An explicit ONLY_FUNCS (or RCCL_IMAGE_GIN_SMOKE)
+# always wins. Unset (default) => full set + A2A smoke gate.
+COLLECTIVE="${COLLECTIVE:-}"
+case "${COLLECTIVE}" in
+  a2a) : "${ONLY_FUNCS:=SendRecv|AlltoAllPivot|AlltoAllGda|AlltoAllvGda}"
+       : "${RCCL_IMAGE_GIN_SMOKE:=1}" ;;
+  "")  ;;
+  *)   echo "WARN: unknown COLLECTIVE='${COLLECTIVE}' (use a2a); building full set" >&2 ;;
+esac
+ONLY_FUNCS="${ONLY_FUNCS-SendRecv|AlltoAllPivot|AlltoAllGda|AlltoAllvGda|Broadcast|AllGather|AllReduce|Reduce}"
+
+GIT_CLONE_ROOT="${GIT_CLONE_ROOT:-$PWD}"
+DEV_ARTI_DIR="${GIT_CLONE_ROOT}/ddai-artifacts"
+DOCKERFILE_PATH="${DEV_ARTI_DIR}/docker/${DOCKERFILE}"
+
+# Dockerfile COPY extra-rdma-debs/ requires the directory in build context (optional .deb install).
+mkdir -p extra-rdma-debs
+
+if [ "$DOCKER_NO_CACHE" -eq 1 ]; then
+  DOCKER_CACHE_OPT="--no-cache"
+  RCCL_CACHE_BUST=1
+  ROCSHMEM_CACHE_BUST=1
+else
+  DOCKER_CACHE_OPT=""
+fi
+
+export RCCL_CACHE_BUST=${RCCL_CACHE_BUST:-1}
+export ROCSHMEM_CACHE_BUST=${ROCSHMEM_CACHE_BUST:-1}
+
+RCCL_GIN_ALLTOALL_DEVICE_TRACE="${RCCL_GIN_ALLTOALL_DEVICE_TRACE:-0}"
+
+TRACE_BUILD_ARGS=()
+if [[ "${RCCL_GIN_ALLTOALL_DEVICE_TRACE}" == 1 ]]; then
+  TRACE_BUILD_ARGS+=(--build-arg RCCL_GIN_ALLTOALL_DEVICE_TRACE=1)
+  echo "docker build: RCCL_GIN_ALLTOALL_DEVICE_TRACE=1 (GPU kernel phase markers)"
+fi
+
+# Optional network mode for RUN steps. On hosts whose docker daemon disables the
+# default bridge (daemon.json "bridge":"none", e.g. some shared/slurm nodes), the
+# default RUN sandbox fails with "network bridge not found"; set
+# DOCKER_BUILD_NETWORK=host to route RUN steps over host networking instead.
+DOCKER_NET_OPT=()
+[[ -n "${DOCKER_BUILD_NETWORK:-}" ]] && DOCKER_NET_OPT=(--network="${DOCKER_BUILD_NETWORK}")
+
+${DOCKER_CMD} build -f ${DOCKERFILE_PATH} -t ${DOCKER_IMAGE} \
+    "${DOCKER_NET_OPT[@]}" \
+    ${DOCKER_CACHE_OPT} \
+    --build-arg GPU_TARGETS=${TARGET_GPU_ARCH} \
+    --build-arg USE_LOCAL_SRC=${USE_LOCAL_SRC} \
+    --build-arg ONLY_FUNCS="${ONLY_FUNCS}" \
+    --build-arg ROCSHMEM_USE_SDMA=${ROCSHMEM_USE_SDMA} \
+    --build-arg RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS=${RCCL_IMAGE_REQUIRE_MLX5_DMABUF_SYMBOLS} \
+    "${TRACE_BUILD_ARGS[@]}" \
+    --build-arg RCCL_CACHE_BUST=$((RCCL_CACHE_BUST++)) \
+    --build-arg ROCSHMEM_CACHE_BUST=$((ROCSHMEM_CACHE_BUST++)) \
+    .
+${DOCKER_CMD} image inspect "${DOCKER_IMAGE}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# Build hardening (runtime): assert real GIN Anvil-SDMA bring-up on GPUs.
+# A previous rebuild shipped an image whose communicator came up with
+# ginType=NONE ("GIN support is not enabled"); static checks cannot catch that,
+# so run a minimal Test#5 (NCCL_GIN_TYPE=5) and fail if GIN does not initialize.
+# Skips cleanly on GPU-less builders or when RCCL_IMAGE_GIN_SMOKE=0.
+#   RCCL_IMAGE_GIN_SMOKE=0  disable this assert
+#   GIN_SMOKE_NP=<n>        GPU/rank count (default 8)
+#   GIN_SMOKE_SIZE=<bytes>  max message size, e.g. 1M (default 1M)
+# ---------------------------------------------------------------------------
+RCCL_IMAGE_GIN_SMOKE="${RCCL_IMAGE_GIN_SMOKE:-1}"
+GIN_SMOKE_NP="${GIN_SMOKE_NP:-8}"
+GIN_SMOKE_SIZE="${GIN_SMOKE_SIZE:-1M}"
+if [ "${RCCL_IMAGE_GIN_SMOKE}" = "1" ]; then
+  if [ ! -e /dev/kfd ]; then
+    echo "WARN: GIN smoke assert skipped (no /dev/kfd; GPU-less builder). Set RCCL_IMAGE_GIN_SMOKE=0 to silence." >&2
+  else
+    echo "=== Build hardening: GIN Anvil-SDMA smoke assert (NP=${GIN_SMOKE_NP}, NCCL_GIN_TYPE=5, -e ${GIN_SMOKE_SIZE}) ==="
+    GIN_SMOKE_LOG="$(mktemp)"
+    RCCL_GIN_RUN_TESTS=5 TEST5_MLX5_PREFLIGHT=0 \
+      bash "${DEV_ARTI_DIR}/scripts/gin-sdma-a2a-test.bash" "${GIN_SMOKE_NP}" "${GIN_SMOKE_SIZE}" \
+      > "${GIN_SMOKE_LOG}" 2>&1
+    if grep -qE "GIN support is not enabled for this communicator|Failed to initialize any GIN plugin|Test failure" "${GIN_SMOKE_LOG}" \
+       || ! grep -q "Out of bounds values : 0 OK" "${GIN_SMOKE_LOG}"; then
+      echo "ERROR: GIN Anvil-SDMA bring-up FAILED for image '${DOCKER_IMAGE}'." >&2
+      echo "       The communicator did not enable GIN (ginType=NONE) or validation failed." >&2
+      echo "       This image is NOT safe for GIN tests. Smoke log tail:" >&2
+      echo "------------------------------ smoke log tail ------------------------------" >&2
+      tail -n 40 "${GIN_SMOKE_LOG}" >&2
+      echo "----------------------------------------------------------------------------" >&2
+      rm -f "${GIN_SMOKE_LOG}"
+      exit 1
+    fi
+    echo "GIN smoke OK: $(grep 'Avg bus bandwidth' "${GIN_SMOKE_LOG}" | tail -n1 | sed 's/^# *//')"
+    rm -f "${GIN_SMOKE_LOG}"
+  fi
+else
+  echo "NOTE: GIN smoke assert disabled (RCCL_IMAGE_GIN_SMOKE=0)."
+fi

--- a/ddai-artifacts/scripts/gin-sdma-a2a-test.bash
+++ b/ddai-artifacts/scripts/gin-sdma-a2a-test.bash
@@ -1,0 +1,585 @@
+#! /usr/bin/env bash
+# Single-node GIN alltoall perf harness (docker, non-Ruby).
+# Usage: ./docker-gin-gda-sdma-test.bash [NP] [MAX_BYTES]
+# Options: docs/gin-anvil-sdma-backend-tests.md
+
+NP=${1:-8}
+MAX_BYTES="${2:-128M}"
+DOCKER_CMD="${DOCKER_CMD:-docker}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-rccl-gin-gda-sdma-713}"
+RCCL_GIN_RUN_TESTS="${RCCL_GIN_RUN_TESTS:-${RUN_TESTS:-1,5}}"
+GDA_HOST_LIB_DIRS="${TEST2_HOST_SO_SEARCH_DIRS:-${TEST2_HOST_SO_SEARCH_DIRS:-/lib64 /usr/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu}}"
+ROCSHMEM_THRESHOLD=$((128 * 1024 * 1024))
+
+# Shared measurement iteration counts applied to ALL tests (#1-#5) so the host,
+# rocSHMEM, and GIN paths are compared over the SAME warmup(skip)/timed(loop)
+# counts. WARMUP = discarded warmup iters (-w / device "skip"); ITERS = timed
+# iters (-n / device "loop"). For Test#5 device-timing these also feed the
+# in-kernel wall_clock64 skip/loop so its measurement window matches the others.
+A2A_WARMUP="${A2A_WARMUP:-5}"
+A2A_ITERS="${A2A_ITERS:-20}"
+
+_run_test() {
+  [[ ",${RCCL_GIN_RUN_TESTS}," == *",$1,"* ]]
+}
+
+_trace_on() {
+  [[ "${RCCL_GIN_ECHO:-1}" == 1 ]] && set -x
+  return 0
+}
+
+_trace_off() {
+  [[ "${RCCL_GIN_ECHO:-1}" == 1 ]] && set +x
+  return 0
+}
+
+if [[ "${DOCKER_ULIMIT_MEMLOCK:-1}" != 0 ]]; then
+  D_MEMLOCK=(--ulimit memlock=-1:-1)
+else
+  D_MEMLOCK=()
+fi
+
+DOCKER_GPU_COMMON="${D_MEMLOCK[*]} --shm-size 64G --network host --device /dev/dri --device /dev/kfd --device /dev/infiniband --ipc host --group-add video --group-add render --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged ${DOCKER_EXTRA:-}"
+
+GDA_UVERBS_ADDED=0
+_rccl_uverbs_seen=""
+_rccl_add_uverbs() {
+  local p="$1" rp
+  [[ -e "${p}" ]] || return 1
+  rp=$(readlink -f "${p}" 2>/dev/null) || return 1
+  [[ -n "${rp}" ]] || rp="${p}"
+  [[ -c "${rp}" ]] || return 1
+  [[ " ${_rccl_uverbs_seen} " == *" ${rp} "* ]] && return 0
+  DOCKER_GPU_COMMON+=" --device ${rp}"
+  _rccl_uverbs_seen+=" ${rp} "
+  GDA_UVERBS_ADDED=$((GDA_UVERBS_ADDED + 1))
+}
+if [[ "${DOCKER_UVERBS:-1}" != 0 ]]; then
+  shopt -s nullglob
+  for _u in /dev/infiniband/uverbs* /dev/uverbs*; do
+    _rccl_add_uverbs "${_u}" || true
+  done
+  shopt -u nullglob
+  if [[ "${GDA_UVERBS_ADDED}" -eq 0 ]]; then
+    for _i in $(seq 0 31); do
+      _rccl_add_uverbs "/dev/infiniband/uverbs${_i}" || true
+      _rccl_add_uverbs "/dev/uverbs${_i}" || true
+    done
+  fi
+fi
+unset _rccl_uverbs_seen _u _i
+
+if [[ "${DOCKER_RDMA_GROUP:-1}" != 0 ]] && getent group rdma >/dev/null 2>&1; then
+  DOCKER_GPU_COMMON+=" --group-add rdma"
+fi
+
+if [[ "${GIN_GDA_DOCKER_IT:-0}" == 1 ]]; then
+  DOCKER_GPU="-it --rm --init ${DOCKER_GPU_COMMON}"
+else
+  DOCKER_GPU="--rm --init ${DOCKER_GPU_COMMON}"
+fi
+
+MPI_OPT="--allow-run-as-root -mca pml ob1 -mca btl self,vader,tcp -mca btl_vader_single_copy_mechanism none -mca hwloc_base_binding_policy none ${MPI_MCA_EXTRA:-}"
+
+GIN_PLUGIN_X=()
+[[ "${USE_EXTERNAL_PLUGIN:-0}" != 1 ]] && GIN_PLUGIN_X=(-x NCCL_GIN_PLUGIN=none)
+
+MPI_BASE=(
+  -x OMPI_ALLOW_RUN_AS_ROOT=1
+  -x OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+  -x RCCL_ROCSHMEM_ENABLE=0
+  -x ROCSHMEM_BACKEND=ipc
+  -x ROCSHMEM_DISABLE_MIXED_IPC=1
+  -x ROCSHMEM_DEBUG_LEVEL=info:noversion
+  -x RCCL_ROCSHMEM_THRESHOLD="${ROCSHMEM_THRESHOLD}"
+  -x NCCL_DEBUG="${NCCL_DEBUG:-VERSION}"
+  -x NCCL_DEBUG_SUBSYS=INIT,NET
+  -x RCCL_ENABLE_INTRANET=1
+  -x NCCL_DMABUF_ENABLE=1
+  -x NCCL_MSCCL_ENABLE=0
+  -x HSA_NO_SCRATCH_RECLAIM=1
+)
+
+# [GIN-CONN-CHECK][TEST] Optional fault-injection passthrough to exercise the
+# LSA signal connectivity fail-loud abort path deterministically.
+[[ -n "${NCCL_GIN_ANVIL_SDMA_CONN_INJECT_FAIL_RANK:-}" ]] && \
+  MPI_BASE+=(-x "NCCL_GIN_ANVIL_SDMA_CONN_INJECT_FAIL_RANK=${NCCL_GIN_ANVIL_SDMA_CONN_INJECT_FAIL_RANK}")
+
+# [CUMEM-SKIP-FREE][WORKAROUND] gfx950 hipMemUnmap teardown deadlock: forward
+# NCCL_CUMEM_SKIP_FREE=1 to ranks so ncclCuMemFree skips the hanging cuMem unmap
+# at ncclCommDestroy (leaks the aperture; OS reclaims at process exit).
+[[ -n "${NCCL_CUMEM_SKIP_FREE:-}" ]] && \
+  MPI_BASE+=(-x "NCCL_CUMEM_SKIP_FREE=${NCCL_CUMEM_SKIP_FREE}")
+
+DOCKER_TEST2_VOLUMES=""
+DOCKER_TEST5_MLX5_VOLUMES=""
+_rccl_bind_seen=""
+
+_rccl_bind_add() {
+  local src="$1" dst="$2"
+  [[ -n "${src}" && -e "${src}" && -n "${dst}" ]] || return 0
+  [[ " ${_rccl_bind_seen} " == *" ${dst} "* ]] && return 0
+  DOCKER_TEST2_VOLUMES+=" -v ${src}:${dst}:ro"
+  _rccl_bind_seen+=" ${dst} "
+}
+
+_rccl_resolve_lib() {
+  local base="$1" d cand
+  for d in ${GDA_HOST_LIB_DIRS}; do
+    cand="${d}/${base}"
+    [[ -e "${cand}" ]] || continue
+    readlink -f "${cand}" 2>/dev/null || echo "${cand}"
+    return 0
+  done
+  return 1
+}
+
+_rccl_bind_lib_paths() {
+  local base="$1" real d cand
+  real=$(_rccl_resolve_lib "${base}") || return 1
+  for d in ${GDA_HOST_LIB_DIRS}; do
+    cand="${d}/${base}"
+    [[ -e "${cand}" ]] || continue
+    _rccl_bind_add "${real}" "${cand}"
+    [[ "${real}" != "${cand}" ]] && _rccl_bind_add "${real}" "${real}"
+  done
+}
+
+_rccl_bind_mlx5_adjacent() {
+  local vbdir="$1" mlx cand real d
+  for mlx in libmlx5.so libmlx5.so.1 libmlx5-infiniband.so.1 libmlx5dv.so libmlx5dv.so.1; do
+    cand="${vbdir}/${mlx}"
+    [[ -e "${cand}" ]] || continue
+    real=$(readlink -f "${cand}" 2>/dev/null || echo "${cand}")
+    for d in ${GDA_HOST_LIB_DIRS}; do
+      _rccl_bind_add "${real}" "${d}/${mlx}"
+    done
+  done
+}
+
+_rccl_setup_rdma_volumes() {
+  local d verbs vbdir plug base nl3 nlrt
+
+  if [[ "${TEST2_BIND_HOST_GNU_DIRS:-${TEST2_BIND_HOST_GNU_DIRS:-0}}" != 0 ]]; then
+    echo "warning: TEST2_BIND_HOST_GNU_DIRS=1 can break librccl if host glibc is older than the image." >&2
+    for d in ${TEST2_BIND_HOST_LIBDIRS:-${TEST2_BIND_HOST_LIBDIRS:-/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu}}; do
+      [[ -d "${d}" ]] && DOCKER_TEST2_VOLUMES+=" -v ${d}:${d}:ro"
+    done
+  fi
+
+  if [[ "${TEST2_BIND_HOST_RDMA_SO:-${TEST2_BIND_HOST_RDMA_SO:-1}}" != 0 ]]; then
+    _rccl_bind_seen=""
+    if [[ -n "${TEST2_BIND_HOST_RDMA_BASE+x}" || -n "${TEST2_BIND_HOST_RDMA_BASE+x}" ]]; then
+      for base in ${TEST2_BIND_HOST_RDMA_BASE:-${TEST2_BIND_HOST_RDMA_BASE:-}} \
+                  ${TEST2_BIND_HOST_RDMA_EXTRA:-${TEST2_BIND_HOST_RDMA_EXTRA:-}} \
+                  libnl-3.so.200 libnl-route-3.so.200; do
+        [[ -n "${base// }" ]] && _rccl_bind_lib_paths "${base}" || true
+      done
+    else
+      for base in librdmacm.so librdmacm.so.1 libibumad.so.3 \
+                  ${TEST2_BIND_HOST_RDMA_EXTRA:-${TEST2_BIND_HOST_RDMA_EXTRA:-}}; do
+        [[ -n "${base// }" ]] && _rccl_bind_lib_paths "${base}" || true
+      done
+      case "${TEST2_BIND_HOST_MLX5_SO:-${TEST2_BIND_HOST_MLX5_SO:-adjacent}}" in
+        1)
+          for base in libmlx5.so libmlx5.so.1 libmlx5-infiniband.so.1 libmlx5dv.so libmlx5dv.so.1; do
+            _rccl_bind_lib_paths "${base}" || true
+          done
+          ;;
+      esac
+    fi
+
+    if verbs=$(_rccl_resolve_lib libibverbs.so.1); then
+      vbdir=$(dirname "${verbs}")
+      for d in ${GDA_HOST_LIB_DIRS}; do
+        _rccl_bind_add "${verbs}" "${d}/libibverbs.so"
+        _rccl_bind_add "${verbs}" "${d}/libibverbs.so.1"
+      done
+      _rccl_bind_add "${verbs}" "${verbs}"
+
+      if nl3=$(_rccl_resolve_lib libnl-3.so.200) && nlrt=$(_rccl_resolve_lib libnl-route-3.so.200); then
+        for d in ${GDA_HOST_LIB_DIRS}; do
+          _rccl_bind_add "${nl3}" "${d}/libnl-3.so.200"
+          _rccl_bind_add "${nlrt}" "${d}/libnl-route-3.so.200"
+        done
+      fi
+
+      plug="${vbdir}/libibverbs"
+      if [[ -d "${plug}" ]]; then
+        for d in ${GDA_HOST_LIB_DIRS}; do
+          _rccl_bind_add "${plug}" "${d}/libibverbs"
+        done
+      fi
+
+      case "${TEST2_BIND_HOST_MLX5_SO:-${TEST2_BIND_HOST_MLX5_SO:-adjacent}}" in
+        0) ;;
+        1) ;;
+        *) _rccl_bind_mlx5_adjacent "${vbdir}" ;;
+      esac
+    fi
+    unset _rccl_bind_seen
+  fi
+
+  if [[ "${TEST2_BIND_HOST_IB_SYSFS:-${TEST2_BIND_HOST_IB_SYSFS:-1}}" != 0 ]]; then
+    for d in /sys/class/infiniband /etc/libibverbs.d; do
+      [[ -e "${d}" ]] && DOCKER_TEST2_VOLUMES+=" -v ${d}:${d}:ro"
+    done
+  fi
+
+  case "${TEST2_BIND_HOST_DEV_IFB:-${TEST2_BIND_HOST_DEV_INFINIBAND:-auto}}" in
+    on) DOCKER_TEST2_VOLUMES+=" -v /dev/infiniband:/dev/infiniband" ;;
+    off) ;;
+    auto)
+      if [[ "${GDA_UVERBS_ADDED:-0}" -eq 0 ]] && { [[ -d /dev/infiniband ]] || [[ -d /sys/class/infiniband ]]; }; then
+        DOCKER_TEST2_VOLUMES+=" -v /dev/infiniband:/dev/infiniband"
+      fi
+      ;;
+    *)
+      echo "error: TEST2_BIND_HOST_DEV_IFB must be auto, on, or off" >&2
+      exit 1
+      ;;
+  esac
+}
+
+_rccl_ver_ge() {
+  local IFS=. a b i ai bi
+  read -r -a a <<< "$1"
+  read -r -a b <<< "$2"
+  for i in 0 1 2 3; do
+    ai=${a[i]:-0}
+    bi=${b[i]:-0}
+    (( 10#${ai} > 10#${bi} )) && return 0
+    (( 10#${ai} < 10#${bi} )) && return 1
+  done
+  return 0
+}
+
+_rccl_skip_test4_auto() {
+  local nic driver fw any_bnxt=0 min="${MIN_BNXT_FW_FOR_GDA:-233.2.104.0}"
+  for nic in /sys/class/net/*; do
+    [[ -e "${nic}" ]] || continue
+    nic=${nic##*/}
+    [[ "${nic}" == lo ]] && continue
+    driver=$(readlink -f "/sys/class/net/${nic}/device/driver" 2>/dev/null)
+    driver=${driver##*/}
+    [[ "${driver}" == bnxt_en ]] || continue
+    any_bnxt=1
+    command -v ethtool >/dev/null 2>&1 || continue
+    fw=$(ethtool -i "${nic}" 2>/dev/null | awk -F': +' '/firmware-version:/{v=$2; gsub(/ .*/,"",v); gsub(/\/.*/,"",v); print v; exit}')
+    [[ -n "${fw}" ]] || continue
+    if ! _rccl_ver_ge "${fw}" "${min}"; then
+      echo "=== RCCL_GIN_GDA: skipping Test#4 (bnxt ${nic} fw ${fw} < ${min}); set TEST4_MODE=run to force ===" >&2
+      return 0
+    fi
+  done
+  if [[ "${any_bnxt}" == 0 ]]; then
+    echo "=== RCCL_GIN_GDA: skipping Test#4 (no bnxt_en); set TEST4_MODE=run to force ===" >&2
+    return 0
+  fi
+  return 1
+}
+
+_should_run_test4() {
+  _run_test 4 || return 1
+  case "${TEST4_MODE:-${TEST4_MODE:-auto}}" in
+    skip) return 1 ;;
+    run) return 0 ;;
+    auto) ! _rccl_skip_test4_auto ;;
+    *)
+      echo "error: TEST4_MODE must be auto, run, or skip" >&2
+      exit 1
+      ;;
+  esac
+}
+
+_rccl_setup_test5_mlx5_volumes() {
+  local dir="$1" cand real base d
+  [[ -d "${dir}" ]] || {
+    echo "error: TEST5_HOST_MLX5_LIB_DIR is not a directory: ${dir}" >&2
+    return 1
+  }
+  _rccl_bind_seen=""
+  shopt -s nullglob
+  for cand in "${dir}"/libmlx5*.so* "${dir}"/libmlx5dv*.so*; do
+    [[ -f "${cand}" ]] || continue
+    real=$(readlink -f "${cand}" 2>/dev/null || echo "${cand}")
+    base=$(basename "${cand}")
+    for d in ${GDA_HOST_LIB_DIRS}; do
+      [[ " ${_rccl_bind_seen} " == *" ${d}/${base} "* ]] && continue
+      DOCKER_TEST5_MLX5_VOLUMES+=" -v ${real}:${d}/${base}:ro"
+      _rccl_bind_seen+=" ${d}/${base} "
+    done
+  done
+  shopt -u nullglob
+  unset _rccl_bind_seen
+  [[ -n "${DOCKER_TEST5_MLX5_VOLUMES}" ]] || {
+    echo "error: no libmlx5*.so* or libmlx5dv*.so* in ${dir}" >&2
+    return 1
+  }
+}
+
+_rccl_setup_rdma_volumes
+if [[ -n "${TEST5_HOST_MLX5_LIB_DIR:-${TEST5_HOST_MLX5_LIB_DIR:-}}" ]]; then
+  _rccl_setup_test5_mlx5_volumes "${TEST5_HOST_MLX5_LIB_DIR:-${TEST5_HOST_MLX5_LIB_DIR}}" || exit 1
+fi
+
+_rccl_test5_mlx5_ok() {
+  [[ -n "${TEST5_HOST_MLX5_LIB_DIR:-${TEST5_HOST_MLX5_LIB_DIR:-}}" ]] && return 0
+  ${DOCKER_CMD} run --rm --init ${DOCKER_TEST5_MLX5_VOLUMES} "${DOCKER_IMAGE}" sh -lc \
+    'f=/lib/x86_64-linux-gnu/libmlx5.so.1; test -e "$f" || f=/usr/lib/x86_64-linux-gnu/libmlx5.so.1; \
+     rf=$(readlink -f "$f"); test -f "$rf" && objdump -T "$rf" | grep -q mlx5dv_reg_dmabuf_mr' \
+    >/dev/null 2>&1
+}
+
+_should_run_test5() {
+  _run_test 5 || return 1
+  [[ "${TEST5_MODE:-${TEST5_MODE:-run}}" != skip ]] || return 1
+  if [[ "${TEST5_MLX5_PREFLIGHT:-${TEST5_MLX5_PREFLIGHT:-0}}" != 0 ]]; then
+    if ! _rccl_test5_mlx5_ok; then
+      echo "=== RCCL_GIN_GDA: skipping Test#5 (image libmlx5 lacks mlx5dv_reg_dmabuf_mr); set TEST5_MLX5_PREFLIGHT=0 or TEST5_HOST_MLX5_LIB_DIR ===" >&2
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# Host-initiated A2A paths (all -D 0), measured 8x MI355X (NCCL_GIN_TYPE=5,
+# 2026-07-24), out-of-place busbw:
+#   * RING (SM copy): pin the channel count so the tuner does not collapse
+#     channels on large messages. Without the pin busbw cliffs hard past 8M
+#     (~182 GB/s @4M -> ~30 @8M -> ~45 @128M); pinning MIN=MAX (any 16..64 is
+#     equivalent) lifts 8M to ~205 and 128M to ~326 with no small-size loss.
+#     Best for <=32M.
+#   * CE/SDMA (copy engines): NCCL_CUMEM_ENABLE=1 + symmetric reg (-R 2) +
+#     NCCL_CTA_POLICY=ZERO. Slow for small/mid but scales to ~373 @128M.
+#     Best for >=64M.
+# TEST1_MODE selects: ring (default) | hybrid (RING<=split, CE>split) | ce.
+_a2a_host_ring() {  # $1=min $2=max
+  ${DOCKER_CMD} run ${DOCKER_GPU} "${DOCKER_IMAGE}" \
+    mpirun -n "${NP}" ${MPI_OPT} \
+    "${MPI_BASE[@]}" \
+    -x NCCL_CUMEM_ENABLE=0 \
+    -x ROCSHMEM_SDMA_ENABLED=0 \
+    -x NCCL_GIN_ENABLE=0 \
+    -x NCCL_GIN_TYPE=0 \
+    -x NCCL_MIN_NCHANNELS="${TEST1_NCHANNELS}" \
+    -x NCCL_MAX_NCHANNELS="${TEST1_NCHANNELS}" \
+    rccl-tests/alltoall_perf -b "$1" -e "$2" -f 2 -g 1 -R 0 -D 0 -A 1 -V 1 -w "${A2A_WARMUP}" -n "${A2A_ITERS}"
+}
+_a2a_host_ce() {  # $1=min $2=max
+  ${DOCKER_CMD} run ${DOCKER_GPU} "${DOCKER_IMAGE}" \
+    mpirun -n "${NP}" ${MPI_OPT} \
+    "${MPI_BASE[@]}" \
+    -x NCCL_CUMEM_ENABLE=1 \
+    -x ROCSHMEM_SDMA_ENABLED=0 \
+    -x NCCL_GIN_ENABLE=0 \
+    -x NCCL_GIN_TYPE=0 \
+    -x NCCL_CTA_POLICY=ZERO \
+    rccl-tests/alltoall_perf -b "$1" -e "$2" -f 2 -g 1 -R 2 -D 0 -A 1 -V 1 -w "${A2A_WARMUP}" -n "${A2A_ITERS}"
+}
+
+# --- UT: GIN-SDMA host policy unit tests (no GPU); optional preflight gate ---
+# Validates the shared tier-selection / threshold / chunk logic that the device
+# kernels rely on. Fast, GPU-free but OFF by default: the gin_sdma_policy_test
+# binary is not built into the current image, so the gate would abort the run.
+# Set RUN_POLICY_UT=1 to enable once the binary is present in the image.
+POLICY_UT="${POLICY_UT:-rccl-tests/gin_sdma_policy_test}"
+if [[ "${RUN_POLICY_UT:-0}" != "0" ]]; then
+  echo "=== UT: host policy unit tests (${POLICY_UT}) ==="
+  ${DOCKER_CMD} run --rm --init "${DOCKER_IMAGE}" "${POLICY_UT}" \
+    || { echo "FATAL: GIN-SDMA policy unit tests failed"; exit 1; }
+fi
+
+if _run_test 1; then
+  _trace_on
+  TEST1_NCHANNELS="${TEST1_NCHANNELS:-32}"
+  TEST1_MODE="${TEST1_MODE:-ring}"
+  case "${TEST1_MODE}" in
+    ring)
+      echo "=== Test#1: A2A, ${NP} gpus, Host Initiated RING (channels=${TEST1_NCHANNELS}) ==="
+      _a2a_host_ring 128 "${MAX_BYTES}"
+      ;;
+    ce)
+      echo "=== Test#1: A2A, ${NP} gpus, Host Initiated CE/SDMA ==="
+      _a2a_host_ce 128 "${MAX_BYTES}"
+      ;;
+    hybrid)
+      # RING for <=split, CE/SDMA for >split. Default split 32M; CE phase
+      # starts at the next f2 step (2*split). Override split with
+      # TEST1_HYBRID_SPLIT (bytes).
+      TEST1_HYBRID_SPLIT="${TEST1_HYBRID_SPLIT:-33554432}"
+      _ce_min=$(( TEST1_HYBRID_SPLIT * 2 ))
+      echo "=== Test#1a: A2A, ${NP} gpus, Host Initiated HYBRID/RING (channels=${TEST1_NCHANNELS}) 128..${TEST1_HYBRID_SPLIT} ==="
+      _a2a_host_ring 128 "${TEST1_HYBRID_SPLIT}"
+      echo "=== Test#1b: A2A, ${NP} gpus, Host Initiated HYBRID/CE-SDMA ${_ce_min}..${MAX_BYTES} ==="
+      _a2a_host_ce "${_ce_min}" "${MAX_BYTES}"
+      ;;
+    *)
+      echo "error: TEST1_MODE must be ring, hybrid, or ce" >&2
+      exit 1
+      ;;
+  esac
+  _trace_off
+fi
+
+if _run_test 2; then
+  _trace_on
+  echo "=== Test#2: A2A, ${NP} gpus, GIN Host Proxy (NCCL_GIN_TYPE=2) ==="
+  ${DOCKER_CMD} run ${DOCKER_GPU}${DOCKER_TEST2_VOLUMES} "${DOCKER_IMAGE}" \
+    mpirun -n "${NP}" ${MPI_OPT} \
+    "${MPI_BASE[@]}" \
+    "${GIN_PLUGIN_X[@]}" \
+    -x NCCL_CUMEM_ENABLE=1 \
+    -x NCCL_NET_PLUGIN=none \
+    -x NCCL_ENV_PLUGIN=none \
+    -x ROCSHMEM_SDMA_ENABLED=0 \
+    -x NCCL_DEBUG="${NCCL_DEBUG:-VERSION}" \
+    -x NCCL_GIN_ENABLE=1 \
+    -x NCCL_GIN_TYPE=2 \
+    -x HSA_FORCE_FINE_GRAIN_PCIE=1 \
+    rccl-tests/alltoall_perf -b 128 -e "${MAX_BYTES}" -f 2 -g 1 -R 2 -D 3 -A 1 -V 1 -w "${A2A_WARMUP}" -n "${A2A_ITERS}"
+  _trace_off
+fi
+
+if _should_run_test4; then
+  _trace_on
+  echo "=== Test#4: A2A, ${NP} gpus, GIN GDA ==="
+  ${DOCKER_CMD} run ${DOCKER_GPU} "${DOCKER_IMAGE}" \
+    mpirun -n "${NP}" ${MPI_OPT} \
+    "${MPI_BASE[@]}" \
+    "${GIN_PLUGIN_X[@]}" \
+    -x NCCL_CUMEM_ENABLE=1 \
+    -x NCCL_NET_PLUGIN=none \
+    -x ROCSHMEM_SDMA_ENABLED=1 \
+    -x NCCL_GIN_ENABLE=1 \
+    -x NCCL_GIN_TYPE=4 \
+    rccl-tests/alltoall_perf -b 128 -e "${MAX_BYTES}" -f 2 -g 1 -R 2 -D 3 -A 1 -V 1 -w "${A2A_WARMUP}" -n "${A2A_ITERS}"
+  _trace_off
+fi
+
+if _should_run_test5; then
+  _trace_on
+  # Backend gin.put SDMA control (rsCtx->sdmaThreshold): 0 = every GIN put uses
+  # the copy engine. Kept at 0 so the -D 3 SDMA branch always drives SDMA.
+  NCCL_GIN_ANVIL_SDMA_THRESHOLD="${NCCL_GIN_ANVIL_SDMA_THRESHOLD:-0}"
+  NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK="${NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK:-8192}"
+  # Kernel-level LSA<->SDMA switch for the -D 3 size-hybrid (per-peer bytes).
+  # Set explicitly so it takes precedence over the shared THRESHOLD=0 above
+  # (which would otherwise force the kernel all-SDMA). Default matches the
+  # rccl-tests built-in default (2097152 = 2 MiB/peer = 16M total on 8 ranks,
+  # the F1/F2/F3-measured LSA<->SDMA crossover). Set to 0 to force all-SDMA, or
+  # a huge value to force all-LSA (sweeps).
+  TEST5_A2A_THRESHOLD="${TEST5_A2A_THRESHOLD:-2097152}"
+  # Optional LSA-tier CTA-count override (F1 tuning knob): 0 = use the adaptive
+  # a2aLsaCtaCount ladder (default), >0 = force that grid for the LSA tier.
+  TEST5_A2A_LSA_CTAS="${TEST5_A2A_LSA_CTAS:-0}"
+  # Multi-CTA LL tier (small-message tail prototype): per-peer bytes cap to enable
+  # the barrier-free LL scatter/gather (0/unset = disabled -> direct-LSA copy),
+  # and an optional CTA-count override for that tier (0 = use kA2aLLCtas default).
+  TEST5_A2A_LL_MAX="${TEST5_A2A_LL_MAX:-0}"
+  TEST5_A2A_LL_CTAS="${TEST5_A2A_LL_CTAS:-0}"
+  # LSA-tier cross-rank sync mode: 3 = single exit barrier (default, +9-17% vs
+  # legacy), 0 = two LSA barriers (legacy), 1 = none (diagnostic ceiling, correct
+  # only under external sync), 2 = point-to-point done-flag completion (diagnostic).
+  TEST5_A2A_SYNC_MODE="${TEST5_A2A_SYNC_MODE:-3}"
+  # Device-side (in-kernel wall_clock64) timing (AICOMRCCL-1459, rocSHMEM method).
+  # Reports the pure GPU device-function execution time (excludes host launch /
+  # teardown / graph overhead). Modes:
+  #   0 = off (default).
+  #   1 = augment: normal graph/hipEvent run PLUS an extra "#[a2a-devtime]" line.
+  #   2 = device-time-only: skip the graph/hipEvent timed loop for the
+  #       out-of-place pass and report the device time as THE metric (warmup +
+  #       datacheck still run for #wrong). Fastest, cleanest single number.
+  # LOOP/SKIP mirror rocSHMEM defaults (10/10); auto-reduced for large chunks.
+  TEST5_A2A_DEVICE_TIMING="${TEST5_A2A_DEVICE_TIMING:-0}"
+  # Default the device-timing skip/loop to the shared harness counts so Test#5's
+  # in-kernel measurement window matches the -w/-n used by Test#1-#4.
+  TEST5_A2A_DEVTIME_LOOP="${TEST5_A2A_DEVTIME_LOOP:-${A2A_ITERS}}"
+  TEST5_A2A_DEVTIME_SKIP="${TEST5_A2A_DEVTIME_SKIP:-${A2A_WARMUP}}"
+  TEST5_MPI_EXTRA=(
+    -x "NCCL_GIN_ANVIL_SDMA_THRESHOLD=${NCCL_GIN_ANVIL_SDMA_THRESHOLD}"
+    -x "NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK=${NCCL_GIN_ANVIL_SDMA_MAX_COPY_CHUNK}"
+    -x "NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=${TEST5_A2A_THRESHOLD}"
+    -x "NCCL_GIN_ANVIL_A2A_LSA_CTAS=${TEST5_A2A_LSA_CTAS}"
+    -x "NCCL_GIN_ANVIL_A2A_LL_MAX_BYTES=${TEST5_A2A_LL_MAX}"
+    -x "NCCL_GIN_ANVIL_A2A_LL_CTAS=${TEST5_A2A_LL_CTAS}"
+    -x "NCCL_GIN_ANVIL_A2A_SYNC_MODE=${TEST5_A2A_SYNC_MODE}"
+    -x "NCCL_GIN_ANVIL_A2A_DEVICE_TIMING=${TEST5_A2A_DEVICE_TIMING}"
+    -x "NCCL_GIN_ANVIL_A2A_DEVTIME_LOOP=${TEST5_A2A_DEVTIME_LOOP}"
+    -x "NCCL_GIN_ANVIL_A2A_DEVTIME_SKIP=${TEST5_A2A_DEVTIME_SKIP}"
+  )
+  # GIN Anvil-SDMA A2A device paths (NCCL_GIN_TYPE=5), measured 8x MI355X
+  # (2026-07-26), out-of-place:
+  #   * -D 3 GinHybridAlltoAllKernel: size-hybrid. Per-peer chunk <=threshold
+  #     uses a direct LSA all-peers copy (all CTAs; ~11us small-msg latency,
+  #     ~2x mid-range busbw vs SDMA); above threshold uses all-peers GIN puts
+  #     (SDMA copy engines; scales to ~390 GB/s @128M). Needs -V 8 so the LSA
+  #     branch gets enough CTAs; SDMA is CTA-insensitive. Best across the range.
+  #   * -D 4 HybridAlltoAllKernel: topology split (CTA 0 = remote via GIN, CTAs
+  #     1..N = intra-node via LSA). On a single node LSA carries all traffic:
+  #     low small-msg latency but scalar SM copy caps large BW. Kept for debug.
+  # TEST5_MODE: d3 (default, kernel size-hybrid -V 8) | d4 (LSA topology split).
+  TEST5_MODE="${TEST5_MODE:-d3}"
+  TEST5_D4_CTA_COUNT="${TEST5_D4_CTA_COUNT:-${TEST5_CTA_COUNT:-8}}"
+  TEST5_D3_CTA_COUNT="${TEST5_D3_CTA_COUNT:-8}"
+  # HIP-graph capture for the Test#5 measurement (-G/--cudagraph). Captures the
+  # timed iters loop once and replays it TEST5_CUDAGRAPH times, so per-iteration
+  # *host* kernel-launch overhead is removed from the reported GPU time. Smoke-
+  # tested on 8x MI355X: the GIN -D 3 kernel captures and validates cleanly
+  # (#wrong=0) across both the LSA (small) and SDMA (large) branches.
+  # Caveat: -G removes only host launch latency. The in-kernel opening cross-
+  # node barrier and closing waitSignal+flush execute on every replay and are
+  # still counted (isolating those needs device-side timing, out of scope here).
+  # Warmup must be >=1 so GIN connection setup / first-touch allocation happen
+  # BEFORE capture (a cudaMalloc during ThreadLocal stream capture is illegal).
+  # Set TEST5_CUDAGRAPH=0 to disable -G and fall back to launch-inclusive timing.
+  # Only Test#5 uses -G; Test#1 (host baseline) stays launch-inclusive by design.
+  # Default is 0 (eager): HIP graph capture cannot drive the out-of-band SDMA
+  # hardware queue, so -G forces the LSA-only graph-safe fallback (see Option A in
+  # alltoall.cu), which pins large-message busbw at ~20 GB/s vs ~390 GB/s eager and
+  # can also deadlock. Set TEST5_CUDAGRAPH=4 explicitly only to measure the
+  # launch-latency-removed LSA path.
+  TEST5_CUDAGRAPH="${TEST5_CUDAGRAPH:-0}"
+  TEST5_WARMUP="${TEST5_WARMUP:-${A2A_WARMUP}}"
+  TEST5_ITERS="${TEST5_ITERS:-${A2A_ITERS}}"
+  TEST5_GRAPH_ARGS=()
+  if [[ "${TEST5_CUDAGRAPH}" != 0 ]]; then
+    TEST5_GRAPH_ARGS=(-G "${TEST5_CUDAGRAPH}")
+    if [[ "${TEST5_WARMUP}" == 0 ]]; then
+      echo "warning: TEST5_CUDAGRAPH>0 with TEST5_WARMUP=0 can fail graph capture (lazy alloc during capture); using -w 1" >&2
+      TEST5_WARMUP=1
+    fi
+  fi
+  _a2a_gin() {  # $1=deviceImpl $2=ctaCount $3=minBytes $4=maxBytes
+    ${DOCKER_CMD} run ${DOCKER_GPU}${DOCKER_TEST5_MLX5_VOLUMES} "${DOCKER_IMAGE}" \
+      mpirun -n "${NP}" ${MPI_OPT} \
+      "${MPI_BASE[@]}" \
+      "${GIN_PLUGIN_X[@]}" \
+      -x NCCL_CUMEM_ENABLE=1 \
+      -x NCCL_NET_PLUGIN=none \
+      -x ROCSHMEM_SDMA_ENABLED=0 \
+      -x NCCL_DEBUG="${NCCL_DEBUG:-VERSION}" \
+      -x NCCL_GIN_ENABLE=1 \
+      -x NCCL_GIN_TYPE=5 \
+      -x NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS="${TEST5_NUM_CHANNELS:-1}" \
+      -x HSA_FORCE_FINE_GRAIN_PCIE=1 \
+      "${TEST5_MPI_EXTRA[@]}" \
+      rccl-tests/alltoall_perf -b "$3" -e "$4" -f 2 -g 1 -R 2 -D "$1" -A 1 -V "$2" \
+      -w "${TEST5_WARMUP}" -n "${TEST5_ITERS}" "${TEST5_GRAPH_ARGS[@]}"
+  }
+  case "${TEST5_MODE}" in
+    d3)
+      echo "=== Test#5: A2A, ${NP} gpus, GIN Anvil SDMA -D 3 size-hybrid (LSA<=${TEST5_A2A_THRESHOLD}B/peer, SDMA above; V=${TEST5_D3_CTA_COUNT}, NCCL_GIN_TYPE=5, cudagraph=${TEST5_CUDAGRAPH}, w=${TEST5_WARMUP}, n=${TEST5_ITERS}) ==="
+      _a2a_gin 3 "${TEST5_D3_CTA_COUNT}" 128 "${MAX_BYTES}"
+      ;;
+    d4)
+      echo "=== Test#5: A2A, ${NP} gpus, GIN hybrid -D 4 LSA (V=${TEST5_D4_CTA_COUNT}, NCCL_GIN_TYPE=5, cudagraph=${TEST5_CUDAGRAPH}, w=${TEST5_WARMUP}, n=${TEST5_ITERS}) ==="
+      _a2a_gin 4 "${TEST5_D4_CTA_COUNT}" 128 "${MAX_BYTES}"
+      ;;
+    *)
+      echo "error: TEST5_MODE must be d3 or d4" >&2
+      exit 1
+      ;;
+  esac
+  _trace_off
+fi

--- a/projects/rccl-tests/src/alltoall.cu
+++ b/projects/rccl-tests/src/alltoall.cu
@@ -1,6 +1,6 @@
 /*************************************************************************
  * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
- * Modifications Copyright (c) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -12,12 +12,8 @@
 #include "rccl_vector_types.h"
 #endif
 
-#if defined(NCCL_OS_LINUX)
-#pragma weak ncclAlltoAll
-#endif
-
 void AlltoAllGetCollByteCount(size_t *sendcount, size_t *recvcount, size_t *paramcount, size_t *sendInplaceOffset, size_t *recvInplaceOffset, size_t count, size_t eltSize, int nranks) {
-  *paramcount = (count/nranks) & ~(16/eltSize - 1);
+  *paramcount = (count/nranks) & -(16/eltSize);
   *sendcount = nranks*(*paramcount);
   *recvcount = *sendcount;
   *sendInplaceOffset = 0;
@@ -46,7 +42,7 @@ testResult_t AlltoAllInitData(struct threadArgs* args, ncclDataType_t type, nccl
   return testSuccess;
 }
 
-void AlltoAllGetBw(size_t count, size_t typesize, double sec, double* algBw, double* busBw, int nranks) {
+void AlltoAllGetBw(size_t count, int typesize, double sec, double* algBw, double* busBw, int nranks) {
   double baseBw = (double)(count * nranks * typesize) / 1.0E9 / sec;
 
   *algBw = baseBw;
@@ -56,58 +52,41 @@ void AlltoAllGetBw(size_t count, size_t typesize, double sec, double* algBw, dou
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,0)
 // set devComm reqs for alltoall device kernels
-testResult_t AlltoAllGetDevCommRequirements(int deviceImpl, ncclDevCommRequirements* reqs, ncclComm_t comm) {
-  if (!reqs || !comm) return testInternalError;
-
-  ncclCommProperties_t commProperties = NCCL_COMM_PROPERTIES_INITIALIZER;
-  if (ncclCommQueryProperties(comm, &commProperties) != ncclSuccess) {
-    return testNcclError;
-  }
+testResult_t AlltoAllGetDevCommRequirements(int deviceImpl, ncclDevCommRequirements* reqs, ncclCommProperties_t* commProperties) {
+  if (!reqs || !commProperties) return testInternalError;
 
   switch(deviceImpl) {
     case 1: // NvlAlltoAllKernel
     case 2: // NvlAlltoAllKernelOptimized
-      if (commProperties.nRanks != ncclTeamLsa(comm).nRanks) {
-        fprintf(stderr, "DeviceImplementation 1 and 2 requires CUDA P2P "
-                        "connectivity across all ranks. Not all ranks of this "
-                        "communicator have P2P connectivity.\n");
-        return testInvalidUsage;
-      }
       reqs->lsaBarrierCount = deviceCtaCount;
       return testSuccess;
-    #if defined(NCCL_OS_LINUX)
-    case 3: // GinAlltoAllKernel: all CTAs participate
-      if (commProperties.ginType == NCCL_GIN_TYPE_NONE) {
+    case 3: // GinAlltoAllKernel: all CTAs participate, one barrier per CTA
+      if (commProperties->ginType == NCCL_GIN_TYPE_NONE) {
         fprintf(stderr, "This test requires GIN support, but GIN support is not enabled for this communicator.\n");
-        return testInvalidUsage;
+        return testInternalError;
       }
       reqs->barrierCount = deviceCtaCount;
       reqs->ginSignalCount = deviceCtaCount;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,7)
       reqs->ginConnectionType = NCCL_GIN_CONNECTION_FULL;
 #else
       reqs->ginForceEnable = true;
 #endif
       return testSuccess;
-    case 4: // HybridAlltoAllKernel: CTA 0 = GIN, CTAs 1..N = LSA
-      if (deviceCtaCount < 2) {
-        fprintf(stderr, "HybridAlltoAllKernel requires at least 2 CTAs.\n");
-        return testInvalidUsage;
-      }
-      if (commProperties.ginType == NCCL_GIN_TYPE_NONE) {
+    case 4: // HybridAlltoAllKernel: CTA 0 = GIN (1 barrier), CTAs 1..N = LSA
+      if (commProperties->ginType == NCCL_GIN_TYPE_NONE) {
         fprintf(stderr, "This test requires GIN support, but GIN support is not enabled for this communicator.\n");
-        return testInvalidUsage;
+        return testInternalError;
       }
       reqs->barrierCount = 1;
       reqs->lsaBarrierCount = deviceCtaCount - 1;
       reqs->ginSignalCount = 1;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,7)
       reqs->ginConnectionType = NCCL_GIN_CONNECTION_FULL;
 #else
       reqs->ginForceEnable = true;
 #endif
       return testSuccess;
-    #endif
     default:
       return testNotImplemented;
   }
@@ -123,13 +102,12 @@ bool AlltoAllGetDevCommRequirements(int deviceImpl, ncclDevCommRequirements* req
     case 2: // NvlAlltoAllKernelOptimized
       reqs->lsaBarrierCount = deviceCtaCount;
       return true;
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7) && defined(NCCL_OS_LINUX)
-    case 3: // GinAlltoAllKernel: all CTAs participate
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7)
+    case 3: // GinAlltoAllKernel: all CTAs, one barrier per CTA
       reqs->barrierCount = deviceCtaCount;
       reqs->ginSignalCount = deviceCtaCount;
       return true;
-    case 4: // HybridAlltoAllKernel: CTA 0 = GIN, CTAs 1..N = LSA
-      if (deviceCtaCount < 2) return false;
+    case 4: // HybridAlltoAllKernel: CTA 0 = GIN (1 barrier), CTAs 1..N = LSA
       reqs->barrierCount = 1;
       reqs->lsaBarrierCount = deviceCtaCount - 1;
       reqs->ginSignalCount = 1;
@@ -252,7 +230,7 @@ __global__ void NvlAlltoAllKernelOptimized(ncclWindow_t sendwin, size_t sendoffs
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
 }
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7) && defined(NCCL_OS_LINUX)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7)
 template <typename T>
 __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   int ginContext = 0;
@@ -261,12 +239,18 @@ __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
   uint64_t signalValue = gin.readSignal(signalIndex);
 
   ncclBarrierSession<ncclCoopCta> bar { ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x };
+  //TODO: this contains a cross-node barrier with all ranks, essentially doubling latency
+  //      is it however a valid requirement that we do not start writting to the dest buffer before
+  //      the remote is ready, which is what this barrier achieves, need to think if a better alltoall
+  //      could avoid this requirement (shmem does not require it).
   bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   int nthreads = blockDim.x * gridDim.x;
 
-  /* send to all peers via GIN */
+  /* send to all peers via GIN; the Anvil-SDMA backend segments large puts
+   * internally (<=128 MiB per SDMA copy) so a single gin.put() is safe at any
+   * size and needs no application-side chunking. */
   const size_t size = count * sizeof(T);
   for (int r=tid; r<devComm.nRanks; r+=nthreads) {
     gin.put(ncclTeamWorld(devComm), r,
@@ -280,9 +264,15 @@ __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
     gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + devComm.nRanks);
   gin.flush(ncclCoopCta());
 
-  bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
+  //TODO: this fence presumed redundant because: RDMA dest buffer visible after waitsignal; remote done writting after waitSignal; local done writting after flush, so we are already peerwise quiet with all peers, no need for a secondary barrier to enforce it.
+  //bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
 }
 
+// Hybrid LSA+GIN alltoall: CTA 0 handles remote peers via GIN,
+// CTAs 1..N handle intra-node peers via LSA.
+// GIN barrier is scoped to CTA 0 only (barrierCount=1), costing
+// O(nRanks) signals once, not O(nCTAs x nRanks).
+// LSA CTAs use their own lsaBarrier (pure intra-node, no GIN signals).
 template <typename T>
 __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclTeam world = ncclTeamWorld(devComm);
@@ -300,10 +290,15 @@ __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, nc
     uint64_t signalValue = gin.readSignal(signalIndex);
 
     ncclBarrierSession<ncclCoopCta> bar { ncclCoopCta(), ncclTeamTagWorld(), gin, 0 };
+    //TODO: this contains a cross-node barrier with all ranks, essentially doubling latency
+    //      is it however a valid requirement that we do not start writting to the dest buffer before
+    //      the remote is ready, which is what this barrier achieves, need to think if a better alltoall
+    //      could avoid this requirement (shmem does not require it).
     bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
 
     int tid = threadIdx.x;
     int nthreads = blockDim.x;
+
     for (int r = tid; r < startLsa; r += nthreads) {
       gin.put(world, r,
           recvwin, recvoffset + world.rank * size,
@@ -317,19 +312,21 @@ __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, nc
           size, ncclGin_SignalInc{signalIndex});
     }
 
-    if (numRemotePeers > 0)
+    if (numRemotePeers > 0) {
       gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + numRemotePeers);
+    }
     gin.flush(ncclCoopCta());
-    bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
+
+    //TODO: this fence presumed redundant because: RDMA dest buffer visible after waitsignal; remote done writting after waitSignal; local done writting after flush, so we are already peerwise quiet with all peers, no need for a secondary barrier to enforce it.
+    //bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
   } else {
     /* CTAs 1..N: local peers via LSA */
-    ncclLsaBarrierSession<ncclCoopCta> lsaBar {
-      ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x - 1
-    };
+    ncclLsaBarrierSession<ncclCoopCta> lsaBar { ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x - 1 };
     lsaBar.sync(ncclCoopCta(), cuda::memory_order_acquire);
 
     int tid = threadIdx.x + (blockIdx.x - 1) * blockDim.x;
     int nthreads = blockDim.x * (gridDim.x - 1);
+
     T* sendLocal = (T*)ncclGetLocalPointer(sendwin, sendoffset);
     for (size_t offset = tid; offset < count; offset += nthreads) {
       for (int lp = 0; lp < lsa.nRanks; lp++) {
@@ -338,6 +335,7 @@ __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, nc
         recvPtr[world.rank * count + offset] = sendLocal[wr * count + offset];
       }
     }
+
     lsaBar.sync(ncclCoopCta(), cuda::memory_order_release);
   }
 }
@@ -357,7 +355,9 @@ testResult_t AlltoAllRunColl(void* sendbuff, size_t sendoffset, void* recvbuff, 
       NCCLCHECK(ncclAllToAll(sptr, rptr, count, type, comm, stream));
       return testSuccess;
     }
-    // fall-through to send/recv implementation if ncclAlltoAll is not available
+    printf("RCCL 2.19 or later is needed for alltoall API path. This test was compiled with %d.%d, but is running with RCCL %d.\n",
+           NCCL_MAJOR, NCCL_MINOR, test_ncclVersion);
+    return testNcclError;
 #endif
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,7,0)
     int nRanks;
@@ -383,7 +383,7 @@ testResult_t AlltoAllRunColl(void* sendbuff, size_t sendoffset, void* recvbuff, 
         TESTCHECK(testLaunchDeviceKernel(SPECIALIZE_KERNEL(NvlAlltoAllKernelOptimized, type, op), sendbuff, sendoffset, recvbuff, recvoffset, count, type, op, root, comm, stream));
         return testSuccess;
 #endif
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7) && defined(NCCL_OS_LINUX)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7)
       case 3:
         TESTCHECK(testLaunchDeviceKernel(SPECIALIZE_KERNEL(GinAlltoAllKernel, type, op), sendbuff, sendoffset, recvbuff, recvoffset, count, type, op, root, comm, stream));
         return testSuccess;
@@ -435,13 +435,10 @@ testResult_t AlltoAllRunTest(struct threadArgs* args, int root, ncclDataType_t t
   return testSuccess;
 }
 
-NCCL_WEAK struct testEngine ncclTestEngine = {
-  /* .getBuffSize = */ AlltoAllGetBuffSize,
-  /* .runTest = */ AlltoAllRunTest,
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,14,0)
-  /* .initCommConfig = */ nullptr,
-#endif
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,0) || (defined(ENABLE_DEVICE_API) && NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0))
-  /* .getDevCommRequirements = */ AlltoAllGetDevCommRequirements
+struct testEngine ncclTestEngine = {
+  .getBuffSize = AlltoAllGetBuffSize,
+  .runTest = AlltoAllRunTest,
+#if defined(ENABLE_DEVICE_API) && NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)
+  .getDevCommRequirements = AlltoAllGetDevCommRequirements
 #endif
 };

--- a/projects/rccl-tests/test/test_AllToAll.py
+++ b/projects/rccl-tests/test/test_AllToAll.py
@@ -1,0 +1,183 @@
+#################################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+# GIN-SDMA AllToAll regression tests for the >1 GiB SDMA hang fix (PR #9927).
+#
+# These drive the real GinHybridAlltoAllKernel (deviceImpl 3, NCCL_GIN_TYPE=5)
+# at per-peer transfer sizes that cross the two single-descriptor limits the
+# 128 MiB SDMA copy clamp guards. The clamp now lives in the Anvil-SDMA backend
+# Put (ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>), which segments every
+# gin.put() into <=128 MiB SDMA copies; the kernels just call plain gin.put():
+#
+#   1. >128 MiB/peer  -- exercises the new multi-segment put loop.
+#   2. >1 GiB/peer    -- crosses the 30-bit (1 GiB) count-field boundary, where
+#                        an unclamped single put would silently truncate.
+#   3. 2 GiB total    -- the original hang repro (256 MiB/peer at 8 ranks); a
+#                        subprocess timeout turns a reintroduced hang into a
+#                        test failure instead of stalling the runner forever.
+#
+# Exact-integer datatypes are used so a truncated or stale tail cannot be masked
+# by floating-point tolerance; the perf binary's built-in data check (-c 1) sets
+# a non-zero exit code on any wrong element.
+#
+# These require an 8x MI355X (or similar) node, an MPI launcher, and a
+# GIN-SDMA-capable RCCL build, so the module is skipped unless
+# RCCL_TESTS_GIN_SDMA_A2A is set in the environment. Configuration is taken from
+# environment variables (see below) with defaults matching the 8-GPU repro:
+#   RCCL_TESTS_A2A_NP        MPI ranks (default: detected GPU count)
+#   RCCL_TESTS_MPI_LAUNCHER  launcher binary (default: mpirun)
+#   RCCL_TESTS_MPI_OPTS      extra launcher opts (e.g. --allow-run-as-root -mca ...)
+#   RCCL_TESTS_A2A_XENV      extra "-x K=V" env the backend needs on this cluster
+#                            (e.g. HSA_FORCE_FINE_GRAIN_PCIE=1 NCCL_CUMEM_ENABLE=1)
+#   RCCL_TESTS_A2A_EXE       path to alltoall_perf (default: ../build/alltoall_perf)
+#   RCCL_TESTS_A2A_TIMEOUT_S per-run hang timeout in seconds (default: 900)
+#
+# Verified on 8x MI355X (ROCm 7.13, NCCL_GIN_TYPE=5, force1ch): 256 MiB/peer and
+# 2 GiB/peer int32 and the 2 GiB-total guard all pass with #wrong=0, no hang
+# (busbw ~424-428 GB/s).
+
+import os
+import shlex
+import signal
+import subprocess
+
+import pytest
+
+MiB = 1024 * 1024
+GiB = 1024 * MiB
+
+path = os.path.dirname(os.path.abspath(__file__))
+# Path to alltoall_perf. Override with RCCL_TESTS_A2A_EXE when the binary is not
+# at the default build/ location (e.g. an installed/container path).
+executable = os.environ.get(
+    "RCCL_TESTS_A2A_EXE", os.path.join(path, "..", "build", "alltoall_perf"))
+
+# Opt-in: only run where the GIN-SDMA backend + hardware are available.
+_enabled = os.environ.get("RCCL_TESTS_GIN_SDMA_A2A", "") not in ("", "0", "false", "False")
+
+
+def _detect_ngpus():
+    if os.environ.get("ROCR_VISIBLE_DEVICES") is not None:
+        return len(os.environ["ROCR_VISIBLE_DEVICES"].split(","))
+    if os.environ.get("HIP_VISIBLE_DEVICES") is not None:
+        return len(os.environ["HIP_VISIBLE_DEVICES"].split(","))
+    try:
+        out = subprocess.check_output(
+            'rocminfo | grep "Device Type:.\\s*.GPU" | wc -l', shell=True)
+        return int(out)
+    except Exception:
+        return 0
+
+
+NP = int(os.environ.get("RCCL_TESTS_A2A_NP", "0")) or _detect_ngpus()
+LAUNCHER = os.environ.get("RCCL_TESTS_MPI_LAUNCHER", "mpirun")
+CTAS = os.environ.get("RCCL_TESTS_A2A_CTAS", "16")
+# Generous per-call timeout; a real hang spins forever, so a finite cap is what
+# converts item (3) into a detectable failure. Scaled up for the multi-GiB case.
+TIMEOUT_S = int(os.environ.get("RCCL_TESTS_A2A_TIMEOUT_S", "900"))
+
+# Extra launcher options (e.g. "--allow-run-as-root -mca pml ob1 ...") and any
+# deployment-specific env the GIN-SDMA backend needs beyond the essentials below
+# (e.g. HSA_FORCE_FINE_GRAIN_PCIE=1 NCCL_CUMEM_ENABLE=1 RCCL_ENABLE_INTRANET=1).
+# GIN enablement itself is site-specific, so it is injected here rather than
+# hard-coded, keeping the test portable across clusters.
+MPI_OPTS = shlex.split(os.environ.get("RCCL_TESTS_MPI_OPTS", ""))
+XENV = shlex.split(os.environ.get("RCCL_TESTS_A2A_XENV", ""))
+
+pytestmark = pytest.mark.skipif(
+    not _enabled,
+    reason="GIN-SDMA AllToAll tests are opt-in; set RCCL_TESTS_GIN_SDMA_A2A=1 on "
+           "a GIN-SDMA-capable (e.g. 8x MI355X) node to enable.")
+
+
+def _run_a2a(request, total_bytes, dtype):
+    """Run one all-to-all at a fixed total (per-rank) size, forcing the GIN-SDMA
+    tier. Returns (returncode, stdout). A timeout (hang) fails the test."""
+    if NP < 2:
+        pytest.skip("need >= 2 ranks/GPUs for AllToAll")
+
+    size = str(int(total_bytes))
+    # Essentials to exercise the GIN-SDMA put path; force the SDMA (large) tier
+    # for every size. Deployment-specific env comes from RCCL_TESTS_A2A_XENV.
+    gin_env = []
+    for kv in ["NCCL_GIN_ENABLE=1", "NCCL_GIN_TYPE=5",
+               "NCCL_GIN_ANVIL_SDMA_THRESHOLD=0",
+               "NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=0"] + XENV:
+        gin_env += ["-x", kv]
+
+    hostfile = request.config.getoption("--hostfile")
+    launch = [LAUNCHER, "-np", str(NP)] + MPI_OPTS
+    if hostfile:
+        launch += ["-host", hostfile]
+
+    args = launch + gin_env + [
+        executable,
+        "-b", size, "-e", size,
+        "-f", "2",
+        "-g", "1",
+        "-R", "2",
+        "-D", "3",
+        "-V", CTAS,
+        "-d", dtype,
+        "-c", "1",       # data check: nonzero exit on any wrong element
+        "-w", "1",
+        "-n", "3",
+    ]
+    cmd = " ".join(shlex.quote(a) for a in args)
+    print(cmd)
+    # Run in a new session so a hang can be killed as a whole process group --
+    # otherwise a wedged launcher leaves orphaned ranks pinning the GPUs (and
+    # exhausting SDMA queues for later tests).
+    proc = subprocess.Popen(cmd, shell=True, universal_newlines=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            start_new_session=True)
+    try:
+        out, _ = proc.communicate(timeout=TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        out, _ = proc.communicate()
+        pytest.fail(
+            "AllToAll GIN-SDMA HANG: no completion within {}s at total={} bytes "
+            "({} MiB/peer), dtype={}. Output tail:\n{}".format(
+                TIMEOUT_S, size, total_bytes // NP // MiB, dtype, (out or "")[-2000:]))
+    print(out)
+    return proc.returncode, out
+
+
+# (item 1 + 2) Multi-segment loop and the 1 GiB truncation boundary. per_peer is
+# the transfer to each peer; total per-rank bytes = per_peer * NP.
+@pytest.mark.parametrize("per_peer_mib", [256, 2048])  # 256 MiB (2 seg), 2 GiB (16 seg)
+@pytest.mark.parametrize("dtype", ["int32", "int64", "uint8"])
+def test_AllToAllGinSdmaLargeSegmented(request, per_peer_mib, dtype):
+    total = per_peer_mib * MiB * NP
+    rc, _ = _run_a2a(request, total, dtype)
+    assert rc == 0, "AllToAll data check failed (nonzero exit) at {} MiB/peer, dtype={}".format(
+        per_peer_mib, dtype)
+
+
+# (item 3) The original 2 GiB-total hang repro, as a completion guard. At 8 ranks
+# this is 256 MiB/peer -- the size that hung as a single unclamped put.
+def test_AllToAllGinSdma2GiBTotalHangGuard(request):
+    rc, _ = _run_a2a(request, 2 * GiB, "int32")
+    assert rc == 0, "AllToAll 2 GiB-total data check failed (nonzero exit)"

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -28,8 +28,6 @@ set(SRC_FILES
   mem_manager.cc
   debug.cc
   dev_runtime.cc
-  dev_runtime_segments.cc
-  dev_runtime_internal.h
   dda_all_reduce_ipc.cu
   dda_reduce_scatter_ipc.cu
   dda_all_gather_ipc.cu
@@ -63,7 +61,6 @@ set(SRC_FILES
   sym_kernels.cc
   transport.cc
   device/all_gather.h
-  device/all_gather_v.h
   device/all_reduce.h
   device/alltoall_pivot.h
   device/alltoall_gda.h
@@ -81,14 +78,10 @@ set(SRC_FILES
   device/reduce_scatter.h
   device/rccl_metadata.h
   device/sendrecv.h
-  device/hierarchical_shuffle.h
+  device/hierarchical_ag_shuffle.h
   device/ce_reduce.cc
   device/common.cu
   device/onerank.cu
-  device/tdm/cachePolicy.h
-  device/tdm/syncPolicy.h
-  device/tdm/asyncCopy.h
-  device/tdm/tdmCopy.h
   device/network/unpack/unpack_defs.h
   device/network/unpack/unpack.h
   device/symmetric/all_gather.cuh
@@ -102,6 +95,7 @@ set(SRC_FILES
   device/symmetric/primitives.cuh
   device/symmetric/reduce_scatter.cuh
   device/symmetric/reduce_scatter_gin.cuh
+  device/symmetric/tma_ptx.cuh
   graph/connect.cc
   graph/paths.cc
   graph/rings.cc
@@ -138,7 +132,6 @@ set(SRC_FILES
   include/algorithms/alltoall/alltoall_dda_fabric_ll128.h
   include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll.h
   include/algorithms/reduce_scatter/reduce_scatter_dda_fabric_ll128.h
-  include/alltoallv_meta.h
   include/alt_rsmi.h
   include/archinfo.h
   include/api_trace.h
@@ -174,7 +167,6 @@ set(SRC_FILES
   include/fabric_init.h
   include/fabric_gpu_barrier.h
   include/fabric_mem_handler.h
-  include/gdr_peermem.h
   include/gdrwrap.h
   include/git_version.h
   include/graph.h
@@ -253,6 +245,7 @@ set(SRC_FILES
   include/nccl_device/gin/rocshmem_gda/gin_rocshmem_device_host_common_gda.h
   include/nccl_device/gin/rocshmem_gda/queue_pair_device.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+  include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_copy.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_table.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_table_device.h
@@ -325,7 +318,6 @@ set(SRC_FILES
   include/plugin/nccl_tuner.h
   include/plugin/nccl_env.h
   include/plugin/env/env_v1.h
-  include/plugin/env/env_v2.h
   include/plugin/plugin.h
   include/plugin/net/net_v6.h
   include/plugin/net/net_v7.h
@@ -350,23 +342,19 @@ set(SRC_FILES
   include/plugin/tuner/tuner_v5.h
   include/plugin/tuner/tuner_v6.h
   include/plugin/nccl_gin.h
+  include/plugin/gin/gin_v11.h
+  include/plugin/gin/gin_v12.h
   include/plugin/gin/gin_v13.h
-  include/plugin/gin/gin_v14.h
-  include/plugin/nccl_rma.h
-  include/plugin/rma/rma_v13.h
-  include/plugin/rma/rma_v14.h
   misc/alt_rsmi.cc
   misc/archinfo.cc
   misc/argcheck.cc
   misc/api_trace.c
   misc/api_trace.cc
 # misc/cudawrap.cc
-  misc/gdr_peermem.cc
 # misc/gdrwrap.cc
   misc/ibvsymbols.cc
   misc/ibvwrap.cc
   os/linux_ipcsocket.cc
-  os/linux_socket_pair.cc
   misc/mlx5dvsymbols.cc
   misc/mlx5dvwrap.cc
   misc/ionicdvsymbols.cc
@@ -390,7 +378,6 @@ set(SRC_FILES
   nccl_device/lsa_barrier.cc
   os/linux.cc
   include/os.h
-  include/os_socket_pair.h
   include/os/linux.h
   include/os/windows.h
   param/c_api.cc
@@ -411,7 +398,6 @@ set(SRC_FILES
   rma/rma_proxy.cc
   rma/rma_proxy_launch.cc
   rma/rma_proxy_progress.cc
-  include/rma.h
   include/rma/rma.h
   include/rma/rma_ce.h
   include/rma/rma_proxy.h
@@ -419,8 +405,6 @@ set(SRC_FILES
   plugin/net.cc
   plugin/env.cc
   plugin/env/env_v1.cc
-  plugin/env/env_v2.cc
-  plugin/env/default_env.cc
   plugin/plugin_open.cc
   plugin/profiler.cc
   plugin/tuner.cc
@@ -444,11 +428,9 @@ set(SRC_FILES
   plugin/tuner/tuner_v6.cc
   plugin/tuner/csv_tuner.cc
   plugin/gin.cc
+  plugin/gin/gin_v11.cc
+  plugin/gin/gin_v12.cc
   plugin/gin/gin_v13.cc
-  plugin/gin/gin_v14.cc
-  plugin/rma.cc
-  plugin/rma/rma_v13.cc
-  plugin/rma/rma_v14.cc
   ras/client.cc
   ras/client_support.cc
   ras/collectives.cc
@@ -473,7 +455,6 @@ set(SRC_FILES
   transport/net_ib/gin.cc
   transport/net_ib/gin.h
   transport/net_ib/init.cc
-  transport/net_ib/net_ib_flush_fault_inject.h
   transport/net_ib/p2p.cc
   transport/net_ib/p2p.h
   transport/net_ib/p2p_resiliency.cc
@@ -491,8 +472,6 @@ set(SRC_FILES
   transport/shm.cc
   gin/gin_host.cc
   gin/gin_host_proxy.cc
-  gin/proxy_gpucontext/gpucontext.h
-  gin/proxy_gpucontext/gpucontext_v1.h
   include/latency_profiler/CollTrace.h
   include/latency_profiler/CollTraceEvent.h
   include/latency_profiler/CollTraceFunc.h
@@ -515,6 +494,7 @@ if(ENABLE_ROCSHMEM_GIN)
     src/gin/gin_rocshmem_gda_factory.cc
     src/gin/gin_plugin_anvil_sdma.cc
     src/gin/gin_anvil_ipc_table_host.cc
+    src/gin/gin_anvil_sdma_oss7_device.cc
   )
 endif()
 
@@ -669,52 +649,6 @@ foreach(_hdr common gin p2p)
 endforeach()
 add_custom_target(net_ib_header_symlinks DEPENDS ${NET_IB_HEADER_SYMLINKS})
 
-# The top-level include/rma.h and include/rma/rma.h share the basename "rma.h",
-# so add_file_unique() renames the second-listed one (include/rma/rma.h) to
-# include/rma/rma_tmp.h. comm.h (included nearly everywhere, host + device) does
-# #include "rma/rma.h", so symlink it back to the _tmp output, same as net_ib.
-set(RMA_HIPIFY_DIR "${HIPIFY_DIR}/src/include/rma")
-add_custom_command(
-  OUTPUT  "${RMA_HIPIFY_DIR}/rma.h"
-  DEPENDS "${RMA_HIPIFY_DIR}/rma_tmp.h"
-  COMMAND ${CMAKE_COMMAND} -E create_symlink
-          "rma_tmp.h" "${RMA_HIPIFY_DIR}/rma.h"
-  COMMENT "Symlinking rma/rma_tmp.h -> rma/rma.h"
-)
-add_custom_target(rma_header_symlinks DEPENDS "${RMA_HIPIFY_DIR}/rma.h")
-
-# hipify_all is the contract for "the staged tree is ready to compile against",
-# including for consumers that build it as a standalone prerequisite
-# (test/host/run_host_tests.sh). The symlinks above are part of that tree: the
-# hipified sources still #include the un-suffixed names, so staging without them
-# yields a tree that cannot compile.
-add_dependencies(hipify_all net_ib_header_symlinks rma_header_symlinks)
-
-# nccl_device/{core,comm,gin}.h share basenames with the top-level src/include/
-# {core,comm,gin}.h, so add_file_unique() renames the nccl_device copies to
-# *_tmp.h in the hipify tree. Hipified sources have their #includes rewritten to
-# the _tmp names, but the IR bitcode wrapper (bindings/ir/nccl_device_wrapper.h)
-# is staged verbatim (not hipified) and includes "nccl_device/core.h" directly.
-# Symlink the un-suffixed names back to the _tmp outputs, same as net_ib/ and
-# rma/ above, so the EMIT_LLVM_IR build can resolve them.
-set(NCCL_DEVICE_HIPIFY_DIR "${HIPIFY_DIR}/src/include/nccl_device")
-set(NCCL_DEVICE_HEADER_SYMLINKS "")
-foreach(_hdr core comm gin)
-  add_custom_command(
-    OUTPUT  "${NCCL_DEVICE_HIPIFY_DIR}/${_hdr}.h"
-    DEPENDS "${NCCL_DEVICE_HIPIFY_DIR}/${_hdr}_tmp.h"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-            "${_hdr}_tmp.h" "${NCCL_DEVICE_HIPIFY_DIR}/${_hdr}.h"
-    COMMENT "Symlinking nccl_device/${_hdr}_tmp.h -> ${_hdr}.h"
-  )
-  list(APPEND NCCL_DEVICE_HEADER_SYMLINKS "${NCCL_DEVICE_HIPIFY_DIR}/${_hdr}.h")
-endforeach()
-add_custom_target(nccl_device_header_symlinks DEPENDS ${NCCL_DEVICE_HEADER_SYMLINKS})
-
-# Create the symlinks before the nccl_device headers are copied into
-# ${PROJECT_BINARY_DIR}/include (consumed by the IR bitcode build).
-add_dependencies(copy_nccl_device_headers nccl_device_header_symlinks)
-
 
 # Generate device/host tables and all the collective functions that are going to be in librccl.so
 #==================================================================================================
@@ -725,7 +659,6 @@ endif()
 
 set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 set(GEN_SYM_DIR "${GEN_DIR}/symmetric")
-set(GEN_CE_REDUCE_DIR "${GEN_DIR}/ce_reduce")
 
 if(ONLY_FUNCS)
   message(WARNING "Using ONLY_FUNCS = ${ONLY_FUNCS}. Not meant for release builds.")
@@ -755,20 +688,6 @@ if (GENERATE_SYM_KERNELS)
     message(SEND_ERROR "Error: ${gen_sym_py_error}")
     message(FATAL_ERROR "${RCCL_SOURCE_DIR}/src/device/symmetric/generate.py failed")
   endif()
-endif()
-
-# Execute the python script to generate one TU per CE-reduce kernel
-# instantiation (see src/device/ce_reduce/generate.py for why this is split
-# out instead of living in a single ce_reduce.cc).
-execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${RCCL_SOURCE_DIR}/src/device/ce_reduce/generate.py ${GEN_CE_REDUCE_DIR}
-    WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
-    RESULT_VARIABLE gen_ce_reduce_py_result
-    ERROR_VARIABLE gen_ce_reduce_py_error
-)
-if (gen_ce_reduce_py_result)
-  message(SEND_ERROR "Error: ${gen_ce_reduce_py_error}")
-  message(FATAL_ERROR "${RCCL_SOURCE_DIR}/src/device/ce_reduce/generate.py failed")
 endif()
 
 # Find the generated files in the output directory
@@ -814,12 +733,12 @@ if(ENABLE_DEVICE_LINKER)
   list(FILTER HIP_SOURCES EXCLUDE REGEX "dda_alltoall_fabric_ll128\\.cu\\.cpp$")
   list(FILTER HIP_SOURCES EXCLUDE REGEX "dda_reduce_scatter_fabric_ll\\.cu\\.cpp$")
   list(FILTER HIP_SOURCES EXCLUDE REGEX "dda_reduce_scatter_fabric_ll128\\.cu\\.cpp$")
-  # ce_reduce.cc is now pure host code (a dispatcher calling into the
-  # per-instantiation launchers generated under gensrc/ce_reduce/, which are
-  # excluded above by the "gensrc/.*\\.cpp$" filter and compiled separately
-  # by cmake/DeviceLinker.cmake). It stays in the main target and is
-  # compiled --offload-host-only like ce_coll.cc.
-  message(STATUS "Device Linker: filtered HIP_SOURCES (removed device .cpp under gensrc/ + subdirs, common.cu, onerank.cu, collectives.cc, dda_all_reduce_ipc.cu.cpp, dda_reduce_scatter_ipc.cu.cpp, dda_all_gather_ipc.cu.cpp, dda_alltoall_ipc.cu.cpp, dda_all_reduce_fabric.cu.cpp, dda_all_reduce_fabric_ll.cu.cpp, dda_reduce_scatter_fabric.cu.cpp, dda_all_gather_fabric.cu.cpp, dda_all_gather_fabric_ll.cu.cpp, dda_alltoall_fabric.cu.cpp)")
+  # ce_reduce.cc contains the CE AllReduce __global__ kernel and its launcher;
+  # it is compiled with full HIP by the device linker step (ce_reduce.o) so the
+  # fat binary is properly embedded. ce_coll.cc (no __global__ call sites)
+  # stays in the main target and is compiled --offload-host-only as usual.
+  list(FILTER HIP_SOURCES EXCLUDE REGEX "device/ce_reduce\\.cc$")
+  message(STATUS "Device Linker: filtered HIP_SOURCES (removed device .cpp under gensrc/ + subdirs, common.cu, onerank.cu, collectives.cc, device/ce_reduce.cc, dda_all_reduce_ipc.cu.cpp, dda_reduce_scatter_ipc.cu.cpp, dda_all_gather_ipc.cu.cpp, dda_alltoall_ipc.cu.cpp, dda_all_reduce_fabric.cu.cpp, dda_all_reduce_fabric_ll.cu.cpp, dda_reduce_scatter_fabric.cu.cpp, dda_all_gather_fabric.cu.cpp, dda_all_gather_fabric_ll.cu.cpp, dda_alltoall_fabric.cu.cpp)")
 endif()
 
 # Create an initial git_version.cpp file (that will be updated with latest git version)
@@ -845,7 +764,7 @@ add_library(rccl ${HIP_SOURCES})
 
 ## Set RCCL dependencies
 ## Ensure git version is updated before building rccl
-add_dependencies(rccl update_git_version copy_nccl_device_headers net_ib_header_symlinks rma_header_symlinks)
+add_dependencies(rccl update_git_version copy_nccl_device_headers net_ib_header_symlinks)
 
 ## Set RCCL include directories
 target_include_directories(rccl PRIVATE ${PROJECT_BINARY_DIR}/include)        # for generated rccl.h header
@@ -913,14 +832,10 @@ else()
   message(STATUS "HIP_VMM_UNCACHED_MEMORY disabled")
 endif()
 
-# ==== rocSHMEM integration (optional, mutually exclusive) ====
-# ENABLE_ROCSHMEM: alltoall_wg offload.  Links librocshmem.a into librccl.so
-#   via -fgpu-rdc --hip-link.  Does not enable GIN plugins.
-# ENABLE_ROCSHMEM_GIN: GIN plugins (GDA, SDMA).  Device symbols (QueuePair)
-#   resolved via per-arch bitcode in the device linker pipeline +
-#   -mlink-builtin-bitcode for symmetric kernels.  Host symbols left unresolved
-#   (--allow-shlib-undefined), resolved at runtime from the executable.
-#   Does not enable alltoall_wg offload.
+# ==== rocSHMEM integration (optional) ====
+# ENABLE_ROCSHMEM: full rocshmem (device + host), links librocshmem.a into librccl.so
+# ENABLE_ROCSHMEM_GIN: GIN host code only (no device deps), rocshmem host symbols
+#   resolved at runtime from the executable that links librocshmem.a
 if (ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN)
   add_rocshmem_targets()
   # Ensure rocSHMEM is fully built/installed before compiling rccl
@@ -938,11 +853,13 @@ if (ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN)
     if (ROCSHMEM_BUILD_DIR)
       target_include_directories(rccl PRIVATE ${ROCSHMEM_BUILD_DIR})
     else()
-      target_include_directories(rccl PRIVATE ${ROCSHMEM_SOURCE_DIR}/build/include ${ROCSHMEM_SOURCE_DIR}/build/include/rocshmem)
+      target_include_directories(rccl PRIVATE ${ROCSHMEM_SOURCE_DIR}/build/include/rocshmem)
     endif()
   endif()
 endif()
 if (ENABLE_ROCSHMEM)
+  # Moved to where rocSHMEM target_links
+  ## target_link_libraries(rccl PRIVATE ${ROCSHMEM_LIBRARY})
   target_link_libraries(rccl PRIVATE ${IBVERBS})
 endif()
 
@@ -1180,6 +1097,7 @@ if(RCCL_ROCPROFILER_REGISTER)
   target_link_libraries(
       rccl PRIVATE rocprofiler-register::rocprofiler-register)
 endif()
+
 # Device Linker: include pipeline and wire up dependencies
 # (placed after all target_compile_definitions so DeviceLinker.cmake
 #  can read the rccl target's definitions directly)
@@ -1187,9 +1105,6 @@ endif()
 if(ENABLE_DEVICE_LINKER)
   include(${PROJECT_SOURCE_DIR}/cmake/DeviceLinker.cmake)
   add_dependencies(rccl device_linker_build)
-  # device_linker_build compiles DDA sources that pull in comm.h -> rma/rma.h,
-  # so it needs the rma_tmp.h symlink in place before it runs.
-  add_dependencies(device_linker_build rma_header_symlinks)
   target_link_libraries(rccl PRIVATE ${DEVICE_LINKER_OBJECTS})
 endif()
 
@@ -1260,10 +1175,10 @@ if(ENABLE_ROCSHMEM)
   list(REMOVE_DUPLICATES _rocshmem_offload_arch_flags)
   target_link_options(rccl PRIVATE -fgpu-rdc --hip-link ${_rocshmem_offload_arch_flags})
 elseif(ENABLE_ROCSHMEM_GIN)
-  # GIN device templates (Put/Flush/etc.) reference rocshmem device symbols.
-  # With the device linker (default), per-arch .bc files are injected directly
-  # into the per-arch device link step via DeviceLinker.cmake.
-  # Host symbols from GIN plugins are left unresolved via --allow-shlib-undefined.
+  # GIN-only: rocshmem device symbols (QueuePair methods for GDA backend)
+  # are left unresolved in librccl.so and resolved from the executable
+  # that links librocshmem.a. This avoids duplicating rocshmem device state
+  # (__constant__ memory) across librccl.so and the executable.
   target_link_options(rccl PRIVATE "LINKER:--allow-shlib-undefined")
 endif()
 

--- a/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
+++ b/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
@@ -7,7 +7,7 @@
 #ifdef ENABLE_ROCSHMEM_GIN
 
 /**
- * GIN plugin: SDMA Anvil device path (NCCL_GIN_TYPE=6).
+ * GIN plugin: SDMA Anvil device path (NCCL_GIN_TYPE=5).
  * Small messages use inlined IPC flat stores via GIN-owned device-memory peer table in GPU context.
  * Large messages use standalone Anvil SDMA (gin_anvil_sdma_factory).
  */
@@ -68,6 +68,7 @@ struct GinAnvilPendingEntry {
 };
 
 static std::map<struct ncclComm*, GinAnvilPendingEntry*> g_pendingByComm;
+static std::map<struct ncclComm*, int> g_nextSignalSlot;
 
 static void ginAnvilPendingAdd(struct ncclComm* comm, ginAnvilGinCtx* ctx) {
   std::lock_guard<std::mutex> lock(pluginMutex);
@@ -96,6 +97,7 @@ static void ginAnvilPendingClear(struct ncclComm* comm) {
     e = next;
   }
   g_pendingByComm.erase(comm);
+  g_nextSignalSlot.erase(comm);
 }
 
 struct ginAnvilMemHandle {
@@ -128,6 +130,7 @@ void ncclGinAnvilPluginTestResetHostState(void) {
       e = next;
     }
     g_pendingByComm.erase(comm);
+    g_nextSignalSlot.erase(comm);
   }
   bufferRegRefcount.clear();
 }
@@ -143,16 +146,6 @@ static ncclResult_t ginAnvilInit(void** ctx, uint64_t commId, ncclDebugLogger_t 
 
 static ncclResult_t ginAnvilDevices(int* ndev) {
   *ndev = 1;
-  return ncclSuccess;
-}
-
-// v14 GIN plugins expose GIN capability flags via getGinProperties. The Anvil
-// SDMA backend uses intra-node LSA (flat) signals, which behave as both strong
-// and VA-addressable signals; report both as supported (matches the behavior
-// previously injected by the v13->v14 shim for internal plugins).
-static ncclResult_t ginAnvilGetGinProperties(ncclGinProperties_t* ginProps) {
-  ginProps->supportsStrongSignals = true;
-  ginProps->supportsVASignals = true;
   return ncclSuccess;
 }
 
@@ -190,9 +183,16 @@ static int ginAnvilSdmaThresholdFromEnv() {
   return ginAnvilEnvInt("NCCL_GIN_ANVIL_SDMA_THRESHOLD", (int)NCCL_GIN_ANVIL_SDMA_THRESHOLD_DEFAULT);
 }
 
-static int ginAnvilSdmaNumChannelsFromEnv() {
-  int v = ginAnvilEnvInt("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", 1);
-  return v >= 1 && v <= 8 ? v : 1;
+static int ginAnvilSdmaNumChannels() {
+  // Forced to a single SDMA channel. Multi-channel (>=4 channels) at
+  // >=256 MiB/peer aborts with a fail-loud "unhandled system error" on
+  // 8x MI355X, and the collective GIN-put paths issue their puts from a single
+  // warp anyway (channel 0), so additional channels provide no benefit. The
+  // multi-channel machinery (per-(peer,channel) queue handles, effectiveChannel,
+  // dirty tracking, Flush) is retained and simply operates with numChannels==1,
+  // so nothing downstream changes. The former NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS
+  // tunable is intentionally no longer honored.
+  return 1;
 }
 
 static uint32_t ginAnvilFusedSignalFromEnv() {
@@ -230,7 +230,7 @@ static ncclResult_t ginAnvilConnect(void* ctx, void* handles[], int nranks, int 
     return ncclSystemError;
   }
 
-  int numCh = ginAnvilSdmaNumChannelsFromEnv();
+  int numCh = ginAnvilSdmaNumChannels();
 
   gin_anvil_sdma_handle_t h = nullptr;
   void* gpu_handles = nullptr;
@@ -461,12 +461,10 @@ ncclResult_t ncclGinAnvilBindResourceWindowSignals(struct ncclComm* comm, void* 
   if (!comm || !resourceUserPtr || nContexts < 1 || nSignalsPerContext < 1) return ncclInvalidArgument;
 
   ncclResult_t ret = ncclSuccess;
-  int slot = 0;
   for (GinAnvilPendingEntry* e = g_pendingByComm[comm]; e != nullptr; e = e->next) {
     ginAnvilGinCtx* ctx = e->ctx;
     if (ctx->nSignals <= 0) continue;
-    ctx->signalSlot = slot++;
-    if (ctx->signalSlot >= nContexts) {
+    if (ctx->signalSlot < 0 || ctx->signalSlot >= nContexts) {
       WARN("GIN anvil-sdma: signal slot %d out of range (nContexts=%d)", ctx->signalSlot, nContexts);
       ginAnvilPendingClear(comm);
       return ncclInvalidArgument;
@@ -491,7 +489,7 @@ fail:
   return ret;
 }
 
-static ncclResult_t ginAnvilCreateContext(void* collComm, ncclGinConfig_t* config, void** outGinCtx,
+static ncclResult_t ginAnvilCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** outGinCtx,
                                           ncclNetDeviceHandle_v11_t** outDevHandle) {
   ginAnvilCollCtx* cctx = (ginAnvilCollCtx*)collComm;
   ncclResult_t ret = ncclSuccess;
@@ -501,7 +499,10 @@ static ncclResult_t ginAnvilCreateContext(void* collComm, ncclGinConfig_t* confi
   ctx->nSignals = config->nSignals;
   ctx->nCounters = config->nCounters;
   ctx->comm = cctx->comm;
-  ctx->signalSlot = -1;  // assigned during ncclGinAnvilBindResourceWindowSignals
+  {
+    std::lock_guard<std::mutex> lock(pluginMutex);
+    ctx->signalSlot = g_nextSignalSlot[cctx->comm]++;
+  }
   ctx->hasError = false;
   ctx->signalsBound = false;
   ctx->gpu_queue_handles = cctx->gpu_queue_handles;
@@ -628,7 +629,6 @@ __attribute__((visibility("default"))) ncclGin_t ncclGinAnvilSdmaPlugin = {
   .name = "gin-anvil-sdma",
   .init = ginAnvilInit,
   .devices = ginAnvilDevices,
-  .getGinProperties = ginAnvilGetGinProperties,
   .getProperties = ginAnvilGetProperties,
   .listen = ginAnvilListen,
   .connect = ginAnvilConnect,
@@ -639,6 +639,11 @@ __attribute__((visibility("default"))) ncclGin_t ncclGinAnvilSdmaPlugin = {
   .destroyContext = ginAnvilDestroyContext,
   .closeColl = ginAnvilCloseColl,
   .closeListen = ginAnvilCloseListen,
+  .iput = NULL,
+  .iputSignal = NULL,
+  .iget = NULL,
+  .iflush = NULL,
+  .test = NULL,
   .ginProgress = ginAnvilGinProgress,
   .queryLastError = ginAnvilQueryLastError,
   .finalize = ginAnvilFinalize,

--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
@@ -10,6 +10,7 @@
 #include "../gin_device_common.h"
 #include "../../hip_compat.h"
 #include "gin_anvil_sdma_device_host_common.h"
+#include "gin_anvil_sdma_put_policy.h"
 #include "gin_anvil_ipc_copy.h"
 #include "gin_anvil_ipc_table_device.h"
 #include "sdma/anvil_device.hpp"
@@ -28,6 +29,14 @@ NCCL_DEVICE_INLINE bool anvilCtxValid(ncclGinAnvilSdmaGPUContext* rsCtx) {
   return rsCtx != nullptr && loadConst(&rsCtx->layoutMagic) == NCCL_GIN_ANVIL_SDMA_LAYOUT_MAGIC;
 }
 
+__device__ uint64_t anvilGinDummySignal;
+
+NCCL_DEVICE_INLINE uint64_t* anvilSignalPtrOrDummy(ncclGinAnvilSdmaGPUContext* rsCtx, ncclGinSignal_t signalId) {
+  if (!anvilCtxValid(rsCtx)) return &anvilGinDummySignal;
+  uint64_t* signals = loadConst(&rsCtx->signals);
+  if (signals == nullptr) return &anvilGinDummySignal;
+  return signals + signalId;
+}
 
 NCCL_DEVICE_INLINE void* resolveRemotePeerVa(ncclGinAnvilSdmaGPUContext* rsCtx, ncclGinAnvilSdmaMemHandle* mh, int peer,
                                              size_t off) {
@@ -225,10 +234,25 @@ struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
             if (remoteSig != nullptr) sdmaFusedSignal = true;
           }
           __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
-          if (sdmaFusedSignal) {
-            ::sdma_anvil::putSignal(*handle, dstAddr, srcAddr, bytes, remoteSig);
-          } else {
-            ::sdma_anvil::put(*handle, dstAddr, srcAddr, bytes);
+          // The SDMA linear-copy count field is 30 bits (max 1 GiB), and a single
+          // fused copy+signal >=256 MiB stalls the engine on MI355X, so split any
+          // large put into <= kGinPutSegBytes (128 MiB) segments. The backend runs
+          // a single in-order SDMA queue per peer (numChannels forced to 1), so the
+          // fused signal on the FINAL segment (or the explicit SignalInc emitted
+          // below when the copy is not fused) still means the whole message landed.
+          // See gin_anvil_sdma_put_policy.h. A <=128 MiB put is one segment, so the
+          // common path is unchanged.
+          const size_t segMax = gin_sdma::kGinPutSegBytes;
+          const size_t nSeg = gin_sdma::ginPutSegmentCount(bytes, segMax);
+          for (size_t si = 0; si < nSeg; ++si) {
+            const gin_sdma::PutSegment seg = gin_sdma::ginPutSegmentAt(bytes, segMax, si);
+            void* segDst = static_cast<void*>(static_cast<char*>(dstAddr) + seg.offset);
+            void* segSrc = static_cast<void*>(static_cast<char*>(srcAddr) + seg.offset);
+            if (seg.isFinal && sdmaFusedSignal) {
+              ::sdma_anvil::putSignal(*handle, segDst, segSrc, seg.bytes, remoteSig);
+            } else {
+              ::sdma_anvil::put(*handle, segDst, segSrc, seg.bytes);
+            }
           }
           markSdmaDirty(rsCtx, peer, loadConst(&rsCtx->numChannels), effectiveChannel(rsCtx, blockId));
         }
@@ -335,10 +359,10 @@ struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 
 template <>
 struct ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
+  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
     ncclGinAnvilSdmaGPUContext* rsCtx = (ncclGinAnvilSdmaGPUContext*)ctx.handle;
-    if (!nccl::gin::anvil::detail::anvilCtxValid(rsCtx)) return {nullptr, 0};
-    return {nccl::utility::loadConst(&rsCtx->counters) + counterId, 0};
+    if (!nccl::gin::anvil::detail::anvilCtxValid(rsCtx)) return nullptr;
+    return nccl::utility::loadConst(&rsCtx->counters) + counterId;
   }
 };
 
@@ -354,14 +378,9 @@ struct ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 
 template <>
 struct ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
-    using nccl::gin::anvil::detail::anvilCtxValid;
-    using nccl::utility::loadConst;
+  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
     ncclGinAnvilSdmaGPUContext* rsCtx = (ncclGinAnvilSdmaGPUContext*)ctx.handle;
-    assert(anvilCtxValid(rsCtx));
-    uint64_t* signals = loadConst(&rsCtx->signals);
-    assert(signals != nullptr);
-    return {signals + signalId, 0};
+    return nccl::gin::anvil::detail::anvilSignalPtrOrDummy(rsCtx, signalId);
   }
 };
 
@@ -380,10 +399,7 @@ struct ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 template <>
 struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor, cuda::memory_order ord, uint32_t* abortFlag) {
-    (void)hasDescriptor;
-    (void)descriptor;
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, cuda::memory_order ord, uint32_t* abortFlag) {
     (void)ord;
     (void)abortFlag;
     using nccl::utility::loadConst;
@@ -419,32 +435,6 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
       coop.sync();
     }
     __threadfence_system();
-  }
-};
-
-template <>
-struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t,
-                                      ncclGinWindow_t, size_t, size_t, bool,
-                                      ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
-    __builtin_trap();
-  }
-};
-
-template <>
-struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool,
-                                      ncclGinDescriptorSmem*, uint32_t) {
-    __builtin_trap();
-  }
-};
-
-template <>
-struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool,
-                                      ncclGinDescriptorSmem*, cuda::memory_order, uint32_t*) {
-    __builtin_trap();
   }
 };
 

--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
@@ -1,0 +1,108 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Put-size limits and segment math for the GIN Anvil-SDMA device backend.
+// The single source of truth for the two per-put byte caps that
+// ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> segments every SDMA copy
+// against, plus the pure segmentation arithmetic itself. Kept as a standalone,
+// dependency-free header (no ncclDevComm, no GPU intrinsics, no getenv) so the
+// same code is (a) called from the SDMA backend Put on device and (b) unit-tested
+// on the host with GoogleTest (define GIN_SDMA_HOST_ONLY to drop the device
+// attributes and compile it as plain host C++; see
+// projects/rccl/test/gin/gin_sdma_policy_test.cpp).
+
+#ifndef _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_
+#define _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_
+
+#include <cstddef>
+
+// The device backend gets __host__ __device__; plain host builds (and the host
+// unit test, which defines GIN_SDMA_HOST_ONLY) get no attribute so the header
+// compiles as ordinary C++ with no device codegen.
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && !defined(GIN_SDMA_HOST_ONLY)
+#define GIN_SDMA_HD __host__ __device__
+#else
+#define GIN_SDMA_HD
+#endif
+
+namespace gin_sdma {
+
+// Max bytes per single SDMA copy on the Anvil-SDMA backend. The SDMA linear-copy
+// descriptor count field is 30 bits and 1-based (HW encodes count = bytes - 1,
+// see rocr-runtime amd_blit_sdma.cpp / sdma_registers.h), so the largest single
+// packet is (2^30 - 1) + 1 = 2^30 = exactly 1 GiB. A put of >1 GiB silently
+// truncates: a 2 GiB put encodes count = (2^31-1) & 0x3FFFFFFF = 2^30-1 and the
+// HW copies only 1 GiB, corrupting the transfer. Every SDMA copy must be split
+// into segments of at most this size.
+//
+// Set to exactly 1 GiB: this is the hardware maximum, so the segmentation clamp
+// (seg <= kGinPutMaxBytes) guarantees count = seg-1 <= 2^30-1 = 0x3FFFFFFF, which
+// fills the 30-bit field exactly with no truncation. Zero margin by design; do
+// NOT raise above 2^30. 1 GiB is a multiple of 32 B, satisfying the copy
+// descriptor's 32 B length alignment.
+static constexpr size_t kGinPutMaxBytes = 1024ull * 1024 * 1024;  // 1 GiB (2^30, HW max)
+
+// Max bytes per single SDMA copy that the Anvil-SDMA backend copies *reliably*
+// on MI355X + ROCm 7.13 (NCCL_GIN_TYPE=5). This is SMALLER than kGinPutMaxBytes:
+// the 30-bit count field bounds correctness at 1 GiB, but a single copy
+// descriptor at/above 256 MiB (2^28) on the fused COPY_LINEAR_WAIT_SIGNAL_MI4
+// path stalls the SDMA engine, so the fused copy never lands AND its SignalInc
+// never fires -> every rank spins forever in waitSignal (a HANG, not a data
+// miscompare). Measured on 8x MI355X (2026-08-07, alltoall_perf -D 3): a single
+// 256 MiB/peer put (AllToAll @ 2 GiB total) HANGS; capping each copy to 128 MiB
+// (2 copies/peer) completes with identical bandwidth (busbw ~423 GB/s, unchanged
+// vs the 1 GiB total case). 128 MiB is proven safe with zero measured perf loss;
+// do not raise without re-measuring. The backend Put segments every SDMA copy to
+// this size, so it protects ALL callers of gin.put() on the Anvil-SDMA backend.
+static constexpr size_t kGinSdmaSafeCopyBytes = 128ull * 1024 * 1024;  // 128 MiB (reliable single-copy max)
+
+// The single per-copy segmentation limit the backend Put clamps to: the smaller
+// of the two constants above (correctness bound AND reliability bound). Compile-
+// time constant so the device loop and the host unit test share one value.
+static constexpr size_t kGinPutSegBytes =
+    kGinSdmaSafeCopyBytes < kGinPutMaxBytes ? kGinSdmaSafeCopyBytes : kGinPutMaxBytes;
+
+// ------------------------------ segment math ------------------------------
+//
+// Pure arithmetic for splitting one peer transfer into <=kGinPutSegBytes copies.
+// The Anvil-SDMA backend Put drives its ::sdma_anvil::put() loop entirely from
+// these two functions, so the same code that runs on device is what the host
+// unit test exercises. Every SDMA copy must satisfy: no segment exceeds the cap,
+// the segments tile [0,bytes) contiguously and sum back to bytes, and exactly
+// one segment is flagged final (it alone carries the caller's SignalInc).
+
+// One SDMA-copy segment of a chunked transfer.
+struct PutSegment {
+  size_t offset;   // byte offset of this segment within the transfer
+  size_t bytes;    // segment length in bytes (always <= maxSeg)
+  bool   isFinal;  // last segment: carries the caller's remote action (signal)
+};
+
+// Number of copy segments a `bytes`-length transfer splits into when each copy
+// is capped at `maxSeg`. A zero-length transfer still issues exactly one (empty)
+// copy so its trailing signal fires; otherwise it is ceil(bytes/maxSeg).
+// maxSeg == 0 is a caller error and yields 0 (callers pass a nonzero cap).
+GIN_SDMA_HD inline size_t ginPutSegmentCount(size_t bytes, size_t maxSeg) {
+  if (maxSeg == 0) return 0;
+  if (bytes == 0) return 1;
+  return (bytes + maxSeg - 1) / maxSeg;
+}
+
+// The i-th (0-based, i < ginPutSegmentCount) segment of a `bytes`-length transfer
+// capped at `maxSeg`. Segments tile [0,bytes) contiguously; the last one is
+// flagged isFinal so the backend carries the remote action on it alone.
+GIN_SDMA_HD inline PutSegment ginPutSegmentAt(size_t bytes, size_t maxSeg, size_t i) {
+  PutSegment s{0, 0, false};
+  s.offset = i * maxSeg;
+  const size_t rem = bytes - s.offset;
+  s.bytes = rem > maxSeg ? maxSeg : rem;
+  s.isFinal = (s.offset + s.bytes >= bytes);
+  return s;
+}
+
+}  // namespace gin_sdma
+
+#endif  // _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -8,7 +8,7 @@ if(BUILD_TESTS)
   option(OPENMP_TESTS_ENABLED "Enable OpenMP for unit tests" OFF)
   option(ENABLE_MPI_TESTS "Enable MPI-based tests" OFF)
   #Automatically enabled when MPI-based tests available
-  option(RCCL_HAS_RMA_IB_PROXY "Build the IB Proxy RMA transport-level tests" ON)
+  option(RCCL_HAS_GIN_IB_PROXY "Build the IB Proxy GIN transport-level tests" ON)
   option(ENABLE_HOST_API_TESTS "Build the host-API tests" ON)
 
 
@@ -25,22 +25,6 @@ if(BUILD_TESTS)
     COMMAND "${Python3_EXECUTABLE}"
             "${PROJECT_SOURCE_DIR}/src/device/test_generate_device_table.py"
   )
-
-  # CPU-only generator unit test: guards src/device/ce_reduce/generate.py's
-  # per-instantiation TU splitting (ce_reduce_impl.h.in / ce_reduce_launcher.cpp.in
-  # template expansion). Needs no GPU and no built library.
-  add_test(
-    NAME rccl-generate-ce-reduce
-    COMMAND "${Python3_EXECUTABLE}"
-            "${PROJECT_SOURCE_DIR}/src/device/ce_reduce/test_generate_ce_reduce.py"
-  )
-
-  # The kernel-count leak guards (src/device/test_generate_kernel_counts.py and
-  # src/device/symmetric/test_generate_symmetric.py) are intentionally NOT
-  # registered as ctest cases here: nothing in RCCL CI runs `ctest`, so an
-  # add_test() would never gate. They run in CI via the CPU-only host-test
-  # pipeline instead -- see test/host/run_host_tests.sh (the `guards` phase,
-  # folded into `run`).
 
   if (ENABLE_CODE_COVERAGE)
     add_compile_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
@@ -126,7 +110,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h, net_ib/net_ib_flush_fault_inject.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
   )
@@ -146,8 +130,8 @@ if(BUILD_TESTS)
   endif()
   if(ENABLE_MPI_TESTS)
     list(APPEND RCCL_COMMON_COMPILE_DEFS MPI_TESTS_ENABLED)
-    if(RCCL_HAS_RMA_IB_PROXY)
-      list(APPEND RCCL_COMMON_COMPILE_DEFS RCCL_HAS_RMA_IB_PROXY)
+    if(RCCL_HAS_GIN_IB_PROXY)
+      list(APPEND RCCL_COMMON_COMPILE_DEFS RCCL_HAS_GIN_IB_PROXY)
     endif()
     if(ENABLE_HOST_API_TESTS)
       list(APPEND RCCL_COMMON_COMPILE_DEFS RCCL_ENABLE_HOST_API_TESTS)
@@ -164,19 +148,6 @@ if(BUILD_TESTS)
   set(RCCL_COMMON_LINK_LIBS
     ${GTEST_BOTH_LIBRARIES}
     hip::host hip::device hsa-runtime64::hsa-runtime64
-    Threads::Threads
-    dl
-    fmt::fmt-header-only
-  )
-
-  # Link libs for the host-only micro-test binary (test/host). Deliberately no
-  # HIP runtime on the link line, so any un-shimmed HIP API call surfaces as an
-  # undefined-symbol link error instead of silently binding to libamdhip64.so.
-  # HIP's *compile* requirements (device intrinsics, gfx codegen, headers) are
-  # applied in test/host/CMakeLists.txt via $<TARGET_PROPERTY:hip::*,...> (a
-  # CMake 3.16-safe stand-in for $<COMPILE_ONLY:hip::*>, which needs 3.27).
-  set(MICRO_TEST_LINK_LIBS
-    ${GTEST_BOTH_LIBRARIES}
     Threads::Threads
     dl
     fmt::fmt-header-only
@@ -226,11 +197,9 @@ if(BUILD_TESTS)
     DdaIpcTests.cpp
     NetPluginReloadTests.cpp
     plugin/net_reload_plugin.cpp
-    ProfilerPluginCloseTests.cpp
     CpuAffinityTests.cpp
     TeardownStressTests.cpp
     _RecorderTests.cpp
-    IbvSymbolsEnvTests.cpp
     common/main.cpp
     common/CallCollectiveForked.cpp
     common/CollectiveArgs.cpp
@@ -254,7 +223,6 @@ if(BUILD_TESTS)
     list(APPEND TEST_SOURCE_FILES
       ../src/misc/recorder.cc
       ../src/misc/proxy_trace/proxy_trace.cc
-      ../src/misc/ibvsymbols.cc  # buildIbvSymbols() is hidden in librccl; compile it in for IbvSymbolsEnvTests
     )
   endif()
 
@@ -263,8 +231,8 @@ if(BUILD_TESTS)
   # Create rccl-UnitTests binary
   add_executable(rccl-UnitTests ${TEST_SOURCE_FILES})
 
-  # AICOMRCCL-1534 / net-plugin assignment tests: net_reload_plugin.cpp is compiled into
-  # rccl-UnitTests and loaded in-process via NCCL_NET_PLUGIN=STATIC_PLUGIN (dlopen(NULL)).
+  # AICOMRCCL-1534: net_reload_plugin.cpp is compiled into rccl-UnitTests and loaded
+  # in-process via NCCL_NET_PLUGIN=STATIC_PLUGIN (dlopen(NULL)), so no external .so.
   # Scope its headers to the file so the generic example headers don't shadow others.
   set_source_files_properties(plugin/net_reload_plugin.cpp PROPERTIES
     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../plugins/net/example/nccl)
@@ -272,25 +240,7 @@ if(BUILD_TESTS)
   # dlsym(dlopen(NULL), ...) only finds symbols present in the dynamic symbol table;
   # export just the one plugin symbol (narrow, unlike a broad -rdynamic).
   target_link_options(rccl-UnitTests PRIVATE
-    "LINKER:--export-dynamic-symbol=ncclNetPlugin_v12")
-
-  # A real shared library, unlike the net plugin above: ProfilerPluginCloseTests checks
-  # that RCCL unloads an external profiler plugin, so it needs a separately loadable
-  # object. It lands beside rccl-UnitTests in the build tree and is installed beside it
-  # too, so the test can find it by name relative to its own executable.
-  add_library(rccl-test-profiler-stub SHARED plugin/profiler_stub_plugin.cpp)
-  add_dependencies(rccl-UnitTests rccl-test-profiler-stub)
-  target_compile_definitions(rccl-UnitTests PRIVATE
-    RCCL_TEST_PROFILER_STUB_NAME="$<TARGET_FILE_NAME:rccl-test-profiler-stub>")
-
-  # The test suite also runs from an install: TheRock CI executes the packaged
-  # rccl-UnitTests with no build tree present, so the stub has to ship with it.
-  # Deliberately not rocm_install(): that sends libraries to the library directory and
-  # adds them to the package export set, while this stub has to ship beside the test
-  # binaries that rocm_install() puts in CMAKE_INSTALL_BINDIR.
-  install(TARGETS rccl-test-profiler-stub
-    LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT tests)
+    "LINKER:--export-dynamic-symbol=ncclNetPlugin_v10")
 
   # rccl-UnitTestsFixtures: Tests that only use header-only internal dependencies
   # (inline, static, constexpr, template functions) and can run in both Release and Debug.
@@ -305,16 +255,10 @@ if(BUILD_TESTS)
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       DdaCollCommonTests.cpp
-      CheapPostSendFenceTests.cpp
       VersionInfoTests.cpp
       device/TestOp128.cpp
-      device/TestTDM.cpp
-      device/TestTdmCopy.cpp
-      device/TestAsyncCopy.cpp
-      device/TestLdsTransfer.cpp
       device/GinDeviceTests.cpp
       device/GinAnvilIpcDevice_test.cpp
-      device/HierarchicalShuffleTests.cpp
       DeviceApiTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp
@@ -343,18 +287,6 @@ if(BUILD_TESTS)
       ${PROJECT_BINARY_DIR}/hipify/src/include
       ${PROJECT_BINARY_DIR}/hipify/src/include/nccl_device
     )
-
-    # device/TestTdmCopy.cpp exercises tdm/tdmCopy.h, which detects TDM toolchain
-    # support via __has_include(<hip/amd_detail/amd_gfx1250_TDM.h>). An SDK that omits
-    # that descriptor header compiles every tdm:: entry point to a deleted stub and
-    # IsTdmCopySupported() reports the GPU as unsupported, so warn rather than let the
-    # TDM coverage silently degrade to no-ops.
-    find_path(RCCL_GFX1250_TDM_HEADER
-      NAMES hip/amd_detail/amd_gfx1250_TDM.h
-      PATHS ${RCCL_COMMON_INCLUDE_DIRS} "${ROCM_PATH}/include")
-    if(NOT RCCL_GFX1250_TDM_HEADER)
-      message(WARNING "SDK lacks hip/amd_detail/amd_gfx1250_TDM.h; tdm:: entry points will compile to no-op stubs and device/TestTdmCopy.cpp will report TDM as unsupported")
-    endif()
 
   if(ENABLE_ROCSHMEM_GIN)
     target_compile_definitions(rccl-UnitTestsFixtures PRIVATE ENABLE_ROCSHMEM_GIN)
@@ -412,37 +344,21 @@ if(BUILD_TESTS)
   endif()
   endif()
 
-  # rccl-UnitTestsDevRuntime: self-contained host micro-test that #includes the
-  # hipified src/dev_runtime.cc directly to reach its file-static symMemory*
-  # helpers. Links no librccl.so; dependencies come from DevRuntimeTestsStubs.cc.
-  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400")
-    list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsDevRuntime)
-
-    add_executable(rccl-UnitTestsDevRuntime
-      DevRuntimeTests.cpp
-      DevRuntimeTestsStubs.cc
-      common/main_fixtures.cpp
-      common/EnvVars.cpp
-      common/TestChecks.cpp
-      common/ProcessIsolatedTestRunner.cpp
-    )
-
-    target_include_directories(rccl-UnitTestsDevRuntime PRIVATE
-      ${PROJECT_BINARY_DIR}/hipify/src
-      ${PROJECT_BINARY_DIR}/hipify/src/include
-      ${PROJECT_BINARY_DIR}/hipify/src/include/nccl_device
-      ${PROJECT_BINARY_DIR}/hipify/src/device
-    )
-
-    set_source_files_properties(DevRuntimeTests.cpp PROPERTIES
-      COMPILE_DEFINITIONS
-        "DEV_RUNTIME_CC_PATH=\"${PROJECT_BINARY_DIR}/hipify/src/dev_runtime.cc\"")
-
-    # The included source and its headers live in the hipify-staged tree.
-    add_dependencies(rccl-UnitTestsDevRuntime
-      hipify_all copy_nccl_device_headers
-      net_ib_header_symlinks rma_header_symlinks)
-  endif()
+  # GIN Anvil-SDMA put-segmentation host unit test (no GPU). Pure host C++: the
+  # segment-math header (nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h) is
+  # compiled with GIN_SDMA_HOST_ONLY so it needs neither a built librccl nor device
+  # codegen. It exercises the exact ginPutSegmentCount/ginPutSegmentAt the SDMA
+  # backend Put drives on device. Runs under `ctest -L unit`.
+  add_executable(rccl-UnitTestsGinSdmaPolicy gin/gin_sdma_policy_test.cpp)
+  set_source_files_properties(gin/gin_sdma_policy_test.cpp PROPERTIES LANGUAGE CXX)
+  target_include_directories(rccl-UnitTestsGinSdmaPolicy PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/include)
+  target_compile_definitions(rccl-UnitTestsGinSdmaPolicy PRIVATE GIN_SDMA_HOST_ONLY)
+  target_link_libraries(rccl-UnitTestsGinSdmaPolicy PRIVATE ${GTEST_BOTH_LIBRARIES} Threads::Threads)
+  set_target_properties(rccl-UnitTestsGinSdmaPolicy PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test")
+  add_test(NAME rccl-UnitTestsGinSdmaPolicy COMMAND rccl-UnitTestsGinSdmaPolicy)
+  set_tests_properties(rccl-UnitTestsGinSdmaPolicy PROPERTIES LABELS "unit")
 
   # rccl-UnitTestsFixturesDebug: Tests that access internal symbols compiled into
   # librccl.so which are only visible in Debug builds (hidden visibility in Release).
@@ -458,15 +374,11 @@ if(BUILD_TESTS)
       DdaAlltoAllThresholdTests.cpp
       DdaIpcEligibilityTests.cpp
       DdaFabricEligibilityTests.cpp
-      CeAllReduceEligibilityTests.cpp
-      CeAlltoAllvEligibilityTests.cpp
       EnqueueTests.cpp
-      LL128RegVariantKernel_test.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp
       TopoNicFusionTests.cpp
       NetSocketTests.cpp
-      PluginCompatV10_test.cpp
       PluginCompatV11_test.cpp
       ProxyTests.cpp
       RcclWrapTests.cpp
@@ -509,11 +421,9 @@ if(BUILD_TESTS)
     target_compile_definitions(rccl-UnitTestsFixturesDebug PRIVATE
       RCCL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-    # PluginCompatV10_test.cpp / PluginCompatV11_test.cpp resolve their in-process
-    # mock plugin symbols via dlsym(dlopen(NULL), ...), which only sees the
-    # executable's dynamic symbols.
+    # PluginCompatV11_test.cpp resolves its in-process mock plugin symbols via
+    # dlsym(dlopen(NULL), ...), which only sees the executable's dynamic symbols.
     target_link_options(rccl-UnitTestsFixturesDebug PRIVATE
-      -Wl,--export-dynamic-symbol=ncclNetPlugin_v10
       -Wl,--export-dynamic-symbol=ncclNetPlugin_v11
       -Wl,--export-dynamic-symbol=ncclCollNetPlugin_v11)
   endif()
@@ -546,20 +456,6 @@ if(BUILD_TESTS)
     endif()
   endif()
 
-  # rccl-UnitTestsGdr: Compiles the peer-memory detection helper (gdr_peermem.cc,
-  # shared by the net_ib and net_ib_cast transports) directly so the sysfs scan can
-  # be exercised against a mock `memory_peers` tree in a temp directory. The helper
-  # is pure (no HIP, no librccl.so symbols, no GPU), so this target builds in
-  # Release and Debug.
-  list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsGdr)
-
-  set(TEST_GDR_SOURCE_FILES
-    GdrPeerMemTests.cpp
-    ../src/misc/gdr_peermem.cc
-    common/main_altrsmi.cpp
-  )
-
-  add_executable(rccl-UnitTestsGdr ${TEST_GDR_SOURCE_FILES})
   # rccl-UnitTestsAmdSmi: tests for the amdsmi_wrap layer.
   #
   # AmdSmiFabricTests.cpp covers the fabric predicates and struct layout pinned in
@@ -649,12 +545,11 @@ if(BUILD_TESTS)
       transport/NetMPITests.cpp
       transport/ShmMPITests.cpp
       transport/NetIbMPI/GeneralTests.cpp
-      transport/NetIbMPI/GdrFlushTests.cpp
       transport/NetIbMPI/NicFusionTests.cpp
       transport/NetIbMPI/CastTests.cpp
       transport/NetIbMPI/FaultInjectTests.cpp
       transport/NetIbMPI/OpsFaultUnitTests.cpp
-      transport/RmaMPI/RmaMPITests.cpp
+      transport/GinMPI/GinMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp
@@ -669,24 +564,14 @@ if(BUILD_TESTS)
       ce/CeInternalMPITests.cpp
       GrowMPITests.cpp
       GinNcclTimeoutMPITests.cpp
-      InspectorPromP2pMPITests.cpp
       SymmetricKernelMPITests.cpp
       SymmetricWindowMPITests.cpp
       DeviceApiMPITests.cpp
       CommNetMismatchMPITests.cpp
-      test_sparse_send_recv.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsMPI)
-
-    # Hand the in-tree Inspector plugin to InspectorPromP2pMPITests so it can
-    # load a profiler without the caller setting NCCL_INSPECTOR_PLUGIN_SO.
-    if(TARGET rccl-profiler-inspector)
-      add_dependencies(rccl-UnitTestsMPI rccl-profiler-inspector)
-      target_compile_definitions(rccl-UnitTestsMPI PRIVATE
-        RCCL_INSPECTOR_PLUGIN_SO="$<TARGET_FILE:rccl-profiler-inspector>")
-    endif()
   endif()
 
   foreach(test_executable IN LISTS RCCL_TEST_EXECUTABLES)
@@ -714,17 +599,7 @@ if(BUILD_TESTS)
         set_target_properties(${test_executable} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
       endif()
     endif()
-    # rccl-UnitTestsGinAnvilPlugin is a self-contained host unit test: it compiles
-    # the plugin sources directly and provides its own stubs (bootstrap/devr/debug/
-    # factory), so it must NOT link librccl.so. When RCCL is built with
-    # ENABLE_ROCSHMEM_GIN=ON but ENABLE_ROCSHMEM=OFF, librccl.so carries unresolved
-    # rocSHMEM symbols (e.g. rocshmem::envvar::log_flags) that would fail at load
-    # time for any executable linking it.
-    if(test_executable STREQUAL "rccl-UnitTestsGinAnvilPlugin" OR
-       test_executable STREQUAL "rccl-UnitTestsDevRuntime")
-      # Intentionally no rccl link; needed symbols come from the compiled-in
-      # source(s) + stubs and RCCL_COMMON_LINK_LIBS (hip/hsa/gtest/dl).
-    elseif(BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS)
       target_link_libraries(${test_executable} PRIVATE rccl)
       if(${HOST_OS_ID} STREQUAL "debian")
         set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_BINARY_DIR}")
@@ -888,10 +763,5 @@ if(BUILD_TESTS)
     COMPONENT tests
     RENAME "CTestTestfile.cmake"
   )
-
-  # Host-only micro-test binaries (rccl-UnitTestsMicro). The host/ CMakeLists
-  # is dual-mode: under BUILD_TESTS it builds only the in-RCCL-build micro-test
-  # target and returns; invoked standalone it builds rccl-HostUnitTests too.
-  add_subdirectory(host)
 
 endif()

--- a/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
+++ b/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
@@ -20,7 +20,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include <vector>
 
 namespace RcclUnitTesting
@@ -80,9 +79,7 @@ class GinAnvilPluginTest : public ::testing::Test {
     if (hipGetDeviceCount(&ndev) == hipSuccess && ndev > 0) {
       ASSERT_EQ(hipSetDevice(0), hipSuccess);
     }
-    // Anvil-SDMA is ncclNetDeviceType NCCL_NET_DEVICE_GIN_ANVIL_SDMA (=6); derive
-    // from the enum so this never drifts from net_device.h (type 5 is ROCSHMEM_GDA).
-    setenv("NCCL_GIN_TYPE", std::to_string(static_cast<int>(NCCL_NET_DEVICE_GIN_ANVIL_SDMA)).c_str(), 1);
+    setenv("NCCL_GIN_TYPE", "5", 1);
     GinAnvilPluginStubs::SetProbeResult(1);
     GinAnvilPluginStubs::SetBootstrapNranks(1);
   }
@@ -232,7 +229,7 @@ TEST_F(GinAnvilPluginTest, CreateContext_MissingInfra) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 0;
   cfg.nCounters = 0;
   void* ginCtx = nullptr;
@@ -250,7 +247,7 @@ TEST_F(GinAnvilPluginTest, CreateContext_EnvAndCounters) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 2;
   cfg.nCounters = 1;
   void* ginCtx = nullptr;
@@ -288,7 +285,7 @@ TEST_F(GinAnvilPluginTest, BindSignals_SlotOutOfRange) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 1;
   void* ginCtx1 = nullptr;
   void* ginCtx2 = nullptr;
@@ -312,7 +309,7 @@ TEST_F(GinAnvilPluginTest, BindSignals_Success) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 2;
   void* ginCtx = nullptr;
   ncclNetDeviceHandle_v11_t* devHandle = nullptr;
@@ -340,14 +337,28 @@ TEST_F(GinAnvilPluginTest, Misc_NoOpPaths) {
   EXPECT_EQ(plugin_.ginProgress(nullptr), ncclSuccess);
 }
 
-// G16: env int parsing via channels (invalid -> default 1).
-TEST_F(GinAnvilPluginTest, Connect_EnvNumChannelsClamp) {
-  ScopedEnv ch("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", "0");
+// G16: the SDMA channel count is forced to 1; NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS is
+// no longer honored. Even with the (now-ignored) env set to a former multi-channel
+// value, connect + createContext must bring the context up with numChannels == 1.
+TEST_F(GinAnvilPluginTest, Connect_NumChannelsForcedSingle) {
+  ScopedEnv ch("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", "4");
   void* ictx = nullptr;
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
   ASSERT_NE(coll, nullptr);
+
+  ncclGinConfig_v13_t cfg{};
+  cfg.nSignals = 1;
+  void* ginCtx = nullptr;
+  ncclNetDeviceHandle_v11_t* devHandle = nullptr;
+  ASSERT_EQ(plugin_.createContext(coll, &cfg, &ginCtx, &devHandle), ncclSuccess);
+
+  ncclGinAnvilSdmaGPUContext hostCtx{};
+  ASSERT_EQ(hipMemcpy(&hostCtx, devHandle->handle, sizeof(hostCtx), hipMemcpyDeviceToHost), hipSuccess);
+  EXPECT_EQ(hostCtx.numChannels, 1);
+
+  plugin_.destroyContext(ginCtx);
   plugin_.closeColl(coll);
   plugin_.finalize(ictx);
 }
@@ -358,7 +369,7 @@ TEST_F(GinAnvilPluginTest, BindSignals_LsaResolveFail) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 1;
   void* ginCtx = nullptr;
   ncclNetDeviceHandle_v11_t* devHandle = nullptr;
@@ -379,7 +390,7 @@ TEST_F(GinAnvilPluginTest, BindSignals_IpcTableFull) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 1;
   void* ginCtx = nullptr;
   ncclNetDeviceHandle_v11_t* devHandle = nullptr;
@@ -410,7 +421,7 @@ TEST_F(GinAnvilPluginTest, CloseColl_AfterSignalBind) {
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
-  ncclGinConfig_t cfg{};
+  ncclGinConfig_v13_t cfg{};
   cfg.nSignals = 1;
   void* ginCtx = nullptr;
   ncclNetDeviceHandle_v11_t* devHandle = nullptr;

--- a/projects/rccl/test/gin/gin_sdma_policy_test.cpp
+++ b/projects/rccl/test/gin/gin_sdma_policy_test.cpp
@@ -1,0 +1,135 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host unit tests for the pure GIN Anvil-SDMA put-segmentation math in
+// projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h.
+// These validate the exact loop that ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>
+// drives on device -- the header is compiled here as plain host C++
+// (GIN_SDMA_HOST_ONLY drops the __host__ __device__ attributes), and the same
+// ginPutSegmentCount / ginPutSegmentAt functions are called by the SDMA backend
+// Put, so exercising them here exercises the real segmentation code with no GPU.
+//
+// Invariants asserted for every transfer size:
+//   * no segment exceeds the 128 MiB single-copy cap (kGinPutSegBytes),
+//   * the segments tile [0, bytes) contiguously and sum back to bytes,
+//   * exactly one segment is flagged final (it alone carries the SignalInc),
+//   * the final flag lands on the last segment.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+#define GIN_SDMA_HOST_ONLY 1
+#include "nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h"
+
+using namespace gin_sdma;
+
+namespace {
+
+constexpr size_t kMiB = 1024ull * 1024;
+constexpr size_t kGiB = 1024ull * kMiB;
+
+// The clamp the backend Put actually uses: 128 MiB (min of the reliability and
+// correctness limits). Kept in lockstep with the header so a future change to
+// either constant is caught here.
+TEST(GinPutSeg, SegLimitIsMinOfBothCaps) {
+  EXPECT_EQ(kGinPutSegBytes, kGinSdmaSafeCopyBytes);
+  EXPECT_LE(kGinPutSegBytes, kGinPutMaxBytes);
+  EXPECT_EQ(kGinPutSegBytes, 128ull * kMiB);
+  // The 128 MiB cap must divide 1 GiB so a 1 GiB descriptor limit is a whole
+  // number of safe copies, and be 32 B aligned for the SDMA copy descriptor.
+  EXPECT_EQ(kGinPutMaxBytes % kGinPutSegBytes, 0u);
+  EXPECT_EQ(kGinPutSegBytes % 32u, 0u);
+}
+
+// Re-derive the whole segmentation for `bytes` and assert every invariant.
+void checkSegmentation(size_t bytes) {
+  const size_t maxSeg = kGinPutSegBytes;
+  const size_t n = ginPutSegmentCount(bytes, maxSeg);
+
+  // Non-empty transfers => ceil(bytes/maxSeg); a zero transfer still issues one
+  // (empty) put so its trailing signal fires.
+  const size_t expectedN = (bytes == 0) ? 1 : (bytes + maxSeg - 1) / maxSeg;
+  ASSERT_EQ(n, expectedN) << "bytes=" << bytes;
+  ASSERT_GE(n, 1u) << "bytes=" << bytes;
+
+  size_t sum = 0;
+  size_t expectedOffset = 0;
+  int finalCount = 0;
+  for (size_t i = 0; i < n; ++i) {
+    const PutSegment s = ginPutSegmentAt(bytes, maxSeg, i);
+
+    // No segment exceeds the cap.
+    EXPECT_LE(s.bytes, maxSeg) << "bytes=" << bytes << " i=" << i;
+
+    // Segments tile [0, bytes) contiguously with no gaps or overlaps.
+    EXPECT_EQ(s.offset, expectedOffset) << "bytes=" << bytes << " i=" << i;
+    expectedOffset += s.bytes;
+
+    // Only the last segment is final.
+    if (s.isFinal) ++finalCount;
+    EXPECT_EQ(s.isFinal, (i == n - 1)) << "bytes=" << bytes << " i=" << i;
+
+    // Interior segments are exactly full (only the tail may be short).
+    if (i + 1 < n) {
+      EXPECT_EQ(s.bytes, maxSeg) << "bytes=" << bytes << " i=" << i;
+    }
+
+    sum += s.bytes;
+  }
+
+  // Exactly one signal is carried, and the segments reconstruct the transfer.
+  EXPECT_EQ(finalCount, 1) << "bytes=" << bytes;
+  EXPECT_EQ(sum, bytes) << "bytes=" << bytes;
+  EXPECT_EQ(expectedOffset, bytes) << "bytes=" << bytes;
+}
+
+// The sizes called out in review: the 128 MiB cap boundary, the 1 GiB 30-bit
+// truncation boundary, and the 2 GiB total hang repro (256 MiB/peer at 8 ranks).
+TEST(GinPutSeg, CoversBoundarySizes) {
+  const size_t sizes[] = {
+      0,
+      1,
+      128 * kMiB,          // exactly one segment (at the cap)
+      128 * kMiB + 1,      // just over: 2 segments (1 B tail)
+      256 * kMiB,          // 2 segments; the size that HUNG as a single put
+      1 * kGiB,            // 8 segments; the 30-bit single-descriptor max
+      1 * kGiB + 1,        // 9 segments; just past the correctness boundary
+      2 * kGiB,            // 16 segments; the original 2 GiB-total hang repro
+  };
+  for (size_t b : sizes) checkSegmentation(b);
+}
+
+// Segment counts for the documented boundaries (128 MiB cap).
+TEST(GinPutSeg, SegmentCounts) {
+  EXPECT_EQ(ginPutSegmentCount(0, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(1, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(128 * kMiB, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(128 * kMiB + 1, kGinPutSegBytes), 2u);
+  EXPECT_EQ(ginPutSegmentCount(256 * kMiB, kGinPutSegBytes), 2u);
+  EXPECT_EQ(ginPutSegmentCount(1 * kGiB, kGinPutSegBytes), 8u);
+  EXPECT_EQ(ginPutSegmentCount(2 * kGiB, kGinPutSegBytes), 16u);
+}
+
+// A dense scan around each cap multiple catches off-by-one tiling errors.
+TEST(GinPutSeg, DenseScanAroundCapMultiples) {
+  const size_t maxSeg = kGinPutSegBytes;
+  for (size_t k = 0; k <= 18; ++k) {
+    const size_t base = k * maxSeg;
+    for (long d = -2; d <= 2; ++d) {
+      if (base == 0 && d < 0) continue;  // no negative sizes
+      checkSegmentation(base + (size_t)d);
+    }
+  }
+}
+
+// maxSeg == 0 is a caller error; guard returns 0 (no puts) rather than dividing.
+TEST(GinPutSeg, ZeroCapIsGuarded) {
+  EXPECT_EQ(ginPutSegmentCount(1 * kGiB, 0), 0u);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Supersedes #9927 (base branch deleted). Segments GIN Anvil-SDMA `put` operations inside the backend at 128 MiB per copy so AllToAll device paths no longer hang on transfers larger than ~1 GiB total (e.g. 256 MiB/peer @ 2 GiB on 8 GPUs).

- Add `gin_anvil_sdma_put_policy.h` with shared host/device segmentation math; wire it into the SDMA backend `Put` and host unit tests (`gin_sdma_policy_test.cpp`).
- Remove the earlier rccl-tests `ginPutChunked` workaround from `alltoall.cu`; add `test_AllToAll.py` coverage for large-message GIN paths.
- Include reconciled `ddai-artifacts/` (docker build + A2A test harness, docs, MI350/MI355 perf logs) for reproduction and validation.

## Test plan

- [ ] Host unit tests: `gin_sdma_policy_test` (segmentation invariants for sizes through multi-GB)
- [ ] `projects/rccl-tests/test/test_AllToAll.py` (large-message GIN Anvil-SDMA paths)
- [ ] `ddai-artifacts/scripts/docker-gin-gda-sdma-build.bash` (image build + NCCL_GIN_TYPE=5 A2A smoke gate)
- [ ] `ddai-artifacts/scripts/gin-sdma-a2a-test.bash` on MI355: functional sweep including >1 GiB total (Test#5 -D 3)
- [ ] CI: GIN single-node testing


Made with [Cursor](https://cursor.com)