### PR TITLE
docs(rocprofiler-compute): Define kernel replay architecture

### DIFF
--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -52,7 +52,7 @@ relies on.
 | `1` | Ordinary single-execution path. No replay window, no snapshot, no `PASS` callbacks. |
 | Greater than `1` | Opens a replay window with that many passes. |
 
-SDK also lets a profiling tool locally stop a context for selected replay passes.
+The SDK also lets a profiling tool locally stop a context for selected replay passes.
 
 ```mermaid
 sequenceDiagram
@@ -134,7 +134,7 @@ application replay requires a lot of time.
 - **This is not free.** Kernel replay drops the repeated full-workload launches but adds snapshot,
   restoration, dispatch replay, and isolation costs. It will not be faster for every workload.
 
-The flows below compares counter collection when *N* is greater than one. It does not include other
+The flows below compare counter collection when *N* is greater than one. It does not include other
 services outside counter collection.
 
 ### Application replay
@@ -184,8 +184,8 @@ flowchart TD
 
 | ID | Requirement |
 | --- | --- |
-| **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`. `--iteration-multiplexing` stay independent. |
-| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses kernel-replay and retains existing path. |
+| **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`. `--iteration-multiplexing` remains independent. |
+| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses kernel replay and retains the existing path. |
 | **FR-3** | Kernel replay requires the native tool. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native tool, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. |
 
 #### Passes and buckets
@@ -200,7 +200,7 @@ flowchart TD
 
 | ID | Requirement |
 | --- | --- |
-| **FR-7** | One kernel-replay invocation produces one consolidated counter result using the existing naming and discovery convention, which analysis path consume with no analysis-side contract change. |
+| **FR-7** | One kernel-replay invocation produces one consolidated counter result using the existing naming and discovery convention, which the analysis path consumes with no analysis-side contract change. |
 | **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. |
 | **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. |
 
@@ -208,19 +208,19 @@ flowchart TD
 
 | ID | Requirement |
 | --- | --- |
-| **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. |
-| **FR-12** | A dispatch whose kernel is excluded is not replayed. |
-| **FR-13** | `--dispatch` retains its per-kernel dispatch filtering. Replay-ineligible kernel dispatch is not replayed. |
-| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the risk. |
+| **FR-10** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. |
+| **FR-11** | A dispatch whose kernel is excluded is not replayed. |
+| **FR-12** | `--dispatch` retains its per-kernel dispatch filtering. A replay-ineligible kernel dispatch is not replayed. |
+| **FR-13** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the risk. |
 
 #### Failure
 
 | ID | Requirement |
 | --- | --- |
-| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. |
-| **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. |
-| **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. |
-| **FR-18** | If counters were requested but an agent has no usable counter profiles, do not silently degrade the dispatch to one pass. |
+| **FR-14** | An SDK below the supported version floor is a hard error stating the required version. |
+| **FR-15** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. |
+| **FR-16** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. |
+| **FR-17** | If counters were requested but an agent has no usable counter profiles, do not silently degrade the dispatch to one pass. |
 
 ### Non-functional requirements
 
@@ -296,7 +296,7 @@ pass count exactly once before any replay pass.
 flowchart TD
     Kernel{"Kernel admitted by<br/>the kernel filter?"}
     Range{"Dispatch admitted by<br/>the dispatch filter?"}
-    Filtered["Do not profile <br/> dispatched kernel"]
+    Filtered["Do not profile<br/>the dispatched kernel"]
     Request{"Counter request has<br/>at least one bucket?"}
     Zero["Bypass kernel replay<br/>use existing non-counter path"]
     Gate{"Dispatch reaches<br/>the replay gate?"}
@@ -326,7 +326,7 @@ flowchart TD
     Size -- more than one --> N
 ```
 
-| Actual kernel dispatch | When | What the execution selects |
+| Pass count returned | When | What the execution selects |
 | --- | --- | --- |
 | `1` — filtered | A confirmed filter miss — the kernel or dispatch is excluded. | Not profiled. |
 | `1` — admitted | The dispatch is admitted and its agent's profile vector contains exactly one bucket, no PC sampling. | SDK selects the sole profile and produces a complete one-bucket result. |
@@ -344,7 +344,7 @@ written, every pass for a logical dispatch must be collapsed.
 | 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. |
 | 3. Hand off | The existing identity and pivot contracts see a single set per dispatch. |
 
-Pass identity survive transiently for normalization and diagnostics but it does not reach
+Pass identity survives transiently for normalization and diagnostics, but it does not reach
 the counter result output. Non-replay identity behavior is untouched.
 
 ### Co-active service composition
@@ -356,7 +356,7 @@ the counter result output. Non-replay identity behavior is untouched.
 | Code-object tracing | Unchanged | Load-time only. Replay never multiplies it. |
 | Marker / ROCTx | Emitted once, spans all passes | Duration semantics are an open question. |
 | PC sampling | One extra pass, appended after the counter passes | Runs counter-disabled. |
-| Roofline | Unchanged |  |
+| Roofline | Unchanged | |
 
 ### Mode and option compatibility
 
@@ -365,9 +365,9 @@ flags kernel replay as experimental.
 
 | Option or condition | With kernel replay |
 | --- | --- |
-| `--iteration-multiplexing` | Rejected | 
-| `--attach-pid` | Rejected | Live attach cannot open a replay window over an already-running process. |
-| `--no-native-tool`, `rocprofv3` backend | Rejected | 
+| `--iteration-multiplexing` | Rejected |
+| `--attach-pid` | Rejected. Live attach cannot open a replay window over an already-running process. |
+| `--no-native-tool`, `rocprofv3` backend | Rejected |
 | `--pc-sampling` | Accepted, *N*+1 passes |
 | `--roof-only`, `--set`, `--block` | Accepted, unchanged |
 | Multi-rank | Accepted, with a kernel-replay-specific diagnostic |
@@ -387,7 +387,7 @@ quietly turns a multi-bucket request into a single pass.
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
 | Upstream drain timeout or process abort | Abort the failed run. |
 
-One wrinkle: a declined snapshot currently leave a successful process status behind, so the
+One wrinkle: a declined snapshot currently leaves a successful process status behind, so the
 required outcome cannot lean on subprocess failure alone. Classifying an upstream warning string is
 the signal available today. A structured detection mechanism remains an open question.
 
@@ -396,7 +396,7 @@ the signal available today. A structured detection mechanism remains an open que
 | Phase | Delivers | Observable after this phase |
 | --- | --- | --- |
 | **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface and rejections with their error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
-| **2. Native-tool kernel replay** | Coalesced counter groups delivered to the SDK invocation; the multi-group admission check extended to admit kernel replay; `pass_count_cb` implemented from the per-agent profile-vector size; both filters applied; and diagnosed failure on a missing or unexpectedly empty counter profiles. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
+| **2. Native-tool kernel replay** | Coalesced counter groups delivered to the SDK invocation; the multi-group admission check extended to admit kernel replay; `pass_count_cb` implemented from the per-agent profile-vector size; both filters applied; and diagnosed failure on missing or unexpectedly empty counter profiles. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
 | **3. Consolidated output and dispatch ID** | One consolidated counter result using the existing naming convention, cross-pass timestamp and dispatch ID normalization. | Analysis consumes kernel-replay profiling output; Top Stats and dispatch information report non-multiplied values. |
 
 ## Validation, security and debuggability
@@ -407,43 +407,43 @@ the signal available today. A structured detection mechanism remains an open que
 | --- | --- | --- |
 | 1 | **Counter accuracy** | For a deterministic workload requesting more than one bucket; for each logical dispatch, every kernel-replay counter value matches its corresponding application-replay counter value. Evaluate cache-sensitive counters separately, as a documented limitation. |
 | 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every counter appears exactly once, and all passes collapse to one `Dispatch_ID`. Incomplete results fail before analysis. |
-| 3 | **Filtering** | Kernel and dispatch excluded kernels are not profiled and no errors are thrown. The same `--dispatch` range selects the same dispatches in both replay modes. | 
+| 3 | **Filtering** | Kernels excluded by the kernel or dispatch filter are not profiled and no errors are thrown. The same `--dispatch` range selects the same dispatches in both replay modes. |
 | 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values, and final analysis results agree, and existing application replay is unchanged. |
-| 5 | **Kernel tracing** | Verify independently that kernel tracing emits one pass-0 record per logical dispatch and that is used for kernel duration in analysis. | 
+| 5 | **Kernel tracing** | Verify independently that kernel tracing emits one pass-0 record per logical dispatch and that is used for kernel duration in analysis. |
 | 6 | **PC sampling** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. |
 | 7 | **Compatibility** | Every accepted option behaves as expected — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective kernel risk, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. |
-| 8 | **Configuration rejection** | Each unmet condition on its own — no native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | 
+| 8 | **Configuration rejection** | Each unmet condition on its own — no native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. |
 | 9 | **Failure paths** | An unsupported SDK, a missing or unexpectedly empty profile vector when counters were requested, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. A zero-bucket request follows the existing bypass and is not misclassified as a missing-profile failure. |
-| 10 | **Diagnostics** | Every run identifies the replay mode and names its specific condition. |
+| 10 | **Diagnostics** | Every run identifies the replay mode, and every failure names its specific unmet condition. |
 
 ### Security
 
 - Kernel replay adds no network interface and no new privilege boundary.
 - Its one security-sensitive operation is the SDK-managed host snapshot of application device memory.
-  That snapshot hold application data and should stay inside the profiled process's trust boundary, and `rocprof-compute` must never
-  persist its contents in result artifacts or print them in diagnostics.
+  That snapshot holds application data and should stay inside the profiled process's trust
+  boundary, and `rocprof-compute` must never persist its contents in result artifacts or print them
+  in diagnostics.
 - Snapshot allocation and restore failures are availability failures, and follow the same fail-closed
   rule as every other incomplete replay condition.
 
 ### Debuggability
 
+A diagnostic must name the specific unmet condition. It must identify:
 
-A diagnostic must name the specific unmet condition.
-
- A diagnostic must identify :
 - Selected replay mode and backend
 - Multi-rank detection under kernel replay
 - SDK capability and agent
 - Counter-to-pass mapping
-- Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort
+- Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot
+  decline, or upstream abort
 - That partial results are unusable
-- snapshot decline and recommend application replay
+- A snapshot decline, with a recommendation to use application replay
 
 ## Open questions
 
 | # | Question | Why it matters |
 | --- | --- | --- |
-| 1 | Should kernel replay exclude collective kernels? | This will make multi-rank profiling with kernel possible but the metrics won't reflect the statistics for all kernel invocations. |
-| 2 | Marker durations: reject the combination, or correct the duration? | The host emits these regions once, but they span every pass, so their durations subsumes multiple kernel replay durations. |
-| 3 | Are cache-related metrics trustworthy at all under kernel replay? | Nothing restores cache state between passes, so cache-related counters do not represent the true cache behavior. | 
+| 1 | Should kernel replay exclude collective kernels? | This will make multi-rank profiling with kernel replay possible, but the metrics won't reflect the statistics for all kernel invocations. |
+| 2 | Marker durations: reject the combination, or correct the duration? | The host emits these regions once, but they span every pass, so their durations subsume multiple kernel replay durations. |
+| 3 | Are cache-related metrics trustworthy at all under kernel replay? | Nothing restores cache state between passes, so cache-related counters do not represent the true cache behavior. |
 | 4 | How should `rocprof-compute` detect a declined snapshot? | Today the only signal is classifying an upstream warning string, and the process status can still report success. |

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -4,45 +4,32 @@
 
 ### Counter collection today
 
-`rocprof-compute` maps the requested analysis metrics to hardware counters and uses its
-architecture-aware `perfmon_coalesce` policy to pack those counters into groups that each fit one
-hardware pass. The groups are materialized as `perfmon/pmc_perf_*.yaml` buckets. Their count
-therefore determines how many counter-collection passes are needed.
+`rocprof-compute` maps the requested analysis metrics to hardware counters and
+packs those counters into groups that each fit one hardware pass. The number of
+groups therefore determines how many counter-collection passes are needed.
 
-The profiling layer can invoke `rocprofv3`, or `rocprofiler-sdk` with or without the
+The profiling layer can invoke `rocprofv3`,`rocprofiler-sdk`, or
 `rocprof-compute` native collector. All three configurations consume the same buckets. Application
-replay and single-bucket collection work across them; iteration multiplexing is limited to
-`rocprofiler-sdk` with the native collector.
+replay work across them; iteration multiplexing is limited to native collector.
 
-The `--kernel <regex>` and `--dispatch <range>` filters are existing capabilities on all
-three configurations. Kernel filtering resolves at code-object load time by constructing the
-target kernel-ID set. Dispatch filtering resolves at dispatch time against a logical-dispatch
-index maintained per kernel.
 
 | Strategy | Execution model | What it covers | What it does not cover |
 | --- | --- | --- | --- |
-| **Application replay** (default for multiple buckets) | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning because the complete application is repeated. |
-| **Iteration multiplexing** | Launch the workload once for counter collection and use the native collector to rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough repeated, stable dispatches. | Does not collect every bucket from one logical dispatch. One-off or undersampled kernels cannot produce a complete metric set, and imputation introduces an accuracy trade-off. It also requires the native collector. |
-| **Single-bucket collection** | Launch the workload once for counter collection and collect the one bucket. This is the ordinary one-pass case, not a separate replay mode. | Provides the requested counters without replay or imputation when they fit one hardware pass. | Cannot provide a full report when the requested counters require multiple buckets. |
+| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning. |
+| **Iteration multiplexing** | Launch the workload once for counter collection and use the native collector to rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Does not collect every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. It also requires the native collector. |
 
 Application replay is therefore the only current strategy that covers a multi-bucket request
-without cross-dispatch imputation, but its unit of repetition is the entire workload. Iteration
-multiplexing changes that cost by distributing the buckets across dispatches; it does not replay a
-single dispatch against the same starting state.
+without cross-dispatch imputation.
 
 ### Co-active profiling services
 
 Counter collection never runs alone. Every counter invocation must yield kernel-dispatch records;
-those records supply the kernel counts and durations in Top Stats and the rows in
-`pmc_dispatch_info.csv`. The SDK backend explicitly enables kernel dispatch tracing and adds
-marker or ROCTx tracing for a framework-selected run. The current `rocprofv3` framework option
-selects marker tracing in place of its ordinary kernel-trace option, so its replay adapter must
-verify that the marker configuration yields the required dispatch rows or enable both services.
-Marker regions are consumed by the ML API trace analysis.
+those records supply the kernel counts and durations. The SDK backend explicitly enables kernel dispatch tracing and adds
+marker or ROCTx tracing for a framework-selected run.
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
 objects rather than individual dispatches and are not multiplied by kernel replay. PC sampling runs
-in a separate invocation and roofline counters use the ordinary counter-bucket path.
+in a separate invocation.
 
 ### Proposed SDK replay mechanism
 
@@ -110,48 +97,29 @@ agent is discovered and captured separately. While replay is active, ordinary di
 reader side of the same per-agent lock, while replay windows on different agents can proceed
 concurrently.
 
-### Assumptions and constraints
-
-- The `rocprof-compute` design assumes homogeneous target agents. They use the same counter
-  definitions and therefore the same bucket and pass count. This is a design assumption, not an SDK
-  restriction: the proposed callback is per dispatch, the tool can return different counts for
-  different agents, and the SDK supports those per-dispatch counts.
-- PR 8622 is open and unmerged. The HLD targets its proposed interface, so the integration may need
-  adjustment when the upstream contract lands; no released SDK version floor can be named yet.
-
 ## Problem statement
 
 When a counter request produces *N* hardware-pass buckets, where *N* is greater than one,
 application replay launches and runs the complete workload once per bucket. Counter collection
-therefore repeats process startup, runtime initialization, host-side work, and the workload itself
-*N* times even though each run collects only one bucket. This repeated full-workload work is
-undesirable for workloads with large startup cost.
+therefore repeats process startup, runtime initialization, host-side work, and the kernel run
+*N* times even though only the kernel needs to be profiled *N* times. This repeated full-workload work
+is undesirable for workloads with large startup cost.
 
-Iteration multiplexing avoids those launches, but it obtains the buckets from different dispatch
-occurrences and fills each occurrence's missing counters during analysis. It does not cover the need
-to collect every bucket through repeated executions of one logical dispatch within a single
+Iteration multiplexing avoids those launches, but it obtains the counters from different dispatches
+and fills each dispatch's missing counters during analysis. It does not cover the need
+to collect every counter through repeated executions of one logical dispatch within a single
 workload run.
 
-Kernel replay is intended to fill that gap as an opt-in mode. It retains the same *N* buckets, runs
+Kernel replay is intended to fill that gap. It retains the same *N* buckets, runs
 the workload once, and executes each replay-eligible dispatch in *N* passes, with one bucket collected
-per pass. Application replay remains the default.
+per pass.
 
 Replay also multiplies co-active per-dispatch services. Without explicit handling, kernel dispatch
 tracing emits *N* records for one logical dispatch. Top Stats would then report an inflated dispatch
-count and aggregate GPU duration, and `pmc_dispatch_info.csv` would expose the duplicated rows.
+count and aggregate GPU duration.
 
-Filtering exposes a separate callback-ordering defect on the native collector. Its counter-dispatch
-callback runs once per replay pass and currently increments the per-kernel dispatch index there. An
-*N*-pass replay therefore consumes *N* indices for one logical dispatch, so `--dispatch 3` can
-select the third pass of the first dispatch rather than the third logical dispatch and label the
-wrong work as requested. Because both filters currently reject work in that later callback, after
-the pass count has been chosen, an excluded dispatch would still pay the snapshot, restore, and
-replay-window costs before its counters were discarded.
-
-The motivation is qualitative. No measured startup-cost data, speedup, overhead bound, or break-even
-point is available. Kernel replay removes repeated full-workload launches but adds snapshot,
-restoration, dispatch replay, and isolation costs. There is therefore no claim that it will be
-faster for every workload.
+Kernel replay removes repeated full-workload launches but adds snapshot,
+restoration, dispatch replay, and isolation costs. Therefore it may not be faster for every workload.
 
 The following flow compares counter collection for *N* greater than one. It does not include
 separate profiler invocations outside counter collection.
@@ -160,11 +128,11 @@ separate profiler invocations outside counter collection.
 flowchart LR
     Buckets["N hardware-counter buckets<br/>N greater than 1"]
 
-    subgraph Application["Current default: application replay"]
+    subgraph Application["Application replay"]
         direction TB
         AppSelect["Choose bucket i"]
         AppLaunch["Launch profiling and the full workload"]
-        AppRun["Run process startup, runtime initialization,<br/>host work, and the entire workload"]
+        AppRun["Run process startup, runtime initialization,<br/>host work, and kernel execution"]
         AppCollect["Collect bucket i"]
         AppDone{"All N buckets collected?"}
         AppResult["Counter collection complete<br/>N full workload launches"]
@@ -174,19 +142,19 @@ flowchart LR
         AppDone -- yes --> AppResult
     end
 
-    subgraph Kernel["Proposed opt-in: kernel replay"]
+    subgraph Kernel["Kernel replay"]
         direction TB
         KernelLaunch["Launch profiling and the full workload once"]
         KernelSetup["Run process startup and runtime initialization once"]
-        KernelDispatch{"Next workload dispatch?"}
-        KernelOrdinary["Execute ordinary dispatch once"]
-        KernelReplay["Execute replay-eligible dispatch in N passes<br/>one counter bucket per pass"]
+        KernelDispatch{"Next kernel dispatch?"}
+        KernelOrdinary["Execute unselected dispatch once"]
+        KernelReplay["Execute selected dispatch in N passes<br/>one counter bucket per pass"]
         KernelContinue["Continue host-side workload execution"]
         KernelResult["Counter collection complete<br/>one full workload launch"]
 
         KernelLaunch --> KernelSetup --> KernelDispatch
-        KernelDispatch -- ordinary or not selected --> KernelOrdinary --> KernelContinue
-        KernelDispatch -- selected and replay-eligible --> KernelReplay --> KernelContinue
+        KernelDispatch -- not selected --> KernelOrdinary --> KernelContinue
+        KernelDispatch -- selected --> KernelReplay --> KernelContinue
         KernelContinue --> KernelDispatch
         KernelDispatch -- workload complete --> KernelResult
     end
@@ -197,52 +165,60 @@ flowchart LR
 
 ## Requirements
 
-`P0` requirements are necessary for correct and compatible counter collection. `P1` requirements
-are necessary for a usable experimental mode but do not define counter correctness. Both priorities
-are normative.
-
 ### Functional requirements
 
-| ID | Priority | Requirement | Decision trace |
-| --- | --- | --- | --- |
-| FR-01 | P0 | `rocprof-compute profile` shall expose `--replay-mode {application,kernel}`, default to `application`, and require explicit selection of kernel replay. `--iteration-multiplexing` and its policy argument shall remain independent. | Plan—Purpose, CLI, iteration multiplexing; Initial Q3; Final Q18 |
-| FR-02 | P0 | For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No user-supplied pass count shall be required. | Plan—Purpose, bucketing; Initial Q3/Q6 |
-| FR-03 | P0 | Kernel replay shall support `rocprofv3`, `rocprofiler-sdk` with the native collector, and `rocprofiler-sdk` without it. An unavailable backend configuration shall produce a hard error naming a supported alternative rather than falling back. | Plan—Backends, failure paths; Initial Q4/Q5 |
-| FR-04 | P0 | Kernel replay shall preserve the bucket membership used by application replay. The pass count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC grouping, and same-bucket priority shall remain unchanged. | Plan—Bucketing; Initial Q6/Q7 |
-| FR-05 | P0 | One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the existing workload join and analysis path can consume without an analysis-side contract change. | Plan—Output (Q7 reversal); Final Q7 |
-| FR-06 | P0 | All passes of one logical dispatch shall resolve to one `Dispatch_ID` group containing the complete counter set. Start and end timestamps shall follow the same cross-pass normalization semantics used for application-replay results. | Plan—Dispatch identity; Initial Q10 |
-| FR-07 | P0 | Kernel replay combined with `--iteration-multiplexing`, `--attach-pid`, or `--pc-sampling` shall produce a hard error. `--roof-only`, `--set`, and `--block` shall continue to interoperate unchanged. | Plan—PC sampling (Q3 reversal), failure paths; Final Q3/Q20 |
-| FR-08 | P0 | Kernel replay shall produce a hard error when the installed SDK predates the supported version floor and shall state the required version. | Plan—version-floor open question; Initial Q12; HLD questionnaire Q20 |
-| FR-09 | P0 | Kernel replay shall support homogeneous multi-agent configurations and shall produce a hard error identifying heterogeneous agents. | Plan—Failure paths; HLD questionnaire Q15; Final Q20 |
-| FR-10 | P0 | Kernel replay shall remain available for multi-rank workloads and shall retain the multi-rank warning. | Plan—Multi-rank; Final Q1–Q2 |
-| FR-11 | P0 | If the SDK declines a device-memory snapshot, `rocprof-compute` shall abandon the profile without retry, reject the incomplete data, and recommend application replay in the diagnostic. | Plan—Failure paths; Final Q8–Q10 |
-| FR-12 | P0 | If the upstream replay mechanism aborts the workload, `rocprof-compute` shall report the failed run without attempting recovery or analysis of partial output. | Plan—Failure paths; HLD questionnaire Q10; Final Q20 |
-| FR-13 | P0 | If an agent has no usable counter profiles, `rocprof-compute` shall diagnose the condition rather than silently degrading that dispatch to one pass. | Plan—Failure paths; Final Q16 |
-| FR-14 | P0 | Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and `pmc_dispatch_info.csv` preserve non-replay semantics by reporting one dispatch and its pass-0 logical duration rather than replay-multiplied values. | Plan v2—kernel-trace deduplication, Phase 2 requirements |
-| FR-15 | P0 | Roofline counter collection shall follow the selected replay mode through the ordinary counter-bucket path without special handling. | Plan v2—roofline |
-| FR-16 | P0 | Kernel filtering shall compose with kernel replay on the native collector. A dispatch whose kernel is excluded by `--kernel` shall not be replayed and shall incur no snapshot or restore. | Plan v3—native kernel filtering |
-| FR-17 | P0 | Dispatch filtering shall compose with kernel replay on the native collector. `--dispatch` indices shall count logical dispatches, not replay passes, so an index selects the same work whether or not kernel replay is selected. An excluded dispatch shall not be replayed. | Plan v3—logical dispatch indexing |
-
-The concrete SDK version in FR-08 remains a placeholder until PR 8622 merges. The version value is
-an external dependency; version-gated failure behavior is settled. FR-10 does not settle whether
-collective-bearing dispatches must be excluded; that policy remains an open question.
-
-FR-16 and FR-17 are separate because the filters resolve at different times and can fail
-independently: correcting kernel-regex exclusion does not correct a pass-indexed `--dispatch`,
-and vice versa. They guarantee filter composition only for the native collector. Filtered kernel
-replay on the two non-native configurations is not claimed here and remains an open question.
+- `rocprof-compute profile` shall expose `--replay-mode {application,kernel}`, default to
+  `application`, and require explicit selection of kernel replay. `--iteration-multiplexing` and its
+  policy argument shall remain independent.
+- For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
+  collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No
+  user-supplied pass count shall be required.
+- Kernel replay shall support `rocprofv3`, native collector, and `rocprofiler-sdk`.
+- Kernel replay shall preserve the counter bucket membership used by application replay. The pass count
+  shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC
+  grouping, and same-bucket priority shall remain unchanged.
+- One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the
+  existing workload join and analysis path can consume without an analysis-side contract change.
+- All passes of one logical dispatch shall resolve to one `Dispatch_ID` group containing the
+  complete counter set. Start and end timestamps shall follow the same cross-pass normalization
+  semantics used for application-replay results.
+- Kernel replay combined with `--iteration-multiplexing`, `--attach-pid`, or `--pc-sampling` shall
+  produce a hard error. `--roof-only`, `--set`, and `--block` shall continue to interoperate
+  unchanged.
+- Kernel replay shall produce a hard error when the installed SDK predates the supported version
+  floor and shall state the required version.
+- Kernel replay shall remain available for multi-rank workloads.
+- If the SDK declines a device-memory snapshot, `rocprof-compute` shall abandon the profile without
+  retry and recommend application replay in the diagnostic.
+- If the upstream replay mechanism aborts, `rocprof-compute` shall report the failed run
+  without attempting recovery.
+- If an agent has no usable counter profiles, `rocprof-compute` shall diagnose the condition rather
+  than silently degrading that dispatch to one pass.
+- Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and
+  `pmc_dispatch_info.csv` preserve non-replay semantics by reporting one dispatch and its pass-0
+  logical duration rather than replay-multiplied values.
+- Kernel filtering shall compose with kernel replay on the native collector. A dispatch whose kernel
+  is excluded shall not be replayed and shall incur no snapshot or restore.
+- Dispatch filtering shall compose with kernel replay on the native collector. `--dispatch` indices
+  shall count logical dispatches, not replay passes, so an index selects the same work whether or not
+  kernel replay is selected. An excluded dispatch shall not be replayed.
 
 ### Non-functional requirements
 
-| ID | Priority | Requirement | Decision trace |
-| --- | --- | --- | --- |
-| NFR-01 | P0 | For state covered by the replay-equivalence guarantee, a counter present in more than one bucket shall have the same value across passes of the same dispatch. Cache-sensitive counters are outside this invariant because cache state is not restored. | Plan—Validation and cache-state limitation; Initial Q14/Q15 |
-| NFR-02 | P0 | Kernel replay shall fail closed whenever it cannot provide a complete bucket set. Silently partial counter data shall not reach analysis. | Plan—Failure paths; Final Q9/Q16 |
-| NFR-03 | P0 | Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. It shall make no equivalence guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked device footprint. | Plan—Phase 4 limitations; Initial Q14; HLD questionnaire Q23 |
-| NFR-04 | P0 | Workflows that do not select kernel replay shall retain their current collection behavior, and kernel-replay output shall preserve the existing analysis input contract. | Plan—Purpose, output; Initial Q3; Final Q7 |
-| NFR-05 | P1 | Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. | Plan—Phase 5 debuggability; Final Q8–Q10/Q16/Q20 |
-| NFR-06 | P1 | CLI help shall identify kernel replay as experimental. | Plan—CLI; Final Q19 |
-| NFR-07 | P1 | Kernel-replay performance shall be evaluated qualitatively. The system shall make no wall-time speedup guarantee and shall have no symbolic or numeric replay-overhead acceptance bound. | Plan—Cost model; Initial Q16; Final Q21 |
+- For state covered by the replay-equivalence guarantee, a counter present in more than one bucket
+  shall have the same value across passes of the same dispatch. Cache-sensitive counters are outside
+  this invariant because cache state is not restored.
+- Kernel replay shall fail closed whenever it cannot provide a complete bucket set. Silently partial
+  counter data shall not be collected.
+- Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and
+  module-scope device or constant state. It shall make no equivalence guarantee for unified,
+  managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions,
+  unfenced asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked
+  device footprint.
+- Workflows that do not select kernel replay shall retain their current collection behavior, and
+  kernel-replay output shall preserve the existing analysis input contract.
+- Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific
+  failure condition.
 
 ## Design
 
@@ -543,15 +519,8 @@ snapshot-decline diagnostic also recommends application replay.
 
 ## Open questions
 
-1. **SDK version floor.** Which released ROCm SDK version will first contain the kernel-replay
-   contract after PR 8622 merges, and what concrete minimum should the CLI diagnostic require?
-2. **Measured startup cost.** Which representative workloads show that avoiding repeated startup
-   outweighs snapshot, restoration, isolation, and replay overhead? No speedup or break-even claim
-   can be made until those measurements exist.
 3. **Collective-bearing kernels.** Should dispatches participating in inter-process collectives be
-   excluded from kernel replay, despite retaining multi-rank support and its existing warning?
-4. **Snapshot-decline detection.** Can the upstream SDK expose a structured status for a declined
-   snapshot instead of requiring `rocprof-compute` to classify a fragile log string?
+   excluded from kernel replay?
 5. **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
    their durations include replay overhead and are not comparable with a non-replay run. Should the
    combination be corrected, annotated, or rejected?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -482,3 +482,5 @@ snapshot-decline diagnostic also recommends application replay.
 - **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
    native collector resolve filters inside the SDK tool library. Will `rocprofv3` support
    in future?
+- **Cache related counter value validity.** Can cache-related metrics be trusted
+   since the cache state is not restored between replay passes?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -1,0 +1,564 @@
+# Kernel replay in rocprof-compute
+
+## System Context
+
+### Counter collection today
+
+`rocprof-compute` maps the requested analysis metrics to hardware counters and uses its
+architecture-aware `perfmon_coalesce` policy to pack those counters into groups that each fit one
+hardware pass. The groups are materialized as `perfmon/pmc_perf_*.yaml` buckets. Their count
+therefore determines how many counter-collection passes are needed.
+
+The profiling layer can invoke `rocprofv3`, or `rocprofiler-sdk` with or without the
+`rocprof-compute` native collector. All three configurations consume the same buckets. Application
+replay and single-bucket collection work across them; iteration multiplexing is limited to
+`rocprofiler-sdk` with the native collector.
+
+The `--kernel <regex>` and `--dispatch <range>` filters are existing capabilities on all
+three configurations. Kernel filtering resolves at code-object load time by constructing the
+target kernel-ID set. Dispatch filtering resolves at dispatch time against a logical-dispatch
+index maintained per kernel.
+
+| Strategy | Execution model | What it covers | What it does not cover |
+| --- | --- | --- | --- |
+| **Application replay** (default for multiple buckets) | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning because the complete application is repeated. |
+| **Iteration multiplexing** | Launch the workload once for counter collection and use the native collector to rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough repeated, stable dispatches. | Does not collect every bucket from one logical dispatch. One-off or undersampled kernels cannot produce a complete metric set, and imputation introduces an accuracy trade-off. It also requires the native collector. |
+| **Single-bucket collection** | Launch the workload once for counter collection and collect the one bucket. This is the ordinary one-pass case, not a separate replay mode. | Provides the requested counters without replay or imputation when they fit one hardware pass. | Cannot provide a full report when the requested counters require multiple buckets. |
+
+Application replay is therefore the only current strategy that covers a multi-bucket request
+without cross-dispatch imputation, but its unit of repetition is the entire workload. Iteration
+multiplexing changes that cost by distributing the buckets across dispatches; it does not replay a
+single dispatch against the same starting state.
+
+### Co-active profiling services
+
+Counter collection never runs alone. Every counter invocation must yield kernel-dispatch records;
+those records supply the kernel counts and durations in Top Stats and the rows in
+`pmc_dispatch_info.csv`. The SDK backend explicitly enables kernel dispatch tracing and adds
+marker or ROCTx tracing for a framework-selected run. The current `rocprofv3` framework option
+selects marker tracing in place of its ordinary kernel-trace option, so its replay adapter must
+verify that the marker configuration yields the required dispatch rows or enable both services.
+Marker regions are consumed by the ML API trace analysis.
+
+The native collector also subscribes to code-object tracing, but those events describe load-time
+objects rather than individual dispatches and are not multiplied by kernel replay. PC sampling runs
+in a separate invocation and roofline counters use the ordinary counter-bucket path.
+
+### Proposed SDK replay mechanism
+
+[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism that this
+design must consume. The mechanism is a surrounding component and an external constraint; this HLD
+does not propose changes to its replay algorithm.
+
+The PR adds a `KERNEL_REPLAY` callback domain with `CONFIG` and `PASS` operations. In the fixed-pass
+path that `rocprof-compute` would use, a profiling tool supplies `pass_count_cb` during `CONFIG`.
+The callback is evaluated for each dispatch that reaches the replay gate and can use its agent
+information. Returning `1` opts out: the SDK follows its ordinary single-execution path without
+taking a snapshot or issuing `PASS` callbacks. Returning a count greater than one opens a replay
+window, and `PASS` enter and exit callbacks delimit each execution in that window.
+
+The same upstream mechanism lets a tool locally stop a context for selected replay passes. Kernel
+dispatch tracing honors that local stop and omits the disabled context's dispatch record. This is an
+external capability used by the service-composition design below.
+
+The replay window isolates one GPU agent. The SDK takes a host-side writer lock keyed by that
+agent, holds the application's completion signal, drains prior work on the submitting and sibling
+queues, and copies the supported device state to a host snapshot. It then executes the dispatch
+once per pass, restoring the snapshot between passes so each begins from the same device state. The
+SDK exits `CONFIG`, signals one application-visible completion, and releases the writer lock.
+
+```mermaid
+sequenceDiagram
+    participant App as Application thread
+    participant SDK as SDK replay service
+    participant Tool as Profiling tool
+    participant Agent as GPU agent and queues
+    participant Snapshot as Host snapshot manager
+
+    App->>SDK: Submit dispatch
+    SDK->>Tool: KERNEL_REPLAY CONFIG enter
+    Tool-->>SDK: Register pass_count_cb
+    SDK->>Tool: pass_count_cb for this dispatch
+    Tool-->>SDK: Return pass count N
+    alt N equals 1: opt out
+        SDK->>Tool: KERNEL_REPLAY CONFIG exit
+        SDK->>Agent: Execute ordinary dispatch
+        Agent-->>App: One application-visible completion
+    else N is greater than 1
+        SDK->>SDK: Acquire per-agent writer lock
+        Note over SDK,Agent: Hold the application completion signal
+        SDK->>Agent: Drain prior submitting and sibling queue work
+        SDK->>Snapshot: Snapshot supported agent state
+        loop Repeat N times
+            SDK->>Tool: KERNEL_REPLAY PASS enter
+            SDK->>Agent: Execute the same dispatch
+            Agent-->>SDK: Pass completes and handler drains
+            SDK->>Tool: KERNEL_REPLAY PASS exit
+            opt Another pass remains
+                SDK->>Snapshot: Restore captured agent state
+            end
+        end
+        SDK->>Tool: KERNEL_REPLAY CONFIG exit
+        SDK-->>App: Signal one application-visible completion
+        SDK->>SDK: Release per-agent writer lock
+    end
+```
+
+The snapshot covers tracked, agent-owned, coarse-grained device allocations that are neither
+kernarg nor executable memory. Module-scope `__device__` and `__constant__` storage visible to the
+agent is discovered and captured separately. While replay is active, ordinary dispatches use the
+reader side of the same per-agent lock, while replay windows on different agents can proceed
+concurrently.
+
+### Assumptions and constraints
+
+- The `rocprof-compute` design assumes homogeneous target agents. They use the same counter
+  definitions and therefore the same bucket and pass count. This is a design assumption, not an SDK
+  restriction: the proposed callback is per dispatch, the tool can return different counts for
+  different agents, and the SDK supports those per-dispatch counts.
+- PR 8622 is open and unmerged. The HLD targets its proposed interface, so the integration may need
+  adjustment when the upstream contract lands; no released SDK version floor can be named yet.
+
+## Problem statement
+
+When a counter request produces *N* hardware-pass buckets, where *N* is greater than one,
+application replay launches and runs the complete workload once per bucket. Counter collection
+therefore repeats process startup, runtime initialization, host-side work, and the workload itself
+*N* times even though each run collects only one bucket. This repeated full-workload work is
+undesirable for workloads with large startup cost.
+
+Iteration multiplexing avoids those launches, but it obtains the buckets from different dispatch
+occurrences and fills each occurrence's missing counters during analysis. It does not cover the need
+to collect every bucket through repeated executions of one logical dispatch within a single
+workload run.
+
+Kernel replay is intended to fill that gap as an opt-in mode. It retains the same *N* buckets, runs
+the workload once, and executes each replay-eligible dispatch in *N* passes, with one bucket collected
+per pass. Application replay remains the default.
+
+Replay also multiplies co-active per-dispatch services. Without explicit handling, kernel dispatch
+tracing emits *N* records for one logical dispatch. Top Stats would then report an inflated dispatch
+count and aggregate GPU duration, and `pmc_dispatch_info.csv` would expose the duplicated rows.
+
+Filtering exposes a separate callback-ordering defect on the native collector. Its counter-dispatch
+callback runs once per replay pass and currently increments the per-kernel dispatch index there. An
+*N*-pass replay therefore consumes *N* indices for one logical dispatch, so `--dispatch 3` can
+select the third pass of the first dispatch rather than the third logical dispatch and label the
+wrong work as requested. Because both filters currently reject work in that later callback, after
+the pass count has been chosen, an excluded dispatch would still pay the snapshot, restore, and
+replay-window costs before its counters were discarded.
+
+The motivation is qualitative. No measured startup-cost data, speedup, overhead bound, or break-even
+point is available. Kernel replay removes repeated full-workload launches but adds snapshot,
+restoration, dispatch replay, and isolation costs. There is therefore no claim that it will be
+faster for every workload.
+
+The following flow compares counter collection for *N* greater than one. It does not include
+separate profiler invocations outside counter collection.
+
+```mermaid
+flowchart LR
+    Buckets["N hardware-counter buckets<br/>N greater than 1"]
+
+    subgraph Application["Current default: application replay"]
+        direction TB
+        AppSelect["Choose bucket i"]
+        AppLaunch["Launch profiling and the full workload"]
+        AppRun["Run process startup, runtime initialization,<br/>host work, and the entire workload"]
+        AppCollect["Collect bucket i"]
+        AppDone{"All N buckets collected?"}
+        AppResult["Counter collection complete<br/>N full workload launches"]
+
+        AppSelect --> AppLaunch --> AppRun --> AppCollect --> AppDone
+        AppDone -- next bucket --> AppSelect
+        AppDone -- yes --> AppResult
+    end
+
+    subgraph Kernel["Proposed opt-in: kernel replay"]
+        direction TB
+        KernelLaunch["Launch profiling and the full workload once"]
+        KernelSetup["Run process startup and runtime initialization once"]
+        KernelDispatch{"Next workload dispatch?"}
+        KernelOrdinary["Execute ordinary dispatch once"]
+        KernelReplay["Execute replay-eligible dispatch in N passes<br/>one counter bucket per pass"]
+        KernelContinue["Continue host-side workload execution"]
+        KernelResult["Counter collection complete<br/>one full workload launch"]
+
+        KernelLaunch --> KernelSetup --> KernelDispatch
+        KernelDispatch -- ordinary or not selected --> KernelOrdinary --> KernelContinue
+        KernelDispatch -- selected and replay-eligible --> KernelReplay --> KernelContinue
+        KernelContinue --> KernelDispatch
+        KernelDispatch -- workload complete --> KernelResult
+    end
+
+    Buckets --> AppSelect
+    Buckets --> KernelLaunch
+```
+
+## Requirements
+
+`P0` requirements are necessary for correct and compatible counter collection. `P1` requirements
+are necessary for a usable experimental mode but do not define counter correctness. Both priorities
+are normative.
+
+### Functional requirements
+
+| ID | Priority | Requirement | Decision trace |
+| --- | --- | --- | --- |
+| FR-01 | P0 | `rocprof-compute profile` shall expose `--replay-mode {application,kernel}`, default to `application`, and require explicit selection of kernel replay. `--iteration-multiplexing` and its policy argument shall remain independent. | Plan—Purpose, CLI, iteration multiplexing; Initial Q3; Final Q18 |
+| FR-02 | P0 | For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No user-supplied pass count shall be required. | Plan—Purpose, bucketing; Initial Q3/Q6 |
+| FR-03 | P0 | Kernel replay shall support `rocprofv3`, `rocprofiler-sdk` with the native collector, and `rocprofiler-sdk` without it. An unavailable backend configuration shall produce a hard error naming a supported alternative rather than falling back. | Plan—Backends, failure paths; Initial Q4/Q5 |
+| FR-04 | P0 | Kernel replay shall preserve the bucket membership used by application replay. The pass count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC grouping, and same-bucket priority shall remain unchanged. | Plan—Bucketing; Initial Q6/Q7 |
+| FR-05 | P0 | One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the existing workload join and analysis path can consume without an analysis-side contract change. | Plan—Output (Q7 reversal); Final Q7 |
+| FR-06 | P0 | All passes of one logical dispatch shall resolve to one `Dispatch_ID` group containing the complete counter set. Start and end timestamps shall follow the same cross-pass normalization semantics used for application-replay results. | Plan—Dispatch identity; Initial Q10 |
+| FR-07 | P0 | Kernel replay combined with `--iteration-multiplexing`, `--attach-pid`, or `--pc-sampling` shall produce a hard error. `--roof-only`, `--set`, and `--block` shall continue to interoperate unchanged. | Plan—PC sampling (Q3 reversal), failure paths; Final Q3/Q20 |
+| FR-08 | P0 | Kernel replay shall produce a hard error when the installed SDK predates the supported version floor and shall state the required version. | Plan—version-floor open question; Initial Q12; HLD questionnaire Q20 |
+| FR-09 | P0 | Kernel replay shall support homogeneous multi-agent configurations and shall produce a hard error identifying heterogeneous agents. | Plan—Failure paths; HLD questionnaire Q15; Final Q20 |
+| FR-10 | P0 | Kernel replay shall remain available for multi-rank workloads and shall retain the multi-rank warning. | Plan—Multi-rank; Final Q1–Q2 |
+| FR-11 | P0 | If the SDK declines a device-memory snapshot, `rocprof-compute` shall abandon the profile without retry, reject the incomplete data, and recommend application replay in the diagnostic. | Plan—Failure paths; Final Q8–Q10 |
+| FR-12 | P0 | If the upstream replay mechanism aborts the workload, `rocprof-compute` shall report the failed run without attempting recovery or analysis of partial output. | Plan—Failure paths; HLD questionnaire Q10; Final Q20 |
+| FR-13 | P0 | If an agent has no usable counter profiles, `rocprof-compute` shall diagnose the condition rather than silently degrading that dispatch to one pass. | Plan—Failure paths; Final Q16 |
+| FR-14 | P0 | Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and `pmc_dispatch_info.csv` preserve non-replay semantics by reporting one dispatch and its pass-0 logical duration rather than replay-multiplied values. | Plan v2—kernel-trace deduplication, Phase 2 requirements |
+| FR-15 | P0 | Roofline counter collection shall follow the selected replay mode through the ordinary counter-bucket path without special handling. | Plan v2—roofline |
+| FR-16 | P0 | Kernel filtering shall compose with kernel replay on the native collector. A dispatch whose kernel is excluded by `--kernel` shall not be replayed and shall incur no snapshot or restore. | Plan v3—native kernel filtering |
+| FR-17 | P0 | Dispatch filtering shall compose with kernel replay on the native collector. `--dispatch` indices shall count logical dispatches, not replay passes, so an index selects the same work whether or not kernel replay is selected. An excluded dispatch shall not be replayed. | Plan v3—logical dispatch indexing |
+
+The concrete SDK version in FR-08 remains a placeholder until PR 8622 merges. The version value is
+an external dependency; version-gated failure behavior is settled. FR-10 does not settle whether
+collective-bearing dispatches must be excluded; that policy remains an open question.
+
+FR-16 and FR-17 are separate because the filters resolve at different times and can fail
+independently: correcting kernel-regex exclusion does not correct a pass-indexed `--dispatch`,
+and vice versa. They guarantee filter composition only for the native collector. Filtered kernel
+replay on the two non-native configurations is not claimed here and remains an open question.
+
+### Non-functional requirements
+
+| ID | Priority | Requirement | Decision trace |
+| --- | --- | --- | --- |
+| NFR-01 | P0 | For state covered by the replay-equivalence guarantee, a counter present in more than one bucket shall have the same value across passes of the same dispatch. Cache-sensitive counters are outside this invariant because cache state is not restored. | Plan—Validation and cache-state limitation; Initial Q14/Q15 |
+| NFR-02 | P0 | Kernel replay shall fail closed whenever it cannot provide a complete bucket set. Silently partial counter data shall not reach analysis. | Plan—Failure paths; Final Q9/Q16 |
+| NFR-03 | P0 | Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. It shall make no equivalence guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked device footprint. | Plan—Phase 4 limitations; Initial Q14; HLD questionnaire Q23 |
+| NFR-04 | P0 | Workflows that do not select kernel replay shall retain their current collection behavior, and kernel-replay output shall preserve the existing analysis input contract. | Plan—Purpose, output; Initial Q3; Final Q7 |
+| NFR-05 | P1 | Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. | Plan—Phase 5 debuggability; Final Q8–Q10/Q16/Q20 |
+| NFR-06 | P1 | CLI help shall identify kernel replay as experimental. | Plan—CLI; Final Q19 |
+| NFR-07 | P1 | Kernel-replay performance shall be evaluated qualitatively. The system shall make no wall-time speedup guarantee and shall have no symbolic or numeric replay-overhead acceptance bound. | Plan—Cost model; Initial Q16; Final Q21 |
+
+## Design
+
+### Counter groups and backend boundaries
+
+Kernel replay changes the invocation shape, not counter partitioning. `perfmon_coalesce` remains
+the only authority for bucket membership and one-pass fit. Its `_ACCUM` pairing, TCC grouping,
+and same-bucket priority policies produce *N* buckets for both application and kernel replay. The
+kernel-replay adapter translates those buckets into each backend's syntax without regrouping them.
+
+| Backend configuration | Single-invocation encoding | Pass-count owner |
+| --- | --- | --- |
+| `rocprofiler-sdk` with the native collector | Deliver all *N* groups through `ROCPROF_COUNTERS` to one replay-enabled invocation. | The native collector derives the count from the per-agent profiles it created. |
+| `rocprofiler-sdk` without the native collector | Deliver all *N* `ROCPROF_COUNTERS` groups and enable `ROCPROF_KERNEL_REPLAY`. | The SDK tool library derives the count from its per-agent profiles. |
+| `rocprofv3` | Bypass `-i`, emit one repeated `--pmc` group per bucket, and enable the upstream replay option. | The SDK tool library derives the count from its per-agent profiles. |
+
+No separate pass-count option or environment value is introduced. That would create a second value
+that could disagree with the profiles actually accepted by the SDK. The final spelling of the
+multi-group SDK-tool contract must be checked against the merged upstream interface: the current
+proposal distinguishes more than one environment-variable spelling. That integration detail may
+change, but the `ROCPROF_COUNTERS` semantic contract selected here and the authoritative bucket
+membership may not.
+
+### Pass-count ownership and profile validity
+
+On the native path, counter-group parsing creates one profile-vector entry per group and per agent.
+For an admitted dispatch, `pass_count_cb` returns the size of the vector for the dispatch's
+agent, and replay pass *i* selects entry *i* from that same vector. The count is agent-local and
+proves that the requested groups became usable profiles.
+
+The callback's ordinary value of one means “do not replay.” It is not a valid fallback when an agent
+lookup fails or its vector is empty: that would execute the dispatch once, collect only one bucket,
+and make incomplete data look successful. A missing or empty vector must instead diagnose the
+agent/profile mismatch and fail the complete profile. The callback has no error return, so a later
+low-level design may choose the exact fatal-tool or run-failure transport; it may not substitute a
+count of one.
+
+The non-native SDK and `rocprofv3` paths follow the same ownership rule inside the SDK tool
+library. `rocprof-compute` supplies groups and replay enablement; the tool that materializes the
+per-agent profiles supplies the callback and count.
+
+The component diagram shows both counter and kernel-trace data. The trace mechanisms differ because
+only the native collector is `rocprof-compute`-owned code.
+
+```mermaid
+graph LR
+    subgraph Compute["rocprof-compute"]
+        Buckets["perfmon_coalesce<br/>N authoritative buckets"]
+        Adapter["Kernel-replay backend adapter"]
+        Normalize["Cross-pass counter identity<br/>and timestamp normalization"]
+        Dedup["Post-run kernel-trace deduplication<br/>non-native SDK and rocprofv3"]
+        Output["Consolidated counter result<br/>and one logical trace record"]
+        Analysis["Existing join and analysis path"]
+        Buckets --> Adapter
+        Normalize --> Output
+        Dedup --> Output
+        Output --> Analysis
+    end
+
+    subgraph Tools["Profiler and tool boundary"]
+        Native["SDK with native collector<br/>per-agent profile vector"]
+        NonNative["SDK with SDK tool library"]
+        V3["rocprofv3 with SDK tool library"]
+        Reject["Diagnose and reject invalid profile<br/>never treat it as filter opt-out"]
+    end
+
+    subgraph SDK["rocprofiler-sdk"]
+        Replay["Kernel replay service<br/>N passes per logical dispatch"]
+        Counters["Dispatch counter collection<br/>group i on pass i"]
+        Trace["Kernel dispatch tracing"]
+        Replay --> Counters
+        Replay --> Trace
+    end
+
+    Adapter -- "ROCPROF_COUNTERS groups<br/>native replay setup" --> Native
+    Adapter -- "ROCPROF_COUNTERS groups<br/>ROCPROF_KERNEL_REPLAY" --> NonNative
+    Adapter -- "repeated --pmc groups<br/>replay option; bypass -i" --> V3
+
+    Native -- "pass_count_cb<br/>selected: profile-vector size<br/>filtered: one" --> Replay
+    NonNative -- "SDK tool derives count" --> Replay
+    V3 -- "SDK tool derives count" --> Replay
+    Native -- "missing or empty vector" --> Reject
+
+    Native -. "locally stop trace context<br/>on passes 1 through N-1" .-> Trace
+    Counters --> Normalize
+    Trace -- "native path: pass-0 record" --> Output
+    Trace -- "other paths: N raw records" --> Dedup
+    Normalize -. "shared logical-dispatch identity" .-> Dedup
+```
+
+### Native filtering at the pass-count decision
+
+On the native-collector path, `pass_count_cb` is also the filter decision point because it runs
+once per logical dispatch before any replay pass. Before choosing a count, the collector confirms
+that the dispatch's agent has a non-empty profile vector. It then assigns the dispatch's per-kernel
+logical index exactly once, evaluates the kernel-ID target set built during code-object loading and
+the requested dispatch range, and returns the profile-vector size only when both filters admit the
+dispatch. A confirmed filter miss returns one, intentionally selecting the SDK's ordinary path
+without a snapshot or restore. A missing or empty profile vector remains a fatal profile error and
+must never use that return.
+
+The per-pass counter-dispatch callback reads the assigned logical index instead of incrementing it.
+A non-replay run has one pass per dispatch, so relocating the increment preserves its existing
+indices while preventing replay passes from consuming additional indices. Completeness checks apply
+only to admitted dispatches; an intentionally excluded dispatch produces no counter set and is not
+an incomplete replay result.
+
+### Output and dispatch identity
+
+One kernel-replay counter invocation produces one consolidated
+`results_*.csv` artifact, compressed when the existing output policy requires it. The existing
+`join_workload_csvs` discovery and concatenation then produce `pmc_perf.csv`, and
+`create_df_pmc` performs the existing long-to-wide counter pivot. Kernel replay does not write
+`pmc_perf.csv` directly and does not add a replay-specific analysis branch.
+
+Before that artifact is written, all pass rows for one logical dispatch must receive one
+`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity may be retained
+transiently for normalization and diagnostics, but it need not enter `pmc_perf.csv`.
+Non-replay identity behavior remains unchanged.
+
+Application replay aligns corresponding dispatches because each workload invocation starts a fresh
+positional ID assignment, even though their timestamps differ. It does not literally rewrite
+timestamps. Kernel replay needs the analogous alignment inside one invocation: first correlate the
+pass rows using replay-stable logical-dispatch identity, then normalize their timestamp pair before
+the existing identity and pivot contracts consume them.
+
+Without that step, the current timestamp-bearing identity key assigns a new `Dispatch_ID` to
+every pass. Analysis groups on `Dispatch_ID` before it pivots counter names into columns, so
+each group would contain only one bucket and no row would have the complete metric inputs. This is
+why normalization belongs at the output boundary rather than in metric evaluation.
+
+### Co-active service composition
+
+Kernel dispatch tracing must yield one record per logical dispatch, independent of the pass count.
+The mechanism differs at the ownership boundary:
+
+- The native collector can control its own SDK contexts. It traces pass 0 and locally stops the
+  kernel-trace context for passes 1 through *N*−1.
+- The non-native SDK and `rocprofv3` paths execute the SDK-owned tool library, which
+  `rocprof-compute` cannot instrument. Those paths collapse the *N* raw trace records after the
+  run, using the normalized logical-dispatch identity.
+
+This split is forced by code ownership, not by a preference for two deduplication strategies. Both
+must produce the same dispatch count for Top Stats and `pmc_dispatch_info.csv`.
+
+Pass 0 is retained because it executes against the pristine pre-snapshot state. Every later pass
+follows a full host-to-device restore of the tracked footprint, which perturbs memory-system state.
+Pass 0 is therefore the closest available timing proxy for an ordinary dispatch. The design
+preserves one non-multiplied logical duration; it does not promise numeric equality with a separate
+non-replay measurement.
+
+Roofline uses the selected replay mode through the ordinary counter path and needs no special
+handling. Code-object tracing is load-time only and needs no replay treatment. Marker and ROCTx
+regions are emitted once on the host but span all passes; their duration semantics remain open.
+
+### Mode and option compatibility
+
+`--replay-mode` accepts `application` and `kernel`. Application replay remains the
+default, and CLI help identifies kernel replay as experimental. The selected mode is carried to the
+backend adapter; it does not change `--iteration-multiplexing` into a mode selector.
+
+Kernel mode is rejected before profiling when combined with iteration multiplexing, live attach, or
+PC sampling. PC sampling is agent-wide, does not consume the localized context override, and today
+runs in a separate counter-disabled invocation. There is therefore no supported replay pass into
+which it can be inserted.
+
+`--roof-only`, `--set`, and `--block` continue through ordinary counter selection.
+Multi-rank profiling remains available and retains its warning. Kernel replay additionally requires
+a supported SDK version and a homogeneous agent configuration. Whether collective-bearing
+dispatches require exclusion is not settled by that support statement.
+
+### Failure behavior
+
+All failures reject partial replay data. None falls back to application replay or silently changes a
+multi-bucket request into one pass.
+
+| Condition | Required behavior |
+| --- | --- |
+| Unsupported backend configuration | Hard error naming the configuration and a supported alternative. |
+| SDK below the supported version floor | Hard error stating the required version. The numeric floor remains pending upstream merge. |
+| Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
+| Heterogeneous target agents | Hard error because this design assumes one uniform bucket and pass count. |
+| Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
+| SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
+| Upstream drain timeout or process abort | Report the failed run without recovery or analysis of partial output. |
+| Any incomplete bucket set | Reject it before the workload join or metric analysis. |
+
+A declined snapshot can currently leave a successful process status, so the required outcome cannot
+depend only on subprocess failure. Classifying an upstream warning string is the available but
+fragile signal; a structured detection mechanism remains an open question.
+
+### Support boundaries and rationale
+
+Kernel replay inherits the upstream mechanism's support boundaries:
+
+- The host snapshot can require memory equal to the complete tracked device footprint.
+- Equivalent-state guarantees cover tracked coarse-grained device VRAM and module-scope
+  `__device__` or `__constant__` state. Unified, managed, and `hipMallocAsync`
+  allocations are not restored.
+- HIP graph launches are unsupported.
+- Only single-packet, single-dispatch submissions are replayed; other submissions execute without
+  replay.
+- Asynchronous SDMA or HSA copies are not fenced by the replay window.
+- Cache state is not restored, so cache-sensitive counter values may vary.
+- Bounded drain expiry aborts the process instead of returning a recoverable error.
+- Multi-rank dispatches that participate in collectives remain unsafe pending an exclusion policy.
+
+Keeping grouping in `perfmon_coalesce` preserves the architecture policies used by application
+replay. Deriving the count where profiles are materialized avoids a second source of truth.
+Backend-local encoding contains profiler syntax at the adapter, and preserving the existing output
+contract avoids a second analysis implementation. These contracts are settled. The remaining
+choices concern the final upstream interface, declined-snapshot signaling, and the explicitly
+deferred service policies below.
+
+## Implementation phases
+
+These are proposed vertical slices for future implementation work; they are not scheduled by this
+HLD. No source implementation, tests, or user documentation are delivered with the design.
+Application replay remains the default throughout, and kernel-replay output must not reach analysis
+until the implementation can provide a complete bucket set or fail closed.
+
+1. **Mode selection and validation.** Add the experimental
+   `--replay-mode {application,kernel}` surface, carry the selected mode through the profiling
+   backends, and implement compatibility checks and hard-error diagnostics. Replay execution
+   remains disabled in this slice, so its observable behavior is mode selection and validation
+   without changing existing application-replay output.
+2. **Native-collector replay.** Deliver the coalesced counter groups to one native SDK invocation,
+   implement the native collector's `pass_count_cb` from its per-agent profile-vector size,
+   and diagnose a missing or empty vector instead of returning one pass. Preserve application
+   replay while this slice is brought up, and keep replay output away from normal analysis
+   until the next slice establishes its completeness contract.
+3. **Consolidated output and dispatch identity.** Produce one consolidated
+   `results_*.csv`, normalize cross-pass timestamps and identity so all passes of one logical
+   dispatch resolve to one `Dispatch_ID`, and reject incomplete bucket sets before they reach
+   the unchanged workload join and analysis pivot.
+4. **Remaining backends.** Add equivalent single-invocation behavior to `rocprofv3`, using
+   repeated `--pmc` groups while bypassing `-i`, and to the non-native SDK
+   configuration, using the counter groups and kernel-replay enablement expected by the SDK tool
+   library. Both paths converge on the same trace, validation, failure, identity, and output
+   contracts as the native path.
+
+## Validation, security and debuggability
+
+This section defines the strategy for a future implementation. This HLD does not add or schedule
+tests.
+
+### Validation
+
+Validation spans the CLI, each backend adapter, replay-profile construction, output normalization,
+and the unchanged analysis boundary for all three supported configurations.
+
+- **Counter accuracy.** For one logical dispatch and state covered by the equivalence guarantee, a
+  counter present in more than one bucket must have the same value in every pass. A mismatch is a
+  validation failure. Cache-sensitive counters must be evaluated separately as a documented
+  limitation rather than used as an equality oracle.
+- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed
+  pass count must equal the authoritative `perfmon_coalesce` bucket count, every bucket must appear
+  exactly once, and all pass rows must collapse to one complete `Dispatch_ID`. Incomplete results
+  must fail before analysis.
+- **Native filtering.** Logical indices must advance once per dispatch, not once per pass. A
+  confirmed filter exclusion must take the ordinary no-snapshot path and must not be classified as
+  a missing-profile failure or an incomplete replay result.
+- **Application-replay comparison.** The same deterministic workload and counter request must be
+  profiled in both modes to compare bucket membership, counter completeness, dispatch
+  correspondence, and final analysis results. Existing application-replay and single-bucket
+  behavior must remain unchanged.
+- **Service composition.** Kernel replay must expose one pass-0 trace record and one non-multiplied
+  logical duration per dispatch. Native local-stop output and post-run deduplication output must be
+  compared against the same non-replay dispatch inventory.
+- **Compatibility.** Accepted options and every rejected combination must be covered, including
+  iteration multiplexing, live attach, PC sampling, roofline selection, multi-rank warning
+  retention, and the experimental default-off behavior.
+- **Failure paths.** Coverage must include an unsupported SDK or backend, heterogeneous agents, a
+  missing profile vector, declined snapshot, incomplete bucket set, and upstream abort. Each case
+  must prove that no one-pass fallback or partial analysis occurs.
+
+Unit tests should cover option rules, group serialization, profile-derived counts, identity
+normalization, and trace deduplication. Backend integration tests should cover pass-to-profile
+selection and failure propagation. End-to-end CLI tests should compare the generated artifacts and
+analysis for application and kernel replay. No wall-time threshold is a pass criterion.
+
+### Security
+
+Kernel replay introduces no network interface or new privilege boundary. Its security-sensitive
+operation is the SDK-managed host snapshot of application device memory. The snapshot can contain
+application data and can consume host memory comparable to the tracked footprint. It remains inside
+the profiled process's trust boundary; `rocprof-compute` must not persist its contents in
+result artifacts or print them in diagnostics. Snapshot allocation and restore failures are
+availability failures and follow the same fail-closed rule as other incomplete replay conditions.
+
+### Debuggability
+
+Run diagnostics must identify the selected replay mode and backend, SDK capability, agent, and the
+mapping from every `perfmon_coalesce` bucket to its replay pass. They must distinguish option
+conflicts, unsupported configurations, heterogeneous agents, missing profiles, snapshot decline,
+incomplete buckets, and upstream abort, and state that partial results are unusable. A
+snapshot-decline diagnostic also recommends application replay.
+
+## Open questions
+
+1. **SDK version floor.** Which released ROCm SDK version will first contain the kernel-replay
+   contract after PR 8622 merges, and what concrete minimum should the CLI diagnostic require?
+2. **Measured startup cost.** Which representative workloads show that avoiding repeated startup
+   outweighs snapshot, restoration, isolation, and replay overhead? No speedup or break-even claim
+   can be made until those measurements exist.
+3. **Collective-bearing kernels.** Should dispatches participating in inter-process collectives be
+   excluded from kernel replay, despite retaining multi-rank support and its existing warning?
+4. **Snapshot-decline detection.** Can the upstream SDK expose a structured status for a declined
+   snapshot instead of requiring `rocprof-compute` to classify a fragile log string?
+5. **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
+   their durations include replay overhead and are not comparable with a non-replay run. Should the
+   combination be corrected, annotated, or rejected?
+6. **Trace-deduplication equivalence.** How will native pass-0 context control and post-run
+   deduplication share one definition of a logical dispatch, and how will divergence between those
+   mechanisms be detected?
+7. **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
+   native collector resolve filters inside the SDK tool library. Does that library count logical
+   dispatches or replay passes under kernel replay? If it counts passes, an upstream correction or
+   an explicit documented restriction is required.

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -231,42 +231,33 @@ kernel-replay adapter translates those buckets into each backend's syntax withou
 
 | Backend configuration | Single-invocation encoding | Pass-count owner |
 | --- | --- | --- |
-| `rocprofiler-sdk` with the native collector | Deliver all *N* groups through `ROCPROF_COUNTERS` to one replay-enabled invocation. | The native collector derives the count from the per-agent profiles it created. |
-| `rocprofiler-sdk` without the native collector | Deliver all *N* `ROCPROF_COUNTERS` groups and enable `ROCPROF_KERNEL_REPLAY`. | The SDK tool library derives the count from its per-agent profiles. |
+| Native collector | Deliver all *N* groups through `ROCPROF_COUNTERS` to one replay-enabled invocation. | The native collector derives the count from the per-agent profiles it created. |
+| `rocprofiler-sdk` | Deliver all *N* `ROCPROF_COUNTERS` groups and enable `ROCPROF_KERNEL_REPLAY`. | The SDK tool library derives the count from its per-agent profiles. |
 | `rocprofv3` | Bypass `-i`, emit one repeated `--pmc` group per bucket, and enable the upstream replay option. | The SDK tool library derives the count from its per-agent profiles. |
 
-No separate pass-count option or environment value is introduced. That would create a second value
-that could disagree with the profiles actually accepted by the SDK. The final spelling of the
-multi-group SDK-tool contract must be checked against the merged upstream interface: the current
-proposal distinguishes more than one environment-variable spelling. That integration detail may
-change, but the `ROCPROF_COUNTERS` semantic contract selected here and the authoritative bucket
-membership may not.
+No separate pass-count option or environment value is introduced.
 
 ### Pass-count ownership and profile validity
 
 On the native path, counter-group parsing creates one profile-vector entry per group and per agent.
 For an admitted dispatch, `pass_count_cb` returns the size of the vector for the dispatch's
-agent, and replay pass *i* selects entry *i* from that same vector. The count is agent-local and
-proves that the requested groups became usable profiles.
+agent, and replay pass *i* selects entry *i* from that same vector.
 
 The callback's ordinary value of one means “do not replay.” It is not a valid fallback when an agent
 lookup fails or its vector is empty: that would execute the dispatch once, collect only one bucket,
 and make incomplete data look successful. A missing or empty vector must instead diagnose the
-agent/profile mismatch and fail the complete profile. The callback has no error return, so a later
-low-level design may choose the exact fatal-tool or run-failure transport; it may not substitute a
-count of one.
+agent/profile mismatch and fail the complete profile.
 
 The non-native SDK and `rocprofv3` paths follow the same ownership rule inside the SDK tool
-library. `rocprof-compute` supplies groups and replay enablement; the tool that materializes the
-per-agent profiles supplies the callback and count.
+library. `rocprof-compute` supplies groups and replay enablement.
 
 The component diagram shows both counter and kernel-trace data. The trace mechanisms differ because
-only the native collector is `rocprof-compute`-owned code.
+only the native collector have fine-grained control over sdk services.
 
 ```mermaid
 graph LR
     subgraph Compute["rocprof-compute"]
-        Buckets["perfmon_coalesce<br/>N authoritative buckets"]
+        Buckets["N buckets"]
         Adapter["Kernel-replay backend adapter"]
         Normalize["Cross-pass counter identity<br/>and timestamp normalization"]
         Dedup["Post-run kernel-trace deduplication<br/>non-native SDK and rocprofv3"]
@@ -279,9 +270,9 @@ graph LR
     end
 
     subgraph Tools["Profiler and tool boundary"]
-        Native["SDK with native collector<br/>per-agent profile vector"]
-        NonNative["SDK with SDK tool library"]
-        V3["rocprofv3 with SDK tool library"]
+        Native["Native collector<br/>per-agent profile vector"]
+        NonNative["SDK tool"]
+        V3["rocprofv3"]
         Reject["Diagnose and reject invalid profile<br/>never treat it as filter opt-out"]
     end
 
@@ -329,10 +320,7 @@ an incomplete replay result.
 ### Output and dispatch identity
 
 One kernel-replay counter invocation produces one consolidated
-`results_*.csv` artifact, compressed when the existing output policy requires it. The existing
-`join_workload_csvs` discovery and concatenation then produce `pmc_perf.csv`, and
-`create_df_pmc` performs the existing long-to-wide counter pivot. Kernel replay does not write
-`pmc_perf.csv` directly and does not add a replay-specific analysis branch.
+`results_*.csv` artifact.
 
 Before that artifact is written, all pass rows for one logical dispatch must receive one
 `Dispatch_ID` and one canonical start/end timestamp pair. Pass identity may be retained
@@ -347,8 +335,7 @@ the existing identity and pivot contracts consume them.
 
 Without that step, the current timestamp-bearing identity key assigns a new `Dispatch_ID` to
 every pass. Analysis groups on `Dispatch_ID` before it pivots counter names into columns, so
-each group would contain only one bucket and no row would have the complete metric inputs. This is
-why normalization belongs at the output boundary rather than in metric evaluation.
+each group would contain only one bucket and no row would have the complete metric inputs.
 
 ### Co-active service composition
 
@@ -359,16 +346,9 @@ The mechanism differs at the ownership boundary:
   kernel-trace context for passes 1 through *N*−1.
 - The non-native SDK and `rocprofv3` paths execute the SDK-owned tool library, which
   `rocprof-compute` cannot instrument. Those paths collapse the *N* raw trace records after the
-  run, using the normalized logical-dispatch identity.
+  run.
 
-This split is forced by code ownership, not by a preference for two deduplication strategies. Both
-must produce the same dispatch count for Top Stats and `pmc_dispatch_info.csv`.
-
-Pass 0 is retained because it executes against the pristine pre-snapshot state. Every later pass
-follows a full host-to-device restore of the tracked footprint, which perturbs memory-system state.
-Pass 0 is therefore the closest available timing proxy for an ordinary dispatch. The design
-preserves one non-multiplied logical duration; it does not promise numeric equality with a separate
-non-replay measurement.
+This split is forced by code ownership. Both must produce the same dispatch count for Top Stats and `pmc_dispatch_info.csv`.
 
 Roofline uses the selected replay mode through the ordinary counter path and needs no special
 handling. Code-object tracing is load-time only and needs no replay treatment. Marker and ROCTx
@@ -388,7 +368,7 @@ which it can be inserted.
 `--roof-only`, `--set`, and `--block` continue through ordinary counter selection.
 Multi-rank profiling remains available and retains its warning. Kernel replay additionally requires
 a supported SDK version and a homogeneous agent configuration. Whether collective-bearing
-dispatches require exclusion is not settled by that support statement.
+dispatches require exclusion is an open question.
 
 ### Failure behavior
 
@@ -400,11 +380,9 @@ multi-bucket request into one pass.
 | Unsupported backend configuration | Hard error naming the configuration and a supported alternative. |
 | SDK below the supported version floor | Hard error stating the required version. The numeric floor remains pending upstream merge. |
 | Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
-| Heterogeneous target agents | Hard error because this design assumes one uniform bucket and pass count. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
-| Upstream drain timeout or process abort | Report the failed run without recovery or analysis of partial output. |
-| Any incomplete bucket set | Reject it before the workload join or metric analysis. |
+| Upstream drain timeout or process abort | Report the failed run without recovery. |
 
 A declined snapshot can currently leave a successful process status, so the required outcome cannot
 depend only on subprocess failure. Classifying an upstream warning string is the available but
@@ -414,7 +392,7 @@ fragile signal; a structured detection mechanism remains an open question.
 
 Kernel replay inherits the upstream mechanism's support boundaries:
 
-- The host snapshot can require memory equal to the complete tracked device footprint.
+- The host snapshot require memory atleast equal to the complete tracked device footprint.
 - Equivalent-state guarantees cover tracked coarse-grained device VRAM and module-scope
   `__device__` or `__constant__` state. Unified, managed, and `hipMallocAsync`
   allocations are not restored.
@@ -426,44 +404,28 @@ Kernel replay inherits the upstream mechanism's support boundaries:
 - Bounded drain expiry aborts the process instead of returning a recoverable error.
 - Multi-rank dispatches that participate in collectives remain unsafe pending an exclusion policy.
 
-Keeping grouping in `perfmon_coalesce` preserves the architecture policies used by application
-replay. Deriving the count where profiles are materialized avoids a second source of truth.
-Backend-local encoding contains profiler syntax at the adapter, and preserving the existing output
-contract avoids a second analysis implementation. These contracts are settled. The remaining
-choices concern the final upstream interface, declined-snapshot signaling, and the explicitly
-deferred service policies below.
-
 ## Implementation phases
 
-These are proposed vertical slices for future implementation work; they are not scheduled by this
-HLD. No source implementation, tests, or user documentation are delivered with the design.
-Application replay remains the default throughout, and kernel-replay output must not reach analysis
-until the implementation can provide a complete bucket set or fail closed.
+These are proposed vertical slices for future implementation work:
 
-1. **Mode selection and validation.** Add the experimental
+- **Mode selection and validation.** Add the experimental
    `--replay-mode {application,kernel}` surface, carry the selected mode through the profiling
    backends, and implement compatibility checks and hard-error diagnostics. Replay execution
    remains disabled in this slice, so its observable behavior is mode selection and validation
    without changing existing application-replay output.
-2. **Native-collector replay.** Deliver the coalesced counter groups to one native SDK invocation,
-   implement the native collector's `pass_count_cb` from its per-agent profile-vector size,
-   and diagnose a missing or empty vector instead of returning one pass. Preserve application
-   replay while this slice is brought up, and keep replay output away from normal analysis
-   until the next slice establishes its completeness contract.
-3. **Consolidated output and dispatch identity.** Produce one consolidated
-   `results_*.csv`, normalize cross-pass timestamps and identity so all passes of one logical
-   dispatch resolve to one `Dispatch_ID`, and reject incomplete bucket sets before they reach
-   the unchanged workload join and analysis pivot.
-4. **Remaining backends.** Add equivalent single-invocation behavior to `rocprofv3`, using
+- **v3 and SDK backends.** Add single-invocation behavior to `rocprofv3`, using
    repeated `--pmc` groups while bypassing `-i`, and to the non-native SDK
    configuration, using the counter groups and kernel-replay enablement expected by the SDK tool
-   library. Both paths converge on the same trace, validation, failure, identity, and output
-   contracts as the native path.
+   library.
+- **Consolidated output and dispatch identity.** Produce one consolidated
+   `results_*.csv`, normalize cross-pass timestamps and identity so all passes of one logical
+   dispatch resolve to one `Dispatch_ID`.
+- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation,
+   implement the native collector's `pass_count_cb` from its per-agent profile-vector size,
+   and diagnose a missing or empty vector instead of returning one pass. Preserve application
+   replay.
 
 ## Validation, security and debuggability
-
-This section defines the strategy for a future implementation. This HLD does not add or schedule
-tests.
 
 ### Validation
 
@@ -473,32 +435,25 @@ and the unchanged analysis boundary for all three supported configurations.
 - **Counter accuracy.** For one logical dispatch and state covered by the equivalence guarantee, a
   counter present in more than one bucket must have the same value in every pass. A mismatch is a
   validation failure. Cache-sensitive counters must be evaluated separately as a documented
-  limitation rather than used as an equality oracle.
+  limitation.
 - **Completeness and identity.** For each dispatch admitted by the replay filters, the observed
-  pass count must equal the authoritative `perfmon_coalesce` bucket count, every bucket must appear
+  pass count must equal the application replay count, every bucket must appear
   exactly once, and all pass rows must collapse to one complete `Dispatch_ID`. Incomplete results
   must fail before analysis.
 - **Native filtering.** Logical indices must advance once per dispatch, not once per pass. A
   confirmed filter exclusion must take the ordinary no-snapshot path and must not be classified as
   a missing-profile failure or an incomplete replay result.
 - **Application-replay comparison.** The same deterministic workload and counter request must be
-  profiled in both modes to compare bucket membership, counter completeness, dispatch
-  correspondence, and final analysis results. Existing application-replay and single-bucket
-  behavior must remain unchanged.
+  profiled in both modes to compare bucket membership, counter completeness and final analysis results.
+  Existing application-replay must remain unchanged.
 - **Service composition.** Kernel replay must expose one pass-0 trace record and one non-multiplied
-  logical duration per dispatch. Native local-stop output and post-run deduplication output must be
-  compared against the same non-replay dispatch inventory.
+  logical duration per dispatch.
 - **Compatibility.** Accepted options and every rejected combination must be covered, including
-  iteration multiplexing, live attach, PC sampling, roofline selection, multi-rank warning
-  retention, and the experimental default-off behavior.
-- **Failure paths.** Coverage must include an unsupported SDK or backend, heterogeneous agents, a
-  missing profile vector, declined snapshot, incomplete bucket set, and upstream abort. Each case
-  must prove that no one-pass fallback or partial analysis occurs.
-
-Unit tests should cover option rules, group serialization, profile-derived counts, identity
-normalization, and trace deduplication. Backend integration tests should cover pass-to-profile
-selection and failure propagation. End-to-end CLI tests should compare the generated artifacts and
-analysis for application and kernel replay. No wall-time threshold is a pass criterion.
+  iteration multiplexing, live attach, PC sampling, roofline selection, multi-rank warning,
+  and the default-off behavior.
+- **Failure paths.** Coverage must include an unsupported SDK or backend, a
+  missing profile vector, declined snapshot, and upstream abort. Each case
+  must prove that no one-pass fallback.
 
 ### Security
 
@@ -512,22 +467,21 @@ availability failures and follow the same fail-closed rule as other incomplete r
 ### Debuggability
 
 Run diagnostics must identify the selected replay mode and backend, SDK capability, agent, and the
-mapping from every `perfmon_coalesce` bucket to its replay pass. They must distinguish option
-conflicts, unsupported configurations, heterogeneous agents, missing profiles, snapshot decline,
-incomplete buckets, and upstream abort, and state that partial results are unusable. A
+mapping from every counter bucket to its replay pass. They must distinguish option
+conflicts, unsupported configurations, missing profiles, snapshot decline,
+and upstream abort, and state that partial results are unusable. A
 snapshot-decline diagnostic also recommends application replay.
 
 ## Open questions
 
-3. **Collective-bearing kernels.** Should dispatches participating in inter-process collectives be
+- **Collective-bearing kernels.** Should dispatches participating in inter-process collectives be
    excluded from kernel replay?
-5. **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
+- **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
    their durations include replay overhead and are not comparable with a non-replay run. Should the
-   combination be corrected, annotated, or rejected?
-6. **Trace-deduplication equivalence.** How will native pass-0 context control and post-run
+   combination be corrected or rejected?
+- **Trace-deduplication equivalence.** How will native pass-0 context control and post-run
    deduplication share one definition of a logical dispatch, and how will divergence between those
    mechanisms be detected?
-7. **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
-   native collector resolve filters inside the SDK tool library. Does that library count logical
-   dispatches or replay passes under kernel replay? If it counts passes, an upstream correction or
-   an explicit documented restriction is required.
+- **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
+   native collector resolve filters inside the SDK tool library. Will `rocprofv3` support
+   in future?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -8,12 +8,9 @@
 counters into groups small enough to fit a single hardware pass. However many groups fall out of
 that packing is how many counter-collection passes the run needs.
 
-The profiling layer can drive either `rocprofv3` or `rocprofiler-sdk`. On the `rocprofiler-sdk`
-path, `rocprof-compute` can also preload its own **native collector**, which takes over counter
-collection and leaves the SDK tool library handling tracing. So the native collector is a sub-mode
-of the `rocprofiler-sdk` configuration, not a third backend. It is unavailable in three cases: the
-user opted out of it, the backend is `rocprofv3`, or the installed ROCm predates the version that
-supports it.
+`rocprof-compute` can preload its own **native collector**, which takes over counter collection
+while tracing runs in a separate context. The native collector is unavailable in two cases: the
+user declined it, or the installed ROCm predates the version that supports it.
 
 Every configuration consumes the same buckets. Application replay works across all of them.
 Iteration multiplexing already depends on the native collector and hard-errors without it.
@@ -31,9 +28,10 @@ without borrowing counters from neighbouring dispatches.
 
 Counter collection never runs on its own. Every counter invocation has to produce kernel-dispatch
 records, because those records carry the kernel counts and durations. Under native collection the
-work is split: the native collector owns counters, while the SDK tool library does kernel dispatch
-tracing and adds marker or ROCTx tracing for a framework-selected run. That split matters here — the
-trace records come from a context the native collector can control but does not itself emit.
+work is split: the native collector owns counters, while kernel dispatch tracing and marker or
+ROCTx tracing for a framework-selected run happen in a separate tracing context. That split matters
+here — the trace records come from a context the native collector can control but does not itself
+emit.
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
 objects rather than individual dispatches, so kernel replay does not multiply them. PC sampling runs
@@ -179,10 +177,10 @@ flowchart LR
 - For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
   collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No
   user-supplied pass count shall be required.
-- Kernel replay shall require the native collector. When the selected configuration cannot supply
-  it — because the native collector was declined, because the backend is `rocprofv3`, or because the
-  installed ROCm does not support it — kernel replay shall produce a hard error naming the unmet
-  condition, before any workload runs.
+- Kernel replay shall require the native collector. The `rocprofv3` backend and `--no-native-tool`
+  are unsupported configurations. When the selected configuration cannot supply the native
+  collector — because it was declined, or because the installed ROCm does not support it — kernel
+  replay shall produce a hard error naming the unmet condition, before any workload runs.
 - Kernel replay shall preserve the counter bucket membership used by application replay. The pass
   count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM`
   pairing, TCC grouping, and same-bucket priority shall remain unchanged.
@@ -361,9 +359,9 @@ knowable at the same moment. So rejection happens in two places:
 - **Flag conflict**, decidable from the arguments alone: kernel replay selected while the native
   collector is declined. Rejected immediately, before any discovery and before the workload directory
   is created.
-- **Capability failure**, decidable only once discovery has resolved the backend, the ROCm version,
-  and the native library: a `rocprofv3` backend, an unsupported ROCm version, or a library that
-  cannot be resolved. Rejected later, but still before the workload runs.
+- **Capability failure**, decidable only once discovery has resolved the ROCm version and the
+  native library: an unsupported ROCm version, or a library that cannot be resolved. Rejected
+  later, but still before the workload runs.
 
 Both are hard errors. The split is not incidental — a reader needs to know that a capability failure
 leaves a workload directory behind, whereas a flag conflict leaves nothing.
@@ -387,7 +385,7 @@ none quietly turns a multi-bucket request into a single pass.
 | Condition | Required behavior |
 | --- | --- |
 | Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
-| Native collector unavailable: `rocprofv3` backend, unsupported ROCm version, or unresolvable library | Hard error after discovery, naming which of the three conditions failed. |
+| Native collector unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two conditions failed. |
 | SDK below the supported version floor | Hard error stating the required version. This is distinct from the ROCm version the native collector needs, so the diagnostic has to say which one is unmet. The numeric floor is pending upstream merge. |
 | Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
@@ -458,8 +456,8 @@ normalization, and the analysis boundary that should not have moved.
   multiplexing, live attach, PC sampling, roofline selection, the multi-rank warning, and the
   default-off behavior.
 - **Configuration rejection.** Cover each unmet native-collector condition on its own — declined
-  native collector, `rocprofv3` backend, unsupported ROCm version, unresolvable library. Each must
-  fail before profiling starts, with a diagnostic naming that specific condition.
+  native collector, unsupported ROCm version, unresolvable library. Each must fail before profiling
+  starts, with a diagnostic naming that specific condition.
 - **Failure paths.** Cover an unsupported SDK, a missing profile vector, a declined snapshot, and an
   upstream abort. Each case has to prove no one-pass fallback happened.
 
@@ -481,9 +479,9 @@ plainly that partial results are unusable. A snapshot-decline diagnostic additio
 application replay.
 
 A configuration diagnostic has to name the specific unmet condition instead of reporting that the
-native collector is unavailable. One message covering a `rocprofv3` backend, an unsupported ROCm
-version, and an unresolvable library leaves the user with no action to take, because the remedy is
-different in each case.
+native collector is unavailable. One message covering both an unsupported ROCm version and an
+unresolvable library leaves the user with no action to take, because the remedy is different in
+each case.
 
 ## Open questions
 
@@ -492,10 +490,5 @@ different in each case.
 - **Marker and ROCTx semantics.** Host regions are emitted once but span every replay pass, so their
    durations include replay overhead and are not comparable with a non-replay run. Reject the
    combination, or correct the duration?
-- **Extending kernel replay beyond the native collector.** `rocprofv3` and `rocprofiler-sdk` without
-   the native collector run the SDK's own tool library, which `rocprof-compute` cannot instrument.
-   Neither the pass-0 trace stop nor the filter decision at `pass_count_cb` has an equivalent there,
-   and filter resolution happens inside that library. Whether support would need upstream changes or
-   post-run reconstruction is unresolved.
 - **Cache-related counter validity.** Can cache-related metrics be trusted at all, given that cache
    state is not restored between replay passes?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -248,8 +248,6 @@ flowchart TD
     subgraph ComputeSetup["rocprof-compute · setup"]
         direction TB
         Buckets["N counter buckets"]
-        Adapter["Kernel-replay adapter"]
-        Buckets --> Adapter
     end
 
     subgraph NativeTool["Native tool"]
@@ -275,7 +273,7 @@ flowchart TD
         Normalize --> Output --> Analysis
     end
 
-    Adapter -- "ROCPROF_COUNTERS groups<br/>and native replay setup" --> Profiles
+    Buckets -- "ROCPROF_COUNTERS groups<br/>and native replay setup" --> Profiles
     Profiles -. "register pass_count_cb" .-> Replay
     Replay -- "invoke pass_count_cb" --> Profiles
     Profiles -- "admitted: vector size<br/>filtered: 1" --> Replay
@@ -289,42 +287,41 @@ flowchart TD
 
 ### The pass-count decision
 
-Counter-group parsing creates one profile-vector entry per group, per agent. Before replay setup, a
-zero-bucket request bypasses the replay counter adapter and follows the existing non-counter path.
-For a counter request, `pass_count_cb` is the single decision point for admission and pass count,
-because it runs exactly once for each dispatch that reaches the replay gate and before any replay
-pass. It consults the existing 1-based, per-kernel logical-occurrence index; it does not create a
-second replay-only index sequence.
+Kernel and dispatch filters establish whether the dispatch is admitted before counter-bucket
+availability is considered. An admitted zero-bucket request bypasses kernel replay and
+follows the existing path. For an admitted counter request, `pass_count_cb` determines the
+pass count exactly once before any replay pass.
 
 ```mermaid
 flowchart TD
+    Observe["Dispatch-counting service assigns<br/>per-kernel logical occurrence once"]
+    Kernel{"Kernel admitted by<br/>the kernel filter?"}
+    Range{"Per-kernel occurrence admitted by<br/>the dispatch range?"}
+    Filtered["Return 1 as filtered<br/>select no counter profile"]
     Request{"Counter request has<br/>at least one bucket?"}
     Zero["Bypass replay counter adapter<br/>use existing non-counter path"]
-    Observe["Dispatch-counting service assigns<br/>per-kernel logical occurrence once"]
     Gate{"Dispatch reaches<br/>the replay gate?"}
     Ordinary["Execute once outside replay<br/>retain ordinary dispatch handling"]
     Start["pass_count_cb runs once"]
     Vector{"Agent has the expected<br/>non-empty profile vector?"}
     Fatal["Fatal: agent/profile mismatch<br/>reject the whole profile"]
-    Kernel{"Kernel admitted by<br/>the kernel filter?"}
-    Range{"Per-kernel occurrence admitted by<br/>the dispatch range?"}
-    Filtered["Return 1 as filtered<br/>select no counter profile"]
     Size{"Profile-vector size?"}
     Single["Return 1 as admitted<br/>select the sole profile"]
     PC{"PC sampling selected?"}
     N["Return N<br/>one counter bucket per pass"]
     NPlus["Return N+1<br/>N counter passes, then one<br/>counter-disabled PC sampling pass"]
 
-    Request -- no --> Zero
-    Request -- yes --> Observe --> Gate
-    Gate -- no --> Ordinary
-    Gate -- yes --> Start --> Vector
-    Vector -- no --> Fatal
-    Vector -- yes --> Kernel
+    Observe --> Kernel
     Kernel -- no --> Filtered
     Kernel -- yes --> Range
     Range -- no --> Filtered
-    Range -- yes --> PC
+    Range -- yes --> Request
+    Request -- no --> Zero
+    Request -- yes --> Gate
+    Gate -- no --> Ordinary
+    Gate -- yes --> Start --> Vector
+    Vector -- no --> Fatal
+    Vector -- yes --> PC
     PC -- yes --> NPlus
     PC -- no --> Size
     Size -- one --> Single
@@ -337,13 +334,16 @@ flowchart TD
 | `1` — admitted | The dispatch is admitted and its agent's profile vector contains exactly one bucket. | The ordinary execution selects the sole profile. This is a complete one-bucket result, not a filter outcome. |
 | *N*, where *N* > 1 | Admitted, no PC sampling. *N* is the size of the profile vector for this dispatch's agent. | Pass *i* selects entry *i* of that vector. |
 | *N*+1 | Admitted, PC sampling selected. *N* is the non-zero size of the profile vector. | Passes 0 through *N*−1 map one-to-one onto the vector. Pass *N* selects no counter profile and runs counter-disabled. |
-| *(fatal)* | Counters were requested, but the agent is missing or its expected profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
+| *(fatal)* | The dispatch passed both filters and requested counters, but the agent is missing or its expected profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
 
 Three consequences worth stating plainly:
 
 - **Admission is state, not a numeric inference.** Both a filtered dispatch and an admitted
   single-bucket dispatch return `1`, but only the admitted case selects a profile and participates in
   completeness checking. The adapter records that distinction explicitly.
+- **Filters run before counter admission.** A kernel or dispatch-range miss returns `1` as filtered
+  before the bucket and profile-vector checks. Missing profile state is fatal only for a dispatch that
+  passed both filters and requested counters.
 - **`1` is never a fallback for a missing expected profile.** Returning it for an agent/profile
   mismatch would execute the dispatch once, collect at most one bucket, and present incomplete data
   as a success.
@@ -352,9 +352,9 @@ Three consequences worth stating plainly:
   cannot replay. `pass_count_cb` only reads that stable index, and replay passes never consume another
   occurrence.
 
-Completeness checks apply only to admitted dispatches. A dispatch excluded on purpose produces no
-counter set, and that is not an incomplete replay result. A zero-bucket request bypasses the adapter
-before dispatch admission, so it is likewise not a missing or incomplete replay result.
+Completeness checks apply only to admitted counter requests. A dispatch excluded on purpose produces
+no counter set, and that is not an incomplete replay result. After both filters admit a dispatch, a
+zero-bucket request bypasses the adapter and is likewise not a missing or incomplete replay result.
 
 ### Output and dispatch identity
 

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -8,9 +8,15 @@
 packs those counters into groups that each fit one hardware pass. The number of
 groups therefore determines how many counter-collection passes are needed.
 
-The profiling layer can invoke `rocprofv3`,`rocprofiler-sdk`, or
-`rocprof-compute` native collector. All three configurations consume the same buckets. Application
-replay work across them; iteration multiplexing is limited to native collector.
+The profiling layer can invoke `rocprofv3` or `rocprofiler-sdk`. On the `rocprofiler-sdk` path,
+`rocprof-compute` additionally preloads its own **native collector**, which takes over counter
+collection and leaves the SDK tool library doing tracing. The native collector is therefore a
+sub-mode of the `rocprofiler-sdk` configuration rather than a third backend, and it is unavailable
+when the user opts out of it, when the backend is `rocprofv3`, or when the installed ROCm predates
+the version that supports it.
+
+All configurations consume the same buckets. Application replay works across all of them;
+iteration multiplexing already requires the native collector and hard-errors otherwise.
 
 
 | Strategy | Execution model | What it covers | What it does not cover |
@@ -24,8 +30,10 @@ without cross-dispatch imputation.
 ### Co-active profiling services
 
 Counter collection never runs alone. Every counter invocation must yield kernel-dispatch records;
-those records supply the kernel counts and durations. The SDK backend explicitly enables kernel dispatch tracing and adds
-marker or ROCTx tracing for a framework-selected run.
+those records supply the kernel counts and durations. Under native collection the work is split: the
+native collector owns counters, while the SDK tool library performs kernel dispatch tracing and adds
+marker or ROCTx tracing for a framework-selected run. That split matters here, because it means the
+trace records are produced by a context the native collector can control but does not itself emit.
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
 objects rather than individual dispatches and are not multiplied by kernel replay. PC sampling runs
@@ -173,7 +181,10 @@ flowchart LR
 - For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
   collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No
   user-supplied pass count shall be required.
-- Kernel replay shall support `rocprofv3`, native collector, and `rocprofiler-sdk`.
+- Kernel replay shall require the native collector. When the selected configuration cannot provide
+  it — because the native collector was declined, because the backend is `rocprofv3`, or because the
+  installed ROCm does not support it — kernel replay shall produce a hard error naming the unmet
+  condition, before any workload runs.
 - Kernel replay shall preserve the counter bucket membership used by application replay. The pass count
   shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC
   grouping, and same-bucket priority shall remain unchanged.
@@ -197,11 +208,11 @@ flowchart LR
 - Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and
   `pmc_dispatch_info.csv` preserve non-replay semantics by reporting one dispatch and its pass-0
   logical duration rather than replay-multiplied values.
-- Kernel filtering shall compose with kernel replay on the native collector. A dispatch whose kernel
-  is excluded shall not be replayed and shall incur no snapshot or restore.
-- Dispatch filtering shall compose with kernel replay on the native collector. `--dispatch` indices
-  shall count logical dispatches, not replay passes, so an index selects the same work whether or not
-  kernel replay is selected. An excluded dispatch shall not be replayed.
+- Kernel filtering shall compose with kernel replay. A dispatch whose kernel is excluded shall not
+  be replayed and shall incur no snapshot or restore.
+- Dispatch filtering shall compose with kernel replay. `--dispatch` indices shall count logical
+  dispatches, not replay passes, so an index selects the same work whether or not kernel replay is
+  selected. An excluded dispatch shall not be replayed.
 
 ### Non-functional requirements
 
@@ -222,57 +233,46 @@ flowchart LR
 
 ## Design
 
-### Counter groups and backend boundaries
+### Counter groups and the collector boundary
 
 Kernel replay changes the invocation shape, not counter partitioning. `perfmon_coalesce` remains
 the only authority for bucket membership and one-pass fit. Its `_ACCUM` pairing, TCC grouping,
 and same-bucket priority policies produce *N* buckets for both application and kernel replay. The
-kernel-replay adapter translates those buckets into each backend's syntax without regrouping them.
+kernel-replay adapter translates those buckets for the native collector without regrouping them.
 
-| Backend configuration | Single-invocation encoding | Pass-count owner |
-| --- | --- | --- |
-| Native collector | Deliver all *N* groups through `ROCPROF_COUNTERS` to one replay-enabled invocation. | The native collector derives the count from the per-agent profiles it created. |
-| `rocprofiler-sdk` | Deliver all *N* `ROCPROF_COUNTERS` groups and enable `ROCPROF_KERNEL_REPLAY`. | The SDK tool library derives the count from its per-agent profiles. |
-| `rocprofv3` | Bypass `-i`, emit one repeated `--pmc` group per bucket, and enable the upstream replay option. | The SDK tool library derives the count from its per-agent profiles. |
-
-No separate pass-count option or environment value is introduced.
+All *N* counter groups are delivered to a single replay-enabled invocation, and the native collector
+derives the pass count from the per-agent profiles it created from them. No separate pass-count
+option or environment value is introduced, so the bucket count and the pass count cannot disagree.
 
 ### Pass-count ownership and profile validity
 
-On the native path, counter-group parsing creates one profile-vector entry per group and per agent.
-For an admitted dispatch, `pass_count_cb` returns the size of the vector for the dispatch's
-agent, and replay pass *i* selects entry *i* from that same vector.
+Counter-group parsing creates one profile-vector entry per group and per agent. For an admitted
+dispatch, `pass_count_cb` returns the size of the vector for the dispatch's agent, and replay pass
+*i* selects entry *i* from that same vector.
 
 The callback's ordinary value of one means “do not replay.” It is not a valid fallback when an agent
 lookup fails or its vector is empty: that would execute the dispatch once, collect only one bucket,
 and make incomplete data look successful. A missing or empty vector must instead diagnose the
 agent/profile mismatch and fail the complete profile.
 
-The non-native SDK and `rocprofv3` paths follow the same ownership rule inside the SDK tool
-library. `rocprof-compute` supplies groups and replay enablement.
-
-The component diagram shows both counter and kernel-trace data. The trace mechanisms differ because
-only the native collector have fine-grained control over sdk services.
+The component diagram shows both counter and kernel-trace data, and where each crosses the
+collector boundary.
 
 ```mermaid
 graph LR
     subgraph Compute["rocprof-compute"]
         Buckets["N buckets"]
-        Adapter["Kernel-replay backend adapter"]
+        Adapter["Kernel-replay adapter"]
         Normalize["Cross-pass counter identity<br/>and timestamp normalization"]
-        Dedup["Post-run kernel-trace deduplication<br/>non-native SDK and rocprofv3"]
         Output["Consolidated counter result<br/>and one logical trace record"]
         Analysis["Existing join and analysis path"]
         Buckets --> Adapter
         Normalize --> Output
-        Dedup --> Output
         Output --> Analysis
     end
 
-    subgraph Tools["Profiler and tool boundary"]
+    subgraph Tools["Tool boundary"]
         Native["Native collector<br/>per-agent profile vector"]
-        NonNative["SDK tool"]
-        V3["rocprofv3"]
         Reject["Diagnose and reject invalid profile<br/>never treat it as filter opt-out"]
     end
 
@@ -285,29 +285,22 @@ graph LR
     end
 
     Adapter -- "ROCPROF_COUNTERS groups<br/>native replay setup" --> Native
-    Adapter -- "ROCPROF_COUNTERS groups<br/>ROCPROF_KERNEL_REPLAY" --> NonNative
-    Adapter -- "repeated --pmc groups<br/>replay option; bypass -i" --> V3
 
-    Native -- "pass_count_cb<br/>selected: profile-vector size<br/>filtered: one" --> Replay
-    NonNative -- "SDK tool derives count" --> Replay
-    V3 -- "SDK tool derives count" --> Replay
+    Native -- "pass_count_cb<br/>admitted: profile-vector size<br/>filtered: one" --> Replay
     Native -- "missing or empty vector" --> Reject
 
     Native -. "locally stop trace context<br/>on passes 1 through N-1" .-> Trace
     Counters --> Normalize
-    Trace -- "native path: pass-0 record" --> Output
-    Trace -- "other paths: N raw records" --> Dedup
-    Normalize -. "shared logical-dispatch identity" .-> Dedup
+    Trace -- "pass-0 record only" --> Output
 ```
 
-### Native filtering at the pass-count decision
+### Filtering at the pass-count decision
 
-On the native-collector path, `pass_count_cb` is also the filter decision point because it runs
-once per logical dispatch before any replay pass. Before choosing a count, the collector confirms
-that the dispatch's agent has a non-empty profile vector. It then assigns the dispatch's per-kernel
-logical index exactly once, evaluates the kernel-ID target set built during code-object loading and
-the requested dispatch range, and returns the profile-vector size only when both filters admit the
-dispatch. A confirmed filter miss returns one, intentionally selecting the SDK's ordinary path
+`pass_count_cb` is also the filter decision point, because it runs once per logical dispatch before
+any replay pass. Before choosing a count, the collector confirms that the dispatch's agent has a
+non-empty profile vector. It then assigns the dispatch's per-kernel logical index exactly once,
+evaluates the kernel-ID target set built during code-object loading and the requested dispatch
+range, and returns the profile-vector size only when both filters admit the dispatch. A confirmed filter miss returns one, intentionally selecting the SDK's ordinary path
 without a snapshot or restore. A missing or empty profile vector remains a fatal profile error and
 must never use that return.
 
@@ -339,16 +332,19 @@ each group would contain only one bucket and no row would have the complete metr
 
 ### Co-active service composition
 
-Kernel dispatch tracing must yield one record per logical dispatch, independent of the pass count.
-The mechanism differs at the ownership boundary:
+Kernel dispatch tracing must yield one record per logical dispatch, independent of the pass count,
+so that Top Stats and `pmc_dispatch_info.csv` report the same dispatch count and duration they would
+without replay.
 
-- The native collector can control its own SDK contexts. It traces pass 0 and locally stops the
-  kernel-trace context for passes 1 through *N*−1.
-- The non-native SDK and `rocprofv3` paths execute the SDK-owned tool library, which
-  `rocprof-compute` cannot instrument. Those paths collapse the *N* raw trace records after the
-  run.
+The native collector controls its own SDK contexts, so the duplicate records are suppressed at the
+source rather than removed afterwards: it traces pass 0 and locally stops the kernel-trace context
+for passes 1 through *N*−1. Pass 0 is chosen because it alone runs against pristine pre-snapshot
+state; every later pass executes immediately after a full restore of the tracked footprint, so its
+timing reflects replay overhead rather than the dispatch.
 
-This split is forced by code ownership. Both must produce the same dispatch count for Top Stats and `pmc_dispatch_info.csv`.
+Suppressing at the source rather than collapsing records after the run is what makes this cheap and
+exact — there is no need to reconstruct which records belonged to the same logical dispatch, because
+the extra records are never emitted.
 
 Roofline uses the selected replay mode through the ordinary counter path and needs no special
 handling. Code-object tracing is load-time only and needs no replay treatment. Marker and ROCTx
@@ -358,12 +354,27 @@ regions are emitted once on the host but span all passes; their duration semanti
 
 `--replay-mode` accepts `application` and `kernel`. Application replay remains the
 default, and CLI help identifies kernel replay as experimental. The selected mode is carried to the
-backend adapter; it does not change `--iteration-multiplexing` into a mode selector.
+kernel-replay adapter; it does not change `--iteration-multiplexing` into a mode selector.
 
-Kernel mode is rejected before profiling when combined with iteration multiplexing, live attach, or
-PC sampling. PC sampling is agent-wide, does not consume the localized context override, and today
-runs in a separate counter-disabled invocation. There is therefore no supported replay pass into
-which it can be inserted.
+Kernel mode requires the native collector, and the conditions that supply it do not all become
+knowable at the same moment. Rejection therefore happens in two places:
+
+- **Flag conflict**, decidable from the arguments alone: selecting kernel replay while declining the
+  native collector. This is rejected immediately, before any discovery and before the workload
+  directory is created.
+- **Capability failure**, decidable only after discovery resolves the backend, the ROCm version, and
+  the native library: a `rocprofv3` backend, an unsupported ROCm version, or a library that cannot
+  be resolved. These are rejected later, but still before the workload runs.
+
+Both are hard errors. The split is not incidental — a reader needs to know that a capability
+failure occurs after the workload directory exists, whereas a flag conflict leaves nothing behind.
+
+Kernel mode is likewise rejected before profiling when combined with iteration multiplexing, live
+attach, or PC sampling. Iteration multiplexing is rejected because both strategies claim the same
+per-dispatch passes, not because of any backend restriction — it requires the native collector too.
+PC sampling is agent-wide, does not consume the localized context override, and today runs in a
+separate counter-disabled invocation. There is therefore no supported replay pass into which it can
+be inserted.
 
 `--roof-only`, `--set`, and `--block` continue through ordinary counter selection.
 Multi-rank profiling remains available and retains its warning. Kernel replay additionally requires
@@ -377,8 +388,9 @@ multi-bucket request into one pass.
 
 | Condition | Required behavior |
 | --- | --- |
-| Unsupported backend configuration | Hard error naming the configuration and a supported alternative. |
-| SDK below the supported version floor | Hard error stating the required version. The numeric floor remains pending upstream merge. |
+| Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
+| Native collector unavailable: `rocprofv3` backend, unsupported ROCm version, or unresolvable library | Hard error after discovery, naming which of the three conditions failed. |
+| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native collector needs; the diagnostic must say which one is unmet. The numeric floor remains pending upstream merge. |
 | Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
@@ -410,27 +422,23 @@ These are proposed vertical slices for future implementation work:
 
 - **Mode selection and validation.** Add the experimental
    `--replay-mode {application,kernel}` surface, carry the selected mode through the profiling
-   backends, and implement compatibility checks and hard-error diagnostics. Replay execution
-   remains disabled in this slice, so its observable behavior is mode selection and validation
-   without changing existing application-replay output.
-- **v3 and SDK backends.** Add single-invocation behavior to `rocprofv3`, using
-   repeated `--pmc` groups while bypassing `-i`, and to the non-native SDK
-   configuration, using the counter groups and kernel-replay enablement expected by the SDK tool
-   library.
+   path, and implement both rejection layers with their hard-error diagnostics. Replay execution
+   remains disabled in this slice, so its observable behavior is mode selection and correct
+   rejection, without changing existing application-replay output.
+- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation,
+   implement `pass_count_cb` from the per-agent profile-vector size, apply the kernel and dispatch
+   filters at that same decision point, and diagnose a missing or empty vector instead of returning
+   one pass. Preserve application replay.
 - **Consolidated output and dispatch identity.** Produce one consolidated
    `results_*.csv`, normalize cross-pass timestamps and identity so all passes of one logical
-   dispatch resolve to one `Dispatch_ID`.
-- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation,
-   implement the native collector's `pass_count_cb` from its per-agent profile-vector size,
-   and diagnose a missing or empty vector instead of returning one pass. Preserve application
-   replay.
+   dispatch resolve to one `Dispatch_ID`, and expose the single pass-0 trace record.
 
 ## Validation, security and debuggability
 
 ### Validation
 
-Validation spans the CLI, each backend adapter, replay-profile construction, output normalization,
-and the unchanged analysis boundary for all three supported configurations.
+Validation spans the CLI, the kernel-replay adapter, replay-profile construction, output
+normalization, and the unchanged analysis boundary.
 
 - **Counter accuracy.** For one logical dispatch and state covered by the equivalence guarantee, a
   counter present in more than one bucket must have the same value in every pass. A mismatch is a
@@ -440,7 +448,7 @@ and the unchanged analysis boundary for all three supported configurations.
   pass count must equal the application replay count, every bucket must appear
   exactly once, and all pass rows must collapse to one complete `Dispatch_ID`. Incomplete results
   must fail before analysis.
-- **Native filtering.** Logical indices must advance once per dispatch, not once per pass. A
+- **Filtering.** Logical indices must advance once per dispatch, not once per pass. A
   confirmed filter exclusion must take the ordinary no-snapshot path and must not be classified as
   a missing-profile failure or an incomplete replay result.
 - **Application-replay comparison.** The same deterministic workload and counter request must be
@@ -451,9 +459,11 @@ and the unchanged analysis boundary for all three supported configurations.
 - **Compatibility.** Accepted options and every rejected combination must be covered, including
   iteration multiplexing, live attach, PC sampling, roofline selection, multi-rank warning,
   and the default-off behavior.
-- **Failure paths.** Coverage must include an unsupported SDK or backend, a
-  missing profile vector, declined snapshot, and upstream abort. Each case
-  must prove that no one-pass fallback.
+- **Configuration rejection.** Each unmet native-collector condition must be covered separately —
+  declined native collector, `rocprofv3` backend, unsupported ROCm version, unresolvable library —
+  and each must fail before profiling starts, with a diagnostic identifying that specific condition.
+- **Failure paths.** Coverage must include an unsupported SDK, a missing profile vector, a declined
+  snapshot, and an upstream abort. Each case must prove that no one-pass fallback occurs.
 
 ### Security
 
@@ -468,9 +478,14 @@ availability failures and follow the same fail-closed rule as other incomplete r
 
 Run diagnostics must identify the selected replay mode and backend, SDK capability, agent, and the
 mapping from every counter bucket to its replay pass. They must distinguish option
-conflicts, unsupported configurations, missing profiles, snapshot decline,
+conflicts, unavailable native collection, missing profiles, snapshot decline,
 and upstream abort, and state that partial results are unusable. A
 snapshot-decline diagnostic also recommends application replay.
+
+A configuration diagnostic must name the specific unmet condition rather than reporting that the
+native collector is unavailable. A single message covering a `rocprofv3` backend, an unsupported
+ROCm version, and an unresolvable library leaves the user without an action, because the remedy
+differs in each case.
 
 ## Open questions
 
@@ -479,8 +494,10 @@ snapshot-decline diagnostic also recommends application replay.
 - **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
    their durations include replay overhead and are not comparable with a non-replay run. Should the
    combination be rejected or duration be corrected?
-- **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
-   native collector resolve filters inside the SDK tool library. Will `rocprofv3` support
-   in future?
+- **Extending kernel replay beyond the native collector.** `rocprofv3` and `rocprofiler-sdk`
+   without the native collector run the SDK's own tool library, which `rocprof-compute` cannot
+   instrument. Neither the pass-0 trace stop nor the filter decision at `pass_count_cb` has an
+   equivalent there, and filter resolution happens inside that library. Whether support requires
+   upstream changes or post-run reconstruction is unresolved.
 - **Cache related counter value validity.** Can cache-related metrics be trusted
    since the cache state is not restored between replay passes?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -14,8 +14,8 @@
 
 | Strategy | Execution model | Pros | Cons |
 | --- | --- | --- | --- |
-| **Application replay** | Launch and run the complete workload once per bucket. | Every bucket, across corresponding replayed dispatch occurrences — nothing is estimated from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected; communicating multi-rank workloads warn. |
-| **Iteration multiplexing** | Launch once and let the native tool rotate buckets across comparable dispatch occurrences. Analysis imputes each occurrence's missing counters. | Avoids repeated launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. Requires the native tool. |
+| **Application replay** | Launch and run the complete workload once per bucket. | Every bucket, across corresponding replayed dispatch occurrences — nothing is estimated from other occurrences. | Repeats process startup, runtime initialization and host work. |
+| **Iteration multiplexing** | Launch once and let the native tool rotate buckets across comparable dispatches. Analysis imputes each dispatch's missing counters. | Avoids repeated launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. |
 
 - Every configuration consumes the same buckets. Application replay works across all of them;
   iteration multiplexing hard-errors without the native tool.
@@ -24,27 +24,23 @@
 
 ### Co-active profiling services
 
-Counter collection never runs alone. Every counter invocation must produce kernel-dispatch records,
-because those records carry the kernel counts and durations.
+Counter collection never runs alone. Every counter collection invocation must produce kernel-dispatch records,
+because those records carry the kernel records.
 
 | Service | Context owner | Per dispatch? | Consequence under replay |
 | --- | --- | --- | --- |
-| Kernel dispatch tracing | Separate tracing context | Yes | *N* records for one logical dispatch. Inflates Top Stats and `pmc_dispatch_info.csv`. |
-| Marker / ROCTx tracing | Separate tracing context, framework runs only | Host-side, spans all passes | Region duration absorbs replay overhead. |
-| Code-object tracing | Native tool | No — load time | Unaffected. Replay does not multiply load-time events. |
+| Kernel dispatch tracing | Separate tracing context | Yes | *N* records for one logical dispatch. |
+| Marker / ROCTx tracing | Separate tracing context | Host-side, spans all passes | Region duration absorbs replay overhead. |
+| Code-object tracing | Native tool | No | Unaffected |
 | PC sampling | Own invocation today | Agent-wide | Becomes its own replay pass. |
 | Counter collection | Native tool | Yes | The point of the feature: one bucket per pass. |
 
-The split matters: the trace records come from a context the native tool can control but does
-not itself emit.
-
 ### Proposed SDK replay mechanism
 
-[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism this design
-must consume. Treat it as a surrounding component and an external constraint — nothing here proposes
-changes to its replay algorithm.
+[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism that this design
+relies on.
 
-| Domain / operation | Fires | The tool's part |
+| Domain / operation | SDK | Profiling tool |
 | --- | --- | --- |
 | `KERNEL_REPLAY` `CONFIG` enter | Once per dispatch reaching the replay gate | Supply `pass_count_cb` (fixed-pass path). |
 | `pass_count_cb` | Once per dispatch, before any pass | Return the pass count. May consult the dispatch's agent information. |
@@ -56,9 +52,7 @@ changes to its replay algorithm.
 | `1` | Ordinary single-execution path. No replay window, no snapshot, no `PASS` callbacks. |
 | Greater than `1` | Opens a replay window with that many passes. |
 
-The same upstream mechanism lets a tool locally stop a context for selected replay passes. Kernel
-dispatch tracing honors that local stop and omits the disabled context's dispatch record — an
-external capability the service-composition design below leans on.
+SDK also lets a profiling tool locally stop a context for selected replay passes.
 
 ```mermaid
 sequenceDiagram
@@ -100,8 +94,7 @@ sequenceDiagram
 - **Snapshot coverage.** Tracked, agent-owned, coarse-grained device allocations that are neither
   kernarg nor executable memory. The SDK separately discovers and captures module-scope `__device__`
   and `__constant__` storage visible to the agent.
-- **Isolation.** A replay window isolates one GPU agent. Ordinary dispatches take the reader side of
-  the same per-agent lock; replay windows on different agents still run concurrently.
+- **Isolation.** A replay window isolates a GPU agent.
 - **Restoration.** The snapshot is restored between passes, so every pass starts from identical
   device state.
 
@@ -118,58 +111,55 @@ When a counter request produces *N* buckets and *N* is greater than one:
 | Executions of every other dispatch | *N* | 1 |
 | Added cost | — | Snapshot, restore, queue drain, agent isolation |
 
-Only the kernel actually needs profiling *N* times. For workloads with a large startup cost,
-application replay wastes a lot of wall-clock repeating everything else.
+Only the selected kernel needs profiling *N* times. For workloads with a large startup cost,
+application replay requires a lot of time.
 
-- **Iteration multiplexing does not close this gap.** It avoids the repeated launches, but pulls
+- **Iteration multiplexing does not close this gap.** It avoids the repeated launches, but collects
   counters from different dispatches and fills each dispatch's gaps during analysis. It cannot
   collect every counter from repeated executions of *one* logical dispatch in a single workload run.
-- **Replay multiplies the co-active services.** Left alone, kernel dispatch tracing emits *N* records
-  for one logical dispatch, and Top Stats reports an inflated dispatch count and aggregate GPU
-  duration.
 - **This is not free.** Kernel replay drops the repeated full-workload launches but adds snapshot,
   restoration, dispatch replay, and isolation costs. It will not be faster for every workload.
 
-The flow below compares counter collection when *N* is greater than one. It leaves out profiler
-invocations outside counter collection.
+The flows below compares counter collection when *N* is greater than one. It does not include other
+services outside counter collection.
+
+### Application replay
 
 ```mermaid
-flowchart LR
+flowchart TD
     Buckets["N buckets<br/>N greater than 1"]
+    AppSelect["Choose bucket i"]
+    AppLaunch["Launch profiling and full workload"]
+    AppRun["Startup, runtime init,<br/>host work, kernel execution"]
+    AppCollect["Collect bucket i"]
+    AppDone{"All N buckets?"}
+    AppResult["Complete<br/>N full workload launches"]
 
-    subgraph Application["Application replay"]
-        direction TB
-        AppSelect["Choose bucket i"]
-        AppLaunch["Launch profiling and full workload"]
-        AppRun["Startup, runtime init,<br/>host work, kernel execution"]
-        AppCollect["Collect bucket i"]
-        AppDone{"All N buckets?"}
-        AppResult["Complete<br/>N full workload launches"]
+    Buckets --> AppSelect --> AppLaunch --> AppRun --> AppCollect --> AppDone
+    AppDone -- next bucket --> AppSelect
+    AppDone -- yes --> AppResult
+```
 
-        AppSelect --> AppLaunch --> AppRun --> AppCollect --> AppDone
-        AppDone -- next bucket --> AppSelect
-        AppDone -- yes --> AppResult
-    end
+### Kernel replay
 
-    subgraph Kernel["Kernel replay"]
-        direction TB
-        KernelLaunch["Launch profiling and full workload once"]
-        KernelSetup["Startup and runtime init once"]
-        KernelDispatch{"Next dispatch?"}
-        KernelOrdinary["Execute unselected dispatch once"]
-        KernelReplay["Execute selected dispatch N times<br/>one bucket per pass"]
-        KernelContinue["Continue host-side execution"]
-        KernelResult["Complete<br/>one full workload launch"]
+```mermaid
+flowchart TD
+    Buckets["N buckets<br/>N greater than 1"]
+    KernelLaunch["Launch profiling and full workload once"]
+    KernelSetup["Startup and runtime init once"]
+    KernelDispatch{"Next dispatch?"}
+    KernelOrdinary["Execute unselected dispatch once"]
+    KernelReplay["Execute selected dispatch N times<br/>one bucket per pass"]
+    KernelContinue["Continue host-side execution"]
+    KernelDone{"Workload complete?"}
+    KernelResult["Complete<br/>one full workload launch"]
 
-        KernelLaunch --> KernelSetup --> KernelDispatch
-        KernelDispatch -- not selected --> KernelOrdinary --> KernelContinue
-        KernelDispatch -- selected --> KernelReplay --> KernelContinue
-        KernelContinue --> KernelDispatch
-        KernelDispatch -- workload complete --> KernelResult
-    end
-
-    Buckets --> AppSelect
-    Buckets --> KernelLaunch
+    Buckets --> KernelLaunch --> KernelSetup --> KernelDispatch
+    KernelDispatch -- not selected --> KernelOrdinary --> KernelContinue
+    KernelDispatch -- selected --> KernelReplay --> KernelContinue
+    KernelContinue --> KernelDone
+    KernelDone -- no, next dispatch --> KernelDispatch
+    KernelDone -- yes --> KernelResult
 ```
 
 ## Requirements
@@ -178,74 +168,72 @@ flowchart LR
 
 #### Mode selection
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`, and requires explicit selection of kernel replay. `--iteration-multiplexing` and its policy argument stay independent. | Kernel replay carries support boundaries application replay does not. Opt-in, not inferred. |
-| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses the kernel-replay counter adapter and retains the existing non-counter path, including the PC-sampling-only path. | Removing the repeated launches is the whole point. A user-set pass count could disagree with the bucket count. A request with no counters has nothing to replay through the counter adapter. |
-| **FR-3** | Kernel replay requires the native tool. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native tool, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. | Only the native tool owns the SDK contexts replay needs. Failing late wastes a workload run. |
+| ID | Requirement |
+| --- | --- |
+| **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`. `--iteration-multiplexing` stay independent. |
+| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses the kernel-replay counter adapter and retains the existing non-counter path, including the PC-sampling-only path. |
+| **FR-3** | Kernel replay requires the native tool. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native tool, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. |
 
 #### Passes and buckets
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **FR-4** | Bucket membership matches application replay. `_ACCUM` pairing, TCC grouping, and same-bucket priority are unchanged, and every bucket still fits one hardware pass. | Kernel replay changes the shape of the invocation, not how counters partition. Divergence would make the two modes incomparable. |
-| **FR-5** | Pass count equals the bucket count, or the bucket count plus one when `--pc-sampling` is selected. | Derived, never configured, so the two cannot drift apart. |
-| **FR-6** | The PC sampling pass runs with counter collection disabled, and alters neither bucket membership nor the ordering of the counter passes preceding it. | PC sampling is agent-wide and must not perturb counter results. |
+| ID | Requirement |
+| --- | --- |
+| **FR-4** | Bucket membership matches application replay. `_ACCUM` pairing, TCC grouping, and same-bucket priority are unchanged, and every bucket still fits one hardware pass. |
+| **FR-5** | Pass count equals the bucket count, or the bucket count plus one when `--pc-sampling` is selected. |
+| **FR-6** | The PC sampling pass runs with counter collection disabled, and alters neither bucket membership nor the ordering of the counter passes preceding it. |
 
 #### Output and identity
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **FR-7** | One kernel-replay invocation produces one consolidated `results_*.csv`, using the existing first-input-stem naming convention, that the existing workload join and analysis path consumes with no analysis-side contract change. | Analysis should not need to know which replay mode produced its input, and kernel mode should not introduce another result-discovery convention. |
-| **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. | Analysis groups on `Dispatch_ID` before pivoting counters into columns. Per-pass IDs would leave every group holding one bucket. |
-| **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. | Same reason as FR-8, and it keeps durations comparable between modes. |
-| **FR-10** | Preserve two independent one-dispatch contracts: suppress kernel-dispatch tracing after pass 0 so exactly one trace record remains, and consolidate the normalized counter rows into one logical dispatch with its pass-0 duration before analysis. Top Stats and `pmc_dispatch_info.csv` consume the latter PMC data, not the trace stream. | Trace artifacts and PMC-derived summaries have separate inputs. Both must avoid replay-multiplied dispatch counts and GPU time. |
+| ID | Requirement |
+| --- | --- |
+| **FR-7** | One kernel-replay invocation produces one consolidated counter result using the existing naming and discovery convention, which the workload join and analysis path consume with no analysis-side contract change. |
+| **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. |
+| **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. |
+| **FR-10** | Preserve two independent one-dispatch contracts: suppress kernel-dispatch tracing after pass 0 so exactly one trace record remains, and consolidate the normalized counter rows into one logical dispatch with its pass-0 duration before analysis. Top Stats and the dispatch information output consume the latter counter data, not the trace stream. |
 
 #### Composition and filtering
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. | Both replay strategies claim the same per-dispatch passes. The rest only select counters. |
-| **FR-12** | Kernel filtering composes. A dispatch whose kernel is excluded is not replayed and incurs no snapshot or restore. | A filtered dispatch paying full replay cost, only to have its counters discarded, is pure waste. |
-| **FR-13** | Dispatch filtering composes. `--dispatch` retains its 1-based, per-kernel logical-occurrence semantics: indices count each kernel's logical dispatches, not replay passes or a global dispatch sequence. Replay-ineligible submissions still advance the existing per-kernel occurrence counter when the dispatch-counting service observes them, and an excluded dispatch is not replayed. | Otherwise replay passes or submissions skipped by the replay gate shift the per-kernel occurrence selected by the user, so `--dispatch 3` can select different work in the two modes. |
-| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the unresolved risk that one rank may replay a collective-bearing dispatch while its peers do not. It does not reuse the application-replay warning about repeated workload launches or recommend iteration multiplexing. | Multi-rank workloads are exactly the ones with expensive startup, but Open Question 1 remains a safety boundary the user must see. |
+| ID | Requirement |
+| --- | --- |
+| **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. |
+| **FR-12** | Kernel filtering composes. A dispatch whose kernel is excluded is not replayed and incurs no snapshot or restore. |
+| **FR-13** | Dispatch filtering composes. `--dispatch` retains its 1-based, per-kernel logical-occurrence semantics: indices count each kernel's logical dispatches, not replay passes or a global dispatch sequence. Replay-ineligible submissions still advance the existing per-kernel occurrence counter when the dispatch-counting service observes them, and an excluded dispatch is not replayed. |
+| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the unresolved risk that one rank may replay a collective-bearing dispatch while its peers do not. It does not reuse the application-replay warning about repeated workload launches or recommend iteration multiplexing. |
 
 #### Failure
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. | Distinct from the ROCm version the native tool needs. The user must know which one is unmet. |
-| **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. | Without a snapshot there is no equivalent state, so no pass after the first is trustworthy. Application replay is the working alternative. |
-| **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. | Upstream drain expiry aborts the process; there is no recoverable error to catch. |
-| **FR-18** | If counters were requested but an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. A request that resolves to zero counter buckets bypasses the replay counter adapter under FR-2 and is not this failure. | A single-pass "success" would present one bucket as a complete metric set, while treating an intentional zero-counter request as an agent mismatch would reject a valid non-counter path. |
+| ID | Requirement |
+| --- | --- |
+| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. |
+| **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. |
+| **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. |
+| **FR-18** | If counters were requested but an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. A request that resolves to zero counter buckets bypasses the replay counter adapter under FR-2 and is not this failure. |
 
 ### Non-functional requirements
 
-| ID | Requirement | Why |
-| --- | --- | --- |
-| **NFR-1** | For deterministic workloads and state covered by the replay-equivalence guarantee, each kernel-replay bucket matches the corresponding application-replay bucket for the same logical dispatch. Cache-sensitive counters fall outside this invariant. | This is an observable correctness claim even though normal bucket construction assigns each counter to one bucket. Cache state is not restored, so it is excluded explicitly. |
-| **NFR-2** | Fail closed whenever a complete bucket set cannot be delivered. Never collect partial counter data silently. | Partial counters produce plausible-looking but wrong metrics. |
-| **NFR-3** | Guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. No guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state. May require host memory equal to the tracked device footprint. | Inherited from the upstream mechanism. Overstating coverage would mislead users into trusting unsupported cases. |
-| **NFR-4** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. | The feature is experimental. It must not regress the default path. |
-| **NFR-5** | Diagnostics identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. | Every failure here is fatal, so the message is the user's only route to a remedy. |
+| ID | Requirement |
+| --- | --- |
+| **NFR-1** | For deterministic workloads and state covered by the replay-equivalence guarantee, each kernel-replay bucket matches the corresponding application-replay bucket for the same logical dispatch. Cache-sensitive counters fall outside this invariant. |
+| **NFR-2** | Fail closed whenever a complete bucket set cannot be delivered. Never collect partial counter data silently. |
+| **NFR-3** | Guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. No guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state. May require host memory equal to the tracked device footprint. |
+| **NFR-4** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. |
+| **NFR-5** | Diagnostics identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. |
 
 ## Design
 
 ### Counter groups and the native-tool boundary
 
-- **`perfmon_coalesce` stays the single authority** on bucket membership and one-pass fit. Its
+- **The counter-grouping logic stays the single authority** on bucket membership and one-pass fit. Its
   `_ACCUM` pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for
   both modes, and the kernel-replay adapter hands those buckets to the native tool without
   regrouping them.
 - **All *N* groups go to a single replay-enabled invocation.** The native tool derives the pass
   count from the per-agent profiles it built from them, adding one when PC sampling is selected. The
-  existing `run_prof` multi-file admission check, which recognizes iteration multiplexing today, must
-  also admit kernel replay as a separate condition. Every other unsupported multi-file input keeps
+  existing multi-group admission check, which recognizes iteration multiplexing today, must also
+  admit kernel replay as a separate condition. Every other unsupported multi-group input keeps
   hard-erroring, and kernel replay remains mutually exclusive with iteration multiplexing.
-- **The consolidated filename keeps the existing convention.** `run_prof` derives the result basename
-  from the first input counter-group file. Deterministic bucket ordering keeps that input stable, so
-  kernel replay writes the same `results_<first-input-stem>.csv` shape and existing result discovery
-  needs no mode-specific branch.
+- **Consolidated results keep the existing naming convention.** Deterministic bucket ordering keeps
+  the naming input stable, so existing result discovery needs no mode-specific branch.
 - **No separate pass-count option or environment value exists.** Deriving the count from the buckets
   is what stops the two from drifting apart. A request with zero buckets bypasses this adapter and
   follows the existing non-counter path.
@@ -357,17 +345,17 @@ before dispatch admission, so it is likewise not a missing or incomplete replay 
 
 ### Output and dispatch identity
 
-One kernel-replay counter invocation produces one consolidated `results_*.csv`. Before it is
+One kernel-replay counter invocation produces one consolidated counter result. Before it is
 written, every pass row for a logical dispatch must collapse to one identity.
 
 | Step | What happens | If skipped |
 | --- | --- | --- |
 | 1. Correlate | Group the pass rows by replay-stable logical-dispatch identity. | Nothing ties the passes of one dispatch together. |
-| 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. | The timestamp-bearing identity key can hand every pass its own `Dispatch_ID`, and PMC-derived duration summaries can retain replay-pass timing. |
-| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. Top Stats and `pmc_dispatch_info.csv` are generated from this consolidated PMC dataframe. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs; PMC-derived dispatch counts and durations can also be multiplied. |
+| 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. | The timestamp-bearing identity key can hand every pass its own `Dispatch_ID`, and counter-derived duration summaries can retain replay-pass timing. |
+| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. Top Stats and the dispatch information output are generated from this consolidated counter data. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs; counter-derived dispatch counts and durations can also be multiplied. |
 
 - Pass identity may survive transiently for normalization and diagnostics; it does not need to reach
-  `pmc_perf.csv`. Non-replay identity behavior is untouched.
+  the counter result output. Non-replay identity behavior is untouched.
 - Application replay achieves the same alignment differently: each workload invocation restarts
   positional ID assignment from scratch, even though timestamps differ between runs. It never
   literally rewrites timestamps. Kernel replay needs that alignment *inside* a single invocation.
@@ -377,7 +365,7 @@ written, every pass row for a logical dispatch must collapse to one identity.
 | Service or output | Under kernel replay | Mechanism |
 | --- | --- | --- |
 | Kernel dispatch tracing | One trace record per logical dispatch, from pass 0 | The native tool owns the context, so it locally stops kernel tracing for passes 1 through *N*−1. |
-| Top Stats and `pmc_dispatch_info.csv` | One logical PMC dispatch and its pass-0 duration | These outputs consume the consolidated counter/PMC dataframe from Output and dispatch identity, not the kernel-dispatch trace stream. |
+| Top Stats and dispatch information | One logical counter dispatch and its pass-0 duration | These outputs consume the consolidated counter data from Output and dispatch identity, not the kernel-dispatch trace stream. |
 | Code-object tracing | Unchanged | Load-time only. Replay never multiplies it. |
 | Marker / ROCTx | Emitted once, spans all passes | Duration semantics are an open question. |
 | PC sampling | One extra pass, appended after the counter passes | Runs counter-disabled. |
@@ -388,7 +376,7 @@ written, every pass row for a logical dispatch must collapse to one identity.
   replay overhead than about the dispatch.
 - **Why suppress at the source.** Nothing has to reconstruct which trace records belonged to the same
   logical dispatch, because the extra records never exist. That makes trace suppression both cheap
-  and exact. It is independent of PMC-row consolidation: Top Stats and `pmc_dispatch_info.csv` remain
+  and exact. It is independent of counter-row consolidation: Top Stats and dispatch information remain
   correct only when the Output and dispatch identity path also collapses the counter rows.
 
 ### Mode and option compatibility
@@ -460,8 +448,8 @@ Kernel replay inherits the upstream mechanism's support boundaries.
 | Phase | Delivers | Observable after this phase |
 | --- | --- | --- |
 | **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface, the selected mode carried through the profiling path, and both rejection layers with their hard-error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
-| **2. Native-tool replay** | Coalesced counter groups delivered to the SDK invocation; the `run_prof` multi-file gate extended to admit kernel replay independently of iteration multiplexing; `pass_count_cb` implemented from the per-agent profile-vector size and explicit admission state; both filters applied from the existing per-kernel occurrence index; and diagnosed failure on a missing or unexpectedly empty vector when counters were requested. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
-| **3. Consolidated output and dispatch identity** | One consolidated `results_*.csv` using the existing first-input-stem convention, cross-pass timestamp and identity normalization for PMC rows, and the independently suppressed pass-0 trace record. | Analysis consumes kernel-replay output unchanged; Top Stats and `pmc_dispatch_info.csv` report non-multiplied PMC values; trace output contains one record per logical dispatch. |
+| **2. Native-tool replay** | Coalesced counter groups delivered to the SDK invocation; the multi-group admission check extended to admit kernel replay independently of iteration multiplexing; `pass_count_cb` implemented from the per-agent profile-vector size and explicit admission state; both filters applied from the existing per-kernel occurrence index; and diagnosed failure on a missing or unexpectedly empty vector when counters were requested. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
+| **3. Consolidated output and dispatch identity** | One consolidated counter result using the existing naming convention, cross-pass timestamp and identity normalization for counter rows, and the independently suppressed pass-0 trace record. | Analysis consumes kernel-replay output unchanged; Top Stats and dispatch information report non-multiplied counter values; trace output contains one record per logical dispatch. |
 
 ## Validation, security and debuggability
 
@@ -473,10 +461,10 @@ normalization, and the analysis boundary that should not have moved.
 | # | Check | Pass criterion | Covers |
 | --- | --- | --- | --- |
 | 1 | **Counter accuracy** | Use a deterministic request producing more than one bucket. For each logical dispatch and state covered by the equivalence guarantee, every kernel-replay bucket matches its corresponding application-replay bucket. A single-bucket run or a comparison with no corresponding application-replay values is not evidence for NFR-1. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, NFR-3 |
-| 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Multiple counter-group files are admitted in kernel mode without iteration multiplexing, and the consolidated file uses and is discovered through the existing first-input-stem convention. Incomplete results fail before analysis; a zero-bucket request bypasses this check. | FR-2, FR-5, FR-7, FR-8 |
+| 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Multiple counter groups are admitted in kernel mode without iteration multiplexing, and the consolidated result uses and is discovered through the existing naming convention. Incomplete results fail before analysis; a zero-bucket request bypasses this check. | FR-2, FR-5, FR-7, FR-8 |
 | 3 | **Filtering** | The existing 1-based, per-kernel logical-occurrence index advances once for every observed dispatch of that kernel, including replay-ineligible submissions, and never once per replay pass. Kernel and dispatch exclusions take the ordinary no-snapshot path and are read as neither missing-profile failures nor incomplete replay results. The same `--dispatch` range selects the same per-kernel occurrences in both replay modes. | FR-12, FR-13 |
 | 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values subject to NFR-1, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-1, NFR-4 |
-| 5 | **Service composition** | Verify independently that tracing emits one pass-0 record per logical dispatch and that consolidated PMC data feeds Top Stats and `pmc_dispatch_info.csv` one logical dispatch with one non-multiplied pass-0 duration. Trace suppression alone does not satisfy this check. | FR-8, FR-10 |
+| 5 | **Service composition** | Verify independently that tracing emits one pass-0 record per logical dispatch and that consolidated counter data feeds Top Stats and dispatch information one logical dispatch with one non-multiplied pass-0 duration. Trace suppression alone does not satisfy this check. | FR-8, FR-10 |
 | 6 | **PC sampling composition** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. | FR-6 |
 | 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective-desynchronization risk without describing repeated workload launches or recommending iteration multiplexing, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
 | 8 | **Configuration rejection** | Each unmet native-tool condition on its own — declined native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -36,7 +36,7 @@ records come from a context the native collector can control but does not itself
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
 objects rather than individual dispatches, so kernel replay does not multiply them. PC sampling runs
-in its own invocation.
+in its own invocation today; under kernel replay it occupies its own replay pass instead.
 
 ### Proposed SDK replay mechanism
 
@@ -183,16 +183,19 @@ flowchart LR
   may not support it. In either case, kernel replay shall produce a hard error naming the unmet
   condition before any workload runs.
 - Kernel replay shall preserve the counter bucket membership used by application replay. The pass
-  count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM`
-  pairing, TCC grouping, and same-bucket priority shall remain unchanged.
+  count shall equal the bucket count, or the bucket count plus one when `--pc-sampling` is selected.
+  Every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC grouping, and same-bucket
+  priority shall remain unchanged.
 - One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the
   existing workload join and analysis path can consume without an analysis-side contract change.
 - All passes of one logical dispatch shall resolve to one `Dispatch_ID` group holding the complete
   counter set. Start and end timestamps shall follow the same cross-pass normalization semantics used
   for application-replay results.
-- Kernel replay combined with `--iteration-multiplexing`, `--attach-pid`, or `--pc-sampling` shall
-  produce a hard error. `--roof-only`, `--set`, and `--block` shall continue to interoperate
-  unchanged.
+- Kernel replay combined with `--iteration-multiplexing` or `--attach-pid` shall produce a hard
+  error. `--roof-only`, `--set`, and `--block` shall continue to interoperate unchanged.
+- Kernel replay shall compose with `--pc-sampling` by adding one replay pass to every admitted
+  dispatch. That pass shall run with counter collection disabled, and shall not alter the bucket
+  membership or the ordering of the counter passes that precede it.
 - Kernel replay shall produce a hard error when the installed SDK predates the supported version
   floor, and shall state the required version.
 - Kernel replay shall remain available for multi-rank workloads.
@@ -239,14 +242,21 @@ application and kernel replay, and the kernel-replay adapter hands those buckets
 collector without regrouping them.
 
 All *N* counter groups go to a single replay-enabled invocation, and the native collector derives the
-pass count from the per-agent profiles it built from them. There is no separate pass-count option or
-environment value, which is what keeps the bucket count and the pass count from ever disagreeing.
+pass count from the per-agent profiles it built from them, adding one pass when PC sampling is
+selected. There is no separate pass-count option or environment value. The pass count is always
+derived from the buckets rather than configured alongside them, so the two cannot drift apart.
 
 ### Pass-count ownership and profile validity
 
 Counter-group parsing creates one profile-vector entry per group, per agent. For an admitted
 dispatch, `pass_count_cb` returns the size of the vector belonging to that dispatch's agent, and
 replay pass *i* selects entry *i* from the same vector.
+
+When PC sampling is selected, `pass_count_cb` returns that size plus one. Passes 0 through *N*−1
+still map one-to-one onto the profile vector; pass *N* selects no counter profile and runs with
+counter collection disabled. This changes only the count the callback returns — the rule below,
+that a return of one means "do not replay," is unaffected, so a filtered dispatch opts out of the
+PC sampling pass along with the counter passes.
 
 A return value of one carries a specific meaning: "do not replay." It is not a safe fallback when an
 agent lookup fails or its vector turns out to be empty. Using it that way would execute the dispatch
@@ -368,11 +378,15 @@ Both are hard errors. The split matters: a capability failure leaves a workload 
 whereas a flag conflict leaves nothing.
 
 `rocprof-compute` likewise rejects kernel mode before profiling when it appears alongside iteration
-multiplexing, live attach, or PC sampling. Kernel replay rejects iteration multiplexing because both
-strategies claim the same per-dispatch passes, not because of any backend restriction — iteration
-multiplexing needs the native collector too. PC
-sampling is agent-wide, does not consume the localized context override, and today runs in a separate
-counter-disabled invocation, so there is no supported replay pass to insert it into.
+multiplexing or live attach. Kernel replay rejects iteration multiplexing because both strategies
+claim the same per-dispatch passes, not because of any backend restriction — iteration multiplexing
+needs the native collector too.
+
+PC sampling is different. It is agent-wide, it does not consume the localized context override, and
+today it runs in a separate counter-disabled invocation. None of that rules out replay: PC sampling
+takes a replay pass of its own, appended after the *N* counter passes and running with counter
+collection disabled. Kernel replay therefore accepts `--pc-sampling` and replays each admitted
+dispatch *N*+1 times.
 
 `--roof-only`, `--set`, and `--block` continue through ordinary counter selection. Multi-rank
 profiling stays available and keeps its warning. Kernel replay also needs a supported SDK version
@@ -389,7 +403,7 @@ none quietly turns a multi-bucket request into a single pass.
 | Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
 | Native collector unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two conditions failed. |
 | SDK below the supported version floor | Hard error stating the required version. This is distinct from the ROCm version the native collector needs, so the diagnostic has to say which one is unmet. The numeric floor is pending upstream merge. |
-| Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
+| Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
 | Upstream drain timeout or process abort | Abort the failed run without recovery. |
@@ -442,10 +456,10 @@ normalization, and the analysis boundary that should not have moved.
 - **Counter accuracy.** For one logical dispatch, and for state covered by the equivalence guarantee,
   a counter present in more than one bucket must report the same value in every pass. A mismatch is a
   validation failure. Evaluate cache-sensitive counters separately, as a documented limitation.
-- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed pass
-  count must equal the application replay count, every bucket must appear exactly once, and all pass
-  rows must collapse into one complete `Dispatch_ID`. Incomplete results have to fail before
-  analysis.
+- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed
+  counter-pass count must equal the application replay count, every bucket must appear exactly once,
+  and all pass rows must collapse into one complete `Dispatch_ID`. Incomplete results have to fail
+  before analysis.
 - **Filtering.** Logical indices must advance once per dispatch, not once per pass. A confirmed
   filter exclusion must take the ordinary no-snapshot path. Kernel replay must not misread it as a
   missing-profile failure or an incomplete replay result.
@@ -454,9 +468,12 @@ normalization, and the analysis boundary that should not have moved.
   Existing application replay must come out unchanged.
 - **Service composition.** Kernel replay must expose one pass-0 trace record and one non-multiplied
   logical duration per dispatch.
-- **Compatibility.** Cover the accepted options and every rejected combination: iteration
-  multiplexing, live attach, PC sampling, roofline selection, the multi-rank warning, and the
-  default-off behavior.
+- **PC sampling composition.** With `--pc-sampling` selected, each admitted dispatch must replay
+  *N*+1 times. Every counter bucket must still appear exactly once across passes 0 through *N*−1,
+  and pass *N* must produce PC sampling output and no counter rows.
+- **Compatibility.** Cover the accepted options — PC sampling, roofline selection, the multi-rank
+  warning, and the default-off behavior — and every rejected combination: iteration multiplexing and
+  live attach.
 - **Configuration rejection.** Cover each unmet native-collector condition on its own — declined
   native collector, unsupported ROCm version, unresolvable library. Each must fail before profiling
   starts, with a diagnostic naming that specific condition.

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -287,19 +287,18 @@ flowchart TD
 
 ### The pass-count decision
 
-Kernel and dispatch filters establish whether the dispatch is admitted before counter-bucket
+Kernel and dispatch filters establish whether the dispatch is profiled before counter-bucket
 availability is considered. An admitted zero-bucket request bypasses kernel replay and
-follows the existing path. For an admitted counter request, `pass_count_cb` determines the
+follows the existing path. For an admitted kernel, `pass_count_cb` determines the
 pass count exactly once before any replay pass.
 
 ```mermaid
 flowchart TD
-    Observe["Dispatch-counting service assigns<br/>per-kernel logical occurrence once"]
     Kernel{"Kernel admitted by<br/>the kernel filter?"}
-    Range{"Per-kernel occurrence admitted by<br/>the dispatch range?"}
-    Filtered["Return 1 as filtered<br/>select no counter profile"]
+    Range{"Dispatch admitted by<br/>the dispatch filter?"}
+    Filtered["Do not profile <br/> dispatched kernel"]
     Request{"Counter request has<br/>at least one bucket?"}
-    Zero["Bypass replay counter adapter<br/>use existing non-counter path"]
+    Zero["Bypass kernel replay<br/>use existing non-counter path"]
     Gate{"Dispatch reaches<br/>the replay gate?"}
     Ordinary["Execute once outside replay<br/>retain ordinary dispatch handling"]
     Start["pass_count_cb runs once"]
@@ -311,7 +310,6 @@ flowchart TD
     N["Return N<br/>one counter bucket per pass"]
     NPlus["Return N+1<br/>N counter passes, then one<br/>counter-disabled PC sampling pass"]
 
-    Observe --> Kernel
     Kernel -- no --> Filtered
     Kernel -- yes --> Range
     Range -- no --> Filtered
@@ -328,116 +326,70 @@ flowchart TD
     Size -- more than one --> N
 ```
 
-| Returns | When | What the execution selects |
+| Actual kernel dispatch | When | What the execution selects |
 | --- | --- | --- |
-| `1` — filtered | A confirmed filter miss — the kernel or its per-kernel logical occurrence is excluded. | Nothing. The SDK takes its ordinary path, deliberately paying no snapshot or restore. |
-| `1` — admitted | The dispatch is admitted and its agent's profile vector contains exactly one bucket. | The ordinary execution selects the sole profile. This is a complete one-bucket result, not a filter outcome. |
+| `1` — filtered | A confirmed filter miss — the kernel or dispatch is excluded. | Not profiled. |
+| `1` — admitted | The dispatch is admitted and its agent's profile vector contains exactly one bucket, no PC sampling. | SDK selects the sole profile and produces a complete one-bucket result. |
 | *N*, where *N* > 1 | Admitted, no PC sampling. *N* is the size of the profile vector for this dispatch's agent. | Pass *i* selects entry *i* of that vector. |
 | *N*+1 | Admitted, PC sampling selected. *N* is the non-zero size of the profile vector. | Passes 0 through *N*−1 map one-to-one onto the vector. Pass *N* selects no counter profile and runs counter-disabled. |
-| *(fatal)* | The dispatch passed both filters and requested counters, but the agent is missing or its expected profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
 
-Three consequences worth stating plainly:
+### Output and dispatch ID
 
-- **Admission is state, not a numeric inference.** Both a filtered dispatch and an admitted
-  single-bucket dispatch return `1`, but only the admitted case selects a profile and participates in
-  completeness checking. The adapter records that distinction explicitly.
-- **Filters run before counter admission.** A kernel or dispatch-range miss returns `1` as filtered
-  before the bucket and profile-vector checks. Missing profile state is fatal only for a dispatch that
-  passed both filters and requested counters.
-- **`1` is never a fallback for a missing expected profile.** Returning it for an agent/profile
-  mismatch would execute the dispatch once, collect at most one bucket, and present incomplete data
-  as a success.
-- **The logical index remains owned by dispatch observation.** The dispatch-counting service advances
-  the 1-based index once per logical occurrence of each kernel, including submissions the replay gate
-  cannot replay. `pass_count_cb` only reads that stable index, and replay passes never consume another
-  occurrence.
+A single dispatch produces one consolidated counter result. Before it is
+written, every pass for a logical dispatch must be collapsed.
 
-Completeness checks apply only to admitted counter requests. A dispatch excluded on purpose produces
-no counter set, and that is not an incomplete replay result. After both filters admit a dispatch, a
-zero-bucket request bypasses the adapter and is likewise not a missing or incomplete replay result.
+| Step | What happens |
+| --- | --- |
+| 1. Correlate | Group the pass rows by logical-dispatch ID. |
+| 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. |
+| 3. Hand off | The existing identity and pivot contracts see a single set per dispatch. |
 
-### Output and dispatch identity
-
-One kernel-replay counter invocation produces one consolidated counter result. Before it is
-written, every pass row for a logical dispatch must collapse to one identity.
-
-| Step | What happens | If skipped |
-| --- | --- | --- |
-| 1. Correlate | Group the pass rows by replay-stable logical-dispatch identity. | Nothing ties the passes of one dispatch together. |
-| 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. | The timestamp-bearing identity key can hand every pass its own `Dispatch_ID`, and counter-derived duration summaries can retain replay-pass timing. |
-| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. Top Stats and the dispatch information output are generated from this consolidated counter data. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs; counter-derived dispatch counts and durations can also be multiplied. |
-
-- Pass identity may survive transiently for normalization and diagnostics; it does not need to reach
-  the counter result output. Non-replay identity behavior is untouched.
-- Application replay achieves the same alignment differently: each workload invocation restarts
-  positional ID assignment from scratch, even though timestamps differ between runs. It never
-  literally rewrites timestamps. Kernel replay needs that alignment *inside* a single invocation.
+Pass identity survive transiently for normalization and diagnostics but it does not reach
+the counter result output. Non-replay identity behavior is untouched.
 
 ### Co-active service composition
 
 | Service or output | Under kernel replay | Mechanism |
 | --- | --- | --- |
 | Kernel dispatch tracing | One trace record per logical dispatch, from pass 0 | The native tool owns the context, so it locally stops kernel tracing for passes 1 through *N*−1. |
-| Top Stats and dispatch information | One logical counter dispatch and its pass-0 duration | These outputs consume the consolidated counter data from Output and dispatch identity, not the kernel-dispatch trace stream. |
+| Top Stats and dispatch information | One logical counter dispatch and its pass-0 duration | These outputs consume the consolidated dispatch data. |
 | Code-object tracing | Unchanged | Load-time only. Replay never multiplies it. |
 | Marker / ROCTx | Emitted once, spans all passes | Duration semantics are an open question. |
 | PC sampling | One extra pass, appended after the counter passes | Runs counter-disabled. |
-| Roofline | Unchanged | Picks up the selected mode through the ordinary counter path. |
-
-- **Why pass 0.** It is the only pass running against pristine pre-snapshot state. Every later pass
-  starts immediately after a full restore of the tracked footprint, so its timing says more about
-  replay overhead than about the dispatch.
-- **Why suppress at the source.** Nothing has to reconstruct which trace records belonged to the same
-  logical dispatch, because the extra records never exist. That makes trace suppression both cheap
-  and exact. It is independent of counter-row consolidation: Top Stats and dispatch information remain
-  correct only when the Output and dispatch identity path also collapses the counter rows.
+| Roofline | Unchanged |  |
 
 ### Mode and option compatibility
 
 `--replay-mode` accepts `application` and `kernel`. Application replay stays the default, CLI help
-flags kernel replay as experimental, and the selected mode travels down to the kernel-replay adapter.
-This does not turn `--iteration-multiplexing` into a mode selector.
+flags kernel replay as experimental.
 
-| Option or condition | With kernel replay | Reason |
-| --- | --- | --- |
-| `--iteration-multiplexing` | Rejected | Both strategies claim the same per-dispatch passes. Not a backend restriction — iteration multiplexing needs the native tool too. |
+| Option or condition | With kernel replay |
+| --- | --- |
+| `--iteration-multiplexing` | Rejected | 
 | `--attach-pid` | Rejected | Live attach cannot open a replay window over an already-running process. |
-| `--no-native-tool`, `rocprofv3` backend | Rejected | Kernel replay needs the SDK contexts only the native tool owns. |
-| `--pc-sampling` | Accepted, *N*+1 passes | Agent-wide, and it does not consume the localized context override. It takes a counter-disabled pass of its own. |
-| `--roof-only`, `--set`, `--block` | Accepted, unchanged | Ordinary counter selection. |
-| Multi-rank | Accepted, with a kernel-replay-specific diagnostic | Warn that replaying one rank's collective-bearing dispatch while peers do not may desynchronize the collective. Do not reuse the application-replay warning about multiple workload launches or recommend iteration multiplexing. Open Question 1 remains unresolved. |
-| Heterogeneous agents | Rejected | Kernel replay needs a homogeneous agent configuration. |
-
-Kernel mode needs the native tool, but the conditions that supply one do not all become
-knowable at the same moment, so rejection happens in two layers:
-
-| Layer | Decidable from | Rejected when | Workload directory left behind? |
-| --- | --- | --- | --- |
-| **Flag conflict** | The arguments alone | Kernel replay selected while the native tool is declined | No — rejected before discovery and before the directory is created |
-| **Capability failure** | Discovery, once it has resolved the ROCm version and native library | Unsupported ROCm version, or a library that cannot be resolved | Yes — rejected later, but still before the workload runs |
-
-Both are hard errors. Iteration multiplexing and live attach are likewise rejected before profiling
-starts.
+| `--no-native-tool`, `rocprofv3` backend | Rejected | 
+| `--pc-sampling` | Accepted, *N*+1 passes |
+| `--roof-only`, `--set`, `--block` | Accepted, unchanged |
+| Multi-rank | Accepted, with a kernel-replay-specific diagnostic |
 
 ### Failure behavior
 
 Every failure below rejects partial replay data. None falls back to application replay, and none
 quietly turns a multi-bucket request into a single pass.
 
-| Condition | Required behavior | Covers |
-| --- | --- | --- |
-| Native tool declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. | FR-3 |
-| Native tool unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3 |
-| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native tool needs, so the diagnostic must say which one is unmet. The numeric floor is pending upstream merge. | FR-15 |
-| Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. | FR-11 |
-| Missing or unexpectedly empty per-agent profile vector when counters were requested | Diagnose the agent/profile mismatch and reject the profile. Never return `1` as a fallback. A zero-bucket request bypasses the replay adapter before this point and is not this failure. | FR-18, NFR-2 |
-| SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. | FR-16, NFR-2 |
-| Upstream drain timeout or process abort | Abort the failed run without recovery. | FR-17 |
+| Condition | Required behavior |
+| --- | --- |
+| Native tool not selected while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
+| Native tool unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. |
+| SDK below the supported version floor | Hard error stating the required version. |
+| Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. |
+| Missing or unexpectedly empty per-agent profile vector when counters were requested | Hard error describing the profile mismatch. |
+| SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
+| Upstream drain timeout or process abort | Abort the failed run. |
 
-One wrinkle: a declined snapshot can currently leave a successful process status behind, so the
+One wrinkle: a declined snapshot currently leave a successful process status behind, so the
 required outcome cannot lean on subprocess failure alone. Classifying an upstream warning string is
-the signal available today, and it is a fragile one. A structured detection mechanism remains an
-open question.
+the signal available today. A structured detection mechanism remains an open question.
 
 ## Implementation phases
 

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -4,63 +4,64 @@
 
 ### Counter collection today
 
-`rocprof-compute` maps the requested analysis metrics to hardware counters and
-packs those counters into groups that each fit one hardware pass. The number of
-groups therefore determines how many counter-collection passes are needed.
+`rocprof-compute` turns the metrics an analysis asks for into hardware counters, then packs those
+counters into groups small enough to fit a single hardware pass. However many groups fall out of
+that packing is how many counter-collection passes the run needs.
 
-The profiling layer can invoke `rocprofv3` or `rocprofiler-sdk`. On the `rocprofiler-sdk` path,
-`rocprof-compute` additionally preloads its own **native collector**, which takes over counter
-collection and leaves the SDK tool library doing tracing. The native collector is therefore a
-sub-mode of the `rocprofiler-sdk` configuration rather than a third backend, and it is unavailable
-when the user opts out of it, when the backend is `rocprofv3`, or when the installed ROCm predates
-the version that supports it.
+The profiling layer can drive either `rocprofv3` or `rocprofiler-sdk`. On the `rocprofiler-sdk`
+path, `rocprof-compute` can also preload its own **native collector**, which takes over counter
+collection and leaves the SDK tool library handling tracing. So the native collector is a sub-mode
+of the `rocprofiler-sdk` configuration, not a third backend. It is unavailable in three cases: the
+user opted out of it, the backend is `rocprofv3`, or the installed ROCm predates the version that
+supports it.
 
-All configurations consume the same buckets. Application replay works across all of them;
-iteration multiplexing already requires the native collector and hard-errors otherwise.
+Every configuration consumes the same buckets. Application replay works across all of them.
+Iteration multiplexing already depends on the native collector and hard-errors without it.
 
 
 | Strategy | Execution model | What it covers | What it does not cover |
 | --- | --- | --- | --- |
-| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning. |
-| **Iteration multiplexing** | Launch the workload once for counter collection and use the native collector to rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Does not collect every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. It also requires the native collector. |
+| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences, without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning. |
+| **Iteration multiplexing** | Launch the workload once for counter collection and let the native collector rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set, and the whole strategy needs the native collector. |
 
-Application replay is therefore the only current strategy that covers a multi-bucket request
-without cross-dispatch imputation.
+That leaves application replay as the only strategy today that can satisfy a multi-bucket request
+without borrowing counters from neighbouring dispatches.
 
 ### Co-active profiling services
 
-Counter collection never runs alone. Every counter invocation must yield kernel-dispatch records;
-those records supply the kernel counts and durations. Under native collection the work is split: the
-native collector owns counters, while the SDK tool library performs kernel dispatch tracing and adds
-marker or ROCTx tracing for a framework-selected run. That split matters here, because it means the
-trace records are produced by a context the native collector can control but does not itself emit.
+Counter collection never runs on its own. Every counter invocation has to produce kernel-dispatch
+records, because those records carry the kernel counts and durations. Under native collection the
+work is split: the native collector owns counters, while the SDK tool library does kernel dispatch
+tracing and adds marker or ROCTx tracing for a framework-selected run. That split matters here — the
+trace records come from a context the native collector can control but does not itself emit.
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
-objects rather than individual dispatches and are not multiplied by kernel replay. PC sampling runs
-in a separate invocation.
+objects rather than individual dispatches, so kernel replay does not multiply them. PC sampling runs
+in its own invocation.
 
 ### Proposed SDK replay mechanism
 
-[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism that this
-design must consume. The mechanism is a surrounding component and an external constraint; this HLD
-does not propose changes to its replay algorithm.
+[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism this
+design has to consume. Treat it as a surrounding component and an external constraint: nothing here
+proposes changes to its replay algorithm.
 
-The PR adds a `KERNEL_REPLAY` callback domain with `CONFIG` and `PASS` operations. In the fixed-pass
-path, a profiling tool supplies `pass_count_cb` during `CONFIG`.
-The callback is evaluated for each dispatch that reaches the replay gate and can use its agent
-information. Returning `1` opts out: the SDK follows its ordinary single-execution path without
-taking a snapshot or issuing `PASS` callbacks. Returning a count greater than one opens a replay
-window, and `PASS` enter and exit callbacks delimit each execution in that window.
+The PR adds a `KERNEL_REPLAY` callback domain with `CONFIG` and `PASS` operations. On the
+fixed-pass path, a profiling tool supplies `pass_count_cb` during `CONFIG`. The SDK evaluates that
+callback for each dispatch reaching the replay gate, and the callback can consult the dispatch's
+agent information. Return `1` to opt out, and the SDK takes its ordinary single-execution path with
+no snapshot and no `PASS` callbacks. Return anything greater than one and the SDK opens a replay
+window, with `PASS` enter and exit callbacks delimiting each execution inside it.
 
 The same upstream mechanism lets a tool locally stop a context for selected replay passes. Kernel
-dispatch tracing honors that local stop and omits the disabled context's dispatch record. This is an
-external capability used by the service-composition design below.
+dispatch tracing honors that local stop and omits the disabled context's dispatch record — an
+external capability the service-composition design below leans on.
 
-The replay window isolates one GPU agent. The SDK takes a host-side writer lock keyed by that
-agent, holds the application's completion signal, drains prior work on the submitting and sibling
-queues, and copies the supported device state to a host snapshot. It then executes the dispatch
-once per pass, restoring the snapshot between passes so each begins from the same device state. The
-SDK exits `CONFIG`, signals one application-visible completion, and releases the writer lock.
+A replay window isolates one GPU agent. The SDK takes a host-side writer lock keyed by that agent,
+holds the application's completion signal, drains prior work on the submitting and sibling queues,
+and copies the supported device state into a host snapshot. It then runs the dispatch once per
+pass, restoring the snapshot between passes so every pass starts from identical device state.
+Finally it exits `CONFIG`, signals a single application-visible completion, and releases the writer
+lock.
 
 ```mermaid
 sequenceDiagram
@@ -99,38 +100,35 @@ sequenceDiagram
     end
 ```
 
-The snapshot covers tracked, agent-owned, coarse-grained device allocations that are neither
-kernarg nor executable memory. Module-scope `__device__` and `__constant__` storage visible to the
-agent is discovered and captured separately. While replay is active, ordinary dispatches use the
-reader side of the same per-agent lock, while replay windows on different agents can proceed
-concurrently.
+The snapshot covers tracked, agent-owned, coarse-grained device allocations that are neither kernarg
+nor executable memory. Module-scope `__device__` and `__constant__` storage visible to the agent is
+discovered and captured separately. While a replay is active, ordinary dispatches take the reader
+side of the same per-agent lock; replay windows on different agents still run concurrently.
 
 ## Problem statement
 
-When a counter request produces *N* hardware-pass buckets, where *N* is greater than one,
-application replay launches and runs the complete workload once per bucket. Counter collection
-therefore repeats process startup, runtime initialization, host-side work, and the kernel run
-*N* times even though only the kernel needs to be profiled *N* times. This repeated full-workload work
-is undesirable for workloads with large startup cost.
+When a counter request produces *N* hardware-pass buckets and *N* is greater than one, application
+replay launches and runs the complete workload once per bucket. Process startup, runtime
+initialization, host-side work, and the kernel run all repeat *N* times, even though only the kernel
+actually needs profiling *N* times. For workloads with a large startup cost, that is a lot of wasted
+wall-clock.
 
-Iteration multiplexing avoids those launches, but it obtains the counters from different dispatches
-and fills each dispatch's missing counters during analysis. It does not cover the need
-to collect every counter through repeated executions of one logical dispatch within a single
-workload run.
+Iteration multiplexing avoids the repeated launches, but it pulls counters from different dispatches
+and fills in each dispatch's gaps during analysis. It does not answer the need to collect every
+counter from repeated executions of one logical dispatch inside a single workload run.
 
-Kernel replay is intended to fill that gap. It retains the same *N* buckets, runs
-the workload once, and executes each replay-eligible dispatch in *N* passes, with one bucket collected
-per pass.
+Kernel replay is meant to close that gap. It keeps the same *N* buckets, runs the workload once, and
+executes each replay-eligible dispatch *N* times, collecting one bucket per pass.
 
-Replay also multiplies co-active per-dispatch services. Without explicit handling, kernel dispatch
-tracing emits *N* records for one logical dispatch. Top Stats would then report an inflated dispatch
-count and aggregate GPU duration.
+Replay also multiplies the co-active per-dispatch services. Left alone, kernel dispatch tracing would
+emit *N* records for one logical dispatch, and Top Stats would report an inflated dispatch count and
+aggregate GPU duration.
 
-Kernel replay removes repeated full-workload launches but adds snapshot,
-restoration, dispatch replay, and isolation costs. Therefore it may not be faster for every workload.
+None of this is free. Kernel replay drops the repeated full-workload launches but adds snapshot,
+restoration, dispatch replay, and isolation costs, so it will not be faster for every workload.
 
-The following flow compares counter collection for *N* greater than one. It does not include
-separate profiler invocations outside counter collection.
+The flow below compares counter collection when *N* is greater than one. It leaves out profiler
+invocations outside counter collection.
 
 ```mermaid
 flowchart LR
@@ -181,35 +179,35 @@ flowchart LR
 - For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
   collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No
   user-supplied pass count shall be required.
-- Kernel replay shall require the native collector. When the selected configuration cannot provide
+- Kernel replay shall require the native collector. When the selected configuration cannot supply
   it — because the native collector was declined, because the backend is `rocprofv3`, or because the
   installed ROCm does not support it — kernel replay shall produce a hard error naming the unmet
   condition, before any workload runs.
-- Kernel replay shall preserve the counter bucket membership used by application replay. The pass count
-  shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC
-  grouping, and same-bucket priority shall remain unchanged.
+- Kernel replay shall preserve the counter bucket membership used by application replay. The pass
+  count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM`
+  pairing, TCC grouping, and same-bucket priority shall remain unchanged.
 - One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the
   existing workload join and analysis path can consume without an analysis-side contract change.
-- All passes of one logical dispatch shall resolve to one `Dispatch_ID` group containing the
-  complete counter set. Start and end timestamps shall follow the same cross-pass normalization
-  semantics used for application-replay results.
+- All passes of one logical dispatch shall resolve to one `Dispatch_ID` group holding the complete
+  counter set. Start and end timestamps shall follow the same cross-pass normalization semantics used
+  for application-replay results.
 - Kernel replay combined with `--iteration-multiplexing`, `--attach-pid`, or `--pc-sampling` shall
   produce a hard error. `--roof-only`, `--set`, and `--block` shall continue to interoperate
   unchanged.
 - Kernel replay shall produce a hard error when the installed SDK predates the supported version
-  floor and shall state the required version.
+  floor, and shall state the required version.
 - Kernel replay shall remain available for multi-rank workloads.
 - If the SDK declines a device-memory snapshot, `rocprof-compute` shall abandon the profile without
   retry and recommend application replay in the diagnostic.
-- If the upstream replay mechanism aborts, `rocprof-compute` shall report the failed run
-  without attempting recovery.
+- If the upstream replay mechanism aborts, `rocprof-compute` shall report the failed run without
+  attempting recovery.
 - If an agent has no usable counter profiles, `rocprof-compute` shall diagnose the condition rather
   than silently degrading that dispatch to one pass.
 - Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and
-  `pmc_dispatch_info.csv` preserve non-replay semantics by reporting one dispatch and its pass-0
-  logical duration rather than replay-multiplied values.
-- Kernel filtering shall compose with kernel replay. A dispatch whose kernel is excluded shall not
-  be replayed and shall incur no snapshot or restore.
+  `pmc_dispatch_info.csv` keep their non-replay semantics: one dispatch and its pass-0 logical
+  duration, not replay-multiplied values.
+- Kernel filtering shall compose with kernel replay. A dispatch whose kernel is excluded shall not be
+  replayed and shall incur no snapshot or restore.
 - Dispatch filtering shall compose with kernel replay. `--dispatch` indices shall count logical
   dispatches, not replay passes, so an index selects the same work whether or not kernel replay is
   selected. An excluded dispatch shall not be replayed.
@@ -217,16 +215,16 @@ flowchart LR
 ### Non-functional requirements
 
 - For state covered by the replay-equivalence guarantee, a counter present in more than one bucket
-  shall have the same value across passes of the same dispatch. Cache-sensitive counters are outside
-  this invariant because cache state is not restored.
-- Kernel replay shall fail closed whenever it cannot provide a complete bucket set. Silently partial
+  shall have the same value across passes of the same dispatch. Cache-sensitive counters fall outside
+  this invariant, because cache state is not restored.
+- Kernel replay shall fail closed whenever it cannot deliver a complete bucket set. Silently partial
   counter data shall not be collected.
 - Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and
-  module-scope device or constant state. It shall make no equivalence guarantee for unified,
-  managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions,
-  unfenced asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked
-  device footprint.
-- Workflows that do not select kernel replay shall retain their current collection behavior, and
+  module-scope device or constant state. It shall make no equivalence guarantee for unified, managed,
+  or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced
+  asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked device
+  footprint.
+- Workflows that do not select kernel replay shall keep their current collection behavior, and
   kernel-replay output shall preserve the existing analysis input contract.
 - Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific
   failure condition.
@@ -235,27 +233,28 @@ flowchart LR
 
 ### Counter groups and the collector boundary
 
-Kernel replay changes the invocation shape, not counter partitioning. `perfmon_coalesce` remains
-the only authority for bucket membership and one-pass fit. Its `_ACCUM` pairing, TCC grouping,
-and same-bucket priority policies produce *N* buckets for both application and kernel replay. The
-kernel-replay adapter translates those buckets for the native collector without regrouping them.
+Kernel replay changes the shape of the invocation, not how counters are partitioned.
+`perfmon_coalesce` stays the single authority on bucket membership and one-pass fit. Its `_ACCUM`
+pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for both
+application and kernel replay, and the kernel-replay adapter hands those buckets to the native
+collector without regrouping them.
 
-All *N* counter groups are delivered to a single replay-enabled invocation, and the native collector
-derives the pass count from the per-agent profiles it created from them. No separate pass-count
-option or environment value is introduced, so the bucket count and the pass count cannot disagree.
+All *N* counter groups go to a single replay-enabled invocation, and the native collector derives the
+pass count from the per-agent profiles it built from them. There is no separate pass-count option or
+environment value, which is what keeps the bucket count and the pass count from ever disagreeing.
 
 ### Pass-count ownership and profile validity
 
-Counter-group parsing creates one profile-vector entry per group and per agent. For an admitted
-dispatch, `pass_count_cb` returns the size of the vector for the dispatch's agent, and replay pass
-*i* selects entry *i* from that same vector.
+Counter-group parsing creates one profile-vector entry per group, per agent. For an admitted
+dispatch, `pass_count_cb` returns the size of the vector belonging to that dispatch's agent, and
+replay pass *i* selects entry *i* from the same vector.
 
-The callback's ordinary value of one means “do not replay.” It is not a valid fallback when an agent
-lookup fails or its vector is empty: that would execute the dispatch once, collect only one bucket,
-and make incomplete data look successful. A missing or empty vector must instead diagnose the
-agent/profile mismatch and fail the complete profile.
+A return value of one carries a specific meaning: "do not replay." It is not a safe fallback when an
+agent lookup fails or its vector turns out to be empty. Using it that way would execute the dispatch
+once, collect a single bucket, and present incomplete data as a success. A missing or empty vector
+has to diagnose the agent/profile mismatch and fail the whole profile instead.
 
-The component diagram shows both counter and kernel-trace data, and where each crosses the
+The component diagram shows both counter and kernel-trace data, and where each one crosses the
 collector boundary.
 
 ```mermaid
@@ -296,208 +295,207 @@ graph LR
 
 ### Filtering at the pass-count decision
 
-`pass_count_cb` is also the filter decision point, because it runs once per logical dispatch before
-any replay pass. Before choosing a count, the collector confirms that the dispatch's agent has a
-non-empty profile vector. It then assigns the dispatch's per-kernel logical index exactly once,
-evaluates the kernel-ID target set built during code-object loading and the requested dispatch
-range, and returns the profile-vector size only when both filters admit the dispatch. A confirmed filter miss returns one, intentionally selecting the SDK's ordinary path
-without a snapshot or restore. A missing or empty profile vector remains a fatal profile error and
-must never use that return.
+`pass_count_cb` doubles as the filter decision point, because it runs exactly once per logical
+dispatch and before any replay pass. Before picking a count, the collector confirms the dispatch's
+agent has a non-empty profile vector. It then assigns the dispatch's per-kernel logical index — once,
+and only here — evaluates the kernel-ID target set built during code-object loading along with the
+requested dispatch range, and returns the profile-vector size only if both filters admit the
+dispatch. A confirmed filter miss returns one, deliberately choosing the SDK's ordinary path with no
+snapshot and no restore. A missing or empty profile vector stays a fatal profile error and must never
+borrow that return value.
 
-The per-pass counter-dispatch callback reads the assigned logical index instead of incrementing it.
-A non-replay run has one pass per dispatch, so relocating the increment preserves its existing
-indices while preventing replay passes from consuming additional indices. Completeness checks apply
-only to admitted dispatches; an intentionally excluded dispatch produces no counter set and is not
-an incomplete replay result.
+The per-pass counter-dispatch callback reads the assigned logical index rather than incrementing it.
+A non-replay run has one pass per dispatch, so moving the increment keeps existing indices intact
+while stopping replay passes from consuming extra ones. Completeness checks apply only to admitted
+dispatches: a dispatch excluded on purpose produces no counter set, and that is not an incomplete
+replay result.
 
 ### Output and dispatch identity
 
-One kernel-replay counter invocation produces one consolidated
-`results_*.csv` artifact.
+One kernel-replay counter invocation produces one consolidated `results_*.csv` artifact.
 
-Before that artifact is written, all pass rows for one logical dispatch must receive one
-`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity may be retained
-transiently for normalization and diagnostics, but it need not enter `pmc_perf.csv`.
-Non-replay identity behavior remains unchanged.
+Before that artifact is written, every pass row for a logical dispatch has to receive one
+`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity can be kept around
+transiently for normalization and diagnostics, but it does not need to reach `pmc_perf.csv`.
+Non-replay identity behavior is untouched.
 
-Application replay aligns corresponding dispatches because each workload invocation starts a fresh
-positional ID assignment, even though their timestamps differ. It does not literally rewrite
-timestamps. Kernel replay needs the analogous alignment inside one invocation: first correlate the
-pass rows using replay-stable logical-dispatch identity, then normalize their timestamp pair before
-the existing identity and pivot contracts consume them.
+Application replay lines up corresponding dispatches because each workload invocation restarts
+positional ID assignment from scratch, even though the timestamps differ between runs — it never
+literally rewrites timestamps. Kernel replay needs the same alignment, but inside a single
+invocation: correlate the pass rows using replay-stable logical-dispatch identity first, then
+normalize their timestamp pair before the existing identity and pivot contracts see them.
 
-Without that step, the current timestamp-bearing identity key assigns a new `Dispatch_ID` to
-every pass. Analysis groups on `Dispatch_ID` before it pivots counter names into columns, so
-each group would contain only one bucket and no row would have the complete metric inputs.
+Skip that step and the current timestamp-bearing identity key hands every pass its own
+`Dispatch_ID`. Analysis groups on `Dispatch_ID` before pivoting counter names into columns, so each
+group would hold a single bucket and no row would carry the complete metric inputs.
 
 ### Co-active service composition
 
-Kernel dispatch tracing must yield one record per logical dispatch, independent of the pass count,
-so that Top Stats and `pmc_dispatch_info.csv` report the same dispatch count and duration they would
-without replay.
+Kernel dispatch tracing has to yield one record per logical dispatch regardless of pass count, so
+Top Stats and `pmc_dispatch_info.csv` report the same dispatch count and duration they would without
+replay.
 
-The native collector controls its own SDK contexts, so the duplicate records are suppressed at the
-source rather than removed afterwards: it traces pass 0 and locally stops the kernel-trace context
-for passes 1 through *N*−1. Pass 0 is chosen because it alone runs against pristine pre-snapshot
-state; every later pass executes immediately after a full restore of the tracked footprint, so its
-timing reflects replay overhead rather than the dispatch.
+Because the native collector owns its SDK contexts, the duplicate records are suppressed at the
+source instead of cleaned up afterwards: it traces pass 0 and locally stops the kernel-trace context
+for passes 1 through *N*−1. Pass 0 gets the honor because it is the only pass running against
+pristine pre-snapshot state. Every later pass starts immediately after a full restore of the tracked
+footprint, so its timing says more about replay overhead than about the dispatch.
 
-Suppressing at the source rather than collapsing records after the run is what makes this cheap and
-exact — there is no need to reconstruct which records belonged to the same logical dispatch, because
-the extra records are never emitted.
+Suppressing at the source is what makes this both cheap and exact. Nothing has to reconstruct which
+records belonged to the same logical dispatch, because the extra records never exist.
 
-Roofline uses the selected replay mode through the ordinary counter path and needs no special
-handling. Code-object tracing is load-time only and needs no replay treatment. Marker and ROCTx
-regions are emitted once on the host but span all passes; their duration semantics remain open.
+Roofline picks up the selected replay mode through the ordinary counter path and needs no special
+handling. Code-object tracing is load-time only, so replay does not touch it. Marker and ROCTx
+regions are emitted once on the host but span every pass, and their duration semantics are still
+open.
 
 ### Mode and option compatibility
 
-`--replay-mode` accepts `application` and `kernel`. Application replay remains the
-default, and CLI help identifies kernel replay as experimental. The selected mode is carried to the
-kernel-replay adapter; it does not change `--iteration-multiplexing` into a mode selector.
+`--replay-mode` accepts `application` and `kernel`. Application replay stays the default, and CLI
+help flags kernel replay as experimental. The selected mode is carried down to the kernel-replay
+adapter; it does not turn `--iteration-multiplexing` into a mode selector.
 
-Kernel mode requires the native collector, and the conditions that supply it do not all become
-knowable at the same moment. Rejection therefore happens in two places:
+Kernel mode needs the native collector, and the conditions that supply one do not all become
+knowable at the same moment. So rejection happens in two places:
 
-- **Flag conflict**, decidable from the arguments alone: selecting kernel replay while declining the
-  native collector. This is rejected immediately, before any discovery and before the workload
-  directory is created.
-- **Capability failure**, decidable only after discovery resolves the backend, the ROCm version, and
-  the native library: a `rocprofv3` backend, an unsupported ROCm version, or a library that cannot
-  be resolved. These are rejected later, but still before the workload runs.
+- **Flag conflict**, decidable from the arguments alone: kernel replay selected while the native
+  collector is declined. Rejected immediately, before any discovery and before the workload directory
+  is created.
+- **Capability failure**, decidable only once discovery has resolved the backend, the ROCm version,
+  and the native library: a `rocprofv3` backend, an unsupported ROCm version, or a library that
+  cannot be resolved. Rejected later, but still before the workload runs.
 
-Both are hard errors. The split is not incidental — a reader needs to know that a capability
-failure occurs after the workload directory exists, whereas a flag conflict leaves nothing behind.
+Both are hard errors. The split is not incidental — a reader needs to know that a capability failure
+leaves a workload directory behind, whereas a flag conflict leaves nothing.
 
-Kernel mode is likewise rejected before profiling when combined with iteration multiplexing, live
-attach, or PC sampling. Iteration multiplexing is rejected because both strategies claim the same
-per-dispatch passes, not because of any backend restriction — it requires the native collector too.
-PC sampling is agent-wide, does not consume the localized context override, and today runs in a
-separate counter-disabled invocation. There is therefore no supported replay pass into which it can
-be inserted.
+Kernel mode is likewise rejected before profiling when it is combined with iteration multiplexing,
+live attach, or PC sampling. Iteration multiplexing loses out because both strategies claim the same
+per-dispatch passes, not because of any backend restriction — it needs the native collector too. PC
+sampling is agent-wide, does not consume the localized context override, and today runs in a separate
+counter-disabled invocation, so there is no supported replay pass to insert it into.
 
-`--roof-only`, `--set`, and `--block` continue through ordinary counter selection.
-Multi-rank profiling remains available and retains its warning. Kernel replay additionally requires
-a supported SDK version and a homogeneous agent configuration. Whether collective-bearing
-dispatches require exclusion is an open question.
+`--roof-only`, `--set`, and `--block` continue through ordinary counter selection. Multi-rank
+profiling stays available and keeps its warning. On top of all that, kernel replay needs a supported
+SDK version and a homogeneous agent configuration. Whether collective-bearing dispatches have to be
+excluded is still an open question.
 
 ### Failure behavior
 
-All failures reject partial replay data. None falls back to application replay or silently changes a
-multi-bucket request into one pass.
+Every failure below rejects partial replay data. None of them falls back to application replay, and
+none quietly turns a multi-bucket request into a single pass.
 
 | Condition | Required behavior |
 | --- | --- |
 | Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
 | Native collector unavailable: `rocprofv3` backend, unsupported ROCm version, or unresolvable library | Hard error after discovery, naming which of the three conditions failed. |
-| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native collector needs; the diagnostic must say which one is unmet. The numeric floor remains pending upstream merge. |
+| SDK below the supported version floor | Hard error stating the required version. This is distinct from the ROCm version the native collector needs, so the diagnostic has to say which one is unmet. The numeric floor is pending upstream merge. |
 | Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
 | Upstream drain timeout or process abort | Abort the failed run without recovery. |
 
-A declined snapshot can currently leave a successful process status, so the required outcome cannot
-depend only on subprocess failure. Classifying an upstream warning string is the available but
-fragile signal; a structured detection mechanism remains an open question.
+One wrinkle: a declined snapshot can currently leave a successful process status behind, so the
+required outcome cannot lean on subprocess failure alone. Classifying an upstream warning string is
+the signal available today, and it is a fragile one. A structured detection mechanism remains an open
+question.
 
 ### Support boundaries and rationale
 
 Kernel replay inherits the upstream mechanism's support boundaries:
 
-- The host snapshot require memory atleast equal to the complete tracked device footprint.
+- The host snapshot requires at least as much memory as the complete tracked device footprint.
 - Equivalent-state guarantees cover tracked coarse-grained device VRAM and module-scope
-  `__device__` or `__constant__` state. Unified, managed, and `hipMallocAsync`
-  allocations are not restored.
+  `__device__` or `__constant__` state. Unified, managed, and `hipMallocAsync` allocations are not
+  restored.
 - HIP graph launches are unsupported.
-- Only single-packet, single-dispatch submissions are replayed; other submissions execute without
+- Only single-packet, single-dispatch submissions are replayed; anything else executes without
   replay.
 - Asynchronous SDMA or HSA copies are not fenced by the replay window.
-- Cache state is not restored, so cache-sensitive counter values may vary.
-- Bounded drain expiry aborts the process instead of returning a recoverable error.
-- Multi-rank dispatches that participate in collectives remain unsafe pending an exclusion policy.
+- Cache state is not restored, so cache-sensitive counter values may vary between passes.
+- Bounded drain expiry aborts the process rather than returning a recoverable error.
+- Multi-rank dispatches taking part in collectives remain unsafe until there is an exclusion policy.
 
 ## Implementation phases
 
-These are proposed vertical slices for future implementation work:
+Proposed vertical slices for the implementation work ahead:
 
-- **Mode selection and validation.** Add the experimental
-   `--replay-mode {application,kernel}` surface, carry the selected mode through the profiling
-   path, and implement both rejection layers with their hard-error diagnostics. Replay execution
-   remains disabled in this slice, so its observable behavior is mode selection and correct
-   rejection, without changing existing application-replay output.
-- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation,
-   implement `pass_count_cb` from the per-agent profile-vector size, apply the kernel and dispatch
-   filters at that same decision point, and diagnose a missing or empty vector instead of returning
-   one pass. Preserve application replay.
-- **Consolidated output and dispatch identity.** Produce one consolidated
-   `results_*.csv`, normalize cross-pass timestamps and identity so all passes of one logical
-   dispatch resolve to one `Dispatch_ID`, and expose the single pass-0 trace record.
+- **Mode selection and validation.** Add the experimental `--replay-mode {application,kernel}`
+   surface, carry the selected mode through the profiling path, and implement both rejection layers
+   with their hard-error diagnostics. Replay execution stays disabled in this slice, so the only
+   observable behavior is mode selection and correct rejection — existing application-replay output
+   does not change.
+- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation, implement
+   `pass_count_cb` from the per-agent profile-vector size, apply the kernel and dispatch filters at
+   that same decision point, and diagnose a missing or empty vector instead of returning one pass.
+   Application replay keeps working throughout.
+- **Consolidated output and dispatch identity.** Produce one consolidated `results_*.csv`, normalize
+   cross-pass timestamps and identity so every pass of a logical dispatch resolves to one
+   `Dispatch_ID`, and expose the single pass-0 trace record.
 
 ## Validation, security and debuggability
 
 ### Validation
 
 Validation spans the CLI, the kernel-replay adapter, replay-profile construction, output
-normalization, and the unchanged analysis boundary.
+normalization, and the analysis boundary that should not have moved.
 
-- **Counter accuracy.** For one logical dispatch and state covered by the equivalence guarantee, a
-  counter present in more than one bucket must have the same value in every pass. A mismatch is a
-  validation failure. Cache-sensitive counters must be evaluated separately as a documented
-  limitation.
-- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed
-  pass count must equal the application replay count, every bucket must appear
-  exactly once, and all pass rows must collapse to one complete `Dispatch_ID`. Incomplete results
-  must fail before analysis.
-- **Filtering.** Logical indices must advance once per dispatch, not once per pass. A
-  confirmed filter exclusion must take the ordinary no-snapshot path and must not be classified as
-  a missing-profile failure or an incomplete replay result.
-- **Application-replay comparison.** The same deterministic workload and counter request must be
-  profiled in both modes to compare bucket membership, counter completeness and final analysis results.
-  Existing application-replay must remain unchanged.
+- **Counter accuracy.** For one logical dispatch, and for state covered by the equivalence guarantee,
+  a counter present in more than one bucket must report the same value in every pass. A mismatch is a
+  validation failure. Cache-sensitive counters need separate evaluation as a documented limitation.
+- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed pass
+  count must equal the application replay count, every bucket must appear exactly once, and all pass
+  rows must collapse into one complete `Dispatch_ID`. Incomplete results have to fail before
+  analysis.
+- **Filtering.** Logical indices must advance once per dispatch, not once per pass. A confirmed
+  filter exclusion must take the ordinary no-snapshot path, and must not be misread as a
+  missing-profile failure or an incomplete replay result.
+- **Application-replay comparison.** Profile the same deterministic workload and counter request in
+  both modes, then compare bucket membership, counter completeness, and final analysis results.
+  Existing application replay must come out unchanged.
 - **Service composition.** Kernel replay must expose one pass-0 trace record and one non-multiplied
   logical duration per dispatch.
-- **Compatibility.** Accepted options and every rejected combination must be covered, including
-  iteration multiplexing, live attach, PC sampling, roofline selection, multi-rank warning,
-  and the default-off behavior.
-- **Configuration rejection.** Each unmet native-collector condition must be covered separately —
-  declined native collector, `rocprofv3` backend, unsupported ROCm version, unresolvable library —
-  and each must fail before profiling starts, with a diagnostic identifying that specific condition.
-- **Failure paths.** Coverage must include an unsupported SDK, a missing profile vector, a declined
-  snapshot, and an upstream abort. Each case must prove that no one-pass fallback occurs.
+- **Compatibility.** Cover the accepted options and every rejected combination: iteration
+  multiplexing, live attach, PC sampling, roofline selection, the multi-rank warning, and the
+  default-off behavior.
+- **Configuration rejection.** Cover each unmet native-collector condition on its own — declined
+  native collector, `rocprofv3` backend, unsupported ROCm version, unresolvable library. Each must
+  fail before profiling starts, with a diagnostic naming that specific condition.
+- **Failure paths.** Cover an unsupported SDK, a missing profile vector, a declined snapshot, and an
+  upstream abort. Each case has to prove no one-pass fallback happened.
 
 ### Security
 
-Kernel replay introduces no network interface or new privilege boundary. Its security-sensitive
-operation is the SDK-managed host snapshot of application device memory. The snapshot can contain
-application data and can consume host memory comparable to the tracked footprint. It remains inside
-the profiled process's trust boundary; `rocprof-compute` must not persist its contents in
-result artifacts or print them in diagnostics. Snapshot allocation and restore failures are
-availability failures and follow the same fail-closed rule as other incomplete replay conditions.
+Kernel replay adds no network interface and no new privilege boundary. Its one security-sensitive
+operation is the SDK-managed host snapshot of application device memory. That snapshot can hold
+application data and can consume host memory comparable to the tracked footprint. It stays inside the
+profiled process's trust boundary, and `rocprof-compute` must never persist its contents in result
+artifacts or print them in diagnostics. Snapshot allocation and restore failures are availability
+failures, and they follow the same fail-closed rule as every other incomplete replay condition.
 
 ### Debuggability
 
-Run diagnostics must identify the selected replay mode and backend, SDK capability, agent, and the
-mapping from every counter bucket to its replay pass. They must distinguish option
-conflicts, unavailable native collection, missing profiles, snapshot decline,
-and upstream abort, and state that partial results are unusable. A
-snapshot-decline diagnostic also recommends application replay.
+Run diagnostics have to identify the selected replay mode and backend, SDK capability, agent, and the
+mapping from every counter bucket to its replay pass. They also have to tell apart option conflicts,
+unavailable native collection, missing profiles, snapshot decline, and upstream abort — and say
+plainly that partial results are unusable. A snapshot-decline diagnostic additionally recommends
+application replay.
 
-A configuration diagnostic must name the specific unmet condition rather than reporting that the
-native collector is unavailable. A single message covering a `rocprofv3` backend, an unsupported
-ROCm version, and an unresolvable library leaves the user without an action, because the remedy
-differs in each case.
+A configuration diagnostic has to name the specific unmet condition instead of reporting that the
+native collector is unavailable. One message covering a `rocprofv3` backend, an unsupported ROCm
+version, and an unresolvable library leaves the user with no action to take, because the remedy is
+different in each case.
 
 ## Open questions
 
-- **Collective-bearing kernels.** Should dispatches participating in inter-process collectives be
+- **Collective-bearing kernels.** Should dispatches taking part in inter-process collectives be
    excluded from kernel replay?
-- **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
-   their durations include replay overhead and are not comparable with a non-replay run. Should the
-   combination be rejected or duration be corrected?
-- **Extending kernel replay beyond the native collector.** `rocprofv3` and `rocprofiler-sdk`
-   without the native collector run the SDK's own tool library, which `rocprof-compute` cannot
-   instrument. Neither the pass-0 trace stop nor the filter decision at `pass_count_cb` has an
-   equivalent there, and filter resolution happens inside that library. Whether support requires
-   upstream changes or post-run reconstruction is unresolved.
-- **Cache related counter value validity.** Can cache-related metrics be trusted
-   since the cache state is not restored between replay passes?
+- **Marker and ROCTx semantics.** Host regions are emitted once but span every replay pass, so their
+   durations include replay overhead and are not comparable with a non-replay run. Reject the
+   combination, or correct the duration?
+- **Extending kernel replay beyond the native collector.** `rocprofv3` and `rocprofiler-sdk` without
+   the native collector run the SDK's own tool library, which `rocprof-compute` cannot instrument.
+   Neither the pass-0 trace stop nor the filter decision at `pass_count_cb` has an equivalent there,
+   and filter resolution happens inside that library. Whether support would need upstream changes or
+   post-run reconstruction is unresolved.
+- **Cache-related counter validity.** Can cache-related metrics be trusted at all, given that cache
+   state is not restored between replay passes?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -478,10 +478,7 @@ snapshot-decline diagnostic also recommends application replay.
    excluded from kernel replay?
 - **Marker and ROCTx semantics.** Host regions are emitted once but span all replay passes, so
    their durations include replay overhead and are not comparable with a non-replay run. Should the
-   combination be corrected or rejected?
-- **Trace-deduplication equivalence.** How will native pass-0 context control and post-run
-   deduplication share one definition of a logical dispatch, and how will divergence between those
-   mechanisms be detected?
+   combination be rejected or duration be corrected?
 - **Filtering on non-native backends.** `rocprofv3` and `rocprofiler-sdk` without the
    native collector resolve filters inside the SDK tool library. Will `rocprofv3` support
    in future?

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -430,15 +430,14 @@ the signal available today. A structured detection mechanism remains an open que
 
 A diagnostic must name the specific unmet condition.
 
-| A diagnostic must identify |
-| --- | --- |
-| Selected replay mode and backend | 
-| Multi-rank detection under kernel replay |
-| SDK capability and agent | 
-| Counter-to-pass mapping |
-| Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort |
-| That partial results are unusable |
-| A recommendation of application replay, on snapshot decline |
+ A diagnostic must identify :
+- Selected replay mode and backend
+- Multi-rank detection under kernel replay
+- SDK capability and agent
+- Counter-to-pass mapping
+- Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort
+- That partial results are unusable
+- snapshot decline and recommend application replay
 
 ## Open questions
 

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -98,6 +98,20 @@ sequenceDiagram
 - **Restoration.** The snapshot is restored between passes, so every pass starts from identical
   device state.
 
+#### Replay coverage and limitations
+
+| State or feature | Replay guarantee |
+| --- | --- |
+| Allocated device memory (`hipMalloc`) | Snapshotted and restored between passes. |
+| Module-scope `__device__` / `__constant__` state | Discovered and captured by the SDK. |
+| Unified, managed, `hipMallocAsync` allocations | Not restored. No equivalence guarantee. |
+| Cache state | Not restored. Cache-sensitive counter values may vary between passes. |
+| HIP graph launches | Unsupported. |
+| Multi-packet or multi-dispatch submissions | Not replayed. Only single-packet, single-dispatch submissions are. |
+| Asynchronous SDMA or HSA copies | Not fenced by the replay window. |
+| Host memory | Required at least as much as the tracked device memory footprint. |
+| Multi-rank dispatches | Unsafe. |
+
 ## Problem statement
 
 When a counter request produces *N* buckets and *N* is greater than one:
@@ -171,7 +185,7 @@ flowchart TD
 | ID | Requirement |
 | --- | --- |
 | **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`. `--iteration-multiplexing` stay independent. |
-| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses the kernel-replay counter adapter and retains the existing non-counter path, including the PC-sampling-only path. |
+| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses kernel-replay and retains existing path. |
 | **FR-3** | Kernel replay requires the native tool. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native tool, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. |
 
 #### Passes and buckets
@@ -186,19 +200,18 @@ flowchart TD
 
 | ID | Requirement |
 | --- | --- |
-| **FR-7** | One kernel-replay invocation produces one consolidated counter result using the existing naming and discovery convention, which the workload join and analysis path consume with no analysis-side contract change. |
+| **FR-7** | One kernel-replay invocation produces one consolidated counter result using the existing naming and discovery convention, which analysis path consume with no analysis-side contract change. |
 | **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. |
 | **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. |
-| **FR-10** | Preserve two independent one-dispatch contracts: suppress kernel-dispatch tracing after pass 0 so exactly one trace record remains, and consolidate the normalized counter rows into one logical dispatch with its pass-0 duration before analysis. Top Stats and the dispatch information output consume the latter counter data, not the trace stream. |
 
 #### Composition and filtering
 
 | ID | Requirement |
 | --- | --- |
 | **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. |
-| **FR-12** | Kernel filtering composes. A dispatch whose kernel is excluded is not replayed and incurs no snapshot or restore. |
-| **FR-13** | Dispatch filtering composes. `--dispatch` retains its 1-based, per-kernel logical-occurrence semantics: indices count each kernel's logical dispatches, not replay passes or a global dispatch sequence. Replay-ineligible submissions still advance the existing per-kernel occurrence counter when the dispatch-counting service observes them, and an excluded dispatch is not replayed. |
-| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the unresolved risk that one rank may replay a collective-bearing dispatch while its peers do not. It does not reuse the application-replay warning about repeated workload launches or recommend iteration multiplexing. |
+| **FR-12** | A dispatch whose kernel is excluded is not replayed. |
+| **FR-13** | `--dispatch` retains its per-kernel dispatch filtering. Replay-ineligible kernel dispatch is not replayed. |
+| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the risk. |
 
 #### Failure
 
@@ -207,71 +220,71 @@ flowchart TD
 | **FR-15** | An SDK below the supported version floor is a hard error stating the required version. |
 | **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. |
 | **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. |
-| **FR-18** | If counters were requested but an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. A request that resolves to zero counter buckets bypasses the replay counter adapter under FR-2 and is not this failure. |
+| **FR-18** | If counters were requested but an agent has no usable counter profiles, do not silently degrade the dispatch to one pass. |
 
 ### Non-functional requirements
 
 | ID | Requirement |
 | --- | --- |
-| **NFR-1** | For deterministic workloads and state covered by the replay-equivalence guarantee, each kernel-replay bucket matches the corresponding application-replay bucket for the same logical dispatch. Cache-sensitive counters fall outside this invariant. |
-| **NFR-2** | Fail closed whenever a complete bucket set cannot be delivered. Never collect partial counter data silently. |
-| **NFR-3** | Guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. No guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state. May require host memory equal to the tracked device footprint. |
-| **NFR-4** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. |
-| **NFR-5** | Diagnostics identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. |
+| **NFR-1** | For deterministic workload and counters, each kernel-replay counter value matches the corresponding application-replay counter value for the same logical dispatch. |
+| **NFR-2** | Fail closed whenever a complete counter set cannot be delivered. Never collect partial counter data silently. |
+| **NFR-3** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. |
 
 ## Design
 
 ### Counter groups and the native-tool boundary
 
-- **The counter-grouping logic stays the single authority** on bucket membership and one-pass fit. Its
+- **The counter-grouping logic stays the same for both modes.**
   `_ACCUM` pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for
-  both modes, and the kernel-replay adapter hands those buckets to the native tool without
-  regrouping them.
-- **All *N* groups go to a single replay-enabled invocation.** The native tool derives the pass
-  count from the per-agent profiles it built from them, adding one when PC sampling is selected. The
-  existing multi-group admission check, which recognizes iteration multiplexing today, must also
-  admit kernel replay as a separate condition. Every other unsupported multi-group input keeps
-  hard-erroring, and kernel replay remains mutually exclusive with iteration multiplexing.
-- **Consolidated results keep the existing naming convention.** Deterministic bucket ordering keeps
-  the naming input stable, so existing result discovery needs no mode-specific branch.
-- **No separate pass-count option or environment value exists.** Deriving the count from the buckets
-  is what stops the two from drifting apart. A request with zero buckets bypasses this adapter and
-  follows the existing non-counter path.
+  both modes.
+- **All *N* groups go to a single tool invocation.** The native tool derives the pass
+  count from the per-agent counter profiles, adding one when PC sampling is selected.
+- **Consolidated results keep the existing naming convention.**
+- **Results have unified structure across modes.**
+- **No separate pass-count option or environment value.**
 
 ```mermaid
-graph LR
-    subgraph Compute["rocprof-compute"]
-        Buckets["N buckets"]
+flowchart TD
+    subgraph ComputeSetup["rocprof-compute · setup"]
+        direction TB
+        Buckets["N counter buckets"]
         Adapter["Kernel-replay adapter"]
-        Normalize["Cross-pass counter identity<br/>and timestamp normalization"]
-        Output["Consolidated PMC rows<br/>plus one logical trace record"]
-        Analysis["Existing join and analysis path"]
         Buckets --> Adapter
-        Normalize --> Output
-        Output --> Analysis
     end
 
-    subgraph Tools["Tool boundary"]
-        Native["Native tool<br/>per-agent profile vector"]
-        Reject["Diagnose and reject invalid profile<br/>never treat it as filter opt-out"]
+    subgraph NativeTool["Native tool"]
+        direction TB
+        Profiles["Per-agent profile vector<br/>and pass_count_cb"]
+        Collect["Select group i on pass i<br/>and collect counters"]
+        Write["Write per-pass PMC results"]
+        Reject["Reject invalid profile<br/>never treat as filter opt-out"]
+        Collect --> Write
     end
 
     subgraph SDK["rocprofiler-sdk"]
+        direction TB
         Replay["Kernel replay service<br/>N passes per logical dispatch"]
-        Counters["Dispatch counter collection<br/>group i on pass i"]
         Trace["Kernel dispatch tracing"]
-        Replay --> Counters
-        Replay --> Trace
     end
 
-    Adapter -- "ROCPROF_COUNTERS groups<br/>native replay setup" --> Native
+    subgraph ComputeResults["rocprof-compute · results"]
+        direction TB
+        Normalize["Normalize cross-pass identity<br/>and timestamps"]
+        Output["Consolidated PMC rows"]
+        Analysis["Existing join and analysis path"]
+        Normalize --> Output --> Analysis
+    end
 
-    Native -- "pass_count_cb<br/>admitted: profile-vector size<br/>filtered: one" --> Replay
-    Native -- "missing or unexpectedly empty vector<br/>when counters were requested" --> Reject
-
-    Native -. "locally stop trace context<br/>on passes 1 through N-1" .-> Trace
-    Counters -- "per-pass PMC rows" --> Normalize
-    Trace -- "independent pass-0 trace record" --> Output
+    Adapter -- "ROCPROF_COUNTERS groups<br/>and native replay setup" --> Profiles
+    Profiles -. "register pass_count_cb" .-> Replay
+    Replay -- "invoke pass_count_cb" --> Profiles
+    Profiles -- "admitted: vector size<br/>filtered: 1" --> Replay
+    Profiles -- "counter request with<br/>missing or empty vector" --> Reject
+    Replay -- "PASS enter / exit" --> Collect
+    Replay -- "replayed dispatches" --> Trace
+    Collect -. "stop tracing locally<br/>on passes 1 through N-1" .-> Trace
+    Write -- "per-pass PMC rows" --> Normalize
+    Trace --> TraceOutput["Independent pass-0<br/>trace record"]
 ```
 
 ### The pass-count decision
@@ -414,7 +427,7 @@ quietly turns a multi-bucket request into a single pass.
 | Condition | Required behavior | Covers |
 | --- | --- | --- |
 | Native tool declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. | FR-3 |
-| Native tool unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3, NFR-5 |
+| Native tool unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3 |
 | SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native tool needs, so the diagnostic must say which one is unmet. The numeric floor is pending upstream merge. | FR-15 |
 | Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. | FR-11 |
 | Missing or unexpectedly empty per-agent profile vector when counters were requested | Diagnose the agent/profile mismatch and reject the profile. Never return `1` as a fallback. A zero-bucket request bypasses the replay adapter before this point and is not this failure. | FR-18, NFR-2 |
@@ -425,23 +438,6 @@ One wrinkle: a declined snapshot can currently leave a successful process status
 required outcome cannot lean on subprocess failure alone. Classifying an upstream warning string is
 the signal available today, and it is a fragile one. A structured detection mechanism remains an
 open question.
-
-### Support boundaries and rationale
-
-Kernel replay inherits the upstream mechanism's support boundaries.
-
-| State or feature | Replay guarantee |
-| --- | --- |
-| Tracked coarse-grained device VRAM | Snapshotted and restored between passes. |
-| Module-scope `__device__` / `__constant__` state | Discovered and captured by the SDK. |
-| Unified, managed, `hipMallocAsync` allocations | Not restored. No equivalence guarantee. |
-| Cache state | Not restored. Cache-sensitive counter values may vary between passes. |
-| HIP graph launches | Unsupported. |
-| Multi-packet or multi-dispatch submissions | Not replayed. Only single-packet, single-dispatch submissions are; anything else executes without replay. |
-| Asynchronous SDMA or HSA copies | Not fenced by the replay window. |
-| Host memory | Requires at least as much as the complete tracked device footprint. |
-| Bounded drain expiry | Aborts the process rather than returning a recoverable error. |
-| Multi-rank dispatches in collectives | Unsafe until there is an exclusion policy. |
 
 ## Implementation phases
 
@@ -460,16 +456,16 @@ normalization, and the analysis boundary that should not have moved.
 
 | # | Check | Pass criterion | Covers |
 | --- | --- | --- | --- |
-| 1 | **Counter accuracy** | Use a deterministic request producing more than one bucket. For each logical dispatch and state covered by the equivalence guarantee, every kernel-replay bucket matches its corresponding application-replay bucket. A single-bucket run or a comparison with no corresponding application-replay values is not evidence for NFR-1. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, NFR-3 |
+| 1 | **Counter accuracy** | Use a deterministic request producing more than one bucket. For each logical dispatch and state covered by the equivalence guarantee, every kernel-replay bucket matches its corresponding application-replay bucket. A single-bucket run or a comparison with no corresponding application-replay values is not evidence for NFR-1. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, Replay coverage and limitations |
 | 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Multiple counter groups are admitted in kernel mode without iteration multiplexing, and the consolidated result uses and is discovered through the existing naming convention. Incomplete results fail before analysis; a zero-bucket request bypasses this check. | FR-2, FR-5, FR-7, FR-8 |
 | 3 | **Filtering** | The existing 1-based, per-kernel logical-occurrence index advances once for every observed dispatch of that kernel, including replay-ineligible submissions, and never once per replay pass. Kernel and dispatch exclusions take the ordinary no-snapshot path and are read as neither missing-profile failures nor incomplete replay results. The same `--dispatch` range selects the same per-kernel occurrences in both replay modes. | FR-12, FR-13 |
-| 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values subject to NFR-1, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-1, NFR-4 |
+| 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values subject to NFR-1, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-1, NFR-3 |
 | 5 | **Service composition** | Verify independently that tracing emits one pass-0 record per logical dispatch and that consolidated counter data feeds Top Stats and dispatch information one logical dispatch with one non-multiplied pass-0 duration. Trace suppression alone does not satisfy this check. | FR-8, FR-10 |
 | 6 | **PC sampling composition** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. | FR-6 |
 | 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective-desynchronization risk without describing repeated workload launches or recommending iteration multiplexing, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
 | 8 | **Configuration rejection** | Each unmet native-tool condition on its own — declined native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |
 | 9 | **Failure paths** | An unsupported SDK, a missing or unexpectedly empty profile vector when counters were requested, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. A zero-bucket request follows the existing bypass and is not misclassified as a missing-profile failure. | FR-2, FR-15, FR-16, FR-17, FR-18, NFR-2 |
-| 10 | **Diagnostics** | Every run identifies the replay mode and the bucket-to-pass mapping; every failure names its specific condition. | NFR-5 |
+| 10 | **Diagnostics** | Every run identifies the replay mode and the bucket-to-pass mapping; every failure names its specific condition. | — |
 
 ### Security
 

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -2,65 +2,63 @@
 
 ## System Context
 
+### Terms
+
+| Term | Meaning |
+| --- | --- |
+| **Bucket** | A group of hardware counters small enough to fit one hardware pass. `rocprof-compute` turns the metrics an analysis asks for into counters, then packs them into buckets. The bucket count is the pass count. |
+| **Logical dispatch** | One kernel launch as the application issued it, however many times a replay strategy executes it. |
+| **Native collector** | A `rocprof-compute` library it can preload to take over counter collection, while tracing runs in a separate context. Unavailable when the user declines it, or when the installed ROCm predates support for it. |
+
 ### Counter collection today
 
-`rocprof-compute` turns the metrics an analysis asks for into hardware counters, then packs those
-counters into buckets — groups small enough to fit a single hardware pass. However many buckets fall
-out of that packing is how many counter-collection passes the run needs.
-
-`rocprof-compute` can preload its own **native collector**, which takes over counter collection
-while tracing runs in a separate context. The native collector is unavailable in two cases: the
-user declined it, or the installed ROCm predates the version that supports it.
-
-Every configuration consumes the same buckets. Application replay works across all of them.
-Iteration multiplexing already depends on the native collector and hard-errors without it. A
-**logical dispatch** is one kernel launch as the application issued it, however many times a replay
-strategy executes it.
-
-
-| Strategy | Execution model | What it covers | What it does not cover |
+| Strategy | Execution model | Covers | Does not cover |
 | --- | --- | --- | --- |
-| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences, without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. `rocprof-compute` rejects multi-bucket live attach, and communicating multi-rank workloads currently trigger a warning. |
-| **Iteration multiplexing** | Launch the workload once for counter collection and let the native collector rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set, and iteration multiplexing needs the native collector. |
+| **Application replay** | Launch and run the complete workload once per bucket, then combine the counters. | Every bucket, across corresponding replayed dispatch occurrences — nothing is estimated from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected; communicating multi-rank workloads warn. |
+| **Iteration multiplexing** | Launch once and let the native collector rotate buckets across comparable dispatch occurrences. Analysis imputes each occurrence's missing counters. | Avoids repeated launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. Requires the native collector. |
 
-That leaves application replay as the only strategy today that can satisfy a multi-bucket request
-without borrowing counters from neighbouring dispatches.
+- Every configuration consumes the same buckets. Application replay works across all of them;
+  iteration multiplexing hard-errors without the native collector.
+- Application replay is therefore the only strategy today that satisfies a multi-bucket request
+  without borrowing counters from neighbouring dispatches.
 
 ### Co-active profiling services
 
-Counter collection never runs on its own. Every counter invocation has to produce kernel-dispatch
-records, because those records carry the kernel counts and durations. Native collection splits the
-work. The native collector owns counters; kernel dispatch tracing and marker or ROCTx tracing for a
-framework-selected run happen in a separate tracing context. That split matters here — the trace
-records come from a context the native collector can control but does not itself emit.
+Counter collection never runs alone. Every counter invocation must produce kernel-dispatch records,
+because those records carry the kernel counts and durations.
 
-The native collector also subscribes to code-object tracing, but those events describe load-time
-objects rather than individual dispatches, so kernel replay does not multiply them. PC sampling runs
-in its own invocation today; under kernel replay it occupies its own replay pass instead.
+| Service | Context owner | Per dispatch? | Consequence under replay |
+| --- | --- | --- | --- |
+| Kernel dispatch tracing | Separate tracing context | Yes | *N* records for one logical dispatch. Inflates Top Stats and `pmc_dispatch_info.csv`. |
+| Marker / ROCTx tracing | Separate tracing context, framework runs only | Host-side, spans all passes | Region duration absorbs replay overhead. |
+| Code-object tracing | Native collector | No — load time | Unaffected. Replay does not multiply load-time events. |
+| PC sampling | Own invocation today | Agent-wide | Becomes its own replay pass. |
+| Counter collection | Native collector | Yes | The point of the feature: one bucket per pass. |
+
+The split matters: the trace records come from a context the native collector can control but does
+not itself emit.
 
 ### Proposed SDK replay mechanism
 
-[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism this
-design has to consume. Treat it as a surrounding component and an external constraint: nothing here
-proposes changes to its replay algorithm.
+[ROCm PR 8622](https://github.com/ROCm/rocm-systems/pull/8622) proposes the SDK mechanism this design
+must consume. Treat it as a surrounding component and an external constraint — nothing here proposes
+changes to its replay algorithm.
 
-The PR adds a `KERNEL_REPLAY` callback domain with `CONFIG` and `PASS` operations. On the
-fixed-pass path, a profiling tool supplies `pass_count_cb` during `CONFIG`. The SDK evaluates that
-callback for each dispatch reaching the replay gate, and the callback can consult the dispatch's
-agent information. Return `1` to opt out, and the SDK takes its ordinary single-execution path with
-no snapshot and no `PASS` callbacks. Return anything greater than one and the SDK opens a replay
-window, with `PASS` enter and exit callbacks delimiting each execution inside it.
+| Domain / operation | Fires | The tool's part |
+| --- | --- | --- |
+| `KERNEL_REPLAY` `CONFIG` enter | Once per dispatch reaching the replay gate | Supply `pass_count_cb` (fixed-pass path). |
+| `pass_count_cb` | Once per dispatch, before any pass | Return the pass count. May consult the dispatch's agent information. |
+| `KERNEL_REPLAY` `PASS` enter / exit | Delimits each execution inside a replay window | Select the counter profile for this pass. |
+| `KERNEL_REPLAY` `CONFIG` exit | After the last pass | — |
+
+| `pass_count_cb` returns | SDK behavior |
+| --- | --- |
+| `1` | Ordinary single-execution path. No replay window, no snapshot, no `PASS` callbacks. |
+| Greater than `1` | Opens a replay window with that many passes. |
 
 The same upstream mechanism lets a tool locally stop a context for selected replay passes. Kernel
 dispatch tracing honors that local stop and omits the disabled context's dispatch record — an
 external capability the service-composition design below leans on.
-
-A replay window isolates one GPU agent. The SDK takes a host-side writer lock keyed by that agent,
-holds the application's completion signal, drains prior work on the submitting and sibling queues,
-and copies the supported device state into a host snapshot. It then runs the dispatch once per
-pass, restoring the snapshot between passes so every pass starts from identical device state.
-Finally it exits `CONFIG`, signals a single application-visible completion, and releases the writer
-lock.
 
 ```mermaid
 sequenceDiagram
@@ -99,48 +97,54 @@ sequenceDiagram
     end
 ```
 
-The snapshot covers tracked, agent-owned, coarse-grained device allocations that are neither kernarg
-nor executable memory. The SDK separately discovers and captures module-scope `__device__` and
-`__constant__` storage visible to the agent. While a replay is active, ordinary dispatches take the reader
-side of the same per-agent lock; replay windows on different agents still run concurrently.
+- **Snapshot coverage.** Tracked, agent-owned, coarse-grained device allocations that are neither
+  kernarg nor executable memory. The SDK separately discovers and captures module-scope `__device__`
+  and `__constant__` storage visible to the agent.
+- **Isolation.** A replay window isolates one GPU agent. Ordinary dispatches take the reader side of
+  the same per-agent lock; replay windows on different agents still run concurrently.
+- **Restoration.** The snapshot is restored between passes, so every pass starts from identical
+  device state.
 
 ## Problem statement
 
-When a counter request produces *N* hardware-pass buckets and *N* is greater than one, application
-replay launches and runs the complete workload once per bucket. Process startup, runtime
-initialization, host-side work, and the kernel run all repeat *N* times, even though only the kernel
-actually needs profiling *N* times. For workloads with a large startup cost, that is a lot of wasted
-wall-clock.
+When a counter request produces *N* buckets and *N* is greater than one:
 
-Iteration multiplexing avoids the repeated launches, but it pulls counters from different dispatches
-and fills in each dispatch's gaps during analysis. It does not answer the need to collect every
-counter from repeated executions of one logical dispatch inside a single workload run.
+| Per counter-collection run | Application replay | Kernel replay |
+| --- | --- | --- |
+| Workload launches | *N* | 1 |
+| Process startup, runtime initialization | *N*× | 1× |
+| Host-side work | *N*× | 1× |
+| Executions of a replay-eligible dispatch | *N* (one per launch) | *N* (one per pass) |
+| Executions of every other dispatch | *N* | 1 |
+| Added cost | — | Snapshot, restore, queue drain, agent isolation |
 
-Kernel replay is meant to close that gap. It keeps the same *N* buckets, runs the workload once, and
-executes each replay-eligible dispatch *N* times, collecting one bucket per pass.
+Only the kernel actually needs profiling *N* times. For workloads with a large startup cost,
+application replay wastes a lot of wall-clock repeating everything else.
 
-Replay also multiplies the co-active per-dispatch services. Left alone, kernel dispatch tracing would
-emit *N* records for one logical dispatch, and Top Stats would report an inflated dispatch count and
-aggregate GPU duration.
-
-None of this is free. Kernel replay drops the repeated full-workload launches but adds snapshot,
-restoration, dispatch replay, and isolation costs, so it will not be faster for every workload.
+- **Iteration multiplexing does not close this gap.** It avoids the repeated launches, but pulls
+  counters from different dispatches and fills each dispatch's gaps during analysis. It cannot
+  collect every counter from repeated executions of *one* logical dispatch in a single workload run.
+- **Replay multiplies the co-active services.** Left alone, kernel dispatch tracing emits *N* records
+  for one logical dispatch, and Top Stats reports an inflated dispatch count and aggregate GPU
+  duration.
+- **This is not free.** Kernel replay drops the repeated full-workload launches but adds snapshot,
+  restoration, dispatch replay, and isolation costs. It will not be faster for every workload.
 
 The flow below compares counter collection when *N* is greater than one. It leaves out profiler
 invocations outside counter collection.
 
 ```mermaid
 flowchart LR
-    Buckets["N hardware-counter buckets<br/>N greater than 1"]
+    Buckets["N buckets<br/>N greater than 1"]
 
     subgraph Application["Application replay"]
         direction TB
         AppSelect["Choose bucket i"]
-        AppLaunch["Launch profiling and the full workload"]
-        AppRun["Run process startup, runtime initialization,<br/>host work, and kernel execution"]
+        AppLaunch["Launch profiling and full workload"]
+        AppRun["Startup, runtime init,<br/>host work, kernel execution"]
         AppCollect["Collect bucket i"]
-        AppDone{"All N buckets collected?"}
-        AppResult["Counter collection complete<br/>N full workload launches"]
+        AppDone{"All N buckets?"}
+        AppResult["Complete<br/>N full workload launches"]
 
         AppSelect --> AppLaunch --> AppRun --> AppCollect --> AppDone
         AppDone -- next bucket --> AppSelect
@@ -149,13 +153,13 @@ flowchart LR
 
     subgraph Kernel["Kernel replay"]
         direction TB
-        KernelLaunch["Launch profiling and the full workload once"]
-        KernelSetup["Run process startup and runtime initialization once"]
-        KernelDispatch{"Next kernel dispatch?"}
+        KernelLaunch["Launch profiling and full workload once"]
+        KernelSetup["Startup and runtime init once"]
+        KernelDispatch{"Next dispatch?"}
         KernelOrdinary["Execute unselected dispatch once"]
-        KernelReplay["Execute selected dispatch in N passes<br/>one counter bucket per pass"]
-        KernelContinue["Continue host-side workload execution"]
-        KernelResult["Counter collection complete<br/>one full workload launch"]
+        KernelReplay["Execute selected dispatch N times<br/>one bucket per pass"]
+        KernelContinue["Continue host-side execution"]
+        KernelResult["Complete<br/>one full workload launch"]
 
         KernelLaunch --> KernelSetup --> KernelDispatch
         KernelDispatch -- not selected --> KernelOrdinary --> KernelContinue
@@ -172,99 +176,71 @@ flowchart LR
 
 ### Functional requirements
 
-- `rocprof-compute profile` shall expose `--replay-mode {application,kernel}`, default to
-  `application`, and require explicit selection of kernel replay. `--iteration-multiplexing` and its
-  policy argument shall remain independent.
-- For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
-  collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. Kernel
-  replay shall not require a user-supplied pass count.
-- Kernel replay shall require the native collector. The `rocprofv3` backend and `--no-native-tool`
-  are unsupported configurations. The user may decline the native collector, or the installed ROCm
-  may not support it. In either case, kernel replay shall produce a hard error naming the unmet
-  condition before any workload runs.
-- Kernel replay shall preserve the counter bucket membership used by application replay. The pass
-  count shall equal the bucket count, or the bucket count plus one when `--pc-sampling` is selected.
-  Every bucket shall fit one hardware pass, and `_ACCUM` pairing, TCC grouping, and same-bucket
-  priority shall remain unchanged.
-- One kernel-replay invocation shall produce a consolidated `results_*.csv` artifact that the
-  existing workload join and analysis path can consume without an analysis-side contract change.
-- All passes of one logical dispatch shall resolve to one `Dispatch_ID` group holding the complete
-  counter set. Start and end timestamps shall follow the same cross-pass normalization semantics used
-  for application-replay results.
-- Kernel replay combined with `--iteration-multiplexing` or `--attach-pid` shall produce a hard
-  error. `--roof-only`, `--set`, and `--block` shall continue to interoperate unchanged.
-- Kernel replay shall compose with `--pc-sampling` by adding one replay pass to every admitted
-  dispatch. That pass shall run with counter collection disabled, and shall not alter the bucket
-  membership or the ordering of the counter passes that precede it.
-- Kernel replay shall produce a hard error when the installed SDK predates the supported version
-  floor, and shall state the required version.
-- Kernel replay shall remain available for multi-rank workloads.
-- If the SDK declines a device-memory snapshot, `rocprof-compute` shall abandon the profile without
-  retry and recommend application replay in the diagnostic.
-- If the upstream replay mechanism aborts, `rocprof-compute` shall report the failed run without
-  attempting recovery.
-- If an agent has no usable counter profiles, `rocprof-compute` shall diagnose the condition rather
-  than silently degrading that dispatch to one pass.
-- Kernel replay shall expose one kernel-dispatch trace record per logical dispatch, so Top Stats and
-  `pmc_dispatch_info.csv` keep their non-replay semantics: one dispatch and its pass-0 logical
-  duration, not replay-multiplied values.
-- Kernel filtering shall compose with kernel replay. A dispatch whose kernel is excluded shall not be
-  replayed and shall incur no snapshot or restore.
-- Dispatch filtering shall compose with kernel replay. `--dispatch` indices shall count logical
-  dispatches, not replay passes, so an index selects the same work whether or not kernel replay is
-  selected. An excluded dispatch shall not be replayed.
+#### Mode selection
+
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`, and requires explicit selection of kernel replay. `--iteration-multiplexing` and its policy argument stay independent. | Kernel replay carries support boundaries application replay does not. Opt-in, not inferred. |
+| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. | Removing the repeated launches is the whole point. A user-set pass count could disagree with the bucket count. |
+| **FR-3** | Kernel replay requires the native collector. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native collector, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. | Only the native collector owns the SDK contexts replay needs. Failing late wastes a workload run. |
+
+#### Passes and buckets
+
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **FR-4** | Bucket membership matches application replay. `_ACCUM` pairing, TCC grouping, and same-bucket priority are unchanged, and every bucket still fits one hardware pass. | Kernel replay changes the shape of the invocation, not how counters partition. Divergence would make the two modes incomparable. |
+| **FR-5** | Pass count equals the bucket count, or the bucket count plus one when `--pc-sampling` is selected. | Derived, never configured, so the two cannot drift apart. |
+| **FR-6** | The PC sampling pass runs with counter collection disabled, and alters neither bucket membership nor the ordering of the counter passes preceding it. | PC sampling is agent-wide and must not perturb counter results. |
+
+#### Output and identity
+
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **FR-7** | One kernel-replay invocation produces one consolidated `results_*.csv` that the existing workload join and analysis path consumes with no analysis-side contract change. | Analysis should not need to know which replay mode produced its input. |
+| **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. | Analysis groups on `Dispatch_ID` before pivoting counters into columns. Per-pass IDs would leave every group holding one bucket. |
+| **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. | Same reason as FR-8, and it keeps durations comparable between modes. |
+| **FR-10** | Exactly one kernel-dispatch trace record per logical dispatch, so Top Stats and `pmc_dispatch_info.csv` keep non-replay semantics: one dispatch and its pass-0 logical duration, not replay-multiplied values. | Top Stats is the first table users read. *N*× dispatch counts and GPU time would be wrong there. |
+
+#### Composition and filtering
+
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. | Both replay strategies claim the same per-dispatch passes. The rest only select counters. |
+| **FR-12** | Kernel filtering composes. A dispatch whose kernel is excluded is not replayed and incurs no snapshot or restore. | A filtered dispatch paying full replay cost, only to have its counters discarded, is pure waste. |
+| **FR-13** | Dispatch filtering composes. `--dispatch` indices count logical dispatches, not replay passes, so an index selects the same work in either mode. An excluded dispatch is not replayed. | Otherwise `--dispatch 3` with 4 buckets selects the third *pass of the first* dispatch, labelled as the one the user asked for. |
+| **FR-14** | Kernel replay stays available for multi-rank workloads. | Multi-rank workloads are exactly the ones with expensive startup. |
+
+#### Failure
+
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. | Distinct from the ROCm version the native collector needs. The user must know which one is unmet. |
+| **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. | Without a snapshot there is no equivalent state, so no pass after the first is trustworthy. Application replay is the working alternative. |
+| **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. | Upstream drain expiry aborts the process; there is no recoverable error to catch. |
+| **FR-18** | If an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. | A single-pass "success" would present one bucket as a complete metric set. |
 
 ### Non-functional requirements
 
-- For state covered by the replay-equivalence guarantee, a counter present in more than one bucket
-  shall have the same value across passes of the same dispatch. Cache-sensitive counters fall outside
-  this invariant, because cache state is not restored.
-- Kernel replay shall fail closed whenever it cannot deliver a complete bucket set. Kernel replay
-  shall not collect partial counter data silently.
-- Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and
-  module-scope device or constant state. It shall make no equivalence guarantee for unified, managed,
-  or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced
-  asynchronous SDMA copies, or cache state. It may also require host memory equal to the tracked
-  device footprint.
-- Workflows that do not select kernel replay shall keep their current collection behavior, and
-  kernel-replay output shall preserve the existing analysis input contract.
-- Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific
-  failure condition.
+| ID | Requirement | Why |
+| --- | --- | --- |
+| **NFR-1** | For state covered by the replay-equivalence guarantee, a counter present in more than one bucket has the same value across passes of the same dispatch. Cache-sensitive counters fall outside this invariant. | This is the correctness claim kernel replay rests on. Cache state is not restored, so it is excluded explicitly. |
+| **NFR-2** | Fail closed whenever a complete bucket set cannot be delivered. Never collect partial counter data silently. | Partial counters produce plausible-looking but wrong metrics. |
+| **NFR-3** | Guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. No guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state. May require host memory equal to the tracked device footprint. | Inherited from the upstream mechanism. Overstating coverage would mislead users into trusting unsupported cases. |
+| **NFR-4** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. | The feature is experimental. It must not regress the default path. |
+| **NFR-5** | Diagnostics identify the selected replay mode, the bucket-to-pass mapping, and the specific failure condition. | Every failure here is fatal, so the message is the user's only route to a remedy. |
 
 ## Design
 
 ### Counter groups and the collector boundary
 
-Kernel replay changes the shape of the invocation, not how counters are partitioned.
-`perfmon_coalesce` stays the single authority on bucket membership and one-pass fit. Its `_ACCUM`
-pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for both
-application and kernel replay, and the kernel-replay adapter hands those buckets to the native
-collector without regrouping them.
-
-All *N* counter groups go to a single replay-enabled invocation, and the native collector derives the
-pass count from the per-agent profiles it built from them, adding one pass when PC sampling is
-selected. There is no separate pass-count option or environment value. The pass count is always
-derived from the buckets rather than configured alongside them, so the two cannot drift apart.
-
-### Pass-count ownership and profile validity
-
-Counter-group parsing creates one profile-vector entry per group, per agent. For an admitted
-dispatch, `pass_count_cb` returns the size of the vector belonging to that dispatch's agent, and
-replay pass *i* selects entry *i* from the same vector.
-
-When PC sampling is selected, `pass_count_cb` returns that size plus one. Passes 0 through *N*−1
-still map one-to-one onto the profile vector; pass *N* selects no counter profile and runs with
-counter collection disabled. This changes only the count the callback returns — the rule below,
-that a return of one means "do not replay," is unaffected, so a filtered dispatch opts out of the
-PC sampling pass along with the counter passes.
-
-A return value of one carries a specific meaning: "do not replay." It is not a safe fallback when an
-agent lookup fails or its vector turns out to be empty. Using it that way would execute the dispatch
-once, collect a single bucket, and present incomplete data as a success. On a missing or empty
-vector, the collector has to diagnose the agent/profile mismatch and fail the whole profile instead.
-
-The component diagram shows both counter and kernel-trace data, and where each one crosses the
-collector boundary.
+- **`perfmon_coalesce` stays the single authority** on bucket membership and one-pass fit. Its
+  `_ACCUM` pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for
+  both modes, and the kernel-replay adapter hands those buckets to the native collector without
+  regrouping them.
+- **All *N* groups go to a single replay-enabled invocation.** The native collector derives the pass
+  count from the per-agent profiles it built from them, adding one when PC sampling is selected.
+- **No separate pass-count option or environment value exists.** Deriving the count from the buckets
+  is what stops the two from drifting apart.
 
 ```mermaid
 graph LR
@@ -302,149 +278,158 @@ graph LR
     Trace -- "pass-0 record only" --> Output
 ```
 
-### Filtering at the pass-count decision
+### The pass-count decision
 
-`pass_count_cb` doubles as the filter decision point, because it runs exactly once per logical
-dispatch and before any replay pass. Before picking a count, the collector confirms the dispatch's
-agent has a non-empty profile vector. It then assigns the dispatch's per-kernel logical index, once
-and only here. Next it evaluates two filters: the kernel-ID target set built during code-object
-loading, and the requested dispatch range. It returns the profile-vector size only if both filters
-admit the dispatch. A confirmed filter miss returns one, deliberately choosing the SDK's ordinary path with no
-snapshot and no restore. A missing or empty profile vector stays a fatal profile error and must never
-borrow that return value.
+Counter-group parsing creates one profile-vector entry per group, per agent. `pass_count_cb` is the
+single decision point for both the pass count and the filters, because it runs exactly once per
+logical dispatch and before any replay pass.
 
-The per-pass counter-dispatch callback reads the assigned logical index rather than incrementing it.
-A non-replay run has one pass per dispatch, so moving the increment keeps existing indices intact
-while stopping replay passes from consuming extra ones. Completeness checks apply only to admitted
-dispatches: a dispatch excluded on purpose produces no counter set, and that is not an incomplete
-replay result.
+```mermaid
+flowchart TD
+    Start["Dispatch reaches the replay gate<br/>pass_count_cb runs once"]
+    Vector{"Agent has a non-empty<br/>profile vector?"}
+    Fatal["Fatal: agent/profile mismatch<br/>reject the whole profile"]
+    Index["Assign the logical dispatch index<br/>once, here only"]
+    Kernel{"Kernel admitted by<br/>the kernel filter?"}
+    Range{"Index admitted by<br/>the dispatch range?"}
+    One["Return 1<br/>ordinary path, no snapshot, no restore"]
+    PC{"PC sampling selected?"}
+    N["Return N<br/>one counter bucket per pass"]
+    NPlus["Return N+1<br/>N counter passes, then one<br/>counter-disabled PC sampling pass"]
+
+    Start --> Vector
+    Vector -- no --> Fatal
+    Vector -- yes --> Index --> Kernel
+    Kernel -- no --> One
+    Kernel -- yes --> Range
+    Range -- no --> One
+    Range -- yes --> PC
+    PC -- no --> N
+    PC -- yes --> NPlus
+```
+
+| Returns | When | What the passes select |
+| --- | --- | --- |
+| `1` | A confirmed filter miss — the kernel or the dispatch index is excluded. | Nothing. The SDK takes its ordinary path, deliberately paying no snapshot or restore. |
+| *N* | Admitted, no PC sampling. *N* is the size of the profile vector for this dispatch's agent. | Pass *i* selects entry *i* of that vector. |
+| *N*+1 | Admitted, PC sampling selected. | Passes 0 through *N*−1 map one-to-one onto the vector. Pass *N* selects no counter profile and runs counter-disabled. |
+| *(fatal)* | The agent is missing, or its profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
+
+Two consequences worth stating plainly:
+
+- **`1` means "do not replay". It is never a fallback.** Returning it on a missing or empty vector
+  would execute the dispatch once, collect a single bucket, and present incomplete data as a success.
+- **The logical index is assigned here, not incremented per pass.** The per-pass counter-dispatch
+  callback reads it. A non-replay run has one pass per dispatch, so moving the increment leaves
+  existing indices intact while stopping replay passes from consuming extra ones.
+
+Completeness checks apply only to admitted dispatches. A dispatch excluded on purpose produces no
+counter set, and that is not an incomplete replay result.
 
 ### Output and dispatch identity
 
-One kernel-replay counter invocation produces one consolidated `results_*.csv` artifact.
+One kernel-replay counter invocation produces one consolidated `results_*.csv`. Before it is
+written, every pass row for a logical dispatch must collapse to one identity.
 
-Before that artifact is written, every pass row for a logical dispatch has to receive one
-`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity may survive transiently for
-normalization and diagnostics, but it does not need to reach `pmc_perf.csv`.
-Non-replay identity behavior is untouched.
+| Step | What happens | If skipped |
+| --- | --- | --- |
+| 1. Correlate | Group the pass rows by replay-stable logical-dispatch identity. | Nothing ties the passes of one dispatch together. |
+| 2. Normalize timestamps | Give the group one canonical start/end pair. | The timestamp-bearing identity key hands every pass its own `Dispatch_ID`. |
+| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs. |
 
-Application replay lines up corresponding dispatches because each workload invocation restarts
-positional ID assignment from scratch, even though the timestamps differ between runs — it never
-literally rewrites timestamps. Kernel replay needs the same alignment, but inside a single
-invocation: correlate the pass rows using replay-stable logical-dispatch identity first, then
-normalize their timestamp pair before the existing identity and pivot contracts see them.
-
-Skip that step and the current timestamp-bearing identity key hands every pass its own
-`Dispatch_ID`. Analysis groups on `Dispatch_ID` before pivoting counter names into columns, so each
-group would hold a single bucket and no row would carry the complete metric inputs.
+- Pass identity may survive transiently for normalization and diagnostics; it does not need to reach
+  `pmc_perf.csv`. Non-replay identity behavior is untouched.
+- Application replay achieves the same alignment differently: each workload invocation restarts
+  positional ID assignment from scratch, even though timestamps differ between runs. It never
+  literally rewrites timestamps. Kernel replay needs that alignment *inside* a single invocation.
 
 ### Co-active service composition
 
-Kernel dispatch tracing has to yield one record per logical dispatch regardless of pass count, so
-Top Stats and `pmc_dispatch_info.csv` report the same dispatch count and duration they would without
-replay.
+| Service | Under kernel replay | Mechanism |
+| --- | --- | --- |
+| Kernel dispatch tracing | One record per logical dispatch, from pass 0 | The native collector owns the context, so it locally stops kernel tracing for passes 1 through *N*−1. |
+| Code-object tracing | Unchanged | Load-time only. Replay never multiplies it. |
+| Marker / ROCTx | Emitted once, spans all passes | Duration semantics are an open question. |
+| PC sampling | One extra pass, appended after the counter passes | Runs counter-disabled. |
+| Roofline | Unchanged | Picks up the selected mode through the ordinary counter path. |
 
-Because the native collector owns its SDK contexts, it can suppress the duplicate records at the
-source instead of cleaning them up afterwards. It traces pass 0 and locally stops the kernel-trace
-context for passes 1 through *N*−1. The collector picks pass 0 because it is the only pass running
-against pristine pre-snapshot state. Every later pass starts immediately after a full restore of the tracked
-footprint, so its timing says more about replay overhead than about the dispatch.
-
-Suppressing at the source is what makes this both cheap and exact. Nothing has to reconstruct which
-records belonged to the same logical dispatch, because the extra records never exist.
-
-Roofline picks up the selected replay mode through the ordinary counter path and needs no special
-handling. Code-object tracing is load-time only, so replay does not touch it. Marker and ROCTx
-regions are emitted once on the host but span every pass, and their duration semantics are still
-open.
+- **Why pass 0.** It is the only pass running against pristine pre-snapshot state. Every later pass
+  starts immediately after a full restore of the tracked footprint, so its timing says more about
+  replay overhead than about the dispatch.
+- **Why suppress at the source.** Nothing has to reconstruct which records belonged to the same
+  logical dispatch, because the extra records never exist. That makes it both cheap and exact.
 
 ### Mode and option compatibility
 
-`--replay-mode` accepts `application` and `kernel`. Application replay stays the default, and CLI
-help flags kernel replay as experimental. `rocprof-compute` carries the selected mode down to the
-kernel-replay adapter. This does not turn `--iteration-multiplexing` into a mode selector.
+`--replay-mode` accepts `application` and `kernel`. Application replay stays the default, CLI help
+flags kernel replay as experimental, and the selected mode travels down to the kernel-replay adapter.
+This does not turn `--iteration-multiplexing` into a mode selector.
 
-Kernel mode needs the native collector, and the conditions that supply one do not all become
-knowable at the same moment. So rejection happens in two places:
+| Option or condition | With kernel replay | Reason |
+| --- | --- | --- |
+| `--iteration-multiplexing` | Rejected | Both strategies claim the same per-dispatch passes. Not a backend restriction — iteration multiplexing needs the native collector too. |
+| `--attach-pid` | Rejected | Live attach cannot open a replay window over an already-running process. |
+| `--no-native-tool`, `rocprofv3` backend | Rejected | Kernel replay needs the SDK contexts only the native collector owns. |
+| `--pc-sampling` | Accepted, *N*+1 passes | Agent-wide, and it does not consume the localized context override. It takes a counter-disabled pass of its own. |
+| `--roof-only`, `--set`, `--block` | Accepted, unchanged | Ordinary counter selection. |
+| Multi-rank | Accepted, keeps its warning | See the open question on collective-bearing dispatches. |
+| Heterogeneous agents | Rejected | Kernel replay needs a homogeneous agent configuration. |
 
-- **Flag conflict**, decidable from the arguments alone: kernel replay selected while the native
-  collector is declined. `rocprof-compute` rejects this immediately, before any discovery and before
-  it creates the workload directory.
-- **Capability failure**, decidable only once discovery has resolved the ROCm version and the
-  native library: an unsupported ROCm version, or a library that cannot be resolved.
-  `rocprof-compute` rejects this later, but still before the workload runs.
+Kernel mode needs the native collector, but the conditions that supply one do not all become
+knowable at the same moment, so rejection happens in two layers:
 
-Both are hard errors. The split matters: a capability failure leaves a workload directory behind,
-whereas a flag conflict leaves nothing.
+| Layer | Decidable from | Rejected when | Workload directory left behind? |
+| --- | --- | --- | --- |
+| **Flag conflict** | The arguments alone | Kernel replay selected while the native collector is declined | No — rejected before discovery and before the directory is created |
+| **Capability failure** | Discovery, once it has resolved the ROCm version and native library | Unsupported ROCm version, or a library that cannot be resolved | Yes — rejected later, but still before the workload runs |
 
-`rocprof-compute` likewise rejects kernel mode before profiling when it appears alongside iteration
-multiplexing or live attach. Kernel replay rejects iteration multiplexing because both strategies
-claim the same per-dispatch passes, not because of any backend restriction — iteration multiplexing
-needs the native collector too.
-
-PC sampling is different. It is agent-wide, it does not consume the localized context override, and
-today it runs in a separate counter-disabled invocation. None of that rules out replay: PC sampling
-takes a replay pass of its own, appended after the *N* counter passes and running with counter
-collection disabled. Kernel replay therefore accepts `--pc-sampling` and replays each admitted
-dispatch *N*+1 times.
-
-`--roof-only`, `--set`, and `--block` continue through ordinary counter selection. Multi-rank
-profiling stays available and keeps its warning. Kernel replay also needs a supported SDK version
-and a homogeneous agent configuration. Whether kernel replay has to exclude collective-bearing
-dispatches is still an open question.
+Both are hard errors. Iteration multiplexing and live attach are likewise rejected before profiling
+starts.
 
 ### Failure behavior
 
-Every failure below rejects partial replay data. None of them falls back to application replay, and
-none quietly turns a multi-bucket request into a single pass.
+Every failure below rejects partial replay data. None falls back to application replay, and none
+quietly turns a multi-bucket request into a single pass.
 
-| Condition | Required behavior |
-| --- | --- |
-| Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. |
-| Native collector unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two conditions failed. |
-| SDK below the supported version floor | Hard error stating the required version. This is distinct from the ROCm version the native collector needs, so the diagnostic has to say which one is unmet. The numeric floor is pending upstream merge. |
-| Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. |
-| Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
-| SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
-| Upstream drain timeout or process abort | Abort the failed run without recovery. |
+| Condition | Required behavior | Covers |
+| --- | --- | --- |
+| Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. | FR-3 |
+| Native collector unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3, NFR-5 |
+| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native collector needs, so the diagnostic must say which one is unmet. The numeric floor is pending upstream merge. | FR-15 |
+| Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. | FR-11 |
+| Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile. Never return `1` as a fallback. | FR-18, NFR-2 |
+| SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. | FR-16, NFR-2 |
+| Upstream drain timeout or process abort | Abort the failed run without recovery. | FR-17 |
 
 One wrinkle: a declined snapshot can currently leave a successful process status behind, so the
 required outcome cannot lean on subprocess failure alone. Classifying an upstream warning string is
-the signal available today, and it is a fragile one. A structured detection mechanism remains an open
-question.
+the signal available today, and it is a fragile one. A structured detection mechanism remains an
+open question.
 
 ### Support boundaries and rationale
 
-Kernel replay inherits the upstream mechanism's support boundaries:
+Kernel replay inherits the upstream mechanism's support boundaries.
 
-- The host snapshot requires at least as much memory as the complete tracked device footprint.
-- Equivalent-state guarantees cover tracked coarse-grained device VRAM and module-scope
-  `__device__` or `__constant__` state. Unified, managed, and `hipMallocAsync` allocations are not
-  restored.
-- HIP graph launches are unsupported.
-- Only single-packet, single-dispatch submissions are replayed; anything else executes without
-  replay.
-- Asynchronous SDMA or HSA copies are not fenced by the replay window.
-- Cache state is not restored, so cache-sensitive counter values may vary between passes.
-- Bounded drain expiry aborts the process rather than returning a recoverable error.
-- Multi-rank dispatches taking part in collectives remain unsafe until there is an exclusion policy.
+| State or feature | Replay guarantee |
+| --- | --- |
+| Tracked coarse-grained device VRAM | Snapshotted and restored between passes. |
+| Module-scope `__device__` / `__constant__` state | Discovered and captured by the SDK. |
+| Unified, managed, `hipMallocAsync` allocations | Not restored. No equivalence guarantee. |
+| Cache state | Not restored. Cache-sensitive counter values may vary between passes. |
+| HIP graph launches | Unsupported. |
+| Multi-packet or multi-dispatch submissions | Not replayed. Only single-packet, single-dispatch submissions are; anything else executes without replay. |
+| Asynchronous SDMA or HSA copies | Not fenced by the replay window. |
+| Host memory | Requires at least as much as the complete tracked device footprint. |
+| Bounded drain expiry | Aborts the process rather than returning a recoverable error. |
+| Multi-rank dispatches in collectives | Unsafe until there is an exclusion policy. |
 
 ## Implementation phases
 
-Proposed vertical slices for the implementation work ahead:
-
-- **Mode selection and validation.** Add the experimental `--replay-mode {application,kernel}`
-   surface, carry the selected mode through the profiling path, and implement both rejection layers
-   with their hard-error diagnostics. Replay execution stays disabled in this slice, so the only
-   observable behavior is mode selection and correct rejection — existing application-replay output
-   does not change.
-- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation, and
-   implement `pass_count_cb` from the per-agent profile-vector size. Apply the kernel and dispatch
-   filters at that same decision point, and diagnose a missing or empty vector instead of returning
-   one pass. Application replay keeps working throughout.
-- **Consolidated output and dispatch identity.** Produce one consolidated `results_*.csv`, normalize
-   cross-pass timestamps and identity so every pass of a logical dispatch resolves to one
-   `Dispatch_ID`, and expose the single pass-0 trace record.
+| Phase | Delivers | Observable after this phase |
+| --- | --- | --- |
+| **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface, the selected mode carried through the profiling path, and both rejection layers with their hard-error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
+| **2. Native-collector replay** | Coalesced counter groups delivered to the SDK invocation, `pass_count_cb` implemented from the per-agent profile-vector size, both filters applied at that decision point, and a diagnosed failure on a missing or empty vector. | Replayed dispatches collect every bucket in one run. Application replay keeps working throughout. |
+| **3. Consolidated output and dispatch identity** | One consolidated `results_*.csv`, cross-pass timestamp and identity normalization, and the single pass-0 trace record. | Analysis consumes kernel-replay output unchanged, and Top Stats reports non-multiplied values. |
 
 ## Validation, security and debuggability
 
@@ -453,61 +438,49 @@ Proposed vertical slices for the implementation work ahead:
 Validation spans the CLI, the kernel-replay adapter, replay-profile construction, output
 normalization, and the analysis boundary that should not have moved.
 
-- **Counter accuracy.** For one logical dispatch, and for state covered by the equivalence guarantee,
-  a counter present in more than one bucket must report the same value in every pass. A mismatch is a
-  validation failure. Evaluate cache-sensitive counters separately, as a documented limitation.
-- **Completeness and identity.** For each dispatch admitted by the replay filters, the observed
-  counter-pass count must equal the application replay count, every bucket must appear exactly once,
-  and all pass rows must collapse into one complete `Dispatch_ID`. Incomplete results have to fail
-  before analysis.
-- **Filtering.** Logical indices must advance once per dispatch, not once per pass. A confirmed
-  filter exclusion must take the ordinary no-snapshot path. Kernel replay must not misread it as a
-  missing-profile failure or an incomplete replay result.
-- **Application-replay comparison.** Profile the same deterministic workload and counter request in
-  both modes, then compare bucket membership, counter completeness, and final analysis results.
-  Existing application replay must come out unchanged.
-- **Service composition.** Kernel replay must expose one pass-0 trace record and one non-multiplied
-  logical duration per dispatch.
-- **PC sampling composition.** With `--pc-sampling` selected, each admitted dispatch must replay
-  *N*+1 times. Every counter bucket must still appear exactly once across passes 0 through *N*−1,
-  and pass *N* must produce PC sampling output and no counter rows.
-- **Compatibility.** Cover the accepted options — PC sampling, roofline selection, the multi-rank
-  warning, and the default-off behavior — and every rejected combination: iteration multiplexing and
-  live attach.
-- **Configuration rejection.** Cover each unmet native-collector condition on its own — declined
-  native collector, unsupported ROCm version, unresolvable library. Each must fail before profiling
-  starts, with a diagnostic naming that specific condition.
-- **Failure paths.** Cover an unsupported SDK, a missing profile vector, a declined snapshot, and an
-  upstream abort. Each case has to prove no one-pass fallback happened.
+| # | Check | Pass criterion | Covers |
+| --- | --- | --- | --- |
+| 1 | **Counter accuracy** | For one logical dispatch, and for state covered by the equivalence guarantee, a counter present in more than one bucket reports the same value in every pass. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, NFR-3 |
+| 2 | **Completeness and identity** | For each admitted dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Incomplete results fail before analysis. | FR-2, FR-5, FR-7, FR-8 |
+| 3 | **Filtering** | Logical indices advance once per dispatch, not once per pass. A confirmed filter exclusion takes the ordinary no-snapshot path, and is read as neither a missing-profile failure nor an incomplete replay result. | FR-12, FR-13 |
+| 4 | **Application-replay comparison** | Profile the same deterministic workload and counter request in both modes. Bucket membership, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-4 |
+| 5 | **Service composition** | One pass-0 trace record and one non-multiplied logical duration per dispatch. | FR-10 |
+| 6 | **PC sampling composition** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. | FR-6 |
+| 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, the multi-rank warning, default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
+| 8 | **Configuration rejection** | Each unmet native-collector condition on its own — declined collector, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |
+| 9 | **Failure paths** | An unsupported SDK, a missing profile vector, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. | FR-15, FR-16, FR-17, FR-18, NFR-2 |
+| 10 | **Diagnostics** | Every run identifies the replay mode and the bucket-to-pass mapping; every failure names its specific condition. | NFR-5 |
 
 ### Security
 
-Kernel replay adds no network interface and no new privilege boundary. Its one security-sensitive
-operation is the SDK-managed host snapshot of application device memory. That snapshot can hold
-application data and can consume host memory comparable to the tracked footprint. It stays inside the
-profiled process's trust boundary, and `rocprof-compute` must never persist its contents in result
-artifacts or print them in diagnostics. Snapshot allocation and restore failures are availability
-failures, and they follow the same fail-closed rule as every other incomplete replay condition.
+- Kernel replay adds no network interface and no new privilege boundary.
+- Its one security-sensitive operation is the SDK-managed host snapshot of application device memory.
+  That snapshot can hold application data and can consume host memory comparable to the tracked
+  footprint. It stays inside the profiled process's trust boundary, and `rocprof-compute` must never
+  persist its contents in result artifacts or print them in diagnostics.
+- Snapshot allocation and restore failures are availability failures, and follow the same fail-closed
+  rule as every other incomplete replay condition.
 
 ### Debuggability
 
-Run diagnostics have to identify the selected replay mode and backend, SDK capability, agent, and the
-mapping from every counter bucket to its replay pass. They also have to tell apart option conflicts,
-unavailable native collection, missing profiles, snapshot decline, and upstream abort — and say
-plainly that partial results are unusable. A snapshot-decline diagnostic also recommends
-application replay.
+| A diagnostic must identify | Why |
+| --- | --- |
+| Selected replay mode and backend | The two modes fail differently. The user needs to know which one ran. |
+| SDK capability and agent | Version floors and agent homogeneity are both rejection causes. |
+| Bucket-to-pass mapping | The only way to confirm the derived pass count matches the request. |
+| Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort | Each has a different remedy. |
+| That partial results are unusable | Otherwise a user may try to analyze what was written before the failure. |
+| A recommendation of application replay, on snapshot decline | It is the working alternative for that specific failure. |
 
-A configuration diagnostic has to name the specific unmet condition instead of reporting that the
+A configuration diagnostic must name the specific unmet condition rather than reporting that the
 native collector is unavailable. One message covering both an unsupported ROCm version and an
-unresolvable library leaves the user with no action to take, because the remedy is different in
-each case.
+unresolvable library leaves the user with no action to take, because the remedy differs in each case.
 
 ## Open questions
 
-- **Collective-bearing kernels.** Should kernel replay exclude dispatches taking part in
-   inter-process collectives?
-- **Marker and ROCTx semantics.** The host emits these regions once, but they span every replay
-   pass, so their durations include replay overhead and are not comparable with a non-replay run.
-   Reject the combination, or correct the duration?
-- **Cache-related counter validity.** Are cache-related metrics trustworthy at all, when nothing
-   restores cache state between replay passes?
+| # | Question | Why it matters | Blocks |
+| --- | --- | --- | --- |
+| 1 | Should kernel replay exclude dispatches taking part in inter-process collectives? | Replaying one rank's dispatch while its peers do not desynchronizes the collective. | Multi-rank support boundary (FR-14) |
+| 2 | Marker and ROCTx durations: reject the combination, or correct the duration? | The host emits these regions once, but they span every pass, so their durations include replay overhead and are not comparable with a non-replay run. | Marker/ROCTx composition |
+| 3 | Are cache-related metrics trustworthy at all under replay? | Nothing restores cache state between passes, so cache-sensitive counters vary by pass. | Scope of NFR-1 |
+| 4 | How should `rocprof-compute` detect a declined snapshot? | Today the only signal is classifying an upstream warning string, and the process status can still report success. | FR-16 |

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -38,7 +38,7 @@ design must consume. The mechanism is a surrounding component and an external co
 does not propose changes to its replay algorithm.
 
 The PR adds a `KERNEL_REPLAY` callback domain with `CONFIG` and `PASS` operations. In the fixed-pass
-path that `rocprof-compute` would use, a profiling tool supplies `pass_count_cb` during `CONFIG`.
+path, a profiling tool supplies `pass_count_cb` during `CONFIG`.
 The callback is evaluated for each dispatch that reaches the replay gate and can use its agent
 information. Returning `1` opts out: the SDK follows its ordinary single-execution path without
 taking a snapshot or issuing `PASS` callbacks. Returning a count greater than one opens a replay
@@ -382,7 +382,7 @@ multi-bucket request into one pass.
 | Iteration multiplexing, live attach, or PC sampling selected with kernel replay | Hard error before profiling starts. |
 | Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile; never return one as a fallback. |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. |
-| Upstream drain timeout or process abort | Report the failed run without recovery. |
+| Upstream drain timeout or process abort | Abort the failed run without recovery. |
 
 A declined snapshot can currently leave a successful process status, so the required outcome cannot
 depend only on subprocess failure. Classifying an upstream warning string is the available but

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -6,19 +6,19 @@
 
 | Term | Meaning |
 | --- | --- |
-| **Bucket** | A group of hardware counters small enough to fit one hardware pass. `rocprof-compute` turns the metrics an analysis asks for into counters, then packs them into buckets. The bucket count is the pass count. |
+| **Bucket** | A group of hardware counters small enough to fit one hardware pass. |
 | **Logical dispatch** | One kernel launch as the application issued it, however many times a replay strategy executes it. |
-| **Native collector** | A `rocprof-compute` library it can preload to take over counter collection, while tracing runs in a separate context. Unavailable when the user declines it, or when the installed ROCm predates support for it. |
+| **Native tool** | A `rocprof-compute` library. |
 
 ### Counter collection today
 
-| Strategy | Execution model | Covers | Does not cover |
+| Strategy | Execution model | Pros | Cons |
 | --- | --- | --- | --- |
-| **Application replay** | Launch and run the complete workload once per bucket, then combine the counters. | Every bucket, across corresponding replayed dispatch occurrences — nothing is estimated from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected; communicating multi-rank workloads warn. |
-| **Iteration multiplexing** | Launch once and let the native collector rotate buckets across comparable dispatch occurrences. Analysis imputes each occurrence's missing counters. | Avoids repeated launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. Requires the native collector. |
+| **Application replay** | Launch and run the complete workload once per bucket. | Every bucket, across corresponding replayed dispatch occurrences — nothing is estimated from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected; communicating multi-rank workloads warn. |
+| **Iteration multiplexing** | Launch once and let the native tool rotate buckets across comparable dispatch occurrences. Analysis imputes each occurrence's missing counters. | Avoids repeated launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set. Requires the native tool. |
 
 - Every configuration consumes the same buckets. Application replay works across all of them;
-  iteration multiplexing hard-errors without the native collector.
+  iteration multiplexing hard-errors without the native tool.
 - Application replay is therefore the only strategy today that satisfies a multi-bucket request
   without borrowing counters from neighbouring dispatches.
 
@@ -31,11 +31,11 @@ because those records carry the kernel counts and durations.
 | --- | --- | --- | --- |
 | Kernel dispatch tracing | Separate tracing context | Yes | *N* records for one logical dispatch. Inflates Top Stats and `pmc_dispatch_info.csv`. |
 | Marker / ROCTx tracing | Separate tracing context, framework runs only | Host-side, spans all passes | Region duration absorbs replay overhead. |
-| Code-object tracing | Native collector | No — load time | Unaffected. Replay does not multiply load-time events. |
+| Code-object tracing | Native tool | No — load time | Unaffected. Replay does not multiply load-time events. |
 | PC sampling | Own invocation today | Agent-wide | Becomes its own replay pass. |
-| Counter collection | Native collector | Yes | The point of the feature: one bucket per pass. |
+| Counter collection | Native tool | Yes | The point of the feature: one bucket per pass. |
 
-The split matters: the trace records come from a context the native collector can control but does
+The split matters: the trace records come from a context the native tool can control but does
 not itself emit.
 
 ### Proposed SDK replay mechanism
@@ -181,8 +181,8 @@ flowchart LR
 | ID | Requirement | Why |
 | --- | --- | --- |
 | **FR-1** | `rocprof-compute profile` exposes `--replay-mode {application,kernel}`, defaults to `application`, and requires explicit selection of kernel replay. `--iteration-multiplexing` and its policy argument stay independent. | Kernel replay carries support boundaries application replay does not. Opt-in, not inferred. |
-| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. | Removing the repeated launches is the whole point. A user-set pass count could disagree with the bucket count. |
-| **FR-3** | Kernel replay requires the native collector. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native collector, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. | Only the native collector owns the SDK contexts replay needs. Failing late wastes a workload run. |
+| **FR-2** | For *N* buckets, kernel mode uses one workload invocation for counter collection and collects one bucket in each of *N* passes, for every replay-eligible dispatch. No user-supplied pass count. A zero-bucket request bypasses the kernel-replay counter adapter and retains the existing non-counter path, including the PC-sampling-only path. | Removing the repeated launches is the whole point. A user-set pass count could disagree with the bucket count. A request with no counters has nothing to replay through the counter adapter. |
+| **FR-3** | Kernel replay requires the native tool. The `rocprofv3` backend and `--no-native-tool` are unsupported. A declined native tool, or a ROCm version that does not support one, is a hard error naming the unmet condition, before any workload runs. | Only the native tool owns the SDK contexts replay needs. Failing late wastes a workload run. |
 
 #### Passes and buckets
 
@@ -196,10 +196,10 @@ flowchart LR
 
 | ID | Requirement | Why |
 | --- | --- | --- |
-| **FR-7** | One kernel-replay invocation produces one consolidated `results_*.csv` that the existing workload join and analysis path consumes with no analysis-side contract change. | Analysis should not need to know which replay mode produced its input. |
+| **FR-7** | One kernel-replay invocation produces one consolidated `results_*.csv`, using the existing first-input-stem naming convention, that the existing workload join and analysis path consumes with no analysis-side contract change. | Analysis should not need to know which replay mode produced its input, and kernel mode should not introduce another result-discovery convention. |
 | **FR-8** | All passes of one logical dispatch resolve to one `Dispatch_ID` group holding the complete counter set. | Analysis groups on `Dispatch_ID` before pivoting counters into columns. Per-pass IDs would leave every group holding one bucket. |
 | **FR-9** | Start and end timestamps follow the same cross-pass normalization semantics used for application-replay results. | Same reason as FR-8, and it keeps durations comparable between modes. |
-| **FR-10** | Exactly one kernel-dispatch trace record per logical dispatch, so Top Stats and `pmc_dispatch_info.csv` keep non-replay semantics: one dispatch and its pass-0 logical duration, not replay-multiplied values. | Top Stats is the first table users read. *N*× dispatch counts and GPU time would be wrong there. |
+| **FR-10** | Preserve two independent one-dispatch contracts: suppress kernel-dispatch tracing after pass 0 so exactly one trace record remains, and consolidate the normalized counter rows into one logical dispatch with its pass-0 duration before analysis. Top Stats and `pmc_dispatch_info.csv` consume the latter PMC data, not the trace stream. | Trace artifacts and PMC-derived summaries have separate inputs. Both must avoid replay-multiplied dispatch counts and GPU time. |
 
 #### Composition and filtering
 
@@ -207,23 +207,23 @@ flowchart LR
 | --- | --- | --- |
 | **FR-11** | Kernel replay with `--iteration-multiplexing` or `--attach-pid` is a hard error. `--roof-only`, `--set`, and `--block` interoperate unchanged. | Both replay strategies claim the same per-dispatch passes. The rest only select counters. |
 | **FR-12** | Kernel filtering composes. A dispatch whose kernel is excluded is not replayed and incurs no snapshot or restore. | A filtered dispatch paying full replay cost, only to have its counters discarded, is pure waste. |
-| **FR-13** | Dispatch filtering composes. `--dispatch` indices count logical dispatches, not replay passes, so an index selects the same work in either mode. An excluded dispatch is not replayed. | Otherwise `--dispatch 3` with 4 buckets selects the third *pass of the first* dispatch, labelled as the one the user asked for. |
-| **FR-14** | Kernel replay stays available for multi-rank workloads. | Multi-rank workloads are exactly the ones with expensive startup. |
+| **FR-13** | Dispatch filtering composes. `--dispatch` retains its 1-based, per-kernel logical-occurrence semantics: indices count each kernel's logical dispatches, not replay passes or a global dispatch sequence. Replay-ineligible submissions still advance the existing per-kernel occurrence counter when the dispatch-counting service observes them, and an excluded dispatch is not replayed. | Otherwise replay passes or submissions skipped by the replay gate shift the per-kernel occurrence selected by the user, so `--dispatch 3` can select different work in the two modes. |
+| **FR-14** | Kernel replay stays available for multi-rank workloads and emits a kernel-replay-specific diagnostic describing the unresolved risk that one rank may replay a collective-bearing dispatch while its peers do not. It does not reuse the application-replay warning about repeated workload launches or recommend iteration multiplexing. | Multi-rank workloads are exactly the ones with expensive startup, but Open Question 1 remains a safety boundary the user must see. |
 
 #### Failure
 
 | ID | Requirement | Why |
 | --- | --- | --- |
-| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. | Distinct from the ROCm version the native collector needs. The user must know which one is unmet. |
+| **FR-15** | An SDK below the supported version floor is a hard error stating the required version. | Distinct from the ROCm version the native tool needs. The user must know which one is unmet. |
 | **FR-16** | If the SDK declines a device-memory snapshot, abandon the profile without retry and recommend application replay in the diagnostic. | Without a snapshot there is no equivalent state, so no pass after the first is trustworthy. Application replay is the working alternative. |
 | **FR-17** | If the upstream replay mechanism aborts, report the failed run without attempting recovery. | Upstream drain expiry aborts the process; there is no recoverable error to catch. |
-| **FR-18** | If an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. | A single-pass "success" would present one bucket as a complete metric set. |
+| **FR-18** | If counters were requested but an agent has no usable counter profiles, diagnose the condition rather than silently degrading that dispatch to one pass. A request that resolves to zero counter buckets bypasses the replay counter adapter under FR-2 and is not this failure. | A single-pass "success" would present one bucket as a complete metric set, while treating an intentional zero-counter request as an agent mismatch would reject a valid non-counter path. |
 
 ### Non-functional requirements
 
 | ID | Requirement | Why |
 | --- | --- | --- |
-| **NFR-1** | For state covered by the replay-equivalence guarantee, a counter present in more than one bucket has the same value across passes of the same dispatch. Cache-sensitive counters fall outside this invariant. | This is the correctness claim kernel replay rests on. Cache state is not restored, so it is excluded explicitly. |
+| **NFR-1** | For deterministic workloads and state covered by the replay-equivalence guarantee, each kernel-replay bucket matches the corresponding application-replay bucket for the same logical dispatch. Cache-sensitive counters fall outside this invariant. | This is an observable correctness claim even though normal bucket construction assigns each counter to one bucket. Cache state is not restored, so it is excluded explicitly. |
 | **NFR-2** | Fail closed whenever a complete bucket set cannot be delivered. Never collect partial counter data silently. | Partial counters produce plausible-looking but wrong metrics. |
 | **NFR-3** | Guarantee equivalent replay state only for tracked coarse-grained VRAM and module-scope device or constant state. No guarantee for unified, managed, or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced asynchronous SDMA copies, or cache state. May require host memory equal to the tracked device footprint. | Inherited from the upstream mechanism. Overstating coverage would mislead users into trusting unsupported cases. |
 | **NFR-4** | Workflows that do not select kernel replay keep their current collection behavior, and kernel-replay output preserves the existing analysis input contract. | The feature is experimental. It must not regress the default path. |
@@ -231,16 +231,24 @@ flowchart LR
 
 ## Design
 
-### Counter groups and the collector boundary
+### Counter groups and the native-tool boundary
 
 - **`perfmon_coalesce` stays the single authority** on bucket membership and one-pass fit. Its
   `_ACCUM` pairing, TCC grouping, and same-bucket priority policies produce the same *N* buckets for
-  both modes, and the kernel-replay adapter hands those buckets to the native collector without
+  both modes, and the kernel-replay adapter hands those buckets to the native tool without
   regrouping them.
-- **All *N* groups go to a single replay-enabled invocation.** The native collector derives the pass
-  count from the per-agent profiles it built from them, adding one when PC sampling is selected.
+- **All *N* groups go to a single replay-enabled invocation.** The native tool derives the pass
+  count from the per-agent profiles it built from them, adding one when PC sampling is selected. The
+  existing `run_prof` multi-file admission check, which recognizes iteration multiplexing today, must
+  also admit kernel replay as a separate condition. Every other unsupported multi-file input keeps
+  hard-erroring, and kernel replay remains mutually exclusive with iteration multiplexing.
+- **The consolidated filename keeps the existing convention.** `run_prof` derives the result basename
+  from the first input counter-group file. Deterministic bucket ordering keeps that input stable, so
+  kernel replay writes the same `results_<first-input-stem>.csv` shape and existing result discovery
+  needs no mode-specific branch.
 - **No separate pass-count option or environment value exists.** Deriving the count from the buckets
-  is what stops the two from drifting apart.
+  is what stops the two from drifting apart. A request with zero buckets bypasses this adapter and
+  follows the existing non-counter path.
 
 ```mermaid
 graph LR
@@ -248,7 +256,7 @@ graph LR
         Buckets["N buckets"]
         Adapter["Kernel-replay adapter"]
         Normalize["Cross-pass counter identity<br/>and timestamp normalization"]
-        Output["Consolidated counter result<br/>and one logical trace record"]
+        Output["Consolidated PMC rows<br/>plus one logical trace record"]
         Analysis["Existing join and analysis path"]
         Buckets --> Adapter
         Normalize --> Output
@@ -256,7 +264,7 @@ graph LR
     end
 
     subgraph Tools["Tool boundary"]
-        Native["Native collector<br/>per-agent profile vector"]
+        Native["Native tool<br/>per-agent profile vector"]
         Reject["Diagnose and reject invalid profile<br/>never treat it as filter opt-out"]
     end
 
@@ -271,60 +279,81 @@ graph LR
     Adapter -- "ROCPROF_COUNTERS groups<br/>native replay setup" --> Native
 
     Native -- "pass_count_cb<br/>admitted: profile-vector size<br/>filtered: one" --> Replay
-    Native -- "missing or empty vector" --> Reject
+    Native -- "missing or unexpectedly empty vector<br/>when counters were requested" --> Reject
 
     Native -. "locally stop trace context<br/>on passes 1 through N-1" .-> Trace
-    Counters --> Normalize
-    Trace -- "pass-0 record only" --> Output
+    Counters -- "per-pass PMC rows" --> Normalize
+    Trace -- "independent pass-0 trace record" --> Output
 ```
 
 ### The pass-count decision
 
-Counter-group parsing creates one profile-vector entry per group, per agent. `pass_count_cb` is the
-single decision point for both the pass count and the filters, because it runs exactly once per
-logical dispatch and before any replay pass.
+Counter-group parsing creates one profile-vector entry per group, per agent. Before replay setup, a
+zero-bucket request bypasses the replay counter adapter and follows the existing non-counter path.
+For a counter request, `pass_count_cb` is the single decision point for admission and pass count,
+because it runs exactly once for each dispatch that reaches the replay gate and before any replay
+pass. It consults the existing 1-based, per-kernel logical-occurrence index; it does not create a
+second replay-only index sequence.
 
 ```mermaid
 flowchart TD
-    Start["Dispatch reaches the replay gate<br/>pass_count_cb runs once"]
-    Vector{"Agent has a non-empty<br/>profile vector?"}
+    Request{"Counter request has<br/>at least one bucket?"}
+    Zero["Bypass replay counter adapter<br/>use existing non-counter path"]
+    Observe["Dispatch-counting service assigns<br/>per-kernel logical occurrence once"]
+    Gate{"Dispatch reaches<br/>the replay gate?"}
+    Ordinary["Execute once outside replay<br/>retain ordinary dispatch handling"]
+    Start["pass_count_cb runs once"]
+    Vector{"Agent has the expected<br/>non-empty profile vector?"}
     Fatal["Fatal: agent/profile mismatch<br/>reject the whole profile"]
-    Index["Assign the logical dispatch index<br/>once, here only"]
     Kernel{"Kernel admitted by<br/>the kernel filter?"}
-    Range{"Index admitted by<br/>the dispatch range?"}
-    One["Return 1<br/>ordinary path, no snapshot, no restore"]
+    Range{"Per-kernel occurrence admitted by<br/>the dispatch range?"}
+    Filtered["Return 1 as filtered<br/>select no counter profile"]
+    Size{"Profile-vector size?"}
+    Single["Return 1 as admitted<br/>select the sole profile"]
     PC{"PC sampling selected?"}
     N["Return N<br/>one counter bucket per pass"]
     NPlus["Return N+1<br/>N counter passes, then one<br/>counter-disabled PC sampling pass"]
 
-    Start --> Vector
+    Request -- no --> Zero
+    Request -- yes --> Observe --> Gate
+    Gate -- no --> Ordinary
+    Gate -- yes --> Start --> Vector
     Vector -- no --> Fatal
-    Vector -- yes --> Index --> Kernel
-    Kernel -- no --> One
+    Vector -- yes --> Kernel
+    Kernel -- no --> Filtered
     Kernel -- yes --> Range
-    Range -- no --> One
+    Range -- no --> Filtered
     Range -- yes --> PC
-    PC -- no --> N
     PC -- yes --> NPlus
+    PC -- no --> Size
+    Size -- one --> Single
+    Size -- more than one --> N
 ```
 
-| Returns | When | What the passes select |
+| Returns | When | What the execution selects |
 | --- | --- | --- |
-| `1` | A confirmed filter miss — the kernel or the dispatch index is excluded. | Nothing. The SDK takes its ordinary path, deliberately paying no snapshot or restore. |
-| *N* | Admitted, no PC sampling. *N* is the size of the profile vector for this dispatch's agent. | Pass *i* selects entry *i* of that vector. |
-| *N*+1 | Admitted, PC sampling selected. | Passes 0 through *N*−1 map one-to-one onto the vector. Pass *N* selects no counter profile and runs counter-disabled. |
-| *(fatal)* | The agent is missing, or its profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
+| `1` — filtered | A confirmed filter miss — the kernel or its per-kernel logical occurrence is excluded. | Nothing. The SDK takes its ordinary path, deliberately paying no snapshot or restore. |
+| `1` — admitted | The dispatch is admitted and its agent's profile vector contains exactly one bucket. | The ordinary execution selects the sole profile. This is a complete one-bucket result, not a filter outcome. |
+| *N*, where *N* > 1 | Admitted, no PC sampling. *N* is the size of the profile vector for this dispatch's agent. | Pass *i* selects entry *i* of that vector. |
+| *N*+1 | Admitted, PC sampling selected. *N* is the non-zero size of the profile vector. | Passes 0 through *N*−1 map one-to-one onto the vector. Pass *N* selects no counter profile and runs counter-disabled. |
+| *(fatal)* | Counters were requested, but the agent is missing or its expected profile vector is empty. | Nothing. Diagnose the agent/profile mismatch and fail the whole profile. |
 
-Two consequences worth stating plainly:
+Three consequences worth stating plainly:
 
-- **`1` means "do not replay". It is never a fallback.** Returning it on a missing or empty vector
-  would execute the dispatch once, collect a single bucket, and present incomplete data as a success.
-- **The logical index is assigned here, not incremented per pass.** The per-pass counter-dispatch
-  callback reads it. A non-replay run has one pass per dispatch, so moving the increment leaves
-  existing indices intact while stopping replay passes from consuming extra ones.
+- **Admission is state, not a numeric inference.** Both a filtered dispatch and an admitted
+  single-bucket dispatch return `1`, but only the admitted case selects a profile and participates in
+  completeness checking. The adapter records that distinction explicitly.
+- **`1` is never a fallback for a missing expected profile.** Returning it for an agent/profile
+  mismatch would execute the dispatch once, collect at most one bucket, and present incomplete data
+  as a success.
+- **The logical index remains owned by dispatch observation.** The dispatch-counting service advances
+  the 1-based index once per logical occurrence of each kernel, including submissions the replay gate
+  cannot replay. `pass_count_cb` only reads that stable index, and replay passes never consume another
+  occurrence.
 
 Completeness checks apply only to admitted dispatches. A dispatch excluded on purpose produces no
-counter set, and that is not an incomplete replay result.
+counter set, and that is not an incomplete replay result. A zero-bucket request bypasses the adapter
+before dispatch admission, so it is likewise not a missing or incomplete replay result.
 
 ### Output and dispatch identity
 
@@ -334,8 +363,8 @@ written, every pass row for a logical dispatch must collapse to one identity.
 | Step | What happens | If skipped |
 | --- | --- | --- |
 | 1. Correlate | Group the pass rows by replay-stable logical-dispatch identity. | Nothing ties the passes of one dispatch together. |
-| 2. Normalize timestamps | Give the group one canonical start/end pair. | The timestamp-bearing identity key hands every pass its own `Dispatch_ID`. |
-| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs. |
+| 2. Normalize timestamps | Give the group one canonical start/end pair using pass 0's logical duration. | The timestamp-bearing identity key can hand every pass its own `Dispatch_ID`, and PMC-derived duration summaries can retain replay-pass timing. |
+| 3. Hand off | The existing identity and pivot contracts see one row set per dispatch. Top Stats and `pmc_dispatch_info.csv` are generated from this consolidated PMC dataframe. | Analysis pivots each single-bucket group separately, so no row carries the complete metric inputs; PMC-derived dispatch counts and durations can also be multiplied. |
 
 - Pass identity may survive transiently for normalization and diagnostics; it does not need to reach
   `pmc_perf.csv`. Non-replay identity behavior is untouched.
@@ -345,9 +374,10 @@ written, every pass row for a logical dispatch must collapse to one identity.
 
 ### Co-active service composition
 
-| Service | Under kernel replay | Mechanism |
+| Service or output | Under kernel replay | Mechanism |
 | --- | --- | --- |
-| Kernel dispatch tracing | One record per logical dispatch, from pass 0 | The native collector owns the context, so it locally stops kernel tracing for passes 1 through *N*−1. |
+| Kernel dispatch tracing | One trace record per logical dispatch, from pass 0 | The native tool owns the context, so it locally stops kernel tracing for passes 1 through *N*−1. |
+| Top Stats and `pmc_dispatch_info.csv` | One logical PMC dispatch and its pass-0 duration | These outputs consume the consolidated counter/PMC dataframe from Output and dispatch identity, not the kernel-dispatch trace stream. |
 | Code-object tracing | Unchanged | Load-time only. Replay never multiplies it. |
 | Marker / ROCTx | Emitted once, spans all passes | Duration semantics are an open question. |
 | PC sampling | One extra pass, appended after the counter passes | Runs counter-disabled. |
@@ -356,8 +386,10 @@ written, every pass row for a logical dispatch must collapse to one identity.
 - **Why pass 0.** It is the only pass running against pristine pre-snapshot state. Every later pass
   starts immediately after a full restore of the tracked footprint, so its timing says more about
   replay overhead than about the dispatch.
-- **Why suppress at the source.** Nothing has to reconstruct which records belonged to the same
-  logical dispatch, because the extra records never exist. That makes it both cheap and exact.
+- **Why suppress at the source.** Nothing has to reconstruct which trace records belonged to the same
+  logical dispatch, because the extra records never exist. That makes trace suppression both cheap
+  and exact. It is independent of PMC-row consolidation: Top Stats and `pmc_dispatch_info.csv` remain
+  correct only when the Output and dispatch identity path also collapses the counter rows.
 
 ### Mode and option compatibility
 
@@ -367,20 +399,20 @@ This does not turn `--iteration-multiplexing` into a mode selector.
 
 | Option or condition | With kernel replay | Reason |
 | --- | --- | --- |
-| `--iteration-multiplexing` | Rejected | Both strategies claim the same per-dispatch passes. Not a backend restriction — iteration multiplexing needs the native collector too. |
+| `--iteration-multiplexing` | Rejected | Both strategies claim the same per-dispatch passes. Not a backend restriction — iteration multiplexing needs the native tool too. |
 | `--attach-pid` | Rejected | Live attach cannot open a replay window over an already-running process. |
-| `--no-native-tool`, `rocprofv3` backend | Rejected | Kernel replay needs the SDK contexts only the native collector owns. |
+| `--no-native-tool`, `rocprofv3` backend | Rejected | Kernel replay needs the SDK contexts only the native tool owns. |
 | `--pc-sampling` | Accepted, *N*+1 passes | Agent-wide, and it does not consume the localized context override. It takes a counter-disabled pass of its own. |
 | `--roof-only`, `--set`, `--block` | Accepted, unchanged | Ordinary counter selection. |
-| Multi-rank | Accepted, keeps its warning | See the open question on collective-bearing dispatches. |
+| Multi-rank | Accepted, with a kernel-replay-specific diagnostic | Warn that replaying one rank's collective-bearing dispatch while peers do not may desynchronize the collective. Do not reuse the application-replay warning about multiple workload launches or recommend iteration multiplexing. Open Question 1 remains unresolved. |
 | Heterogeneous agents | Rejected | Kernel replay needs a homogeneous agent configuration. |
 
-Kernel mode needs the native collector, but the conditions that supply one do not all become
+Kernel mode needs the native tool, but the conditions that supply one do not all become
 knowable at the same moment, so rejection happens in two layers:
 
 | Layer | Decidable from | Rejected when | Workload directory left behind? |
 | --- | --- | --- | --- |
-| **Flag conflict** | The arguments alone | Kernel replay selected while the native collector is declined | No — rejected before discovery and before the directory is created |
+| **Flag conflict** | The arguments alone | Kernel replay selected while the native tool is declined | No — rejected before discovery and before the directory is created |
 | **Capability failure** | Discovery, once it has resolved the ROCm version and native library | Unsupported ROCm version, or a library that cannot be resolved | Yes — rejected later, but still before the workload runs |
 
 Both are hard errors. Iteration multiplexing and live attach are likewise rejected before profiling
@@ -393,11 +425,11 @@ quietly turns a multi-bucket request into a single pass.
 
 | Condition | Required behavior | Covers |
 | --- | --- | --- |
-| Native collector declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. | FR-3 |
-| Native collector unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3, NFR-5 |
-| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native collector needs, so the diagnostic must say which one is unmet. The numeric floor is pending upstream merge. | FR-15 |
+| Native tool declined while kernel replay is selected | Hard error from the argument combination alone, before discovery. | FR-3 |
+| Native tool unavailable: unsupported ROCm version or unresolvable library | Hard error after discovery, naming which of the two failed. | FR-3, NFR-5 |
+| SDK below the supported version floor | Hard error stating the required version. Distinct from the ROCm version the native tool needs, so the diagnostic must say which one is unmet. The numeric floor is pending upstream merge. | FR-15 |
 | Iteration multiplexing or live attach selected with kernel replay | Hard error before profiling starts. | FR-11 |
-| Missing or empty per-agent profile vector | Diagnose the agent/profile mismatch and reject the profile. Never return `1` as a fallback. | FR-18, NFR-2 |
+| Missing or unexpectedly empty per-agent profile vector when counters were requested | Diagnose the agent/profile mismatch and reject the profile. Never return `1` as a fallback. A zero-bucket request bypasses the replay adapter before this point and is not this failure. | FR-18, NFR-2 |
 | SDK declines the device-memory snapshot | Abandon the entire profile without retry, reject incomplete output, and recommend application replay. | FR-16, NFR-2 |
 | Upstream drain timeout or process abort | Abort the failed run without recovery. | FR-17 |
 
@@ -428,8 +460,8 @@ Kernel replay inherits the upstream mechanism's support boundaries.
 | Phase | Delivers | Observable after this phase |
 | --- | --- | --- |
 | **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface, the selected mode carried through the profiling path, and both rejection layers with their hard-error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
-| **2. Native-collector replay** | Coalesced counter groups delivered to the SDK invocation, `pass_count_cb` implemented from the per-agent profile-vector size, both filters applied at that decision point, and a diagnosed failure on a missing or empty vector. | Replayed dispatches collect every bucket in one run. Application replay keeps working throughout. |
-| **3. Consolidated output and dispatch identity** | One consolidated `results_*.csv`, cross-pass timestamp and identity normalization, and the single pass-0 trace record. | Analysis consumes kernel-replay output unchanged, and Top Stats reports non-multiplied values. |
+| **2. Native-tool replay** | Coalesced counter groups delivered to the SDK invocation; the `run_prof` multi-file gate extended to admit kernel replay independently of iteration multiplexing; `pass_count_cb` implemented from the per-agent profile-vector size and explicit admission state; both filters applied from the existing per-kernel occurrence index; and diagnosed failure on a missing or unexpectedly empty vector when counters were requested. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
+| **3. Consolidated output and dispatch identity** | One consolidated `results_*.csv` using the existing first-input-stem convention, cross-pass timestamp and identity normalization for PMC rows, and the independently suppressed pass-0 trace record. | Analysis consumes kernel-replay output unchanged; Top Stats and `pmc_dispatch_info.csv` report non-multiplied PMC values; trace output contains one record per logical dispatch. |
 
 ## Validation, security and debuggability
 
@@ -440,15 +472,15 @@ normalization, and the analysis boundary that should not have moved.
 
 | # | Check | Pass criterion | Covers |
 | --- | --- | --- | --- |
-| 1 | **Counter accuracy** | For one logical dispatch, and for state covered by the equivalence guarantee, a counter present in more than one bucket reports the same value in every pass. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, NFR-3 |
-| 2 | **Completeness and identity** | For each admitted dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Incomplete results fail before analysis. | FR-2, FR-5, FR-7, FR-8 |
-| 3 | **Filtering** | Logical indices advance once per dispatch, not once per pass. A confirmed filter exclusion takes the ordinary no-snapshot path, and is read as neither a missing-profile failure nor an incomplete replay result. | FR-12, FR-13 |
-| 4 | **Application-replay comparison** | Profile the same deterministic workload and counter request in both modes. Bucket membership, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-4 |
-| 5 | **Service composition** | One pass-0 trace record and one non-multiplied logical duration per dispatch. | FR-10 |
+| 1 | **Counter accuracy** | Use a deterministic request producing more than one bucket. For each logical dispatch and state covered by the equivalence guarantee, every kernel-replay bucket matches its corresponding application-replay bucket. A single-bucket run or a comparison with no corresponding application-replay values is not evidence for NFR-1. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, NFR-3 |
+| 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Multiple counter-group files are admitted in kernel mode without iteration multiplexing, and the consolidated file uses and is discovered through the existing first-input-stem convention. Incomplete results fail before analysis; a zero-bucket request bypasses this check. | FR-2, FR-5, FR-7, FR-8 |
+| 3 | **Filtering** | The existing 1-based, per-kernel logical-occurrence index advances once for every observed dispatch of that kernel, including replay-ineligible submissions, and never once per replay pass. Kernel and dispatch exclusions take the ordinary no-snapshot path and are read as neither missing-profile failures nor incomplete replay results. The same `--dispatch` range selects the same per-kernel occurrences in both replay modes. | FR-12, FR-13 |
+| 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values subject to NFR-1, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-1, NFR-4 |
+| 5 | **Service composition** | Verify independently that tracing emits one pass-0 record per logical dispatch and that consolidated PMC data feeds Top Stats and `pmc_dispatch_info.csv` one logical dispatch with one non-multiplied pass-0 duration. Trace suppression alone does not satisfy this check. | FR-8, FR-10 |
 | 6 | **PC sampling composition** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. | FR-6 |
-| 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, the multi-rank warning, default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
-| 8 | **Configuration rejection** | Each unmet native-collector condition on its own — declined collector, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |
-| 9 | **Failure paths** | An unsupported SDK, a missing profile vector, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. | FR-15, FR-16, FR-17, FR-18, NFR-2 |
+| 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective-desynchronization risk without describing repeated workload launches or recommending iteration multiplexing, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
+| 8 | **Configuration rejection** | Each unmet native-tool condition on its own — declined native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |
+| 9 | **Failure paths** | An unsupported SDK, a missing or unexpectedly empty profile vector when counters were requested, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. A zero-bucket request follows the existing bypass and is not misclassified as a missing-profile failure. | FR-2, FR-15, FR-16, FR-17, FR-18, NFR-2 |
 | 10 | **Diagnostics** | Every run identifies the replay mode and the bucket-to-pass mapping; every failure names its specific condition. | NFR-5 |
 
 ### Security
@@ -466,6 +498,7 @@ normalization, and the analysis boundary that should not have moved.
 | A diagnostic must identify | Why |
 | --- | --- |
 | Selected replay mode and backend | The two modes fail differently. The user needs to know which one ran. |
+| Multi-rank detection under kernel replay | The collective-desynchronization risk remains unresolved. The diagnostic must describe that risk rather than reuse application replay's repeated-launch warning or recommend an incompatible mode. |
 | SDK capability and agent | Version floors and agent homogeneity are both rejection causes. |
 | Bucket-to-pass mapping | The only way to confirm the derived pass count matches the request. |
 | Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort | Each has a different remedy. |
@@ -473,7 +506,7 @@ normalization, and the analysis boundary that should not have moved.
 | A recommendation of application replay, on snapshot decline | It is the working alternative for that specific failure. |
 
 A configuration diagnostic must name the specific unmet condition rather than reporting that the
-native collector is unavailable. One message covering both an unsupported ROCm version and an
+native tool is unavailable. One message covering both an unsupported ROCm version and an
 unresolvable library leaves the user with no action to take, because the remedy differs in each case.
 
 ## Open questions

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -395,61 +395,56 @@ the signal available today. A structured detection mechanism remains an open que
 
 | Phase | Delivers | Observable after this phase |
 | --- | --- | --- |
-| **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface, the selected mode carried through the profiling path, and both rejection layers with their hard-error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
-| **2. Native-tool replay** | Coalesced counter groups delivered to the SDK invocation; the multi-group admission check extended to admit kernel replay independently of iteration multiplexing; `pass_count_cb` implemented from the per-agent profile-vector size and explicit admission state; both filters applied from the existing per-kernel occurrence index; and diagnosed failure on a missing or unexpectedly empty vector when counters were requested. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
-| **3. Consolidated output and dispatch identity** | One consolidated counter result using the existing naming convention, cross-pass timestamp and identity normalization for counter rows, and the independently suppressed pass-0 trace record. | Analysis consumes kernel-replay output unchanged; Top Stats and dispatch information report non-multiplied counter values; trace output contains one record per logical dispatch. |
+| **1. Mode selection and validation** | The experimental `--replay-mode {application,kernel}` surface and rejections with their error diagnostics. Replay execution stays disabled. | Mode selection and correct rejection. Existing application-replay output does not change. |
+| **2. Native-tool kernel replay** | Coalesced counter groups delivered to the SDK invocation; the multi-group admission check extended to admit kernel replay; `pass_count_cb` implemented from the per-agent profile-vector size; both filters applied; and diagnosed failure on a missing or unexpectedly empty counter profiles. | Replayed dispatches collect every bucket in one run, including valid one-bucket requests, while zero-bucket requests retain the existing bypass. Application replay keeps working throughout. |
+| **3. Consolidated output and dispatch ID** | One consolidated counter result using the existing naming convention, cross-pass timestamp and dispatch ID normalization. | Analysis consumes kernel-replay profiling output; Top Stats and dispatch information report non-multiplied values. |
 
 ## Validation, security and debuggability
 
 ### Validation
 
-Validation spans the CLI, the kernel-replay adapter, replay-profile construction, output
-normalization, and the analysis boundary that should not have moved.
-
-| # | Check | Pass criterion | Covers |
-| --- | --- | --- | --- |
-| 1 | **Counter accuracy** | Use a deterministic request producing more than one bucket. For each logical dispatch and state covered by the equivalence guarantee, every kernel-replay bucket matches its corresponding application-replay bucket. A single-bucket run or a comparison with no corresponding application-replay values is not evidence for NFR-1. Any mismatch is a failure. Evaluate cache-sensitive counters separately, as a documented limitation. | NFR-1, Replay coverage and limitations |
-| 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every bucket appears exactly once, and all pass rows collapse into one complete `Dispatch_ID`. Multiple counter groups are admitted in kernel mode without iteration multiplexing, and the consolidated result uses and is discovered through the existing naming convention. Incomplete results fail before analysis; a zero-bucket request bypasses this check. | FR-2, FR-5, FR-7, FR-8 |
-| 3 | **Filtering** | The existing 1-based, per-kernel logical-occurrence index advances once for every observed dispatch of that kernel, including replay-ineligible submissions, and never once per replay pass. Kernel and dispatch exclusions take the ordinary no-snapshot path and are read as neither missing-profile failures nor incomplete replay results. The same `--dispatch` range selects the same per-kernel occurrences in both replay modes. | FR-12, FR-13 |
-| 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values subject to NFR-1, counter completeness, and final analysis results agree, and existing application replay is unchanged. | FR-4, FR-9, NFR-1, NFR-3 |
-| 5 | **Service composition** | Verify independently that tracing emits one pass-0 record per logical dispatch and that consolidated counter data feeds Top Stats and dispatch information one logical dispatch with one non-multiplied pass-0 duration. Trace suppression alone does not satisfy this check. | FR-8, FR-10 |
-| 6 | **PC sampling composition** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. | FR-6 |
-| 7 | **Compatibility** | Every accepted option behaves — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective-desynchronization risk without describing repeated workload launches or recommending iteration multiplexing, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. | FR-1, FR-11, FR-14 |
-| 8 | **Configuration rejection** | Each unmet native-tool condition on its own — declined native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | FR-3 |
-| 9 | **Failure paths** | An unsupported SDK, a missing or unexpectedly empty profile vector when counters were requested, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. A zero-bucket request follows the existing bypass and is not misclassified as a missing-profile failure. | FR-2, FR-15, FR-16, FR-17, FR-18, NFR-2 |
-| 10 | **Diagnostics** | Every run identifies the replay mode and the bucket-to-pass mapping; every failure names its specific condition. | — |
+| # | Check | Pass criterion |
+| --- | --- | --- |
+| 1 | **Counter accuracy** | For a deterministic workload requesting more than one bucket; for each logical dispatch, every kernel-replay counter value matches its corresponding application-replay counter value. Evaluate cache-sensitive counters separately, as a documented limitation. |
+| 2 | **Completeness and identity** | For each admitted dispatch, including an admitted one-bucket dispatch, the observed counter-pass count equals the application-replay count, every counter appears exactly once, and all passes collapse to one `Dispatch_ID`. Incomplete results fail before analysis. |
+| 3 | **Filtering** | Kernel and dispatch excluded kernels are not profiled and no errors are thrown. The same `--dispatch` range selects the same dispatches in both replay modes. | 
+| 4 | **Application-replay comparison** | Profile the same deterministic workload and multi-bucket counter request in both modes. Compare corresponding buckets for each logical dispatch; bucket membership, counter values, and final analysis results agree, and existing application replay is unchanged. |
+| 5 | **Kernel tracing** | Verify independently that kernel tracing emits one pass-0 record per logical dispatch and that is used for kernel duration in analysis. | 
+| 6 | **PC sampling** | Each admitted dispatch replays *N*+1 times. Every bucket appears exactly once across passes 0 through *N*−1, and pass *N* produces PC sampling output and no counter rows. |
+| 7 | **Compatibility** | Every accepted option behaves as expected — PC sampling, roofline selection, a kernel-replay-specific multi-rank diagnostic that names the collective kernel risk, and default-off — and every rejected combination is rejected: iteration multiplexing, live attach. |
+| 8 | **Configuration rejection** | Each unmet condition on its own — no native tool, unsupported ROCm version, unresolvable library — fails before profiling starts, with a diagnostic naming that specific condition. | 
+| 9 | **Failure paths** | An unsupported SDK, a missing or unexpectedly empty profile vector when counters were requested, a declined snapshot, and an upstream abort each fail, and each proves no one-pass fallback happened. A zero-bucket request follows the existing bypass and is not misclassified as a missing-profile failure. |
+| 10 | **Diagnostics** | Every run identifies the replay mode and names its specific condition. |
 
 ### Security
 
 - Kernel replay adds no network interface and no new privilege boundary.
 - Its one security-sensitive operation is the SDK-managed host snapshot of application device memory.
-  That snapshot can hold application data and can consume host memory comparable to the tracked
-  footprint. It stays inside the profiled process's trust boundary, and `rocprof-compute` must never
+  That snapshot hold application data and should stay inside the profiled process's trust boundary, and `rocprof-compute` must never
   persist its contents in result artifacts or print them in diagnostics.
 - Snapshot allocation and restore failures are availability failures, and follow the same fail-closed
   rule as every other incomplete replay condition.
 
 ### Debuggability
 
-| A diagnostic must identify | Why |
-| --- | --- |
-| Selected replay mode and backend | The two modes fail differently. The user needs to know which one ran. |
-| Multi-rank detection under kernel replay | The collective-desynchronization risk remains unresolved. The diagnostic must describe that risk rather than reuse application replay's repeated-launch warning or recommend an incompatible mode. |
-| SDK capability and agent | Version floors and agent homogeneity are both rejection causes. |
-| Bucket-to-pass mapping | The only way to confirm the derived pass count matches the request. |
-| Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort | Each has a different remedy. |
-| That partial results are unusable | Otherwise a user may try to analyze what was written before the failure. |
-| A recommendation of application replay, on snapshot decline | It is the working alternative for that specific failure. |
 
-A configuration diagnostic must name the specific unmet condition rather than reporting that the
-native tool is unavailable. One message covering both an unsupported ROCm version and an
-unresolvable library leaves the user with no action to take, because the remedy differs in each case.
+A diagnostic must name the specific unmet condition.
+
+| A diagnostic must identify |
+| --- | --- |
+| Selected replay mode and backend | 
+| Multi-rank detection under kernel replay |
+| SDK capability and agent | 
+| Counter-to-pass mapping |
+| Which failure occurred: option conflict, unavailable native collection, missing profile, snapshot decline, or upstream abort |
+| That partial results are unusable |
+| A recommendation of application replay, on snapshot decline |
 
 ## Open questions
 
-| # | Question | Why it matters | Blocks |
-| --- | --- | --- | --- |
-| 1 | Should kernel replay exclude dispatches taking part in inter-process collectives? | Replaying one rank's dispatch while its peers do not desynchronizes the collective. | Multi-rank support boundary (FR-14) |
-| 2 | Marker and ROCTx durations: reject the combination, or correct the duration? | The host emits these regions once, but they span every pass, so their durations include replay overhead and are not comparable with a non-replay run. | Marker/ROCTx composition |
-| 3 | Are cache-related metrics trustworthy at all under replay? | Nothing restores cache state between passes, so cache-sensitive counters vary by pass. | Scope of NFR-1 |
-| 4 | How should `rocprof-compute` detect a declined snapshot? | Today the only signal is classifying an upstream warning string, and the process status can still report success. | FR-16 |
+| # | Question | Why it matters |
+| --- | --- | --- |
+| 1 | Should kernel replay exclude collective kernels? | This will make multi-rank profiling with kernel possible but the metrics won't reflect the statistics for all kernel invocations. |
+| 2 | Marker durations: reject the combination, or correct the duration? | The host emits these regions once, but they span every pass, so their durations subsumes multiple kernel replay durations. |
+| 3 | Are cache-related metrics trustworthy at all under kernel replay? | Nothing restores cache state between passes, so cache-related counters do not represent the true cache behavior. | 
+| 4 | How should `rocprof-compute` detect a declined snapshot? | Today the only signal is classifying an upstream warning string, and the process status can still report success. |

--- a/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
+++ b/projects/rocprofiler-compute/docs/design/hld-kernel-replay.md
@@ -5,21 +5,23 @@
 ### Counter collection today
 
 `rocprof-compute` turns the metrics an analysis asks for into hardware counters, then packs those
-counters into groups small enough to fit a single hardware pass. However many groups fall out of
-that packing is how many counter-collection passes the run needs.
+counters into buckets — groups small enough to fit a single hardware pass. However many buckets fall
+out of that packing is how many counter-collection passes the run needs.
 
 `rocprof-compute` can preload its own **native collector**, which takes over counter collection
 while tracing runs in a separate context. The native collector is unavailable in two cases: the
 user declined it, or the installed ROCm predates the version that supports it.
 
 Every configuration consumes the same buckets. Application replay works across all of them.
-Iteration multiplexing already depends on the native collector and hard-errors without it.
+Iteration multiplexing already depends on the native collector and hard-errors without it. A
+**logical dispatch** is one kernel launch as the application issued it, however many times a replay
+strategy executes it.
 
 
 | Strategy | Execution model | What it covers | What it does not cover |
 | --- | --- | --- | --- |
-| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences, without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. Multi-bucket live attach is rejected, and communicating multi-rank workloads currently trigger a warning. |
-| **Iteration multiplexing** | Launch the workload once for counter collection and let the native collector rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set, and the whole strategy needs the native collector. |
+| **Application replay** | Launch and run the complete workload once per bucket, then combine the collected counters. | Collects every bucket across corresponding replayed dispatch occurrences, without estimating missing counters from other occurrences. | Repeats process startup, runtime initialization, host work, and the workload itself. `rocprof-compute` rejects multi-bucket live attach, and communicating multi-rank workloads currently trigger a warning. |
+| **Iteration multiplexing** | Launch the workload once for counter collection and let the native collector rotate buckets across different comparable dispatch occurrences. Analysis imputes the counters missing from each occurrence. | Avoids repeated application launches for workloads with enough dispatches. | Never collects every bucket from one logical dispatch. Undersampled kernels cannot produce a complete metric set, and iteration multiplexing needs the native collector. |
 
 That leaves application replay as the only strategy today that can satisfy a multi-bucket request
 without borrowing counters from neighbouring dispatches.
@@ -27,11 +29,10 @@ without borrowing counters from neighbouring dispatches.
 ### Co-active profiling services
 
 Counter collection never runs on its own. Every counter invocation has to produce kernel-dispatch
-records, because those records carry the kernel counts and durations. Under native collection the
-work is split: the native collector owns counters, while kernel dispatch tracing and marker or
-ROCTx tracing for a framework-selected run happen in a separate tracing context. That split matters
-here — the trace records come from a context the native collector can control but does not itself
-emit.
+records, because those records carry the kernel counts and durations. Native collection splits the
+work. The native collector owns counters; kernel dispatch tracing and marker or ROCTx tracing for a
+framework-selected run happen in a separate tracing context. That split matters here — the trace
+records come from a context the native collector can control but does not itself emit.
 
 The native collector also subscribes to code-object tracing, but those events describe load-time
 objects rather than individual dispatches, so kernel replay does not multiply them. PC sampling runs
@@ -99,8 +100,8 @@ sequenceDiagram
 ```
 
 The snapshot covers tracked, agent-owned, coarse-grained device allocations that are neither kernarg
-nor executable memory. Module-scope `__device__` and `__constant__` storage visible to the agent is
-discovered and captured separately. While a replay is active, ordinary dispatches take the reader
+nor executable memory. The SDK separately discovers and captures module-scope `__device__` and
+`__constant__` storage visible to the agent. While a replay is active, ordinary dispatches take the reader
 side of the same per-agent lock; replay windows on different agents still run concurrently.
 
 ## Problem statement
@@ -175,12 +176,12 @@ flowchart LR
   `application`, and require explicit selection of kernel replay. `--iteration-multiplexing` and its
   policy argument shall remain independent.
 - For *N* counter buckets, kernel-replay mode shall use one workload invocation for counter
-  collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. No
-  user-supplied pass count shall be required.
+  collection and collect one bucket in each of *N* passes for every replay-eligible dispatch. Kernel
+  replay shall not require a user-supplied pass count.
 - Kernel replay shall require the native collector. The `rocprofv3` backend and `--no-native-tool`
-  are unsupported configurations. When the selected configuration cannot supply the native
-  collector — because it was declined, or because the installed ROCm does not support it — kernel
-  replay shall produce a hard error naming the unmet condition, before any workload runs.
+  are unsupported configurations. The user may decline the native collector, or the installed ROCm
+  may not support it. In either case, kernel replay shall produce a hard error naming the unmet
+  condition before any workload runs.
 - Kernel replay shall preserve the counter bucket membership used by application replay. The pass
   count shall equal the bucket count, every bucket shall fit one hardware pass, and `_ACCUM`
   pairing, TCC grouping, and same-bucket priority shall remain unchanged.
@@ -215,13 +216,13 @@ flowchart LR
 - For state covered by the replay-equivalence guarantee, a counter present in more than one bucket
   shall have the same value across passes of the same dispatch. Cache-sensitive counters fall outside
   this invariant, because cache state is not restored.
-- Kernel replay shall fail closed whenever it cannot deliver a complete bucket set. Silently partial
-  counter data shall not be collected.
+- Kernel replay shall fail closed whenever it cannot deliver a complete bucket set. Kernel replay
+  shall not collect partial counter data silently.
 - Kernel replay shall guarantee equivalent replay state only for tracked coarse-grained VRAM and
   module-scope device or constant state. It shall make no equivalence guarantee for unified, managed,
   or `hipMallocAsync` memory, HIP graphs, multi-packet or multi-dispatch submissions, unfenced
-  asynchronous SDMA copies, or cache state, and may require host memory equal to the tracked device
-  footprint.
+  asynchronous SDMA copies, or cache state. It may also require host memory equal to the tracked
+  device footprint.
 - Workflows that do not select kernel replay shall keep their current collection behavior, and
   kernel-replay output shall preserve the existing analysis input contract.
 - Diagnostics shall identify the selected replay mode, the bucket-to-pass mapping, and the specific
@@ -249,8 +250,8 @@ replay pass *i* selects entry *i* from the same vector.
 
 A return value of one carries a specific meaning: "do not replay." It is not a safe fallback when an
 agent lookup fails or its vector turns out to be empty. Using it that way would execute the dispatch
-once, collect a single bucket, and present incomplete data as a success. A missing or empty vector
-has to diagnose the agent/profile mismatch and fail the whole profile instead.
+once, collect a single bucket, and present incomplete data as a success. On a missing or empty
+vector, the collector has to diagnose the agent/profile mismatch and fail the whole profile instead.
 
 The component diagram shows both counter and kernel-trace data, and where each one crosses the
 collector boundary.
@@ -295,10 +296,10 @@ graph LR
 
 `pass_count_cb` doubles as the filter decision point, because it runs exactly once per logical
 dispatch and before any replay pass. Before picking a count, the collector confirms the dispatch's
-agent has a non-empty profile vector. It then assigns the dispatch's per-kernel logical index — once,
-and only here — evaluates the kernel-ID target set built during code-object loading along with the
-requested dispatch range, and returns the profile-vector size only if both filters admit the
-dispatch. A confirmed filter miss returns one, deliberately choosing the SDK's ordinary path with no
+agent has a non-empty profile vector. It then assigns the dispatch's per-kernel logical index, once
+and only here. Next it evaluates two filters: the kernel-ID target set built during code-object
+loading, and the requested dispatch range. It returns the profile-vector size only if both filters
+admit the dispatch. A confirmed filter miss returns one, deliberately choosing the SDK's ordinary path with no
 snapshot and no restore. A missing or empty profile vector stays a fatal profile error and must never
 borrow that return value.
 
@@ -313,8 +314,8 @@ replay result.
 One kernel-replay counter invocation produces one consolidated `results_*.csv` artifact.
 
 Before that artifact is written, every pass row for a logical dispatch has to receive one
-`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity can be kept around
-transiently for normalization and diagnostics, but it does not need to reach `pmc_perf.csv`.
+`Dispatch_ID` and one canonical start/end timestamp pair. Pass identity may survive transiently for
+normalization and diagnostics, but it does not need to reach `pmc_perf.csv`.
 Non-replay identity behavior is untouched.
 
 Application replay lines up corresponding dispatches because each workload invocation restarts
@@ -333,10 +334,10 @@ Kernel dispatch tracing has to yield one record per logical dispatch regardless 
 Top Stats and `pmc_dispatch_info.csv` report the same dispatch count and duration they would without
 replay.
 
-Because the native collector owns its SDK contexts, the duplicate records are suppressed at the
-source instead of cleaned up afterwards: it traces pass 0 and locally stops the kernel-trace context
-for passes 1 through *N*−1. Pass 0 gets the honor because it is the only pass running against
-pristine pre-snapshot state. Every later pass starts immediately after a full restore of the tracked
+Because the native collector owns its SDK contexts, it can suppress the duplicate records at the
+source instead of cleaning them up afterwards. It traces pass 0 and locally stops the kernel-trace
+context for passes 1 through *N*−1. The collector picks pass 0 because it is the only pass running
+against pristine pre-snapshot state. Every later pass starts immediately after a full restore of the tracked
 footprint, so its timing says more about replay overhead than about the dispatch.
 
 Suppressing at the source is what makes this both cheap and exact. Nothing has to reconstruct which
@@ -350,32 +351,33 @@ open.
 ### Mode and option compatibility
 
 `--replay-mode` accepts `application` and `kernel`. Application replay stays the default, and CLI
-help flags kernel replay as experimental. The selected mode is carried down to the kernel-replay
-adapter; it does not turn `--iteration-multiplexing` into a mode selector.
+help flags kernel replay as experimental. `rocprof-compute` carries the selected mode down to the
+kernel-replay adapter. This does not turn `--iteration-multiplexing` into a mode selector.
 
 Kernel mode needs the native collector, and the conditions that supply one do not all become
 knowable at the same moment. So rejection happens in two places:
 
 - **Flag conflict**, decidable from the arguments alone: kernel replay selected while the native
-  collector is declined. Rejected immediately, before any discovery and before the workload directory
-  is created.
+  collector is declined. `rocprof-compute` rejects this immediately, before any discovery and before
+  it creates the workload directory.
 - **Capability failure**, decidable only once discovery has resolved the ROCm version and the
-  native library: an unsupported ROCm version, or a library that cannot be resolved. Rejected
-  later, but still before the workload runs.
+  native library: an unsupported ROCm version, or a library that cannot be resolved.
+  `rocprof-compute` rejects this later, but still before the workload runs.
 
-Both are hard errors. The split is not incidental — a reader needs to know that a capability failure
-leaves a workload directory behind, whereas a flag conflict leaves nothing.
+Both are hard errors. The split matters: a capability failure leaves a workload directory behind,
+whereas a flag conflict leaves nothing.
 
-Kernel mode is likewise rejected before profiling when it is combined with iteration multiplexing,
-live attach, or PC sampling. Iteration multiplexing loses out because both strategies claim the same
-per-dispatch passes, not because of any backend restriction — it needs the native collector too. PC
+`rocprof-compute` likewise rejects kernel mode before profiling when it appears alongside iteration
+multiplexing, live attach, or PC sampling. Kernel replay rejects iteration multiplexing because both
+strategies claim the same per-dispatch passes, not because of any backend restriction — iteration
+multiplexing needs the native collector too. PC
 sampling is agent-wide, does not consume the localized context override, and today runs in a separate
 counter-disabled invocation, so there is no supported replay pass to insert it into.
 
 `--roof-only`, `--set`, and `--block` continue through ordinary counter selection. Multi-rank
-profiling stays available and keeps its warning. On top of all that, kernel replay needs a supported
-SDK version and a homogeneous agent configuration. Whether collective-bearing dispatches have to be
-excluded is still an open question.
+profiling stays available and keeps its warning. Kernel replay also needs a supported SDK version
+and a homogeneous agent configuration. Whether kernel replay has to exclude collective-bearing
+dispatches is still an open question.
 
 ### Failure behavior
 
@@ -422,10 +424,10 @@ Proposed vertical slices for the implementation work ahead:
    with their hard-error diagnostics. Replay execution stays disabled in this slice, so the only
    observable behavior is mode selection and correct rejection — existing application-replay output
    does not change.
-- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation, implement
-   `pass_count_cb` from the per-agent profile-vector size, apply the kernel and dispatch filters at
-   that same decision point, and diagnose a missing or empty vector instead of returning one pass.
-   Application replay keeps working throughout.
+- **Native-collector replay.** Deliver the coalesced counter groups to the SDK invocation, and
+   implement `pass_count_cb` from the per-agent profile-vector size. Apply the kernel and dispatch
+   filters at that same decision point, and diagnose a missing or empty vector instead of returning
+   one pass. Application replay keeps working throughout.
 - **Consolidated output and dispatch identity.** Produce one consolidated `results_*.csv`, normalize
    cross-pass timestamps and identity so every pass of a logical dispatch resolves to one
    `Dispatch_ID`, and expose the single pass-0 trace record.
@@ -439,13 +441,13 @@ normalization, and the analysis boundary that should not have moved.
 
 - **Counter accuracy.** For one logical dispatch, and for state covered by the equivalence guarantee,
   a counter present in more than one bucket must report the same value in every pass. A mismatch is a
-  validation failure. Cache-sensitive counters need separate evaluation as a documented limitation.
+  validation failure. Evaluate cache-sensitive counters separately, as a documented limitation.
 - **Completeness and identity.** For each dispatch admitted by the replay filters, the observed pass
   count must equal the application replay count, every bucket must appear exactly once, and all pass
   rows must collapse into one complete `Dispatch_ID`. Incomplete results have to fail before
   analysis.
 - **Filtering.** Logical indices must advance once per dispatch, not once per pass. A confirmed
-  filter exclusion must take the ordinary no-snapshot path, and must not be misread as a
+  filter exclusion must take the ordinary no-snapshot path. Kernel replay must not misread it as a
   missing-profile failure or an incomplete replay result.
 - **Application-replay comparison.** Profile the same deterministic workload and counter request in
   both modes, then compare bucket membership, counter completeness, and final analysis results.
@@ -475,7 +477,7 @@ failures, and they follow the same fail-closed rule as every other incomplete re
 Run diagnostics have to identify the selected replay mode and backend, SDK capability, agent, and the
 mapping from every counter bucket to its replay pass. They also have to tell apart option conflicts,
 unavailable native collection, missing profiles, snapshot decline, and upstream abort — and say
-plainly that partial results are unusable. A snapshot-decline diagnostic additionally recommends
+plainly that partial results are unusable. A snapshot-decline diagnostic also recommends
 application replay.
 
 A configuration diagnostic has to name the specific unmet condition instead of reporting that the
@@ -485,10 +487,10 @@ each case.
 
 ## Open questions
 
-- **Collective-bearing kernels.** Should dispatches taking part in inter-process collectives be
-   excluded from kernel replay?
-- **Marker and ROCTx semantics.** Host regions are emitted once but span every replay pass, so their
-   durations include replay overhead and are not comparable with a non-replay run. Reject the
-   combination, or correct the duration?
-- **Cache-related counter validity.** Can cache-related metrics be trusted at all, given that cache
-   state is not restored between replay passes?
+- **Collective-bearing kernels.** Should kernel replay exclude dispatches taking part in
+   inter-process collectives?
+- **Marker and ROCTx semantics.** The host emits these regions once, but they span every replay
+   pass, so their durations include replay overhead and are not comparable with a non-replay run.
+   Reject the combination, or correct the duration?
+- **Cache-related counter validity.** Are cache-related metrics trustworthy at all, when nothing
+   restores cache state between replay passes?


### PR DESCRIPTION
## Motivation

Multi-bucket counter requests currently require full application replay, repeating process startup, host work, and kernel invocationfor every bucket. This HLD defines an opt-in kernel-replay design that collects one bucket per dispatch pass within a single workload invocation while preserving application replay as the default.

## Technical Details

- Define `--replay-mode` behavior and compatibility across the native collector, `rocprofiler-sdk`, and `rocprofv3` backends.
- Preserve application-replay counter buckets while deriving replay passes from per-agent profiles and failing closed when profiles or snapshots are unavailable.
- Normalize cross-pass dispatch identity and timestamps, and reduce replay-multiplied trace records to one logical dispatch for existing analysis inputs.
- Evaluate native kernel and dispatch filters before replay so excluded work avoids snapshot and restore costs.
- Document replay state limits, implementation phases, validation, security, diagnostics, and unresolved service semantics.

## JIRA ID

ISSUE ID: AIPROFCOMP-666

## PR Stack

<!-- rocprof-compute-stack:start -->
<!-- stack-position: 1/1 -->
<!-- stack-current: standalone|users/abchoudh/kernel_replay_hld -->
<!-- stack-previous: none -->
<!-- stack-next: none -->
<!-- stack-jira: AIPROFCOMP-666 -->
<!-- stack-entry: 1|standalone|users/abchoudh/kernel_replay_hld|self -->
1. **standalone** — `users/abchoudh/kernel_replay_hld` (current)
<!-- rocprof-compute-stack:end -->

## Test Plan

- [x] Run workload: git diff --check origin/rocprofiler-compute-develop...HEAD

## Test Result

- [x] workload: git diff --check origin/rocprofiler-compute-develop...HEAD passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.