### PR TITLE
rocjitsu: Point the XCD distribution test at the config that exists

### DIFF
--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -34,10 +34,10 @@ namespace {
 
 using namespace rocjitsu;
 
-const std::string CONFIG_PATH = test::config_path("gfx950_cdna4.json");
+const std::string CONFIG_PATH = test::config_path("gfx950_mi355x.json");
 
 constexpr uint32_t kTotalXcds = 8;
-constexpr uint32_t kCusPerXcd = 32; // 4 SEs x 8 CUs
+constexpr uint32_t kCusPerXcd = 36; // 4 SEs x 9 CUs
 constexpr uint32_t kTotalCus = kTotalXcds * kCusPerXcd;
 constexpr uint64_t kKdAddr = 0x10000;
 constexpr uint32_t kWavefrontSize = 64;
@@ -89,7 +89,7 @@ uint32_t assigned_xcd_index(const SoC &soc, const amdgpu::CommandProcessor *cp) 
 //
 // This pins CURRENT behavior, which is a fidelity gap: a multi-XCD part running
 // as one partition spreads a dispatch over every XCD. The topology here
-// advertises 256 CUs, so a single-queue application reaches an eighth of them.
+// instantiates 288 CUs, so a single-queue application reaches an eighth of them.
 // Follow-on work in this stack flips this expectation to an even spread.
 TEST(XcdDistributionTest, SingleQueueGridLandsOnOneXcd) {
   XcdDistributionFixture fx;


### PR DESCRIPTION
The test named a gfx950 config that had been renamed out from under it, and described a part with 32 CUs per XCD. Both facts came from the same commit: aligning the MI350X configs with the captured KFD topology renamed gfx950_cdna4.json to gfx950_mi355x.json and widened a shader array from eight CUs to nine. Neither branch touched the other's files, so the merge was clean and the breakage appeared only once both were on develop -- every test in the suite threw before reaching an assertion, because the fixture could not open its config at all.

Name the config that ships and derive the geometry from it: four shader engines of nine CUs is 36 per XCD and 288 across the eight, which is what the topology instantiates. The active-CU count the driver reports is still 256, since 1024 SIMDs at four per CU excludes the harvested slots, but nothing here models a harvest mask and every instantiated slot is schedulable -- so the count these tests must agree with is the physical one.