### PR TITLE
[rocjitsu] Model gfx1250 SRAM ECC semantics for D16 loads

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3730,9 +3730,13 @@ class CodeGenerator:
 
         The last register is partial when the written bytes (num_elems *
         elem_size) do not fill whole 32-bit registers (e.g. ushort_d16, or
-        format_d16_xyz).
+        format_d16_xyz). Architectures with SRAM ECC can instead zero-fill the
+        unselected half, making the destination a full write rather than a
+        read-modify-write.
         """
         if not self.semantics:
+            return False
+        if self.isa_spec.profile.d16_loads_zero_unselected_half:
             return False
         sem = self.semantics.instructions.get(inst.name)
         if not sem or sem.num_elems is None or sem.elem_size is None:
@@ -8196,13 +8200,14 @@ class CodeGenerator:
                     dst_idx = 0
                     vgpr_msb_src_role_idx = 0
                     reads_dst = self._dst_is_also_source(inst)
-                    # D16(_HI) loads read the destination they partially write.
-                    # Model it as an implicit use so vdst stays out of the
-                    # printed operand list (see _d16_load_reads_dst). The
-                    # override declaration/definition is emitted below, sharing
-                    # the path with generic partial defs (buffer/tbuffer loads
-                    # name the dest 'vdata' and are sized as a full 32-bit
-                    # register, so _partial_def_outputs does not catch them).
+                    # D16(_HI) loads on architectures without SRAM ECC read the
+                    # destination they partially write. Model that preservation
+                    # as an implicit use so vdst stays out of the printed operand
+                    # list (see _d16_load_reads_dst). The override
+                    # declaration/definition is emitted below, sharing the path
+                    # with generic partial defs (buffer/tbuffer loads name the
+                    # dest 'vdata' and are sized as a full 32-bit register, so
+                    # _partial_def_outputs does not catch them).
                     d16_implicit_use_opnd = None
                     # Offset (in 32-bit registers) of the one partially-written
                     # register within the destination: only the last register of

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -314,6 +314,11 @@ class IsaProfile(ABC):
         return False
 
     @property
+    def d16_loads_zero_unselected_half(self) -> bool:
+        """True when D16 loads zero the unselected destination half."""
+        return False
+
+    @property
     def uses_packed_16bit_e32_source_selectors(self) -> bool:
         """True when E32 16-bit source selectors can address packed high halves."""
         return False
@@ -1178,6 +1183,11 @@ class CdnaProfile(_AmdgpuProfileBase):
         # zero the upper half; see the CDNA ISA OP_SEL field description.
         return True
 
+    @property
+    def d16_loads_zero_unselected_half(self) -> bool:
+        # CDNA2/3/4 enable SRAM ECC in the runtime ISA traits.
+        return True
+
 
 class Cdna4Profile(CdnaProfile):
     """ISA profile for CDNA4-only encoding capabilities."""
@@ -1218,7 +1228,12 @@ class Cdna1Profile(CdnaProfile):
     - GFX9-style GLC-only coherency model.
     - Scratch base via SGPR pair (not HW register).
     - ENC_VOP3PX2 does not exist in CDNA1 XML.
+    - The current runtime ISA trait leaves SRAM ECC disabled.
     """
+
+    @property
+    def d16_loads_zero_unselected_half(self) -> bool:
+        return False
 
     @property
     def has_acc_vgpr(self) -> bool:
@@ -1908,6 +1923,10 @@ class Cdna5Profile(Rdna4Profile):
 
     @property
     def uses_vgpr_msb_indexing(self) -> bool:
+        return True
+
+    @property
+    def d16_loads_zero_unselected_half(self) -> bool:
         return True
 
     @property

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -4702,39 +4702,43 @@ def test_only_gfx1250_generates_implicit_use_operands_overrides(
 
 
 @pytest.mark.parametrize(
-    'src_file,class_name',
+    'src_file,class_name,dst_name',
     [
-        ('vflat.cpp', 'FlatLoadD16U8Vflat'),
-        ('vglobal.cpp', 'GlobalLoadD16U8Vglobal'),
-        ('vscratch.cpp', 'ScratchLoadD16U8Vscratch'),
+        ('vbuffer.cpp', 'BufferLoadD16U8Vbuffer', 'vdata'),
+        ('vds.cpp', 'DsLoadU8D16Vds', 'vdst'),
+        ('vflat.cpp', 'FlatLoadD16U8Vflat', 'vdst'),
+        ('vglobal.cpp', 'GlobalLoadD16U8Vglobal', 'vdst'),
+        ('vscratch.cpp', 'ScratchLoadD16U8Vscratch', 'vdst'),
     ],
 )
-def test_gfx1250_d16_load_preserves_destination_without_printing_it(
-    gfx1250_generated_root: Path, src_file, class_name
+def test_gfx1250_d16_load_does_not_preserve_destination(
+    gfx1250_generated_root: Path, src_file, class_name, dst_name
 ):
-    """A D16 partial-def load reads vdst via the implicit hooks, not src_operands_.
+    """A gfx1250 D16 load zero-fills rather than preserve-reading its destination.
 
-    GLOBAL/SCRATCH share semantic_class 'flat_load' with FLAT but emit to
-    separate files, so cover all three. Listing vdst as a source would print it
-    twice in disassembly; pin that a future generator change doing so fails here.
+    Cover every generated memory family because each independently emits its
+    instruction class and hidden-use overrides.
     """
     cpp = (gfx1250_generated_root / src_file).read_text()
     ctor = _generated_constructor_body(cpp, class_name)
 
-    # vdst is a destination, never a source (kept out of the printed operands).
-    assert 'dst_operands_[0] = &vdst;' in ctor
-    assert not re.search(r'src_operands_\[[^\]]*\]\s*=\s*&vdst;', ctor)
+    assert f'dst_operands_[0] = &{dst_name};' in ctor
+    assert not re.search(rf'src_operands_\[[^\]]*\]\s*=\s*&{dst_name};', ctor)
 
-    # The preserved-destination read is modeled via both implicit hooks.
     uses_override = f'void {class_name}::implicit_uses(RegisterSet &uses) const'
     operands_override = f'void {class_name}::implicit_use_operands('
-    assert uses_override in cpp
-    assert operands_override in cpp
-    uses_start = cpp.index(uses_override)
-    uses_body = cpp[uses_start : cpp.index('\n}', uses_start)]
-    assert 'if (auto r = vdst.to_register_ref())' in uses_body
-    assert 'uses.expand(*r);' in uses_body
-    operands_start = cpp.index(operands_override)
-    operands_body = cpp[operands_start : cpp.index('\n}', operands_start)]
-    assert 'if (vdst.to_register_ref())' in operands_body
-    assert 'operands.push_back(&vdst);' in operands_body
+    assert uses_override not in cpp
+    assert operands_override not in cpp
+
+
+def test_cdna4_d16_load_does_not_preserve_destination(
+    amdgpu_generated_root: Path,
+):
+    """CDNA4 D16 loads are full VGPR writes because gfx950 enables SRAM ECC."""
+    cpp = (amdgpu_generated_root / 'cdna4' / 'mubuf.cpp').read_text()
+    class_name = 'BufferLoadUbyteD16Mubuf'
+    ctor = _generated_constructor_body(cpp, class_name)
+
+    assert 'dst_operands_[0] = &vdata;' in ctor
+    assert not re.search(r'src_operands_\[[^\]]*\]\s*=\s*&vdata;', ctor)
+    assert f'void {class_name}::implicit_uses(RegisterSet &uses) const' not in cpp

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_profile_properties.py
@@ -432,6 +432,9 @@ class TestCdnaProfile:
     def test_waitcnt_lgkmcnt_mask(self):
         assert self.p.waitcnt_lgkmcnt_mask == '0x0F'
 
+    def test_d16_loads_zero_unselected_half(self):
+        assert self.p.d16_loads_zero_unselected_half is True
+
     def test_field_renames_flat(self):
         renames = self.p.field_renames('ENC_FLAT')
         assert renames.get('sve') == 'lds'
@@ -489,6 +492,9 @@ class TestCdna1Profile:
     def test_wave_size_inherited(self):
         assert self.p.wave_size == 64
 
+    def test_d16_loads_preserve_unselected_half(self):
+        assert self.p.d16_loads_zero_unselected_half is False
+
 
 class TestCdna2Profile:
     """Cdna2Profile: AccVGPR base 512, GFX9_GLC coherency, sgpr_pair scratch."""
@@ -507,6 +513,9 @@ class TestCdna2Profile:
 
     def test_flat_scratch_mechanism(self):
         assert self.p.flat_scratch_mechanism == 'sgpr_pair'
+
+    def test_d16_loads_zero_unselected_half(self):
+        assert self.p.d16_loads_zero_unselected_half is True
 
 
 class TestRdna1Profile:
@@ -668,6 +677,9 @@ class TestCdna5Profile:
 
     def test_vgpr_msb_indexing(self):
         assert self.p.uses_vgpr_msb_indexing is True
+
+    def test_d16_loads_zero_unselected_half(self):
+        assert self.p.d16_loads_zero_unselected_half is True
 
     def test_source_split_limits_leave_precommit_margin(self):
         limits = self.p.source_split_max_bytes

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/isa.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/isa.h
@@ -71,6 +71,7 @@ struct Isa : amdgpu::RdnaIsaBase {
 
   static constexpr uint32_t WF_SIZE_MAX = 32; ///< gfx1250 is Wave32-only.
   static constexpr uint32_t MAX_WF_SLOTS = 64;
+  static constexpr bool SRAM_ECC = true; ///< gfx1250 enables SRAM ECC.
   // gfx1250 uses the RDNA base decoder shape, but its MODE[27] enables VGPR
   // high-bank indexing rather than RDNA4 DISABLE_PERF.
   static constexpr bool MODE_HAS_GPR_IDX_EN = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.cpp
@@ -2674,12 +2674,6 @@ DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
 }
 } // namespace detail
 
-void DsReadU8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU8D16HiDs)),
@@ -2710,12 +2704,6 @@ DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadU8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
     : Ds("ds_read_i8_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadI8D16Ds)),
@@ -2744,12 +2732,6 @@ DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadI8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_i8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2781,12 +2763,6 @@ DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadI8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
     : Ds("ds_read_u16_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU16D16Ds)),
@@ -2815,12 +2791,6 @@ DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEm
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u16_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2851,12 +2821,6 @@ DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
     : Ds("ds_add_f64", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds.h
@@ -820,7 +820,6 @@ class DsReadU8D16Ds : public Ds {
 public:
   DsReadU8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -830,7 +829,6 @@ class DsReadU8D16HiDs : public Ds {
 public:
   DsReadU8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -840,7 +838,6 @@ class DsReadI8D16Ds : public Ds {
 public:
   DsReadI8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -850,7 +847,6 @@ class DsReadI8D16HiDs : public Ds {
 public:
   DsReadI8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -860,7 +856,6 @@ class DsReadU16D16Ds : public Ds {
 public:
   DsReadU16D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -870,7 +865,6 @@ class DsReadU16D16HiDs : public Ds {
 public:
   DsReadU16D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.cpp
@@ -760,13 +760,6 @@ DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadUbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadUbyteD16HiFlat)),
@@ -810,13 +803,6 @@ DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadUbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -862,13 +848,6 @@ DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadSbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadSbyteD16HiFlat)),
@@ -912,13 +891,6 @@ DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadSbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
     : Flat("flat_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -964,13 +936,6 @@ DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadShortD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadShortD16HiFlat)),
@@ -1014,13 +979,6 @@ DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadShortD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
     : Flat("flat_atomic_swap", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/flat.h
@@ -194,7 +194,6 @@ class FlatLoadUbyteD16Flat : public Flat {
 public:
   FlatLoadUbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -206,7 +205,6 @@ class FlatLoadUbyteD16HiFlat : public Flat {
 public:
   FlatLoadUbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -218,7 +216,6 @@ class FlatLoadSbyteD16Flat : public Flat {
 public:
   FlatLoadSbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -230,7 +227,6 @@ class FlatLoadSbyteD16HiFlat : public Flat {
 public:
   FlatLoadSbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -242,7 +238,6 @@ class FlatLoadShortD16Flat : public Flat {
 public:
   FlatLoadShortD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -254,7 +249,6 @@ class FlatLoadShortD16HiFlat : public Flat {
 public:
   FlatLoadShortD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.cpp
@@ -319,12 +319,6 @@ DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void TbufferLoadFormatD16XMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
 TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::TbufferLoadFormatD16XyMtbuf)),
@@ -392,12 +386,6 @@ DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
-
-void TbufferLoadFormatD16XyzMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mtbuf.h
@@ -98,7 +98,6 @@ class TbufferLoadFormatD16XMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -119,7 +118,6 @@ class TbufferLoadFormatD16XyzMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XyzMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.cpp
@@ -319,13 +319,6 @@ DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadFormatD16XMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadFormatD16XyMubuf)),
@@ -392,13 +385,6 @@ DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16XyzMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),
@@ -1130,13 +1116,6 @@ DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadUbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadUbyteD16HiMubuf)),
@@ -1169,13 +1148,6 @@ DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadUbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1210,13 +1182,6 @@ DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadSbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadSbyteD16HiMubuf)),
@@ -1249,13 +1214,6 @@ DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadSbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1290,13 +1248,6 @@ DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadShortD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadShortD16HiMubuf)),
@@ -1329,13 +1280,6 @@ DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadShortD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),
@@ -1370,13 +1314,6 @@ DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16HiXMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_store_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/mubuf.h
@@ -98,7 +98,6 @@ class BufferLoadFormatD16XMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -119,7 +118,6 @@ class BufferLoadFormatD16XyzMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XyzMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -340,7 +338,6 @@ class BufferLoadUbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadUbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -351,7 +348,6 @@ class BufferLoadUbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadUbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -362,7 +358,6 @@ class BufferLoadSbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadSbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -373,7 +368,6 @@ class BufferLoadSbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadSbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -384,7 +378,6 @@ class BufferLoadShortD16Mubuf : public Mubuf {
 public:
   BufferLoadShortD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -395,7 +388,6 @@ class BufferLoadShortD16HiMubuf : public Mubuf {
 public:
   BufferLoadShortD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -406,7 +398,6 @@ class BufferLoadFormatD16HiXMubuf : public Mubuf {
 public:
   BufferLoadFormatD16HiXMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.cpp
@@ -2727,12 +2727,6 @@ DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
 }
 } // namespace detail
 
-void DsReadU8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU8D16HiDs)),
@@ -2763,12 +2757,6 @@ DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadU8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
     : Ds("ds_read_i8_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadI8D16Ds)),
@@ -2797,12 +2785,6 @@ DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadI8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_i8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2834,12 +2816,6 @@ DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadI8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
     : Ds("ds_read_u16_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU16D16Ds)),
@@ -2868,12 +2844,6 @@ DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEm
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u16_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2904,12 +2874,6 @@ DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
     : Ds("ds_add_f64", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds.h
@@ -836,7 +836,6 @@ class DsReadU8D16Ds : public Ds {
 public:
   DsReadU8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -846,7 +845,6 @@ class DsReadU8D16HiDs : public Ds {
 public:
   DsReadU8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -856,7 +854,6 @@ class DsReadI8D16Ds : public Ds {
 public:
   DsReadI8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -866,7 +863,6 @@ class DsReadI8D16HiDs : public Ds {
 public:
   DsReadI8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -876,7 +872,6 @@ class DsReadU16D16Ds : public Ds {
 public:
   DsReadU16D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -886,7 +881,6 @@ class DsReadU16D16HiDs : public Ds {
 public:
   DsReadU16D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.cpp
@@ -761,13 +761,6 @@ DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadUbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadUbyteD16HiFlat)),
@@ -811,13 +804,6 @@ DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadUbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -863,13 +849,6 @@ DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadSbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadSbyteD16HiFlat)),
@@ -913,13 +892,6 @@ DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadSbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
     : Flat("flat_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -965,13 +937,6 @@ DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadShortD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadShortD16HiFlat)),
@@ -1015,13 +980,6 @@ DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadShortD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
     : Flat("flat_atomic_swap", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/flat.h
@@ -194,7 +194,6 @@ class FlatLoadUbyteD16Flat : public Flat {
 public:
   FlatLoadUbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -206,7 +205,6 @@ class FlatLoadUbyteD16HiFlat : public Flat {
 public:
   FlatLoadUbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -218,7 +216,6 @@ class FlatLoadSbyteD16Flat : public Flat {
 public:
   FlatLoadSbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -230,7 +227,6 @@ class FlatLoadSbyteD16HiFlat : public Flat {
 public:
   FlatLoadSbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -242,7 +238,6 @@ class FlatLoadShortD16Flat : public Flat {
 public:
   FlatLoadShortD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -254,7 +249,6 @@ class FlatLoadShortD16HiFlat : public Flat {
 public:
   FlatLoadShortD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.cpp
@@ -320,12 +320,6 @@ DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void TbufferLoadFormatD16XMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
 TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::TbufferLoadFormatD16XyMtbuf)),
@@ -393,12 +387,6 @@ DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
-
-void TbufferLoadFormatD16XyzMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mtbuf.h
@@ -98,7 +98,6 @@ class TbufferLoadFormatD16XMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -119,7 +118,6 @@ class TbufferLoadFormatD16XyzMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XyzMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.cpp
@@ -320,13 +320,6 @@ DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadFormatD16XMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadFormatD16XyMubuf)),
@@ -393,13 +386,6 @@ DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16XyzMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),
@@ -1131,13 +1117,6 @@ DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadUbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadUbyteD16HiMubuf)),
@@ -1170,13 +1149,6 @@ DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadUbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1211,13 +1183,6 @@ DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadSbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadSbyteD16HiMubuf)),
@@ -1250,13 +1215,6 @@ DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadSbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1291,13 +1249,6 @@ DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadShortD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadShortD16HiMubuf)),
@@ -1330,13 +1281,6 @@ DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadShortD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),
@@ -1371,13 +1315,6 @@ DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16HiXMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_store_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/mubuf.h
@@ -98,7 +98,6 @@ class BufferLoadFormatD16XMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -119,7 +118,6 @@ class BufferLoadFormatD16XyzMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XyzMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -340,7 +338,6 @@ class BufferLoadUbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadUbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -351,7 +348,6 @@ class BufferLoadUbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadUbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -362,7 +358,6 @@ class BufferLoadSbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadSbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -373,7 +368,6 @@ class BufferLoadSbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadSbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -384,7 +378,6 @@ class BufferLoadShortD16Mubuf : public Mubuf {
 public:
   BufferLoadShortD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -395,7 +388,6 @@ class BufferLoadShortD16HiMubuf : public Mubuf {
 public:
   BufferLoadShortD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -406,7 +398,6 @@ class BufferLoadFormatD16HiXMubuf : public Mubuf {
 public:
   BufferLoadFormatD16HiXMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.cpp
@@ -2737,12 +2737,6 @@ DecodeResult decodeDsReadU8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
 }
 } // namespace detail
 
-void DsReadU8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU8D16HiDs::DsReadU8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU8D16HiDs)),
@@ -2773,12 +2767,6 @@ DecodeResult decodeDsReadU8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadU8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadI8D16Ds::DsReadI8D16Ds(const MachineInst *inst)
     : Ds("ds_read_i8_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadI8D16Ds)),
@@ -2807,12 +2795,6 @@ DecodeResult decodeDsReadI8D16Ds(const MachineInst *opcode, const DecodeErrorEmi
   return std::make_unique<DsReadI8D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadI8D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadI8D16HiDs::DsReadI8D16HiDs(const MachineInst *inst)
     : Ds("ds_read_i8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2844,12 +2826,6 @@ DecodeResult decodeDsReadI8D16HiDs(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsReadI8D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
 DsReadU16D16Ds::DsReadU16D16Ds(const MachineInst *inst)
     : Ds("ds_read_u16_d16", reinterpret_cast<const OpEncoding *>(inst),
          selected_exec_fn(InstructionExecutionId::DsReadU16D16Ds)),
@@ -2878,12 +2854,6 @@ DecodeResult decodeDsReadU16D16Ds(const MachineInst *opcode, const DecodeErrorEm
   return std::make_unique<DsReadU16D16Ds>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16Ds::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsReadU16D16HiDs::DsReadU16D16HiDs(const MachineInst *inst)
     : Ds("ds_read_u16_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -2914,12 +2884,6 @@ DecodeResult decodeDsReadU16D16HiDs(const MachineInst *opcode,
   return std::make_unique<DsReadU16D16HiDs>(opcode);
 }
 } // namespace detail
-
-void DsReadU16D16HiDs::implicit_uses(RegisterSet &uses) const {
-  Ds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
 
 DsAddF64Ds::DsAddF64Ds(const MachineInst *inst)
     : Ds("ds_add_f64", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds.h
@@ -840,7 +840,6 @@ class DsReadU8D16Ds : public Ds {
 public:
   DsReadU8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -850,7 +849,6 @@ class DsReadU8D16HiDs : public Ds {
 public:
   DsReadU8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -860,7 +858,6 @@ class DsReadI8D16Ds : public Ds {
 public:
   DsReadI8D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -870,7 +867,6 @@ class DsReadI8D16HiDs : public Ds {
 public:
   DsReadI8D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -880,7 +876,6 @@ class DsReadU16D16Ds : public Ds {
 public:
   DsReadU16D16Ds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -890,7 +885,6 @@ class DsReadU16D16HiDs : public Ds {
 public:
   DsReadU16D16HiDs(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.cpp
@@ -795,13 +795,6 @@ DecodeResult decodeFlatLoadUbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadUbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadUbyteD16HiFlat::FlatLoadUbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadUbyteD16HiFlat)),
@@ -847,13 +840,6 @@ DecodeResult decodeFlatLoadUbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadUbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadUbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadSbyteD16Flat::FlatLoadSbyteD16Flat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -901,13 +887,6 @@ DecodeResult decodeFlatLoadSbyteD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadSbyteD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadSbyteD16HiFlat::FlatLoadSbyteD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadSbyteD16HiFlat)),
@@ -953,13 +932,6 @@ DecodeResult decodeFlatLoadSbyteD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadSbyteD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadSbyteD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatLoadShortD16Flat::FlatLoadShortD16Flat(const MachineInst *inst)
     : Flat("flat_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1007,13 +979,6 @@ DecodeResult decodeFlatLoadShortD16Flat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadShortD16Flat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
-
 FlatLoadShortD16HiFlat::FlatLoadShortD16HiFlat(const MachineInst *inst)
     : Flat("flat_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::FlatLoadShortD16HiFlat)),
@@ -1059,13 +1024,6 @@ DecodeResult decodeFlatLoadShortD16HiFlat(const MachineInst *opcode,
   return std::make_unique<FlatLoadShortD16HiFlat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadShortD16HiFlat::implicit_uses(RegisterSet &uses) const {
-  Flat::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdst.to_register_ref())
-      uses.expand(*r);
-}
 
 FlatAtomicSwapFlat::FlatAtomicSwapFlat(const MachineInst *inst)
     : Flat("flat_atomic_swap", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/flat.h
@@ -210,7 +210,6 @@ class FlatLoadUbyteD16Flat : public Flat {
 public:
   FlatLoadUbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -223,7 +222,6 @@ class FlatLoadUbyteD16HiFlat : public Flat {
 public:
   FlatLoadUbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -236,7 +234,6 @@ class FlatLoadSbyteD16Flat : public Flat {
 public:
   FlatLoadSbyteD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -249,7 +246,6 @@ class FlatLoadSbyteD16HiFlat : public Flat {
 public:
   FlatLoadSbyteD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -262,7 +258,6 @@ class FlatLoadShortD16Flat : public Flat {
 public:
   FlatLoadShortD16Flat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;
@@ -275,7 +270,6 @@ class FlatLoadShortD16HiFlat : public Flat {
 public:
   FlatLoadShortD16HiFlat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdst;
   Operand addr;
   Operand flat_scratch;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.cpp
@@ -338,12 +338,6 @@ DecodeResult decodeTbufferLoadFormatD16XMtbuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void TbufferLoadFormatD16XMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
 TbufferLoadFormatD16XyMtbuf::TbufferLoadFormatD16XyMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::TbufferLoadFormatD16XyMtbuf)),
@@ -415,12 +409,6 @@ DecodeResult decodeTbufferLoadFormatD16XyzMtbuf(const MachineInst *opcode,
   return std::make_unique<TbufferLoadFormatD16XyzMtbuf>(opcode);
 }
 } // namespace detail
-
-void TbufferLoadFormatD16XyzMtbuf::implicit_uses(RegisterSet &uses) const {
-  Mtbuf::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 TbufferLoadFormatD16XyzwMtbuf::TbufferLoadFormatD16XyzwMtbuf(const MachineInst *inst)
     : Mtbuf("tbuffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mtbuf.h
@@ -106,7 +106,6 @@ class TbufferLoadFormatD16XMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -129,7 +128,6 @@ class TbufferLoadFormatD16XyzMtbuf : public Mtbuf {
 public:
   TbufferLoadFormatD16XyzMtbuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.cpp
@@ -338,13 +338,6 @@ DecodeResult decodeBufferLoadFormatD16XMubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadFormatD16XMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadFormatD16XyMubuf::BufferLoadFormatD16XyMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xy", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadFormatD16XyMubuf)),
@@ -415,13 +408,6 @@ DecodeResult decodeBufferLoadFormatD16XyzMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16XyzMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16XyzMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(RegisterRef{r->cls, static_cast<uint16_t>(r->index + 1), 1});
-}
 
 BufferLoadFormatD16XyzwMubuf::BufferLoadFormatD16XyzwMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_xyzw", reinterpret_cast<const OpEncoding *>(inst),
@@ -1197,13 +1183,6 @@ DecodeResult decodeBufferLoadUbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadUbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadUbyteD16HiMubuf::BufferLoadUbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_ubyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadUbyteD16HiMubuf)),
@@ -1238,13 +1217,6 @@ DecodeResult decodeBufferLoadUbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadUbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadUbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadSbyteD16Mubuf::BufferLoadSbyteD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1281,13 +1253,6 @@ DecodeResult decodeBufferLoadSbyteD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadSbyteD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadSbyteD16HiMubuf::BufferLoadSbyteD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_sbyte_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadSbyteD16HiMubuf)),
@@ -1322,13 +1287,6 @@ DecodeResult decodeBufferLoadSbyteD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadSbyteD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadSbyteD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadShortD16Mubuf::BufferLoadShortD16Mubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1365,13 +1323,6 @@ DecodeResult decodeBufferLoadShortD16Mubuf(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadShortD16Mubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
-
 BufferLoadShortD16HiMubuf::BufferLoadShortD16HiMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_short_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::BufferLoadShortD16HiMubuf)),
@@ -1406,13 +1357,6 @@ DecodeResult decodeBufferLoadShortD16HiMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadShortD16HiMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadShortD16HiMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferLoadFormatD16HiXMubuf::BufferLoadFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_load_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),
@@ -1449,13 +1393,6 @@ DecodeResult decodeBufferLoadFormatD16HiXMubuf(const MachineInst *opcode,
   return std::make_unique<BufferLoadFormatD16HiXMubuf>(opcode);
 }
 } // namespace detail
-
-void BufferLoadFormatD16HiXMubuf::implicit_uses(RegisterSet &uses) const {
-  Mubuf::implicit_uses(uses);
-  if (!inst_.lds)
-    if (auto r = vdata.to_register_ref())
-      uses.expand(*r);
-}
 
 BufferStoreFormatD16HiXMubuf::BufferStoreFormatD16HiXMubuf(const MachineInst *inst)
     : Mubuf("buffer_store_format_d16_hi_x", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/mubuf.h
@@ -106,7 +106,6 @@ class BufferLoadFormatD16XMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -129,7 +128,6 @@ class BufferLoadFormatD16XyzMubuf : public Mubuf {
 public:
   BufferLoadFormatD16XyzMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -372,7 +370,6 @@ class BufferLoadUbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadUbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -384,7 +381,6 @@ class BufferLoadUbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadUbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -396,7 +392,6 @@ class BufferLoadSbyteD16Mubuf : public Mubuf {
 public:
   BufferLoadSbyteD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -408,7 +403,6 @@ class BufferLoadSbyteD16HiMubuf : public Mubuf {
 public:
   BufferLoadSbyteD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -420,7 +414,6 @@ class BufferLoadShortD16Mubuf : public Mubuf {
 public:
   BufferLoadShortD16Mubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -432,7 +425,6 @@ class BufferLoadShortD16HiMubuf : public Mubuf {
 public:
   BufferLoadShortD16HiMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;
@@ -444,7 +436,6 @@ class BufferLoadFormatD16HiXMubuf : public Mubuf {
 public:
   BufferLoadFormatD16HiXMubuf(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
   Operand vdata;
   Operand vaddr;
   Operand srsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.cpp
@@ -517,19 +517,6 @@ DecodeResult decodeBufferLoadD16U8Vbuffer(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadD16U8Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16U8Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
-
 BufferLoadD16I8Vbuffer::BufferLoadD16I8Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_load_d16_i8", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::BufferLoadD16I8Vbuffer)),
@@ -562,19 +549,6 @@ DecodeResult decodeBufferLoadD16I8Vbuffer(const MachineInst *opcode,
   return std::make_unique<BufferLoadD16I8Vbuffer>(opcode);
 }
 } // namespace detail
-
-void BufferLoadD16I8Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16I8Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
 
 BufferLoadD16B16Vbuffer::BufferLoadD16B16Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_load_d16_b16", reinterpret_cast<const OpEncoding *>(inst),
@@ -609,19 +583,6 @@ DecodeResult decodeBufferLoadD16B16Vbuffer(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadD16B16Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16B16Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
-
 BufferLoadD16HiU8Vbuffer::BufferLoadD16HiU8Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_load_d16_hi_u8", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::BufferLoadD16HiU8Vbuffer)),
@@ -654,19 +615,6 @@ DecodeResult decodeBufferLoadD16HiU8Vbuffer(const MachineInst *opcode,
   return std::make_unique<BufferLoadD16HiU8Vbuffer>(opcode);
 }
 } // namespace detail
-
-void BufferLoadD16HiU8Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16HiU8Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
 
 BufferLoadD16HiI8Vbuffer::BufferLoadD16HiI8Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_load_d16_hi_i8", reinterpret_cast<const OpEncoding *>(inst),
@@ -701,19 +649,6 @@ DecodeResult decodeBufferLoadD16HiI8Vbuffer(const MachineInst *opcode,
 }
 } // namespace detail
 
-void BufferLoadD16HiI8Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16HiI8Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
-
 BufferLoadD16HiB16Vbuffer::BufferLoadD16HiB16Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_load_d16_hi_b16", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::BufferLoadD16HiB16Vbuffer)),
@@ -746,19 +681,6 @@ DecodeResult decodeBufferLoadD16HiB16Vbuffer(const MachineInst *opcode,
   return std::make_unique<BufferLoadD16HiB16Vbuffer>(opcode);
 }
 } // namespace detail
-
-void BufferLoadD16HiB16Vbuffer::implicit_uses(RegisterSet &uses) const {
-  Vbuffer::implicit_uses(uses);
-  if (auto r = vdata.to_register_ref())
-    uses.expand(*r);
-}
-
-void BufferLoadD16HiB16Vbuffer::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vbuffer::implicit_use_operands(operands);
-  if (vdata.to_register_ref())
-    operands.push_back(&vdata);
-}
 
 BufferStoreD16HiB8Vbuffer::BufferStoreD16HiB8Vbuffer(const MachineInst *inst)
     : Vbuffer("buffer_store_d16_hi_b8", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vbuffer.h
@@ -172,8 +172,6 @@ class BufferLoadD16U8Vbuffer : public Vbuffer {
 public:
   BufferLoadD16U8Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;
@@ -185,8 +183,6 @@ class BufferLoadD16I8Vbuffer : public Vbuffer {
 public:
   BufferLoadD16I8Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;
@@ -198,8 +194,6 @@ class BufferLoadD16B16Vbuffer : public Vbuffer {
 public:
   BufferLoadD16B16Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;
@@ -211,8 +205,6 @@ class BufferLoadD16HiU8Vbuffer : public Vbuffer {
 public:
   BufferLoadD16HiU8Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;
@@ -224,8 +216,6 @@ class BufferLoadD16HiI8Vbuffer : public Vbuffer {
 public:
   BufferLoadD16HiI8Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;
@@ -237,8 +227,6 @@ class BufferLoadD16HiB16Vbuffer : public Vbuffer {
 public:
   BufferLoadD16HiB16Vbuffer(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdata;
   Operand vaddr;
   Operand rsrc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.cpp
@@ -3229,19 +3229,6 @@ DecodeResult decodeDsLoadU8D16Vds(const MachineInst *opcode, const DecodeErrorEm
 }
 } // namespace detail
 
-void DsLoadU8D16Vds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadU8D16Vds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 DsLoadU8D16HiVds::DsLoadU8D16HiVds(const MachineInst *inst)
     : Vds("ds_load_u8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
           selected_exec_fn(InstructionExecutionId::DsLoadU8D16HiVds)),
@@ -3270,19 +3257,6 @@ DecodeResult decodeDsLoadU8D16HiVds(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsLoadU8D16HiVds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadU8D16HiVds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 DsLoadI8D16Vds::DsLoadI8D16Vds(const MachineInst *inst)
     : Vds("ds_load_i8_d16", reinterpret_cast<const OpEncoding *>(inst),
           selected_exec_fn(InstructionExecutionId::DsLoadI8D16Vds)),
@@ -3309,19 +3283,6 @@ DecodeResult decodeDsLoadI8D16Vds(const MachineInst *opcode, const DecodeErrorEm
   return std::make_unique<DsLoadI8D16Vds>(opcode);
 }
 } // namespace detail
-
-void DsLoadI8D16Vds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadI8D16Vds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 DsLoadI8D16HiVds::DsLoadI8D16HiVds(const MachineInst *inst)
     : Vds("ds_load_i8_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
@@ -3351,19 +3312,6 @@ DecodeResult decodeDsLoadI8D16HiVds(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsLoadI8D16HiVds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadI8D16HiVds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 DsLoadU16D16Vds::DsLoadU16D16Vds(const MachineInst *inst)
     : Vds("ds_load_u16_d16", reinterpret_cast<const OpEncoding *>(inst),
           selected_exec_fn(InstructionExecutionId::DsLoadU16D16Vds)),
@@ -3392,19 +3340,6 @@ DecodeResult decodeDsLoadU16D16Vds(const MachineInst *opcode,
 }
 } // namespace detail
 
-void DsLoadU16D16Vds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadU16D16Vds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 DsLoadU16D16HiVds::DsLoadU16D16HiVds(const MachineInst *inst)
     : Vds("ds_load_u16_d16_hi", reinterpret_cast<const OpEncoding *>(inst),
           selected_exec_fn(InstructionExecutionId::DsLoadU16D16HiVds)),
@@ -3432,19 +3367,6 @@ DecodeResult decodeDsLoadU16D16HiVds(const MachineInst *opcode,
   return std::make_unique<DsLoadU16D16HiVds>(opcode);
 }
 } // namespace detail
-
-void DsLoadU16D16HiVds::implicit_uses(RegisterSet &uses) const {
-  Vds::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void DsLoadU16D16HiVds::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vds::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 DsCondSubRtnU32Vds::DsCondSubRtnU32Vds(const MachineInst *inst)
     : Vds("ds_cond_sub_rtn_u32", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds.h
@@ -1097,8 +1097,6 @@ class DsLoadU8D16Vds : public Vds {
 public:
   DsLoadU8D16Vds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -1108,8 +1106,6 @@ class DsLoadU8D16HiVds : public Vds {
 public:
   DsLoadU8D16HiVds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -1119,8 +1115,6 @@ class DsLoadI8D16Vds : public Vds {
 public:
   DsLoadI8D16Vds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -1130,8 +1124,6 @@ class DsLoadI8D16HiVds : public Vds {
 public:
   DsLoadI8D16HiVds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -1141,8 +1133,6 @@ class DsLoadU16D16Vds : public Vds {
 public:
   DsLoadU16D16Vds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;
@@ -1152,8 +1142,6 @@ class DsLoadU16D16HiVds : public Vds {
 public:
   DsLoadU16D16HiVds(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand addr;
   Operand dsmem;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.cpp
@@ -499,19 +499,6 @@ DecodeResult decodeFlatLoadD16U8Vflat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadD16U8Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16U8Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 FlatLoadD16I8Vflat::FlatLoadD16I8Vflat(const MachineInst *inst)
     : Vflat("flat_load_d16_i8", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::FlatLoadD16I8Vflat)),
@@ -543,19 +530,6 @@ DecodeResult decodeFlatLoadD16I8Vflat(const MachineInst *opcode,
   return std::make_unique<FlatLoadD16I8Vflat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadD16I8Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16I8Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 FlatLoadD16B16Vflat::FlatLoadD16B16Vflat(const MachineInst *inst)
     : Vflat("flat_load_d16_b16", reinterpret_cast<const OpEncoding *>(inst),
@@ -589,19 +563,6 @@ DecodeResult decodeFlatLoadD16B16Vflat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadD16B16Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16B16Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 FlatLoadD16HiU8Vflat::FlatLoadD16HiU8Vflat(const MachineInst *inst)
     : Vflat("flat_load_d16_hi_u8", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::FlatLoadD16HiU8Vflat)),
@@ -633,19 +594,6 @@ DecodeResult decodeFlatLoadD16HiU8Vflat(const MachineInst *opcode,
   return std::make_unique<FlatLoadD16HiU8Vflat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadD16HiU8Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16HiU8Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 FlatLoadD16HiI8Vflat::FlatLoadD16HiI8Vflat(const MachineInst *inst)
     : Vflat("flat_load_d16_hi_i8", reinterpret_cast<const OpEncoding *>(inst),
@@ -679,19 +627,6 @@ DecodeResult decodeFlatLoadD16HiI8Vflat(const MachineInst *opcode,
 }
 } // namespace detail
 
-void FlatLoadD16HiI8Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16HiI8Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 FlatLoadD16HiB16Vflat::FlatLoadD16HiB16Vflat(const MachineInst *inst)
     : Vflat("flat_load_d16_hi_b16", reinterpret_cast<const OpEncoding *>(inst),
             selected_exec_fn(InstructionExecutionId::FlatLoadD16HiB16Vflat)),
@@ -723,19 +658,6 @@ DecodeResult decodeFlatLoadD16HiB16Vflat(const MachineInst *opcode,
   return std::make_unique<FlatLoadD16HiB16Vflat>(opcode);
 }
 } // namespace detail
-
-void FlatLoadD16HiB16Vflat::implicit_uses(RegisterSet &uses) const {
-  Vflat::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void FlatLoadD16HiB16Vflat::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vflat::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 FlatStoreD16HiB8Vflat::FlatStoreD16HiB8Vflat(const MachineInst *inst)
     : Vflat("flat_store_d16_hi_b8", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vflat.h
@@ -158,8 +158,6 @@ class FlatLoadD16U8Vflat : public Vflat {
 public:
   FlatLoadD16U8Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -170,8 +168,6 @@ class FlatLoadD16I8Vflat : public Vflat {
 public:
   FlatLoadD16I8Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -182,8 +178,6 @@ class FlatLoadD16B16Vflat : public Vflat {
 public:
   FlatLoadD16B16Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -194,8 +188,6 @@ class FlatLoadD16HiU8Vflat : public Vflat {
 public:
   FlatLoadD16HiU8Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -206,8 +198,6 @@ class FlatLoadD16HiI8Vflat : public Vflat {
 public:
   FlatLoadD16HiI8Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -218,8 +208,6 @@ class FlatLoadD16HiB16Vflat : public Vflat {
 public:
   FlatLoadD16HiB16Vflat(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.cpp
@@ -499,19 +499,6 @@ DecodeResult decodeGlobalLoadD16U8Vglobal(const MachineInst *opcode,
 }
 } // namespace detail
 
-void GlobalLoadD16U8Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16U8Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 GlobalLoadD16I8Vglobal::GlobalLoadD16I8Vglobal(const MachineInst *inst)
     : Vglobal("global_load_d16_i8", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::GlobalLoadD16I8Vglobal)),
@@ -543,19 +530,6 @@ DecodeResult decodeGlobalLoadD16I8Vglobal(const MachineInst *opcode,
   return std::make_unique<GlobalLoadD16I8Vglobal>(opcode);
 }
 } // namespace detail
-
-void GlobalLoadD16I8Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16I8Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 GlobalLoadD16B16Vglobal::GlobalLoadD16B16Vglobal(const MachineInst *inst)
     : Vglobal("global_load_d16_b16", reinterpret_cast<const OpEncoding *>(inst),
@@ -589,19 +563,6 @@ DecodeResult decodeGlobalLoadD16B16Vglobal(const MachineInst *opcode,
 }
 } // namespace detail
 
-void GlobalLoadD16B16Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16B16Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 GlobalLoadD16HiU8Vglobal::GlobalLoadD16HiU8Vglobal(const MachineInst *inst)
     : Vglobal("global_load_d16_hi_u8", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::GlobalLoadD16HiU8Vglobal)),
@@ -633,19 +594,6 @@ DecodeResult decodeGlobalLoadD16HiU8Vglobal(const MachineInst *opcode,
   return std::make_unique<GlobalLoadD16HiU8Vglobal>(opcode);
 }
 } // namespace detail
-
-void GlobalLoadD16HiU8Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16HiU8Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 GlobalLoadD16HiI8Vglobal::GlobalLoadD16HiI8Vglobal(const MachineInst *inst)
     : Vglobal("global_load_d16_hi_i8", reinterpret_cast<const OpEncoding *>(inst),
@@ -679,19 +627,6 @@ DecodeResult decodeGlobalLoadD16HiI8Vglobal(const MachineInst *opcode,
 }
 } // namespace detail
 
-void GlobalLoadD16HiI8Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16HiI8Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 GlobalLoadD16HiB16Vglobal::GlobalLoadD16HiB16Vglobal(const MachineInst *inst)
     : Vglobal("global_load_d16_hi_b16", reinterpret_cast<const OpEncoding *>(inst),
               selected_exec_fn(InstructionExecutionId::GlobalLoadD16HiB16Vglobal)),
@@ -723,19 +658,6 @@ DecodeResult decodeGlobalLoadD16HiB16Vglobal(const MachineInst *opcode,
   return std::make_unique<GlobalLoadD16HiB16Vglobal>(opcode);
 }
 } // namespace detail
-
-void GlobalLoadD16HiB16Vglobal::implicit_uses(RegisterSet &uses) const {
-  Vglobal::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void GlobalLoadD16HiB16Vglobal::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vglobal::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 GlobalStoreD16HiB8Vglobal::GlobalStoreD16HiB8Vglobal(const MachineInst *inst)
     : Vglobal("global_store_d16_hi_b8", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal.h
@@ -158,8 +158,6 @@ class GlobalLoadD16U8Vglobal : public Vglobal {
 public:
   GlobalLoadD16U8Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -170,8 +168,6 @@ class GlobalLoadD16I8Vglobal : public Vglobal {
 public:
   GlobalLoadD16I8Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -182,8 +178,6 @@ class GlobalLoadD16B16Vglobal : public Vglobal {
 public:
   GlobalLoadD16B16Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -194,8 +188,6 @@ class GlobalLoadD16HiU8Vglobal : public Vglobal {
 public:
   GlobalLoadD16HiU8Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -206,8 +198,6 @@ class GlobalLoadD16HiI8Vglobal : public Vglobal {
 public:
   GlobalLoadD16HiI8Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -218,8 +208,6 @@ class GlobalLoadD16HiB16Vglobal : public Vglobal {
 public:
   GlobalLoadD16HiB16Vglobal(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.cpp
@@ -462,19 +462,6 @@ DecodeResult decodeScratchLoadD16U8Vscratch(const MachineInst *opcode,
 }
 } // namespace detail
 
-void ScratchLoadD16U8Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16U8Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 ScratchLoadD16I8Vscratch::ScratchLoadD16I8Vscratch(const MachineInst *inst)
     : Vscratch("scratch_load_d16_i8", reinterpret_cast<const OpEncoding *>(inst),
                selected_exec_fn(InstructionExecutionId::ScratchLoadD16I8Vscratch)),
@@ -504,19 +491,6 @@ DecodeResult decodeScratchLoadD16I8Vscratch(const MachineInst *opcode,
   return std::make_unique<ScratchLoadD16I8Vscratch>(opcode);
 }
 } // namespace detail
-
-void ScratchLoadD16I8Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16I8Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 ScratchLoadD16B16Vscratch::ScratchLoadD16B16Vscratch(const MachineInst *inst)
     : Vscratch("scratch_load_d16_b16", reinterpret_cast<const OpEncoding *>(inst),
@@ -548,19 +522,6 @@ DecodeResult decodeScratchLoadD16B16Vscratch(const MachineInst *opcode,
 }
 } // namespace detail
 
-void ScratchLoadD16B16Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16B16Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 ScratchLoadD16HiU8Vscratch::ScratchLoadD16HiU8Vscratch(const MachineInst *inst)
     : Vscratch("scratch_load_d16_hi_u8", reinterpret_cast<const OpEncoding *>(inst),
                selected_exec_fn(InstructionExecutionId::ScratchLoadD16HiU8Vscratch)),
@@ -590,19 +551,6 @@ DecodeResult decodeScratchLoadD16HiU8Vscratch(const MachineInst *opcode,
   return std::make_unique<ScratchLoadD16HiU8Vscratch>(opcode);
 }
 } // namespace detail
-
-void ScratchLoadD16HiU8Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16HiU8Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 ScratchLoadD16HiI8Vscratch::ScratchLoadD16HiI8Vscratch(const MachineInst *inst)
     : Vscratch("scratch_load_d16_hi_i8", reinterpret_cast<const OpEncoding *>(inst),
@@ -634,19 +582,6 @@ DecodeResult decodeScratchLoadD16HiI8Vscratch(const MachineInst *opcode,
 }
 } // namespace detail
 
-void ScratchLoadD16HiI8Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16HiI8Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
-
 ScratchLoadD16HiB16Vscratch::ScratchLoadD16HiB16Vscratch(const MachineInst *inst)
     : Vscratch("scratch_load_d16_hi_b16", reinterpret_cast<const OpEncoding *>(inst),
                selected_exec_fn(InstructionExecutionId::ScratchLoadD16HiB16Vscratch)),
@@ -677,19 +612,6 @@ DecodeResult decodeScratchLoadD16HiB16Vscratch(const MachineInst *opcode,
   return std::make_unique<ScratchLoadD16HiB16Vscratch>(opcode);
 }
 } // namespace detail
-
-void ScratchLoadD16HiB16Vscratch::implicit_uses(RegisterSet &uses) const {
-  Vscratch::implicit_uses(uses);
-  if (auto r = vdst.to_register_ref())
-    uses.expand(*r);
-}
-
-void ScratchLoadD16HiB16Vscratch::implicit_use_operands(
-    std::vector<const ::rocjitsu::Operand *> &operands) const {
-  Vscratch::implicit_use_operands(operands);
-  if (vdst.to_register_ref())
-    operands.push_back(&vdst);
-}
 
 ScratchStoreD16HiB8Vscratch::ScratchStoreD16HiB8Vscratch(const MachineInst *inst)
     : Vscratch("scratch_store_d16_hi_b8", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vscratch.h
@@ -158,8 +158,6 @@ class ScratchLoadD16U8Vscratch : public Vscratch {
 public:
   ScratchLoadD16U8Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -170,8 +168,6 @@ class ScratchLoadD16I8Vscratch : public Vscratch {
 public:
   ScratchLoadD16I8Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -182,8 +178,6 @@ class ScratchLoadD16B16Vscratch : public Vscratch {
 public:
   ScratchLoadD16B16Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -194,8 +188,6 @@ class ScratchLoadD16HiU8Vscratch : public Vscratch {
 public:
   ScratchLoadD16HiU8Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -206,8 +198,6 @@ class ScratchLoadD16HiI8Vscratch : public Vscratch {
 public:
   ScratchLoadD16HiI8Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;
@@ -218,8 +208,6 @@ class ScratchLoadD16HiB16Vscratch : public Vscratch {
 public:
   ScratchLoadD16HiB16Vscratch(const MachineInst *inst);
   void execute_impl(amdgpu::Wavefront &wf);
-  void implicit_uses(RegisterSet &uses) const override;
-  void implicit_use_operands(std::vector<const ::rocjitsu::Operand *> &operands) const override;
   Operand vdst;
   Operand vaddr;
   Operand saddr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -189,8 +189,8 @@ struct VectorMemState : DynamicInstState {
   bool scratch_swizzle = false;
   uint64_t scratch_lane_mask = 0;
   uint32_t scratch_addr_stride = 0;
-  bool d16_hi = false;                 ///< D16_HI load: write to upper 16 bits, preserve lower 16.
-  bool d16_lo = false;                 ///< D16 load: write to lower 16 bits, preserve upper 16.
+  bool d16_hi = false; ///< D16_HI load: write upper 16 bits; preserve or zero lower per SRAM ECC.
+  bool d16_lo = false; ///< D16 load: write lower 16 bits; preserve or zero upper per SRAM ECC.
   AtomicOp atomic_op = AtomicOp::NONE; ///< Atomic RMW operation (NONE for regular loads/stores).
   bool lds_dst = false;                ///< Buffer load with LDS bit: write to LDS, not VGPRs.
   /// Reference LDS address for LDS-destination loads. For ordinary LDS-dst

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/plugins/race_detector/plugin.h"
 
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/lds.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
@@ -28,6 +29,17 @@ void warn_cluster_peer_writes_ignored_once() {
     util::Logger::warn(
         "race detector does not model cluster LDS multicast peer writes; peer writes are ignored");
   });
+}
+
+uint8_t vector_memory_byte_mask(const amdgpu::VectorMemState &state,
+                                const amdgpu::Wavefront &wave) {
+  if (state.is_load && wave.cu().sram_ecc() && (state.d16_lo || state.d16_hi))
+    return ExecutionPlugin::kFullByteMask;
+  if (state.d16_lo)
+    return ExecutionPlugin::kLowHalfByteMask;
+  if (state.d16_hi)
+    return ExecutionPlugin::kHighHalfByteMask;
+  return ExecutionPlugin::kFullByteMask;
 }
 
 } // namespace
@@ -279,7 +291,7 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
       for (uint32_t i = 0; i < d.num_elems; ++i)
         registers[i] = logicalBase + i;
     }
-    uint8_t byte_mask = d.d16_lo ? 0x3 : d.d16_hi ? 0xC : 0xF;
+    uint8_t byte_mask = vector_memory_byte_mask(d, wf);
     rs->registerLdsEvent(wf.pc, type, std::move(registers), wf.exec(), wf.wf_size(),
                          std::span<const uint32_t>(laneAddrs, wf.wf_size()), d.elem_size,
                          byte_mask);
@@ -314,7 +326,7 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
       std::vector<uint32_t> registers(d.num_elems);
       for (uint32_t i = 0; i < d.num_elems; ++i)
         registers[i] = logicalBase + i;
-      uint8_t byte_mask = d.d16_lo ? 0x3 : d.d16_hi ? 0xC : 0xF;
+      uint8_t byte_mask = vector_memory_byte_mask(d, wf);
       rs->registerEvent(wf.pc, MemoryEventType::GLOBAL_TO_VGPR, std::move(registers), d.exec_mask,
                         byte_mask);
     } else if (!d.is_load) {

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -3974,10 +3974,10 @@ TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseResolvesDestinationBank) {
       << "the low-bank alias must not be treated as the read register";
 }
 
-TEST(LivenessAnalysis, Gfx1250D16LoadImplicitUseResolvesDestinationBank) {
-  // A gfx1250 D16 load's destination preserve-read must resolve through the Dst
-  // VGPR-MSB bank via implicit_use_operands(); implicit_uses() VGPRs are dropped
-  // there. DST bank 2 (0x80), vdst v1 -> physical v513 must be live before it.
+TEST(LivenessAnalysis, Gfx1250D16LoadDoesNotReadDestination) {
+  // gfx1250 SRAM ECC makes a D16 load a full-dword write by zero-filling the
+  // unselected half. Even with DST bank 2 (0x80), neither physical v513 nor its
+  // low-bank alias v1 is therefore live before the load.
   constexpr auto set_dst_bank_two = cdna5::build_sopp(cdna5::kSSetVgprMsbSopp, {.simm16 = 0x80});
   constexpr auto load = cdna5::build_vflat(cdna5::kFlatLoadD16U8Vflat, {.vdst = 1});
   constexpr auto end = cdna5::build_sopp(cdna5::kSEndpgmSopp);
@@ -3999,10 +3999,10 @@ TEST(LivenessAnalysis, Gfx1250D16LoadImplicitUseResolvesDestinationBank) {
   ASSERT_NE(instruction, blocks.front()->instructions().end());
   ASSERT_EQ(std::string_view((*instruction).mnemonic()), "flat_load_d16_u8");
   EXPECT_EQ(liveness.vgpr_msb_bank_before(*instruction, amdgpu::VgprMsbRole::Dst), 2);
-  EXPECT_TRUE(liveness.is_live_before(*instruction, {RegClass::VGPR, 513, 1}))
-      << "D16 load preserve-read must resolve to the DST bank";
+  EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 513, 1}))
+      << "SRAM ECC zero-fills the unselected half instead of preserving it";
   EXPECT_FALSE(liveness.is_live_before(*instruction, {RegClass::VGPR, 1, 1}))
-      << "the low-bank alias must not be treated as the read register";
+      << "the low-bank alias must not be treated as a read register";
 }
 
 TEST(LivenessAnalysis, Gfx1250ImplicitVgprUseResolvesDespiteExplicitBank0Alias) {
@@ -5945,14 +5945,21 @@ std::unique_ptr<Instruction> decode_cdna3(std::initializer_list<uint32_t> words)
   return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, buf.data()) : nullptr);
 }
 
-TEST(GeneratedInstDefUse, D16TbufferLoadReadsDestination) {
+std::unique_ptr<Instruction> decode_cdna1(std::initializer_list<uint32_t> words) {
+  std::array<uint32_t, 4> buf{};
+  std::copy(words.begin(), words.end(), buf.begin());
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA1);
+  return std::unique_ptr<Instruction>(decoder ? decode_valid(*decoder, buf.data()) : nullptr);
+}
+
+TEST(GeneratedInstDefUse, D16TbufferLoadDoesNotReadDestinationWithSramEcc) {
   auto inst = decode_cdna3({0xE8040000U, 0x00000500U}); // tbuffer_load_format_d16_x, vdata=5
   ASSERT_NE(inst, nullptr);
   ASSERT_EQ(std::string_view(inst->mnemonic()), "tbuffer_load_format_d16_x");
 
   InstDefUse idu(*inst);
   EXPECT_TRUE(idu.defs.contains({RegClass::VGPR, 5, 1}));
-  EXPECT_TRUE(idu.uses.contains({RegClass::VGPR, 5, 1}));
+  EXPECT_FALSE(idu.uses.contains({RegClass::VGPR, 5, 1}));
 }
 
 // Negative case: D16 stores share the d16 flags but are not in
@@ -6001,17 +6008,17 @@ TEST(GeneratedInstDefUse, D16TypedFormatXyzLoadUnderVbufferReadsOnlyLastDestinat
 // On older MUBUF encodings the LDS bit (word0 bit 16) redirects the loaded data
 // to LDS, leaving no VGPR destination -- so the preserved-destination read must
 // be suppressed there, or liveness invents a false live range. Same opcode
-// (buffer_load_short_d16, MUBUF op 36 on CDNA3), toggling only LDS. VDATA is
+// (buffer_load_short_d16, MUBUF op 36 on CDNA1), toggling only LDS. VDATA is
 // word1[8:15] (=5).
 TEST(GeneratedInstDefUse, D16BufferLoadLdsBitSuppressesDestinationRead) {
-  auto normal = decode_cdna3({0xE0900000U, 0x00000500U}); // buffer_load_short_d16, vdata=5, lds=0
+  auto normal = decode_cdna1({0xE0900000U, 0x00000500U}); // buffer_load_short_d16, vdata=5, lds=0
   ASSERT_NE(normal, nullptr);
   ASSERT_EQ(std::string_view(normal->mnemonic()), "buffer_load_short_d16");
   InstDefUse normal_idu(*normal);
   EXPECT_TRUE(normal_idu.uses.contains({RegClass::VGPR, 5, 1}))
       << "LDS clear: the preserved half of vdata is a read";
 
-  auto lds = decode_cdna3({0xE0910000U, 0x00000500U}); // ...same, lds=1 (bit 16 set)
+  auto lds = decode_cdna1({0xE0910000U, 0x00000500U}); // ...same, lds=1 (bit 16 set)
   ASSERT_NE(lds, nullptr);
   ASSERT_EQ(std::string_view(lds->mnemonic()), "buffer_load_short_d16");
   InstDefUse lds_idu(*lds);

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -191,6 +191,7 @@ TEST(Gfx1250ConfigTest, ConfigLoadsTopology) {
   EXPECT_EQ(cu->config().sgprs_per_wf, kGfx1250ScalarSlots);
   EXPECT_EQ(cu->config().vgprs_per_wf, kGfx1250Wave32VgprAllocation);
   EXPECT_EQ(cu->config().lds_size_kb, kGfx1250LdsSizeKb);
+  EXPECT_TRUE(cu->sram_ecc());
   EXPECT_EQ(soc->xcd(0)->command_processor()->vgpr_granularity(), kGfx1250VgprEncodingGranule);
   EXPECT_EQ(soc->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx1250);

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -32,11 +32,94 @@ public:
   uint32_t read_count = 0;
 };
 
+class Gfx1250MemoryTestCu
+    : public amdgpu::IsaExecComputeUnit<simdojo::ExecMode::FUNCTIONAL, cdna5::Isa> {
+public:
+  using Base = amdgpu::IsaExecComputeUnit<simdojo::ExecMode::FUNCTIONAL, cdna5::Isa>;
+
+  Gfx1250MemoryTestCu(std::string name, const amdgpu::ComputeUnitCore::Config &config,
+                      amdgpu::GpuMemory *memory, amdgpu::L2Cache *l2)
+      : Base(std::move(name), config, memory, l2) {
+    l2->set_backing_memory(memory);
+    set_memory(memory);
+    set_l2(l2);
+  }
+
+  void execute_and_route(std::unique_ptr<Instruction> instruction, amdgpu::Wavefront &wave) {
+    execute_instruction(instruction.get(), wave);
+    if (instruction->is_memory_op())
+      route_memory_inst(instruction.release(), wave);
+  }
+};
+
 TEST(Gfx1250ExecutionTest, TargetProvidesImmutableExecutionBackend) {
   const IsaTargetDescriptor *target = default_isa_target_registry().find("cdna5");
   ASSERT_NE(target, nullptr);
   EXPECT_TRUE(target->supports_execution);
   EXPECT_TRUE(cdna5::Operand::full_execution_backend_complete());
+}
+
+TEST(Gfx1250ExecutionTest, SramEccD16LoadsZeroUnselectedHalf) {
+  amdgpu::GpuMemory memory("gfx1250_d16_memory");
+  amdgpu::L2Cache l2("gfx1250_d16_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA5;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = kGfx1250ScalarSlots;
+  config.vgprs_per_wf = 64;
+  config.lds_size_kb = kGfx1250LdsSizeKb;
+  auto compute_unit = std::make_unique<Gfx1250MemoryTestCu>("gfx1250_d16_cu", config, &memory, &l2);
+
+  auto *wave = compute_unit->dispatch_wf(0, 0, config.sgprs_per_wf, config.vgprs_per_wf);
+  ASSERT_NE(wave, nullptr);
+  ASSERT_TRUE(compute_unit->sram_ecc());
+  wave->set_exec(1u);
+
+  constexpr uint64_t kAddress = 0x1000;
+  memory.write8(kAddress + 1, 0x7eu);
+  memory.write8(kAddress + 2, 0x7fu);
+  write_wave_sgpr(*compute_unit, *wave, 24, static_cast<uint32_t>(kAddress));
+  write_wave_sgpr(*compute_unit, *wave, 25, static_cast<uint32_t>(kAddress >> 32));
+  write_wave_sgpr(*compute_unit, *wave, 26, 0x100u);
+  write_wave_sgpr(*compute_unit, *wave, 27, 0u);
+
+  const uint32_t vgpr_base = wave->vgpr_alloc().base;
+  compute_unit->write_vgpr(vgpr_base + 33, 0, 0u);
+  struct LoadCase {
+    std::string_view mnemonic;
+    std::array<uint32_t, 3> words;
+    uint32_t destination;
+    uint32_t expected;
+  };
+
+  constexpr std::array<LoadCase, 2> kLoads = {{
+      {
+          "buffer_load_d16_u8",
+          {0xc407807cu, 0x40803038u, 0x00000121u},
+          56,
+          0x0000007eu,
+      },
+      {
+          "buffer_load_d16_hi_u8",
+          {0xc408407cu, 0x40803039u, 0x00000221u},
+          57,
+          0x007f0000u,
+      },
+  }};
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &test : kLoads) {
+    SCOPED_TRACE(test.mnemonic);
+    compute_unit->write_vgpr(vgpr_base + test.destination, 0, 0xdeadbeefu);
+    std::unique_ptr<Instruction> load(decode_valid(*decoder, test.words.data()));
+    ASSERT_NE(load, nullptr);
+    ASSERT_EQ(std::string_view(load->mnemonic()), test.mnemonic);
+
+    compute_unit->execute_and_route(std::move(load), *wave);
+
+    EXPECT_EQ(compute_unit->read_vgpr(vgpr_base + test.destination, 0), test.expected);
+  }
 }
 
 TEST(Gfx1250ExecutionTest, ScalarMovesTreatS102AndS103AsOrdinarySgprs) {

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -2370,7 +2370,7 @@ TEST(ExecutionPluginTest, MemoryPipelineCompletionDoesNotObserveInstructionWrite
 }
 
 TEST(ExecutionPluginTest, D16MemoryCompletionPreservesHalfWithoutObservation) {
-  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"cdna5", /*wavefront_size=*/32);
+  PluginFixture f(/*num_wf_slots=*/1, /*arch=*/"rdna4", /*wavefront_size=*/32);
   auto *plugin = f.attach_ordering_plugin();
   auto *cu = f.cu();
   auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
@@ -2410,6 +2410,52 @@ TEST(ExecutionPluginTest, D16MemoryCompletionPreservesHalfWithoutObservation) {
     const uint32_t expected = high_half ? 0x1122CCDDu : 0xAABB1122u;
     EXPECT_EQ(cu->read_vgpr_storage(physical_dst, 0), expected);
   }
+}
+
+TEST(RaceDetectorPluginTest, D16LoadTracksFullDwordWhenSramEccEnabled) {
+  auto opposite_half_read_reports_race = [](std::string_view arch, uint32_t wavefront_size) {
+    PluginFixture f(/*num_wf_slots=*/1, arch, wavefront_size);
+    PluginSinkConfig sink_config;
+    StringSink &sink = sink_config.emplace<StringSink>();
+    f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+    if (!f.plugin_group_->add(std::make_unique<RaceDetectorPlugin>())) {
+      ADD_FAILURE() << "failed to attach race detector";
+      return false;
+    }
+    f.soc->set_plugin_group(f.plugin_group_);
+    f.plugin_group_->onInit();
+
+    auto *cu = f.cu();
+    auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*sgprs=*/104, /*vgprs=*/256);
+    EXPECT_NE(wf, nullptr);
+    if (wf == nullptr)
+      return false;
+    wf->set_exec(1u);
+    std::array<amdgpu::Wavefront *, 1> waves{wf};
+    f.plugin_group_->onAmdgpuWorkgroupDispatched(
+        /*dispatch_id=*/1, /*wg_id=*/0, /*physical_vgpr_count=*/256, /*sgpr_count=*/104, waves);
+
+    constexpr uint32_t kDst = 4;
+    auto state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+    state->elem_size = 1;
+    state->num_elems = 1;
+    state->is_load = true;
+    state->wf_size = wf->wf_size();
+    state->exec_mask = 1;
+    state->lane_mask = 1;
+    state->dst_reg_base = wf->vgpr_alloc().base + kDst;
+    state->d16_lo = true;
+    TestMemoryInstruction load(std::move(state));
+    f.plugin_group_->onAmdgpuRouteMemoryInstruction(load, *wf);
+
+    f.plugin_group_->onAmdgpuReadVgprLanes(wf, wf->vgpr_alloc().base + kDst, /*lane_mask=*/1,
+                                           ExecutionPlugin::kHighHalfByteMask);
+    return sink.str().find("RACE ") != std::string::npos;
+  };
+
+  EXPECT_TRUE(opposite_half_read_reports_race("cdna4", /*wavefront_size=*/64));
+  EXPECT_TRUE(opposite_half_read_reports_race("cdna5", /*wavefront_size=*/32));
+  EXPECT_FALSE(opposite_half_read_reports_race("rdna4", /*wavefront_size=*/32));
 }
 
 TEST(ExecutionPluginTest, F64SimdSourceReadObservationReportsBothHalves) {

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -1176,33 +1176,10 @@ TEST_F(Gfx950RaceTest, scratch_vmcnt_race) {
   EXPECT_NE(t.mark0.find("global_load_dword"), npos) << "mark0: " << t.mark0;
 }
 
-// TODO(newling): D16 (partial-register) HIP tests.
-//
-// Concrete gap: the rocjitsu CU's read_vgpr always reads the full 32-bit
-// register, so checkVgprRead is called with byteMask=0xF. Sub-dword store
-// instructions (ds_write_b16, global_store_short) only consume 16 bits of
-// the source VGPR, but trigger a full-register race check — false positive
-// when the other half has a pending D16 load.
-//
-// Fix: add read_vgpr_masked(reg, lane, byteMask) to the CU, and have the
-// codegen (_gen_ds_write in codegen.py, esz <= 2) emit the masked variant.
-// See compute_unit.h for details. The original race-emulator solved this
-// with Wave::getHalfVgpr(reg, lane, hi) which passed byteMask=0x3/0xC.
-// See /home/jnewling/workspace/rocm-libraries/shared/race-emulator/tests/
-// race_tests.cpp (D16_LdsLoad_NoFalsePositive, D16_HiLoadOutstanding_LoReadSafe)
-// for the original tests exercising this.
-//
-// The write-side byte mask propagation IS done: registerEvent/registerLdsEvent
-// pass 0x3/0xC from VectorMemState::d16_lo/hi. The core D16 tests using
-// RaceTestBuilder (which bypasses read_vgpr) pass correctly.
-//
-// Deeper observation: even if an instruction reads "garbage" from pending
-// bytes, it only matters if that garbage propagates to an observable side
-// effect (global store, host-visible memory). Garbage churned through
-// computation but never stored is arguably not a user-visible race. The
-// current race detector flags at the point of register read, which is
-// conservative. A more precise (but much harder) approach would track
-// whether tainted values reach observable side effects.
+// gfx950 enables SRAM ECC, so D16 loads write the full 32-bit VGPR and the
+// race detector registers a full-byte-mask pending write. Independent
+// low/high-half D16 behavior applies only to targets without SRAM ECC and is
+// covered by the architecture-parameterized C++ plugin tests.
 
 // --- VGPR WAW: pending load then instruction write ---
 


### PR DESCRIPTION
gfx1250 does support SRAM ECC:

- LLVM's `GFX1250` processor model enables `FEATURE_SRAMECC`:
  https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AMDGPU/GCNProcessors.td
- The AMD Instinct CDNA5 ISA specifies that, on chips with ECC, D16 and
  D16_HI loads write the full 32-bit VGPR and fill the unused portion with
  zero:
  https://docs.amd.com/api/khub/documents/YblmXrYRcxw2GO7d0No8Lw/content

Correcting this in rocJITsu fixes a numerical failure in an i8 hipBLASLt
GEMM.

All of the agent-generated details, including the exact workload, provenance,
commands, deterministic before/after results, and instruction-level
regression, can be found here:

https://gist.github.com/newling/038f6eb6fc9dfb9c53437a5791a26301

## Issue Tracking

Related: #9935
