### PR TITLE
feat(amdsmi): add chip_rev_id and external_rev_id to amdsmi_get_gpu_asic_info

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Added `chip_rev_id` and `external_rev_id` to `amdsmi_get_gpu_asic_info()`**.  
   - Reports the amdgpu `chip_rev` and `external_rev` values from the `AMDGPU_INFO_DEV_INFO` DRM query. Both are distinct from `rev_id`, which is the PCI config-space revision.
   - `chip_rev_id` is the internal chip revision, or stepping, numbered A0 = 0 and A1 = 1 by AMD convention. `external_rev_id` is family-scoped, so the same value can appear on unrelated ASIC families; interpret it alongside `device_id`.
-  - Exposed under the same names in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. Both report `0xFFFFFFFF` (`N/A`) when unsupported.
+  - Exposed under the same names in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. The C fields report `0xFFFFFFFF` when unsupported; Python and the CLI render that as `N/A`.
   - ABI-preserving: the two fields consume two `uint32_t` slots from `amdsmi_asic_info_t.reserved`, so the structure size and the offsets of every pre-existing named field except `reserved` are unchanged. `reserved` moves by two slots and shrinks from 17 to 15 entries.
 
 ### Changed
@@ -77,8 +77,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `amdsmi_get_nic_rdma_dev_info()` returns `AMDSMI_STATUS_SUCCESS` with `num_rdma_dev` set to 0.
   - `amd-smi static` reports `RDMA_DEVICES: N/A` instead of omitting the device. All other NIC information is reported as usual.
 
-- **Fixed `amdsmi_get_gpu_asic_info()` reporting `rev_id` as `0x0` when the DRM query fails**.  
-  - `rev_id` was assigned from the device-info structure before the `AMDGPU_INFO_DEV_INFO` query populated it, so every early-return path overwrote the not-supported value with a plausible-looking zero. It now reports `N/A`, matching the other identifiers in the same structure.
+- **Fixed `amdsmi_get_gpu_asic_info()` reporting `rev_id` as a real revision when it is not available**.  
+  - The WSL backend returned success with a zeroed structure, so `rev_id` read as `0x0`, and where it did report the not-supported value Python rendered it as the raw `0xffffffff`. Python and the CLI now render it as `N/A`.
+  - `rev_id` was also assigned from the device-info structure before the `AMDGPU_INFO_DEV_INFO` query populated it. Every such path already returned an error, so this was not observable through a checked return, but the value no longer contradicts the status.
   - `amdsmi_asic_info_t` is now reset through one shared initializer used by every backend, so a field a backend cannot supply keeps its not-supported value rather than a plausible zero.
 
 ### Upcoming Changes

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -29,7 +29,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Added `chip_rev_id` and `external_rev_id` to `amdsmi_get_gpu_asic_info()`**.  
   - Reports the amdgpu `chip_rev` and `external_rev` values from the `AMDGPU_INFO_DEV_INFO` DRM query. Both are distinct from `rev_id`, which is the PCI config-space revision.
-  - `chip_rev_id` is the internal chip revision, or stepping, numbered A0 = 0 and A1 = 1 by AMD convention. `external_rev_id` is family-scoped, so the same value can appear on unrelated ASIC families; interpret it alongside `device_id`.
+  - `chip_rev_id` is the internal chip revision, or stepping, exactly as the driver reports it; AMD SMI does not decode it into a lifecycle label. `external_rev_id` is family-scoped, so the same value can appear on unrelated ASIC families; interpret it alongside `device_id`.
   - Exposed under the same names in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. The C fields report `0xFFFFFFFF` when unsupported; Python and the CLI render that as `N/A`.
   - ABI-preserving: the two fields consume two `uint32_t` slots from `amdsmi_asic_info_t.reserved`, so the structure size and the offsets of every pre-existing named field except `reserved` are unchanged. `reserved` moves by two slots and shrinks from 17 to 15 entries.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -27,6 +27,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Populated by `amdsmi_get_gpu_enumeration_info()`, UALoE-backed like the existing `physical_acc_id` field in `amdsmi_asic_info_t`.
   - CLI: `amd-smi list --enumeration` now includes `PHYSICAL_ACC_ID` next to `OAM_ID`.
 
+- **Added `chip_rev_id` and `external_rev_id` to `amdsmi_get_gpu_asic_info()`**.  
+  - Reports the amdgpu `chip_rev` and `external_rev` values from the `AMDGPU_INFO_DEV_INFO` DRM query. Both are distinct from `rev_id`, which is the PCI config-space revision.
+  - `chip_rev_id` is the internal chip revision, or stepping, numbered A0 = 0 and A1 = 1 by AMD convention. `external_rev_id` is family-scoped, so the same value can appear on unrelated ASIC families; interpret it alongside `device_id`.
+  - Exposed under the same names in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. Both report `0xFFFFFFFF` (`N/A`) when unsupported.
+  - ABI-preserving: the two fields consume two `uint32_t` slots from `amdsmi_asic_info_t.reserved`, so the structure size and the offsets of every pre-existing named field except `reserved` are unchanged. `reserved` moves by two slots and shrinks from 17 to 15 entries.
+
 ### Changed
 
 - **`amdsmi_get_clock_info()` now returns `AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS` for clock values that exceed `INT_MAX`**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -71,6 +71,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `amdsmi_get_nic_rdma_dev_info()` returns `AMDSMI_STATUS_SUCCESS` with `num_rdma_dev` set to 0.
   - `amd-smi static` reports `RDMA_DEVICES: N/A` instead of omitting the device. All other NIC information is reported as usual.
 
+- **Fixed `amdsmi_get_gpu_asic_info()` reporting `rev_id` as `0x0` when the DRM query fails**.  
+  - `rev_id` was assigned from the device-info structure before the `AMDGPU_INFO_DEV_INFO` query populated it, so every early-return path overwrote the not-supported value with a plausible-looking zero. It now reports `N/A`, matching the other identifiers in the same structure.
+  - `amdsmi_asic_info_t` is now reset through one shared initializer used by every backend, so a field a backend cannot supply keeps its not-supported value rather than a plausible zero.
+
 ### Upcoming Changes
 
 - **UUIDs will be replaced by CUIDs in an upcoming version**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added `silicon_rev_id` to `amdsmi_get_gpu_asic_info()`**.  
+  - Reports the silicon stepping (the amdgpu driver's `external_rev_id`), read from the `AMDGPU_INFO_DEV_INFO` DRM query. This is distinct from `rev_id`, which is the PCI config-space revision.
+  - Exposed as `silicon_rev_id` in the Python `amdsmi_get_gpu_asic_info()` dictionary and in `amd-smi static --asic`. Reports `0xFFFFFFFF` (`N/A`) when unsupported.
+  - ABI-preserving: the field consumes one `uint32_t` from `amdsmi_asic_info_t.reserved`, so the structure size and all existing field offsets are unchanged.
+
 ### Changed
 
 ### Optimized

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -294,6 +294,8 @@ class StaticCommands:
                 "device_id": "N/A",
                 "subsystem_id": "N/A",
                 "rev_id": "N/A",
+                "chip_rev_id": "N/A",
+                "external_rev_id": "N/A",
                 "asic_serial": "N/A",
                 "oam_id": "N/A",
                 "physical_acc_id": "N/A",

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -294,6 +294,7 @@ class StaticCommands:
                 "device_id": "N/A",
                 "subsystem_id": "N/A",
                 "rev_id": "N/A",
+                "silicon_rev_id": "N/A",
                 "asic_serial": "N/A",
                 "oam_id": "N/A",
                 "num_compute_units": "N/A",

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1222,6 +1222,8 @@ GPU: 0
         DEVICE_ID: 0x74a0
         SUBSYSTEM_ID: 0x74a0
         REV_ID: 0x00
+        CHIP_REV_ID: 0x01
+        EXTERNAL_REV_ID: 0x47
         ASIC_SERIAL: 0xXXXXXXXXXXXXXXXX
         OAM_ID: 0
         PHYSICAL_ACC_ID: N/A

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1171,6 +1171,7 @@ GPU: 0
         DEVICE_ID: 0x74a0
         SUBSYSTEM_ID: 0x74a0
         REV_ID: 0x00
+        SILICON_REV_ID: 0x46
         ASIC_SERIAL: 0xXXXXXXXXXXXXXXXX
         OAM_ID: 0
         NUM_COMPUTE_UNITS: 228

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -621,7 +621,7 @@ Field | Content
 `vendor_name` |  vendor name
 `device_id` |  device id
 `rev_id` |  PCI config-space revision id (`"N/A"` if not supported)
-`chip_rev_id` | amdgpu `chip_rev`; internal chip revision (stepping), numbered A0 = 0, A1 = 1 by AMD convention (`"N/A"` if not supported)
+`chip_rev_id` | amdgpu `chip_rev`; internal chip revision (stepping) as the driver reports it, not decoded (`"N/A"` if not supported)
 `external_rev_id` | amdgpu `external_rev`; family-scoped, so interpret it alongside `device_id` (`"N/A"` if not supported)
 `asic_serial` | asic serial
 `oam_id` | oam id

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -620,9 +620,9 @@ Field | Content
 `vendor_id` |  vendor id
 `vendor_name` |  vendor name
 `device_id` |  device id
-`rev_id` |  PCI config-space revision id
-`chip_rev_id` | amdgpu `chip_rev`; internal chip revision (stepping), numbered A0 = 0, A1 = 1 by AMD convention
-`external_rev_id` | amdgpu `external_rev`; family-scoped, so interpret it alongside `device_id`
+`rev_id` |  PCI config-space revision id (`"N/A"` if not supported)
+`chip_rev_id` | amdgpu `chip_rev`; internal chip revision (stepping), numbered A0 = 0, A1 = 1 by AMD convention (`"N/A"` if not supported)
+`external_rev_id` | amdgpu `external_rev`; family-scoped, so interpret it alongside `device_id` (`"N/A"` if not supported)
 `asic_serial` | asic serial
 `oam_id` | oam id
 `physical_acc_id` | physical accelerator ID (UALoE-backed; `"N/A"` if not supported)

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -620,7 +620,9 @@ Field | Content
 `vendor_id` |  vendor id
 `vendor_name` |  vendor name
 `device_id` |  device id
-`rev_id` |  revision id
+`rev_id` |  PCI config-space revision id
+`chip_rev_id` | amdgpu `chip_rev`; internal chip revision (stepping), numbered A0 = 0, A1 = 1 by AMD convention
+`external_rev_id` | amdgpu `external_rev`; family-scoped, so interpret it alongside `device_id`
 `asic_serial` | asic serial
 `oam_id` | oam id
 `physical_acc_id` | physical accelerator ID (UALoE-backed; `"N/A"` if not supported)

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -621,6 +621,7 @@ Field | Content
 `vendor_name` |  vendor name
 `device_id` |  device id
 `rev_id` |  revision id
+`silicon_rev_id` | silicon stepping (amdgpu `external_rev_id`)
 `asic_serial` | asic serial
 `oam_id` | oam id
 `num_of_compute_units` | number of compute units on asic

--- a/projects/amdsmi/example/amd_smi_drm_example.cc
+++ b/projects/amdsmi/example/amd_smi_drm_example.cc
@@ -1096,6 +1096,16 @@ int main() {
       printf("\tVendor Name: %s\n", asic_info.vendor_name);
       printf("\tSubVendorID: 0x%04x\n", asic_info.subvendor_id);
       printf("\tRevisionID: 0x%02x\n", asic_info.rev_id);
+      if (asic_info.chip_rev_id != UINT32_MAX) {
+        printf("\tChip RevisionID: 0x%02x\n", asic_info.chip_rev_id);
+      } else {
+        printf("\tChip RevisionID: N/A\n");
+      }
+      if (asic_info.external_rev_id != UINT32_MAX) {
+        printf("\tExternal RevisionID: 0x%02x\n", asic_info.external_rev_id);
+      } else {
+        printf("\tExternal RevisionID: N/A\n");
+      }
       printf("\tSubSystemID: 0x%04x\n", asic_info.subsystem_id);
       printf("\tAsic serial: 0x%s\n", asic_info.asic_serial);
       if (asic_info.oam_id != UINT32_MAX) {

--- a/projects/amdsmi/example/amd_smi_drm_example.cc
+++ b/projects/amdsmi/example/amd_smi_drm_example.cc
@@ -1096,6 +1096,11 @@ int main() {
       printf("\tVendor Name: %s\n", asic_info.vendor_name);
       printf("\tSubVendorID: 0x%04x\n", asic_info.subvendor_id);
       printf("\tRevisionID: 0x%02x\n", asic_info.rev_id);
+      if (asic_info.silicon_rev_id != UINT32_MAX) {
+        printf("\tSilicon RevisionID: 0x%02x\n", asic_info.silicon_rev_id);
+      } else {
+        printf("\tSilicon RevisionID: N/A\n");
+      }
       printf("\tSubSystemID: 0x%04x\n", asic_info.subsystem_id);
       printf("\tAsic serial: 0x%s\n", asic_info.asic_serial);
       if (asic_info.oam_id != UINT32_MAX) {

--- a/projects/amdsmi/example/amd_smi_nodrm_example.cc
+++ b/projects/amdsmi/example/amd_smi_nodrm_example.cc
@@ -106,12 +106,12 @@ int main() {
       printf("\tVendorID: 0x%x\n", asic_info.vendor_id);
       printf("\tRevisionID: 0x%x\n", asic_info.rev_id);
       if (asic_info.chip_rev_id != UINT32_MAX) {
-        printf("\tChip RevisionID: 0x%02x\n", asic_info.chip_rev_id);
+        printf("\tChip RevisionID: 0x%x\n", asic_info.chip_rev_id);
       } else {
         printf("\tChip RevisionID: N/A\n");
       }
       if (asic_info.external_rev_id != UINT32_MAX) {
-        printf("\tExternal RevisionID: 0x%02x\n", asic_info.external_rev_id);
+        printf("\tExternal RevisionID: 0x%x\n", asic_info.external_rev_id);
       } else {
         printf("\tExternal RevisionID: N/A\n");
       }

--- a/projects/amdsmi/example/amd_smi_nodrm_example.cc
+++ b/projects/amdsmi/example/amd_smi_nodrm_example.cc
@@ -105,6 +105,16 @@ int main() {
       printf("\tDeviceID: 0x%lx\n", asic_info.device_id);
       printf("\tVendorID: 0x%x\n", asic_info.vendor_id);
       printf("\tRevisionID: 0x%x\n", asic_info.rev_id);
+      if (asic_info.chip_rev_id != UINT32_MAX) {
+        printf("\tChip RevisionID: 0x%02x\n", asic_info.chip_rev_id);
+      } else {
+        printf("\tChip RevisionID: N/A\n");
+      }
+      if (asic_info.external_rev_id != UINT32_MAX) {
+        printf("\tExternal RevisionID: 0x%02x\n", asic_info.external_rev_id);
+      } else {
+        printf("\tExternal RevisionID: N/A\n");
+      }
       printf("\tSubSystemID: 0x%x\n", asic_info.subsystem_id);
       printf("\tAsic serial: 0x%s\n", asic_info.asic_serial);
       printf("\tOAM id: 0x%x\n", asic_info.oam_id);

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1140,8 +1140,8 @@ typedef struct {
   uint32_t subsystem_id;             //!> The subsystem ID
   uint64_t flags;                    //!< Chip flags
   uint32_t physical_acc_id;          //!< Physical accelerator ID, 0xFFFFFFFF if not supported
-  uint32_t chip_rev_id;              /**< amdgpu chip_rev: internal chip revision (stepping),
-                                          numbered A0 = 0, A1 = 1 by AMD convention.
+  uint32_t chip_rev_id;              /**< amdgpu chip_rev: internal chip revision (stepping)
+                                          as the driver reports it, not decoded.
                                           0xFFFFFFFF if not supported */
   uint32_t external_rev_id;          /**< amdgpu external_rev. Family-scoped, so the same value
                                           recurs across unrelated ASIC families; pair it with

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1140,7 +1140,13 @@ typedef struct {
   uint32_t subsystem_id;             //!> The subsystem ID
   uint64_t flags;                    //!< Chip flags
   uint32_t physical_acc_id;          //!< Physical accelerator ID, 0xFFFFFFFF if not supported
-  uint32_t reserved[17];
+  uint32_t chip_rev_id;              /**< amdgpu chip_rev: internal chip revision (stepping),
+                                          numbered A0 = 0, A1 = 1 by AMD convention.
+                                          0xFFFFFFFF if not supported */
+  uint32_t external_rev_id;          /**< amdgpu external_rev. Family-scoped, so the same value
+                                          recurs across unrelated ASIC families; pair it with
+                                          device_id. 0xFFFFFFFF if not supported */
+  uint32_t reserved[15];
 } amdsmi_asic_info_t;
 
 /**

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1130,7 +1130,8 @@ typedef struct {
   char vendor_name[AMDSMI_MAX_STRING_LENGTH];
   uint32_t subvendor_id;                      //!< The subsystem vendor ID
   uint64_t device_id;                         //!< The device ID of a GPU
-  uint32_t rev_id;                            //!< The revision ID of a GPU
+  uint32_t rev_id;                            //!< PCI config-space revision ID, 0xFFFFFFFF if
+                                              //!< not supported
   char asic_serial[AMDSMI_MAX_STRING_LENGTH]; /**< The socket's unique serial number, 0xFFFFFFFF if
                                                    not supported */
   uint32_t oam_id;                   //!< Corresponds to socket number, 0xFFFFFFFF if not supported

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1137,7 +1137,10 @@ typedef struct {
   uint64_t target_graphics_version;  //!< 0xFFFFFFFFFFFFFFFF if not supported
   uint32_t subsystem_id;             //!> The subsystem ID
   uint64_t flags;                    //!< Chip flags
-  uint32_t reserved[18];
+  uint32_t silicon_rev_id;           /**< Silicon stepping (amdgpu external_rev_id). Distinct from
+                                          rev_id, which is the PCI config-space revision.
+                                          0xFFFFFFFF if not supported */
+  uint32_t reserved[17];
 } amdsmi_asic_info_t;
 
 /**

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -304,6 +304,8 @@ const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type);
  *
  *  Backends call this before filling in what they can, so a field a backend
  *  does not know about reports N/A rather than a plausible zero.
+ *
+ *  @param[inout] info Structure to reset to its not-supported state.
  */
 void init_asic_info_defaults(amdsmi_asic_info_t* info);
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -305,7 +305,7 @@ const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type);
  *  Backends call this before filling in what they can, so a field a backend
  *  does not know about reports N/A rather than a plausible zero.
  *
- *  @param[inout] info Structure to reset to its not-supported state.
+ *  @param[out] info Structure to reset to its not-supported state.
  */
 void init_asic_info_defaults(amdsmi_asic_info_t* info);
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -299,4 +299,12 @@ amdsmi_status_t smi_amdgpu_read_clk_freq_from_pp_dpm(amd::smi::AMDSmiGPUDevice* 
  */
 const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type);
 
+/**
+ *  @brief Reset amdsmi_asic_info_t to its not-supported state.
+ *
+ *  Backends call this before filling in what they can, so a field a backend
+ *  does not know about reports N/A rather than a plausible zero.
+ */
+void init_asic_info_defaults(amdsmi_asic_info_t* info);
+
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_UTILS_H_

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -2870,8 +2870,9 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     asic_info_struct = amdsmi_wrapper.amdsmi_asic_info_t()
-    # An older libamd_smi does not know these fields and leaves the reserved
-    # slots as the caller passed them, so seed N/A rather than the ctypes zero.
+    # A DRM libamd_smi predating these fields leaves the reserved slots as the
+    # caller passed them, so seed N/A rather than the ctypes zero. A WSL library
+    # that old clears the whole structure and still reports zero.
     asic_info_struct.chip_rev_id = MaxUIntegerTypes.UINT32_T
     asic_info_struct.external_rev_id = MaxUIntegerTypes.UINT32_T
     _check_res(

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -2870,6 +2870,10 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     asic_info_struct = amdsmi_wrapper.amdsmi_asic_info_t()
+    # An older libamd_smi does not know these fields and leaves the reserved
+    # slots as the caller passed them, so seed N/A rather than the ctypes zero.
+    asic_info_struct.chip_rev_id = MaxUIntegerTypes.UINT32_T
+    asic_info_struct.external_rev_id = MaxUIntegerTypes.UINT32_T
     _check_res(
         amdsmi_wrapper.amdsmi_get_gpu_asic_info(processor_handle, ctypes.byref(asic_info_struct))
     )
@@ -2879,12 +2883,20 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
     subsystem_id = _validate_if_max_uint(asic_info_struct.subsystem_id, MaxUIntegerTypes.UINT32_T)
     subvendor_id = _validate_if_max_uint(asic_info_struct.subvendor_id, MaxUIntegerTypes.UINT32_T)
     rev_id = _validate_if_max_uint(asic_info_struct.rev_id, MaxUIntegerTypes.UINT32_T)
+    chip_rev_id = _validate_if_max_uint(asic_info_struct.chip_rev_id, MaxUIntegerTypes.UINT32_T)
+    external_rev_id = _validate_if_max_uint(
+        asic_info_struct.external_rev_id, MaxUIntegerTypes.UINT32_T
+    )
     if isinstance(subsystem_id, int):
         subsystem_id = _pad_hex_value(hex(subsystem_id), 4)
     if isinstance(subvendor_id, int):
         subvendor_id = _pad_hex_value(hex(subvendor_id), 4)
     if isinstance(rev_id, int):
         rev_id = _pad_hex_value(hex(rev_id), 2)
+    if isinstance(chip_rev_id, int):
+        chip_rev_id = _pad_hex_value(hex(chip_rev_id), 2)
+    if isinstance(external_rev_id, int):
+        external_rev_id = _pad_hex_value(hex(external_rev_id), 2)
     asic_info = {
         "market_name": market_name,
         "vendor_id": asic_info_struct.vendor_id,
@@ -2892,6 +2904,8 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
         "subvendor_id": subvendor_id,
         "device_id": asic_info_struct.device_id,
         "rev_id": rev_id,
+        "chip_rev_id": chip_rev_id,
+        "external_rev_id": external_rev_id,
         "asic_serial": asic_info_struct.asic_serial.decode("utf-8"),
         "oam_id": _validate_if_max_uint(asic_info_struct.oam_id, MaxUIntegerTypes.UINT32_T),
         "physical_acc_id": _validate_if_max_uint(

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -2878,17 +2878,20 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
     target_graphics_version = hex(asic_info_struct.target_graphics_version)[2:]
     subsystem_id = _validate_if_max_uint(asic_info_struct.subsystem_id, MaxUIntegerTypes.UINT32_T)
     subvendor_id = _validate_if_max_uint(asic_info_struct.subvendor_id, MaxUIntegerTypes.UINT32_T)
+    rev_id = _validate_if_max_uint(asic_info_struct.rev_id, MaxUIntegerTypes.UINT32_T)
     if isinstance(subsystem_id, int):
         subsystem_id = _pad_hex_value(hex(subsystem_id), 4)
     if isinstance(subvendor_id, int):
         subvendor_id = _pad_hex_value(hex(subvendor_id), 4)
+    if isinstance(rev_id, int):
+        rev_id = _pad_hex_value(hex(rev_id), 2)
     asic_info = {
         "market_name": market_name,
         "vendor_id": asic_info_struct.vendor_id,
         "vendor_name": asic_info_struct.vendor_name.decode("utf-8"),
         "subvendor_id": subvendor_id,
         "device_id": asic_info_struct.device_id,
-        "rev_id": _pad_hex_value(hex(asic_info_struct.rev_id), 2),
+        "rev_id": rev_id,
         "asic_serial": asic_info_struct.asic_serial.decode("utf-8"),
         "oam_id": _validate_if_max_uint(asic_info_struct.oam_id, MaxUIntegerTypes.UINT32_T),
         "physical_acc_id": _validate_if_max_uint(

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -2855,10 +2855,15 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
     target_graphics_version = hex(asic_info_struct.target_graphics_version)[2:]
     subsystem_id = _validate_if_max_uint(asic_info_struct.subsystem_id, MaxUIntegerTypes.UINT32_T)
     subvendor_id = _validate_if_max_uint(asic_info_struct.subvendor_id, MaxUIntegerTypes.UINT32_T)
+    silicon_rev_id = _validate_if_max_uint(
+        asic_info_struct.silicon_rev_id, MaxUIntegerTypes.UINT32_T
+    )
     if isinstance(subsystem_id, int):
         subsystem_id = _pad_hex_value(hex(subsystem_id), 4)
     if isinstance(subvendor_id, int):
         subvendor_id = _pad_hex_value(hex(subvendor_id), 4)
+    if isinstance(silicon_rev_id, int):
+        silicon_rev_id = _pad_hex_value(hex(silicon_rev_id), 2)
     asic_info = {
         "market_name": market_name,
         "vendor_id": asic_info_struct.vendor_id,
@@ -2866,6 +2871,7 @@ def amdsmi_get_gpu_asic_info(processor_handle: processor_handle_t) -> Dict[str, 
         "subvendor_id": subvendor_id,
         "device_id": asic_info_struct.device_id,
         "rev_id": _pad_hex_value(hex(asic_info_struct.rev_id), 2),
+        "silicon_rev_id": silicon_rev_id,
         "asic_serial": asic_info_struct.asic_serial.decode("utf-8"),
         "oam_id": _validate_if_max_uint(asic_info_struct.oam_id, MaxUIntegerTypes.UINT32_T),
         "num_compute_units": _validate_if_max_uint(

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1284,7 +1284,9 @@ struct_amdsmi_asic_info_t._fields_ = [
     ('PADDING_1', ctypes.c_ubyte * 4),
     ('flags', ctypes.c_uint64),
     ('physical_acc_id', ctypes.c_uint32),
-    ('reserved', ctypes.c_uint32 * 17),
+    ('chip_rev_id', ctypes.c_uint32),
+    ('external_rev_id', ctypes.c_uint32),
+    ('reserved', ctypes.c_uint32 * 15),
 ]
 
 amdsmi_asic_info_t = struct_amdsmi_asic_info_t

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1298,7 +1298,8 @@ struct_amdsmi_asic_info_t._fields_ = [
     ('subsystem_id', ctypes.c_uint32),
     ('PADDING_1', ctypes.c_ubyte * 4),
     ('flags', ctypes.c_uint64),
-    ('reserved', ctypes.c_uint32 * 18),
+    ('silicon_rev_id', ctypes.c_uint32),
+    ('reserved', ctypes.c_uint32 * 17),
 ]
 
 amdsmi_asic_info_t = struct_amdsmi_asic_info_t

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -939,10 +939,11 @@ pub struct AmdsmiEnumerationInfoT {
     pub hip_id: u32,
     pub hip_uuid: [::std::os::raw::c_char; 256usize],
     pub oam_id: u32,
+    pub physical_acc_id: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiEnumerationInfoT"][::std::mem::size_of::<AmdsmiEnumerationInfoT>() - 276usize];
+    ["Size of AmdsmiEnumerationInfoT"][::std::mem::size_of::<AmdsmiEnumerationInfoT>() - 280usize];
     ["Alignment of AmdsmiEnumerationInfoT"]
         [::std::mem::align_of::<AmdsmiEnumerationInfoT>() - 4usize];
     ["Offset of field: AmdsmiEnumerationInfoT::drm_render"]
@@ -957,6 +958,8 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiEnumerationInfoT, hip_uuid) - 16usize];
     ["Offset of field: AmdsmiEnumerationInfoT::oam_id"]
         [::std::mem::offset_of!(AmdsmiEnumerationInfoT, oam_id) - 272usize];
+    ["Offset of field: AmdsmiEnumerationInfoT::physical_acc_id"]
+        [::std::mem::offset_of!(AmdsmiEnumerationInfoT, physical_acc_id) - 276usize];
 };
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1225,7 +1228,10 @@ pub struct AmdsmiAsicInfoT {
     pub target_graphics_version: u64,
     pub subsystem_id: u32,
     pub flags: u64,
-    pub reserved: [u32; 18usize],
+    pub physical_acc_id: u32,
+    pub chip_rev_id: u32,
+    pub external_rev_id: u32,
+    pub reserved: [u32; 15usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1255,8 +1261,14 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiAsicInfoT, subsystem_id) - 808usize];
     ["Offset of field: AmdsmiAsicInfoT::flags"]
         [::std::mem::offset_of!(AmdsmiAsicInfoT, flags) - 816usize];
+    ["Offset of field: AmdsmiAsicInfoT::physical_acc_id"]
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, physical_acc_id) - 824usize];
+    ["Offset of field: AmdsmiAsicInfoT::chip_rev_id"]
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, chip_rev_id) - 828usize];
+    ["Offset of field: AmdsmiAsicInfoT::external_rev_id"]
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, external_rev_id) - 832usize];
     ["Offset of field: AmdsmiAsicInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiAsicInfoT, reserved) - 824usize];
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, reserved) - 836usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3414,6 +3426,32 @@ const _: () = {
 };
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiComputeTrayTypeT {
+    AmdsmiComputeTrayTypeUnknown = 0,
+    AmdsmiComputeTrayTypeHeliosP = 1,
+    AmdsmiComputeTrayTypeHeliosR = 2,
+    AmdsmiComputeTrayTypeTitan = 3,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiTrayInfoT {
+    pub max_acc_per_tray: u32,
+    pub tray_type: AmdsmiComputeTrayTypeT,
+    pub reserved: [u32; 14usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiTrayInfoT"][::std::mem::size_of::<AmdsmiTrayInfoT>() - 64usize];
+    ["Alignment of AmdsmiTrayInfoT"][::std::mem::align_of::<AmdsmiTrayInfoT>() - 4usize];
+    ["Offset of field: AmdsmiTrayInfoT::max_acc_per_tray"]
+        [::std::mem::offset_of!(AmdsmiTrayInfoT, max_acc_per_tray) - 0usize];
+    ["Offset of field: AmdsmiTrayInfoT::tray_type"]
+        [::std::mem::offset_of!(AmdsmiTrayInfoT, tray_type) - 4usize];
+    ["Offset of field: AmdsmiTrayInfoT::reserved"]
+        [::std::mem::offset_of!(AmdsmiTrayInfoT, reserved) - 8usize];
+};
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum AmdsmiPtlDataFormatT {
     AmdsmiPtlDataFormatI8 = 0,
     AmdsmiPtlDataFormatF16 = 1,
@@ -5099,6 +5137,12 @@ extern "C" {
     pub fn amdsmi_get_npm_info(
         node_handle: AmdsmiNodeHandle,
         info: *mut AmdsmiNpmInfoT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_tray_info(
+        node_handle: AmdsmiNodeHandle,
+        info: *mut AmdsmiTrayInfoT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -1241,7 +1241,8 @@ pub struct AmdsmiAsicInfoT {
     pub target_graphics_version: u64,
     pub subsystem_id: u32,
     pub flags: u64,
-    pub reserved: [u32; 18usize],
+    pub silicon_rev_id: u32,
+    pub reserved: [u32; 17usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1271,8 +1272,10 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiAsicInfoT, subsystem_id) - 808usize];
     ["Offset of field: AmdsmiAsicInfoT::flags"]
         [::std::mem::offset_of!(AmdsmiAsicInfoT, flags) - 816usize];
+    ["Offset of field: AmdsmiAsicInfoT::silicon_rev_id"]
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, silicon_rev_id) - 824usize];
     ["Offset of field: AmdsmiAsicInfoT::reserved"]
-        [::std::mem::offset_of!(AmdsmiAsicInfoT, reserved) - 824usize];
+        [::std::mem::offset_of!(AmdsmiAsicInfoT, reserved) - 828usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2447,20 +2447,6 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   uint16_t device_id = 0;
   uint16_t subsystem_id = 0;
   char temp_market_name[AMDSMI_MAX_STRING_LENGTH] = {0};
-  smi_clear_char_and_reinitialize(info->market_name, AMDSMI_MAX_STRING_LENGTH, temp_market_name);
-  info->market_name[0] = '\0';
-  info->vendor_id = std::numeric_limits<uint32_t>::max();
-  info->vendor_name[0] = '\0';
-  info->subvendor_id = std::numeric_limits<uint32_t>::max();
-  info->device_id = std::numeric_limits<uint64_t>::max();
-  info->rev_id = std::numeric_limits<uint16_t>::max();
-  info->asic_serial[0] = '\0';
-  info->oam_id = std::numeric_limits<uint32_t>::max();
-  info->num_of_compute_units = std::numeric_limits<uint32_t>::max();
-  info->target_graphics_version = std::numeric_limits<uint64_t>::max();
-  info->subsystem_id = std::numeric_limits<uint32_t>::max();
-  info->flags = 0;
-  info->physical_acc_id = std::numeric_limits<uint32_t>::max();
 
   std::ostringstream ss;
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
@@ -2491,13 +2477,12 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
     }
   }
 
+  init_asic_info_defaults(info);
+
   /**
    * For other sysfs related information, get from rocm-smi
    */
 
-  // Ensure asic_serial defaults to an unsupported value
-  std::string max_uint64_str = "ffffffffffffffff";
-  smi_clear_char_and_reinitialize(info->asic_serial, AMDSMI_MAX_STRING_LENGTH, max_uint64_str);
   uint64_t asic_serial_id = 0;
   amdsmi_status_t status =
       rsmi_wrapper(rsmi_dev_asic_serial_get, processor_handle, 0, &asic_serial_id);
@@ -2560,7 +2545,6 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   if (status == AMDSMI_STATUS_SUCCESS) {
     info->device_id = static_cast<uint64_t>(device_id);
   }
-  info->rev_id = dev_info.pci_rev;
   status = rsmi_wrapper(rsmi_dev_vendor_id_get, processor_handle, 0, &vendor_id);
   if (status == AMDSMI_STATUS_SUCCESS) {
     info->vendor_id = vendor_id;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2636,6 +2636,8 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   // TODO(cpoag): check if this is correct, might be able to go through KGD/KFD
   info->rev_id = static_cast<uint32_t>(dev_info.pci_rev);
   info->flags = static_cast<uint64_t>(dev_info.ids_flags);
+  info->chip_rev_id = static_cast<uint32_t>(dev_info.chip_rev);
+  info->external_rev_id = static_cast<uint32_t>(dev_info.external_rev);
   libdrm.unload();
 
   ss << __PRETTY_FUNCTION__ << " | info->market_name: " << info->market_name << "\n"
@@ -2652,6 +2654,12 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
      << " | info->rev_id (dec): " << std::dec << info->rev_id << "\n"
      << " | info->rev_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0') << info->rev_id
      << "\n"
+     << " | info->chip_rev_id (dec): " << std::dec << info->chip_rev_id << "\n"
+     << " | info->chip_rev_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0')
+     << info->chip_rev_id << "\n"
+     << " | info->external_rev_id (dec): " << std::dec << info->external_rev_id << "\n"
+     << " | info->external_rev_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0')
+     << info->external_rev_id << "\n"
      << " | info->asic_serial: 0x" << info->asic_serial << "\n"
      << " | info->oam_id (dec): " << std::dec << info->oam_id << "\n"
      << " | info->oam_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0') << info->oam_id

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2431,6 +2431,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   info->target_graphics_version = std::numeric_limits<uint64_t>::max();
   info->subsystem_id = std::numeric_limits<uint32_t>::max();
   info->flags = 0;
+  info->silicon_rev_id = std::numeric_limits<uint32_t>::max();
 
   std::ostringstream ss;
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
@@ -2620,6 +2621,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
   // TODO(cpoag): check if this is correct, might be able to go through KGD/KFD
   info->rev_id = static_cast<uint32_t>(dev_info.pci_rev);
   info->flags = static_cast<uint64_t>(dev_info.ids_flags);
+  info->silicon_rev_id = static_cast<uint32_t>(dev_info.external_rev);
   libdrm.unload();
 
   ss << __PRETTY_FUNCTION__ << " | info->market_name: " << info->market_name << "\n"
@@ -2636,6 +2638,9 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
      << " | info->rev_id (dec): " << std::dec << info->rev_id << "\n"
      << " | info->rev_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0') << info->rev_id
      << "\n"
+     << " | info->silicon_rev_id (dec): " << std::dec << info->silicon_rev_id << "\n"
+     << " | info->silicon_rev_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0')
+     << info->silicon_rev_id << "\n"
      << " | info->asic_serial: 0x" << info->asic_serial << "\n"
      << " | info->oam_id (dec): " << std::dec << info->oam_id << "\n"
      << " | info->oam_id (hex): 0x" << std::hex << std::setw(4) << std::setfill('0') << info->oam_id

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -1437,3 +1437,20 @@ const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) 
       return nullptr;
   }
 }
+
+void init_asic_info_defaults(amdsmi_asic_info_t* info) {
+  if (info == nullptr) {
+    return;
+  }
+  std::memset(info, 0, sizeof(*info));
+  info->vendor_id = std::numeric_limits<uint32_t>::max();
+  info->subvendor_id = std::numeric_limits<uint32_t>::max();
+  info->device_id = std::numeric_limits<uint64_t>::max();
+  info->rev_id = std::numeric_limits<uint32_t>::max();
+  std::snprintf(info->asic_serial, AMDSMI_MAX_STRING_LENGTH, "ffffffffffffffff");
+  info->oam_id = std::numeric_limits<uint32_t>::max();
+  info->num_of_compute_units = std::numeric_limits<uint32_t>::max();
+  info->target_graphics_version = std::numeric_limits<uint64_t>::max();
+  info->subsystem_id = std::numeric_limits<uint32_t>::max();
+  info->physical_acc_id = std::numeric_limits<uint32_t>::max();
+}

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -1453,4 +1453,6 @@ void init_asic_info_defaults(amdsmi_asic_info_t* info) {
   info->target_graphics_version = std::numeric_limits<uint64_t>::max();
   info->subsystem_id = std::numeric_limits<uint32_t>::max();
   info->physical_acc_id = std::numeric_limits<uint32_t>::max();
+  info->chip_rev_id = std::numeric_limits<uint32_t>::max();
+  info->external_rev_id = std::numeric_limits<uint32_t>::max();
 }

--- a/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
@@ -295,10 +295,8 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
     info->device_id = a.device_id;
     info->rev_id = a.rev_id;
     std::snprintf(info->asic_serial, AMDSMI_MAX_STRING_LENGTH, "%016lx", a.asic_serial);
-    // rocdxg_smi_asic_info_t has no OAM/physical-accelerator-ID fields; gpu_id_ is
-    // just an enumeration index, not real hardware data, so report N/A rather than 0.
-    info->oam_id = std::numeric_limits<uint32_t>::max();
-    info->physical_acc_id = std::numeric_limits<uint32_t>::max();
+    // oam_id and physical_acc_id stay N/A from the defaults; gpu_id_ is only an
+    // enumeration index, not real hardware data.
     info->num_of_compute_units = a.num_of_compute_units;
     // Convert IP version (major<<16|minor<<8|stepping) to the nibble-packed
     // hex format Python expects: hex(value)[2:] == "MMSS" (e.g. 0x1100 → "gfx1100").

--- a/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
@@ -19,6 +19,7 @@
 #include "amd_smi/impl/amd_smi_drm.h"
 #include "amd_smi/impl/amd_smi_gpu_device.h"
 #include "amd_smi/impl/amd_smi_socket.h"
+#include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/amd_smi_uuid.h"
 #include "amd_smi/impl/amd_smi_wsl_syms.h"
 #include "rocm_smi/rocm_smi_logger.h"
@@ -285,7 +286,7 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
   if (info == nullptr) return AMDSMI_STATUS_INVAL;
   if (r == AMDSMI_STATUS_SUCCESS) {
     const auto& a = device_info_.asic;
-    std::memset(info, 0, sizeof(*info));
+    init_asic_info_defaults(info);
     copy_rocdxg_string(info->market_name, a.market_name);
     info->vendor_id = a.vendor_id;
     if (info->vendor_id == 0x1002)
@@ -311,23 +312,16 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
     return AMDSMI_STATUS_SUCCESS;
   }
   if (r != AMDSMI_STATUS_NOT_SUPPORTED) return r;
-  std::memset(info, 0, sizeof(*info));
+  init_asic_info_defaults(info);
   copy_string(info->market_name, marketing_name_);
   info->vendor_id = vendor_id_;
   if (vendor_id_ == 0x1002)
     copy_string(info->vendor_name, "Advanced Micro Devices, Inc. [AMD/ATI]");
-  info->subvendor_id = std::numeric_limits<uint32_t>::max();
   info->device_id = device_id_;
-  info->rev_id = std::numeric_limits<uint32_t>::max();
-  copy_string(info->asic_serial, "ffffffffffffffff");
-  // rocdxg_smi_asic_info_t has no OAM/physical-accelerator-ID fields; gpu_id_ is
-  // just an enumeration index, not real hardware data, so report N/A rather than 0.
-  info->oam_id = std::numeric_limits<uint32_t>::max();
-  info->physical_acc_id = std::numeric_limits<uint32_t>::max();
+  // oam_id and physical_acc_id stay N/A from the defaults; gpu_id_ is only an
+  // enumeration index, not real hardware data.
   info->num_of_compute_units =
       num_compute_units_ ? num_compute_units_ : std::numeric_limits<uint32_t>::max();
-  info->target_graphics_version = std::numeric_limits<uint64_t>::max();
-  info->subsystem_id = std::numeric_limits<uint32_t>::max();
   info->flags = family_id_;
   return AMDSMI_STATUS_SUCCESS;
 }

--- a/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_wsl_device.cc
@@ -293,6 +293,7 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
     info->subvendor_id = a.subvendor_id;
     info->device_id = a.device_id;
     info->rev_id = a.rev_id;
+    info->silicon_rev_id = std::numeric_limits<uint32_t>::max();
     std::snprintf(info->asic_serial, AMDSMI_MAX_STRING_LENGTH, "%016lx", a.asic_serial);
     info->oam_id = gpu_id_;
     info->num_of_compute_units = a.num_of_compute_units;
@@ -316,6 +317,7 @@ amdsmi_status_t WSLGPUBackend::GetAsicInfo(amdsmi_asic_info_t* info) {
   info->subvendor_id = std::numeric_limits<uint32_t>::max();
   info->device_id = device_id_;
   info->rev_id = std::numeric_limits<uint32_t>::max();
+  info->silicon_rev_id = std::numeric_limits<uint32_t>::max();
   copy_string(info->asic_serial, "ffffffffffffffff");
   info->oam_id = gpu_id_;
   info->num_of_compute_units =

--- a/projects/amdsmi/tests/amd_smi_test/test_base.cc
+++ b/projects/amdsmi/tests/amd_smi_test/test_base.cc
@@ -216,6 +216,18 @@ void TestBase::PrintDeviceHeader(amdsmi_processor_handle dv_ind) {
     }
     std::cout << "\t**Revision ID: 0x" << std::hex << std::setfill('0') << std::setw(2)
               << asic_info.rev_id << std::endl;
+    if (checkIfMaxValue(asic_info.chip_rev_id)) {
+      std::cout << "\t**Chip Revision ID: N/A" << std::endl;
+    } else {
+      std::cout << "\t**Chip Revision ID: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                << asic_info.chip_rev_id << std::endl;
+    }
+    if (checkIfMaxValue(asic_info.external_rev_id)) {
+      std::cout << "\t**External Revision ID: N/A" << std::endl;
+    } else {
+      std::cout << "\t**External Revision ID: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                << asic_info.external_rev_id << std::endl;
+    }
     if (checkIfMaxValue(asic_info.subvendor_id)) {
       std::cout << "\t**Subvendor ID: N/A" << std::endl;
     } else {

--- a/projects/amdsmi/tests/amd_smi_test/test_base.cc
+++ b/projects/amdsmi/tests/amd_smi_test/test_base.cc
@@ -216,6 +216,12 @@ void TestBase::PrintDeviceHeader(amdsmi_processor_handle dv_ind) {
     }
     std::cout << "\t**Revision ID: 0x" << std::hex << std::setfill('0') << std::setw(2)
               << asic_info.rev_id << std::endl;
+    if (checkIfMaxValue(asic_info.silicon_rev_id)) {
+      std::cout << "\t**Silicon Revision ID: N/A" << std::endl;
+    } else {
+      std::cout << "\t**Silicon Revision ID: 0x" << std::hex << std::setfill('0') << std::setw(2)
+                << asic_info.silicon_rev_id << std::endl;
+    }
     if (checkIfMaxValue(asic_info.subvendor_id)) {
       std::cout << "\t**Subvendor ID: N/A" << std::endl;
     } else {

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/asic_info_defaults_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/asic_info_defaults_test.cc
@@ -32,6 +32,7 @@ TEST(GpuUnit, AsicInfoDefaultsMarkScalarsNotSupported) {
   EXPECT_EQ(info.chip_rev_id, u32_max);
   EXPECT_EQ(info.external_rev_id, u32_max);
   EXPECT_EQ(info.oam_id, u32_max);
+  EXPECT_EQ(info.physical_acc_id, u32_max);
   EXPECT_EQ(info.num_of_compute_units, u32_max);
   EXPECT_EQ(info.subsystem_id, u32_max);
   EXPECT_EQ(info.device_id, std::numeric_limits<uint64_t>::max());

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/asic_info_defaults_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/asic_info_defaults_test.cc
@@ -1,0 +1,53 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Every backend relies on these defaults to report N/A for what it cannot
+// supply, so a field dropped from the initializer would surface as real data.
+// No GPU required.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <limits>
+#include <string>
+
+#include "amd_smi/impl/amd_smi_utils.h"
+
+namespace {
+
+amdsmi_asic_info_t DefaultsFromGarbage() {
+  amdsmi_asic_info_t info;
+  std::memset(&info, 0x5A, sizeof(info));
+  init_asic_info_defaults(&info);
+  return info;
+}
+
+TEST(GpuUnit, AsicInfoDefaultsMarkScalarsNotSupported) {
+  const amdsmi_asic_info_t info = DefaultsFromGarbage();
+  const auto u32_max = std::numeric_limits<uint32_t>::max();
+
+  EXPECT_EQ(info.vendor_id, u32_max);
+  EXPECT_EQ(info.subvendor_id, u32_max);
+  EXPECT_EQ(info.rev_id, u32_max);
+  EXPECT_EQ(info.chip_rev_id, u32_max);
+  EXPECT_EQ(info.external_rev_id, u32_max);
+  EXPECT_EQ(info.oam_id, u32_max);
+  EXPECT_EQ(info.num_of_compute_units, u32_max);
+  EXPECT_EQ(info.subsystem_id, u32_max);
+  EXPECT_EQ(info.device_id, std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(info.target_graphics_version, std::numeric_limits<uint64_t>::max());
+}
+
+TEST(GpuUnit, AsicInfoDefaultsClearStringsAndReserved) {
+  const amdsmi_asic_info_t info = DefaultsFromGarbage();
+
+  EXPECT_STREQ(info.market_name, "");
+  EXPECT_STREQ(info.vendor_name, "");
+  EXPECT_STREQ(info.asic_serial, "ffffffffffffffff");
+  EXPECT_EQ(info.flags, 0u);
+  for (uint32_t word : info.reserved) {
+    EXPECT_EQ(word, 0u);
+  }
+}
+
+}  // namespace

--- a/projects/amdsmi/tests/python/cli/test_static.py
+++ b/projects/amdsmi/tests/python/cli/test_static.py
@@ -4,6 +4,8 @@
 
 """CLI leaf test: static command (incl. mem-carveout / node GTT display)."""
 
+import csv
+import io
 import json
 
 from cli.base import TestCliBase
@@ -40,14 +42,13 @@ class TestStatic(TestCliBase):
         cmd = "amd-smi static --asic --csv"
         (rc, data, std_err) = self.util.RunCmdSync(cmd)
         self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
-        rows = data.splitlines()
-        header = rows[0].split(",")
+        # vendor_name carries a comma on some backends, so honour the quoting.
+        reader = csv.DictReader(io.StringIO(data))
+        rows = [row for row in reader]
         # Compare the values, not just the header, so a dropped field is caught.
         for key in keys:
-            self.assertIn(key, header)
-            column = header.index(key)
-            csv_values = [row.split(",")[column] for row in rows[1:] if row.strip()]
-            self.assertEqual(csv_values, json_values[key])
+            self.assertIn(key, reader.fieldnames)
+            self.assertEqual([row[key] for row in rows], json_values[key])
         return
 
     def test_mem_carveout_gtt(self):

--- a/projects/amdsmi/tests/python/cli/test_static.py
+++ b/projects/amdsmi/tests/python/cli/test_static.py
@@ -21,6 +21,35 @@ class TestStatic(TestCliBase):
         self.RunCmds(cmds)
         return
 
+    def test_asic_revision_id_keys(self):
+        """The revision ids must reach JSON and CSV, not only the human output."""
+        self.common.print_func_name("")
+        keys = ("chip_rev_id", "external_rev_id")
+
+        cmd = "amd-smi static --asic --json"
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+        payload = json.loads(data)
+        gpus = payload["gpu_data"] if isinstance(payload, dict) else payload
+        self.assertTrue(gpus, f"no GPU entries in '{cmd}'")
+        for gpu in gpus:
+            for key in keys:
+                self.assertIn(key, gpu["asic"])
+        json_values = {key: [gpu["asic"][key] for gpu in gpus] for key in keys}
+
+        cmd = "amd-smi static --asic --csv"
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+        rows = data.splitlines()
+        header = rows[0].split(",")
+        # Compare the values, not just the header, so a dropped field is caught.
+        for key in keys:
+            self.assertIn(key, header)
+            column = header.index(key)
+            csv_values = [row.split(",")[column] for row in rows[1:] if row.strip()]
+            self.assertEqual(csv_values, json_values[key])
+        return
+
     def test_mem_carveout_gtt(self):
         """Test static --mem-carveout and node --gtt flags (display mode only)"""
         self.common.print_func_name("")

--- a/projects/amdsmi/tests/python/functional/gpu/test_asic_revision_ids.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_asic_revision_ids.py
@@ -97,7 +97,9 @@ class TestGpuAsicRevisionIds(unittest.TestCase):
                 render_index = amdsmi.amdsmi_get_gpu_enumeration_info(processor)["drm_render"]
                 render_node = f"/dev/dri/renderD{render_index}"
                 words = _query_dev_info(render_node)
-            except (OSError, amdsmi.AmdSmiLibraryException) as exc:
+            except OSError as exc:
+                # Only an unreadable node is environmental; a library failure
+                # must not be downgraded to a skip.
                 unreachable.append(f"{processor}: {exc}")
                 continue
 

--- a/projects/amdsmi/tests/python/functional/gpu/test_asic_revision_ids.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_asic_revision_ids.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""GPU ASIC: chip_rev_id and external_rev_id cross-checked against the DRM ioctl."""
+
+import ctypes
+import fcntl
+import os
+import struct
+import unittest
+
+import common.common as common
+from common.common import amdsmi
+
+_IOC_NRBITS = 8
+_IOC_SIZESHIFT = 16
+_IOC_DIRSHIFT = 30
+_IOC_WRITE = 1
+
+_DRM_IOCTL_BASE = ord("d")
+_DRM_COMMAND_BASE = 0x40
+_DRM_AMDGPU_INFO = 0x05
+_AMDGPU_INFO_DEV_INFO = 0x16
+
+# Leading word order of struct drm_amdgpu_info_device. Must track
+# include/libdrm/amdgpu_drm.h.
+_CHIP_REV_INDEX = 1
+_EXTERNAL_REV_INDEX = 2
+_PCI_REV_INDEX = 3
+
+
+class _DrmAmdgpuInfo(ctypes.Structure):
+    """struct drm_amdgpu_info from amdgpu_drm.h."""
+
+    _fields_ = [
+        ("return_pointer", ctypes.c_uint64),
+        ("return_size", ctypes.c_uint32),
+        ("query", ctypes.c_uint32),
+        ("_union", ctypes.c_uint8 * 16),
+    ]
+
+
+_DRM_IOCTL_AMDGPU_INFO = (
+    (_IOC_WRITE << _IOC_DIRSHIFT)
+    | (_DRM_IOCTL_BASE << _IOC_NRBITS)
+    | (_DRM_COMMAND_BASE + _DRM_AMDGPU_INFO)
+    | (ctypes.sizeof(_DrmAmdgpuInfo) << _IOC_SIZESHIFT)
+)
+
+
+def _query_dev_info(render_node: str) -> tuple:
+    """Return the leading words of drm_amdgpu_info_device for a render node."""
+    fd = os.open(render_node, os.O_RDWR | os.O_CLOEXEC)
+    try:
+        buf = ctypes.create_string_buffer(1024)
+        request = _DrmAmdgpuInfo()
+        request.return_pointer = ctypes.addressof(buf)
+        request.return_size = ctypes.sizeof(buf)
+        request.query = _AMDGPU_INFO_DEV_INFO
+        fcntl.ioctl(fd, _DRM_IOCTL_AMDGPU_INFO, request)
+    finally:
+        os.close(fd)
+    return struct.unpack_from("<IIII", buf.raw, 0)
+
+
+class TestGpuAsicRevisionIds(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.common = common.Common(common.verbose)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            amdsmi.amdsmi_shut_down()
+        except amdsmi.AmdSmiLibraryException:
+            pass
+
+    def setUp(self):
+        self.raise_exception = None
+        self.common.amdsmi_smart_init()
+        self.common.processors = amdsmi.amdsmi_get_processor_handles()
+
+    def tearDown(self):
+        amdsmi.amdsmi_shut_down()
+
+    def test_revision_ids_match_drm_dev_info(self):
+        self.common.print_func_name("")
+        self.assertTrue(self.common.processors, "no GPU processors enumerated")
+
+        checked = 0
+        unreachable = []
+        for processor in self.common.processors:
+            # drm_render maps a processor handle to its own node; a BDF lookup
+            # cannot, because partitions of one GPU share a single BDF.
+            try:
+                render_index = amdsmi.amdsmi_get_gpu_enumeration_info(processor)["drm_render"]
+                render_node = f"/dev/dri/renderD{render_index}"
+                words = _query_dev_info(render_node)
+            except (OSError, amdsmi.AmdSmiLibraryException) as exc:
+                unreachable.append(f"{processor}: {exc}")
+                continue
+
+            asic_info = amdsmi.amdsmi_get_gpu_asic_info(processor)
+            expected = {
+                "chip_rev_id": words[_CHIP_REV_INDEX],
+                "external_rev_id": words[_EXTERNAL_REV_INDEX],
+                "rev_id": words[_PCI_REV_INDEX],
+            }
+            for key, value in expected.items():
+                reported = asic_info[key]
+                self.assertNotEqual(
+                    reported,
+                    "N/A",
+                    f"{render_node}: {key} reported N/A while the same ioctl returned {hex(value)}",
+                )
+                self.assertEqual(
+                    int(reported, 16), value, f"{render_node}: {key} {reported} != DRM {hex(value)}"
+                )
+            checked += 1
+
+        if checked == 0:
+            self.skipTest(f"no render node was readable: {unreachable}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/functional/gpu/test_asic_silicon_rev_id.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_asic_silicon_rev_id.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cross-checks asic_info["silicon_rev_id"] against the amdgpu DRM ioctl.
+
+The library reads external_rev out of AMDGPU_INFO_DEV_INFO. This test issues the
+same ioctl independently so a plumbing regression (wrong struct offset, stale
+cache, truncation) cannot pass unnoticed.
+"""
+
+import ctypes
+import fcntl
+import glob
+import os
+import struct
+import unittest
+
+import common.common as common
+from common.common import amdsmi
+
+_IOC_NRBITS = 8
+_IOC_TYPEBITS = 8
+_IOC_SIZESHIFT = 16
+_IOC_DIRSHIFT = 30
+_IOC_WRITE = 1
+
+_DRM_IOCTL_BASE = ord("d")
+_DRM_COMMAND_BASE = 0x40
+_DRM_AMDGPU_INFO = 0x05
+_AMDGPU_INFO_DEV_INFO = 0x16
+
+
+class _DrmAmdgpuInfo(ctypes.Structure):
+    """struct drm_amdgpu_info from amdgpu_drm.h."""
+
+    _fields_ = [
+        ("return_pointer", ctypes.c_uint64),
+        ("return_size", ctypes.c_uint32),
+        ("query", ctypes.c_uint32),
+        ("_union", ctypes.c_uint8 * 16),
+    ]
+
+
+_DRM_IOCTL_AMDGPU_INFO = (
+    (_IOC_WRITE << _IOC_DIRSHIFT)
+    | (_DRM_IOCTL_BASE << _IOC_NRBITS)
+    | (_DRM_COMMAND_BASE + _DRM_AMDGPU_INFO)
+    | (ctypes.sizeof(_DrmAmdgpuInfo) << _IOC_SIZESHIFT)
+)
+
+
+def _render_node_for_bdf(bdf):
+    """Return the /dev/dri/renderD* node backing a PCI BDF, or None."""
+    for link in glob.glob("/sys/class/drm/renderD*/device"):
+        if os.path.basename(os.path.realpath(link)) == bdf:
+            return os.path.join("/dev/dri", os.path.basename(os.path.dirname(link)))
+    return None
+
+
+def _query_external_rev(render_node):
+    """Read drm_amdgpu_info_device.external_rev via AMDGPU_INFO_DEV_INFO."""
+    fd = os.open(render_node, os.O_RDWR | os.O_CLOEXEC)
+    try:
+        buf = ctypes.create_string_buffer(1024)
+        request = _DrmAmdgpuInfo()
+        request.return_pointer = ctypes.addressof(buf)
+        request.return_size = ctypes.sizeof(buf)
+        request.query = _AMDGPU_INFO_DEV_INFO
+        fcntl.ioctl(fd, _DRM_IOCTL_AMDGPU_INFO, request)
+    finally:
+        os.close(fd)
+    # struct drm_amdgpu_info_device: __u32 device_id, chip_rev, external_rev, ...
+    return struct.unpack_from("<III", buf.raw, 0)[2]
+
+
+class TestGpuAsicSiliconRevId(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.common = common.Common(common.verbose)
+
+    def setUp(self):
+        self.common.amdsmi_smart_init()
+        self.common.processors = amdsmi.amdsmi_get_processor_handles()
+
+    def tearDown(self):
+        amdsmi.amdsmi_shut_down()
+
+    def test_silicon_rev_id_matches_drm_external_rev(self):
+        self.common.print_func_name("")
+        checked = 0
+        for processor in self.common.processors:
+            asic_info = amdsmi.amdsmi_get_gpu_asic_info(processor)
+            self.assertIn("silicon_rev_id", asic_info)
+
+            bdf = amdsmi.amdsmi_get_gpu_device_bdf(processor)
+            render_node = _render_node_for_bdf(bdf)
+            if render_node is None:
+                continue
+
+            expected = _query_external_rev(render_node)
+            self.assertEqual(
+                int(asic_info["silicon_rev_id"], 16),
+                expected,
+                f"{bdf}: silicon_rev_id {asic_info['silicon_rev_id']} != "
+                f"DRM external_rev {hex(expected)}",
+            )
+            checked += 1
+
+        if checked == 0:
+            self.skipTest("no GPU exposed a matching /dev/dri/renderD* node")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/functional/gpu/test_asic_silicon_rev_id.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_asic_silicon_rev_id.py
@@ -99,6 +99,11 @@ class TestGpuAsicSiliconRevId(unittest.TestCase):
                 continue
 
             expected = _query_external_rev(render_node)
+            self.assertNotEqual(
+                asic_info["silicon_rev_id"],
+                "N/A",
+                f"{bdf}: silicon_rev_id is N/A but DRM reported external_rev {hex(expected)}",
+            )
             self.assertEqual(
                 int(asic_info["silicon_rev_id"], 16),
                 expected,

--- a/projects/amdsmi/tests/python/unit/gpu/test_asic_info_layout.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_asic_info_layout.py
@@ -82,7 +82,7 @@ class TestRevisionIdReporting(unittest.TestCase):
             self.assertEqual(asic_info[key], "N/A")
 
     def test_zero_is_a_real_value_not_na(self):
-        # A0 silicon reports chip_rev 0, so zero must stay distinct from N/A.
+        # Hardware really does report chip_rev 0, so zero must stay distinct from N/A.
         asic_info = _asic_info_with(0x0, 0x0)
         for key in _REVISION_KEYS:
             self.assertEqual(asic_info[key], "0x00")

--- a/projects/amdsmi/tests/python/unit/gpu/test_asic_info_layout.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_asic_info_layout.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""ASIC info struct layout and revision id reporting (hardware-free)."""
+
+import ctypes
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+_ASIC_INFO_SIZE = 896
+_CHIP_REV_ID_OFFSET = 828
+_EXTERNAL_REV_ID_OFFSET = 832
+_RESERVED_OFFSET = 836
+_UINT32_MAX = 0xFFFFFFFF
+_REVISION_KEYS = ("chip_rev_id", "external_rev_id")
+
+
+def _asic_info_with(chip: int = None, external: int = None, rev_id: int = _UINT32_MAX) -> dict:
+    """Return the public dict with a stub library that writes the given revisions.
+
+    Leaving a revision None simulates a library predating the fields, which
+    leaves the reserved slots exactly as the caller handed them over.
+    """
+    handle = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+
+    def _stub(_handle, info_ptr):
+        info_ptr._obj.rev_id = rev_id
+        if chip is not None:
+            info_ptr._obj.chip_rev_id = chip
+        if external is not None:
+            info_ptr._obj.external_rev_id = external
+        return 0
+
+    with mock.patch.object(amdsmi.amdsmi_wrapper, "amdsmi_get_gpu_asic_info", _stub):
+        return amdsmi.amdsmi_interface.amdsmi_get_gpu_asic_info(handle)
+
+
+class TestAsicInfoLayout(unittest.TestCase):
+    """Pins the slots the revision ids took out of the reserved tail."""
+
+    def test_struct_size_unchanged(self):
+        self.assertEqual(
+            ctypes.sizeof(amdsmi.amdsmi_wrapper.struct_amdsmi_asic_info_t), _ASIC_INFO_SIZE
+        )
+
+    def test_new_field_and_reserved_offsets(self):
+        struct_type = amdsmi.amdsmi_wrapper.struct_amdsmi_asic_info_t
+        self.assertEqual(struct_type.chip_rev_id.offset, _CHIP_REV_ID_OFFSET)
+        self.assertEqual(struct_type.external_rev_id.offset, _EXTERNAL_REV_ID_OFFSET)
+        self.assertEqual(struct_type.reserved.offset, _RESERVED_OFFSET)
+
+    def test_reserved_tail_fills_struct(self):
+        reserved = amdsmi.amdsmi_wrapper.struct_amdsmi_asic_info_t.reserved
+        self.assertEqual(reserved.offset + reserved.size, _ASIC_INFO_SIZE)
+
+
+class TestRevisionIdReporting(unittest.TestCase):
+    """The not-supported value must render N/A, never a plausible revision."""
+
+    def test_reports_the_value_the_library_wrote(self):
+        asic_info = _asic_info_with(0x47, 0x47)
+        for key in _REVISION_KEYS:
+            self.assertEqual(asic_info[key], "0x47")
+
+    def test_each_key_reports_its_own_field(self):
+        # Distinct values catch a chip/external swap that equal values hide.
+        asic_info = _asic_info_with(0x11, 0x22)
+        self.assertEqual(asic_info["chip_rev_id"], "0x11")
+        self.assertEqual(asic_info["external_rev_id"], "0x22")
+
+    def test_pads_to_two_hex_digits(self):
+        asic_info = _asic_info_with(0x8, 0x8)
+        for key in _REVISION_KEYS:
+            self.assertEqual(asic_info[key], "0x08")
+
+    def test_not_supported_renders_na(self):
+        asic_info = _asic_info_with(_UINT32_MAX, _UINT32_MAX)
+        for key in _REVISION_KEYS:
+            self.assertEqual(asic_info[key], "N/A")
+
+    def test_zero_is_a_real_value_not_na(self):
+        # A0 silicon reports chip_rev 0, so zero must stay distinct from N/A.
+        asic_info = _asic_info_with(0x0, 0x0)
+        for key in _REVISION_KEYS:
+            self.assertEqual(asic_info[key], "0x00")
+
+    def test_library_without_the_fields_renders_na(self):
+        asic_info = _asic_info_with()
+        for key in _REVISION_KEYS:
+            self.assertEqual(asic_info[key], "N/A")
+
+    def test_rev_id_not_supported_renders_na(self):
+        # rev_id shares the not-supported value, so it must not leak it raw.
+        self.assertEqual(_asic_info_with(0x47, 0x47)["rev_id"], "N/A")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`amdsmi_get_gpu_asic_info()` reports `rev_id`, the PCI config-space revision, but nothing about the silicon itself. Consumers that need the ASIC revision (validation and qualification tooling, telemetry exporters tagging metrics per revision) had no in-band source for it.

The `AMDGPU_INFO_DEV_INFO` DRM query this function already issues carries two more revision values, and they answer different questions:

| Field | amdgpu source | Meaning |
|---|---|---|
| `rev_id` | `pci_rev` | PCI config-space revision (already reported) |
| `chip_rev_id` | `chip_rev` | Internal chip revision, the silicon stepping. The kernel UAPI annotates it "Internal chip revision: A0, A1, etc." |
| `external_rev_id` | `external_rev` | Family-scoped revision. The same value recurs across unrelated ASIC families, so it must be paired with `device_id` |

They are genuinely distinct on real hardware. On a Navi 21 the same part reports `rev_id 0xc3`, `chip_rev_id 0x00`, `external_rev_id 0x28`, so neither existing field can stand in for the others.

## Technical Details

Both values are read from the `dev_info` structure the function already fetches, so no additional ioctl or syscall is introduced.

**ABI:** the two `uint32_t` fields come out of the `amdsmi_asic_info_t` reserved tail. `reserved` shrinks from 17 to 15 entries and moves; the struct stays **896 bytes** and no pre-existing field offset changes.

| Field | Offset |
|---|---|
| `flags` | 816 |
| `physical_acc_id` (existing) | 824 |
| `chip_rev_id` (new) | 828 |
| `external_rev_id` (new) | 832 |
| `reserved[15]` | 836 |

Verified three ways: compiler `offsetof`, the regenerated ctypes wrapper, and the Rust `offset_of!` assertions. Both wrappers were regenerated with `tools/update_wrapper.sh` and `tools/update_rust_wrapper.sh`.

**Behavior change to an existing field.** Calling this out explicitly so it is not missed in review: `rev_id` was assigned from `dev_info` *before* the DRM query populated it, so every early-return path overwrote the not-supported value with a zero that reads like a real revision. `rev_id` now reports `N/A` on those paths instead of `0x0`. Callers that check the return status are unaffected, since those paths already return a non-success status.

To support that, `amdsmi_asic_info_t` is now reset through a single `init_asic_info_defaults()` shared by the DRM and WSL backends. This is required by the feature, not incidental: the WSL backend previously `memset` the struct to zero, which would have reported both new fields as a plausible `0x00` rather than `N/A`.

The Python binding seeds both new fields with the not-supported value before the call, so a newer wrapper running against an older `libamd_smi.so` (supported via the wheel's system-library fallback) reports `N/A` instead of the ctypes zero.

The three commits are split to be reviewed in order: the shared initializer and `rev_id` fix, then the two new fields across the cascade, then the tests.

## Issue Tracking

JIRA ID: ROCM-28626

## Test Plan

- Unit, hardware-free: pin struct size and both new offsets, and the reporting contract through the public Python entry point against a stubbed library (value passthrough, two-digit padding, `0xFFFFFFFF` to `N/A`, `0x0` staying a real value, and a library that predates the fields).
- Unit, C++: fill `amdsmi_asic_info_t` with garbage, call `init_asic_info_defaults()`, assert every field lands on its not-supported value.
- Functional, hardware: resolve each processor's render node, issue `AMDGPU_INFO_DEV_INFO` directly, and assert all three revisions match what `amdsmi_get_gpu_asic_info()` reports.
- CLI: assert both keys reach `--json`, and that the `--csv` column values match the JSON values.
- Build both the default configuration and `-DENABLE_WSL_BACKEND=ON`.

## Test Result

All green on a two-GPU Navi system (Navi 21 and Navi 32).

- Build: 0 errors in both configurations, no new warnings on touched lines.
- Tests: 15 Python tests and 2 gtests pass. `pre-commit` passes on every changed file.
- Each of the three commits builds independently.
- Values match the DRM ioctl exactly:

| Node | ASIC | `rev_id` | `chip_rev_id` | `external_rev_id` | vs ioctl |
|---|---|---|---|---|---|
| renderD128 | Navi 21 | `0xc3` | `0x00` | `0x28` | match |
| renderD129 | Navi 32 | `0xc8` | `0x00` | `0x20` | match |

Previously measured on other silicon: MI210 `chip_rev 0x01` / `external_rev 0x3d`, MI300A `0x01` / `0x47`, MI350 `0x00` / `0x50`.

The swap-detection test was validated by injecting a real `chip_rev_id`/`external_rev_id` swap into the interface: the new assertion failed as intended while the other tests passed, confirming it catches a defect the earlier equal-value test could not.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
