### PR TITLE
fix(rocshmem): USE_SDMA=ON builds would fail GDA+IPC with msg >128B

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -140,17 +140,20 @@ void GDABackend::init() {
   setup_team_world();
   rte_barrier();
 
-  setup_ipc();
-
-  /*
-   * setup_team_shared() must follow setup_ipc() because it uses
-   * ipcImpl.pes_with_ipc_avail to determine shared-memory membership.
-   */
-  setup_team_shared();
-
   setup_ibv();
   setup_heap_memory_rkey();
   setup_gpu_qps();
+
+  /*
+   * setup_ipc() exchanges IPC handles and creates SDMA queues for
+   * node-local peers. Skip when mixed IPC is disabled since GDA will
+   * use the NIC for all traffic.
+   * setup_team_shared() must follow setup_ipc() because it uses
+   * ipcImpl.pes_with_ipc_avail to determine shared-memory membership.
+   */
+  if (!envvar::disable_mixed_ipc)
+    setup_ipc();
+  setup_team_shared();
 
   /*
    * Allocate the symmetric-registration table before contexts are created so
@@ -185,7 +188,8 @@ GDABackend::~GDABackend() {
 
   cleanup_wrk_sync_buffer();
 
-  cleanup_ipc();
+  if (!envvar::disable_mixed_ipc)
+    cleanup_ipc();
 
   cleanup_gpu_qps();
   cleanup_heap_memory_rkey();

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -64,14 +64,8 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id)
                       num_qps * sizeof(QueuePair),
                       hipMemcpyDefault));
 
-  ipcImpl_.ipc_bases = backend->ipcImpl.ipc_bases;
-  ipcImpl_.shm_size = backend->ipcImpl.shm_size;
-  ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;
-  ipcImpl_.heap_size = backend->ipcImpl.heap_size;
-  ipcImpl_.pes_with_ipc_avail = backend->ipcImpl.pes_with_ipc_avail;
-  ipcImpl_.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
-  ipcImpl_.ipc_stride = backend->ipcImpl.ipc_stride;
-  ipcImpl_.symm_table = backend->ipcImpl.symm_table;
+  ipcImpl_.initFrom(backend->ipcImpl);
+  ipcImpl_.assignSdmaChannel(ctx_id);
 }
 
 __host__ GDAContext::~GDAContext() {

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -95,7 +95,8 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   bp->heap_window_info = ro_window_proxy_->get();
 
-  initIPC();
+  if (!envvar::disable_mixed_ipc)
+    initIPC();
 
   transport_->initTransport(envvar::max_num_contexts, &backend_proxy);
 
@@ -188,6 +189,8 @@ void ROBackend::setup_default_ctx_buffers() {
 }
 
 ROBackend::~ROBackend() {
+  if (!envvar::disable_mixed_ipc)
+    ipcImpl.ipcHostStop();
   ro_net_free_runtime();
   CHECK_HIP(hipFree(ctx_array));
 }

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -59,12 +59,8 @@ __host__ ROContext::ROContext(Backend *b,
   }
   ro_net_win_id = block_id % backend->ro_window_proxy_->get_num_MPI_windows();
 
-  ipcImpl_.ipc_bases = b->ipcImpl.ipc_bases;
-  ipcImpl_.shm_size = b->ipcImpl.shm_size;
-  ipcImpl_.shm_rank = b->ipcImpl.shm_rank;
-  ipcImpl_.pes_with_ipc_avail = b->ipcImpl.pes_with_ipc_avail;
-  ipcImpl_.ipc_first_pe = b->ipcImpl.ipc_first_pe;
-  ipcImpl_.ipc_stride = b->ipcImpl.ipc_stride;
+  ipcImpl_.initFrom(b->ipcImpl);
+  ipcImpl_.assignSdmaChannel(block_id);
 
 }
 


### PR DESCRIPTION
## Motivation

Crash when using GDA+IPC when USE_SDMA=ON at compile time

## Technical Details

During recent refactors we modified how certain ipcimpl fields are initialized in the ipc backend, the corresponding changeset did not get applied to  the GDA and RO backends initialization of mixed IPC

Also, do not create SDMA queues and IPC handles if we don't intend to use them anyhow.

## Issue Tracking

JIRA ID: AIROCSHMEM-496

## Test Plan

Ran full cross cardinality of USE_SDMA=ON/OFF, B=ipc/ro/gda, DISABLE_MIXED_IPC=0/1, SDMA_ENABLE=0/1
CI will run pure IPC and pure GDA builds

## Test Result

All combination pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
