### PR TITLE
fix(clr): free interop image descriptor after failed import

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -740,11 +740,11 @@ void Buffer::destroy() {
     return;
   }
 
+  // The root buffer owns this descriptor even if interop mapping failed before
+  // kind_ could be changed to MEMORY_KIND_INTEROP.
+  freeInteropImageDescriptor();
+
   if (kind_ == MEMORY_KIND_INTEROP) {
-    // Owns the interop image descriptor allocated in Buffer::create for swizzle-metadata SRD
-    // reconstruction. Image views borrow it and early-return in Image::destroy without freeing,
-    // and the backing buffer is torn down after its views, so freeing it here is safe.
-    freeInteropImageDescriptor();
     destroyInteropBuffer();
     return;
   }


### PR DESCRIPTION
## Motivation

Contract_ExternalResource_HipImportExternalMemory_ImportMemoryInvalidFd_IsRejected leaks in asan build.

## Technical Details

The descriptor cleanup should occur for an owning root buffer regardless of whether interop mapping succeeded. kind_ is assigned only after a successful import, and due to that it wasn't properly freed.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID : ROCM-29761

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run Contract_ExternalResource_HipImportExternalMemory_ImportMemoryInvalidFd_IsRejected  with asan.

## Test Result

<!-- Briefly summarize test outcomes. -->
No leaks observed, test is passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
