### PR TITLE
chore(rocprofiler-compute): remove SKIP_NATIVE_TOOL_BUILD option

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -26,6 +26,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Removed the Nuitka standalone binary build (`STANDALONEBINARY`, `STANDALONEBINARY_EXTRACT_DIR`), its RHEL 8 docker recipe, and the `--call-binary` pytest option that exercised it.
 
+* Removed the `SKIP_NATIVE_TOOL_BUILD` build option. The counter collection tool is always built, and its sources are no longer installed for runtime compilation.
+
 ### Optimized
 
 ### Resolved issues

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -237,18 +237,10 @@ else()
     set(COVERAGE_DATA_PATH "${PROJECT_SOURCE_DIR}/.coverage")
 endif()
 
-option(
-    SKIP_NATIVE_TOOL_BUILD
-    "Skip building native counter collection tool library (for runtime compilation)"
-    OFF
-)
-
 # -------------------
 # Setup tool library
 # -------------------
-if(NOT SKIP_NATIVE_TOOL_BUILD)
-    add_subdirectory(src/lib)
-endif()
+add_subdirectory(src/lib)
 
 # ---------------------------
 # Profile mode import guard
@@ -1284,24 +1276,11 @@ install(
     COMPONENT main
 )
 
-# install librocprofiler-compute-tool.so or source files
-if(NOT SKIP_NATIVE_TOOL_BUILD)
-    install(
-        TARGETS rocprofiler-compute-tool
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rocprofiler-compute COMPONENT main
-    )
-else()
-    # Install source files for runtime compilation. roctx_recordfn/ is
-    # installed by a dedicated rule above and excluded here.
-    install(
-        DIRECTORY src/lib/
-        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/lib
-        COMPONENT main
-        PATTERN "_build" EXCLUDE
-        PATTERN "tests" EXCLUDE
-        PATTERN "roctx_recordfn" EXCLUDE
-    )
-endif()
+# install librocprofiler-compute-tool.so
+install(
+    TARGETS rocprofiler-compute-tool
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rocprofiler-compute COMPONENT main
+)
 
 # top-level bin/rocprof-compute launcher (re-execs into libexec entrypoint)
 configure_file(

--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -72,7 +72,6 @@ Common CMake options:
 - `-D INSTALL_TESTS=ON` - Install test files and test suite
 - `-D ENABLE_COVERAGE=ON` - Enable code coverage reporting
 - `-D TEST_FROM_INSTALL=ON` - Enable testing from installation directory instead of build directory
-- `-D SKIP_NATIVE_TOOL_BUILD=ON` - Skip building the native profiling tool (enables runtime compilation instead), useful when rocprofiler-sdk is not available during build time
 - `-D TORCH_TRACE_PYTHON=/path/to/python3` - Select the Python interpreter for the `roctx_recordfn` build when `ENABLE_TESTS=ON`
 - `-D ENABLE_SANITIZER=ASAN|HOST_ASAN|TSAN` - Build with sanitizer instrumentation for development (default OFF)
 

--- a/projects/rocprofiler-compute/docs/install/source-install.rst
+++ b/projects/rocprofiler-compute/docs/install/source-install.rst
@@ -77,9 +77,6 @@ follows.
     * - ``TEST_FROM_INSTALL``
       - Should be ON to enable testing from the installation location without dependency on the source directory.
 
-    * - ``SKIP_NATIVE_TOOL_BUILD``
-      - Should be ON to skip building the native profiling tool. When enabled, the native tool will be compiled at runtime instead of build time. This is useful when ROCprofiler-SDK is not available during build time.
-
     * - ``ENABLE_SANITIZER``
       - Builds with sanitizer instrumentation for development.
         One of ``OFF`` (default), ``ASAN``, ``HOST_ASAN``, ``TSAN``, or ``UBSAN``. See


### PR DESCRIPTION
## Motivation

`SKIP_NATIVE_TOOL_BUILD` existed to build without rocprofiler-sdk present, and its
only in-tree consumer was `docker/Dockerfile.standalone`, removed in #10438. Dropping
it makes the counter collection tool build and install path unconditional.

## Technical Details

- `add_subdirectory(src/lib)` and `install(TARGETS rocprofiler-compute-tool ...)` are
  now unconditional.
- Drop the `else()` branch that installed `src/lib/` sources into
  `libexec/rocprofiler-compute/lib` for runtime compilation. The `roctx_recordfn`
  sources keep their own dedicated install rule and are unaffected.
- `NativeToolFinder.__build_collector` in `src/utils/native_tool_finder.py` is
  unchanged. It stays reachable in source-tree layouts, and it was already the second
  tier behind `__find_installed_collector`, which now always finds the installed
  library.

Stacked on #10438 and targeted at that branch; retarget to
`rocprofiler-compute-develop` once it merges.

## JIRA ID

N/A

## Test Plan

Clean configure and install with tests enabled. Confirm the tool library is installed
and that no tool sources land under `libexec`. Confirm the registered ctest names are
unchanged, and run the native tool finder tests.

## Test Result

Works locally on x86_64 (gfx942 container).

- Configure and `--target install` both succeed.
- `install/lib/rocprofiler-compute/librocprofiler-compute-tool.so` present; no `.cpp`
  or `.hpp` under `install/libexec/rocprofiler-compute/lib`, which now holds only
  `roctx_recordfn/`.
- ctest name list identical to the parent branch.
- `pytest tests/unit/utils/test_native_tool_finder.py` passes, and
  `ctest -R test_native_tool_finder` passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
