### PR TITLE
feat(rocr-runtime): expose num_xcc and size-check rocdxg_smi_get_device_info

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
@@ -284,6 +284,7 @@ amdsmi_status_t WSLGPUBackend::shutdown() {
 
 amdsmi_status_t WSLGPUBackend::load_device_info() const {
   std::call_once(device_info_once_, [this]() {
+    device_info_.struct_size = sizeof(device_info_);
     HSAKMT_STATUS hstatus = g_wsl_syms.rocdxg_smi_get_device_info(node_id_, &device_info_);
     device_info_status_ = hsakmt_to_amdsmi(hstatus);
   });

--- a/projects/rocr-runtime/libhsakmt/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists.txt
@@ -411,9 +411,10 @@ else()
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary )
   endif()
-  # Install public headers
+  # Install public headers. rocdxg_smi.h describes librocdxg, which only the
+  # WSL build produces, so it would otherwise ship for a library that is absent.
   install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${HSAKMT_TARGET} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT dev PATTERN "linux" EXCLUDE PATTERN "*virtio*" EXCLUDE)
+    COMPONENT dev PATTERN "linux" EXCLUDE PATTERN "*virtio*" EXCLUDE PATTERN "rocdxg*" EXCLUDE)
 
   # Record our usage data for clients find_package calls. On Windows, this is
   # only relocatable for the prebuilt WKMI path because that path installs

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/rocdxg_smi.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/rocdxg_smi.h
@@ -31,6 +31,7 @@ typedef struct rocdxg_smi_asic_info {
   uint64_t asic_serial;
   char market_name[ROCDXG_SMI_MAX_STRING_LENGTH];
   uint32_t num_of_compute_units;
+  uint32_t num_xcc;
   uint64_t target_graphics_version;
 } rocdxg_smi_asic_info_t;
 
@@ -167,12 +168,15 @@ HSAKMT_STATUS HSAKMTAPI rocdxg_smi_enum_processes(uint32_t node_id,
                                                   uint32_t* num_processes,
                                                   rocdxg_smi_process_info_t* processes);
 
-#ifdef __cplusplus
-}  // extern "C"
-#endif
-
-
+/* Callers must set struct_size to sizeof(rocdxg_smi_device_info_t) before every
+ * rocdxg_smi_get_device_info() call; the call clears the struct, so a reused one
+ * has to be set again. librocdxg is loaded with dlopen and ships separately from
+ * its consumers, so the two can disagree about this layout; the size check turns
+ * that into HSAKMT_STATUS_BUFFER_TOO_SMALL instead of a write past the end of the
+ * caller's struct. struct_size must stay first so it is readable regardless of
+ * what follows. */
 typedef struct rocdxg_smi_device_info {
+  uint32_t                struct_size;
   rocdxg_smi_bdf_info_t   bdf;
   rocdxg_smi_asic_info_t  asic;
   rocdxg_smi_board_info_t board;
@@ -183,12 +187,9 @@ typedef struct rocdxg_smi_device_info {
   rocdxg_smi_fw_info_t     fw;
 } rocdxg_smi_device_info_t;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 HSAKMT_STATUS HSAKMTAPI rocdxg_smi_get_device_info(uint32_t node_id,
                                                    rocdxg_smi_device_info_t* info);
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
 #endif  // ROCDXG_SMI_H_

--- a/projects/rocr-runtime/libhsakmt/src/dxg/rocdxg_smi.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/rocdxg_smi.cpp
@@ -424,6 +424,8 @@ HSAKMT_STATUS HSAKMTAPI rocdxg_smi_enum_processes(uint32_t node_id, uint32_t* nu
 HSAKMT_STATUS HSAKMTAPI rocdxg_smi_get_device_info(uint32_t node_id,
                                                    rocdxg_smi_device_info_t* info) {
   if (info == nullptr) return HSAKMT_STATUS_INVALID_PARAMETER;
+  // Rejects a caller built against a different layout before anything is written.
+  if (info->struct_size != sizeof(*info)) return HSAKMT_STATUS_BUFFER_TOO_SMALL;
   auto* wdev = checked_device(node_id);
   if (wdev == nullptr) return HSAKMT_STATUS_INVALID_NODE_UNIT;
 
@@ -460,6 +462,7 @@ HSAKMT_STATUS HSAKMTAPI rocdxg_smi_get_device_info(uint32_t node_id,
     info->asic.rev_id = wdev->AsicRevision();
     info->asic.asic_serial = wdev->Uuid();
     info->asic.num_of_compute_units = wdev->ComputeUnitCount();
+    info->asic.num_xcc = wdev->NumXcc();
     info->asic.target_graphics_version = target_graphics_version(*wdev);
     copy_string(info->asic.market_name, wdev->ProductName());
   }


### PR DESCRIPTION
> **Stacked on #10434.** Review that first; this PR's diff is against it.

## Motivation

The WDDM device layer already tracks an XCC count (`device.h` `NumXcc()`, used by
`topology.cpp`), but `rocdxg_smi_asic_info_t` had no field for it, so consumers
had no way to size per-XCC data.

Extending the struct is only safe because nothing has shipped yet. `librocdxg` is
`dlopen`ed and ships separately from its consumers (ROCm-on-WSL driver vs
amd-smi-lib), so the two can be built from different headers. The library would
then write its own `sizeof()` into a struct the caller allocated at a different
size, which is a write past the end rather than a diagnosable failure.

## Technical Details

**ABI** (`libhsakmt/include/hsakmt/rocdxg_smi.h`):
- Added `num_xcc` to `rocdxg_smi_asic_info_t`
- Added a caller-supplied `struct_size` as the first member of `rocdxg_smi_device_info_t`. It stays first so it remains readable no matter how the rest of the layout diverges, and must be set before **every** call because the call clears the struct
- Folded `rocdxg_smi_device_info_t` into the surrounding `extern "C"` block; it previously sat between two of them, giving a C++ consumer the struct with C++ linkage while its accessor kept C linkage

**Implementation** (`libhsakmt/src/dxg/rocdxg_smi.cpp`):
- `rocdxg_smi_get_device_info` rejects a `struct_size` mismatch with `BUFFER_TOO_SMALL` before writing anything, and populates `num_xcc`

**Packaging** (`libhsakmt/CMakeLists.txt`):
- Excluded `rocdxg*` from the public-header install. The header was shipping in the Linux devel package for a library only the `WIN_SDK`/dxg build produces

**Consumer** (`amdsmi/src/amd_smi/amd_smi_wsl_device.cc`):
- The existing `load_device_info()` caller sets `struct_size`, so the WSL path keeps working with this PR alone

## JIRA ID
JIRA ID: ROCM-28065

## Test Plan
- Build amd-smi with `-DENABLE_WSL_BACKEND=ON -DBUILD_TESTS=ON`
- Build default (WSL off)
- pre-commit on the changed amd-smi file

## Test Result
- Both configurations build clean, warning counts unchanged
- Not exercised on WSL hardware: the live path is `/dev/dxg`-gated and skips on native Linux

## Submission Checklist
- [x] The PR title follows Conventional Commits
- [x] Unit tests are included (the size-mismatch contract is covered by the WSL functional tests in the follow-up PR, which is where those tests live)
- [x] pre-commit passes
