### PR TITLE
fix(rccl/gin-sdma): cap Anvil-SDMA puts at 128 MiB to fix large-message A2A hang

### DIFF
--- a/projects/rccl-tests/src/alltoall.cu
+++ b/projects/rccl-tests/src/alltoall.cu
@@ -266,7 +266,9 @@ __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   int nthreads = blockDim.x * gridDim.x;
 
-  /* send to all peers via GIN */
+  /* send to all peers via GIN; the Anvil-SDMA backend segments large puts
+   * internally (<=128 MiB per SDMA copy) so a single gin.put() is safe at any
+   * size and needs no application-side chunking. */
   const size_t size = count * sizeof(T);
   for (int r=tid; r<devComm.nRanks; r+=nthreads) {
     gin.put(ncclTeamWorld(devComm), r,

--- a/projects/rccl-tests/test/test_AllToAll.py
+++ b/projects/rccl-tests/test/test_AllToAll.py
@@ -1,0 +1,183 @@
+#################################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+# GIN-SDMA AllToAll regression tests for the >1 GiB SDMA hang fix (PR #9927).
+#
+# These drive the real GinHybridAlltoAllKernel (deviceImpl 3, NCCL_GIN_TYPE=6)
+# at per-peer transfer sizes that cross the two single-descriptor limits the
+# 128 MiB SDMA copy clamp guards. The clamp now lives in the Anvil-SDMA backend
+# Put (ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>), which segments every
+# gin.put() into <=128 MiB SDMA copies; the kernels just call plain gin.put():
+#
+#   1. >128 MiB/peer  -- exercises the new multi-segment put loop.
+#   2. >1 GiB/peer    -- crosses the 30-bit (1 GiB) count-field boundary, where
+#                        an unclamped single put would silently truncate.
+#   3. 2 GiB total    -- the original hang repro (256 MiB/peer at 8 ranks); a
+#                        subprocess timeout turns a reintroduced hang into a
+#                        test failure instead of stalling the runner forever.
+#
+# Exact-integer datatypes are used so a truncated or stale tail cannot be masked
+# by floating-point tolerance; the perf binary's built-in data check (-c 1) sets
+# a non-zero exit code on any wrong element.
+#
+# These require an 8x MI355X (or similar) node, an MPI launcher, and a
+# GIN-SDMA-capable RCCL build, so the module is skipped unless
+# RCCL_TESTS_GIN_SDMA_A2A is set in the environment. Configuration is taken from
+# environment variables (see below) with defaults matching the 8-GPU repro:
+#   RCCL_TESTS_A2A_NP        MPI ranks (default: detected GPU count)
+#   RCCL_TESTS_MPI_LAUNCHER  launcher binary (default: mpirun)
+#   RCCL_TESTS_MPI_OPTS      extra launcher opts (e.g. --allow-run-as-root -mca ...)
+#   RCCL_TESTS_A2A_XENV      extra "-x K=V" env the backend needs on this cluster
+#                            (e.g. HSA_FORCE_FINE_GRAIN_PCIE=1 NCCL_CUMEM_ENABLE=1)
+#   RCCL_TESTS_A2A_EXE       path to alltoall_perf (default: ../build/alltoall_perf)
+#   RCCL_TESTS_A2A_TIMEOUT_S per-run hang timeout in seconds (default: 900)
+#
+# Verified on 8x MI355X (ROCm 7.13, NCCL_GIN_TYPE=6, force1ch): 256 MiB/peer and
+# 2 GiB/peer int32 and the 2 GiB-total guard all pass with #wrong=0, no hang
+# (busbw ~424-428 GB/s).
+
+import os
+import shlex
+import signal
+import subprocess
+
+import pytest
+
+MiB = 1024 * 1024
+GiB = 1024 * MiB
+
+path = os.path.dirname(os.path.abspath(__file__))
+# Path to alltoall_perf. Override with RCCL_TESTS_A2A_EXE when the binary is not
+# at the default build/ location (e.g. an installed/container path).
+executable = os.environ.get(
+    "RCCL_TESTS_A2A_EXE", os.path.join(path, "..", "build", "alltoall_perf"))
+
+# Opt-in: only run where the GIN-SDMA backend + hardware are available.
+_enabled = os.environ.get("RCCL_TESTS_GIN_SDMA_A2A", "") not in ("", "0", "false", "False")
+
+
+def _detect_ngpus():
+    if os.environ.get("ROCR_VISIBLE_DEVICES") is not None:
+        return len(os.environ["ROCR_VISIBLE_DEVICES"].split(","))
+    if os.environ.get("HIP_VISIBLE_DEVICES") is not None:
+        return len(os.environ["HIP_VISIBLE_DEVICES"].split(","))
+    try:
+        out = subprocess.check_output(
+            'rocminfo | grep "Device Type:.\\s*.GPU" | wc -l', shell=True)
+        return int(out)
+    except Exception:
+        return 0
+
+
+NP = int(os.environ.get("RCCL_TESTS_A2A_NP", "0")) or _detect_ngpus()
+LAUNCHER = os.environ.get("RCCL_TESTS_MPI_LAUNCHER", "mpirun")
+CTAS = os.environ.get("RCCL_TESTS_A2A_CTAS", "16")
+# Generous per-call timeout; a real hang spins forever, so a finite cap is what
+# converts item (3) into a detectable failure. Scaled up for the multi-GiB case.
+TIMEOUT_S = int(os.environ.get("RCCL_TESTS_A2A_TIMEOUT_S", "900"))
+
+# Extra launcher options (e.g. "--allow-run-as-root -mca pml ob1 ...") and any
+# deployment-specific env the GIN-SDMA backend needs beyond the essentials below
+# (e.g. HSA_FORCE_FINE_GRAIN_PCIE=1 NCCL_CUMEM_ENABLE=1 RCCL_ENABLE_INTRANET=1).
+# GIN enablement itself is site-specific, so it is injected here rather than
+# hard-coded, keeping the test portable across clusters.
+MPI_OPTS = shlex.split(os.environ.get("RCCL_TESTS_MPI_OPTS", ""))
+XENV = shlex.split(os.environ.get("RCCL_TESTS_A2A_XENV", ""))
+
+pytestmark = pytest.mark.skipif(
+    not _enabled,
+    reason="GIN-SDMA AllToAll tests are opt-in; set RCCL_TESTS_GIN_SDMA_A2A=1 on "
+           "a GIN-SDMA-capable (e.g. 8x MI355X) node to enable.")
+
+
+def _run_a2a(request, total_bytes, dtype):
+    """Run one all-to-all at a fixed total (per-rank) size, forcing the GIN-SDMA
+    tier. Returns (returncode, stdout). A timeout (hang) fails the test."""
+    if NP < 2:
+        pytest.skip("need >= 2 ranks/GPUs for AllToAll")
+
+    size = str(int(total_bytes))
+    # Essentials to exercise the GIN-SDMA put path; force the SDMA (large) tier
+    # for every size. Deployment-specific env comes from RCCL_TESTS_A2A_XENV.
+    gin_env = []
+    for kv in ["NCCL_GIN_ENABLE=1", "NCCL_GIN_TYPE=6",
+               "NCCL_GIN_ANVIL_SDMA_THRESHOLD=0",
+               "NCCL_GIN_ANVIL_SDMA_THRESHOLD_ALLTOALL=0"] + XENV:
+        gin_env += ["-x", kv]
+
+    hostfile = request.config.getoption("--hostfile")
+    launch = [LAUNCHER, "-np", str(NP)] + MPI_OPTS
+    if hostfile:
+        launch += ["-host", hostfile]
+
+    args = launch + gin_env + [
+        executable,
+        "-b", size, "-e", size,
+        "-f", "2",
+        "-g", "1",
+        "-R", "2",
+        "-D", "3",
+        "-V", CTAS,
+        "-d", dtype,
+        "-c", "1",       # data check: nonzero exit on any wrong element
+        "-w", "1",
+        "-n", "3",
+    ]
+    cmd = " ".join(shlex.quote(a) for a in args)
+    print(cmd)
+    # Run in a new session so a hang can be killed as a whole process group --
+    # otherwise a wedged launcher leaves orphaned ranks pinning the GPUs (and
+    # exhausting SDMA queues for later tests).
+    proc = subprocess.Popen(cmd, shell=True, universal_newlines=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            start_new_session=True)
+    try:
+        out, _ = proc.communicate(timeout=TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        out, _ = proc.communicate()
+        pytest.fail(
+            "AllToAll GIN-SDMA HANG: no completion within {}s at total={} bytes "
+            "({} MiB/peer), dtype={}. Output tail:\n{}".format(
+                TIMEOUT_S, size, total_bytes // NP // MiB, dtype, (out or "")[-2000:]))
+    print(out)
+    return proc.returncode, out
+
+
+# (item 1 + 2) Multi-segment loop and the 1 GiB truncation boundary. per_peer is
+# the transfer to each peer; total per-rank bytes = per_peer * NP.
+@pytest.mark.parametrize("per_peer_mib", [256, 2048])  # 256 MiB (2 seg), 2 GiB (16 seg)
+@pytest.mark.parametrize("dtype", ["int32", "int64", "uint8"])
+def test_AllToAllGinSdmaLargeSegmented(request, per_peer_mib, dtype):
+    total = per_peer_mib * MiB * NP
+    rc, _ = _run_a2a(request, total, dtype)
+    assert rc == 0, "AllToAll data check failed (nonzero exit) at {} MiB/peer, dtype={}".format(
+        per_peer_mib, dtype)
+
+
+# (item 3) The original 2 GiB-total hang repro, as a completion guard. At 8 ranks
+# this is 256 MiB/peer -- the size that hung as a single unclamped put.
+def test_AllToAllGinSdma2GiBTotalHangGuard(request):
+    rc, _ = _run_a2a(request, 2 * GiB, "int32")
+    assert rc == 0, "AllToAll 2 GiB-total data check failed (nonzero exit)"

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -255,6 +255,7 @@ set(SRC_FILES
   include/nccl_device/gin/rocshmem_gda/gin_rocshmem_device_host_common_gda.h
   include/nccl_device/gin/rocshmem_gda/queue_pair_device.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+  include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_copy.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_table.h
   include/nccl_device/gin/anvil_sdma/gin_anvil_ipc_table_device.h

--- a/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
+++ b/projects/rccl/src/gin/gin_plugin_anvil_sdma.cc
@@ -190,9 +190,12 @@ static int ginAnvilSdmaThresholdFromEnv() {
   return ginAnvilEnvInt("NCCL_GIN_ANVIL_SDMA_THRESHOLD", (int)NCCL_GIN_ANVIL_SDMA_THRESHOLD_DEFAULT);
 }
 
-static int ginAnvilSdmaNumChannelsFromEnv() {
-  int v = ginAnvilEnvInt("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", 1);
-  return v >= 1 && v <= 8 ? v : 1;
+static int ginAnvilSdmaNumChannels() {
+  // Forced to a single SDMA channel. Multi-channel (>=4 channels) at
+  // >=256 MiB/peer aborts with a fail-loud "unhandled system error" on
+  // 8x MI355X, and the collective GIN-put paths issue their puts from a single
+  // warp anyway (channel 0), so additional channels provide no benefit.
+  return 1;
 }
 
 static uint32_t ginAnvilFusedSignalFromEnv() {
@@ -230,7 +233,7 @@ static ncclResult_t ginAnvilConnect(void* ctx, void* handles[], int nranks, int 
     return ncclSystemError;
   }
 
-  int numCh = ginAnvilSdmaNumChannelsFromEnv();
+  int numCh = ginAnvilSdmaNumChannels();
 
   gin_anvil_sdma_handle_t h = nullptr;
   void* gpu_handles = nullptr;

--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
@@ -10,6 +10,7 @@
 #include "../gin_device_common.h"
 #include "../../hip_compat.h"
 #include "gin_anvil_sdma_device_host_common.h"
+#include "gin_anvil_sdma_put_policy.h"
 #include "gin_anvil_ipc_copy.h"
 #include "gin_anvil_ipc_table_device.h"
 #include "sdma/anvil_device.hpp"
@@ -224,10 +225,25 @@ struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
             if (remoteSig != nullptr) sdmaFusedSignal = true;
           }
           __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
-          if (sdmaFusedSignal) {
-            ::sdma_anvil::putSignal(*handle, dstAddr, srcAddr, bytes, remoteSig);
-          } else {
-            ::sdma_anvil::put(*handle, dstAddr, srcAddr, bytes);
+          // The SDMA linear-copy count field is 30 bits (max 1 GiB), and a single
+          // fused copy+signal >=256 MiB stalls the engine on MI355X, so split any
+          // large put into <= kGinPutSegBytes (128 MiB) segments. The backend runs
+          // a single in-order SDMA queue per peer (numChannels forced to 1), so the
+          // fused signal on the FINAL segment (or the explicit SignalInc emitted
+          // below when the copy is not fused) still means the whole message landed.
+          // See gin_anvil_sdma_put_policy.h. A <=128 MiB put is one segment, so the
+          // common path is unchanged.
+          const size_t segMax = gin_sdma::kGinPutSegBytes;
+          const size_t nSeg = gin_sdma::ginPutSegmentCount(bytes, segMax);
+          for (size_t si = 0; si < nSeg; ++si) {
+            const gin_sdma::PutSegment seg = gin_sdma::ginPutSegmentAt(bytes, segMax, si);
+            void* segDst = static_cast<void*>(static_cast<char*>(dstAddr) + seg.offset);
+            void* segSrc = static_cast<void*>(static_cast<char*>(srcAddr) + seg.offset);
+            if (seg.isFinal && sdmaFusedSignal) {
+              ::sdma_anvil::putSignal(*handle, segDst, segSrc, seg.bytes, remoteSig);
+            } else {
+              ::sdma_anvil::put(*handle, segDst, segSrc, seg.bytes);
+            }
           }
           markSdmaDirty(rsCtx, peer, loadConst(&rsCtx->numChannels), effectiveChannel(rsCtx, blockId));
         }
@@ -424,23 +440,25 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 template <>
 struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t, ncclGinWindow_t, size_t, size_t,
-                                      bool, ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t,
+                                      ncclGinWindow_t, size_t, size_t, bool,
+                                      ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool, ncclGinDescriptorSmem*, uint32_t) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool,
+                                      ncclGinDescriptorSmem*, uint32_t) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool, ncclGinDescriptorSmem*, cuda::memory_order,
-                                      uint32_t*) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool,
+                                      ncclGinDescriptorSmem*, cuda::memory_order, uint32_t*) {
     __builtin_trap();
   }
 };

--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h
@@ -1,0 +1,108 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Put-size limits and segment math for the GIN Anvil-SDMA device backend.
+// The single source of truth for the two per-put byte caps that
+// ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> segments every SDMA copy
+// against, plus the pure segmentation arithmetic itself. Kept as a standalone,
+// dependency-free header (no ncclDevComm, no GPU intrinsics, no getenv) so the
+// same code is (a) called from the SDMA backend Put on device and (b) unit-tested
+// on the host with GoogleTest (define GIN_SDMA_HOST_ONLY to drop the device
+// attributes and compile it as plain host C++; see
+// projects/rccl/test/gin/gin_sdma_policy_test.cpp).
+
+#ifndef _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_
+#define _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_
+
+#include <cstddef>
+
+// The device backend gets __host__ __device__; plain host builds (and the host
+// unit test, which defines GIN_SDMA_HOST_ONLY) get no attribute so the header
+// compiles as ordinary C++ with no device codegen.
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && !defined(GIN_SDMA_HOST_ONLY)
+#define GIN_SDMA_HD __host__ __device__
+#else
+#define GIN_SDMA_HD
+#endif
+
+namespace gin_sdma {
+
+// Max bytes per single SDMA copy on the Anvil-SDMA backend. The SDMA linear-copy
+// descriptor count field is 30 bits and 1-based (HW encodes count = bytes - 1,
+// see rocr-runtime amd_blit_sdma.cpp / sdma_registers.h), so the largest single
+// packet is (2^30 - 1) + 1 = 2^30 = exactly 1 GiB. A put of >1 GiB silently
+// truncates: a 2 GiB put encodes count = (2^31-1) & 0x3FFFFFFF = 2^30-1 and the
+// HW copies only 1 GiB, corrupting the transfer. Every SDMA copy must be split
+// into segments of at most this size.
+//
+// Set to exactly 1 GiB: this is the hardware maximum, so the segmentation clamp
+// (seg <= kGinPutMaxBytes) guarantees count = seg-1 <= 2^30-1 = 0x3FFFFFFF, which
+// fills the 30-bit field exactly with no truncation. Zero margin by design; do
+// NOT raise above 2^30. 1 GiB is a multiple of 32 B, satisfying the copy
+// descriptor's 32 B length alignment.
+static constexpr size_t kGinPutMaxBytes = 1024ull * 1024 * 1024;  // 1 GiB (2^30, HW max)
+
+// Max bytes per single SDMA copy that the Anvil-SDMA backend copies *reliably*
+// on MI355X + ROCm 7.13 (NCCL_GIN_TYPE=5). This is SMALLER than kGinPutMaxBytes:
+// the 30-bit count field bounds correctness at 1 GiB, but a single copy
+// descriptor at/above 256 MiB (2^28) on the fused COPY_LINEAR_WAIT_SIGNAL_MI4
+// path stalls the SDMA engine, so the fused copy never lands AND its SignalInc
+// never fires -> every rank spins forever in waitSignal (a HANG, not a data
+// miscompare). Measured on 8x MI355X (2026-08-07, alltoall_perf -D 3): a single
+// 256 MiB/peer put (AllToAll @ 2 GiB total) HANGS; capping each copy to 128 MiB
+// (2 copies/peer) completes with identical bandwidth (busbw ~423 GB/s, unchanged
+// vs the 1 GiB total case). 128 MiB is proven safe with zero measured perf loss;
+// do not raise without re-measuring. The backend Put segments every SDMA copy to
+// this size, so it protects ALL callers of gin.put() on the Anvil-SDMA backend.
+static constexpr size_t kGinSdmaSafeCopyBytes = 128ull * 1024 * 1024;  // 128 MiB (reliable single-copy max)
+
+// The single per-copy segmentation limit the backend Put clamps to: the smaller
+// of the two constants above (correctness bound AND reliability bound). Compile-
+// time constant so the device loop and the host unit test share one value.
+static constexpr size_t kGinPutSegBytes =
+    kGinSdmaSafeCopyBytes < kGinPutMaxBytes ? kGinSdmaSafeCopyBytes : kGinPutMaxBytes;
+
+// ------------------------------ segment math ------------------------------
+//
+// Pure arithmetic for splitting one peer transfer into <=kGinPutSegBytes copies.
+// The Anvil-SDMA backend Put drives its ::sdma_anvil::put() loop entirely from
+// these two functions, so the same code that runs on device is what the host
+// unit test exercises. Every SDMA copy must satisfy: no segment exceeds the cap,
+// the segments tile [0,bytes) contiguously and sum back to bytes, and exactly
+// one segment is flagged final (it alone carries the caller's SignalInc).
+
+// One SDMA-copy segment of a chunked transfer.
+struct PutSegment {
+  size_t offset;   // byte offset of this segment within the transfer
+  size_t bytes;    // segment length in bytes (always <= maxSeg)
+  bool   isFinal;  // last segment: carries the caller's remote action (signal)
+};
+
+// Number of copy segments a `bytes`-length transfer splits into when each copy
+// is capped at `maxSeg`. A zero-length transfer still issues exactly one (empty)
+// copy so its trailing signal fires; otherwise it is ceil(bytes/maxSeg).
+// maxSeg == 0 is a caller error and yields 0 (callers pass a nonzero cap).
+GIN_SDMA_HD inline size_t ginPutSegmentCount(size_t bytes, size_t maxSeg) {
+  if (maxSeg == 0) return 0;
+  if (bytes == 0) return 1;
+  return (bytes + maxSeg - 1) / maxSeg;
+}
+
+// The i-th (0-based, i < ginPutSegmentCount) segment of a `bytes`-length transfer
+// capped at `maxSeg`. Segments tile [0,bytes) contiguously; the last one is
+// flagged isFinal so the backend carries the remote action on it alone.
+GIN_SDMA_HD inline PutSegment ginPutSegmentAt(size_t bytes, size_t maxSeg, size_t i) {
+  PutSegment s{0, 0, false};
+  s.offset = i * maxSeg;
+  const size_t rem = bytes - s.offset;
+  s.bytes = rem > maxSeg ? maxSeg : rem;
+  s.isFinal = (s.offset + s.bytes >= bytes);
+  return s;
+}
+
+}  // namespace gin_sdma
+
+#endif  // _NCCL_DEVICE_GIN_ANVIL_SDMA_PUT_POLICY_H_

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -445,6 +445,22 @@ if(BUILD_TESTS)
       net_ib_header_symlinks rma_header_symlinks)
   endif()
 
+  # GIN Anvil-SDMA put-segmentation host unit test (no GPU). Pure host C++: the
+  # segment-math header (nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h) is
+  # compiled with GIN_SDMA_HOST_ONLY so it needs neither a built librccl nor device
+  # codegen. It exercises the exact ginPutSegmentCount/ginPutSegmentAt the SDMA
+  # backend Put drives on device. Runs under `ctest -L unit`.
+  add_executable(rccl-UnitTestsGinSdmaPolicy gin/gin_sdma_policy_test.cpp)
+  set_source_files_properties(gin/gin_sdma_policy_test.cpp PROPERTIES LANGUAGE CXX)
+  target_include_directories(rccl-UnitTestsGinSdmaPolicy PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/include)
+  target_compile_definitions(rccl-UnitTestsGinSdmaPolicy PRIVATE GIN_SDMA_HOST_ONLY)
+  target_link_libraries(rccl-UnitTestsGinSdmaPolicy PRIVATE ${GTEST_BOTH_LIBRARIES} Threads::Threads)
+  set_target_properties(rccl-UnitTestsGinSdmaPolicy PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test")
+  add_test(NAME rccl-UnitTestsGinSdmaPolicy COMMAND rccl-UnitTestsGinSdmaPolicy)
+  set_tests_properties(rccl-UnitTestsGinSdmaPolicy PROPERTIES LABELS "unit")
+
   # rccl-UnitTestsFixturesDebug: Tests that access internal symbols compiled into
   # librccl.so which are only visible in Debug builds (hidden visibility in Release).
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
+++ b/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
@@ -20,7 +20,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include <vector>
 
 namespace RcclUnitTesting
@@ -80,9 +79,7 @@ class GinAnvilPluginTest : public ::testing::Test {
     if (hipGetDeviceCount(&ndev) == hipSuccess && ndev > 0) {
       ASSERT_EQ(hipSetDevice(0), hipSuccess);
     }
-    // Anvil-SDMA is ncclNetDeviceType NCCL_NET_DEVICE_GIN_ANVIL_SDMA (=6); derive
-    // from the enum so this never drifts from net_device.h (type 5 is ROCSHMEM_GDA).
-    setenv("NCCL_GIN_TYPE", std::to_string(static_cast<int>(NCCL_NET_DEVICE_GIN_ANVIL_SDMA)).c_str(), 1);
+    setenv("NCCL_GIN_TYPE", "6", 1);
     GinAnvilPluginStubs::SetProbeResult(1);
     GinAnvilPluginStubs::SetBootstrapNranks(1);
   }
@@ -340,14 +337,28 @@ TEST_F(GinAnvilPluginTest, Misc_NoOpPaths) {
   EXPECT_EQ(plugin_.ginProgress(nullptr), ncclSuccess);
 }
 
-// G16: env int parsing via channels (invalid -> default 1).
-TEST_F(GinAnvilPluginTest, Connect_EnvNumChannelsClamp) {
-  ScopedEnv ch("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", "0");
+// G16: the SDMA channel count is forced to 1; NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS is
+// no longer honored. Even with the (now-ignored) env set to a former multi-channel
+// value, connect + createContext must bring the context up with numChannels == 1.
+TEST_F(GinAnvilPluginTest, Connect_NumChannelsForcedSingle) {
+  ScopedEnv ch("NCCL_GIN_ANVIL_SDMA_NUM_CHANNELS", "4");
   void* ictx = nullptr;
   initCtx(&ictx);
   void* coll = nullptr;
   connectColl(ictx, &coll);
   ASSERT_NE(coll, nullptr);
+
+  ncclGinConfig_t cfg{};
+  cfg.nSignals = 1;
+  void* ginCtx = nullptr;
+  ncclNetDeviceHandle_v11_t* devHandle = nullptr;
+  ASSERT_EQ(plugin_.createContext(coll, &cfg, &ginCtx, &devHandle), ncclSuccess);
+
+  ncclGinAnvilSdmaGPUContext hostCtx{};
+  ASSERT_EQ(hipMemcpy(&hostCtx, devHandle->handle, sizeof(hostCtx), hipMemcpyDeviceToHost), hipSuccess);
+  EXPECT_EQ(hostCtx.numChannels, 1);
+
+  plugin_.destroyContext(ginCtx);
   plugin_.closeColl(coll);
   plugin_.finalize(ictx);
 }

--- a/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
+++ b/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
@@ -79,7 +79,9 @@ class GinAnvilPluginTest : public ::testing::Test {
     if (hipGetDeviceCount(&ndev) == hipSuccess && ndev > 0) {
       ASSERT_EQ(hipSetDevice(0), hipSuccess);
     }
-    setenv("NCCL_GIN_TYPE", "6", 1);
+    // Anvil-SDMA is ncclNetDeviceType NCCL_NET_DEVICE_GIN_ANVIL_SDMA (=6); derive
+    // from the enum so this never drifts from net_device.h (type 5 is ROCSHMEM_GDA).
+    setenv("NCCL_GIN_TYPE", std::to_string(static_cast<int>(NCCL_NET_DEVICE_GIN_ANVIL_SDMA)).c_str(), 1);
     GinAnvilPluginStubs::SetProbeResult(1);
     GinAnvilPluginStubs::SetBootstrapNranks(1);
   }

--- a/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
+++ b/projects/rccl/test/gin/GinAnvilPlugin_test.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <vector>
 
 namespace RcclUnitTesting

--- a/projects/rccl/test/gin/gin_sdma_policy_test.cpp
+++ b/projects/rccl/test/gin/gin_sdma_policy_test.cpp
@@ -1,0 +1,135 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host unit tests for the pure GIN Anvil-SDMA put-segmentation math in
+// projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h.
+// These validate the exact loop that ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>
+// drives on device -- the header is compiled here as plain host C++
+// (GIN_SDMA_HOST_ONLY drops the __host__ __device__ attributes), and the same
+// ginPutSegmentCount / ginPutSegmentAt functions are called by the SDMA backend
+// Put, so exercising them here exercises the real segmentation code with no GPU.
+//
+// Invariants asserted for every transfer size:
+//   * no segment exceeds the 128 MiB single-copy cap (kGinPutSegBytes),
+//   * the segments tile [0, bytes) contiguously and sum back to bytes,
+//   * exactly one segment is flagged final (it alone carries the SignalInc),
+//   * the final flag lands on the last segment.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+#define GIN_SDMA_HOST_ONLY 1
+#include "nccl_device/gin/anvil_sdma/gin_anvil_sdma_put_policy.h"
+
+using namespace gin_sdma;
+
+namespace {
+
+constexpr size_t kMiB = 1024ull * 1024;
+constexpr size_t kGiB = 1024ull * kMiB;
+
+// The clamp the backend Put actually uses: 128 MiB (min of the reliability and
+// correctness limits). Kept in lockstep with the header so a future change to
+// either constant is caught here.
+TEST(GinPutSeg, SegLimitIsMinOfBothCaps) {
+  EXPECT_EQ(kGinPutSegBytes, kGinSdmaSafeCopyBytes);
+  EXPECT_LE(kGinPutSegBytes, kGinPutMaxBytes);
+  EXPECT_EQ(kGinPutSegBytes, 128ull * kMiB);
+  // The 128 MiB cap must divide 1 GiB so a 1 GiB descriptor limit is a whole
+  // number of safe copies, and be 32 B aligned for the SDMA copy descriptor.
+  EXPECT_EQ(kGinPutMaxBytes % kGinPutSegBytes, 0u);
+  EXPECT_EQ(kGinPutSegBytes % 32u, 0u);
+}
+
+// Re-derive the whole segmentation for `bytes` and assert every invariant.
+void checkSegmentation(size_t bytes) {
+  const size_t maxSeg = kGinPutSegBytes;
+  const size_t n = ginPutSegmentCount(bytes, maxSeg);
+
+  // Non-empty transfers => ceil(bytes/maxSeg); a zero transfer still issues one
+  // (empty) put so its trailing signal fires.
+  const size_t expectedN = (bytes == 0) ? 1 : (bytes + maxSeg - 1) / maxSeg;
+  ASSERT_EQ(n, expectedN) << "bytes=" << bytes;
+  ASSERT_GE(n, 1u) << "bytes=" << bytes;
+
+  size_t sum = 0;
+  size_t expectedOffset = 0;
+  int finalCount = 0;
+  for (size_t i = 0; i < n; ++i) {
+    const PutSegment s = ginPutSegmentAt(bytes, maxSeg, i);
+
+    // No segment exceeds the cap.
+    EXPECT_LE(s.bytes, maxSeg) << "bytes=" << bytes << " i=" << i;
+
+    // Segments tile [0, bytes) contiguously with no gaps or overlaps.
+    EXPECT_EQ(s.offset, expectedOffset) << "bytes=" << bytes << " i=" << i;
+    expectedOffset += s.bytes;
+
+    // Only the last segment is final.
+    if (s.isFinal) ++finalCount;
+    EXPECT_EQ(s.isFinal, (i == n - 1)) << "bytes=" << bytes << " i=" << i;
+
+    // Interior segments are exactly full (only the tail may be short).
+    if (i + 1 < n) {
+      EXPECT_EQ(s.bytes, maxSeg) << "bytes=" << bytes << " i=" << i;
+    }
+
+    sum += s.bytes;
+  }
+
+  // Exactly one signal is carried, and the segments reconstruct the transfer.
+  EXPECT_EQ(finalCount, 1) << "bytes=" << bytes;
+  EXPECT_EQ(sum, bytes) << "bytes=" << bytes;
+  EXPECT_EQ(expectedOffset, bytes) << "bytes=" << bytes;
+}
+
+// The sizes called out in review: the 128 MiB cap boundary, the 1 GiB 30-bit
+// truncation boundary, and the 2 GiB total hang repro (256 MiB/peer at 8 ranks).
+TEST(GinPutSeg, CoversBoundarySizes) {
+  const size_t sizes[] = {
+      0,
+      1,
+      128 * kMiB,          // exactly one segment (at the cap)
+      128 * kMiB + 1,      // just over: 2 segments (1 B tail)
+      256 * kMiB,          // 2 segments; the size that HUNG as a single put
+      1 * kGiB,            // 8 segments; the 30-bit single-descriptor max
+      1 * kGiB + 1,        // 9 segments; just past the correctness boundary
+      2 * kGiB,            // 16 segments; the original 2 GiB-total hang repro
+  };
+  for (size_t b : sizes) checkSegmentation(b);
+}
+
+// Segment counts for the documented boundaries (128 MiB cap).
+TEST(GinPutSeg, SegmentCounts) {
+  EXPECT_EQ(ginPutSegmentCount(0, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(1, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(128 * kMiB, kGinPutSegBytes), 1u);
+  EXPECT_EQ(ginPutSegmentCount(128 * kMiB + 1, kGinPutSegBytes), 2u);
+  EXPECT_EQ(ginPutSegmentCount(256 * kMiB, kGinPutSegBytes), 2u);
+  EXPECT_EQ(ginPutSegmentCount(1 * kGiB, kGinPutSegBytes), 8u);
+  EXPECT_EQ(ginPutSegmentCount(2 * kGiB, kGinPutSegBytes), 16u);
+}
+
+// A dense scan around each cap multiple catches off-by-one tiling errors.
+TEST(GinPutSeg, DenseScanAroundCapMultiples) {
+  const size_t maxSeg = kGinPutSegBytes;
+  for (size_t k = 0; k <= 18; ++k) {
+    const size_t base = k * maxSeg;
+    for (long d = -2; d <= 2; ++d) {
+      if (base == 0 && d < 0) continue;  // no negative sizes
+      checkSegmentation(base + (size_t)d);
+    }
+  }
+}
+
+// maxSeg == 0 is a caller error; guard returns 0 (no puts) rather than dividing.
+TEST(GinPutSeg, ZeroCapIsGuarded) {
+  EXPECT_EQ(ginPutSegmentCount(1 * kGiB, 0), 0u);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Supersedes #9927.

GIN Anvil-SDMA AllToAll device paths hang on large messages when a single SDMA `put` exceeds what the copy engine can handle in one operation (~1 GiB total on 8 GPUs, e.g. 256 MiB/peer @ 2 GiB).

This PR caps each Anvil-SDMA `put` at **128 MiB per copy** inside the backend, using shared host/device segmentation logic, instead of relying on a rccl-tests-side `ginPutChunked` workaround.

### JIRA ID: AICOMRCCL-1457

### Core change
- Add `gin_anvil_sdma_put_policy.h` with shared host/device segmentation math.
- Wire segmentation into `ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>` in `gin_anvil_sdma.h`.
- Add host unit tests in `gin_sdma_policy_test.cpp` (sizes through multi-GB).
- Remove the rccl-tests `ginPutChunked` workaround from `alltoall.cu`.
- Add `test_AllToAll.py` coverage for large-message GIN Anvil-SDMA paths.

### Supporting commits (develop build/test alignment)
The branch also includes fixes required to build and run against current `develop` (GIN v14, device linker, NCCL 2.29 test harness):

| Commit | Purpose |
|--------|---------|
| Restore develop `CMakeLists.txt` | Drop accidental installsh drift from the original PR#9927 port |
| GIN v14 plugin vtable | `getGinProperties`; drop obsolete `iput*` fields |
| `gin_anvil_sdma.h` API alignment | `GetSignalPtr`/`Flush` signatures, 128 MiB segmentation restore, drop `anvilGinDummySignal`, restore device-linker `Wait`/`FlushAsync`/`Get` stubs |
| Init deadlock fix | Per-ctx signal slots assigned at bind time (same as upstream #9218) |
| `alltoall.cu` | NCCL 2.29 `testEngine` / `getDevCommRequirements` API |

**Head branch:** `users/dondai/gin-sdma-a2a-meta-repro-pr9927`

## Functional validation (MI355 SUT)

Validated on `smci355-ccs-aus-m03-17` (8× MI355X) with GIN Anvil-SDMA AllToAll device kernel (`-D 3`, `NCCL_GIN_TYPE=6`):

| Parameter | Value |
|-----------|-------|
| Message range | 128 B – 4 GB (step factor 2) |
| Validation | `#wrong=0` at all sizes |
| Avg bus bandwidth | ~144 GB/s (full sweep) |
| Peak busbw @ 4 GB | ~420 GB/s |

## Test plan

- [x] Host unit tests: `gin_sdma_policy_test` (segmentation invariants for sizes through multi-GB) — **CI: Host unit tests (CPU-only) passed**
- [x] MI355 SUT: 8× GPU GIN Anvil-SDMA A2A, 128 B–4 GB, `#wrong=0`
- [ ] `projects/rccl-tests/test/test_AllToAll.py` (large-message GIN Anvil-SDMA paths) — pending CI / manual
- [ ] CI: GIN single-node testing — in progress
- [ ] CI: device-API single-node testing — in progress
- [ ] CI: MCI precheckin (rccl, rccl-tests) — in progress