### PR TITLE
fix(rocprofiler-systems): remove dual-parser config handling in rocprof-sys-python

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -11,6 +11,17 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - `ROCPROFSYS_SAMPLING_GPUS` is now restricted by the GPUs the ROCm runtime exposes
   via `ROCR_VISIBLE_DEVICES` / `HIP_VISIBLE_DEVICES`.
 
+- `rocprof-sys-python` no longer accepts abbreviated long options (for example,
+  `--conf` for `--config`). Spell out the full option name.
+
+### Resolved issues
+
+- Fixed `rocprof-sys-python` ignoring the `-c`/`--config` flag. The configuration
+  file is now applied to `ROCPROFSYS_CONFIG_FILE` before the profiler bindings are
+  loaded, so its settings take effect. A configuration file already named by
+  `ROCPROFSYS_CONFIG_FILE` is preserved, and the one given on the command line is
+  appended to it.
+
 ### Removed
 
 - Removed the `ROCPROFSYS_BUILD_SQLITE3` CMake option and the in-tree SQLite3/rocpd

--- a/projects/rocprofiler-systems/source/python/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/python/CMakeLists.txt
@@ -106,6 +106,7 @@ rocprofiler_systems_target_compile_definitions(libpyrocprofiler-systems-interfac
 add_custom_target(libpyrocprofsys)
 
 file(GLOB_RECURSE PYTHON_FILES ${CMAKE_CURRENT_SOURCE_DIR}/rocprofsys/*.py)
+list(FILTER PYTHON_FILES EXCLUDE REGEX "/tests/")
 foreach(_IN ${PYTHON_FILES})
     string(
         REPLACE
@@ -150,3 +151,7 @@ configure_file(
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}/pyproject.toml
     COPYONLY
 )
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(rocprofsys/tests)
+endif()

--- a/projects/rocprofiler-systems/source/python/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/__init__.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import
 
 __author__ = "AMD ROCm"
-__copyright__ = "Copyright 2025, Advanced Micro Devices, Inc."
+__copyright__ = "Copyright 2026, Advanced Micro Devices, Inc."
 __license__ = "MIT"
 __version__ = "@PROJECT_VERSION@"
 __maintainer__ = "AMD ROCm"

--- a/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
@@ -23,6 +23,21 @@ import traceback
 PY3 = sys.version_info[0] == 3
 _ROCPROFSYS_PYTHON_SCRIPT_FILE = None
 
+# Maps a parse_args() destination onto the profiler config attribute it sets.
+# '--label' is handled separately since it fans out into three attributes.
+_CONFIG_OPTION_MAP = {
+    "verbosity": "verbosity",
+    "full_filepath": "full_filepath",
+    "function_include": "include_functions",
+    "function_exclude": "exclude_functions",
+    "function_restrict": "restrict_functions",
+    "module_include": "include_modules",
+    "module_exclude": "exclude_modules",
+    "module_restrict": "restrict_modules",
+    "trace_c": "trace_c",
+    "annotate_trace": "annotate_trace",
+}
+
 # Python 3.x compatibility utils: execfile
 try:
     execfile
@@ -57,12 +72,15 @@ def find_script(script_name):
 
 
 def parse_args(args=None):
-    """Parse the arguments"""
+    """Parse the arguments.
+
+    Options that mirror a profiler config setting default to None, meaning
+    "not specified on the command line". Callers are responsible for merging
+    those against the profiler config's own defaults.
+    """
 
     if args is None:
         args = sys.argv[1:]
-
-    from .libpyrocprofsys.profiler import config as _profiler_config
 
     def str2bool(v):
         if isinstance(v, bool):
@@ -74,17 +92,10 @@ def parse_args(args=None):
         else:
             raise argparse.ArgumentTypeError("Boolean value expected.")
 
-    _default_label = []
-    if _profiler_config.include_args:
-        _default_label.append("args")
-    if _profiler_config.include_filename:
-        _default_label.append("file")
-    if _profiler_config.include_line:
-        _default_label.append("line")
-
     parser = argparse.ArgumentParser(
         "rocprofsys",
         add_help=True,
+        allow_abbrev=False,
         epilog="usage: {} -m rocprofsys <ROCPROFSYS_ARGS> -- <SCRIPT> <SCRIPT_ARGS>".format(
             os.path.basename(sys.executable)
         ),
@@ -93,7 +104,7 @@ def parse_args(args=None):
         "-v",
         "--verbosity",
         type=int,
-        default=_profiler_config.verbosity,
+        default=None,
         help="Logging verbosity",
     )
     parser.add_argument(
@@ -127,7 +138,7 @@ def parse_args(args=None):
         nargs="?",
         metavar="BOOL",
         const=True,
-        default=_profiler_config.full_filepath,
+        default=None,
         help="Encode the full function filename (instead of basename)",
     )
     parser.add_argument(
@@ -135,7 +146,7 @@ def parse_args(args=None):
         type=str,
         choices=("args", "file", "line"),
         nargs="*",
-        default=_default_label,
+        default=None,
         help="Encode the function arguments, filename, and/or line number into the profiling function label",
     )
     parser.add_argument(
@@ -144,7 +155,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FUNC",
-        default=_profiler_config.include_functions,
+        default=None,
         help="Include any entries with these function names",
     )
     parser.add_argument(
@@ -153,7 +164,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FUNC",
-        default=_profiler_config.exclude_functions,
+        default=None,
         help="Filter out any entries with these function names",
     )
     parser.add_argument(
@@ -162,7 +173,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FUNC",
-        default=_profiler_config.restrict_functions,
+        default=None,
         help="Select only entries with these function names",
     )
     parser.add_argument(
@@ -171,7 +182,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FILE",
-        default=_profiler_config.include_modules,
+        default=None,
         help="Include any entries from these files",
     )
     parser.add_argument(
@@ -180,7 +191,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FILE",
-        default=_profiler_config.exclude_modules,
+        default=None,
         help="Filter out any entries from these files",
     )
     parser.add_argument(
@@ -189,7 +200,7 @@ def parse_args(args=None):
         type=str,
         nargs="+",
         metavar="FILE",
-        default=_profiler_config.restrict_modules,
+        default=None,
         help="Select only entries from these files",
     )
     parser.add_argument(
@@ -198,7 +209,7 @@ def parse_args(args=None):
         nargs="?",
         metavar="BOOL",
         const=True,
-        default=_profiler_config.trace_c,
+        default=None,
         help="Enable profiling C functions",
     )
     parser.add_argument(
@@ -208,7 +219,7 @@ def parse_args(args=None):
         nargs="?",
         metavar="BOOL",
         const=True,
-        default=_profiler_config.annotate_trace,
+        default=None,
         help="Enable perfetto debug annotations",
     )
 
@@ -251,21 +262,21 @@ def run(prof, cmd):
     prof.runctx(code, globs, None)
 
 
-def apply_config_option(args):
-    """Set the config-file environment variable before loading profiler bindings."""
-    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    parser.add_argument("-c", "--config")
-    opts, _ = parser.parse_known_args(args)
-    if opts.config is None:
+def apply_config_option(config_path):
+    """Merge a --config file path into ROCPROFSYS_CONFIG_FILE before loading profiler bindings."""
+    if config_path is None:
         return
 
-    # If the environment already has a config file, keep it and add ours after
-    # it (colon-separated), so both get read. Otherwise, just use ours.
-    existing_config_file = os.environ.get("ROCPROFSYS_CONFIG_FILE")
+    # If the environment already has a config file, keep it and append ours so
+    # both get read. The native config reader accepts ':' and ';' as
+    # separators; strip any trailing one to avoid an empty entry.
+    existing_config_file = os.environ.get("ROCPROFSYS_CONFIG_FILE", "").rstrip(":;")
     if existing_config_file:
-        os.environ["ROCPROFSYS_CONFIG_FILE"] = existing_config_file + ":" + opts.config
+        os.environ["ROCPROFSYS_CONFIG_FILE"] = (
+            existing_config_file + os.pathsep + config_path
+        )
     else:
-        os.environ["ROCPROFSYS_CONFIG_FILE"] = opts.config
+        os.environ["ROCPROFSYS_CONFIG_FILE"] = config_path
 
 
 def main(main_args=sys.argv):
@@ -276,7 +287,6 @@ def main(main_args=sys.argv):
     if "--" in main_args:
         _idx = main_args.index("--")
         _argv = main_args[(_idx + 1) :]
-        apply_config_option(main_args[1:_idx])
         opts = parse_args(main_args[1:_idx])
         argv = _argv
     else:
@@ -291,6 +301,9 @@ def main(main_args=sys.argv):
                     "the script and its arguments to ensure correct parsing. \nE.g. "
                     "python -m rocprofsys -- ./script.py".format(" ".join(argv))
                 )
+
+    # Must happen before any profiler bindings are imported below.
+    apply_config_option(opts.config)
 
     if not argv:
         raise RuntimeError(
@@ -322,19 +335,16 @@ def main(main_args=sys.argv):
 
     from .libpyrocprofsys.profiler import config as _profiler_config
 
-    _profiler_config.trace_c = opts.trace_c
-    _profiler_config.include_args = "args" in opts.label
-    _profiler_config.include_line = "line" in opts.label
-    _profiler_config.include_filename = "file" in opts.label
-    _profiler_config.full_filepath = opts.full_filepath
-    _profiler_config.include_functions = opts.function_include
-    _profiler_config.include_modules = opts.module_include
-    _profiler_config.exclude_functions = opts.function_exclude
-    _profiler_config.exclude_modules = opts.module_exclude
-    _profiler_config.restrict_functions = opts.function_restrict
-    _profiler_config.restrict_modules = opts.module_restrict
-    _profiler_config.annotate_trace = opts.annotate_trace
-    _profiler_config.verbosity = opts.verbosity
+    # Unset options are None, and leave the config's own default in place.
+    for opt_name, config_name in _CONFIG_OPTION_MAP.items():
+        value = getattr(opts, opt_name)
+        if value is not None:
+            setattr(_profiler_config, config_name, value)
+
+    if opts.label is not None:
+        _profiler_config.include_args = "args" in opts.label
+        _profiler_config.include_line = "line" in opts.label
+        _profiler_config.include_filename = "file" in opts.label
 
     print("[rocprofsys]> profiling: {}".format(argv))
 

--- a/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/__main__.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import
 
 __author__ = "AMD ROCm"
-__copyright__ = "Copyright 2024, Advanced Micro Devices, Inc."
+__copyright__ = "Copyright 2026, Advanced Micro Devices, Inc."
 __license__ = "MIT"
 __version__ = "@PROJECT_VERSION@"
 __maintainer__ = "AMD ROCm"

--- a/projects/rocprofiler-systems/source/python/rocprofsys/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+find_package(Python3 COMPONENTS Interpreter)
+
+if(NOT Python3_FOUND)
+    rocprofiler_systems_message(
+        STATUS
+        "Python3 interpreter not found: skipping rocprofsys-python-unit-tests"
+    )
+    return()
+endif()
+
+# pytest is not guaranteed to be present in the build environment.
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import pytest"
+    RESULT_VARIABLE _pytest_result
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(NOT _pytest_result EQUAL 0)
+    rocprofiler_systems_message(
+        STATUS
+        "pytest not available: skipping rocprofsys-python-unit-tests"
+    )
+    return()
+endif()
+
+# Disabling the cache plugin and bytecode generation, and running from the
+# binary directory, keeps test artifacts out of the source tree.
+add_test(
+    NAME rocprofsys-python-unit-tests
+    COMMAND
+        ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR} -v -p no:cacheprovider
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set_tests_properties(
+    rocprofsys-python-unit-tests
+    PROPERTIES ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
+)

--- a/projects/rocprofiler-systems/source/python/rocprofsys/tests/test_main.py
+++ b/projects/rocprofiler-systems/source/python/rocprofsys/tests/test_main.py
@@ -1,0 +1,279 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Lightweight unit tests for rocprofsys/__main__.py's pure-Python argument
+parsing and environment handling. These do not require libpyrocprofsys (the
+native bindings) to be built, and don't spawn a subprocess.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_MAIN_PY = Path(__file__).resolve().parent.parent / "__main__.py"
+_spec = importlib.util.spec_from_file_location("rocprofsys_main_under_test", _MAIN_PY)
+rocprofsys_main = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rocprofsys_main)
+
+
+# The functions under test mutate os.environ directly, so snapshot and restore
+# it around every test to keep them order-independent.
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    saved = os.environ.copy()
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+# =============================================================================
+# find_script
+# =============================================================================
+
+
+def test_find_script_direct_path(tmp_path):
+    script = tmp_path / "script.py"
+    script.write_text("pass\n")
+    assert rocprofsys_main.find_script(str(script)) == str(script)
+
+
+def test_find_script_via_path_env(tmp_path, monkeypatch):
+    script = tmp_path / "on_path.py"
+    script.write_text("pass\n")
+    monkeypatch.setenv("PATH", str(tmp_path))
+    assert rocprofsys_main.find_script("on_path.py") == str(script)
+
+
+def test_find_script_missing_raises(monkeypatch):
+    monkeypatch.setenv("PATH", "")
+    with pytest.raises(SystemExit):
+        rocprofsys_main.find_script("does_not_exist.py")
+
+
+# =============================================================================
+# get_value
+# =============================================================================
+
+
+def test_get_value_uses_arg_when_given(monkeypatch):
+    monkeypatch.delenv("SOME_VAR", raising=False)
+    assert rocprofsys_main.get_value("SOME_VAR", 1, int, arg="5") == 5
+
+
+def test_get_value_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("SOME_VAR", "7")
+    assert rocprofsys_main.get_value("SOME_VAR", 1, int) == 7
+
+
+def test_get_value_falls_back_to_default_and_sets_env(monkeypatch):
+    monkeypatch.delenv("SOME_VAR", raising=False)
+    assert rocprofsys_main.get_value("SOME_VAR", 3, int) == 3
+    assert os.environ["SOME_VAR"] == "3"
+
+
+# =============================================================================
+# apply_config_option
+# =============================================================================
+
+
+def test_apply_config_option_noop_when_no_config(monkeypatch):
+    monkeypatch.delenv("ROCPROFSYS_CONFIG_FILE", raising=False)
+    rocprofsys_main.apply_config_option(None)
+    assert "ROCPROFSYS_CONFIG_FILE" not in os.environ
+
+
+def test_apply_config_option_sets_env_var(monkeypatch):
+    monkeypatch.delenv("ROCPROFSYS_CONFIG_FILE", raising=False)
+    rocprofsys_main.apply_config_option("cli.cfg")
+    assert os.environ["ROCPROFSYS_CONFIG_FILE"] == "cli.cfg"
+
+
+def test_apply_config_option_merges_with_existing_env_var(monkeypatch):
+    monkeypatch.setenv("ROCPROFSYS_CONFIG_FILE", "env.cfg")
+    rocprofsys_main.apply_config_option("cli.cfg")
+    assert os.environ["ROCPROFSYS_CONFIG_FILE"] == "env.cfg" + os.pathsep + "cli.cfg"
+
+
+@pytest.mark.parametrize("existing", ["env.cfg:", "env.cfg;", "env.cfg::"])
+def test_apply_config_option_strips_trailing_separators(existing, monkeypatch):
+    """A trailing separator in the env var must not produce an empty entry."""
+    monkeypatch.setenv("ROCPROFSYS_CONFIG_FILE", existing)
+    rocprofsys_main.apply_config_option("cli.cfg")
+    assert os.environ["ROCPROFSYS_CONFIG_FILE"] == "env.cfg" + os.pathsep + "cli.cfg"
+
+
+def test_apply_config_option_ignores_separator_only_env_var(monkeypatch):
+    monkeypatch.setenv("ROCPROFSYS_CONFIG_FILE", ":")
+    rocprofsys_main.apply_config_option("cli.cfg")
+    assert os.environ["ROCPROFSYS_CONFIG_FILE"] == "cli.cfg"
+
+
+# =============================================================================
+# parse_args
+# =============================================================================
+
+
+def test_parse_args_defaults_are_none():
+    opts = rocprofsys_main.parse_args([])
+    assert opts.config is None
+    assert opts.verbosity is None
+    assert opts.full_filepath is None
+    assert opts.label is None
+    assert opts.trace_c is None
+    assert opts.annotate_trace is None
+
+
+@pytest.mark.parametrize("flag", ["-c", "--config"])
+def test_parse_args_config_flag(flag):
+    opts = rocprofsys_main.parse_args([flag, "my.cfg"])
+    assert opts.config == "my.cfg"
+
+
+def test_parse_args_rejects_abbreviations():
+    """Abbreviated flags are rejected, since the parser sets allow_abbrev=False."""
+    with pytest.raises(SystemExit):
+        rocprofsys_main.parse_args(["--conf", "my.cfg"])
+    with pytest.raises(SystemExit):
+        rocprofsys_main.parse_args(["--full", "true"])
+
+
+def test_parse_args_label_accepts_multiple_values():
+    opts = rocprofsys_main.parse_args(["--label", "args", "file"])
+    assert opts.label == ["args", "file"]
+
+
+def test_parse_args_label_rejects_invalid_choice():
+    with pytest.raises(SystemExit):
+        rocprofsys_main.parse_args(["--label", "bogus"])
+
+
+def test_parse_args_verbosity_int_conversion():
+    opts = rocprofsys_main.parse_args(["-v", "10"])
+    assert opts.verbosity == 10
+
+
+# =============================================================================
+# parse_args: str2bool options (-F/--full-filepath, --trace-c, -a/--annotate-trace)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "flag", ["-F", "--full-filepath", "--trace-c", "-a", "--annotate-trace"]
+)
+def test_parse_args_bool_flag_alone_defaults_to_true(flag):
+    dest = {
+        "-F": "full_filepath",
+        "--full-filepath": "full_filepath",
+        "--trace-c": "trace_c",
+        "-a": "annotate_trace",
+        "--annotate-trace": "annotate_trace",
+    }[flag]
+    opts = rocprofsys_main.parse_args([flag])
+    assert getattr(opts, dest) is True
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("true", True),
+        ("yes", True),
+        ("1", True),
+        ("false", False),
+        ("no", False),
+        ("0", False),
+    ],
+)
+def test_parse_args_bool_flag_explicit_value(value, expected):
+    opts = rocprofsys_main.parse_args(["--trace-c", value])
+    assert opts.trace_c is expected
+
+
+def test_parse_args_bool_flag_rejects_invalid_value():
+    with pytest.raises(SystemExit):
+        rocprofsys_main.parse_args(["--trace-c", "not-a-bool"])
+
+
+# =============================================================================
+# parse_args: nargs="+" list options
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "flag,dest",
+    [
+        ("-I", "function_include"),
+        ("--function-include", "function_include"),
+        ("-E", "function_exclude"),
+        ("--function-exclude", "function_exclude"),
+        ("-R", "function_restrict"),
+        ("--function-restrict", "function_restrict"),
+        ("-MI", "module_include"),
+        ("--module-include", "module_include"),
+        ("-ME", "module_exclude"),
+        ("--module-exclude", "module_exclude"),
+        ("-MR", "module_restrict"),
+        ("--module-restrict", "module_restrict"),
+    ],
+)
+def test_parse_args_list_options_accept_multiple_values(flag, dest):
+    opts = rocprofsys_main.parse_args([flag, "foo", "bar"])
+    assert getattr(opts, dest) == ["foo", "bar"]
+
+
+# =============================================================================
+# parse_args: simple flags (-b/--builtin, -s/--setup)
+# =============================================================================
+
+
+def test_parse_args_builtin_flag():
+    opts = rocprofsys_main.parse_args([])
+    assert opts.builtin is False
+    opts = rocprofsys_main.parse_args(["-b"])
+    assert opts.builtin is True
+    opts = rocprofsys_main.parse_args(["--builtin"])
+    assert opts.builtin is True
+
+
+def test_parse_args_setup_option():
+    opts = rocprofsys_main.parse_args([])
+    assert opts.setup is None
+    opts = rocprofsys_main.parse_args(["-s", "setup.py"])
+    assert opts.setup == "setup.py"
+    opts = rocprofsys_main.parse_args(["--setup", "setup.py"])
+    assert opts.setup == "setup.py"
+
+
+# =============================================================================
+# parse_args: combined invocation
+# =============================================================================
+
+
+def test_parse_args_combined_flags():
+    opts = rocprofsys_main.parse_args(
+        [
+            "-c",
+            "my.cfg",
+            "-v",
+            "5",
+            "--builtin",
+            "--label",
+            "args",
+            "line",
+            "-I",
+            "foo",
+            "bar",
+            "--trace-c",
+            "false",
+        ]
+    )
+    assert opts.config == "my.cfg"
+    assert opts.verbosity == 5
+    assert opts.builtin is True
+    assert opts.label == ["args", "line"]
+    assert opts.function_include == ["foo", "bar"]
+    assert opts.trace_c is False


### PR DESCRIPTION
## Motivation

`rocprofsys`'s Python `__main__.py` computed several argparse defaults (verbosity, `--label`, `--trace-c`, etc.) by importing the native profiler config at the top of `parse_args()` — before `-c`/`--config` had been parsed and applied to `ROCPROFSYS_CONFIG_FILE`. A prior fix for this (#9829) added a second, throwaway `ArgumentParser` that pre-scanned argv for `-c`/`--config` early, so the config file could be applied before that native import ran. But that pre-parser disagreed with the real parser on `allow_abbrev`, so an abbreviated flag like `--conf` was silently dropped by the pre-parser while the real parser still accepted it, and `ROCPROFSYS_CONFIG_FILE` was never set for that spelling — reintroducing the exact class of bug the original PR was fixing. Rather than patch that one mismatch, this PR removes the second parser and its root cause entirely.

## Technical Details

- `parse_args()` no longer imports the native config module. Every option that used to default to a `_profiler_config` value (verbosity, `full_filepath`, `label`, function/module include-exclude-restrict, `trace_c`, `annotate_trace`) now defaults to `None`, meaning "not specified on the command line."
- `main()` calls `parse_args()` once (for both the `--`-separated and `-h`/`--help` code paths), applies `-c`/`--config` to `ROCPROFSYS_CONFIG_FILE` immediately after parsing, and only then imports `.libpyrocprofsys.profiler.config`. Options are merged in via `if opts.X is not None: _profiler_config.X = opts.X`, so anything not passed on the command line keeps whatever default the native config already had.
- There is now a single `ArgumentParser(allow_abbrev=False)` with one definition of every flag, so there's no second copy of `-c`/`--config` (or any other flag) left to drift out of sync.
- Side effects of the redesign: `-c`/`--config` and its abbreviations now behave identically regardless of whether `--help` is also passed (previously the `--help` branch skipped the pre-parser entirely), and `parse_args()`/`find_script()`/`get_value()` are now unit-testable without building the native `libpyrocprofsys` extension.

## Testing

- Added `source/python/rocprofsys/tests/test_main.py` — 43 unit tests covering `parse_args` (including abbreviation rejection, `str2bool` flags, `nargs="+"` list options, and invalid-choice handling for `--label`), `find_script`, `get_value`, and the config-file merge logic. Wired into CTest as `rocprofsys-python-unit-tests`, gated on `ROCPROFSYS_BUILD_TESTING`.
- Verified via `ctest --test-dir <build-dir> -R python-unit` and direct `pytest` runs — all 43 cases pass.
- Existing end-to-end `test_config_option` cases in `tests/pytest/test_python.py` are unchanged and continue to cover the original bug's artifact-level behavior.