### PR TITLE
test(hip-tests): scope AQL barrier log checks to event_wait window

### DIFF
--- a/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
@@ -362,10 +362,26 @@ HIP_TEST_CASE(Unit_hipStreamAqlBarrierBit_Scenarios) {
     REQUIRE(dispatchBarrierBitForWorkgroup(log, 18) == 0);
     REQUIRE(dispatchBarrierBitForWorkgroup(log, 19) == 1);
 
+    // Runtime init also emits barrier packets before the scenario kernels run.
+    // Scope collection to the event record/wait pair between wg18 and wg19.
+    const std::string wg18_token = "workgroup=[18, 1, 1]";
+    const std::string wg19_token = "workgroup=[19, 1, 1]";
     std::vector<int> barrier_bits;
     std::istringstream log_lines(log);
     std::string log_line;
+    bool after_wg18_dispatch = false;
     while (std::getline(log_lines, log_line)) {
+      if (!after_wg18_dispatch) {
+        if (log_line.find("Dispatch Header") != std::string::npos &&
+            log_line.find(wg18_token) != std::string::npos) {
+          after_wg18_dispatch = true;
+        }
+        continue;
+      }
+      if (log_line.find("Dispatch Header") != std::string::npos &&
+          log_line.find(wg19_token) != std::string::npos) {
+        break;
+      }
       if (log_line.find("Barrier-AND Header") == std::string::npos &&
           log_line.find("BarrierValue Header") == std::string::npos) {
         continue;
@@ -377,7 +393,7 @@ HIP_TEST_CASE(Unit_hipStreamAqlBarrierBit_Scenarios) {
         barrier_bits.push_back(1);
       }
     }
-    REQUIRE(barrier_bits.size() >= 2);
+    REQUIRE(barrier_bits.size() == 2);
     REQUIRE(barrier_bits[0] == 1);
     REQUIRE(barrier_bits[1] == 0);
   }


### PR DESCRIPTION
Runtime initialization can emit barrier packets before scenario kernels, which made the event_wait section falsely fail on noisy builds (e.g. ASAN) when it scanned the first two barrier lines in the full log.

## Motivation
The event_wait section scanned the first two barrier lines in the full AQL log. Runtime init also emits barrier packets, so ASAN/noisy builds saw init barrier=1 lines before the scenario and failed barrier_bits[1] == 0 even though runtime behavior was correct.

## Technical Details
Scope barrier-bit collection to the log window between the wg=18 and wg=19 dispatch lines, so only the hipEventRecord / hipStreamWaitEvent sync pair is checked. Test-only change; no CLR/runtime changes.


## Issue Tracking
JIRA ID: ROCM-29764

## Test Plan
Run Unit_hipStreamAqlBarrierBit_Scenarios on BM and ASAN with GPU_MAX_HW_QUEUES=1 and DEBUG_CLR_AQL_BARRIER_OPT=1.

## Test Result
Passed on BM and ASAN/TheRock build (Unit_hipStreamAqlBarrierBit_Scenarios, all sections).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
