### PR TITLE
[rocjitsu] Require explicit SDMA queue counts in GPU configs

### DIFF
--- a/emulation/rocjitsu/configs/gfx1100_w7900.json
+++ b/emulation/rocjitsu/configs/gfx1100_w7900.json
@@ -37,6 +37,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 2,
         "num_sdma_xgmi_engines": 0,
+        "num_sdma_queues_per_engine": 6,
         "num_cp_queues": 8,
         "max_engine_clk_fcompute": 1760,
         "location_id": 58112,

--- a/emulation/rocjitsu/configs/gfx1151.json
+++ b/emulation/rocjitsu/configs/gfx1151.json
@@ -37,6 +37,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 1,
         "num_sdma_xgmi_engines": 0,
+        "num_sdma_queues_per_engine": 2,
         "num_cp_queues": 8,
         "max_engine_clk_fcompute": 2700,
         "location_id": 49920,

--- a/emulation/rocjitsu/configs/gfx1201_r9700.json
+++ b/emulation/rocjitsu/configs/gfx1201_r9700.json
@@ -37,6 +37,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 2,
         "num_sdma_xgmi_engines": 0,
+        "num_sdma_queues_per_engine": 6,
         "num_cp_queues": 4,
         "max_engine_clk_fcompute": 2350,
         "location_id": 49920,

--- a/emulation/rocjitsu/configs/gfx1250_mi455x.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x.json
@@ -29,6 +29,7 @@
         "l2_size_kb": 196608,
         "num_sdma_engines": 5,
         "num_sdma_xgmi_engines": 12,
+        "num_sdma_queues_per_engine": 2,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2700
       }

--- a/emulation/rocjitsu/configs/gfx1250_mi455x_kmd_4gpu.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x_kmd_4gpu.json
@@ -36,6 +36,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 5,
         "num_sdma_xgmi_engines": 12,
+        "num_sdma_queues_per_engine": 2,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2700,
         "location_id": 768,

--- a/emulation/rocjitsu/configs/gfx942_cdna3.json
+++ b/emulation/rocjitsu/configs/gfx942_cdna3.json
@@ -27,6 +27,7 @@
         "l2_size_kb": 4096,
         "num_sdma_engines": 4,
         "num_sdma_xgmi_engines": 6,
+        "num_sdma_queues_per_engine": 8,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2100,
         "capability": 2893521536,

--- a/emulation/rocjitsu/configs/gfx942_cdna3_kmd.json
+++ b/emulation/rocjitsu/configs/gfx942_cdna3_kmd.json
@@ -34,6 +34,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 4,
         "num_sdma_xgmi_engines": 6,
+        "num_sdma_queues_per_engine": 8,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2100
       }

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
@@ -33,6 +33,7 @@
       "l2_assoc": 16,
       "num_sdma_engines": 5,
       "num_sdma_xgmi_engines": 12,
+      "num_sdma_queues_per_engine": 8,
       "num_cp_queues": 128,
       "max_engine_clk_fcompute": 2400
     }

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
@@ -33,6 +33,7 @@
       "l2_assoc": 16,
       "num_sdma_engines": 5,
       "num_sdma_xgmi_engines": 12,
+      "num_sdma_queues_per_engine": 8,
       "num_cp_queues": 128,
       "max_engine_clk_fcompute": 2400
     }

--- a/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_simulated_gfx942.json
@@ -35,6 +35,7 @@
       "l2_assoc": 16,
       "num_sdma_engines": 5,
       "num_sdma_xgmi_engines": 12,
+      "num_sdma_queues_per_engine": 8,
       "num_cp_queues": 128,
       "max_engine_clk_fcompute": 2400
     }

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -118,14 +118,16 @@ Components are defined hierarchically under `topology.root`. Range
 expansion (`xcd[0:8]`) creates multiple instances. Links connect
 component ports using pattern expressions with loop variables.
 
-### KFD device section
+### KFD device sections
 
-KFD-mode configs include a `vm.gpu.device` section that defines the
-properties reported through the simulated sysfs topology (GPU ID,
-vendor/device IDs, CU counts, memory sizes, etc.). These must match
-the component hierarchy defined in `topology`. A device with one or more
-regular SDMA engines must explicitly set a nonzero
-`num_sdma_queues_per_engine` value.
+KFD device identity can be defined by `vm.gpu.device` for a simulated GPU and
+by `dbt_guest.guest_device` for a DBT guest. These sections define properties
+reported through the simulated sysfs topology (GPU ID, vendor/device IDs, CU
+counts, memory sizes, etc.). A simulated device's properties must match the
+component hierarchy defined in `topology`.
+
+In either device section, a device with one or more regular SDMA engines must
+explicitly set a nonzero `num_sdma_queues_per_engine` value.
 
 ## FlatBuffers schema
 

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -123,7 +123,9 @@ component ports using pattern expressions with loop variables.
 KFD-mode configs include a `vm.gpu.device` section that defines the
 properties reported through the simulated sysfs topology (GPU ID,
 vendor/device IDs, CU counts, memory sizes, etc.). These must match
-the component hierarchy defined in `topology`.
+the component hierarchy defined in `topology`. A device with one or more
+regular SDMA engines must explicitly set a nonzero
+`num_sdma_queues_per_engine` value.
 
 ## FlatBuffers schema
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace rocjitsu {
@@ -59,7 +60,9 @@ with_parsed_simulation_config_json(const std::string &json, const std::string &s
 /// @details This copies only scalar/string topology values. The resulting
 /// config owns its marketing-name string so it is safe after the FlatBuffers
 /// parser storage goes out of scope.
-inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device) {
+/// @param json_path JSON path of @p device, used in validation diagnostics.
+inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device,
+                                          std::string_view json_path) {
   KfdDeviceConfig config;
   if (device == nullptr)
     return config;
@@ -99,8 +102,9 @@ inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device) {
   config.num_sdma_xgmi_engines = device->num_sdma_xgmi_engines();
   config.num_sdma_queues_per_engine = device->num_sdma_queues_per_engine();
   if (config.num_sdma_engines != 0 && config.num_sdma_queues_per_engine == 0)
-    throw std::runtime_error(
-        "KFD device with regular SDMA engines requires nonzero num_sdma_queues_per_engine");
+    throw std::runtime_error(std::string(json_path) +
+                             ".num_sdma_queues_per_engine must be nonzero when " +
+                             std::string(json_path) + ".num_sdma_engines is nonzero");
   config.num_cp_queues = device->num_cp_queues();
   config.max_engine_clk_fcompute = device->max_engine_clk_fcompute();
   config.location_id = device->location_id();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -98,6 +98,9 @@ inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device) {
   config.num_sdma_engines = device->num_sdma_engines();
   config.num_sdma_xgmi_engines = device->num_sdma_xgmi_engines();
   config.num_sdma_queues_per_engine = device->num_sdma_queues_per_engine();
+  if (config.num_sdma_engines != 0 && config.num_sdma_queues_per_engine == 0)
+    throw std::runtime_error(
+        "KFD device with regular SDMA engines requires nonzero num_sdma_queues_per_engine");
   config.num_cp_queues = device->num_cp_queues();
   config.max_engine_clk_fcompute = device->max_engine_clk_fcompute();
   config.location_id = device->location_id();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -692,7 +692,7 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
 
   // Extract KFD device identity from vm.gpu.device if present.
   if (fb_config->vm() && fb_config->vm()->gpu() && fb_config->vm()->gpu()->device()) {
-    result.device = kfd_device_from_fb(fb_config->vm()->gpu()->device());
+    result.device = kfd_device_from_fb(fb_config->vm()->gpu()->device(), "vm.gpu.device");
   }
 
   result.dbt_guest = dbt_guest_from_fb(fb_config->dbt_guest());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -115,7 +115,7 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
     config.host.simulator_config_path = guest->simulator_config()->str();
   config.log_level = guest->log_level();
   config.signal_backtrace = guest->signal_backtrace();
-  config.guest_device = kfd_device_from_fb(guest->guest_device());
+  config.guest_device = kfd_device_from_fb(guest->guest_device(), "dbt_guest.guest_device");
   config.guest_revision = silicon_revision_from_fb(guest->guest_revision());
   config.host_revision = silicon_revision_from_fb(guest->host_revision());
   validate_guest_device_geometry(config.guest_device);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
@@ -51,7 +51,7 @@ struct KfdDeviceConfig {
   uint32_t l2_size_kb = 4096;                ///< L2 cache size in KiB.
   uint32_t l2_line_size = 128;               ///< L2 cache line size in bytes.
   uint32_t l2_assoc = 16;                    ///< L2 cache associativity.
-  uint32_t num_sdma_engines = 2;             ///< SDMA engine count.
+  uint32_t num_sdma_engines = 0;             ///< SDMA engine count.
   uint32_t num_sdma_xgmi_engines = 0;        ///< XGMI SDMA engine count.
   uint32_t num_cp_queues = 128;              ///< Hardware queue count.
   uint32_t max_engine_clk_fcompute = 2100;   ///< Maximum compute clock in MHz.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
@@ -62,10 +62,7 @@ struct KfdDeviceConfig {
   uint32_t capability2 = 0;                  ///< KFD debug capability2 bits, or 0 to derive.
   uint64_t debug_prop = 0;                   ///< KFD debug_prop bits, or 0 to derive.
   bool present = false;                      ///< True if device section existed in config.
-
-  // TODO(hanchung): Set this in every GPU config, reject zero when regular SDMA engines are
-  // present, and remove the legacy fallback.
-  uint32_t num_sdma_queues_per_engine = 2; ///< Regular SDMA queues; 2 preserves legacy configs.
+  uint32_t num_sdma_queues_per_engine = 0;   ///< Regular SDMA queues per engine.
 };
 
 } // namespace rocjitsu::config

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
@@ -71,7 +71,7 @@ public:
     uint32_t l2_assoc = 16;
 
     // Engines and queues
-    uint32_t num_sdma_engines = 2;
+    uint32_t num_sdma_engines = 0;
     uint32_t num_sdma_xgmi_engines = 0;
     uint32_t num_sdma_queues_per_engine = 0;
     uint32_t num_cp_queues = 128;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
@@ -73,8 +73,7 @@ public:
     // Engines and queues
     uint32_t num_sdma_engines = 2;
     uint32_t num_sdma_xgmi_engines = 0;
-    // TODO(hanchung): Remove this legacy fallback with the KfdDeviceConfig fallback.
-    uint32_t num_sdma_queues_per_engine = 2;
+    uint32_t num_sdma_queues_per_engine = 0;
     uint32_t num_cp_queues = 128;
     uint32_t max_engine_clk_fcompute = 2100; // MHz
 

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -109,11 +109,9 @@ table KfdDeviceInfo {
   capability2: uint32 = 0;
   debug_prop: uint64 = 0;
 
-  // Appended to preserve existing field IDs. The default retains rocJitsu's
-  // legacy synthetic-sysfs value; hardware-backed configs should override it.
-  // TODO(hanchung): Set this in every GPU config, reject zero when regular
-  // SDMA engines are present, and remove the legacy fallback.
-  num_sdma_queues_per_engine: uint32 = 2;
+  // Appended to preserve existing field IDs. Required to be nonzero when
+  // num_sdma_engines is nonzero.
+  num_sdma_queues_per_engine: uint32;
 }
 
 /// Top-level AMDGPU configuration.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -579,6 +579,7 @@ target_link_libraries(
         util
         flatbuffers
         Threads::Threads
+        GTest::gmock
         GTest::gtest_main
 )
 target_include_directories(rocjitsu_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -2630,6 +2631,11 @@ if(RJ_ENABLE_HIP_TESTS)
             ${CMAKE_CURRENT_BINARY_DIR}/daemon_logging_config.json
             @ONLY
         )
+        target_compile_definitions(
+            rocjitsu_tests
+            PRIVATE
+                RJ_DAEMON_LOGGING_CONFIG_PATH="${CMAKE_CURRENT_BINARY_DIR}/daemon_logging_config.json"
+        )
         if(RJ_INSTALL_TESTS)
             install(
                 FILES ${CMAKE_CURRENT_BINARY_DIR}/daemon_logging_config.json
@@ -2857,6 +2863,12 @@ if(RJ_ENABLE_HIP_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/logging/logging_test_config.json.in
             ${LOGGING_INSTALLED_CONFIG}
             @ONLY
+        )
+        target_compile_definitions(
+            rocjitsu_tests
+            PRIVATE
+                RJ_LOGGING_CONFIG_PATH="${LOGGING_SINK_DIR}/config.json"
+                RJ_INSTALLED_LOGGING_CONFIG_PATH="${LOGGING_INSTALLED_CONFIG}"
         )
         if(RJ_INSTALL_TESTS)
             install(

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -27,6 +27,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
 RJ_DIAGNOSTIC_POP
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -487,8 +488,45 @@ TEST(ConfigLoaderTest, RejectsMissingOrZeroSdmaQueuesWhenRegularEnginesArePresen
       }
     })");
 
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(missing.path()), std::runtime_error);
-  EXPECT_THROW(config::load_dbt_guest_config_from_file(zero.path()), std::runtime_error);
+  for (const auto &path : {missing.path(), zero.path()})
+    EXPECT_THAT([&] { (void)config::load_dbt_guest_config_from_file(path); },
+                testing::ThrowsMessage<std::runtime_error>(
+                    testing::AllOf(testing::HasSubstr("dbt_guest.guest_device."),
+                                   testing::HasSubstr("num_sdma_queues_per_engine"))));
+}
+
+TEST(ConfigLoaderTest, SdmaQueueValidationIdentifiesVmDevicePath) {
+  const char *json = R"({
+    "max_ticks": 1,
+    "num_threads": 1,
+    "vm": {
+      "arch": "cdna3",
+      "gpu": { "device": { "num_sdma_engines": 1 } }
+    },
+    "topology": {
+      "root": {
+        "name": "soc", "type": "soc",
+        "children": [
+          { "name": "vram", "type": "gpu_memory" },
+          {
+            "name": "xcd0", "type": "xcd",
+            "children": [
+              { "name": "l2", "type": "l2_cache" },
+              { "name": "cp", "type": "command_processor" },
+              { "name": "se0", "type": "shader_engine",
+                "children": [{ "name": "cu0", "type": "compute_unit" }] }
+            ]
+          }
+        ]
+      },
+      "links": []
+    }
+  })";
+
+  EXPECT_THAT(
+      [&] { (void)config::load_config_from_string(json, rocjitsu::kEmbeddedSchema); },
+      testing::ThrowsMessage<std::runtime_error>(testing::AllOf(
+          testing::HasSubstr("vm.gpu.device."), testing::HasSubstr("num_sdma_queues_per_engine"))));
 }
 
 TEST(ConfigLoaderTest, AllowsZeroSdmaQueuesWithoutRegularEngines) {
@@ -506,6 +544,13 @@ TEST(ConfigLoaderTest, AllowsZeroSdmaQueuesWithoutRegularEngines) {
   ASSERT_TRUE(dbt.guest_device.present);
   EXPECT_EQ(dbt.guest_device.num_sdma_engines, 0u);
   EXPECT_EQ(dbt.guest_device.num_sdma_queues_per_engine, 0u);
+}
+
+TEST(ConfigLoaderTest, DefaultKfdDeviceHasNoRegularSdmaEngines) {
+  const config::KfdDeviceConfig device;
+
+  EXPECT_EQ(device.num_sdma_engines, 0u);
+  EXPECT_EQ(device.num_sdma_queues_per_engine, 0u);
 }
 
 TEST(ConfigLoaderTest, ShippedDevicesDeclareSdmaQueues) {
@@ -532,6 +577,25 @@ TEST(ConfigLoaderTest, ShippedDevicesDeclareSdmaQueues) {
 
   EXPECT_GE(checked, 12u) << "expected every shipped device config to be discovered";
 }
+
+#if defined(RJ_DAEMON_LOGGING_CONFIG_PATH) && defined(RJ_LOGGING_CONFIG_PATH) &&                   \
+    defined(RJ_INSTALLED_LOGGING_CONFIG_PATH)
+TEST(ConfigLoaderTest, GeneratedDeviceConfigsDeclareSdmaQueues) {
+  const std::string paths[] = {
+      RJ_DAEMON_LOGGING_CONFIG_PATH,
+      RJ_LOGGING_CONFIG_PATH,
+      RJ_INSTALLED_LOGGING_CONFIG_PATH,
+  };
+
+  for (const std::string &path : paths) {
+    SCOPED_TRACE(path);
+    auto loaded = config::load_config(path, rocjitsu::kEmbeddedSchema);
+    ASSERT_TRUE(loaded.device.present);
+    ASSERT_NE(loaded.device.num_sdma_engines, 0u);
+    EXPECT_NE(loaded.device.num_sdma_queues_per_engine, 0u);
+  }
+}
+#endif
 
 TEST(ConfigLoaderTest, ShippedGfx950GuestsUseCapturedSdmaQueueCount) {
   unsigned checked = 0;

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -99,6 +99,7 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
   // The part exposes 256 active CUs through simd_count but has capacity for 288.
   EXPECT_EQ(soc->num_xcds(), 8u);
   EXPECT_EQ(soc->num_iods(), 2u);
+  EXPECT_EQ(loaded.device.num_sdma_queues_per_engine, 8u);
   auto *xcd = soc->xcd(0);
   EXPECT_EQ(xcd->num_shader_engines(), 4u);
   EXPECT_EQ(xcd->shader_engine(0)->num_compute_units(), 9u);
@@ -160,6 +161,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna4.device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(rdna4.device.num_cu_per_sh, 8u);
   EXPECT_EQ(rdna4.device.simd_per_cu, 2u);
+  EXPECT_EQ(rdna4.device.num_sdma_queues_per_engine, 6u);
   EXPECT_EQ(rdna4.device.vram_type, kmd::kAmdgpuVramTypeGddr6);
   EXPECT_EQ(rdna4.device.simd_count, rdna4.device.num_shader_engines *
                                          rdna4.device.num_shader_arrays_per_engine *
@@ -206,6 +208,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna3.device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(rdna3.device.num_cu_per_sh, 8u);
   EXPECT_EQ(rdna3.device.simd_per_cu, 2u);
+  EXPECT_EQ(rdna3.device.num_sdma_queues_per_engine, 6u);
   EXPECT_EQ(rdna3.device.vram_type, kmd::kAmdgpuVramTypeGddr6);
   EXPECT_EQ(rdna3.device.simd_count, rdna3.device.num_shader_engines *
                                          rdna3.device.num_shader_arrays_per_engine *
@@ -240,6 +243,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna35.device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(rdna35.device.num_cu_per_sh, 8u);
   EXPECT_EQ(rdna35.device.simd_per_cu, 2u);
+  EXPECT_EQ(rdna35.device.num_sdma_queues_per_engine, 2u);
   EXPECT_EQ(rdna35.device.vram_type, kmd::kAmdgpuVramTypeGddr6);
   EXPECT_EQ(rdna35.device.simd_count, rdna35.device.num_shader_engines *
                                           rdna35.device.num_shader_arrays_per_engine *
@@ -338,7 +342,10 @@ TEST(ConfigLoaderTest, DeviceCapabilityFieldsDefaultToAutoCompute) {
     "num_threads": 1,
     "vm": {
       "arch": "cdna3",
-      "gpu": { "device": { "gfx_target_version": 90500 } }
+      "gpu": { "device": {
+        "gfx_target_version": 90500,
+        "num_sdma_queues_per_engine": 8
+      } }
     },
     "topology": {
       "root": {
@@ -377,6 +384,7 @@ TEST(ConfigLoaderTest, DeviceCapabilityFieldsRoundTripFromJson) {
       "arch": "cdna3",
       "gpu": { "device": {
         "gfx_target_version": 90500,
+        "num_sdma_queues_per_engine": 8,
         "capability": 268468354,
         "capability2": 3,
         "debug_prop": 3119
@@ -431,7 +439,8 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
           "num_shader_engines": 2,
           "num_shader_arrays_per_engine": 2,
           "num_cu_per_sh": 4,
-          "local_mem_size": 309237645312
+          "local_mem_size": 309237645312,
+          "num_sdma_queues_per_engine": 8
         }
       }
     })");
@@ -455,9 +464,94 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
                 dbt.guest_device.num_cu_per_sh * dbt.guest_device.simd_per_cu);
   EXPECT_EQ(dbt.guest_device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(dbt.guest_device.local_mem_size, 309237645312ULL);
+  EXPECT_EQ(dbt.guest_device.num_sdma_queues_per_engine, 8u);
   // Revisions default to Unspecified when the config omits them.
   EXPECT_EQ(dbt.guest_revision, config::DbtSiliconRevision::Unspecified);
   EXPECT_EQ(dbt.host_revision, config::DbtSiliconRevision::Unspecified);
+}
+
+TEST(ConfigLoaderTest, RejectsMissingOrZeroSdmaQueuesWhenRegularEnginesArePresent) {
+  const auto missing = write_temp_config(R"({
+      "dbt_guest": {
+        "guest_device": {
+          "num_sdma_engines": 1
+        }
+      }
+    })");
+  const auto zero = write_temp_config(R"({
+      "dbt_guest": {
+        "guest_device": {
+          "num_sdma_engines": 1,
+          "num_sdma_queues_per_engine": 0
+        }
+      }
+    })");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(missing.path()), std::runtime_error);
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(zero.path()), std::runtime_error);
+}
+
+TEST(ConfigLoaderTest, AllowsZeroSdmaQueuesWithoutRegularEngines) {
+  const auto file = write_temp_config(R"({
+      "dbt_guest": {
+        "guest_device": {
+          "num_sdma_engines": 0,
+          "num_sdma_queues_per_engine": 0
+        }
+      }
+    })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(file.path());
+
+  ASSERT_TRUE(dbt.guest_device.present);
+  EXPECT_EQ(dbt.guest_device.num_sdma_engines, 0u);
+  EXPECT_EQ(dbt.guest_device.num_sdma_queues_per_engine, 0u);
+}
+
+TEST(ConfigLoaderTest, ShippedDevicesDeclareSdmaQueues) {
+  unsigned checked = 0;
+  for (const auto &entry : std::filesystem::directory_iterator(CONFIG_DIR_PATH)) {
+    if (entry.path().extension() != ".json")
+      continue;
+
+    const std::string name = entry.path().filename().string();
+    SCOPED_TRACE(name);
+    if (name.rfind("guest_", 0) == 0) {
+      auto dbt = config::load_dbt_guest_config_from_file(entry.path().string());
+      ASSERT_TRUE(dbt.guest_device.present);
+      ASSERT_NE(dbt.guest_device.num_sdma_engines, 0u);
+      EXPECT_NE(dbt.guest_device.num_sdma_queues_per_engine, 0u);
+    } else {
+      auto loaded = config::load_config(entry.path().string(), rocjitsu::kEmbeddedSchema);
+      ASSERT_TRUE(loaded.device.present);
+      ASSERT_NE(loaded.device.num_sdma_engines, 0u);
+      EXPECT_NE(loaded.device.num_sdma_queues_per_engine, 0u);
+    }
+    ++checked;
+  }
+
+  EXPECT_GE(checked, 12u) << "expected every shipped device config to be discovered";
+}
+
+TEST(ConfigLoaderTest, ShippedGfx950GuestsUseCapturedSdmaQueueCount) {
+  unsigned checked = 0;
+  for (const auto &entry : std::filesystem::directory_iterator(CONFIG_DIR_PATH)) {
+    if (entry.path().extension() != ".json" ||
+        entry.path().filename().string().rfind("guest_", 0) != 0)
+      continue;
+
+    auto dbt = config::load_dbt_guest_config_from_file(entry.path().string());
+    if (dbt.guest_isa != "gfx950")
+      continue;
+
+    SCOPED_TRACE(entry.path().filename().string());
+    ASSERT_TRUE(dbt.guest_device.present);
+    EXPECT_EQ(dbt.guest_device.device_id, 30112u);
+    EXPECT_EQ(dbt.guest_device.num_sdma_queues_per_engine, 8u);
+    ++checked;
+  }
+
+  EXPECT_GE(checked, 3u) << "expected every shipped gfx950 guest config to be discovered";
 }
 
 TEST(ConfigLoaderTest, LoadsDbtGuestSiliconRevisions) {
@@ -496,7 +590,8 @@ TEST(ConfigLoaderTest, RejectsDbtGuestDeviceWithInconsistentSimdCount) {
           "simd_count": 1024,
           "num_shader_engines": 4,
           "num_cu_per_sh": 4,
-          "simd_per_cu": 4
+          "simd_per_cu": 4,
+          "num_sdma_queues_per_engine": 8
         }
       }
     })");
@@ -531,7 +626,8 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
         "num_shader_engines": 2,
         "num_shader_arrays_per_engine": 2,
         "num_cu_per_sh": 4,
-        "local_mem_size": 309237645312
+        "local_mem_size": 309237645312,
+        "num_sdma_queues_per_engine": 8
       }
     },
   )");

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -813,7 +813,8 @@ struct PluginFixture {
                          uint32_t wavefront_size = 64, uint32_t sgprs_per_wf = 104) {
     std::string json = std::format(R"({{
       "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
-      "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{}}}}}}},
+      "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{},
+        "num_sdma_engines":0}}}}}},
       "topology":{{"root":{{"name":"soc","type":"soc","children":[
         {{"name":"vram","type":"gpu_memory"}},
         {{"name":"xcd0","type":"xcd","children":[

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -133,6 +133,7 @@ bool install_inline_dbt_config(std::string simulator_json, const char *host_isa,
       "simd_per_cu": 4,
       "wave_front_size": 64,
       "max_slots_scratch_cu": 32,
+      "num_sdma_queues_per_engine": 2,
       "lds_size_kb": )"
               << lds_size_kb << R"(
     }

--- a/emulation/rocjitsu/tests/logging/logging_test_config.json.in
+++ b/emulation/rocjitsu/tests/logging/logging_test_config.json.in
@@ -34,6 +34,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 5,
         "num_sdma_xgmi_engines": 12,
+        "num_sdma_queues_per_engine": 8,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2400
       }

--- a/emulation/rocjitsu/tests/race-detector/race_test_config.json
+++ b/emulation/rocjitsu/tests/race-detector/race_test_config.json
@@ -34,6 +34,7 @@
         "l2_assoc": 16,
         "num_sdma_engines": 5,
         "num_sdma_xgmi_engines": 12,
+        "num_sdma_queues_per_engine": 2,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2400
       }

--- a/emulation/rocjitsu/tests/sysfs_test.cpp
+++ b/emulation/rocjitsu/tests/sysfs_test.cpp
@@ -341,6 +341,7 @@ TEST(SysfsTopologyGeometryTest, ArrayCountIsScaledByNumXcc) {
     // so a pair that disagrees reports one part two ways.
     EXPECT_EQ(props["simd_count"], 1216u);
     EXPECT_EQ(props["simd_per_cu"], 4u);
+    EXPECT_EQ(props["num_sdma_queues_per_engine"], 8u);
 
     // What libhsakmt derives from those: NumShaderBanks = array_count /
     // simd_arrays_per_engine, i.e. the node's total shader engines.

--- a/emulation/rocjitsu/tests/sysfs_test.cpp
+++ b/emulation/rocjitsu/tests/sysfs_test.cpp
@@ -69,6 +69,18 @@ Sysfs::GpuInfo make_gpu_info(uint32_t gfx_target_version) {
   return gpu;
 }
 
+TEST(SysfsTopologyTest, DefaultGpuInfoHasCoherentSdmaCounts) {
+  Sysfs sysfs;
+  std::string topology_dir = sysfs.generate(make_gpu_info(90500u /* gfx950 */));
+  ASSERT_FALSE(topology_dir.empty());
+
+  auto props = read_properties(topology_dir + "/nodes/1/properties");
+  ASSERT_TRUE(props.count("num_sdma_engines"));
+  ASSERT_TRUE(props.count("num_sdma_queues_per_engine"));
+  EXPECT_EQ(props["num_sdma_engines"], 0u);
+  EXPECT_EQ(props["num_sdma_queues_per_engine"], 0u);
+}
+
 // Golden per-GFXIP expectations. Each row mirrors what
 // kfd_topology_set_capabilities() in drivers/gpu/drm/amd/amdkfd/kfd_topology.c
 // programs for the corresponding GC hardware IP version. The watch-mask lo/hi


### PR DESCRIPTION
The MI350X topology update introduced num_sdma_queues_per_engine with
a default of 2 so configs outside that change's scope would continue
to load. That fallback can silently publish an incorrect KFD topology
for devices whose hardware reports a different queue count.

Make the value explicit in every shipped VM and DBT guest device
config. Use captured KFD topology where it is available, and preserve
the previous value only for synthetic configurations without a
hardware capture:

| Config group | Queues/engine | Source |
| --- | ---: | --- |
| `gfx1100_w7900` | 6 | Captured W7900 KFD value |
| `gfx1201_r9700` | 6 | Captured R9700 KFD value |
| `gfx942_cdna3{,_kmd}` | 8 | Captured MI300X KFD value |
| `guest_gfx950_on_*` | 8 | Captured MI350X KFD value, matched by device ID |
| `gfx950_mi355x{,_kmd,_kmd_2gpu}` | 8 | Captured MI350X KFD value, already explicit |
| `gfx1151` | 2 | Legacy synthetic value |
| `gfx1250_mi455x` | 2 | Legacy synthetic value |
| `race_test_config` | 2 | Legacy test-fixture value |

The gfx950 DBT guest configs expose the captured MI350X device ID, so
use its queue count of 8 instead of materializing the legacy default.
The other pre-existing guest topology fields remain unchanged.

Remove the schema and runtime fallbacks, and reject device configs that
declare regular SDMA engines without a nonzero queue count. Add
regression coverage for missing and zero values, require every shipped
device config to declare the field, and pin the captured queue count for
shipped gfx950 guests.


This is a follow-up of https://github.com/ROCm/rocm-systems/commit/b05a587f893a28ac51ab6ccbd39468c7cfa99eb8

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
