### PR TITLE
[rocjitsu] Align gfx1250 with public CDNA5 ISA

### DIFF
--- a/emulation/rocjitsu/configs/gfx1250_mi455x.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x.json
@@ -11,7 +11,7 @@
         "vendor_id": 4098,
         "device_id": 30145,
         "family_id": 0,
-        "unique_id": 1250,
+        "unique_id": 0,
         "revision_id": 1,
         "marketing_name": "AMD Instinct MI455X",
         "simd_count": 1024,

--- a/emulation/rocjitsu/configs/gfx1250_mi455x.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x.json
@@ -9,7 +9,7 @@
         "gpu_id": 1250,
         "gfx_target_version": 120500,
         "vendor_id": 4098,
-        "device_id": 1250,
+        "device_id": 30145,
         "family_id": 0,
         "unique_id": 1250,
         "revision_id": 1,

--- a/emulation/rocjitsu/docs/codegen.md
+++ b/emulation/rocjitsu/docs/codegen.md
@@ -48,11 +48,12 @@ rocm-systems/shared/machine-readable-isa/isa/
 | Cross-ISA legalization tables | `lib/rocjitsu/src/rocjitsu/code/dbt/generated/` | `legalization_codegen.py` |
 | Encoding decode/encode functions | `lib/rocjitsu/src/rocjitsu/code/dbt/generated/` | `encoding_translator_codegen.py` |
 
-CDNA5's logical generator key and configuration architecture are `cdna5`. Its
-MR ISA name and filename, concrete GPU/runtime target, ELF identity, and public
-DBT target identity intentionally remain `gfx1250`. Its filesystem
+GPUOpen's public CDNA5 MR ISA uses the architecture name `AMD CDNA 5` and the
+filename `amdgpu_isa_cdna5.xml`. rocjitsu's logical generator key and
+configuration architecture are `cdna5`. Its concrete GPU/runtime target, ELF
+identity, and public DBT target identity remain `gfx1250`. Its filesystem
 directories, generated and hand-written C++ namespace (`rocjitsu::cdna5`), and
-internal CMake provider targets use `cdna5`.
+internal CMake provider targets also use `cdna5`.
 
 Hand-written per-ISA files (`isa.h`, `mma_exec.h`, `addr_calc.h/.cpp`) remain
 under `lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/<output-directory>/` and are
@@ -89,15 +90,13 @@ generated.
 ## Regenerating everything
 
 The repository helper derives the repository, shared MR ISA, and generated
-output directories from its own location. Its argument is the CDNA5 MR ISA XML
-with the concrete filename `amdgpu_isa_gfx1250.xml`; the logical generator key
-used by the command is `cdna5`.
+output directories from its own location. It uses the checked-in public CDNA5
+MR ISA alongside the other XML inputs.
 Activate a Python virtual environment containing the generator dependencies and
 `pre-commit`, then run this command from the `rocm-systems` repository root:
 
 ```bash
-./emulation/rocjitsu/scripts/generate-amdisa.sh \
-  /path/to/amdgpu_isa_gfx1250.xml
+./emulation/rocjitsu/scripts/generate-amdisa.sh
 ```
 
 The helper can be invoked from any working directory when given by an
@@ -106,12 +105,10 @@ through `VIRTUAL_ENV` or the active Python interpreter, then formats changed
 generated files through the repository's pre-commit configuration.
 
 The manual commands below are useful for focused generator development and are
-run from the rocjitsu project root. Set `MRISA` to the shared MR ISA directory
-and `CDNA5_MRISA` to the out-of-tree CDNA5 MR ISA XML directory:
+run from the rocjitsu project root. Set `MRISA` to the shared MR ISA directory:
 
 ```bash
 MRISA=../../shared/machine-readable-isa/isa
-CDNA5_MRISA=/path/to/cdna5-mrisa
 
 python -m amdisa \
   --multi \
@@ -124,7 +121,7 @@ python -m amdisa \
     rdna3:$MRISA/amdgpu_isa_rdna3.xml \
     rdna3_5:$MRISA/amdgpu_isa_rdna3_5.xml \
     rdna4:$MRISA/amdgpu_isa_rdna4.xml \
-    cdna5:$CDNA5_MRISA/amdgpu_isa_gfx1250.xml \
+    cdna5:$MRISA/amdgpu_isa_cdna5.xml \
   --isa-output lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated \
   --dbt-output lib/rocjitsu/src/rocjitsu/code/dbt/generated
 
@@ -146,7 +143,7 @@ python -m amdisa \
     rdna3:$MRISA/amdgpu_isa_rdna3.xml \
     rdna3_5:$MRISA/amdgpu_isa_rdna3_5.xml \
     rdna4:$MRISA/amdgpu_isa_rdna4.xml \
-    cdna5:$CDNA5_MRISA/amdgpu_isa_gfx1250.xml \
+    cdna5:$MRISA/amdgpu_isa_cdna5.xml \
   --gen-isas \
   --isa-output lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated
 
@@ -168,7 +165,7 @@ python -m amdisa \
     rdna3:$MRISA/amdgpu_isa_rdna3.xml \
     rdna3_5:$MRISA/amdgpu_isa_rdna3_5.xml \
     rdna4:$MRISA/amdgpu_isa_rdna4.xml \
-    cdna5:$CDNA5_MRISA/amdgpu_isa_gfx1250.xml \
+    cdna5:$MRISA/amdgpu_isa_cdna5.xml \
   --gen-dbt \
   --dbt-output lib/rocjitsu/src/rocjitsu/code/dbt/generated
 

--- a/emulation/rocjitsu/docs/npi.md
+++ b/emulation/rocjitsu/docs/npi.md
@@ -37,7 +37,8 @@ What the grep can't point at are the "create a new thing" steps:
 - Construct a `configs/<gpu>.json` (plus the `_kmd` and any multi-GPU variant)
   for the new device.
 - For a brand-new ISA family: sync `shared/machine-readable-isa` with
-  `download.py`, regenerate the ISA/DBT sources per [codegen.md](codegen.md),
+  `download.py`, adding any parser compatibility required by the complete
+  snapshot. Regenerate the ISA/DBT sources per [codegen.md](codegen.md),
   and author the hand-written per-arch files (`isa.h`, `mma_exec.h`,
   `addr_calc.h/.cpp`, ...) under
   `lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/<isa>/`. The generated files,

--- a/emulation/rocjitsu/lib/python/amdisa/__main__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/__main__.py
@@ -4,7 +4,6 @@
 """CLI entry point: ``python -m amdisa``."""
 
 import argparse
-from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
 import xml.etree.ElementTree as elem_tree
@@ -111,16 +110,11 @@ def _merge_shared_execute_body(
 
 
 def _detect_profile(isa_xml: str) -> str:
-    """Detect the ISA profile from the XML filename and architecture name.
+    """Detect the ISA profile from the XML architecture name.
 
     Parses only the architecture name element to determine the profile
     without loading the full spec.
     """
-    # TODO: Remove this filename override once the gfx1250 XML carries a
-    # finalized architecture name that can be detected through the normal path.
-    if 'gfx1250' in Path(isa_xml).stem:
-        return 'cdna5'
-
     root = elem_tree.parse(isa_xml).getroot()
     isa_node = xs.get_node(root, xs.ISA)
     arch_node = xs.get_node(isa_node, xs.ARCH)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -624,13 +624,13 @@ def test_parser_separates_logical_arch_directory_and_cpp_namespace():
         ('rdna3', Rdna3Profile),
         ('rdna3_5', Rdna3_5Profile),
         ('rdna4', Rdna4Profile),
-        ('gfx1250', Cdna5Profile),
+        ('cdna5', Cdna5Profile),
     ],
 )
 def test_generated_scc_accesses_match_mrisa(isa_name, profile_type):
     isa_xml = _mrisa_dir() / f'amdgpu_isa_{isa_name}.xml'
     if not isa_xml.is_file():
-        pytest.skip('Semantics XML not available')
+        pytest.skip('MR ISA XML not available')
 
     parser = Parser(str(isa_xml), profile_type())
     spec = parser.parse()
@@ -644,7 +644,7 @@ def test_generated_scc_accesses_match_mrisa(isa_name, profile_type):
     mismatches = []
     expected_exclusions = {
         'rdna4': {'S_ALLOC_VGPR', 'S_BARRIER_SIGNAL_ISFIRST'},
-        'gfx1250': {'S_ALLOC_VGPR'},
+        'cdna5': {'S_ALLOC_VGPR'},
     }
     checked_exclusions = set()
     checked = 0
@@ -4966,7 +4966,7 @@ def test_instruction_lookahead_bound_is_derived_from_isa(
 ) -> None:
     isa_xml = _mrisa_dir() / f'amdgpu_isa_{arch_name}.xml'
     if not isa_xml.is_file():
-        pytest.skip(f'{arch_name} semantics XML not available')
+        pytest.skip(f'{arch_name} MR ISA XML not available')
     spec = Parser(str(isa_xml), profile_type()).parse()
     generator = CodeGenerator(spec, '', derive_all_semantics(spec))
     assert generator._max_instruction_word_count() == expected_bound
@@ -5275,6 +5275,7 @@ def _cpp_hwreg_table_values(source: str, table_name: str) -> dict[int, str]:
         ('rdna3', 'RDNA3_HWREGS'),
         ('rdna3_5', 'RDNA3_HWREGS'),
         ('rdna4', 'RDNA4_HWREGS'),
+        ('cdna5', 'GFX1250_HWREGS'),
     ],
 )
 def test_hwreg_descriptor_tables_cover_checked_in_xml(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -1092,9 +1092,12 @@ class TestCdna5Profile:
                 chunk_overhead=0,
             )
 
-    def test_detect_profile_uses_filename_override(self, tmp_path):
-        xml = tmp_path / 'amdgpu_isa_gfx1250.xml'
-        xml.write_text('<Spec />')
+    def test_detect_profile_uses_public_cdna5_architecture(self, tmp_path):
+        xml = tmp_path / 'amdgpu_isa_cdna5.xml'
+        xml.write_text(
+            '<Spec><ISA><Architecture><ArchitectureName>AMD CDNA 5</ArchitectureName>'
+            '</Architecture></ISA></Spec>'
+        )
         assert _detect_profile(str(xml)) == 'cdna5'
 
     def test_test_encoding_uses_primary_decode_key(self):

--- a/emulation/rocjitsu/scripts/generate-amdisa.sh
+++ b/emulation/rocjitsu/scripts/generate-amdisa.sh
@@ -7,12 +7,12 @@
 # changed generated sources through the active virtual environment.
 #
 # Usage:
-#   ./scripts/generate-amdisa.sh /path/to/amdgpu_isa_gfx1250.xml
+#   ./scripts/generate-amdisa.sh
 
 set -Eeuo pipefail
 
 usage() {
-  printf 'usage: %s CDNA5_ISA_XML\n' "$(basename "$0")"
+  printf 'usage: %s\n' "$(basename "$0")"
 }
 
 log() {
@@ -28,7 +28,7 @@ if (($# == 1)) && [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
   exit 0
 fi
-if (($# != 1)); then
+if (($# != 0)); then
   usage >&2
   exit 2
 fi
@@ -39,7 +39,6 @@ repo="$(git -C "$script_dir" rev-parse --show-toplevel)" \
   || die "could not find repository root from $script_dir"
 repo="$(cd "$repo" && pwd -P)"
 isa_xml="$repo/shared/machine-readable-isa/isa"
-cdna5_xml="$1"
 isa_out="$rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated"
 dbt_out="$rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/generated"
 
@@ -79,8 +78,7 @@ isa_entries=(
   "rdna3:$isa_xml/amdgpu_isa_rdna3.xml"
   "rdna3_5:$isa_xml/amdgpu_isa_rdna3_5.xml"
   "rdna4:$isa_xml/amdgpu_isa_rdna4.xml"
-  # CDNA5 retains gfx1250 as its MR ISA target identifier.
-  "cdna5:$cdna5_xml"
+  "cdna5:$isa_xml/amdgpu_isa_cdna5.xml"
 )
 
 for dir in "$repo" "$rocjitsu" "$isa_out" "$dbt_out" "$venv"; do

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -229,6 +229,7 @@ TEST(Gfx1250ConfigTest, ConfigLoadsTopology) {
 
   EXPECT_TRUE(loaded.device.present);
   EXPECT_EQ(loaded.device.gfx_target_version, 120500u);
+  EXPECT_EQ(loaded.device.device_id, 30145u);
   EXPECT_EQ(loaded.device.marketing_name, "AMD Instinct MI455X");
   EXPECT_EQ(loaded.device.simd_count, 1024u);
   EXPECT_EQ(loaded.device.max_waves_per_simd, kGfx1250MaxWavesPerSimd);

--- a/emulation/rocjitsu/tests/sysfs_test.cpp
+++ b/emulation/rocjitsu/tests/sysfs_test.cpp
@@ -108,6 +108,9 @@ constexpr DebugCapExpectation kDebugCapExpectations[] = {
     {120000u, "gfx1200", 7, 29, true, false, true, false, false, 0u, 0u, 0u},
     // gfx1201 (R9700): rocprofiler-sdk tests/data/topology node 6.
     {120001u, "gfx1201", 7, 29, true, false, true, false, false, 1745068672u, 0u, 1495u},
+    // TODO(hanchung): Replace the inferred gfx1250 feature row and pin its
+    // capability/capability2/debug_prop words after capturing a physical MI455X
+    // KFD topology.
     // gfx1250: GC 12.1.0 — precise ALU + memory, per-queue reset, LDS OOR (no dump yet).
     {120500u, "gfx1250", 7, 29, true, true, true, true, true, 0u, 0u, 0u},
 };
@@ -395,6 +398,29 @@ TEST(SysfsTopologyGeometryTest, Mi350xMatchesCapturedPhysicalAndActiveCuCounts) 
     EXPECT_EQ(loaded.device.num_cp_queues, 24u);
     EXPECT_EQ(loaded.device.max_engine_clk_fcompute, 2200u);
   }
+}
+
+// TODO(hanchung): Pin the physical CU geometry, active-CU mask, memory-bank
+// size, clocks, GPU/unique IDs, SDMA engine/queue counts, CP queue count, family
+// ID, and ASIC/PCI revisions after capturing a physical MI455X KFD topology.
+// Until then, this test covers only the checked-in physical device identity and
+// must not be treated as exact rocminfo parity.
+TEST(SysfsTopologyIdentityTest, Mi455xUsesPublishedPhysicalDeviceId) {
+  const std::string config_dir = CONFIG_DIR;
+  auto loaded = config::load_config(config_dir + "/gfx1250_mi455x.json", rocjitsu::kEmbeddedSchema);
+  ASSERT_TRUE(loaded.device.present);
+  ASSERT_NE(loaded.soc(), nullptr);
+
+  Sysfs sysfs;
+  std::string topology_dir =
+      sysfs.generate(gpu_info_from_config(loaded.device, loaded.soc()->num_xcds()));
+  ASSERT_FALSE(topology_dir.empty());
+  auto props = read_properties(topology_dir + "/nodes/1/properties");
+
+  ASSERT_TRUE(props.count("vendor_id"));
+  ASSERT_TRUE(props.count("device_id"));
+  EXPECT_EQ(props["vendor_id"], 4098u);
+  EXPECT_EQ(props["device_id"], 30145u);
 }
 
 // Every shipped config must describe the machine it actually simulates.


### PR DESCRIPTION
Use the AMD CDNA 5 architecture name to select the existing cdna5 profile, and point the generator helper and documentation at the checked-in amdgpu_isa_cdna5.xml. This removes the old filename-based profile override and relies on the complete shared snapshot provided by the parent bump.

Set the MI455X device ID to 30145 (0x75c1) and cover the config-to-sysfs identity path. Keep hardware-derived topology and capability values marked for validation against a physical MI455X capture. The value is from https://github.com/ROCm/rocm-systems/blob/013d1bc79e0e381d7e01bd38c908eb2af859bf4d/projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml#L514-L562

And set the unique_id to 0.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
