### PR TITLE
ci(amdsmi): gate the vendored rocdxg ABI against upstream drift

### DIFF
--- a/.github/workflows/amdsmi-rocdxg-abi.yml
+++ b/.github/workflows/amdsmi-rocdxg-abi.yml
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------
+# Guards amd-smi's vendored copy of the librocdxg ABI against upstream drift.
+#
+# amd-smi mirrors a subset of rocr-runtime's hsakmt headers in
+# include/amd_smi/impl/wsl/rocdxg_abi.h so the normal build needs no path into
+# another project's source tree. librocdxg is dlopen'd and writes into structs
+# amd-smi allocates, so a layout change upstream would corrupt memory rather
+# than fail to compile.
+#
+# This runs on changes to either side, which is the point: drift is introduced
+# by editing the upstream header, and the amd-smi workflows only trigger on
+# projects/amdsmi/**.
+# ---------------------------------------------------------------------------
+
+name: AMDSMI rocdxg ABI
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/include/amd_smi/impl/wsl/rocdxg_abi.h'
+      - 'projects/amdsmi/tests/rocdxg_abi_check/**'
+      - 'projects/rocr-runtime/libhsakmt/include/hsakmt/rocdxg_smi.h'
+      - 'projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h'
+      - '.github/workflows/amdsmi-rocdxg-abi.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/include/amd_smi/impl/wsl/rocdxg_abi.h'
+      - 'projects/amdsmi/tests/rocdxg_abi_check/**'
+      - 'projects/rocr-runtime/libhsakmt/include/hsakmt/rocdxg_smi.h'
+      - 'projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h'
+      - '.github/workflows/amdsmi-rocdxg-abi.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  rocdxg-abi-check:
+    name: rocdxg ABI drift
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Only the two include trees and the check source are needed; the checks
+      # are static_asserts, so nothing is linked and no dependency is required.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            projects/amdsmi/include
+            projects/amdsmi/tests/rocdxg_abi_check
+            projects/rocr-runtime/libhsakmt/include
+            .github/workflows
+
+      - name: Compare the vendored ABI against upstream
+        run: |
+          g++ -std=c++17 -fsyntax-only \
+            -Iprojects/amdsmi/include \
+            -Iprojects/rocr-runtime/libhsakmt/include \
+            projects/amdsmi/tests/rocdxg_abi_check/rocdxg_abi_check.cc


### PR DESCRIPTION
> **Stacked on #10436** (which is stacked on #10435, on #10434). Review those first; this PR's diff is against #10436.

## Motivation

#10436 adds a `VERIFY_ROCDXG_ABI` target that `static_assert`s amd-smi's vendored
copy of the librocdxg ABI against rocr-runtime's headers. It is opt-in and needs
an upstream include tree, so in practice nobody runs it and it catches nothing.
An ABI guard that never runs is decoration.

## Technical Details

**New workflow** (`.github/workflows/amdsmi-rocdxg-abi.yml`):
- Triggers on the vendored header, the check source, and **rocr-runtime's `rocdxg_smi.h` / `hsakmttypes.h`**
- Sparse-checks-out only the two include trees and the check source
- Runs `g++ -std=c++17 -fsyntax-only` with two include paths

### Why standalone rather than a job in `amdsmi-build.yml`

Path filters are per-workflow, not per-job. Drift is introduced by editing
rocr-runtime's header, and every amd-smi workflow triggers only on
`projects/amdsmi/**`, so a guard hosted there could never fire for the case it
exists for. Adding that path to `amdsmi-build.yml` would instead run the whole
GPU test matrix on every libhsakmt header edit.

`rocr-runtime-wsl.yml` was the other candidate and is worse: a self-hosted
Windows runner needing MSVC, the Windows SDK and DVC.

### Why no CMake

Every check is a `static_assert`, so nothing is linked and no dependency is
needed. `-fsyntax-only` with two `-I` paths is the entire job, which is why this
runs on a stock `ubuntu-24.04` in seconds instead of configuring amd-smi.

The CMake `VERIFY_ROCDXG_ABI` target stays as the local entry point for
developers who already have both trees configured.

## JIRA ID
JIRA ID: ROCM-28065

## Test Plan
- `yaml.safe_load` the workflow to confirm it parses and the triggers/job resolve
- Run the job's exact command locally against the real trees
- Simulate the sparse checkout (copy only the three listed paths into an empty tree) and compile from there, to confirm the path list is sufficient
- Negative test: delete `num_xcc` from the vendored mirror and re-run the command

## Test Result
- YAML parses; triggers are `pull_request`, `push`, `workflow_dispatch`
- Exact job command exits 0 against the real trees
- Compiles clean from the simulated sparse checkout, so no path is missing
- Negative test exits 1 with the intended `static_assert` message, and passes again once reverted

## Submission Checklist
- [x] The PR title follows Conventional Commits
- [x] Unit tests are included (this PR is CI-only; the check it runs ships in #10436)
- [x] pre-commit passes
