### PR TITLE
feat(rocjitsu): Implement swizzle enable semantics

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -6551,6 +6551,11 @@ class CodeGenerator:
         'barrier_arrive': 'amdgpu::AtomicOp::BARRIER_ARRIVE',
     }
 
+    def _buffer_payload_exec_expr(self) -> str:
+        if self.isa_spec.profile.buffer_payload_reads_use_effective_exec_mask:
+            return 'd->exec_mask'
+        return 'wf.exec()'
+
     def _gen_flat_atomic(
         self, dst: list[str], src: list[str], sem: InstructionSemantics
     ) -> str:
@@ -6630,7 +6635,7 @@ class CodeGenerator:
         L.append(f'  d->non_temporal = {nt};')
         L.append('  mubuf_calculate_addresses(inst_, wf, *d);')
         L.append('  auto &cu = wf.cu();')
-        L.append('  uint64_t exec = wf.exec();')
+        L.append(f'  uint64_t exec = {self._buffer_payload_exec_expr()};')
         L.append(f"  uint32_t data_base = {self._vgpr_base_expr('vdata')};")
         stride = data_dwords * 4
         L.append(f'  d->store_data.resize(wf.wf_size() * {stride});')
@@ -6990,7 +6995,7 @@ class CodeGenerator:
         L.append(f'  d->non_temporal = {nt};')
         L.append(f'  {addr_fn}(inst_, wf, *d);')
         L.append('  auto &cu = wf.cu();')
-        L.append('  uint64_t exec = wf.exec();')
+        L.append(f'  uint64_t exec = {self._buffer_payload_exec_expr()};')
         L.append(f"  uint32_t data_base = {self._vgpr_base_expr('vdata')};")
         stride = esz * ne
         L.append(f'  d->store_data.resize(wf.wf_size() * {stride});')

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -329,6 +329,11 @@ class IsaProfile(ABC):
         return False
 
     @property
+    def buffer_payload_reads_use_effective_exec_mask(self) -> bool:
+        """True when buffer store/atomic payload reads use post-address-calc EXEC."""
+        return False
+
+    @property
     def generate_scaled_wmma_vop3px2(self) -> bool:
         """True when generator should synthesize scaled-WMMA VOP3PX2 support."""
         return False
@@ -1871,6 +1876,10 @@ class Cdna5Profile(Rdna4Profile):
 
     @property
     def vbuffer_store_data_uses_dst_vgpr_msb_role(self) -> bool:
+        return True
+
+    @property
+    def buffer_payload_reads_use_effective_exec_mask(self) -> bool:
         return True
 
     @property

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -1392,6 +1392,7 @@ def test_gfx1250_profile_enables_generator_backed_quirks():
     assert profile.uses_packed_16bit_e32_source_selectors
     assert profile.uses_true16_vop3_opsel
     assert profile.vbuffer_store_data_uses_dst_vgpr_msb_role
+    assert profile.buffer_payload_reads_use_effective_exec_mask
     assert profile.generate_scaled_wmma_vop3px2
     assert profile.smem_address_uses_access_size
     assert profile.vop3_cmp_sdst_size_bits == 32
@@ -1430,6 +1431,7 @@ def test_rdna3_profile_enables_gfx11_vop3_true16_only():
     assert profile.uses_packed_16bit_e32_source_selectors
     assert profile.uses_true16_vop3_opsel
     assert not profile.vbuffer_store_data_uses_dst_vgpr_msb_role
+    assert not profile.buffer_payload_reads_use_effective_exec_mask
 
 
 def test_rdna4_profile_enables_gfx12_true16_and_mode_hwregs_only():
@@ -1438,6 +1440,7 @@ def test_rdna4_profile_enables_gfx12_true16_and_mode_hwregs_only():
     assert profile.uses_packed_16bit_e32_source_selectors
     assert profile.uses_true16_vop3_opsel
     assert not profile.vbuffer_store_data_uses_dst_vgpr_msb_role
+    assert not profile.buffer_payload_reads_use_effective_exec_mask
     assert not profile.generate_scaled_wmma_vop3px2
     assert not profile.smem_address_uses_access_size
     assert profile.vop3_cmp_sdst_size_bits is None
@@ -4242,6 +4245,42 @@ def test_gfx1250_buffer_cmpswap_payload_width_is_independent_of_element_width():
     assert 'd->elem_size = 8;' in body
     assert 'd->store_data.resize(wf.wf_size() * 16);' in body
     assert 'data_base + 3' in body
+
+
+@pytest.mark.parametrize(
+    'arch_name,profile,expected_exec,unexpected_exec',
+    [
+        ('cdna5', Cdna5Profile(), 'd->exec_mask', 'wf.exec()'),
+        ('rdna4', Rdna4Profile(), 'wf.exec()', 'd->exec_mask'),
+    ],
+)
+def test_buffer_payload_read_exec_policy_is_profile_owned(
+    arch_name, profile, expected_exec, unexpected_exec
+):
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        arch_name=arch_name,
+        profile=profile,
+    )
+
+    store = SimpleNamespace(
+        name='BUFFER_STORE_B32',
+        elem_size=4,
+        num_elems=1,
+    )
+    atomic = SimpleNamespace(
+        name='BUFFER_ATOMIC_ADD_U32',
+        operation='add',
+        elem_size=4,
+        num_elems=1,
+    )
+
+    for body in (
+        codegen._gen_buffer_store([], [], store),
+        codegen._gen_buffer_atomic([], [], atomic),
+    ):
+        assert f'uint64_t exec = {expected_exec};' in body
+        assert f'uint64_t exec = {unexpected_exec};' not in body
 
 
 def test_gfx1250_buffer_u64_atomic_payload_width_uses_two_dwords():

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -14,6 +14,7 @@
 #include "util/except.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <optional>
@@ -22,6 +23,7 @@ namespace rocjitsu::cdna5 {
 namespace {
 
 constexpr uint64_t kBufferOffsetMask = (uint64_t{1} << 45) - 1;
+constexpr std::array<uint32_t, 4> kStrideMultipliers = {1, 4, 8, 32};
 
 uint32_t scaled_vaddr_factor(const amdgpu::VectorMemState &d) {
   // LLVM folds gfx1250 scale_offset when the scale matches the full memory
@@ -78,6 +80,23 @@ void init_vector_mem_state(amdgpu::Wavefront &wf, amdgpu::VectorMemState &d) {
 
 int64_t logical_buffer_offset(uint32_t index, uint32_t stride, uint32_t voffset, int32_t ioffset) {
   return static_cast<int64_t>(index) * stride + voffset + ioffset;
+}
+
+uint64_t swizzled_buffer_offset(uint32_t index, uint32_t stride, uint32_t voffset, int32_t ioffset,
+                                uint32_t soffset) {
+  // CDNA5 section 9.4.2 fixes the combined offset width at 45 bits, groups
+  // indexes in sets of 32, and uses 16-byte swizzle elements.
+  constexpr uint64_t kIndexStride = 32;
+  constexpr uint64_t kElementSize = 16;
+
+  int64_t combined_offset = static_cast<int64_t>(voffset) + ioffset + soffset;
+  uint64_t total_offset = static_cast<uint64_t>(combined_offset) & kBufferOffsetMask;
+  uint64_t index_msb = index / kIndexStride;
+  uint64_t index_lsb = index % kIndexStride;
+  uint64_t offset_msb = total_offset / kElementSize;
+  uint64_t offset_lsb = total_offset % kElementSize;
+  return (index_msb * stride + offset_msb * kElementSize) * kIndexStride +
+         index_lsb * kElementSize + offset_lsb;
 }
 
 bool byte_range_exceeds(int64_t offset, uint32_t size, uint64_t bound) {
@@ -152,14 +171,13 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
 } // namespace
 
 BufferResource decode_buffer_resource(uint32_t srd0, uint32_t srd1, uint32_t srd2, uint32_t srd3) {
-  static constexpr uint32_t stride_multipliers[] = {1, 4, 8, 32};
   BufferResource resource{};
   resource.base_address = (static_cast<uint64_t>(srd1 & 0x01FF'FFFFu) << 32) | srd0;
   resource.num_records =
       ((static_cast<uint64_t>(srd3 & 0x3Fu) << 32) | srd2) << 7 | ((srd1 >> 25) & 0x7Fu);
   resource.raw_stride = (srd3 >> 12) & 0x3FFFu;
-  resource.stride_scale = static_cast<uint8_t>((srd3 >> 26) & 0x3u);
-  resource.stride = resource.raw_stride * stride_multipliers[resource.stride_scale];
+  resource.stride_scale_encoding = static_cast<uint8_t>((srd3 >> 26) & 0x3u);
+  resource.stride = resource.raw_stride * kStrideMultipliers[resource.stride_scale_encoding];
   resource.swizzle_enabled = ((srd3 >> 28) & 0x1u) != 0;
   resource.oob_select = ((srd3 >> 29) & 0x1u) != 0;
   resource.type = static_cast<uint8_t>((srd3 >> 30) & 0x3u);
@@ -251,6 +269,15 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
   uint32_t srd2 = amdgpu::read_scalar_selector(wf, sb_sel + 2);
   uint32_t srd3 = amdgpu::read_scalar_selector(wf, sb_sel + 3);
   BufferResource resource = decode_buffer_resource(srd0, srd1, srd2, srd3);
+  if (resource.type != 0) {
+    // CDNA5 ignores VBUFFER operations whose resource TYPE does not identify
+    // a buffer. Model the access with effective EXEC=0 so loads and returning
+    // atomics preserve their destinations rather than taking the OOB zero path.
+    d.exec_mask = 0;
+    d.lane_mask = 0;
+    d.element_lane_masks.clear();
+    return;
+  }
   uint32_t soffset_val = has_smem_offset(inst.soffset) ? read_sreg_m0_operand(wf, inst.soffset) : 0;
   int32_t ioff = signed_ioffset(inst.ioffset);
   uint32_t vbase = 0;
@@ -287,16 +314,17 @@ void mubuf_calculate_addresses(const VbufferMachineInst &inst, amdgpu::Wavefront
     } else if (inst.offen) {
       voffset = vaddr_region->lane(0, lane);
     }
-    int64_t logical_offset = logical_buffer_offset(index, resource.stride, voffset, ioff);
-    uint64_t buffer_offset = static_cast<uint64_t>(logical_offset) & kBufferOffsetMask;
-    d.per_lane_addr[lane] = resource.base_address + soffset_val + buffer_offset;
-
     if (resource.swizzle_enabled) {
-      // Swizzled address generation is not modeled yet. Preserve the existing
-      // linear address behavior, but do not apply unswizzled bounds rules.
+      uint64_t buffer_offset =
+          swizzled_buffer_offset(index, resource.stride, voffset, ioff, soffset_val);
+      d.per_lane_addr[lane] = resource.base_address + buffer_offset;
       d.lane_mask |= uint64_t{1} << lane;
       continue;
     }
+
+    int64_t logical_offset = logical_buffer_offset(index, resource.stride, voffset, ioff);
+    uint64_t buffer_offset = static_cast<uint64_t>(logical_offset) & kBufferOffsetMask;
+    d.per_lane_addr[lane] = resource.base_address + soffset_val + buffer_offset;
 
     int64_t record_offset = static_cast<int64_t>(soffset_val) + voffset + ioff;
     int64_t total_offset = static_cast<int64_t>(soffset_val) + logical_offset;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.h
@@ -20,14 +20,14 @@ namespace rocjitsu::cdna5 {
 
 /// @brief Decoded CDNA5 buffer resource descriptor fields.
 struct BufferResource {
-  uint64_t base_address = 0;
-  uint64_t num_records = 0;
-  uint32_t raw_stride = 0;
-  uint32_t stride = 0;
-  uint8_t stride_scale = 0;
-  bool swizzle_enabled = false;
-  bool oob_select = false;
-  uint8_t type = 0;
+  uint64_t base_address = 0;         ///< 57-bit byte address from SRD bits 56:0.
+  uint64_t num_records = 0;          ///< 45-bit buffer size in bytes.
+  uint32_t raw_stride = 0;           ///< Unscaled 14-bit byte stride.
+  uint32_t stride = 0;               ///< Effective byte stride after scaling.
+  uint8_t stride_scale_encoding = 0; ///< Encoding selecting multiplier 1, 4, 8, or 32.
+  bool swizzle_enabled = false;      ///< SRD bit 124.
+  bool oob_select = false;           ///< SRD bit 125.
+  uint8_t type = 0;                  ///< SRD bits 127:126; zero identifies a buffer.
 };
 
 BufferResource decode_buffer_resource(uint32_t srd0, uint32_t srd1, uint32_t srd2, uint32_t srd3);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer_exec.cpp
@@ -156,7 +156,7 @@ void BufferStoreB8Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -180,7 +180,7 @@ void BufferStoreB16Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -204,7 +204,7 @@ void BufferStoreB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -228,7 +228,7 @@ void BufferStoreB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -254,7 +254,7 @@ void BufferStoreB96Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -282,7 +282,7 @@ void BufferStoreB128Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -410,7 +410,7 @@ void BufferStoreD16HiB8Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -435,7 +435,7 @@ void BufferStoreD16HiB16Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -463,7 +463,7 @@ void BufferAtomicSwapB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -490,7 +490,7 @@ void BufferAtomicCmpswapB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -519,7 +519,7 @@ void BufferAtomicAddU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -546,7 +546,7 @@ void BufferAtomicSubU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -573,7 +573,7 @@ void BufferAtomicSubClampU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -600,7 +600,7 @@ void BufferAtomicMinI32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -627,7 +627,7 @@ void BufferAtomicMinU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -654,7 +654,7 @@ void BufferAtomicMaxI32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -681,7 +681,7 @@ void BufferAtomicMaxU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -708,7 +708,7 @@ void BufferAtomicAndB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -735,7 +735,7 @@ void BufferAtomicOrB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -762,7 +762,7 @@ void BufferAtomicXorB32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -789,7 +789,7 @@ void BufferAtomicIncU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -816,7 +816,7 @@ void BufferAtomicDecU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -843,7 +843,7 @@ void BufferAtomicSwapB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -872,7 +872,7 @@ void BufferAtomicCmpswapB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -905,7 +905,7 @@ void BufferAtomicAddU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -934,7 +934,7 @@ void BufferAtomicSubU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -963,7 +963,7 @@ void BufferAtomicMinI64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -992,7 +992,7 @@ void BufferAtomicMinU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1021,7 +1021,7 @@ void BufferAtomicMaxI64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1050,7 +1050,7 @@ void BufferAtomicMaxU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1079,7 +1079,7 @@ void BufferAtomicAndB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1108,7 +1108,7 @@ void BufferAtomicOrB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1137,7 +1137,7 @@ void BufferAtomicXorB64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1166,7 +1166,7 @@ void BufferAtomicIncU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1195,7 +1195,7 @@ void BufferAtomicDecU64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1224,7 +1224,7 @@ void BufferAtomicCondSubU32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1251,7 +1251,7 @@ void BufferAtomicMinNumF32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1278,7 +1278,7 @@ void BufferAtomicMaxNumF32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1305,7 +1305,7 @@ void BufferAtomicAddF64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1334,7 +1334,7 @@ void BufferAtomicAddF32Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1361,7 +1361,7 @@ void BufferAtomicPkAddF16Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1388,7 +1388,7 @@ void BufferAtomicPkAddBf16Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1415,7 +1415,7 @@ void BufferAtomicMinNumF64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());
@@ -1444,7 +1444,7 @@ void BufferAtomicMaxNumF64Vbuffer::execute_impl(amdgpu::Wavefront &wf) {
   d->non_temporal = 0;
   mubuf_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
-  uint64_t exec = wf.exec();
+  uint64_t exec = d->exec_mask;
   uint32_t data_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdata.opr_type_, vdata.encoding_value_, vdata.vgpr_msb_role());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -15,10 +15,12 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "rocjitsu/vm/amdgpu/wait_counters.h"
 
-#include <string>
-
 #include <array>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <span>
+#include <string>
 #include <vector>
 
 namespace rocjitsu {
@@ -91,6 +93,58 @@ struct ScalarMemState : DynamicInstState {
   uint32_t store_data[16] = {};
 };
 
+/// @brief Per-element vector-memory lane masks with inline storage for the
+/// common one-to-four-element access widths.
+class ElementLaneMasks {
+public:
+  static constexpr size_t kInlineCapacity = 4;
+
+  [[nodiscard]] bool empty() const { return size_ == 0; }
+  [[nodiscard]] size_t size() const { return size_; }
+
+  void clear() {
+    size_ = 0;
+    overflow_.clear();
+  }
+
+  void assign(size_t count, uint64_t value) {
+    if (count <= kInlineCapacity) {
+      overflow_.clear();
+      for (size_t i = 0; i < count; ++i)
+        inline_[i] = value;
+      size_ = count;
+      return;
+    }
+    overflow_.assign(count, value);
+    size_ = count;
+  }
+
+  uint64_t &operator[](size_t index) {
+    assert(index < size_);
+    return data()[index];
+  }
+
+  const uint64_t &operator[](size_t index) const {
+    assert(index < size_);
+    return data()[index];
+  }
+
+  [[nodiscard]] std::span<const uint64_t> view() const { return {data(), size_}; }
+
+private:
+  [[nodiscard]] uint64_t *data() {
+    return size_ <= kInlineCapacity ? inline_.data() : overflow_.data();
+  }
+
+  [[nodiscard]] const uint64_t *data() const {
+    return size_ <= kInlineCapacity ? inline_.data() : overflow_.data();
+  }
+
+  std::array<uint64_t, kInlineCapacity> inline_{};
+  std::vector<uint64_t> overflow_;
+  size_t size_ = 0;
+};
+
 /// @brief Dynamic pipeline state for vector memory instructions
 /// (FLAT, MUBUF, MTBUF, DS).
 struct VectorMemState : DynamicInstState {
@@ -100,12 +154,13 @@ struct VectorMemState : DynamicInstState {
   }
   std::array<uint64_t, 64> per_lane_addr = {};
   uint64_t lane_mask = 0;
-  /// Optional per-element lane validity. Empty means every element uses
-  /// lane_mask; otherwise the vector contains exactly num_elems masks and
-  /// lane_mask is their union.
-  std::vector<uint64_t> element_lane_masks;
-  uint64_t exec_mask = 0; ///< EXEC mask at issue time. Set by addr calc functions.
-                          ///< Writeback zeroes OOB lanes (exec_mask & ~lane_mask).
+  /// Optional per-element lane validity for untyped DWORD-component bounds.
+  /// Empty means every element uses lane_mask; otherwise the container has
+  /// exactly num_elems masks and lane_mask is their union.
+  ElementLaneMasks element_lane_masks;
+  uint64_t exec_mask = 0; ///< Effective EXEC mask captured by address calculation.
+                          ///< Architecturally ignored accesses clear it; writeback
+                          ///< zeroes OOB lanes (exec_mask & ~lane_mask).
   uint32_t wf_size = 64;  ///< Wavefront width (set from wavefront's wf_size()).
   uint32_t dst_reg_base = 0;
   uint32_t elem_size = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -144,7 +144,8 @@ MemoryAccessCompletion vector_complete(VectorMemState &d, Wavefront &wf, Compute
   uint32_t vgpr_count = is_atomic ? (d.elem_size / 4) : std::max(1u, total_bytes / 4);
 
   // Zero destination VGPRs for OOB lanes. Per AMD ISA spec, out-of-bounds
-  // buffer loads return 0. exec_mask is the original EXEC at issue time;
+  // buffer loads return 0. exec_mask is the effective EXEC at issue time;
+  // ordinary OOB accesses retain it while ignored resource types clear it.
   // lane_mask has OOB lanes removed. The difference gives exec-active OOB lanes.
   uint64_t exec = d.exec_mask;
   uint64_t oob_mask = exec & ~d.lane_mask; // exec-active but OOB
@@ -508,19 +509,20 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
     if (scratch_lanes)
       l1_->load(d.per_lane_addr.data(), scratch_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
-                d.wf_size, wf.process_id(), stride, d.element_lane_masks);
+                d.wf_size, wf.process_id(), stride, d.element_lane_masks.view());
     if (plain_lanes)
       l1_->load(d.per_lane_addr.data(), plain_lanes, d.elem_size, d.num_elems,
                 d.response_data.data(), d.mtype, d.non_temporal, d.request_force_l1_bypass,
-                d.wf_size, wf.process_id(), 0, d.element_lane_masks);
+                d.wf_size, wf.process_id(), 0, d.element_lane_masks.view());
   } else {
     if (scratch_lanes)
       l1_->store(d.per_lane_addr.data(), scratch_lanes, d.elem_size, d.num_elems,
                  d.store_data.data(), d.mtype, d.non_temporal, d.wf_size, wf.process_id(), stride,
-                 d.element_lane_masks);
+                 d.element_lane_masks.view());
     if (plain_lanes)
       l1_->store(d.per_lane_addr.data(), plain_lanes, d.elem_size, d.num_elems, d.store_data.data(),
-                 d.mtype, d.non_temporal, d.wf_size, wf.process_id(), 0, d.element_lane_masks);
+                 d.mtype, d.non_temporal, d.wf_size, wf.process_id(), 0,
+                 d.element_lane_masks.view());
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -287,6 +287,8 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
 
   if (inst.data()->tag() == amdgpu::GLOBAL_MEM) {
     auto &d = *inst.data_as<amdgpu::VectorMemState>();
+    if (d.exec_mask == 0)
+      return;
     if (d.lds_dst) {
       uint32_t perLaneBytes = d.num_elems * d.elem_size;
       if (d.cluster_multicast && d.cluster_mcast_mask != 0) {
@@ -313,10 +315,10 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
       for (uint32_t i = 0; i < d.num_elems; ++i)
         registers[i] = logicalBase + i;
       uint8_t byte_mask = d.d16_lo ? 0x3 : d.d16_hi ? 0xC : 0xF;
-      rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_VGPR, std::move(registers), wf.exec(),
+      rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_VGPR, std::move(registers), d.exec_mask,
                         byte_mask);
     } else if (!d.is_load) {
-      rs->registerEvent(wf.pc, MemoryEventType::VGPR_TO_GLOBAL, {}, wf.exec());
+      rs->registerEvent(wf.pc, MemoryEventType::VGPR_TO_GLOBAL, {}, d.exec_mask);
     }
   }
 

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -4,6 +4,8 @@
 #include "cdna5_sim_test_common.h"
 #include "decode_test_util.h"
 #include "rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 
 namespace {
 
@@ -17,6 +19,17 @@ public:
 
 private:
   bool original_;
+};
+
+class VgprReadRecorder final : public ExecutionPlugin {
+public:
+  VgprReadRecorder() : ExecutionPlugin("vgpr_read_recorder") {}
+
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *, uint32_t, uint64_t, uint8_t) override {
+    ++read_count;
+  }
+
+  uint32_t read_count = 0;
 };
 
 TEST(Gfx1250ExecutionTest, TargetProvidesImmutableExecutionBackend) {
@@ -215,15 +228,16 @@ TEST(Gfx1250ExecutionTest, VbufferB64B96MixedLanesHonorStructuredPartialOob) {
   constexpr uint32_t kStoreVgpr = 16;
   constexpr uint64_t kNumRecords = 32;
   constexpr uint32_t kRawStride = 4;
-  constexpr uint32_t kStrideScale = 1;
-  constexpr uint32_t kStride = kRawStride * 4;
+  constexpr uint32_t kStrideScaleEncoding = 1;
+  constexpr uint32_t kStrideMultiplier = 4;
+  constexpr uint32_t kStride = kRawStride * kStrideMultiplier;
   const std::array<uint32_t, 4> resource = {
       static_cast<uint32_t>(kAddr),
       static_cast<uint32_t>((kAddr >> 32) & 0x01FF'FFFFu) |
           static_cast<uint32_t>((kNumRecords & 0x7Fu) << 25),
       static_cast<uint32_t>(kNumRecords >> 7),
       static_cast<uint32_t>((kNumRecords >> 39) & 0x3Fu) | (kRawStride << 12) |
-          (kStrideScale << 26) | (1u << 29),
+          (kStrideScaleEncoding << 26) | (1u << 29),
   };
   for (uint32_t i = 0; i < resource.size(); ++i)
     cu->write_sgpr(wf->sgpr_alloc().base + kResourceSgpr + i, resource[i]);
@@ -340,6 +354,58 @@ TEST(Gfx1250ExecutionTest, NonReturningVbufferB64AtomicHonorsWholePayloadBounds)
   partial_oob->execute_impl(*wf);
   pipeline.issue(partial_oob, *wf);
   EXPECT_EQ(sim.memory->read64(kAddr), kInitial);
+}
+
+TEST(Gfx1250ExecutionTest, ReturningVbufferAtomicIgnoresNonBufferResourceType) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint64_t kAddr = 0xC180;
+  constexpr uint32_t kResourceSgpr = 4;
+  constexpr uint32_t kDataVgpr = 8;
+  constexpr uint32_t kNonBufferType = 2;
+  constexpr uint32_t kInitialMemory = 0x0102'0304u;
+  constexpr uint32_t kDataSentinel = 0xA1A2'A3A4u;
+  constexpr uint64_t kNumRecords = sizeof(uint32_t);
+  const std::array<uint32_t, 4> resource = {
+      static_cast<uint32_t>(kAddr),
+      static_cast<uint32_t>((kAddr >> 32) & 0x01FF'FFFFu) |
+          static_cast<uint32_t>((kNumRecords & 0x7Fu) << 25),
+      static_cast<uint32_t>(kNumRecords >> 7),
+      static_cast<uint32_t>((kNumRecords >> 39) & 0x3Fu) | (kNonBufferType << 30),
+  };
+  for (uint32_t i = 0; i < resource.size(); ++i)
+    cu->write_sgpr(wf->sgpr_alloc().base + kResourceSgpr + i, resource[i]);
+  sim.memory->write32(kAddr, kInitialMemory);
+  cu->write_vgpr(wf->vgpr_alloc().base + kDataVgpr, 0, kDataSentinel);
+
+  auto plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto recorder = std::make_unique<VgprReadRecorder>();
+  auto *recorder_ptr = recorder.get();
+  ASSERT_TRUE(plugin_group->add(std::move(recorder)));
+  cu->set_plugin_group(plugin_group);
+  plugin_group->onInit();
+
+  cdna5::VbufferMachineInst machine{};
+  machine.vdata = kDataVgpr;
+  machine.rsrc = kResourceSgpr;
+  machine.soffset = cdna5::OPR_SREG_NULL;
+  machine.scope = 3;
+  machine.th = amdgpu::GFX12_TH_ATOMIC_RETURN;
+
+  amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+  auto *atomic =
+      new cdna5::BufferAtomicSwapB32Vbuffer(reinterpret_cast<const cdna5::MachineInst *>(&machine));
+  atomic->execute_impl(*wf);
+  pipeline.issue(atomic, *wf);
+
+  EXPECT_EQ(recorder_ptr->read_count, 0u);
+  EXPECT_EQ(sim.memory->read32(kAddr), kInitialMemory);
+  EXPECT_EQ(cu->read_vgpr(wf->vgpr_alloc().base + kDataVgpr, 0), kDataSentinel);
+  EXPECT_TRUE(wf->wait_counters().empty());
 }
 
 TEST(Gfx1250ExecutionTest, DivScaleWritesExplicitSdstMask) {

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -156,6 +156,11 @@ public:
   }
 };
 
+class TestWaitcntInstruction : public Instruction {
+public:
+  TestWaitcntInstruction() : Instruction("s_waitcnt", nullptr) {}
+};
+
 struct ForceScalarOverride {
   explicit ForceScalarOverride(bool value) : old(util::force_scalar()) {
     util::set_force_scalar_for_testing(value);
@@ -3161,6 +3166,7 @@ TEST(RaceDetectorPluginTest, DroppedAsyncLdsLaneDoesNotCreateLowAddressRace) {
   dropped->lds_dst = true;
   dropped->lds_per_lane_addr = true;
   dropped->wf_size = writer->wf_size();
+  dropped->exec_mask = 0x1u;
   dropped->lane_mask = 0x1u;
   dropped->per_lane_lds_addr[0] = amdgpu::kInvalidLdsAddress;
   TestMemoryInstruction dropped_inst(std::move(dropped));
@@ -3179,6 +3185,95 @@ TEST(RaceDetectorPluginTest, DroppedAsyncLdsLaneDoesNotCreateLowAddressRace) {
 
   EXPECT_EQ(sink.str().find("RACE "), std::string::npos);
 }
+
+class IgnoredGlobalMemoryRaceTest : public ::testing::TestWithParam<AtomicOp> {};
+
+TEST_P(IgnoredGlobalMemoryRaceTest, DoesNotCreateDestinationRace) {
+  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"cdna5", /*wavefront_size=*/32);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *wf = f.cu()->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x1u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
+                                               waves);
+
+  constexpr uint32_t kDestinationVgpr = 7;
+  auto ignored = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  ignored->elem_size = 4;
+  ignored->num_elems = 1;
+  ignored->is_load = true;
+  ignored->atomic_op = GetParam();
+  ignored->exec_mask = 0;
+  ignored->lane_mask = 0;
+  ignored->wf_size = wf->wf_size();
+  ignored->dst_reg_base = wf->vgpr_alloc().base + kDestinationVgpr;
+  TestMemoryInstruction ignored_inst(std::move(ignored));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(ignored_inst, *wf);
+
+  f.plugin_group_->onAmdgpuReadVgprLanes(wf, wf->vgpr_alloc().base + kDestinationVgpr,
+                                         /*lane_mask=*/0x1u, /*byte_mask=*/0xFu);
+  EXPECT_EQ(sink.str().find("RACE "), std::string::npos);
+}
+
+TEST_P(IgnoredGlobalMemoryRaceTest, DoesNotConsumeVmcntOrderingSlot) {
+  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"cdna5", /*wavefront_size=*/32);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *wf = f.cu()->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x1u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
+                                               waves);
+
+  constexpr uint32_t kDestinationVgpr = 7;
+  auto load = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  load->elem_size = 4;
+  load->num_elems = 1;
+  load->is_load = true;
+  load->exec_mask = 0x1u;
+  load->lane_mask = 0x1u;
+  load->wf_size = wf->wf_size();
+  load->dst_reg_base = wf->vgpr_alloc().base + kDestinationVgpr;
+  TestMemoryInstruction load_inst(std::move(load));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(load_inst, *wf);
+
+  auto ignored = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  ignored->elem_size = 4;
+  ignored->num_elems = 1;
+  ignored->is_load = false;
+  ignored->atomic_op = GetParam();
+  ignored->exec_mask = 0;
+  ignored->lane_mask = 0;
+  ignored->wf_size = wf->wf_size();
+  TestMemoryInstruction ignored_inst(std::move(ignored));
+  f.plugin_group_->onAmdgpuRouteMemoryInstruction(ignored_inst, *wf);
+
+  wf->set_wait_target(/*vmcnt=*/1, /*lgkmcnt=*/0, /*expcnt=*/0);
+  TestWaitcntInstruction waitcnt;
+  f.plugin_group_->onAmdgpuAfterExecuteInstruction(wf->pc, waitcnt, *wf);
+
+  f.plugin_group_->onAmdgpuReadVgprLanes(wf, wf->vgpr_alloc().base + kDestinationVgpr,
+                                         /*lane_mask=*/0x1u, /*byte_mask=*/0xFu);
+  EXPECT_NE(sink.str().find("RACE "), std::string::npos);
+}
+
+INSTANTIATE_TEST_SUITE_P(LoadAndReturningAtomic, IgnoredGlobalMemoryRaceTest,
+                         ::testing::Values(AtomicOp::NONE, AtomicOp::SWAP));
 
 TEST(ExecutionPluginGroupTest, OwnsConfiguredSinkForRetainedGroupLifetime) {
   std::vector<std::string> events;

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -37,6 +37,8 @@
 #include "rocjitsu/vm/amdgpu/hwreg.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "test_encodings_util.h"
 #include "util/data_types.h"
 #include "util/except.h"
@@ -212,6 +214,18 @@ public:
     else
       delete inst;
   }
+};
+
+class Gfx1250VgprReadRecorder final : public ExecutionPlugin {
+public:
+  Gfx1250VgprReadRecorder() : ExecutionPlugin("gfx1250_vgpr_read_recorder") {}
+
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *, uint32_t physical_reg, uint64_t,
+                             uint8_t) override {
+    read_registers.push_back(physical_reg);
+  }
+
+  std::vector<uint32_t> read_registers;
 };
 
 /// @brief Check if a mnemonic should be skipped in the execution harness.
@@ -555,6 +569,154 @@ TEST(Gfx1250MemoryExecutionHarness, ExecutesRepresentativeValidAddressStores) {
   EXPECT_EQ(gpu_mem.read32(kBufferAddr + 16), 0x22000000u);
   EXPECT_EQ(gpu_mem.read32(kBufferAddr + 32), 0u);
   EXPECT_EQ(gpu_mem.read32(kBufferAddr + 48), 0x22000001u);
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Gfx1250MemoryExecutionHarness, SwizzledBufferIdxenOffenUsesScaledStride) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_swizzled_buffer_harness_mem");
+  amdgpu::L2Cache l2("gfx1250_swizzled_buffer_harness_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  Gfx1250MemoryTestCu cu("gfx1250", cfg, &gpu_mem, &l2);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu.dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+
+  constexpr uint64_t kBufferAddr = 0x4000;
+  constexpr uint32_t kRawStride = 16;
+  constexpr uint32_t kStrideScaleEncoding = 1;
+  constexpr uint32_t kStrideMultiplier = 4;
+  constexpr uint32_t kIndexStride = 32;
+  constexpr uint32_t kScaledStride = kRawStride * kStrideMultiplier;
+  constexpr uint32_t kSwizzleEnable = 1u << 28;
+  constexpr uint32_t kSecondIndex = kIndexStride;
+  constexpr uint32_t kSecondVoffset = 16;
+  constexpr uint32_t kLinearSecondOffset = kSecondIndex * kScaledStride + kSecondVoffset;
+  constexpr uint32_t kUnscaledSwizzledSecondOffset = (kRawStride + kSecondVoffset) * kIndexStride;
+  constexpr uint32_t kSwizzledSecondOffset = (kScaledStride + kSecondVoffset) * kIndexStride;
+  constexpr std::array<uint32_t, 2> kPayload = {0x3300'0000u, 0x3300'0001u};
+  const uint32_t sb = wf->sgpr_alloc().base;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_sgpr(sb + 4, static_cast<uint32_t>(kBufferAddr));
+  cu.write_sgpr(sb + 5, static_cast<uint32_t>(kBufferAddr >> 32));
+  cu.write_sgpr(sb + 6, 0);
+  cu.write_sgpr(sb + 7, (kRawStride << 12) | (kStrideScaleEncoding << 26) | kSwizzleEnable);
+  gpu_mem.write32(kBufferAddr, 0);
+  gpu_mem.write32(kBufferAddr + kLinearSecondOffset, 0);
+  gpu_mem.write32(kBufferAddr + kUnscaledSwizzledSecondOffset, 0);
+  gpu_mem.write32(kBufferAddr + kSwizzledSecondOffset, 0);
+  for (uint32_t lane = 0; lane < kPayload.size(); ++lane) {
+    cu.write_vgpr(vb, lane, kPayload[lane]);
+    cu.write_vgpr(vb + 1, lane, 0);
+    cu.write_vgpr(vb + 5, lane, lane * kSecondIndex);
+    cu.write_vgpr(vb + 6, lane, lane * kSecondVoffset);
+  }
+
+  // buffer_store_b32 v0, v[5:6], s[4:7], NULL idxen offen
+  const uint32_t buffer_store_words[] = {0xC406807Cu, 0xC0800800u, 0x00000005u};
+  std::unique_ptr<Instruction> buffer_store(decode_valid(*decoder, buffer_store_words));
+  ASSERT_NE(buffer_store, nullptr);
+  ASSERT_EQ(std::string_view(buffer_store->mnemonic()), "buffer_store_b32");
+  cu.execute_and_route(buffer_store.release(), *wf);
+  cu.flush_all();
+
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr), kPayload[0]);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + kLinearSecondOffset), 0u);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + kUnscaledSwizzledSecondOffset), 0u);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + kSwizzledSecondOffset), kPayload[1]);
+
+  // buffer_load_b32 v1, v[5:6], s[4:7], NULL idxen offen
+  const uint32_t buffer_load_words[] = {0xC405007Cu, 0xC0800801u, 0x00000005u};
+  std::unique_ptr<Instruction> buffer_load(decode_valid(*decoder, buffer_load_words));
+  ASSERT_NE(buffer_load, nullptr);
+  ASSERT_EQ(std::string_view(buffer_load->mnemonic()), "buffer_load_b32");
+  cu.execute_and_route(buffer_load.release(), *wf);
+  cu.flush_all();
+
+  EXPECT_EQ(cu.read_vgpr(vb + 1, 0), kPayload[0]);
+  EXPECT_EQ(cu.read_vgpr(vb + 1, 1), kPayload[1]);
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
+TEST(Gfx1250MemoryExecutionHarness, NonBufferResourceTypeSuppressesLoadAndStore) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_non_buffer_type_harness_mem");
+  amdgpu::L2Cache l2("gfx1250_non_buffer_type_harness_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  Gfx1250MemoryTestCu cu("gfx1250", cfg, &gpu_mem, &l2);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu.dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint64_t kBufferAddr = 0x5000;
+  constexpr uint64_t kNumRecords = 64;
+  constexpr uint32_t kNonBufferType = 2;
+  constexpr uint32_t kInitialMemory = 0x1122'3344u;
+  constexpr uint32_t kStorePayload = 0x5566'7788u;
+  constexpr uint32_t kLoadSentinel = 0xA5A5'5A5Au;
+  const uint32_t sb = wf->sgpr_alloc().base;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_sgpr(sb + 4, static_cast<uint32_t>(kBufferAddr));
+  cu.write_sgpr(sb + 5, static_cast<uint32_t>(kBufferAddr >> 32) |
+                            static_cast<uint32_t>((kNumRecords & 0x7Fu) << 25));
+  cu.write_sgpr(sb + 6, static_cast<uint32_t>(kNumRecords >> 7));
+  cu.write_sgpr(sb + 7,
+                static_cast<uint32_t>((kNumRecords >> 39) & 0x3Fu) | (kNonBufferType << 30));
+  cu.write_vgpr(vb, 0, kStorePayload);
+  cu.write_vgpr(vb + 1, 0, kLoadSentinel);
+  cu.write_vgpr(vb + 5, 0, 0);
+  cu.write_vgpr(vb + 6, 0, 0);
+  gpu_mem.write32(kBufferAddr, kInitialMemory);
+
+  auto plugin_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto recorder = std::make_unique<Gfx1250VgprReadRecorder>();
+  auto *recorder_ptr = recorder.get();
+  plugin_group->add(std::move(recorder));
+  cu.set_plugin_group(plugin_group);
+
+  // buffer_store_b32 v0, v[5:6], s[4:7], NULL idxen offen
+  const uint32_t buffer_store_words[] = {0xC406807Cu, 0xC0800800u, 0x00000005u};
+  std::unique_ptr<Instruction> buffer_store(decode_valid(*decoder, buffer_store_words));
+  ASSERT_NE(buffer_store, nullptr);
+  cu.execute_and_route(buffer_store.release(), *wf);
+  cu.flush_all();
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr), kInitialMemory);
+  EXPECT_TRUE(recorder_ptr->read_registers.empty());
+
+  // buffer_load_b32 v1, v[5:6], s[4:7], NULL idxen offen
+  const uint32_t buffer_load_words[] = {0xC405007Cu, 0xC0800801u, 0x00000005u};
+  std::unique_ptr<Instruction> buffer_load(decode_valid(*decoder, buffer_load_words));
+  ASSERT_NE(buffer_load, nullptr);
+  cu.execute_and_route(buffer_load.release(), *wf);
+  cu.flush_all();
+  EXPECT_TRUE(recorder_ptr->read_registers.empty());
+  EXPECT_EQ(cu.read_vgpr(vb + 1, 0), kLoadSentinel);
+  EXPECT_TRUE(wf->wait_counters().empty());
 
   if (!wf->is_halted())
     wf->halt();

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -102,6 +102,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -4511,8 +4512,8 @@ TEST(RdnaAddrCalcTest, Rdna4VbufferWrapsOffsetPartBeforeBaseAddition) {
 }
 
 std::array<uint32_t, 4> encode_gfx1250_buffer_resource(uint64_t base, uint64_t num_records,
-                                                       uint32_t stride = 0,
-                                                       uint32_t stride_scale = 0,
+                                                       uint32_t raw_stride = 0,
+                                                       uint32_t stride_scale_encoding = 0,
                                                        bool swizzle = false,
                                                        bool oob_select = false, uint32_t type = 0) {
   return {
@@ -4520,8 +4521,8 @@ std::array<uint32_t, 4> encode_gfx1250_buffer_resource(uint64_t base, uint64_t n
       static_cast<uint32_t>((base >> 32) & 0x01FF'FFFFu) |
           static_cast<uint32_t>((num_records & 0x7Fu) << 25),
       static_cast<uint32_t>(num_records >> 7),
-      static_cast<uint32_t>((num_records >> 39) & 0x3Fu) | ((stride & 0x3FFFu) << 12) |
-          ((stride_scale & 0x3u) << 26) | (static_cast<uint32_t>(swizzle) << 28) |
+      static_cast<uint32_t>((num_records >> 39) & 0x3Fu) | ((raw_stride & 0x3FFFu) << 12) |
+          ((stride_scale_encoding & 0x3u) << 26) | (static_cast<uint32_t>(swizzle) << 28) |
           (static_cast<uint32_t>(oob_select) << 29) | ((type & 0x3u) << 30),
   };
 }
@@ -4532,12 +4533,44 @@ void write_gfx1250_buffer_resource(amdgpu::ComputeUnitCore &cu, amdgpu::Wavefron
     cu.write_sgpr(wf.sgpr_alloc().base + first_sgpr + i, resource[i]);
 }
 
+void expect_element_lane_masks(const amdgpu::ElementLaneMasks &masks,
+                               std::initializer_list<uint64_t> expected) {
+  const auto actual = masks.view();
+  ASSERT_EQ(actual.size(), expected.size());
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), expected.begin(), expected.end()));
+}
+
+TEST(AmdgpuElementLaneMasksTest, UsesInlineWidthAndPreservesLargerFallback) {
+  amdgpu::ElementLaneMasks masks;
+  EXPECT_TRUE(masks.empty());
+  EXPECT_EQ(amdgpu::ElementLaneMasks::kInlineCapacity, 4u);
+
+  masks.assign(amdgpu::ElementLaneMasks::kInlineCapacity, 0x3u);
+  masks[2] = 0x1u;
+  expect_element_lane_masks(masks, {0x3u, 0x3u, 0x1u, 0x3u});
+
+  masks.assign(32, 0x5u);
+  EXPECT_EQ(masks.size(), 32u);
+  masks[31] = 0x7u;
+  const auto overflow_view = masks.view();
+  ASSERT_EQ(overflow_view.size(), 32u);
+  EXPECT_TRUE(std::all_of(overflow_view.begin(), overflow_view.end() - 1,
+                          [](uint64_t mask) { return mask == 0x5u; }));
+  EXPECT_EQ(overflow_view.back(), 0x7u);
+
+  masks.assign(amdgpu::ElementLaneMasks::kInlineCapacity, 0x9u);
+  expect_element_lane_masks(masks, {0x9u, 0x9u, 0x9u, 0x9u});
+
+  masks.clear();
+  EXPECT_TRUE(masks.empty());
+}
+
 TEST(Gfx1250AddrCalcTest, DecodesBufferResourceFields) {
   constexpr uint64_t kBase = 0x0101'2345'6789'ABCDULL;
   constexpr uint64_t kNumRecords = 0x0123'4567'89ABULL;
   constexpr uint32_t kRawStride = 0x1234;
   auto words = encode_gfx1250_buffer_resource(kBase, kNumRecords, kRawStride,
-                                              /*stride_scale=*/3, /*swizzle=*/true,
+                                              /*stride_scale_encoding=*/3, /*swizzle=*/true,
                                               /*oob_select=*/true, /*type=*/2);
 
   cdna5::BufferResource resource =
@@ -4545,11 +4578,46 @@ TEST(Gfx1250AddrCalcTest, DecodesBufferResourceFields) {
   EXPECT_EQ(resource.base_address, kBase);
   EXPECT_EQ(resource.num_records, kNumRecords);
   EXPECT_EQ(resource.raw_stride, kRawStride);
-  EXPECT_EQ(resource.stride_scale, 3);
+  EXPECT_EQ(resource.stride_scale_encoding, 3);
   EXPECT_EQ(resource.stride, kRawStride * 32);
   EXPECT_TRUE(resource.swizzle_enabled);
   EXPECT_TRUE(resource.oob_select);
   EXPECT_EQ(resource.type, 2);
+}
+
+TEST(Gfx1250AddrCalcTest, NonBufferResourceTypesSuppressAccess) {
+  amdgpu::GpuMemory mem("gfx1250_vbuffer_type_mem");
+  amdgpu::L2Cache l2("gfx1250_vbuffer_type_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250_vbuffer_type_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+
+  cdna5::VbufferMachineInst inst{};
+  inst.rsrc = 40;
+  inst.soffset = cdna5::OPR_SREG_NULL;
+  for (uint32_t type = 1; type <= 3; ++type) {
+    write_gfx1250_buffer_resource(
+        *cu, *wf, 40,
+        encode_gfx1250_buffer_resource(/*base=*/0x4000, /*num_records=*/64,
+                                       /*raw_stride=*/16, /*stride_scale_encoding=*/0,
+                                       /*swizzle=*/false, /*oob_select=*/false, type));
+    amdgpu::VectorMemState state(amdgpu::GLOBAL_MEM);
+    state.elem_size = 4;
+    state.num_elems = 1;
+    cdna5::mubuf_calculate_addresses(inst, *wf, state);
+    EXPECT_EQ(state.exec_mask, 0u);
+    EXPECT_EQ(state.lane_mask, 0u);
+    EXPECT_TRUE(state.element_lane_masks.empty());
+  }
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferUses45BitBufferOffsetAnd57BitBase) {
@@ -4568,7 +4636,7 @@ TEST(Gfx1250AddrCalcTest, VbufferUses45BitBufferOffsetAnd57BitBase) {
   ASSERT_NE(wf, nullptr);
   wf->set_exec(1ULL);
 
-  constexpr uint64_t kBase = 0x0010'0002'0000'1000ULL;
+  constexpr uint64_t kBase = 0x0100'0002'0000'1000ULL;
   constexpr uint64_t kOffset = uint64_t{1} << 32;
   uint32_t vbase = wf->vgpr_alloc().base;
   write_gfx1250_buffer_resource(*cu, *wf, 4, encode_gfx1250_buffer_resource(kBase, kOffset + 4));
@@ -4582,13 +4650,13 @@ TEST(Gfx1250AddrCalcTest, VbufferUses45BitBufferOffsetAnd57BitBase) {
   inst.vaddr = 4;
   inst.ioffset = 0x7E00;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 1;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 1ULL);
-  EXPECT_EQ(d.per_lane_addr[0], kBase + kOffset);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{1ULL}));
+  amdgpu::VectorMemState address_state(amdgpu::GLOBAL_MEM);
+  address_state.elem_size = 4;
+  address_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, address_state);
+  EXPECT_EQ(address_state.lane_mask, 1ULL);
+  EXPECT_EQ(address_state.per_lane_addr[0], kBase + kOffset);
+  expect_element_lane_masks(address_state.element_lane_masks, {1ULL});
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferRangeCheckDoesNotWrapAt45Bits) {
@@ -4610,9 +4678,9 @@ TEST(Gfx1250AddrCalcTest, VbufferRangeCheckDoesNotWrapAt45Bits) {
   constexpr uint64_t kBase = 0x2'0000'1000ULL;
   constexpr uint64_t kMaxNumRecords = (uint64_t{1} << 45) - 1;
   constexpr uint32_t kRawStride = 8192;
-  write_gfx1250_buffer_resource(
-      *cu, *wf, 40,
-      encode_gfx1250_buffer_resource(kBase, kMaxNumRecords, kRawStride, /*stride_scale=*/1));
+  write_gfx1250_buffer_resource(*cu, *wf, 40,
+                                encode_gfx1250_buffer_resource(kBase, kMaxNumRecords, kRawStride,
+                                                               /*stride_scale_encoding=*/1));
   uint32_t vbase = wf->vgpr_alloc().base;
   cu->write_vgpr(vbase + 4, 0, 0);
   cu->write_vgpr(vbase + 5, 0, 0);
@@ -4632,17 +4700,17 @@ TEST(Gfx1250AddrCalcTest, VbufferRangeCheckDoesNotWrapAt45Bits) {
   inst.offen = 1;
   inst.vaddr = 4;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 1;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 0x5ULL);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{0x5ULL}));
-  EXPECT_EQ(d.per_lane_addr[0], kBase);
-  EXPECT_EQ(d.per_lane_addr[1], 0ULL);
-  EXPECT_EQ(d.per_lane_addr[2], kBase + kMaxNumRecords - 4);
-  EXPECT_EQ(d.per_lane_addr[3], 0ULL);
-  EXPECT_EQ(d.per_lane_addr[4], 0ULL);
+  amdgpu::VectorMemState range_state(amdgpu::GLOBAL_MEM);
+  range_state.elem_size = 4;
+  range_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, range_state);
+  EXPECT_EQ(range_state.lane_mask, 0x5ULL);
+  expect_element_lane_masks(range_state.element_lane_masks, {0x5ULL});
+  EXPECT_EQ(range_state.per_lane_addr[0], kBase);
+  EXPECT_EQ(range_state.per_lane_addr[1], 0ULL);
+  EXPECT_EQ(range_state.per_lane_addr[2], kBase + kMaxNumRecords - 4);
+  EXPECT_EQ(range_state.per_lane_addr[3], 0ULL);
+  EXPECT_EQ(range_state.per_lane_addr[4], 0ULL);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferRangeCheckAcceptsExactEndOnly) {
@@ -4674,14 +4742,14 @@ TEST(Gfx1250AddrCalcTest, VbufferRangeCheckAcceptsExactEndOnly) {
   inst.offen = 1;
   inst.vaddr = 4;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 1;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 0x1ULL);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{0x1ULL}));
-  EXPECT_EQ(d.per_lane_addr[0], kBase + 4);
-  EXPECT_EQ(d.per_lane_addr[1], 0ULL);
+  amdgpu::VectorMemState boundary_state(amdgpu::GLOBAL_MEM);
+  boundary_state.elem_size = 4;
+  boundary_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, boundary_state);
+  EXPECT_EQ(boundary_state.lane_mask, 0x1ULL);
+  expect_element_lane_masks(boundary_state.element_lane_masks, {0x1ULL});
+  EXPECT_EQ(boundary_state.per_lane_addr[0], kBase + 4);
+  EXPECT_EQ(boundary_state.per_lane_addr[1], 0ULL);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferZeroNumRecordsMasksAllLanes) {
@@ -4714,14 +4782,14 @@ TEST(Gfx1250AddrCalcTest, VbufferZeroNumRecordsMasksAllLanes) {
   inst.idxen = 0;
   inst.vaddr = 4;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 1;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.exec_mask, 0x3ULL);
-  EXPECT_EQ(d.lane_mask, 0ULL);
-  EXPECT_EQ(d.per_lane_addr[0], 0ULL);
-  EXPECT_EQ(d.per_lane_addr[1], 0ULL);
+  amdgpu::VectorMemState null_range_state(amdgpu::GLOBAL_MEM);
+  null_range_state.elem_size = 4;
+  null_range_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, null_range_state);
+  EXPECT_EQ(null_range_state.exec_mask, 0x3ULL);
+  EXPECT_EQ(null_range_state.lane_mask, 0ULL);
+  EXPECT_EQ(null_range_state.per_lane_addr[0], 0ULL);
+  EXPECT_EQ(null_range_state.per_lane_addr[1], 0ULL);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferStructuredStrideChecksIndexBounds) {
@@ -4756,14 +4824,14 @@ TEST(Gfx1250AddrCalcTest, VbufferStructuredStrideChecksIndexBounds) {
   inst.idxen = 1;
   inst.vaddr = 4;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 1;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.exec_mask, 0x3ULL);
-  EXPECT_EQ(d.lane_mask, 0x1ULL);
-  EXPECT_EQ(d.per_lane_addr[0], kBase + kStride);
-  EXPECT_EQ(d.per_lane_addr[1], 0ULL);
+  amdgpu::VectorMemState structured_state(amdgpu::GLOBAL_MEM);
+  structured_state.elem_size = 4;
+  structured_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, structured_state);
+  EXPECT_EQ(structured_state.exec_mask, 0x3ULL);
+  EXPECT_EQ(structured_state.lane_mask, 0x1ULL);
+  EXPECT_EQ(structured_state.per_lane_addr[0], kBase + kStride);
+  EXPECT_EQ(structured_state.per_lane_addr[1], 0ULL);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferChecksB64B96AndB128DwordsIndependently) {
@@ -4794,7 +4862,7 @@ TEST(Gfx1250AddrCalcTest, VbufferChecksB64B96AndB128DwordsIndependently) {
   b64.num_elems = 2;
   cdna5::mubuf_calculate_addresses(inst, *wf, b64);
   EXPECT_EQ(b64.lane_mask, 1ULL);
-  EXPECT_EQ(b64.element_lane_masks, (std::vector<uint64_t>{1ULL, 0ULL}));
+  expect_element_lane_masks(b64.element_lane_masks, {1ULL, 0ULL});
 
   write_gfx1250_buffer_resource(*cu, *wf, 40,
                                 encode_gfx1250_buffer_resource(kBase, /*num_records=*/10));
@@ -4803,14 +4871,14 @@ TEST(Gfx1250AddrCalcTest, VbufferChecksB64B96AndB128DwordsIndependently) {
   b96.num_elems = 3;
   cdna5::mubuf_calculate_addresses(inst, *wf, b96);
   EXPECT_EQ(b96.lane_mask, 1ULL);
-  EXPECT_EQ(b96.element_lane_masks, (std::vector<uint64_t>{1ULL, 1ULL, 0ULL}));
+  expect_element_lane_masks(b96.element_lane_masks, {1ULL, 1ULL, 0ULL});
 
   amdgpu::VectorMemState b128(amdgpu::GLOBAL_MEM);
   b128.elem_size = 4;
   b128.num_elems = 4;
   cdna5::mubuf_calculate_addresses(inst, *wf, b128);
   EXPECT_EQ(b128.lane_mask, 1ULL);
-  EXPECT_EQ(b128.element_lane_masks, (std::vector<uint64_t>{1ULL, 1ULL, 0ULL, 0ULL}));
+  expect_element_lane_masks(b128.element_lane_masks, {1ULL, 1ULL, 0ULL, 0ULL});
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferNegativeIoffsetCannotReachL1) {
@@ -4837,15 +4905,15 @@ TEST(Gfx1250AddrCalcTest, VbufferNegativeIoffsetCannotReachL1) {
   inst.soffset = cdna5::OPR_SREG_NULL;
   inst.ioffset = 0x00FF'FFFCu; // -4 as a signed 24-bit VBUFFER IOFFSET.
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 2;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
+  amdgpu::VectorMemState negative_ioffset_state(amdgpu::GLOBAL_MEM);
+  negative_ioffset_state.elem_size = 4;
+  negative_ioffset_state.num_elems = 2;
+  cdna5::mubuf_calculate_addresses(inst, *wf, negative_ioffset_state);
 
-  EXPECT_EQ(d.exec_mask, 1ULL);
-  EXPECT_EQ(d.lane_mask, 0ULL);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{0ULL, 0ULL}));
-  EXPECT_EQ(d.per_lane_addr[0], 0ULL);
+  EXPECT_EQ(negative_ioffset_state.exec_mask, 1ULL);
+  EXPECT_EQ(negative_ioffset_state.lane_mask, 0ULL);
+  expect_element_lane_masks(negative_ioffset_state.element_lane_masks, {0ULL, 0ULL});
+  EXPECT_EQ(negative_ioffset_state.per_lane_addr[0], 0ULL);
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferSoffsetParticipatesInNumRecordsAndStrideBounds) {
@@ -4867,8 +4935,8 @@ TEST(Gfx1250AddrCalcTest, VbufferSoffsetParticipatesInNumRecordsAndStrideBounds)
   constexpr uint64_t kBase = 0x2'0000'2800ULL;
   write_gfx1250_buffer_resource(
       *cu, *wf, 40,
-      encode_gfx1250_buffer_resource(kBase, /*num_records=*/16, /*stride=*/16,
-                                     /*stride_scale=*/0, /*swizzle=*/false,
+      encode_gfx1250_buffer_resource(kBase, /*num_records=*/16, /*raw_stride=*/16,
+                                     /*stride_scale_encoding=*/0, /*swizzle=*/false,
                                      /*oob_select=*/true));
 
   cdna5::VbufferMachineInst inst{};
@@ -4882,7 +4950,7 @@ TEST(Gfx1250AddrCalcTest, VbufferSoffsetParticipatesInNumRecordsAndStrideBounds)
   exact_end.num_elems = 2;
   cdna5::mubuf_calculate_addresses(inst, *wf, exact_end);
   EXPECT_EQ(exact_end.lane_mask, 1ULL);
-  EXPECT_EQ(exact_end.element_lane_masks, (std::vector<uint64_t>{1ULL, 1ULL}));
+  expect_element_lane_masks(exact_end.element_lane_masks, {1ULL, 1ULL});
   EXPECT_EQ(exact_end.per_lane_addr[0], kBase + 8);
 
   cu->write_sgpr(sbase + 8, 9);
@@ -4891,7 +4959,7 @@ TEST(Gfx1250AddrCalcTest, VbufferSoffsetParticipatesInNumRecordsAndStrideBounds)
   one_byte_over.num_elems = 2;
   cdna5::mubuf_calculate_addresses(inst, *wf, one_byte_over);
   EXPECT_EQ(one_byte_over.lane_mask, 1ULL);
-  EXPECT_EQ(one_byte_over.element_lane_masks, (std::vector<uint64_t>{1ULL, 0ULL}));
+  expect_element_lane_masks(one_byte_over.element_lane_masks, {1ULL, 0ULL});
   EXPECT_EQ(one_byte_over.per_lane_addr[0], kBase + 9);
 }
 
@@ -4914,8 +4982,8 @@ TEST(Gfx1250AddrCalcTest, VbufferOobSelectAlsoChecksRecordStride) {
   constexpr uint64_t kBase = 0x2'0000'3000ULL;
   write_gfx1250_buffer_resource(
       *cu, *wf, 40,
-      encode_gfx1250_buffer_resource(kBase, /*num_records=*/64, /*stride=*/8,
-                                     /*stride_scale=*/0, /*swizzle=*/false,
+      encode_gfx1250_buffer_resource(kBase, /*num_records=*/64, /*raw_stride=*/8,
+                                     /*stride_scale_encoding=*/0, /*swizzle=*/false,
                                      /*oob_select=*/true));
   cu->write_vgpr(wf->vgpr_alloc().base + 4, 0, 4);
 
@@ -4925,12 +4993,12 @@ TEST(Gfx1250AddrCalcTest, VbufferOobSelectAlsoChecksRecordStride) {
   inst.offen = 1;
   inst.vaddr = 4;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 2;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 1ULL);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{1ULL, 0ULL}));
+  amdgpu::VectorMemState oob_select_state(amdgpu::GLOBAL_MEM);
+  oob_select_state.elem_size = 4;
+  oob_select_state.num_elems = 2;
+  cdna5::mubuf_calculate_addresses(inst, *wf, oob_select_state);
+  EXPECT_EQ(oob_select_state.lane_mask, 1ULL);
+  expect_element_lane_masks(oob_select_state.element_lane_masks, {1ULL, 0ULL});
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferSwizzleDefersBoundsWithNoElementMasks) {
@@ -4950,19 +5018,197 @@ TEST(Gfx1250AddrCalcTest, VbufferSwizzleDefersBoundsWithNoElementMasks) {
   wf->set_exec(1ULL);
   write_gfx1250_buffer_resource(
       *cu, *wf, 40,
-      encode_gfx1250_buffer_resource(/*base=*/0x4000, /*num_records=*/0, /*stride=*/16,
-                                     /*stride_scale=*/0, /*swizzle=*/true));
+      encode_gfx1250_buffer_resource(/*base=*/0x4000, /*num_records=*/0, /*raw_stride=*/16,
+                                     /*stride_scale_encoding=*/0, /*swizzle=*/true));
 
   cdna5::VbufferMachineInst inst{};
   inst.rsrc = 40;
   inst.soffset = cdna5::OPR_SREG_NULL;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 4;
-  d.num_elems = 4;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 1ULL);
-  EXPECT_TRUE(d.element_lane_masks.empty());
+  amdgpu::VectorMemState swizzle_state(amdgpu::GLOBAL_MEM);
+  swizzle_state.elem_size = 4;
+  swizzle_state.num_elems = 4;
+  cdna5::mubuf_calculate_addresses(inst, *wf, swizzle_state);
+  EXPECT_EQ(swizzle_state.lane_mask, 1ULL);
+  EXPECT_TRUE(swizzle_state.element_lane_masks.empty());
+}
+
+TEST(Gfx1250AddrCalcTest, VbufferSwizzleRearrangesIndexAndOffsetGroups) {
+  amdgpu::GpuMemory mem("gfx1250_vbuffer_swizzle_groups_mem");
+  amdgpu::L2Cache l2("gfx1250_vbuffer_swizzle_groups_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250_vbuffer_swizzle_groups_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xFULL);
+
+  constexpr uint64_t kBase = 0x2'0000'1000ULL;
+  constexpr uint32_t kStride = 64;
+  write_gfx1250_buffer_resource(*cu, *wf, 40,
+                                encode_gfx1250_buffer_resource(kBase, /*num_records=*/0, kStride,
+                                                               /*stride_scale_encoding=*/0,
+                                                               /*swizzle=*/true));
+
+  constexpr std::array<uint32_t, 4> kIndexes = {31, 32, 1, 33};
+  constexpr std::array<uint32_t, 4> kOffsets = {15, 15, 16, 31};
+  constexpr std::array<uint64_t, 4> kExpectedOffsets = {511, 2063, 528, 2591};
+  uint32_t vbase = wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < kIndexes.size(); ++lane) {
+    cu->write_vgpr(vbase + 4, lane, kIndexes[lane]);
+    cu->write_vgpr(vbase + 5, lane, kOffsets[lane]);
+  }
+
+  cdna5::VbufferMachineInst inst{};
+  inst.rsrc = 40;
+  inst.soffset = cdna5::OPR_SREG_NULL;
+  inst.idxen = 1;
+  inst.offen = 1;
+  inst.vaddr = 4;
+
+  amdgpu::VectorMemState state(amdgpu::GLOBAL_MEM);
+  state.elem_size = 4;
+  state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, state);
+  EXPECT_EQ(state.exec_mask, 0xFULL);
+  EXPECT_EQ(state.lane_mask, 0xFULL);
+  EXPECT_TRUE(state.element_lane_masks.empty());
+  for (uint32_t lane = 0; lane < kExpectedOffsets.size(); ++lane)
+    EXPECT_EQ(state.per_lane_addr[lane], kBase + kExpectedOffsets[lane]) << "lane " << lane;
+}
+
+TEST(Gfx1250AddrCalcTest, VbufferSwizzlePreserves57BitBaseAndUsesLegalOffsets) {
+  amdgpu::GpuMemory mem("gfx1250_vbuffer_swizzle_offsets_mem");
+  amdgpu::L2Cache l2("gfx1250_vbuffer_swizzle_offsets_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250_vbuffer_swizzle_offsets_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1ULL);
+
+  constexpr uint64_t kBase = (uint64_t{1} << 56) | 0x1000;
+  constexpr uint32_t kStride = 64;
+  constexpr uint32_t kSoffset = 5;
+  constexpr uint32_t kIoffset = 11;
+  constexpr uint32_t kIndex = 1;
+  constexpr uint32_t kVoffset = 20;
+  constexpr uint64_t kExpectedIndexedOffset = 528;
+  constexpr uint64_t kExpectedOffsetOnlyOffset = 1028;
+  write_gfx1250_buffer_resource(*cu, *wf, 40,
+                                encode_gfx1250_buffer_resource(kBase, /*num_records=*/0, kStride,
+                                                               /*stride_scale_encoding=*/0,
+                                                               /*swizzle=*/true));
+  uint32_t sbase = wf->sgpr_alloc().base;
+  uint32_t vbase = wf->vgpr_alloc().base;
+  cu->write_sgpr(sbase + 8, kSoffset);
+
+  cdna5::VbufferMachineInst inst{};
+  inst.rsrc = 40;
+  inst.soffset = 8;
+  inst.idxen = 1;
+  inst.vaddr = 4;
+  inst.ioffset = kIoffset;
+  cu->write_vgpr(vbase + 4, 0, kIndex);
+
+  amdgpu::VectorMemState indexed_state(amdgpu::GLOBAL_MEM);
+  indexed_state.elem_size = 4;
+  indexed_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, indexed_state);
+  EXPECT_EQ(indexed_state.per_lane_addr[0], kBase + kExpectedIndexedOffset);
+
+  inst.idxen = 0;
+  inst.offen = 1;
+  cu->write_vgpr(vbase + 4, 0, kVoffset);
+  amdgpu::VectorMemState offset_state(amdgpu::GLOBAL_MEM);
+  offset_state.elem_size = 4;
+  offset_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, offset_state);
+  EXPECT_EQ(offset_state.per_lane_addr[0], kBase + kExpectedOffsetOnlyOffset);
+
+  inst.offen = 0;
+  inst.soffset = cdna5::OPR_SREG_NULL;
+  inst.ioffset = 0x7F'FFFFu;
+  amdgpu::VectorMemState immediate_state(amdgpu::GLOBAL_MEM);
+  immediate_state.elem_size = 4;
+  immediate_state.num_elems = 1;
+  cdna5::mubuf_calculate_addresses(inst, *wf, immediate_state);
+  constexpr uint64_t kExpectedImmediateOffset = 268'434'959;
+  EXPECT_EQ(immediate_state.per_lane_addr[0], kBase + kExpectedImmediateOffset);
+}
+
+TEST(Gfx1250AddrCalcTest, VbufferStrideScaleAppliesToSwizzledAndLinearAddresses) {
+  amdgpu::GpuMemory mem("gfx1250_vbuffer_stride_scale_mem");
+  amdgpu::L2Cache l2("gfx1250_vbuffer_stride_scale_l2");
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 16;
+  cfg.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250_vbuffer_stride_scale_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 128, 16);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1ULL);
+
+  constexpr uint64_t kBase = 0x2'0000'1000ULL;
+  constexpr uint64_t kNumRecords = uint64_t{1} << 20;
+  constexpr uint32_t kRawStride = 16;
+  constexpr uint32_t kIndex = 33;
+  constexpr uint32_t kVoffset = 16;
+  constexpr uint32_t kIndexStride = 32;
+  constexpr uint32_t kElementSize = 16;
+  constexpr std::array<uint32_t, 4> kStrideScales = {1, 4, 8, 32};
+  uint32_t vbase = wf->vgpr_alloc().base;
+  cu->write_vgpr(vbase + 4, 0, kIndex);
+  cu->write_vgpr(vbase + 5, 0, kVoffset);
+
+  cdna5::VbufferMachineInst inst{};
+  inst.rsrc = 40;
+  inst.soffset = cdna5::OPR_SREG_NULL;
+  inst.idxen = 1;
+  inst.offen = 1;
+  inst.vaddr = 4;
+
+  for (uint32_t scale_encoding = 0; scale_encoding < kStrideScales.size(); ++scale_encoding) {
+    uint32_t stride = kRawStride * kStrideScales[scale_encoding];
+
+    write_gfx1250_buffer_resource(*cu, *wf, 40,
+                                  encode_gfx1250_buffer_resource(kBase, kNumRecords, kRawStride,
+                                                                 scale_encoding,
+                                                                 /*swizzle=*/true));
+    amdgpu::VectorMemState swizzled(amdgpu::GLOBAL_MEM);
+    swizzled.elem_size = 4;
+    swizzled.num_elems = 1;
+    cdna5::mubuf_calculate_addresses(inst, *wf, swizzled);
+    EXPECT_EQ(swizzled.per_lane_addr[0],
+              kBase + (stride + kElementSize) * kIndexStride + kElementSize)
+        << "scale encoding " << scale_encoding;
+
+    write_gfx1250_buffer_resource(
+        *cu, *wf, 40,
+        encode_gfx1250_buffer_resource(kBase, kNumRecords, kRawStride, scale_encoding));
+    amdgpu::VectorMemState linear(amdgpu::GLOBAL_MEM);
+    linear.elem_size = 4;
+    linear.num_elems = 1;
+    cdna5::mubuf_calculate_addresses(inst, *wf, linear);
+    EXPECT_EQ(linear.per_lane_addr[0], kBase + kIndex * stride + kVoffset)
+        << "scale encoding " << scale_encoding;
+  }
 }
 
 TEST(Gfx1250AddrCalcTest, VbufferAtomicChecksWholePayload) {
@@ -4987,14 +5233,14 @@ TEST(Gfx1250AddrCalcTest, VbufferAtomicChecksWholePayload) {
   inst.rsrc = 40;
   inst.soffset = cdna5::OPR_SREG_NULL;
 
-  amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
-  d.elem_size = 8;
-  d.num_elems = 1;
-  d.atomic_op = amdgpu::AtomicOp::ADD;
-  cdna5::mubuf_calculate_addresses(inst, *wf, d);
-  EXPECT_EQ(d.lane_mask, 0ULL);
-  EXPECT_EQ(d.element_lane_masks, (std::vector<uint64_t>{0ULL}));
-  EXPECT_EQ(d.per_lane_addr[0], 0ULL);
+  amdgpu::VectorMemState atomic_state(amdgpu::GLOBAL_MEM);
+  atomic_state.elem_size = 8;
+  atomic_state.num_elems = 1;
+  atomic_state.atomic_op = amdgpu::AtomicOp::ADD;
+  cdna5::mubuf_calculate_addresses(inst, *wf, atomic_state);
+  EXPECT_EQ(atomic_state.lane_mask, 0ULL);
+  expect_element_lane_masks(atomic_state.element_lane_masks, {0ULL});
+  EXPECT_EQ(atomic_state.per_lane_addr[0], 0ULL);
 }
 
 void expect_vector_lane_reads_use_own_wave_vgprs(rj_code_arch_t arch) {


### PR DESCRIPTION
## Motivation

  Implement CDNA5’s swizzle-enable behavior, which rearranges index and offset bits during buffer address calculation to improve cache locality, particularly for arrays-of-structures access patterns.

## Technical Details

  - Implement the CDNA5 swizzled buffer-address formula using:
      - A constant index stride of 32.
      - A fixed 16-byte swizzle element size.
      - The architectural 45-bit combined offset.
  - Apply the resource descriptor’s stride-scale multiplier to both linear and swizzled addressing.
  - Treat VBUFFER operations using a non-buffer resource type as ignored accesses.
  - Propagate the effective EXEC mask through buffer stores, returning atomics, memory completion, and race
    detection so ignored lanes neither access memory nor modify destination registers.

## Issue Tracking

  N/A

  ## Test Plan
  - Added coverage for:
      - Swizzled index/offset regrouping.
      - Stride-scale encodings for linear and swizzled addresses.
      - 45-bit offset wrapping and 57-bit base-address preservation.
      - End-to-end swizzled buffer execution.
      - Ignored non-buffer resource types.
      - Returning atomic destination preservation.
      - Effective-EXEC handling in generated stores and atomics.
      - Race-detector behavior for ignored accesses.
      - Inline and fallback per-element lane-mask storage.

## Test Result
Tests Pass

## Submission Checklist

- [x] Look over the contributing guidelines at  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
