### PR TITLE
refactor(amdsmi): rename IGPUBackend methods to snake_case

### DIFF
--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_backend.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_backend.h
@@ -36,63 +36,70 @@ class IGPUBackend {
  public:
   virtual ~IGPUBackend() = default;
 
-  virtual amdsmi_status_t GetAsicInfo(amdsmi_asic_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetBoardInfo(amdsmi_board_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetKfdInfo(amdsmi_kfd_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetVramInfo(amdsmi_vram_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetMemoryTotal(amdsmi_memory_type_t, uint64_t*) {
+  virtual amdsmi_status_t get_asic_info(amdsmi_asic_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_board_info(amdsmi_board_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetMemoryUsage(amdsmi_memory_type_t, uint64_t*) {
+  virtual amdsmi_status_t get_kfd_info(amdsmi_kfd_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_vram_info(amdsmi_vram_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_memory_total(amdsmi_memory_type_t, uint64_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetTempMetric(amdsmi_temperature_type_t, amdsmi_temperature_metric_t,
-                                        int64_t*) {
+  virtual amdsmi_status_t get_memory_usage(amdsmi_memory_type_t, uint64_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetVoltMetric(amdsmi_voltage_type_t, amdsmi_voltage_metric_t, int64_t*) {
+  virtual amdsmi_status_t get_temp_metric(amdsmi_temperature_type_t, amdsmi_temperature_metric_t,
+                                          int64_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetPowerInfo(amdsmi_power_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetGpuActivity(amdsmi_engine_usage_t*) {
+  virtual amdsmi_status_t get_volt_metric(amdsmi_voltage_type_t, amdsmi_voltage_metric_t,
+                                          int64_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetBusyPercent(uint32_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetClockInfo(amdsmi_clk_type_t, amdsmi_clk_info_t*) {
+  virtual amdsmi_status_t get_power_info(amdsmi_power_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetPcieInfo(amdsmi_pcie_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetDriverInfo(amdsmi_driver_info_t*) {
+  virtual amdsmi_status_t get_gpu_activity(amdsmi_engine_usage_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetVbiosInfo(amdsmi_vbios_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetUuid(unsigned int*, char*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetGpuCacheInfo(amdsmi_gpu_cache_info_t*) {
+  virtual amdsmi_status_t get_busy_percent(uint32_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_clock_info(amdsmi_clk_type_t, amdsmi_clk_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetFwInfo(amdsmi_fw_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetGpuMetricsInfo(amdsmi_gpu_metrics_t*) {
+  virtual amdsmi_status_t get_pcie_info(amdsmi_pcie_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_driver_info(amdsmi_driver_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetPowerCapInfo(amdsmi_power_cap_info_t*) {
+  virtual amdsmi_status_t get_vbios_info(amdsmi_vbios_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetFanRpms(uint32_t, int64_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetFanSpeed(uint32_t, int64_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t GetFanSpeedMax(uint32_t, uint64_t*) {
+  virtual amdsmi_status_t get_uuid(unsigned int*, char*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_gpu_cache_info(amdsmi_gpu_cache_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetVcnBusyPercent(uint32_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
-  virtual amdsmi_status_t AllocFabricTelemetry(uint32_t, amdsmi_fabric_telemetry_t**) {
+  virtual amdsmi_status_t get_fw_info(amdsmi_fw_info_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_gpu_metrics_info(amdsmi_gpu_metrics_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetFabricTelemetryData(amdsmi_fabric_telemetry_t*) {
+  virtual amdsmi_status_t get_power_cap_info(amdsmi_power_cap_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t FreeFabricTelemetry(amdsmi_fabric_telemetry_t*) {
+  virtual amdsmi_status_t get_fan_rpms(uint32_t, int64_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_fan_speed(uint32_t, int64_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t get_fan_speed_max(uint32_t, uint64_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
-  virtual amdsmi_status_t GetGpuFabricInfo(amdsmi_fabric_info_t*) {
+  virtual amdsmi_status_t get_vcn_busy_percent(uint32_t*) { return AMDSMI_STATUS_NOT_SUPPORTED; }
+  virtual amdsmi_status_t alloc_fabric_telemetry(uint32_t, amdsmi_fabric_telemetry_t**) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+  virtual amdsmi_status_t get_fabric_telemetry_data(amdsmi_fabric_telemetry_t*) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+  virtual amdsmi_status_t free_fabric_telemetry(amdsmi_fabric_telemetry_t*) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+  virtual amdsmi_status_t get_gpu_fabric_info(amdsmi_fabric_info_t*) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_wsl_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_wsl_device.h
@@ -49,40 +49,41 @@ class WSLGPUBackend : public IGPUBackend {
   // AMDSmiGPUDevice + WSLGPUBackend pairs, and populates sockets/processors.
   // Returns NOT_SUPPORTED if not a WSL environment.
   // Returns other error codes on WSL init failure.
-  static amdsmi_status_t TryPopulate(std::vector<AMDSmiSocket*>& sockets,
-                                     std::set<AMDSmiProcessor*>& processors);
+  static amdsmi_status_t try_populate(std::vector<AMDSmiSocket*>& sockets,
+                                      std::set<AMDSmiProcessor*>& processors);
 
-  // Returns true if TryPopulate succeeded (WSL devices are in use).
-  static bool IsActive();
+  // Returns true if try_populate succeeded (WSL devices are in use).
+  static bool is_active();
 
-  // Closes the KFD channel opened by TryPopulate. No-op if never populated.
-  static amdsmi_status_t Shutdown();
+  // Closes the KFD channel opened by try_populate. No-op if never populated.
+  static amdsmi_status_t shutdown();
 
   // IGPUBackend overrides
-  amdsmi_status_t GetAsicInfo(amdsmi_asic_info_t*) override;
-  amdsmi_status_t GetBoardInfo(amdsmi_board_info_t*) override;
-  amdsmi_status_t GetKfdInfo(amdsmi_kfd_info_t*) override;
-  amdsmi_status_t GetVramInfo(amdsmi_vram_info_t*) override;
-  amdsmi_status_t GetMemoryTotal(amdsmi_memory_type_t, uint64_t*) override;
-  amdsmi_status_t GetMemoryUsage(amdsmi_memory_type_t, uint64_t*) override;
-  amdsmi_status_t GetTempMetric(amdsmi_temperature_type_t, amdsmi_temperature_metric_t,
-                                int64_t*) override;
-  amdsmi_status_t GetVoltMetric(amdsmi_voltage_type_t, amdsmi_voltage_metric_t, int64_t*) override;
-  amdsmi_status_t GetPowerInfo(amdsmi_power_info_t*) override;
-  amdsmi_status_t GetGpuActivity(amdsmi_engine_usage_t*) override;
-  amdsmi_status_t GetBusyPercent(uint32_t*) override;
-  amdsmi_status_t GetClockInfo(amdsmi_clk_type_t, amdsmi_clk_info_t*) override;
-  amdsmi_status_t GetPcieInfo(amdsmi_pcie_info_t*) override;
-  amdsmi_status_t GetDriverInfo(amdsmi_driver_info_t*) override;
-  amdsmi_status_t GetVbiosInfo(amdsmi_vbios_info_t*) override;
-  amdsmi_status_t GetUuid(unsigned int*, char*) override;
-  amdsmi_status_t GetGpuCacheInfo(amdsmi_gpu_cache_info_t*) override;
-  amdsmi_status_t GetFwInfo(amdsmi_fw_info_t*) override;
-  amdsmi_status_t GetGpuMetricsInfo(amdsmi_gpu_metrics_t*) override;
-  amdsmi_status_t GetPowerCapInfo(amdsmi_power_cap_info_t*) override;
-  amdsmi_status_t GetFanRpms(uint32_t sensor_ind, int64_t* speed) override;
-  amdsmi_status_t GetFanSpeed(uint32_t sensor_ind, int64_t* speed) override;
-  amdsmi_status_t GetFanSpeedMax(uint32_t sensor_ind, uint64_t* max_speed) override;
+  amdsmi_status_t get_asic_info(amdsmi_asic_info_t*) override;
+  amdsmi_status_t get_board_info(amdsmi_board_info_t*) override;
+  amdsmi_status_t get_kfd_info(amdsmi_kfd_info_t*) override;
+  amdsmi_status_t get_vram_info(amdsmi_vram_info_t*) override;
+  amdsmi_status_t get_memory_total(amdsmi_memory_type_t, uint64_t*) override;
+  amdsmi_status_t get_memory_usage(amdsmi_memory_type_t, uint64_t*) override;
+  amdsmi_status_t get_temp_metric(amdsmi_temperature_type_t, amdsmi_temperature_metric_t,
+                                  int64_t*) override;
+  amdsmi_status_t get_volt_metric(amdsmi_voltage_type_t, amdsmi_voltage_metric_t,
+                                  int64_t*) override;
+  amdsmi_status_t get_power_info(amdsmi_power_info_t*) override;
+  amdsmi_status_t get_gpu_activity(amdsmi_engine_usage_t*) override;
+  amdsmi_status_t get_busy_percent(uint32_t*) override;
+  amdsmi_status_t get_clock_info(amdsmi_clk_type_t, amdsmi_clk_info_t*) override;
+  amdsmi_status_t get_pcie_info(amdsmi_pcie_info_t*) override;
+  amdsmi_status_t get_driver_info(amdsmi_driver_info_t*) override;
+  amdsmi_status_t get_vbios_info(amdsmi_vbios_info_t*) override;
+  amdsmi_status_t get_uuid(unsigned int*, char*) override;
+  amdsmi_status_t get_gpu_cache_info(amdsmi_gpu_cache_info_t*) override;
+  amdsmi_status_t get_fw_info(amdsmi_fw_info_t*) override;
+  amdsmi_status_t get_gpu_metrics_info(amdsmi_gpu_metrics_t*) override;
+  amdsmi_status_t get_power_cap_info(amdsmi_power_cap_info_t*) override;
+  amdsmi_status_t get_fan_rpms(uint32_t sensor_ind, int64_t* speed) override;
+  amdsmi_status_t get_fan_speed(uint32_t sensor_ind, int64_t* speed) override;
+  amdsmi_status_t get_fan_speed_max(uint32_t sensor_ind, uint64_t* max_speed) override;
 
   // Device identity (populated from HsaNodeProperties at construction).
   uint32_t node_id() const { return node_id_; }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1294,7 +1294,7 @@ amdsmi_status_t amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_han
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetUuid(uuid_length, uuid);
+  if (auto* b = gpu_device->backend()) return b->get_uuid(uuid_length, uuid);
 #endif
 
   uint64_t device_uuid = 0;
@@ -1490,7 +1490,7 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
 #ifdef ENABLE_WSL_BACKEND
-  if (auto* b = gpu_device->backend()) return b->GetBoardInfo(board_info);
+  if (auto* b = gpu_device->backend()) return b->get_board_info(board_info);
 #endif
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
@@ -1593,7 +1593,7 @@ amdsmi_status_t amdsmi_get_gpu_cache_info(amdsmi_processor_handle processor_hand
   if (status != AMDSMI_STATUS_SUCCESS) return status;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetGpuCacheInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_gpu_cache_info(info);
 #endif
 
   if (info == nullptr) {
@@ -1640,7 +1640,7 @@ amdsmi_status_t amdsmi_get_temp_metric(amdsmi_processor_handle processor_handle,
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetTempMetric(sensor_type, metric, temperature);
+  if (auto* b = gpu_device->backend()) return b->get_temp_metric(sensor_type, metric, temperature);
 #endif
 
   if (temperature == nullptr) {
@@ -1676,7 +1676,7 @@ amdsmi_status_t amdsmi_get_npm_info(amdsmi_node_handle node_handle, amdsmi_npm_i
   }
 
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) {
+  if (amd::smi::WSLGPUBackend::is_active()) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 #endif
@@ -1724,9 +1724,9 @@ amdsmi_status_t amdsmi_get_gpu_vram_usage(amdsmi_processor_handle processor_hand
 #ifdef ENABLE_WSL_BACKEND
   if (gpu_device->backend()) {
     uint64_t used = 0, total = 0;
-    r = gpu_device->backend()->GetMemoryUsage(AMDSMI_MEM_TYPE_VRAM, &used);
+    r = gpu_device->backend()->get_memory_usage(AMDSMI_MEM_TYPE_VRAM, &used);
     if (r != AMDSMI_STATUS_SUCCESS) return r;
-    r = gpu_device->backend()->GetMemoryTotal(AMDSMI_MEM_TYPE_VRAM, &total);
+    r = gpu_device->backend()->get_memory_total(AMDSMI_MEM_TYPE_VRAM, &total);
     if (r != AMDSMI_STATUS_SUCCESS) return r;
     vram_info->vram_used = static_cast<uint32_t>(used / (1024 * 1024));
     vram_info->vram_total = static_cast<uint32_t>(total / (1024 * 1024));
@@ -2276,7 +2276,7 @@ amdsmi_status_t amdsmi_get_gpu_fan_rpms(amdsmi_processor_handle processor_handle
     return r;
   }
   if (auto* b = gpu_device->backend()) {
-    return b->GetFanRpms(sensor_ind, speed);
+    return b->get_fan_rpms(sensor_ind, speed);
   }
 #endif
   return rsmi_wrapper(rsmi_dev_fan_rpms_get, processor_handle, 0, sensor_ind, speed);
@@ -2289,7 +2289,7 @@ amdsmi_status_t amdsmi_get_gpu_fan_speed(amdsmi_processor_handle processor_handl
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetFanSpeed(sensor_ind, speed);
+  if (auto* b = gpu_device->backend()) return b->get_fan_speed(sensor_ind, speed);
 #endif
   return rsmi_wrapper(rsmi_dev_fan_speed_get, processor_handle, 0, sensor_ind, speed);
 }
@@ -2301,7 +2301,7 @@ amdsmi_status_t amdsmi_get_gpu_fan_speed_max(amdsmi_processor_handle processor_h
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetFanSpeedMax(sensor_ind, max_speed);
+  if (auto* b = gpu_device->backend()) return b->get_fan_speed_max(sensor_ind, max_speed);
 #endif
   return rsmi_wrapper(rsmi_dev_fan_speed_max_get, processor_handle, 0, sensor_ind, max_speed);
 }
@@ -2340,7 +2340,7 @@ amdsmi_status_t amdsmi_get_fw_info(amdsmi_processor_handle processor_handle,
   {
     amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
     if (get_gpu_device_from_handle(processor_handle, &gpu_device) == AMDSMI_STATUS_SUCCESS) {
-      if (auto* b = gpu_device->backend()) return b->GetFwInfo(info);
+      if (auto* b = gpu_device->backend()) return b->get_fw_info(info);
     }
   }
 #endif
@@ -2422,7 +2422,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   }
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetAsicInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_asic_info(info);
 #endif
 
   if (info == nullptr) {
@@ -2736,7 +2736,7 @@ amdsmi_status_t amdsmi_get_gpu_kfd_info(amdsmi_processor_handle processor_handle
     return status;
   }
 #ifdef ENABLE_WSL_BACKEND
-  if (auto* b = gpu_device->backend()) return b->GetKfdInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_kfd_info(info);
 #endif
   (void)gpu_device;  // Only used for handle validation
   info->kfd_id = std::numeric_limits<uint64_t>::max();
@@ -2817,7 +2817,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handl
     return r;
   }
 #ifdef ENABLE_WSL_BACKEND
-  if (auto* b = gpu_device->backend()) return b->GetVramInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_vram_info(info);
 #endif
 
   std::ostringstream ss;
@@ -4129,7 +4129,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_process_info(amdsmi_process_info_t* procs
 
   if (num_items == nullptr) return AMDSMI_STATUS_INVAL;
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
   auto r = rsmi_compute_process_info_get(reinterpret_cast<rsmi_process_info_t*>(procs), num_items);
   return amd::smi::rsmi_to_amdsmi_status(r);
@@ -4141,7 +4141,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_process_info_by_pid(uint32_t pid,
 
   if (proc == nullptr) return AMDSMI_STATUS_INVAL;
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
   auto r = rsmi_compute_process_info_by_pid_get(pid, reinterpret_cast<rsmi_process_info_t*>(proc));
   return amd::smi::rsmi_to_amdsmi_status(r);
@@ -4153,7 +4153,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_process_gpus(uint32_t pid, uint32_t* dv_i
 
   if (dv_indices == nullptr || num_devices == nullptr) return AMDSMI_STATUS_INVAL;
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
   auto r = rsmi_compute_process_gpus_get(pid, dv_indices, num_devices);
   return amd::smi::rsmi_to_amdsmi_status(r);
@@ -4229,7 +4229,7 @@ amdsmi_status_t amdsmi_get_gpu_metrics_info(amdsmi_processor_handle processor_ha
     amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
     if (r != AMDSMI_STATUS_SUCCESS) return r;
     // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-    if (auto* b = gpu_device->backend()) return b->GetGpuMetricsInfo(pgpu_metrics);
+    if (auto* b = gpu_device->backend()) return b->get_gpu_metrics_info(pgpu_metrics);
   }
 #endif
 
@@ -4290,7 +4290,7 @@ amdsmi_status_t amdsmi_get_power_cap_info(amdsmi_processor_handle processor_hand
   }
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpudevice->backend()) return b->GetPowerCapInfo(info);
+  if (auto* b = gpudevice->backend()) return b->get_power_cap_info(info);
 #endif
 
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
@@ -4421,7 +4421,7 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     if (auto* b = gpu_device->backend()) {
       // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
       amdsmi_clk_info_t clk_info = {};
-      amdsmi_status_t ret = b->GetClockInfo(clk_type, &clk_info);
+      amdsmi_status_t ret = b->get_clock_info(clk_type, &clk_info);
       if (ret != AMDSMI_STATUS_SUCCESS) return ret;
       if (f == nullptr) return AMDSMI_STATUS_INVAL;
       std::memset(f, 0, sizeof(*f));
@@ -4585,7 +4585,7 @@ amdsmi_status_t amdsmi_get_gpu_memory_total(amdsmi_processor_handle processor_ha
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetMemoryTotal(mem_type, total);
+  if (auto* b = gpu_device->backend()) return b->get_memory_total(mem_type, total);
 #endif
   return rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0,
                       static_cast<rsmi_memory_type_t>(mem_type), total);
@@ -4597,7 +4597,7 @@ amdsmi_status_t amdsmi_get_gpu_memory_usage(amdsmi_processor_handle processor_ha
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetMemoryUsage(mem_type, used);
+  if (auto* b = gpu_device->backend()) return b->get_memory_usage(mem_type, used);
 #endif
   return rsmi_wrapper(rsmi_dev_memory_usage_get, processor_handle, 0,
                       static_cast<rsmi_memory_type_t>(mem_type), used);
@@ -4664,7 +4664,7 @@ amdsmi_status_t amdsmi_get_gpu_volt_metric(amdsmi_processor_handle processor_han
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
-  if (auto* b = gpu_device->backend()) return b->GetVoltMetric(sensor_type, metric, voltage);
+  if (auto* b = gpu_device->backend()) return b->get_volt_metric(sensor_type, metric, voltage);
 #endif
   return rsmi_wrapper(rsmi_dev_volt_metric_get, processor_handle, 0,
                       static_cast<rsmi_voltage_type_t>(sensor_type),
@@ -4725,7 +4725,7 @@ amdsmi_status_t amdsmi_get_vcn_busy_percent(amdsmi_processor_handle processor_ha
   }
 #ifdef ENABLE_WSL_BACKEND
   if (auto* backend = gpudevice->backend()) {
-    return backend->GetVcnBusyPercent(vcn_busy_percent);
+    return backend->get_vcn_busy_percent(vcn_busy_percent);
   }
 #endif
   return smi_amdgpu_get_vcn_busy_percent(gpudevice, vcn_busy_percent);
@@ -4975,7 +4975,7 @@ amdsmi_status_t amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_hand
   }
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetVbiosInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_vbios_info(info);
 #endif
 
   if (info == nullptr) {
@@ -5096,7 +5096,7 @@ amdsmi_status_t amdsmi_get_gpu_activity(amdsmi_processor_handle processor_handle
   if (r != AMDSMI_STATUS_SUCCESS) return r;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetGpuActivity(info);
+  if (auto* b = gpu_device->backend()) return b->get_gpu_activity(info);
 #endif
 
   if (info == nullptr) {
@@ -5150,7 +5150,7 @@ amdsmi_status_t amdsmi_get_clock_info(amdsmi_processor_handle processor_handle,
   if (r != AMDSMI_STATUS_SUCCESS) return r;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetClockInfo(clk_type, info);
+  if (auto* b = gpu_device->backend()) return b->get_clock_info(clk_type, info);
 #endif
 
   if (info == nullptr) {
@@ -5593,7 +5593,7 @@ amdsmi_status_t amdsmi_get_power_info(amdsmi_processor_handle processor_handle,
   if (status != AMDSMI_STATUS_SUCCESS) return status;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetPowerInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_power_info(info);
 #endif
 
   if (info == nullptr) {
@@ -5670,7 +5670,7 @@ amdsmi_status_t amdsmi_get_gpu_driver_info(amdsmi_processor_handle processor_han
   if (r != AMDSMI_STATUS_SUCCESS) return r;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetDriverInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_driver_info(info);
 #endif
 
   if (info == nullptr) {
@@ -5830,7 +5830,7 @@ amdsmi_status_t amdsmi_get_pcie_info(amdsmi_processor_handle processor_handle,
   if (r != AMDSMI_STATUS_SUCCESS) return r;
 #ifdef ENABLE_WSL_BACKEND
   // Check feature support before nullptr so NOT_SUPPORTED takes priority over INVAL.
-  if (auto* b = gpu_device->backend()) return b->GetPcieInfo(info);
+  if (auto* b = gpu_device->backend()) return b->get_pcie_info(info);
 #endif
 
   if (info == nullptr) {
@@ -8713,7 +8713,7 @@ amdsmi_status_t amdsmi_get_ttm_info(amdsmi_ttm_info_t* info) {
     return AMDSMI_STATUS_INVAL;
   }
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
 
   // Read current TTM pages limit from sysfs
@@ -8840,7 +8840,7 @@ amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
     return AMDSMI_STATUS_INVAL;
   }
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
 
   if (is_dry_run()) {
@@ -8887,7 +8887,7 @@ amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
 amdsmi_status_t amdsmi_reset_ttm_pages_limit(void) {
   AMDSMI_CHECK_INIT();
 #ifdef ENABLE_WSL_BACKEND
-  if (amd::smi::WSLGPUBackend::IsActive()) return AMDSMI_STATUS_NOT_SUPPORTED;
+  if (amd::smi::WSLGPUBackend::is_active()) return AMDSMI_STATUS_NOT_SUPPORTED;
 #endif
 
   // Remove modprobe configuration to reset to default. The active module

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -358,9 +358,9 @@ amdsmi_status_t AMDSmiSystem::populate_amd_cpus() {
 
 amdsmi_status_t AMDSmiSystem::populate_amd_gpu_devices() {
 #ifdef ENABLE_WSL_BACKEND
-  // WSL path: TryPopulate handles /dev/dxg detection, librocdxg loading, and
+  // WSL path: try_populate handles /dev/dxg detection, librocdxg loading, and
   // device enumeration. Returns NOT_SUPPORTED when not on WSL.
-  amdsmi_status_t wsl_status = WSLGPUBackend::TryPopulate(sockets_, processors_);
+  amdsmi_status_t wsl_status = WSLGPUBackend::try_populate(sockets_, processors_);
   if (wsl_status == AMDSMI_STATUS_DRIVER_NOT_LOADED) {
     std::ostringstream ss;
     ss << __func__ << ": WSL detected (/dev/dxg) but librocdxg.so.1 failed to load";
@@ -715,8 +715,8 @@ amdsmi_status_t AMDSmiSystem::cleanup() {
     }
     drm_.cleanup();
 #ifdef ENABLE_WSL_BACKEND
-    bool used_wsl = WSLGPUBackend::IsActive();
-    amdsmi_status_t wsl_ret = WSLGPUBackend::Shutdown();
+    bool used_wsl = WSLGPUBackend::is_active();
+    amdsmi_status_t wsl_ret = WSLGPUBackend::shutdown();
     if (wsl_ret != AMDSMI_STATUS_SUCCESS) return wsl_ret;
     if (!used_wsl) {
 #endif

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -618,7 +618,7 @@ amdsmi_status_t amdsmi_alloc_fabric_telemetry(amdsmi_processor_handle processor_
 
 #ifdef ENABLE_WSL_BACKEND
   if (auto* backend = device->backend()) {
-    return backend->AllocFabricTelemetry(category_mask, telemetry);
+    return backend->alloc_fabric_telemetry(category_mask, telemetry);
   }
 #endif
 
@@ -660,7 +660,7 @@ amdsmi_status_t amdsmi_get_fabric_telemetry_data(amdsmi_processor_handle process
 
 #ifdef ENABLE_WSL_BACKEND
   if (auto* backend = device->backend()) {
-    return backend->GetFabricTelemetryData(telemetry);
+    return backend->get_fabric_telemetry_data(telemetry);
   }
 #endif
 
@@ -699,7 +699,7 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
 
 #ifdef ENABLE_WSL_BACKEND
   if (auto* backend = device->backend()) {
-    return backend->FreeFabricTelemetry(telemetry);
+    return backend->free_fabric_telemetry(telemetry);
   }
 #endif
 
@@ -751,7 +751,7 @@ amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_han
 
 #ifdef ENABLE_WSL_BACKEND
   if (auto* backend = device->backend()) {
-    return backend->GetGpuFabricInfo(info);
+    return backend->get_gpu_fabric_info(info);
   }
 #endif
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
@@ -85,7 +85,7 @@ static constexpr const char* kDxgDevPath = "/dev/dxg";
 static constexpr const char* kRocdxgSoV = "librocdxg.so.1";
 static constexpr const char* kRocdxgSo = "librocdxg.so";
 
-// librocdxg handle — owned by TryPopulate, valid for the process lifetime.
+// librocdxg handle — owned by try_populate, valid for the process lifetime.
 static void* g_rocdxg_handle = nullptr;
 
 // Helper: resolve one dlsym symbol; print and return false on failure.
@@ -180,11 +180,11 @@ static AMDSmiDrm g_wsl_drm;
 // Definition of the global WSL symbol table (declared extern in amd_smi_wsl_syms.h).
 WslSyms g_wsl_syms;
 
-// True iff TryPopulate succeeded — tracks whether hsaKmtCloseKFD is needed.
+// True iff try_populate succeeded — tracks whether hsaKmtCloseKFD is needed.
 static bool g_wsl_active = false;
 
 // -----------------------------------------------------------------------------
-// WSLGPUBackend constructor and TryPopulate
+// WSLGPUBackend constructor and try_populate
 // -----------------------------------------------------------------------------
 
 WSLGPUBackend::WSLGPUBackend(uint32_t gpu_id, uint32_t node_id, const HsaNodeProperties& props)
@@ -200,8 +200,8 @@ WSLGPUBackend::WSLGPUBackend(uint32_t gpu_id, uint32_t node_id, const HsaNodePro
       bdf_(make_bdf(props)),
       marketing_name_(marketing_name_from_hsa(props)) {}
 
-amdsmi_status_t WSLGPUBackend::TryPopulate(std::vector<AMDSmiSocket*>& sockets,
-                                           std::set<AMDSmiProcessor*>& processors) {
+amdsmi_status_t WSLGPUBackend::try_populate(std::vector<AMDSmiSocket*>& sockets,
+                                            std::set<AMDSmiProcessor*>& processors) {
   // Not WSL if /dev/dxg is absent.
   if (access(kDxgDevPath, F_OK) != 0) return AMDSMI_STATUS_NOT_SUPPORTED;
 
@@ -250,7 +250,7 @@ amdsmi_status_t WSLGPUBackend::TryPopulate(std::vector<AMDSmiSocket*>& sockets,
 
   // Don't release system properties here — topology_drop_snapshot() clears
   // wdevices_, which rocdxg_smi_* functions need for the process lifetime.
-  // hsaKmtReleaseSystemProperties() is called in Shutdown().
+  // hsaKmtReleaseSystemProperties() is called in shutdown().
 
   if (gpu_index == 0) {
     g_wsl_syms.hsaKmtReleaseSystemProperties();
@@ -261,9 +261,9 @@ amdsmi_status_t WSLGPUBackend::TryPopulate(std::vector<AMDSmiSocket*>& sockets,
   return AMDSMI_STATUS_SUCCESS;
 }
 
-bool WSLGPUBackend::IsActive() { return g_wsl_active; }
+bool WSLGPUBackend::is_active() { return g_wsl_active; }
 
-amdsmi_status_t WSLGPUBackend::Shutdown() {
+amdsmi_status_t WSLGPUBackend::shutdown() {
   if (!g_wsl_active) return AMDSMI_STATUS_SUCCESS;
   g_wsl_active = false;
   g_wsl_syms.hsaKmtReleaseSystemProperties();
@@ -290,14 +290,14 @@ amdsmi_status_t WSLGPUBackend::load_device_info() const {
   return device_info_status_;
 }
 
-amdsmi_status_t WSLGPUBackend::GetKfdInfo(amdsmi_kfd_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_kfd_info(amdsmi_kfd_info_t* info) {
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
   // No KFD in WSL — the KFD ID and node ID concepts don't apply.
   std::memset(info, 0xFF, sizeof(*info));
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_asic_info(amdsmi_asic_info_t* info) {
   amdsmi_status_t r = load_device_info();
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
   if (r != AMDSMI_STATUS_SUCCESS && r != AMDSMI_STATUS_NOT_SUPPORTED) return r;
@@ -345,7 +345,7 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetBoardInfo(amdsmi_board_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_board_info(amdsmi_board_info_t* info) {
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
   amdsmi_status_t r = load_device_info();
   if (r == AMDSMI_STATUS_SUCCESS) {
@@ -361,7 +361,7 @@ amdsmi_status_t WSLGPUBackend::GetBoardInfo(amdsmi_board_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetVramInfo(amdsmi_vram_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_vram_info(amdsmi_vram_info_t* info) {
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
   amdsmi_status_t r = load_device_info();
   if (r == AMDSMI_STATUS_SUCCESS) {
@@ -383,7 +383,7 @@ amdsmi_status_t WSLGPUBackend::GetVramInfo(amdsmi_vram_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetMemoryTotal(amdsmi_memory_type_t mem_type, uint64_t* total) {
+amdsmi_status_t WSLGPUBackend::get_memory_total(amdsmi_memory_type_t mem_type, uint64_t* total) {
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
   if (mem_type != AMDSMI_MEM_TYPE_VRAM && mem_type != AMDSMI_MEM_TYPE_VIS_VRAM)
     return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -398,7 +398,7 @@ amdsmi_status_t WSLGPUBackend::GetMemoryTotal(amdsmi_memory_type_t mem_type, uin
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetMemoryUsage(amdsmi_memory_type_t mem_type, uint64_t* used) {
+amdsmi_status_t WSLGPUBackend::get_memory_usage(amdsmi_memory_type_t mem_type, uint64_t* used) {
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
   if (mem_type != AMDSMI_MEM_TYPE_VRAM && mem_type != AMDSMI_MEM_TYPE_VIS_VRAM)
     return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -412,9 +412,9 @@ amdsmi_status_t WSLGPUBackend::GetMemoryUsage(amdsmi_memory_type_t mem_type, uin
   return hsakmt_to_amdsmi(hstatus);
 }
 
-amdsmi_status_t WSLGPUBackend::GetTempMetric(amdsmi_temperature_type_t sensor_type,
-                                             amdsmi_temperature_metric_t metric,
-                                             int64_t* temperature) {
+amdsmi_status_t WSLGPUBackend::get_temp_metric(amdsmi_temperature_type_t sensor_type,
+                                               amdsmi_temperature_metric_t metric,
+                                               int64_t* temperature) {
   // Native rsmi_dev_temp_metric_get checks nullptr unconditionally, before support
   // determination, for standard sensor types — match that contract here.
   if (temperature == nullptr) return AMDSMI_STATUS_INVAL;
@@ -423,8 +423,8 @@ amdsmi_status_t WSLGPUBackend::GetTempMetric(amdsmi_temperature_type_t sensor_ty
   return hsakmt_to_amdsmi(hstatus);
 }
 
-amdsmi_status_t WSLGPUBackend::GetVoltMetric(amdsmi_voltage_type_t sensor_type,
-                                             amdsmi_voltage_metric_t metric, int64_t* voltage) {
+amdsmi_status_t WSLGPUBackend::get_volt_metric(amdsmi_voltage_type_t sensor_type,
+                                               amdsmi_voltage_metric_t metric, int64_t* voltage) {
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
   if (metric != AMDSMI_VOLT_CURRENT) return AMDSMI_STATUS_NOT_SUPPORTED;
   if (sensor_type != AMDSMI_VOLT_TYPE_VDDGFX) return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -436,7 +436,7 @@ amdsmi_status_t WSLGPUBackend::GetVoltMetric(amdsmi_voltage_type_t sensor_type,
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetPowerInfo(amdsmi_power_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_power_info(amdsmi_power_info_t* info) {
   rocdxg_smi_power_info_t power = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_power_info(node_id_, &power);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -461,7 +461,7 @@ amdsmi_status_t WSLGPUBackend::GetPowerInfo(amdsmi_power_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetBusyPercent(uint32_t* gpu_busy_percent) {
+amdsmi_status_t WSLGPUBackend::get_busy_percent(uint32_t* gpu_busy_percent) {
   rocdxg_smi_gpu_metrics_info_t metrics = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_gpu_metrics_info(node_id_, &metrics);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -471,7 +471,7 @@ amdsmi_status_t WSLGPUBackend::GetBusyPercent(uint32_t* gpu_busy_percent) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetGpuActivity(amdsmi_engine_usage_t* info) {
+amdsmi_status_t WSLGPUBackend::get_gpu_activity(amdsmi_engine_usage_t* info) {
   rocdxg_smi_gpu_metrics_info_t metrics = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_gpu_metrics_info(node_id_, &metrics);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -483,7 +483,7 @@ amdsmi_status_t WSLGPUBackend::GetGpuActivity(amdsmi_engine_usage_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetClockInfo(amdsmi_clk_type_t clk_type, amdsmi_clk_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_clock_info(amdsmi_clk_type_t clk_type, amdsmi_clk_info_t* info) {
   rocdxg_smi_clock_info_t rocdxg_info = {};
   HSAKMT_STATUS hstatus =
       g_wsl_syms.rocdxg_smi_get_clock_info(node_id_, static_cast<uint32_t>(clk_type), &rocdxg_info);
@@ -499,7 +499,7 @@ amdsmi_status_t WSLGPUBackend::GetClockInfo(amdsmi_clk_type_t clk_type, amdsmi_c
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetPcieInfo(amdsmi_pcie_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_pcie_info(amdsmi_pcie_info_t* info) {
   rocdxg_smi_pcie_info_t rocdxg_info = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_pcie_info(node_id_, &rocdxg_info);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -521,7 +521,7 @@ amdsmi_status_t WSLGPUBackend::GetPcieInfo(amdsmi_pcie_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetDriverInfo(amdsmi_driver_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_driver_info(amdsmi_driver_info_t* info) {
   amdsmi_status_t r = load_device_info();
   if (r != AMDSMI_STATUS_SUCCESS) return r;
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
@@ -533,7 +533,7 @@ amdsmi_status_t WSLGPUBackend::GetDriverInfo(amdsmi_driver_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetVbiosInfo(amdsmi_vbios_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_vbios_info(amdsmi_vbios_info_t* info) {
   amdsmi_status_t r = load_device_info();
   if (r != AMDSMI_STATUS_SUCCESS) return r;
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
@@ -547,7 +547,7 @@ amdsmi_status_t WSLGPUBackend::GetVbiosInfo(amdsmi_vbios_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetGpuCacheInfo(amdsmi_gpu_cache_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_gpu_cache_info(amdsmi_gpu_cache_info_t* info) {
   amdsmi_status_t r = load_device_info();
   if (r != AMDSMI_STATUS_SUCCESS) return r;
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
@@ -568,7 +568,7 @@ amdsmi_status_t WSLGPUBackend::GetGpuCacheInfo(amdsmi_gpu_cache_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetFwInfo(amdsmi_fw_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_fw_info(amdsmi_fw_info_t* info) {
   amdsmi_status_t r = load_device_info();
   if (r != AMDSMI_STATUS_SUCCESS) return r;
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
@@ -585,11 +585,11 @@ amdsmi_status_t WSLGPUBackend::GetFwInfo(amdsmi_fw_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetFanRpms(uint32_t /* sensor_ind */, int64_t* /* speed */) {
+amdsmi_status_t WSLGPUBackend::get_fan_rpms(uint32_t /* sensor_ind */, int64_t* /* speed */) {
   return AMDSMI_STATUS_NOT_SUPPORTED;
 }
 
-amdsmi_status_t WSLGPUBackend::GetFanSpeed(uint32_t /* sensor_ind */, int64_t* speed) {
+amdsmi_status_t WSLGPUBackend::get_fan_speed(uint32_t /* sensor_ind */, int64_t* speed) {
   rocdxg_smi_gpu_metrics_info_t metrics = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_gpu_metrics_info(node_id_, &metrics);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -599,15 +599,15 @@ amdsmi_status_t WSLGPUBackend::GetFanSpeed(uint32_t /* sensor_ind */, int64_t* s
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetFanSpeedMax(uint32_t /* sensor_ind */, uint64_t* max_speed) {
+amdsmi_status_t WSLGPUBackend::get_fan_speed_max(uint32_t /* sensor_ind */, uint64_t* max_speed) {
   if (max_speed == nullptr) return AMDSMI_STATUS_INVAL;
   *max_speed = 100;
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetPowerCapInfo(amdsmi_power_cap_info_t* info) {
+amdsmi_status_t WSLGPUBackend::get_power_cap_info(amdsmi_power_cap_info_t* info) {
   amdsmi_power_info_t power = {};
-  amdsmi_status_t r = GetPowerInfo(&power);
+  amdsmi_status_t r = get_power_info(&power);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
   // Feature support checked before nullptr so NOT_SUPPORTED takes priority over INVAL.
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
@@ -617,7 +617,7 @@ amdsmi_status_t WSLGPUBackend::GetPowerCapInfo(amdsmi_power_cap_info_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetGpuMetricsInfo(amdsmi_gpu_metrics_t* info) {
+amdsmi_status_t WSLGPUBackend::get_gpu_metrics_info(amdsmi_gpu_metrics_t* info) {
   rocdxg_smi_gpu_metrics_info_t metrics = {};
   HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_gpu_metrics_info(node_id_, &metrics);
   if (hstatus != HSAKMT_STATUS_SUCCESS) return hsakmt_to_amdsmi(hstatus);
@@ -664,7 +664,7 @@ amdsmi_status_t WSLGPUBackend::GetGpuMetricsInfo(amdsmi_gpu_metrics_t* info) {
   return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t WSLGPUBackend::GetUuid(unsigned int* uuid_length, char* uuid) {
+amdsmi_status_t WSLGPUBackend::get_uuid(unsigned int* uuid_length, char* uuid) {
   if (uuid_length == nullptr || uuid == nullptr || *uuid_length < AMDSMI_GPU_UUID_SIZE)
     return AMDSMI_STATUS_INVAL;
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/gpu/thermal/fan_read_test.cc
@@ -118,7 +118,7 @@ void TestFanRead::Run(void) {
       struct stat dxg_st{};
       bool on_wsl = (stat("/dev/dxg", &dxg_st) == 0);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED && on_wsl) {
-        // fan_rpms dispatches to WSLGPUBackend::GetFanRpms, a hard NOT_SUPPORTED
+        // fan_rpms dispatches to WSLGPUBackend::get_fan_rpms, a hard NOT_SUPPORTED
         // stub (no RPM telemetry over WDDM); fan_speed/fan_speed_max are backed
         // by real rocdxg_smi metrics.
         DISPLAY_AMDSMI_API("amdsmi_get_gpu_fan_rpms", "gpu=" + std::to_string(i), VERB(STANDARD));

--- a/projects/amdsmi/tests/amd_smi_test/functional/wsl/smi/wsl_smi_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/wsl/smi/wsl_smi_read_test.cc
@@ -57,7 +57,7 @@ class WslFunctionalReadOnly : public ::testing::Test {
     if (r != HSAKMT_STATUS_SUCCESS && r != HSAKMT_STATUS_KERNEL_ALREADY_OPENED) return;
     kfd_opened_ = true;
 
-    // Enumerate GPU nodes using the same path as WSLGPUBackend::TryPopulate.
+    // Enumerate GPU nodes using the same path as WSLGPUBackend::try_populate.
     // rocdxg_smi_get_device_count requires the full topology snapshot which
     // hsaKmtAcquireSystemProperties sets up.
     HsaSystemProperties sys_props = {};

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/wsl_backend_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/wsl_backend_test.cc
@@ -42,10 +42,10 @@ using amd::smi::AMDSmiProcessor;
 using amd::smi::AMDSmiSocket;
 using amd::smi::WSLGPUBackend;
 
-// IsActive() is false before any TryPopulate() call.
-TEST(GpuUnit, InactiveByDefault) { EXPECT_FALSE(WSLGPUBackend::IsActive()); }
+// is_active() is false before any try_populate() call.
+TEST(GpuUnit, InactiveByDefault) { EXPECT_FALSE(WSLGPUBackend::is_active()); }
 
-// TryPopulate() on a machine without /dev/dxg returns NOT_SUPPORTED.
+// try_populate() on a machine without /dev/dxg returns NOT_SUPPORTED.
 // Skipped on real WSL machines where /dev/dxg is present.
 TEST(GpuUnit, TryPopulateWithoutDxg) {
   if (access("/dev/dxg", F_OK) == 0) {
@@ -53,11 +53,11 @@ TEST(GpuUnit, TryPopulateWithoutDxg) {
   }
   std::vector<AMDSmiSocket*> sockets;
   std::set<AMDSmiProcessor*> processors;
-  amdsmi_status_t r = WSLGPUBackend::TryPopulate(sockets, processors);
+  amdsmi_status_t r = WSLGPUBackend::try_populate(sockets, processors);
   EXPECT_EQ(r, AMDSMI_STATUS_NOT_SUPPORTED);
   EXPECT_TRUE(sockets.empty());
   EXPECT_TRUE(processors.empty());
-  EXPECT_FALSE(WSLGPUBackend::IsActive());
+  EXPECT_FALSE(WSLGPUBackend::is_active());
 }
 
 #endif  // ENABLE_WSL_BACKEND


### PR DESCRIPTION
## Motivation

`IGPUBackend` was the only part of the internal layer still using PascalCase, so
dispatch sites read `get_gpu_device_from_handle()` on one line and
`backend->GetAsicInfo()` on the next. This is the mechanical rename, split out so
the two follow-up PRs in the stack are readable.

## Technical Details

**Backend interface** (`include/amd_smi/impl/amd_smi_gpu_backend.h`):
- Renamed all 28 virtuals to snake_case

**WSL backend** (`include/amd_smi/impl/amd_smi_wsl_device.h`, `src/amd_smi/amd_smi_wsl_device.cc`):
- Renamed the overrides and the three statics (`TryPopulate`, `IsActive`, `Shutdown`)

**Call sites** (`src/amd_smi/amd_smi.cc`, `amd_smi_ualoe.cc`, `amd_smi_system.cc`, WSL tests):
- Updated to the new names

No behaviour change and no signature change. Names were taken from the
declarations in `amd_smi_gpu_backend.h` rather than matched by prefix, so the
fabric telemetry pair is included.

## JIRA ID
JIRA ID: ROCM-28065

## Test Plan
- Build with `-DBUILD_TESTS=ON` (default, WSL off)
- Build with `-DENABLE_WSL_BACKEND=ON -DBUILD_TESTS=ON`
- `pre-commit run` on the changed files
- `grep` for any remaining PascalCase virtual or `backend->` call

## Test Result
- Both configurations build clean, warning counts unchanged from `develop`
- No PascalCase backend methods remain
- pre-commit passes

## Submission Checklist
- [x] The PR title follows Conventional Commits
- [x] Unit tests are included (existing WSL unit test updated)
- [x] pre-commit passes
