### PR TITLE
[rocjitsu] Add wave instruction throughput plugin

### DIFF
--- a/emulation/rocjitsu/docs/plugins.md
+++ b/emulation/rocjitsu/docs/plugins.md
@@ -10,9 +10,58 @@ wavefront dispatches, memory instructions, register reads, barriers, etc.
 |---|---|---|
 | `RaceDetectorPlugin` | `race_detector/` | Hooks memory instructions, register reads, barriers, and `s_waitcnt` to detect data races. Reports violations with disassembly traces. See [race-detector.md](race-detector.md). |
 | `KernelLoggingPlugin` | `logging/` | Logs kernel dispatches and detects MMA instruction usage. |
+| `ThroughputPlugin` | `throughput/` | Reports per-dispatch and aggregate wave-instruction MIPS with an exclusive instruction-family breakdown. |
 
 The race detector plugin contains both the core detection algorithm
 (`race_detector/core/`) and the rocjitsu adapter (`race_detector/plugin.h`).
+
+### Throughput Plugin
+
+The throughput plugin counts one instruction whenever a wavefront reaches the
+before-execute hook. Counts are therefore executed **wave instructions**, not
+active-lane operations. It reports one JSON object per completed dispatch and
+one aggregate object at shutdown using the `rocjitsu.throughput.v2` JSONL
+schema. Each object contains wall time, total wave instructions, MIPS, and an
+exclusive breakdown into `scalar`, `vector`, `matrix`, `lds`, `global`,
+`control`, and `other`; the family counts always sum to the total. Each family
+reports `execution_seconds` measured between this plugin's before- and
+after-execute callbacks, `execution_mips` using only that family-local time, and
+`dispatch_mips` using the complete dispatch time. Scheduler gaps, dispatch
+setup, runtime work, and time spent executing other families are not included
+in `execution_seconds`. Program terminators close their interval in the
+wave-halt hook because they intentionally have no after-execute callback.
+When other execution plugins are enabled, their before/after hooks can fall
+inside this interval depending on registration order; run `throughput` alone
+when comparing family timing. The timestamps themselves are outside the
+measured interval but still add observer overhead to the run.
+
+For a summary record, `wall_seconds` is the inclusive span from the earliest
+dispatch begin to the latest dispatch end, including idle gaps between
+dispatches. `dispatch_seconds_sum` is the sum of completed dispatch durations.
+Dispatches that never reach the execution-end callback are omitted from both
+per-dispatch output and the summary.
+
+Memory instructions take precedence over their scalar or vector encoding. The
+`lds` and `global` families describe the instruction's pre-routing pipeline tag
+or mnemonic fallback: `lds` covers DS/local-memory instructions, while
+`global` covers global, scalar-memory, flat, buffer, image, and scratch
+instructions. A later shared-aperture FLAT-to-LDS remap is therefore still
+reported as `global`. Their `execution_seconds` measure synchronous instruction
+execution/address generation, not later routing, deferred pipeline completion,
+or stalls charged to wait instructions. Matrix includes MFMA, SMFMAC, WMMA,
+and SWMMAC instructions. Control covers branches, waits, barriers, termination,
+no-ops, sleeps, and delays.
+
+For a machine-readable report:
+
+```json
+{
+  "plugins": { "throughput": {} },
+  "sinks": { "types": ["file"], "dir": "/tmp/rocjitsu-throughput" }
+}
+```
+
+The report is written to `/tmp/rocjitsu-throughput/throughput.log`.
 
 ### Kernel Logging Plugin
 
@@ -41,13 +90,14 @@ plugin's configuration:
 {
   "plugins": {
     "race": {},
-    "logging": {}
+    "logging": {},
+    "throughput": {}
   }
 }
 ```
 
-The bundled plugins are `race` (`RaceDetectorPlugin`) and `logging`
-(`KernelLoggingPlugin`).
+The bundled plugins are `race` (`RaceDetectorPlugin`), `logging`
+(`KernelLoggingPlugin`), and `throughput` (`ThroughputPlugin`).
 
 ### Enabling plugins from the mirage CLI
 
@@ -111,8 +161,8 @@ and passes the resolved JSON object to `rocjitsu_plugin_create`.
 
 ## Plugin output
 
-Plugins write diagnostic output (race reports and kernel logs) through a
-configurable sink system rather than directly to stderr.
+Plugins write reports and logs through a configurable sink system rather than
+directly to stderr.
 This makes output testable and redirectable.
 
 ### Sink configuration
@@ -128,7 +178,8 @@ sink-related environment variables.
 
 When `file` is in `types`, each plugin writes to
 `<dir>/<plugin_name>.log`. Plugin names are fixed:
-`race` for `RaceDetectorPlugin`, `logging` for `KernelLoggingPlugin`.
+`race` for `RaceDetectorPlugin`, `logging` for `KernelLoggingPlugin`, and
+`throughput` for `ThroughputPlugin`.
 
 ### Examples
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/CMakeLists.txt
@@ -17,6 +17,11 @@ rj_add_object_library(
     race_detector/core/wave_race_state.cpp
 )
 
+rj_add_object_library(
+    rocjitsu_plugin_throughput
+    throughput/plugin.cpp
+)
+
 # Host-side loader: discovers and dlopen()s plugin shared objects named in the
 # config file. Linked into the interposer and main shared library.
 rj_add_object_library(
@@ -105,5 +110,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     )
     rj_add_plugin_so(race rocjitsu_plugin_race_detector
         ${CMAKE_CURRENT_SOURCE_DIR}/race_detector/plugin_export.cpp
+    )
+    rj_add_plugin_so(throughput rocjitsu_plugin_throughput
+        ${CMAKE_CURRENT_SOURCE_DIR}/throughput/plugin_export.cpp
     )
 endif()

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.cpp
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/plugins/throughput/plugin.h"
+
+#include "rocjitsu/vm/amdgpu/mem_state.h"
+
+#include <algorithm>
+#include <format>
+#include <memory>
+#include <string>
+
+namespace rocjitsu::plugins::throughput {
+namespace {
+
+constexpr size_t family_index(InstructionFamily family) { return static_cast<size_t>(family); }
+
+bool has_prefix(std::string_view mnemonic, std::string_view prefix) {
+  return mnemonic.starts_with(prefix);
+}
+
+std::string json_escape(std::string_view value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  constexpr char hex[] = "0123456789abcdef";
+  for (const unsigned char c : value) {
+    switch (c) {
+    case '\"':
+      escaped += "\\\"";
+      break;
+    case '\\':
+      escaped += "\\\\";
+      break;
+    case '\b':
+      escaped += "\\b";
+      break;
+    case '\f':
+      escaped += "\\f";
+      break;
+    case '\n':
+      escaped += "\\n";
+      break;
+    case '\r':
+      escaped += "\\r";
+      break;
+    case '\t':
+      escaped += "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        escaped += "\\u00";
+        escaped += hex[c >> 4];
+        escaped += hex[c & 0xf];
+      } else {
+        escaped += static_cast<char>(c);
+      }
+    }
+  }
+  return escaped;
+}
+
+double seconds_between(std::chrono::steady_clock::time_point begin,
+                       std::chrono::steady_clock::time_point end) {
+  return std::chrono::duration<double>(end - begin).count();
+}
+
+double mips(uint64_t instructions, double seconds) {
+  return seconds > 0.0 ? static_cast<double>(instructions) / seconds / 1.0e6 : 0.0;
+}
+
+double nanoseconds_to_seconds(uint64_t nanoseconds) {
+  return static_cast<double>(nanoseconds) / 1.0e9;
+}
+
+} // namespace
+
+ThroughputPlugin::ThroughputPlugin(const char * /*config_json*/) : ExecutionPlugin("throughput") {}
+
+ThroughputPlugin::~ThroughputPlugin() { onShutdown(); }
+
+InstructionFamily ThroughputPlugin::classify(const Instruction &inst) {
+  const std::string_view mnemonic = inst.mnemonic();
+
+  if (inst.is_mfma() || has_prefix(mnemonic, "v_mfma_") || has_prefix(mnemonic, "v_smfmac_") ||
+      has_prefix(mnemonic, "v_wmma_") || has_prefix(mnemonic, "v_swmmac_"))
+    return InstructionFamily::Matrix;
+
+  if (inst.is_memory_op()) {
+    if (const auto *state = inst.data()) {
+      if (state->tag() == amdgpu::LOCAL_MEM)
+        return InstructionFamily::Lds;
+      if (state->tag() == amdgpu::GLOBAL_MEM || state->tag() == amdgpu::SCALAR_MEM)
+        return InstructionFamily::Global;
+    }
+
+    // These fallbacks keep synthetic/model-only instructions useful even when
+    // they do not carry execution-pipeline state.
+    if (has_prefix(mnemonic, "ds_"))
+      return InstructionFamily::Lds;
+    return InstructionFamily::Global;
+  }
+
+  constexpr uint64_t control_flags = BRANCH | COND_BRANCH | INDIRECT_BRANCH | INDIRECT_CALL |
+                                     PROGRAM_TERMINATOR | WAITCNT | BARRIER;
+  if ((inst.flags() & control_flags) != 0 || has_prefix(mnemonic, "s_nop") ||
+      has_prefix(mnemonic, "s_sleep") || has_prefix(mnemonic, "s_delay"))
+    return InstructionFamily::Control;
+  if (has_prefix(mnemonic, "s_"))
+    return InstructionFamily::Scalar;
+  if (has_prefix(mnemonic, "v_"))
+    return InstructionFamily::Vector;
+  return InstructionFamily::Other;
+}
+
+std::string_view ThroughputPlugin::family_name(InstructionFamily family) {
+  constexpr std::array<std::string_view, kInstructionFamilyCount> names = {
+      "scalar", "vector", "matrix", "lds", "global", "control", "other"};
+  const size_t index = family_index(family);
+  return index < names.size() ? names[index] : "other";
+}
+
+uint64_t ThroughputPlugin::total(const InstructionCounts &counts) {
+  uint64_t result = 0;
+  for (const uint64_t count : counts)
+    result += count;
+  return result;
+}
+
+void ThroughputPlugin::add(InstructionCounts &destination, const InstructionCounts &source) {
+  for (size_t i = 0; i < destination.size(); ++i)
+    destination[i] += source[i];
+}
+
+void ThroughputPlugin::finish_instruction(ThroughputWavefrontState &state, Clock::time_point end) {
+  if (!state.instruction_active)
+    return;
+  const auto elapsed =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - state.instruction_begin).count();
+  if (elapsed > 0)
+    state.execution_nanoseconds[family_index(state.active_family)] +=
+        static_cast<uint64_t>(elapsed);
+  state.instruction_active = false;
+}
+
+void ThroughputPlugin::onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) {
+  dispatches_[info.dispatch_id].info = info;
+}
+
+void ThroughputPlugin::onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) {
+  auto &state = dispatches_[dispatch_id];
+  state.info.dispatch_id = dispatch_id;
+  state.begin = Clock::now();
+  state.begun = true;
+}
+
+void ThroughputPlugin::onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) {
+  wf.set_plugin_state(slot_index(), std::make_unique<ThroughputWavefrontState>());
+}
+
+void ThroughputPlugin::onAmdgpuBeforeExecuteInstruction(uint64_t /*pc*/, const Instruction &inst,
+                                                        amdgpu::Wavefront &wf) {
+  auto *state = static_cast<ThroughputWavefrontState *>(wf.plugin_state(slot_index()));
+  const InstructionFamily family = classify(inst);
+  ++state->counts[family_index(family)];
+  state->active_family = family;
+  // Start after classification and accounting so their profiler cost is not
+  // charged to the simulated instruction.
+  state->instruction_begin = Clock::now();
+  state->instruction_active = true;
+}
+
+void ThroughputPlugin::onAmdgpuAfterExecuteInstruction(uint64_t /*pc*/,
+                                                       const Instruction & /*inst*/,
+                                                       amdgpu::Wavefront &wf) {
+  const Clock::time_point end = Clock::now();
+  auto *state = static_cast<ThroughputWavefrontState *>(wf.plugin_state(slot_index()));
+  finish_instruction(*state, end);
+}
+
+void ThroughputPlugin::onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) {
+  const Clock::time_point end = Clock::now();
+  auto *state = static_cast<ThroughputWavefrontState *>(wf.plugin_state(slot_index()));
+  // Program terminators intentionally have no after-execute callback.
+  finish_instruction(*state, end);
+  auto &dispatch = dispatches_[wf.dispatch_id()];
+  add(dispatch.counts, state->counts);
+  add(dispatch.execution_nanoseconds, state->execution_nanoseconds);
+}
+
+void ThroughputPlugin::onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) {
+  const Clock::time_point end = Clock::now();
+  auto iter = dispatches_.find(dispatch_id);
+  if (iter == dispatches_.end())
+    return;
+
+  DispatchState &state = iter->second;
+  const double wall_seconds = state.begun ? seconds_between(state.begin, end) : 0.0;
+  emit_record("dispatch", &state.info, state.counts, state.execution_nanoseconds, wall_seconds);
+
+  add(aggregate_counts_, state.counts);
+  add(aggregate_execution_nanoseconds_, state.execution_nanoseconds);
+  dispatch_seconds_sum_ += wall_seconds;
+  ++completed_dispatches_;
+  if (!have_active_window_) {
+    first_begin_ = state.begun ? state.begin : end;
+    have_active_window_ = true;
+  } else if (state.begun) {
+    first_begin_ = std::min(first_begin_, state.begin);
+  }
+  last_end_ = std::max(last_end_, end);
+  dispatches_.erase(iter);
+}
+
+void ThroughputPlugin::onShutdown() {
+  if (summary_emitted_)
+    return;
+  summary_emitted_ = true;
+  const double wall_seconds = have_active_window_ ? seconds_between(first_begin_, last_end_) : 0.0;
+  emit_record("summary", nullptr, aggregate_counts_, aggregate_execution_nanoseconds_, wall_seconds,
+              dispatch_seconds_sum_);
+}
+
+void ThroughputPlugin::emit_record(std::string_view record, const KernelDispatchInfo *info,
+                                   const InstructionCounts &counts,
+                                   const InstructionNanoseconds &execution_nanoseconds,
+                                   double wall_seconds, double dispatch_seconds_sum) {
+  const uint64_t instruction_count = total(counts);
+  std::string output =
+      std::format("{{\"schema\":\"rocjitsu.throughput.v2\",\"record\":\"{}\"", record);
+  if (info) {
+    output += std::format(",\"dispatch_id\":{},\"kernel_name\":\"{}\",\"kernel_symbol\":\"{}\""
+                          ",\"grid\":[{},{},{}],\"workgroup\":[{},{},{}],\"workgroups\":{}"
+                          ",\"waves_per_workgroup\":{}",
+                          info->dispatch_id, json_escape(info->kernelNameOrUnknown()),
+                          json_escape(info->kernelSymbolOrUnknown()), info->grid_size_x,
+                          info->grid_size_y, info->grid_size_z, info->workgroup_size_x,
+                          info->workgroup_size_y, info->workgroup_size_z, info->workgroup_count,
+                          info->wfs_per_workgroup);
+  } else {
+    output += std::format(",\"dispatches\":{},\"dispatch_seconds_sum\":{:.9g}",
+                          completed_dispatches_, dispatch_seconds_sum);
+  }
+  output += std::format(",\"wall_seconds\":{:.9g},\"wave_instructions\":{},\"mips\":{:.9g}"
+                        ",\"families\":{{",
+                        wall_seconds, instruction_count, mips(instruction_count, wall_seconds));
+
+  for (size_t i = 0; i < counts.size(); ++i) {
+    if (i != 0)
+      output += ',';
+    const double execution_seconds = nanoseconds_to_seconds(execution_nanoseconds[i]);
+    output +=
+        std::format("\"{}\":{{\"instructions\":{},\"execution_seconds\":{:.9g},"
+                    "\"execution_mips\":{:.9g},\"dispatch_mips\":{:.9g}}}",
+                    family_name(static_cast<InstructionFamily>(i)), counts[i], execution_seconds,
+                    mips(counts[i], execution_seconds), mips(counts[i], wall_seconds));
+  }
+  output += "}}\n";
+  sink().write(output);
+}
+
+} // namespace rocjitsu::plugins::throughput

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocjitsu/vm/plugins/execution_plugin.h"
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <unordered_map>
+
+namespace rocjitsu::plugins::throughput {
+
+/// Exclusive instruction families used by the throughput report. The order is
+/// part of the JSONL schema and should remain stable.
+enum class InstructionFamily : size_t {
+  Scalar,
+  Vector,
+  Matrix,
+  Lds,
+  Global,
+  Control,
+  Other,
+  Count,
+};
+
+inline constexpr size_t kInstructionFamilyCount = static_cast<size_t>(InstructionFamily::Count);
+using InstructionCounts = std::array<uint64_t, kInstructionFamilyCount>;
+using InstructionNanoseconds = std::array<uint64_t, kInstructionFamilyCount>;
+
+struct ThroughputWavefrontState final : WavefrontState {
+  InstructionCounts counts{};
+  InstructionNanoseconds execution_nanoseconds{};
+  std::chrono::steady_clock::time_point instruction_begin{};
+  InstructionFamily active_family = InstructionFamily::Other;
+  bool instruction_active = false;
+};
+
+/// Reports simulator throughput in executed wave instructions per host second.
+///
+/// One instruction is counted each time a wavefront reaches the before-execute
+/// hook. It is not multiplied by the number of active lanes.
+class ThroughputPlugin final : public ExecutionPlugin {
+public:
+  /// @param config_json Plugin configuration object as a JSON string (unused;
+  ///        this plugin takes no configuration). May be null.
+  explicit ThroughputPlugin(const char *config_json = nullptr);
+  ~ThroughputPlugin() override;
+
+  void onShutdown() override;
+  void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
+  void onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) override;
+  void onAmdgpuDispatchExecutionEnd(uint32_t dispatch_id) override;
+  void onAmdgpuWavefrontDispatched(amdgpu::Wavefront &wf) override;
+  void onAmdgpuWavefrontHalted(amdgpu::Wavefront &wf) override;
+  void onAmdgpuBeforeExecuteInstruction(uint64_t pc, const Instruction &inst,
+                                        amdgpu::Wavefront &wf) override;
+  void onAmdgpuAfterExecuteInstruction(uint64_t pc, const Instruction &inst,
+                                       amdgpu::Wavefront &wf) override;
+
+  static InstructionFamily classify(const Instruction &inst);
+  static std::string_view family_name(InstructionFamily family);
+
+private:
+  using Clock = std::chrono::steady_clock;
+
+  struct DispatchState {
+    KernelDispatchInfo info;
+    Clock::time_point begin{};
+    bool begun = false;
+    InstructionCounts counts{};
+    InstructionNanoseconds execution_nanoseconds{};
+  };
+
+  static uint64_t total(const InstructionCounts &counts);
+  static void add(InstructionCounts &destination, const InstructionCounts &source);
+  static void finish_instruction(ThroughputWavefrontState &state, Clock::time_point end);
+  void emit_record(std::string_view record, const KernelDispatchInfo *info,
+                   const InstructionCounts &counts,
+                   const InstructionNanoseconds &execution_nanoseconds, double wall_seconds,
+                   double dispatch_seconds_sum = 0.0);
+
+  std::unordered_map<uint32_t, DispatchState> dispatches_;
+  InstructionCounts aggregate_counts_{};
+  InstructionNanoseconds aggregate_execution_nanoseconds_{};
+  Clock::time_point first_begin_{};
+  Clock::time_point last_end_{};
+  double dispatch_seconds_sum_ = 0.0;
+  uint64_t completed_dispatches_ = 0;
+  bool have_active_window_ = false;
+  bool summary_emitted_ = false;
+};
+
+} // namespace rocjitsu::plugins::throughput

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin_export.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin_export.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file plugin_export.cpp
+/// @brief Loader exports for librocjitsu_plugin_throughput.so.
+///
+/// Kept separate from plugin.cpp so the plugin sources can also be linked
+/// into the unit-test binary without colliding on the shared loader exports.
+
+#include "rocjitsu/vm/plugins/plugin_exports.h"
+#include "rocjitsu/vm/plugins/throughput/plugin.h"
+
+ROCJITSU_DEFINE_PLUGIN(rocjitsu::plugins::throughput::ThroughputPlugin, "throughput", "{}")

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(RJ_OBJECT_LIBS
     rocjitsu_vm_amdgpu
     rocjitsu_plugin_logging
     rocjitsu_plugin_race_detector
+    rocjitsu_plugin_throughput
     rocjitsu_plugin_loader
     rocjitsu_vm_risc_v
     rocjitsu_config

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -53,9 +53,12 @@ RJ_DIAGNOSTIC_POP
 
 #include "halt_snapshot_plugin.h"
 #include "rocjitsu/vm/plugins/execution_plugin_group.h"
+#include "rocjitsu/vm/plugins/plugin_config_resolver.h"
 #include "rocjitsu/vm/plugins/plugin_sink.h"
 #include "rocjitsu/vm/plugins/race_detector/plugin.h"
+#include "rocjitsu/vm/plugins/throughput/plugin.h"
 
+#include <flatbuffers/flexbuffers.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -73,6 +76,7 @@ RJ_DIAGNOSTIC_POP
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -884,6 +888,282 @@ TEST(ExecutionPluginTest, NoPluginNoCrash) {
   PluginFixture f;
   const uint32_t code[] = {S_NOP, S_ENDPGM};
   f.run_kernel(code, 2);
+}
+
+class ThroughputTestInstruction final : public Instruction {
+public:
+  explicit ThroughputTestInstruction(std::string_view mnemonic, uint64_t flags = 0,
+                                     std::unique_ptr<DynamicInstState> state = nullptr)
+      : Instruction(mnemonic, nullptr) {
+    flags_ = flags;
+    set_data(std::move(state));
+  }
+};
+
+struct ParsedThroughputRecord {
+  std::string record;
+  uint64_t dispatch_id = 0;
+  std::string kernel_name;
+  std::string kernel_symbol;
+  uint64_t workgroups = 0;
+  uint64_t waves_per_workgroup = 0;
+  double wall_seconds = 0.0;
+  uint64_t wave_instructions = 0;
+  double mips = 0.0;
+  uint64_t dispatches = 0;
+  double dispatch_seconds_sum = 0.0;
+  plugins::throughput::InstructionCounts family_instructions{};
+  std::array<double, plugins::throughput::kInstructionFamilyCount> execution_seconds{};
+  std::array<double, plugins::throughput::kInstructionFamilyCount> execution_mips{};
+  std::array<double, plugins::throughput::kInstructionFamilyCount> dispatch_mips{};
+};
+
+std::vector<ParsedThroughputRecord> parse_throughput_jsonl(std::string_view jsonl) {
+  std::vector<ParsedThroughputRecord> records;
+  std::istringstream lines{std::string(jsonl)};
+  std::string line;
+  while (std::getline(lines, line)) {
+    if (line.empty())
+      continue;
+
+    flexbuffers::Builder builder;
+    if (!plugin_detail::flexbuffer_from_json(line, builder)) {
+      ADD_FAILURE() << "invalid JSONL record: " << line;
+      continue;
+    }
+    auto root = flexbuffers::GetRoot(builder.GetBuffer());
+    if (!root.IsMap()) {
+      ADD_FAILURE() << "throughput record is not a JSON object";
+      continue;
+    }
+    auto object = root.AsMap();
+    const auto schema = object["schema"];
+    const auto record_type = object["record"];
+    EXPECT_TRUE(schema.IsString()) << "schema must be a string";
+    EXPECT_TRUE(record_type.IsString()) << "record must be a string";
+    if (!schema.IsString() || !record_type.IsString())
+      continue;
+    EXPECT_EQ(schema.AsString().str(), "rocjitsu.throughput.v2");
+
+    ParsedThroughputRecord record;
+    record.record = record_type.AsString().str();
+
+    const auto wall_seconds = object["wall_seconds"];
+    const auto wave_instructions = object["wave_instructions"];
+    const auto throughput_mips = object["mips"];
+    const auto families_value = object["families"];
+    EXPECT_TRUE(wall_seconds.IsNumeric()) << "wall_seconds must be numeric";
+    EXPECT_TRUE(wave_instructions.IsIntOrUint()) << "wave_instructions must be an integer";
+    EXPECT_TRUE(throughput_mips.IsNumeric()) << "mips must be numeric";
+    EXPECT_TRUE(families_value.IsMap()) << "families must be an object";
+    if (!wall_seconds.IsNumeric() || !wave_instructions.IsIntOrUint() ||
+        !throughput_mips.IsNumeric() || !families_value.IsMap())
+      continue;
+    record.wall_seconds = wall_seconds.AsDouble();
+    record.wave_instructions = wave_instructions.AsUInt64();
+    record.mips = throughput_mips.AsDouble();
+
+    if (record.record == "dispatch") {
+      const auto dispatch_id = object["dispatch_id"];
+      const auto kernel_name = object["kernel_name"];
+      const auto kernel_symbol = object["kernel_symbol"];
+      const auto grid = object["grid"];
+      const auto workgroup = object["workgroup"];
+      const auto workgroups = object["workgroups"];
+      const auto waves_per_workgroup = object["waves_per_workgroup"];
+      EXPECT_TRUE(dispatch_id.IsIntOrUint()) << "dispatch_id must be an integer";
+      EXPECT_TRUE(kernel_name.IsString()) << "kernel_name must be a string";
+      EXPECT_TRUE(kernel_symbol.IsString()) << "kernel_symbol must be a string";
+      EXPECT_TRUE(grid.IsAnyVector()) << "grid must be an array";
+      EXPECT_TRUE(workgroup.IsAnyVector()) << "workgroup must be an array";
+      EXPECT_TRUE(workgroups.IsIntOrUint()) << "workgroups must be an integer";
+      EXPECT_TRUE(waves_per_workgroup.IsIntOrUint()) << "waves_per_workgroup must be an integer";
+      if (grid.IsAnyVector()) {
+        const auto values = grid.AsVector();
+        EXPECT_EQ(values.size(), 3u);
+        for (size_t i = 0; i < values.size(); ++i)
+          EXPECT_TRUE(values[i].IsIntOrUint()) << "grid[" << i << "] must be an integer";
+      }
+      if (workgroup.IsAnyVector()) {
+        const auto values = workgroup.AsVector();
+        EXPECT_EQ(values.size(), 3u);
+        for (size_t i = 0; i < values.size(); ++i)
+          EXPECT_TRUE(values[i].IsIntOrUint()) << "workgroup[" << i << "] must be an integer";
+      }
+      if (dispatch_id.IsIntOrUint())
+        record.dispatch_id = dispatch_id.AsUInt64();
+      if (kernel_name.IsString())
+        record.kernel_name = kernel_name.AsString().str();
+      if (kernel_symbol.IsString())
+        record.kernel_symbol = kernel_symbol.AsString().str();
+      if (workgroups.IsIntOrUint())
+        record.workgroups = workgroups.AsUInt64();
+      if (waves_per_workgroup.IsIntOrUint())
+        record.waves_per_workgroup = waves_per_workgroup.AsUInt64();
+    } else if (record.record == "summary") {
+      const auto dispatches = object["dispatches"];
+      const auto dispatch_seconds_sum = object["dispatch_seconds_sum"];
+      EXPECT_TRUE(dispatches.IsIntOrUint()) << "dispatches must be an integer";
+      EXPECT_TRUE(dispatch_seconds_sum.IsNumeric()) << "dispatch_seconds_sum must be numeric";
+      if (dispatches.IsIntOrUint())
+        record.dispatches = dispatches.AsUInt64();
+      if (dispatch_seconds_sum.IsNumeric())
+        record.dispatch_seconds_sum = dispatch_seconds_sum.AsDouble();
+    } else {
+      ADD_FAILURE() << "unknown throughput record type: " << record.record;
+    }
+
+    auto families = families_value.AsMap();
+    for (size_t i = 0; i < plugins::throughput::kInstructionFamilyCount; ++i) {
+      const auto family = static_cast<plugins::throughput::InstructionFamily>(i);
+      const auto family_name = plugins::throughput::ThroughputPlugin::family_name(family);
+      const auto family_value = families[family_name.data()];
+      EXPECT_TRUE(family_value.IsMap()) << "families." << family_name << " must be an object";
+      if (!family_value.IsMap())
+        continue;
+      const auto values = family_value.AsMap();
+      const auto instructions = values["instructions"];
+      const auto execution_seconds = values["execution_seconds"];
+      const auto execution_mips = values["execution_mips"];
+      const auto dispatch_mips = values["dispatch_mips"];
+      EXPECT_TRUE(instructions.IsIntOrUint())
+          << "families." << family_name << ".instructions must be an integer";
+      EXPECT_TRUE(execution_seconds.IsNumeric())
+          << "families." << family_name << ".execution_seconds must be numeric";
+      EXPECT_TRUE(execution_mips.IsNumeric())
+          << "families." << family_name << ".execution_mips must be numeric";
+      EXPECT_TRUE(dispatch_mips.IsNumeric())
+          << "families." << family_name << ".dispatch_mips must be numeric";
+      if (instructions.IsIntOrUint())
+        record.family_instructions[i] = instructions.AsUInt64();
+      if (execution_seconds.IsNumeric())
+        record.execution_seconds[i] = execution_seconds.AsDouble();
+      if (execution_mips.IsNumeric())
+        record.execution_mips[i] = execution_mips.AsDouble();
+      if (dispatch_mips.IsNumeric())
+        record.dispatch_mips[i] = dispatch_mips.AsDouble();
+    }
+    records.push_back(std::move(record));
+  }
+  return records;
+}
+
+uint64_t family_total(const ParsedThroughputRecord &record) {
+  uint64_t total = 0;
+  for (const uint64_t count : record.family_instructions)
+    total += count;
+  return total;
+}
+
+TEST(ThroughputPluginTest, ClassifiesExclusiveInstructionFamilies) {
+  using plugins::throughput::InstructionFamily;
+  using plugins::throughput::ThroughputPlugin;
+
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("s_add_u32")),
+            InstructionFamily::Scalar);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("v_add_f32")),
+            InstructionFamily::Vector);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("v_wmma_f32_16x16x16_f16")),
+            InstructionFamily::Matrix);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("v_swmmac_f32_16x16x32_f8")),
+            InstructionFamily::Matrix);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction(
+                "ds_read_b32", MEMORY_OP, std::make_unique<VectorMemState>(LOCAL_MEM))),
+            InstructionFamily::Lds);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("ds_read_b32", MEMORY_OP)),
+            InstructionFamily::Lds);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction(
+                "s_load_b32", MEMORY_OP, std::make_unique<ScalarMemState>())),
+            InstructionFamily::Global);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("global_load_b32", MEMORY_OP)),
+            InstructionFamily::Global);
+  EXPECT_EQ(
+      ThroughputPlugin::classify(ThroughputTestInstruction("s_branch", BRANCH | IGNORES_EXEC)),
+      InstructionFamily::Control);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("s_endpgm", PROGRAM_TERMINATOR)),
+            InstructionFamily::Control);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("s_nop")),
+            InstructionFamily::Control);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("s_sleep")),
+            InstructionFamily::Control);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("s_delay_alu")),
+            InstructionFamily::Control);
+  EXPECT_EQ(ThroughputPlugin::classify(ThroughputTestInstruction("exp")), InstructionFamily::Other);
+}
+
+TEST(ThroughputPluginTest, ReportsExactWaveInstructionCountsAsJsonl) {
+  using plugins::throughput::InstructionFamily;
+
+  PluginFixture f(/*num_wf_slots=*/1);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<plugins::throughput::ThroughputPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  const uint32_t code[] = {vop1_encode(/*v_mov_b32 opcode=*/1, /*vdst=*/0, /*constant 0=*/128),
+                           S_NOP, S_ENDPGM};
+  f.run_kernel(code, 3);
+  f.shutdown();
+
+  const auto records = parse_throughput_jsonl(sink.str());
+  ASSERT_EQ(records.size(), 2u);
+  const auto &dispatch = records[0];
+  EXPECT_EQ(dispatch.record, "dispatch");
+  EXPECT_GT(dispatch.dispatch_id, 0u);
+  EXPECT_FALSE(dispatch.kernel_name.empty());
+  EXPECT_FALSE(dispatch.kernel_symbol.empty());
+  EXPECT_GT(dispatch.workgroups, 0u);
+  EXPECT_GT(dispatch.waves_per_workgroup, 0u);
+  EXPECT_GT(dispatch.wall_seconds, 0.0);
+  EXPECT_EQ(dispatch.wave_instructions, 3u);
+  EXPECT_GT(dispatch.mips, 0.0);
+  EXPECT_EQ(family_total(dispatch), dispatch.wave_instructions);
+  EXPECT_EQ(dispatch.family_instructions[static_cast<size_t>(InstructionFamily::Vector)], 1u);
+  EXPECT_EQ(dispatch.family_instructions[static_cast<size_t>(InstructionFamily::Control)], 2u);
+  EXPECT_GT(dispatch.execution_seconds[static_cast<size_t>(InstructionFamily::Vector)], 0.0);
+  EXPECT_GT(dispatch.execution_seconds[static_cast<size_t>(InstructionFamily::Control)], 0.0);
+  EXPECT_GT(dispatch.execution_mips[static_cast<size_t>(InstructionFamily::Vector)], 0.0);
+  EXPECT_GT(dispatch.execution_mips[static_cast<size_t>(InstructionFamily::Control)], 0.0);
+  EXPECT_GT(dispatch.dispatch_mips[static_cast<size_t>(InstructionFamily::Vector)], 0.0);
+  EXPECT_GT(dispatch.dispatch_mips[static_cast<size_t>(InstructionFamily::Control)], 0.0);
+
+  const auto &summary = records[1];
+  EXPECT_EQ(summary.record, "summary");
+  EXPECT_EQ(summary.dispatches, 1u);
+  EXPECT_GT(summary.dispatch_seconds_sum, 0.0);
+  EXPECT_GT(summary.wall_seconds, 0.0);
+  EXPECT_GT(summary.mips, 0.0);
+  EXPECT_EQ(summary.wave_instructions, dispatch.wave_instructions);
+  EXPECT_EQ(summary.family_instructions, dispatch.family_instructions);
+  EXPECT_EQ(summary.execution_seconds, dispatch.execution_seconds);
+  EXPECT_EQ(summary.execution_mips, dispatch.execution_mips);
+  EXPECT_EQ(family_total(summary), summary.wave_instructions);
+}
+
+TEST(ThroughputPluginTest, TimesTerminatorWithoutAfterExecuteCallback) {
+  using plugins::throughput::InstructionFamily;
+
+  PluginFixture f(/*num_wf_slots=*/1);
+  PluginSinkConfig sink_config;
+  StringSink &sink = sink_config.emplace<StringSink>();
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(std::move(sink_config));
+  ASSERT_TRUE(f.plugin_group_->add(std::make_unique<plugins::throughput::ThroughputPlugin>()));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  const uint32_t code[] = {S_ENDPGM};
+  f.run_kernel(code, 1);
+  f.shutdown();
+
+  const auto records = parse_throughput_jsonl(sink.str());
+  ASSERT_EQ(records.size(), 2u);
+  const auto &dispatch = records[0];
+  const size_t control = static_cast<size_t>(InstructionFamily::Control);
+  EXPECT_EQ(dispatch.wave_instructions, 1u);
+  EXPECT_EQ(dispatch.family_instructions[control], 1u);
+  EXPECT_GT(dispatch.execution_seconds[control], 0.0);
 }
 
 TEST(ExecutionPluginTest, HotHookPolicyComesFromContainedPlugins) {


### PR DESCRIPTION
Add an execution plugin that counts one instruction per wavefront execution and reports per-dispatch JSONL with an exclusive scalar, vector, matrix, LDS, global, control, and other breakdown.

Sample invocation: `mirage run <...> --plugin throughput -- ./my_app`

Measure each instruction from the end of its before-execute hook to the beginning of its after-execute hook, accumulate that time by family, and report both category-local handler throughput and full-dispatch throughput. Close program-terminator intervals from the wave-halt hook because those instructions intentionally omit the after-execute callback.

Keep hot-path state local to each wavefront and merge counters and timing at lifecycle boundaries. Document the units and exclusions, and cover classification, counts, timing fields, and terminator handling.