### PR TITLE
[rocjitsu] Set MI455X simulation revision to B0

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -360,7 +360,9 @@ jobs:
           ROCM_PATH="$(rocm-sdk path --root)"
           export ROCM_PATH
           LAUNCHER="${ROCJITSU_BUILD_DIR}/tools/rocjitsu/rocjitsu"
-          CONFIG="${ROCJITSU_SOURCE_DIR}/configs/gfx1250_mi455x.json"
+          B0_CONFIG="${ROCJITSU_SOURCE_DIR}/configs/gfx1250_mi455x.json"
+          A0_CONFIG="${RUNNER_TEMP}/gfx1250_mi455x_a0.json"
+          jq '.vm.gpu.device.revision_id = 0' "${B0_CONFIG}" > "${A0_CONFIG}"
           HOTSWAP="${ROCJITSU_BUILD_DIR}/lib/rocjitsu/src/rocjitsu/hooks/libhsa_hotswap_rocjitsu.so"
           test -f "${HOTSWAP}"
           # Disable ROCr's built-in mechanism in both legs. Load the branch-built
@@ -368,8 +370,8 @@ jobs:
           # every env option before the shared NAME=VALUE assignment.
           COMMON_UNSETS="-u LD_PRELOAD -u HSA_HOTSWAP_ENABLE"
           COMMON_HOTSWAP_ENV="HSA_HOTSWAP_DISABLE=1"
-          PLAIN_WRAPPER="env ${COMMON_UNSETS} -u HSA_TOOLS_LIB -u HSA_TOOLS_DISABLE_REGISTER -u HSA_HOTSWAP_VERBOSE ${COMMON_HOTSWAP_ENV} ${LAUNCHER} --config ${CONFIG} --"
-          TRANSLATED_WRAPPER="env ${COMMON_UNSETS} ${COMMON_HOTSWAP_ENV} HSA_TOOLS_DISABLE_REGISTER=1 HSA_TOOLS_LIB=${HOTSWAP} HSA_HOTSWAP_VERBOSE=1 ${LAUNCHER} --config ${CONFIG} --"
+          PLAIN_WRAPPER="env ${COMMON_UNSETS} -u HSA_TOOLS_LIB -u HSA_TOOLS_DISABLE_REGISTER -u HSA_HOTSWAP_VERBOSE ${COMMON_HOTSWAP_ENV} ${LAUNCHER} --config ${B0_CONFIG} --"
+          TRANSLATED_WRAPPER="env ${COMMON_UNSETS} ${COMMON_HOTSWAP_ENV} HSA_TOOLS_DISABLE_REGISTER=1 HSA_TOOLS_LIB=${HOTSWAP} HSA_HOTSWAP_VERBOSE=1 ${LAUNCHER} --config ${A0_CONFIG} --"
 
           python3 "${ROCJITSU_SOURCE_DIR}/tests/corpus/test-validate-gfx1250-semantic-translations.py"
 

--- a/emulation/rocjitsu/configs/gfx1250_mi455x.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x.json
@@ -12,6 +12,7 @@
         "device_id": 1250,
         "family_id": 0,
         "unique_id": 1250,
+        "revision_id": 1,
         "marketing_name": "AMD Instinct MI455X",
         "simd_count": 1024,
         "max_waves_per_simd": 16,

--- a/emulation/rocjitsu/tests/sysfs_test.cpp
+++ b/emulation/rocjitsu/tests/sysfs_test.cpp
@@ -217,6 +217,24 @@ TEST(SysfsTopologyDebugCapabilityTest, DefaultDebugPropMatchesHardware) {
   }
 }
 
+TEST(SysfsTopologyDebugCapabilityTest, Mi455xConfigPublishesB0AsicRevision) {
+  auto loaded = config::load_config(std::string(CONFIG_DIR) + "/gfx1250_mi455x.json",
+                                    rocjitsu::kEmbeddedSchema);
+  ASSERT_TRUE(loaded.device.present);
+  ASSERT_EQ(loaded.device.revision_id, 1u);
+
+  Sysfs sysfs;
+  std::string topology_dir = sysfs.generate(debug_gpu_info(loaded.device));
+  ASSERT_FALSE(topology_dir.empty());
+
+  auto props = read_properties(topology_dir + "/nodes/1/properties");
+  ASSERT_TRUE(props.count("capability"));
+  const uint32_t capability = static_cast<uint32_t>(props["capability"]);
+  const uint32_t asic_revision =
+      (capability & HSA_CAP_ASIC_REVISION_MASK) >> HSA_CAP_ASIC_REVISION_SHIFT;
+  EXPECT_EQ(asic_revision, loaded.device.revision_id);
+}
+
 // The address-watch register count is the one capability field a debugger acts
 // on numerically rather than as a flag: rocdbgapi recovers it as 1<<TOTALBITS
 // (os_driver_kfd.cpp) and refuses to insert more watchpoints than that. Every


### PR DESCRIPTION
The MI455X config omits its ASIC revision, so the FlatBuffers default reports revision zero through synthetic KFD topology. ROCr identifies gfx1250 revision zero as A0 and loads the B0-to-A0 HotSwap hook.

Set revision_id to 1 in gfx1250_mi455x.json so the simulated device reports B0. Add sysfs coverage that pins the configured value and the ASIC-revision capability bits exported to runtime clients.

The focused sysfs and topology suite passes 9/9, and a live rocminfo launch reports ASIC revision 1 without installing the HotSwap hook.