### PR TITLE
feat(rocprofiler-compute): remove legacy results CSV analyze path and regen golden workloads

### DIFF
--- a/projects/rocprofiler-compute/.gitignore
+++ b/projects/rocprofiler-compute/.gitignore
@@ -19,6 +19,8 @@ pmc_kernel_top.csv
 VERSION.sha
 **/_build
 **/out
+!tests/workloads/**/out/
+!tests/workloads/**/out/**
 
 # temp files
 /tests/Testing

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -21,12 +21,15 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * gfx950: added LDS Read/Write/Atomic instruction counts and per-channel bandwidth for HBM, xGMI, and PCIe.
 
 * Profile mode retains per-process rocpd databases and native counter CSVs under ``out/{pass}/`` instead of converting them to ``results_*.csv.gz``.
-* Analyze mode merges profile artifacts from ``out/`` into ``pmc_perf.csv.gz``. Workloads that still carry ``results_*.csv.gz`` remain readable until golden workloads are regenerated.
+* Analyze mode merges profile artifacts from ``out/`` into ``pmc_perf.csv.gz``.
+
+* Regenerated MI350 golden workloads (``vcopy``, ``no_roof``, ``vcopy_iteration_multiplexing``) to the ``out/{pass}/`` artifact layout.
 
 ### Removed
 
 * Removed the ``--retain-rocpd-output`` profile option. Per-process ``.db`` files are retained automatically under ``out/``.
 * Removed intermediate ``results_*.csv.gz`` generation during profiling and profile-side native counter injection into rocpd databases.
+* Removed analyze-mode support for legacy ``results_*.csv.gz`` workloads, including the ``concat_result_csvs`` join path.
 
 ### Optimized
 

--- a/projects/rocprofiler-compute/docs/design/profile_interface_architecture.md
+++ b/projects/rocprofiler-compute/docs/design/profile_interface_architecture.md
@@ -444,8 +444,10 @@ Implementation notes:
   `compact_pass_rocpd_dbs` drops unused `rocpd_info_pmc` / `rocpd_pmc_event`
   catalog data and vacuums the database (~15 MiB → ~1 MiB per pass); analyze
   is unchanged (kernel metadata from DB, counters from CSV).
-- Analyze still accepts legacy `results_*.csv.gz` workloads until golden fixtures
-  are regenerated in a follow-up change.
+- Golden workloads must use the `out/{pass}/` layout; legacy `results_*.csv.gz`
+  is no longer read by analyze.
+- Remaining golden workloads still carry legacy artifacts until re-profiled on
+  matching hardware.
 
 ```mermaid
 sequenceDiagram

--- a/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
@@ -24,11 +24,6 @@ choose.
    ``pmc_perf.csv.gz`` for analysis. If the workload directory already contains a
    ``pmc_perf.csv.gz``, that file is used as-is.
 
-.. note::
-
-   Reading legacy ``results_*.csv.gz`` artifacts is deprecated and will be
-   removed once golden workloads are regenerated.
-
 See the following sections to explore ROCm Compute Profiler's analysis and visualization
 options.
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -400,12 +400,6 @@ Raw performance counter data produced by the underlying
 * Analyze merges those artifacts into a single gzip-compressed ``pmc_perf.csv.gz``
   when you run ``rocprof-compute analyze``.
 
-.. note::
-
-   Workloads profiled before this release may still carry ``results_*.csv.gz``
-   files. Analyze accepts those until the workload is re-profiled.
-
-
 .. _filtering:
 
 Filtering

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -3,7 +3,6 @@
 
 import argparse
 import copy
-import csv
 import re
 import sqlite3
 import sys
@@ -377,67 +376,6 @@ class OmniAnalyze_Base:
             )
 
     @demarcate
-    def concat_result_csvs(self, result_files: list[Path], output_file: Path) -> None:
-        """Vertically concatenate rocpd ``results_*.csv.gz`` files into one CSV.
-
-        Every file shares the long-form header rocpd writes, so the header is
-        taken from the first non-empty file and the remaining rows are appended.
-
-        Args:
-            result_files: The results_*.csv.gz files to concatenate
-            output_file: Destination gzip CSV
-        """
-        console_warning(
-            "Reading intermediate results_*.csv.gz files is deprecated and "
-            "will be removed in a future release."
-        )
-
-        rows_written = 0
-        with csv_compression.open_gzip_csv_write(output_file) as outfile:
-            writer = None
-            for file in result_files:
-                # Corruption comes from the source read, not the gzip write.
-                try:
-                    with csv_compression.open_gzip_csv_read(file) as infile:
-                        reader = csv.reader(infile)
-                        header = next(reader, None)
-                        if header is None:
-                            console_warning(f"Skipping empty {file}")
-                            continue
-                        if "Counter_Name" not in header:
-                            output_file.unlink(missing_ok=True)
-                            console_error(
-                                f"{file} is not in the supported rocpd format. "
-                                "Please re-profile this workload with a current "
-                                "release."
-                            )
-                        if writer is None:
-                            writer = csv.writer(outfile)
-                            writer.writerow(header)
-                        for row in reader:
-                            writer.writerow(row)
-                            rows_written += 1
-                except csv_compression.CORRUPT_CSV_ERRORS as e:
-                    # Drop the partial output built from earlier files.
-                    output_file.unlink(missing_ok=True)
-                    console_error(
-                        f"{file} is truncated or corrupt: {e}\n"
-                        "A profile run killed mid-write leaves this behind; "
-                        "re-run 'rocprof-compute profile' to regenerate the "
-                        "workload."
-                    )
-
-        # A header-only output would be reused by later analyze runs.
-        if rows_written == 0:
-            output_file.unlink(missing_ok=True)
-            console_error(
-                f"No counter data in results_*.csv.gz under {output_file.parent}.\n"
-                f"Please re-run 'rocprof-compute profile'."
-            )
-
-        console_debug(f"Created file: {output_file} ({rows_written} counter rows)")
-
-    @demarcate
     def merge_profile_artifacts(self, workload_dir: Path, output_file: Path) -> None:
         """Merge per-process profile artifacts into one gzip CSV."""
         try:
@@ -464,10 +402,8 @@ class OmniAnalyze_Base:
         console_debug(f"Created file: {output_file} ({rows_written} counter rows)")
 
     def join_workload_csvs(self, workload_dir: Path) -> None:
-        """Build pmc_perf.csv.gz from profile artifacts or legacy results CSVs."""
+        """Build pmc_perf.csv.gz from profile artifacts under ``out/``."""
         pmc_perf = csv_compression.compressed_name(workload_dir / "pmc_perf.csv")
-        results_glob = f"results_*.csv{csv_compression.GZIP_SUFFIX}"
-        result_files = sorted(workload_dir.glob(results_glob))
 
         if pmc_perf.exists() and pmc_perf.stat().st_size > 0:
             console_debug(f"Using existing {pmc_perf}")
@@ -475,15 +411,16 @@ class OmniAnalyze_Base:
             console_log(f"Merging profile artifacts for {workload_dir}...")
             self.merge_profile_artifacts(workload_dir, pmc_perf)
             console_log(f"Created {pmc_perf}")
-        elif result_files:
-            console_log(f"Joining {results_glob} for {workload_dir}...")
-            self.concat_result_csvs(result_files, pmc_perf)
-            console_log(f"Created {pmc_perf}")
+        elif sorted(workload_dir.glob(f"results_*.csv{csv_compression.GZIP_SUFFIX}")):
+            console_error(
+                f"Legacy results_*.csv.gz found in {workload_dir}.\n"
+                "These workloads are no longer supported; re-run "
+                "'rocprof-compute profile' to regenerate them."
+            )
         else:
             console_error(
                 f"No profiling data found in {workload_dir}.\n"
-                f"Expected: {pmc_perf.name}, {rocpd_data.OUT_DIR}/ artifacts, "
-                f"or {results_glob}\n"
+                f"Expected: {pmc_perf.name} or {rocpd_data.OUT_DIR}/ artifacts.\n"
                 f"Please run 'rocprof-compute profile' first."
             )
 
@@ -529,7 +466,7 @@ class OmniAnalyze_Base:
                 setattr(self._runs[path_info[0]], attr_name, filter_value)
 
         if not self.pc_sampling_only():
-            # Join results_*.csv.gz source files into pmc_perf.csv.gz if needed
+            # Merge out/ profile artifacts into pmc_perf.csv.gz if needed
             for path_info in args.path:
                 workload_dir = Path(path_info[0])
                 self.join_workload_csvs(workload_dir)

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
@@ -57,7 +57,7 @@ class tui_analysis(OmniAnalyze_Base):
             )
             return
 
-        # Join results_*.csv.gz source files into pmc_perf.csv.gz if needed
+        # Merge out/ profile artifacts into pmc_perf.csv.gz if needed
         self.join_workload_csvs(Path(self.path))
 
         workload.raw_pmc = file_io.create_df_pmc(

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -590,17 +590,25 @@ def validate_workload(path: str) -> None:
     workload_dir = Path(path)
     pmc_perf_path = csv_compression.compressed_name(workload_dir / "pmc_perf.csv")
 
-    # Find PMC data files (merged or separate)
+    if rocpd_data.pass_dirs(workload_dir):
+        return
+
     if pmc_perf_path.is_file():
         files_to_check = [pmc_perf_path]
-    elif rocpd_data.pass_dirs(workload_dir):
-        return
     else:
-        files_to_check = sorted(
-            workload_dir.glob(f"results_*.csv{csv_compression.GZIP_SUFFIX}")
-        )
+        files_to_check = []
 
     if not files_to_check:
+        legacy_results = sorted(
+            workload_dir.glob(f"results_*.csv{csv_compression.GZIP_SUFFIX}")
+        )
+        if legacy_results:
+            console_error(
+                "analysis",
+                "Legacy results_*.csv.gz workloads are no longer supported.\n"
+                "Re-run 'rocprof-compute profile' to regenerate the workload.",
+            )
+            return
         console_error("analysis", "No profiling data found.")
         return
 

--- a/projects/rocprofiler-compute/tests/integration/common.py
+++ b/projects/rocprofiler-compute/tests/integration/common.py
@@ -25,6 +25,7 @@ import pytest
 import yaml
 from common import SUPPORTED_ARCHS
 
+from utils import rocpd_data
 from utils.utils_common import canonical_config_arch
 
 # Runtime config options
@@ -193,6 +194,29 @@ def setup_workload_dir(input_dir, suffix="_tmp", clean_existing=True, param_id=N
     return output_dir
 
 
+def profile_artifact_files(output_dir):
+    """Return searchable profile artifact paths under ``out/``."""
+    out_dir = Path(output_dir) / rocpd_data.OUT_DIR
+    if not out_dir.is_dir():
+        return []
+    return sorted(
+        path
+        for path in out_dir.rglob("*")
+        if path.is_file() and path.suffix in (".csv", ".gz", ".db")
+    )
+
+
+def load_profile_counter_df(output_dir):
+    """Load counter rows from ``pmc_perf.csv.gz`` or ``out/`` profile artifacts."""
+    pmc_perf = Path(output_dir) / "pmc_perf.csv.gz"
+    if pmc_perf.is_file() and pmc_perf.stat().st_size > 0:
+        return pd.read_csv(pmc_perf)
+    rows = list(rocpd_data.iter_workload_rows(output_dir))
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows)
+
+
 def check_csv_files(output_dir, num_devices, num_kernels):
     """Check profiling output csv files for expected
     number of entries (based on kernel invocations)
@@ -205,35 +229,28 @@ def check_csv_files(output_dir, num_devices, num_kernels):
         dict: dictionary housing file contents as pandas dataframe
               (excludes PMC files - those are validated internally)
     """
-    files_in_workload = os.listdir(output_dir)
+    workload_path = Path(output_dir)
+    pass_paths = rocpd_data.pass_dirs(workload_path)
+    pmc_perf = workload_path / "pmc_perf.csv.gz"
+    has_pmc_perf = pmc_perf.is_file() and pmc_perf.stat().st_size > 0
 
-    # Profile counter artifacts are gzip; sysinfo.csv and the other plain
-    # profile CSVs are not.
-    def is_csv(name):
-        if name.startswith("results_"):
-            return name.endswith(".csv.gz")
-        return name.endswith(".csv")
-
-    # Validate PMC data exists (profile creates pmc_perf_*.csv or results_*.csv.gz)
-    has_separate = any(
-        f.startswith("pmc_perf_") and is_csv(f) for f in files_in_workload
-    )
-    has_results = any(f.startswith("results_") and is_csv(f) for f in files_in_workload)
-
-    assert has_separate or has_results, (
-        "Expected pmc_perf_*.csv or results_*.csv.gz from profile mode"
+    assert pass_paths or has_pmc_perf, (
+        "Expected out/{pass}/ profile artifacts or pmc_perf.csv.gz from profile mode"
     )
 
-    # Validate row counts for PMC files (but don't add to return dict)
-    for file in files_in_workload:
-        is_pmc = file.startswith("pmc_perf_") or file.startswith("results_")
-        if is_pmc and is_csv(file):
-            df = pd.read_csv(output_dir + "/" + file)
-            err_msg = (
-                f"PMC file {file} has insufficient rows: "
-                f"{len(df.index)} < {num_kernels}"
-            )
-            assert len(df.index) >= num_kernels, err_msg
+    if pass_paths:
+        row_count = sum(1 for _ in rocpd_data.iter_workload_rows(workload_path))
+        err_msg = (
+            f"Profile artifacts have insufficient counter rows: "
+            f"{row_count} < {num_kernels}"
+        )
+        assert row_count >= num_kernels, err_msg
+    else:
+        df = pd.read_csv(pmc_perf)
+        err_msg = (
+            f"pmc_perf.csv.gz has insufficient rows: {len(df.index)} < {num_kernels}"
+        )
+        assert len(df.index) >= num_kernels, err_msg
 
     # Check and return non-PMC files
     return check_non_pmc_files(output_dir, num_devices, num_kernels)
@@ -256,8 +273,8 @@ def check_non_pmc_files(output_dir, num_devices, num_kernels):
 
     # Load non-PMC files into return dict
     for file in files_in_workload:
-        # Skip PMC files, already validated above
-        if file.startswith("pmc_perf_") or file.startswith("results_"):
+        # Skip merged PMC output and profile artifact tree
+        if file == "pmc_perf.csv.gz" or file == rocpd_data.OUT_DIR:
             continue
 
         if file.endswith(".csv"):

--- a/projects/rocprofiler-compute/tests/integration/test_profile_path.py
+++ b/projects/rocprofiler-compute/tests/integration/test_profile_path.py
@@ -80,7 +80,7 @@ def test_path_rocpd(
     workload_dir = common.get_output_dir()
     binary_handler_profile_rocprof_compute(config, workload_dir)
 
-    # Validate profile outputs (results_*.csv for rocpd format)
+    # Validate profile outputs (out/{pass}/ artifacts)
     integration_common.check_csv_files(workload_dir, num_devices, num_kernels)
 
     # Run analyze to create merged pmc_perf.csv.gz

--- a/projects/rocprofiler-compute/tests/integration/test_profile_section.py
+++ b/projects/rocprofiler-compute/tests/integration/test_profile_section.py
@@ -37,8 +37,8 @@ def test_lds_section(binary_handler_profile_rocprof_compute):
         f"- '{lds_block}'", f"{workload_dir}/profiling_config.yaml"
     )
     lds_counter = "TX_VMW_LDS_INPUT_ACTIVE" if is_gfx1250_soc() else "SQ_INSTS_LDS"
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
-    assert any(common.check_file_pattern(lds_counter, str(f)) for f in results_files)
+    artifact_files = integration_common.profile_artifact_files(workload_dir)
+    assert any(common.check_file_pattern(lds_counter, str(f)) for f in artifact_files)
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 
@@ -63,13 +63,13 @@ def test_instmix_memchart_section(binary_handler_profile_rocprof_compute):
     )
     assert common.check_file_pattern("- '3'", f"{workload_dir}/profiling_config.yaml")
     instmix_counter = "SQ_INSTS_FLAT" if rdna_or_gfx1250 else "TA_FLAT_WAVEFRONTS"
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
+    artifact_files = integration_common.profile_artifact_files(workload_dir)
     assert any(
-        common.check_file_pattern(instmix_counter, str(f)) for f in results_files
+        common.check_file_pattern(instmix_counter, str(f)) for f in artifact_files
     )
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
     assert any(
-        common.check_file_pattern("SQC_TC_DATA_READ_REQ", str(f)) for f in results_files
+        common.check_file_pattern("SQC_TC_DATA_READ_REQ", str(f))
+        for f in artifact_files
     )
     common.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -98,9 +98,9 @@ def test_lds_sol_section(binary_handler_profile_rocprof_compute):
         lds_sol_counter = "TX_VMW_LDS_INPUT_ACTIVE"
     else:
         lds_sol_counter = "SQ_ACTIVE_INST_LDS"
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
+    artifact_files = integration_common.profile_artifact_files(workload_dir)
     assert any(
-        common.check_file_pattern(lds_sol_counter, str(f)) for f in results_files
+        common.check_file_pattern(lds_sol_counter, str(f)) for f in artifact_files
     )
     common.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -133,13 +133,15 @@ def test_instmix_section_global_write_kernel(binary_handler_profile_rocprof_comp
         "- global_write", f"{workload_dir}/profiling_config.yaml"
     )
     kernel_counter = "SQ_INSTS_FLAT_STORE" if rdna_or_gfx1250 else "TA_FLAT_WAVEFRONTS"
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
-    assert any(common.check_file_pattern(kernel_counter, str(f)) for f in results_files)
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
-    assert any(common.check_file_pattern("global_write", str(f)) for f in results_files)
-    results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
+    artifact_files = integration_common.profile_artifact_files(workload_dir)
+    assert any(
+        common.check_file_pattern(kernel_counter, str(f)) for f in artifact_files
+    )
+    assert any(
+        common.check_file_pattern("global_write", str(f)) for f in artifact_files
+    )
     assert not any(
-        common.check_file_pattern("global_read", str(f)) for f in results_files
+        common.check_file_pattern("global_read", str(f)) for f in artifact_files
     )
     common.clean_output_dir(config["cleanup"], workload_dir)
 

--- a/projects/rocprofiler-compute/tests/integration/test_profile_torch_trace.py
+++ b/projects/rocprofiler-compute/tests/integration/test_profile_torch_trace.py
@@ -382,12 +382,7 @@ def test_torch_trace_overhead(binary_handler_profile_rocprof_compute):
     assert returncode_baseline == 0, "Baseline profiling failed"
 
     # Read baseline timestamps
-    baseline_results_files = sorted(
-        Path(workload_dir_baseline).glob("results_*.csv.gz")
-    )
-    baseline_df = pd.concat(
-        [pd.read_csv(f) for f in baseline_results_files], ignore_index=True
-    )
+    baseline_df = integration_common.load_profile_counter_df(workload_dir_baseline)
     baseline_kernel_duration_total = (
         baseline_df["End_Timestamp"].max() - baseline_df["Start_Timestamp"].min()
     )
@@ -406,12 +401,7 @@ def test_torch_trace_overhead(binary_handler_profile_rocprof_compute):
     with_flag_time = time.time() - start_with_flag
     assert returncode_with_flag == 0, "Profiling with torch-trace failed"
     # Read with-flag timestamps
-    with_flag_results_files = sorted(
-        Path(workload_dir_with_flag).glob("results_*.csv.gz")
-    )
-    with_flag_df = pd.concat(
-        [pd.read_csv(f) for f in with_flag_results_files], ignore_index=True
-    )
+    with_flag_df = integration_common.load_profile_counter_df(workload_dir_with_flag)
     with_flag_kernel_duration_total = (
         with_flag_df["End_Timestamp"].max() - with_flag_df["Start_Timestamp"].min()
     )
@@ -630,8 +620,7 @@ def test_torch_trace_deep_tensor_wraps_overhead(
             elapsed = time.time() - start
             assert returncode == 0, "torch-trace profiling run failed"
 
-            results_files = sorted(Path(workload_dir).glob("results_*.csv.gz"))
-            df = pd.concat([pd.read_csv(f) for f in results_files], ignore_index=True)
+            df = integration_common.load_profile_counter_df(workload_dir)
             kernel_duration_total = (
                 df["End_Timestamp"].max() - df["Start_Timestamp"].min()
             )

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -12,155 +12,98 @@ import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from tests.unit.utils.test_rocpd_data import create_rocpd_test_db
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
 
-def _write_results_gz(path: Path, content: str) -> None:
-    with gzip.open(path, "wt", encoding="utf-8") as f:
-        f.write(content)
+def _write_out_pass_db(
+    tmp_path: Path, fbase: str = "pmc_perf_0", pid: str = "100"
+) -> Path:
+    pass_path = tmp_path / "out" / fbase / pid
+    pass_path.mkdir(parents=True)
+    db_path = create_rocpd_test_db(str(pass_path))
+    Path(db_path).rename(pass_path / f"{pid}.db")
+    return pass_path
 
 
-def test_concat_result_csvs_concatenates_rocpd_results(tmp_path, monkeypatch) -> None:
-    """Concatenates rocpd long-form results_*.csv.gz into one pmc_perf.csv.gz."""
+def test_merge_profile_artifacts_writes_pmc_perf(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "warning")
 
-    header = "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n"
-    _write_results_gz(
-        tmp_path / "results_pmc_perf_0.csv.gz",
-        header + "0,kernel_a,SQ_WAVES,10\n0,kernel_a,SQ_WAVES,20\n",
-    )
-    _write_results_gz(
-        tmp_path / "results_pmc_perf_1.csv.gz",
-        header + "0,kernel_a,SQ_BUSY_CYCLES,30\n",
-    )
+    _write_out_pass_db(tmp_path)
 
     inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
-    inst.concat_result_csvs(
-        sorted(tmp_path.glob("results_*.csv.gz")), tmp_path / "pmc_perf.csv.gz"
-    )
+    inst.merge_profile_artifacts(tmp_path, tmp_path / "pmc_perf.csv.gz")
     merged = pd.read_csv(tmp_path / "pmc_perf.csv.gz")
 
-    assert list(merged.columns) == [
-        "GPU_ID",
-        "Kernel_Name",
-        "Counter_Name",
-        "Counter_Value",
-    ]
+    assert "Counter_Name" in merged.columns
     assert len(merged) == 3
-    assert set(merged["Counter_Name"]) == {"SQ_WAVES", "SQ_BUSY_CYCLES"}
-    assert sorted(merged["Counter_Value"].tolist()) == [10, 20, 30]
+    assert set(merged["Counter_Name"]) == {"SQ_WAVES"}
 
 
-def test_concat_result_csvs_skips_empty_and_errors_when_all_empty(
-    tmp_path, monkeypatch
-) -> None:
-    mocks = common.patch_console(monkeypatch, MODULE, "debug", "warning")
-    (tmp_path / "results_pmc_perf_0.csv.gz").write_bytes(b"")
-    (tmp_path / "results_pmc_perf_1.csv.gz").write_bytes(b"")
-
-    inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
-    with pytest.raises(SystemExit):
-        inst.concat_result_csvs(
-            sorted(tmp_path.glob("results_*.csv.gz")),
-            tmp_path / "pmc_perf.csv.gz",
-        )
-
-    assert not (tmp_path / "pmc_perf.csv.gz").exists()
-    skipped = [
-        call.args[0]
-        for call in mocks["warning"].call_args_list
-        if "Skipping empty" in str(call.args[0])
-    ]
-    assert len(skipped) == 2
-
-
-def test_concat_result_csvs_skips_zero_byte_compressed_pass(
-    tmp_path, monkeypatch
-) -> None:
-    common.patch_console(monkeypatch, MODULE, "debug", "warning")
-    header = "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n"
-    _write_results_gz(
-        tmp_path / "results_pmc_perf_0.csv.gz",
-        header + "0,kernel_a,SQ_WAVES,10\n",
-    )
-    (tmp_path / "results_pmc_perf_1.csv.gz").write_bytes(b"")
-
-    inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
-    inst.concat_result_csvs(
-        sorted(tmp_path.glob("results_*.csv.gz")), tmp_path / "pmc_perf.csv.gz"
-    )
-
-    assert pd.read_csv(tmp_path / "pmc_perf.csv.gz")["Counter_Value"].tolist() == [10]
-
-
-def test_join_workload_csvs_finds_compressed_results(tmp_path, monkeypatch) -> None:
-    """join_workload_csvs picks up compressed results_*.csv.gz artifacts."""
+def test_join_workload_csvs_merges_out_artifacts(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "warning", "log")
 
-    header = "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n"
-    _write_results_gz(
-        tmp_path / "results_pmc_perf_0.csv.gz",
-        header + "0,kernel_a,SQ_WAVES,10\n",
-    )
+    _write_out_pass_db(tmp_path)
 
     inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
     inst.join_workload_csvs(tmp_path)
 
-    assert pd.read_csv(tmp_path / "pmc_perf.csv.gz")["Counter_Value"].tolist() == [10]
+    merged = pd.read_csv(tmp_path / "pmc_perf.csv.gz")
+    assert len(merged) == 3
 
 
-def test_concat_result_csvs_errors_on_truncated_compressed_results(
+def test_join_workload_csvs_uses_existing_pmc_perf(tmp_path, monkeypatch) -> None:
+    common.patch_console(monkeypatch, MODULE, "debug", "warning", "log")
+
+    pmc_perf = tmp_path / "pmc_perf.csv.gz"
+    with gzip.open(pmc_perf, "wt", encoding="utf-8") as handle:
+        handle.write(
+            "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n0,kernel_a,SQ_WAVES,99\n"
+        )
+
+    inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
+    inst.join_workload_csvs(tmp_path)
+
+    assert pd.read_csv(pmc_perf)["Counter_Value"].tolist() == [99]
+
+
+def test_join_workload_csvs_errors_without_artifacts(tmp_path, monkeypatch) -> None:
+    common.patch_console(monkeypatch, MODULE, "debug", "warning", "log")
+
+    inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
+    with pytest.raises(SystemExit):
+        inst.join_workload_csvs(tmp_path)
+
+    assert not (tmp_path / "pmc_perf.csv.gz").exists()
+
+
+def test_merge_profile_artifacts_errors_when_no_counter_rows(
     tmp_path, monkeypatch
 ) -> None:
-    """Partial .csv.gz from a killed profile run must not leave output behind."""
     common.patch_console(monkeypatch, MODULE, "debug", "warning")
-    header = "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n"
-    rows = "".join(f"0,kernel_a,SQ_WAVES,{i}\n" for i in range(2000))
-    whole = gzip.compress((header + rows).encode("utf-8"))
-    (tmp_path / "results_pmc_perf_0.csv.gz").write_bytes(whole[: len(whole) // 2])
+
+    pass_path = tmp_path / "out" / "pmc_perf_0" / "100"
+    pass_path.mkdir(parents=True)
+    (pass_path / "100.db").write_bytes(b"")
 
     inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
     with pytest.raises(SystemExit):
-        inst.concat_result_csvs(
-            sorted(tmp_path.glob("results_*.csv.gz")),
-            tmp_path / "pmc_perf.csv.gz",
-        )
+        inst.merge_profile_artifacts(tmp_path, tmp_path / "pmc_perf.csv.gz")
 
     assert not (tmp_path / "pmc_perf.csv.gz").exists()
 
 
-def test_concat_result_csvs_errors_when_only_headers(tmp_path, monkeypatch) -> None:
-    """Header-only results files must not leave a reusable output behind."""
-    common.patch_console(monkeypatch, MODULE, "debug", "warning")
-    header = "GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n"
-    _write_results_gz(tmp_path / "results_pmc_perf_0.csv.gz", header)
-    _write_results_gz(tmp_path / "results_pmc_perf_1.csv.gz", header)
+def test_join_workload_csvs_rejects_legacy_results(tmp_path, monkeypatch) -> None:
+    common.patch_console(monkeypatch, MODULE, "debug", "warning", "log")
+
+    legacy = tmp_path / "results_pmc_perf_0.csv.gz"
+    with gzip.open(legacy, "wt", encoding="utf-8") as handle:
+        handle.write("GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n0,k,SQ_WAVES,1\n")
 
     inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
     with pytest.raises(SystemExit):
-        inst.concat_result_csvs(
-            sorted(tmp_path.glob("results_*.csv.gz")),
-            tmp_path / "pmc_perf.csv.gz",
-        )
-
-    assert not (tmp_path / "pmc_perf.csv.gz").exists()
-
-
-def test_concat_result_csvs_rejects_wide_legacy_results(tmp_path, monkeypatch) -> None:
-    """Wide legacy results_*.csv without Counter_Name are rejected."""
-    common.patch_console(monkeypatch, MODULE, "debug", "warning")
-    _write_results_gz(
-        tmp_path / "results_pmc_perf_0.csv.gz",
-        "GPU_ID,Kernel_Name,Dispatch_ID,SQ_WAVES\n0,kernel_a,0,10\n",
-    )
-
-    inst = OmniAnalyze_Base.__new__(OmniAnalyze_Base)
-    with pytest.raises(SystemExit):
-        inst.concat_result_csvs(
-            sorted(tmp_path.glob("results_*.csv.gz")),
-            tmp_path / "pmc_perf.csv.gz",
-        )
+        inst.join_workload_csvs(tmp_path)
 
     assert not (tmp_path / "pmc_perf.csv.gz").exists()
 

--- a/projects/rocprofiler-compute/tests/unit/utils/test_utils_analysis.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_utils_analysis.py
@@ -141,23 +141,17 @@ NaN,,,""",
     assert "Profiling data could be corrupt" in error_args[1]
 
 
-def test_validate_workload_completely_empty_gzip_csv(tmp_path):
-    """
-    Test validate_workload with a valid gzip file containing no CSV data.
-
-    Args:
-        tmp_path (Path): Temporary directory for test files.
-
-    Returns:
-        None: Asserts function detects empty CSV file.
-    """
+def test_validate_workload_legacy_results_csv_not_supported(tmp_path):
+    """Legacy results_*.csv.gz artifacts are no longer accepted."""
     from unittest.mock import patch
 
     workload_dir = tmp_path / "workload"
     workload_dir.mkdir()
 
     result_file = workload_dir / "results_pmc_perf_0.csv.gz"
-    result_file.write_bytes(gzip.compress(b""))
+    result_file.write_bytes(
+        gzip.compress(b"GPU_ID,Kernel_Name,Counter_Name,Counter_Value\n")
+    )
 
     console_error_calls = []
 
@@ -169,10 +163,8 @@ def test_validate_workload_completely_empty_gzip_csv(tmp_path):
 
     assert len(console_error_calls) == 1
     error_args = console_error_calls[0][0]
-    assert error_args[0] == "profiling"
-    assert "No counter data" in error_args[1]
-    assert str(result_file) in error_args[1]
-    assert "Profiling data could be corrupt" in error_args[1]
+    assert error_args[0] == "analysis"
+    assert "Legacy results_*.csv.gz workloads are no longer supported" in error_args[1]
 
 
 def test_validate_workload_headers_only_csv(tmp_path):


### PR DESCRIPTION
## Motivation

Remove the `results_*.csv.gz` fallback once golden workloads use the `out/{pass}/` layout, and regenerate applicable workloads. 

## Technical Details

- **Removed:** `concat_result_csvs`, `results_*.csv.gz` fallback in `join_workload_csvs` / `validate_workload`.
- Golden workloads regenned

## Issue Tracking

AIPROFCOMP-750

## Test Plan

- Unit tests for analyze merge path (no legacy fallback)
- Per-SOC: regen via `tests/regen_golden_workload.py`, then `test_analyze_workloads.py -k <SOC>`

## Test Result

Unit tests pass locally. Golden workload commits added per SOC as regen completes (MI350 and others in follow-up commits on this branch).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.