### PR TITLE
ci: clone submodules at --depth 1 in the TheRock workflows

### DIFF
--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Fetch sources
         timeout-minutes: 30
         run: |
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --depth 1 --no-include-rocm-systems
 
       - name: Patch rocm-systems
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Fetch sources
         timeout-minutes: 30
         run: |
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --depth 1 --no-include-rocm-systems
 
       - name: Patch rocm-systems
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 30
         run: |
           git config --global core.longpaths true
-          python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          python ./TheRock/build_tools/fetch_sources.py --jobs 12 --depth 1 --no-include-rocm-systems
           dvc pull
 
       - name: Configure Projects

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Fetch sources
         run: |
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --depth 1 --no-include-rocm-systems
 
       - name: Patch rocm-systems
         run: |


### PR DESCRIPTION
## Motivation

The `Fetch sources` step repeatedly exceeds its 30-minute timeout while cloning the
`compiler/amd-llvm` submodule (`ROCm/llvm-project`). The lane dies before CMake configure, so it
yields no signal — neither a pass nor a real failure — and on Linux it surfaces as the misleading
`Executing the custom container implementation failed. Please contact your self hosted runner
administrator.`, usually followed by a `therock_manifest.json not found` cascade.

This is ROCm/TheRock#7170, where it is well characterised across `rocm-libraries`. The two
occurrences below are from **this** repo, so the same gap exists in these workflows.

Both on `aws-linux-scale-rocm-prod`, both exactly 30m00s from `Cloning into …amd-llvm` to the error,
from run [32374262810](https://github.com/ROCm/rocm-systems/actions/runs/32374262810):

| Lane | Job | Elapsed |
| --- | --- | ---: |
| `Linux (… \| gfx950-dcgpu) / Build Linux Packages` | [96441872862](https://github.com/ROCm/rocm-systems/actions/runs/32374262810/job/96441872862) | 30m00s |
| `Linux MI455 Build (gfx125X-dcgpu) / Build Linux Packages` | [96441872677](https://github.com/ROCm/rocm-systems/actions/runs/32374262810/job/96441872677) | 30m00s |

## Technical Details

The `actions/checkout` steps in these workflows already use `fetch-depth: 1`, but
`fetch_sources.py` is invoked without `--depth` and the argument
[defaults to `None`](https://github.com/ROCm/TheRock/blob/main/build_tools/fetch_sources.py), so
every submodule — including `llvm-project` — is cloned at full history. TheRock's own
`multi_arch_build_*.yml` workflows already pass `--depth 1`. This adds it to the four call sites
here:

```
.github/workflows/therock-ci-linux.yml:79
.github/workflows/therock-build-linux.yml:77
.github/workflows/therock-ci-windows.yml:102
.github/workflows/therock-rccl-ci-linux.yml:86
```

### Does anything need submodule history?

This is the confirmation asked for in
[#7170](https://github.com/ROCm/TheRock/issues/7170#issuecomment-5246559218) before making this change. Since
`--depth` affects only the submodules (the superprojects are already `fetch-depth: 1`), the question
is what reads history *of the subproject repos*.

Every git invocation TheRock makes against a subproject is depth-safe:

| Call | Site |
| --- | --- |
| `git rev-parse --git-dir` | `cmake/therock_subproject.cmake:1901` |
| `git rev-parse HEAD` | `cmake/therock_subproject.cmake:1919` |
| `git diff --quiet --ignore-submodules HEAD` | `cmake/therock_subproject.cmake:1941` |
| `git rev-parse HEAD` | `build_tools/generate_therock_manifest.py:315` (`--commit` defaults `HEAD`) |

No `git describe`, `log`, `rev-list`, `merge-base`, `blame` or `tag` anywhere in TheRock's build
path. The subprojects were checked too: `rocgdb` and `mesa-fork` reference history commands only in
docs/release notes; mesa's `bin/git_sha1_gen.py` uses `git rev-parse`; LLVM's `VersionFromVCS.cmake`
uses `git rev-parse` plus `describe --always`, which degrades to an abbreviated hash. `half`,
`rocm-cmake`, `HIPIFY`, `SPIRV-LLVM-Translator` and `libhipcxx` have no build-path uses.

`rocm-systems` itself has the heaviest history use — `git rev-list --count` and `git merge-base` in
the `rocr-runtime`, `rocm-core`, `amdsmi`, `rdc`, `rocm-smi-lib` and `rocminfo` version scripts — but
it is excluded here by `--no-include-rocm-systems` and checked out at `fetch-depth: 1`, so it is
already shallow today and is unchanged by this PR.

### Effect on version metadata: abbreviation length only

23 `rocm-libraries` projects (`rocblas`, `miopen`, `rocfft`, `hipsparse`, `rocprim`,
`composablekernel`, …) call `rocm_setup_version()`, which reaches
`git describe --dirty --long --match [0-9]*` in rocm-cmake's `ROCMSetupVersion.cmake`. That looks
like a regression risk for shallow clones, so I measured it rather than assuming:

| clone | commits | tags | `describe --match '[0-9]*'` | `--always` fallback |
| --- | ---: | ---: | --- | --- |
| full history (blobless) | 101,338 | 20 | `fatal: No tags can describe` | `4f356efc73` |
| `--depth 1` | 1 | 0 | `fatal: No names found` | `4f356efc` |

The describe **already fails at full history**. `rocm-libraries` has only two annotated tags matching
`[0-9]*` and neither is an ancestor of `develop` — `20250912-42` is diverged (behind_by 2886) and
`20250912-17` is diverged (behind_by 2117), per the compare API. So `PROJECT_VERSION_TWEAK` comes
from the `--always` fallback today regardless of depth.

The only actual change is the abbreviation length, **10 characters to 8**, because git scales the
default abbreviation with object count. Worth knowing if anything downstream string-matches that
value; it is not a tag-relative-to-hash regression.

### Why not `--filter=blob:none`

A partial clone was considered as a way to preserve history. It does not help here:

- The tags above are not ancestors of HEAD, so `git describe` falls back either way — a blobless
  clone does not restore tag-relative versions.
- A blobless clone still fetches every tip blob during checkout, so for a job that checks out the
  whole tree the total transfer is roughly `--depth 1` *plus* the commit and tree graph, not less.
  (The 139 MB vs 751 MB initial-clone figures flatter it; that is before checkout.)
- `fetch_sources.py` has no `--filter` option today, so it would need a TheRock-side change first.

For completeness: `rocm_get_commit_count()` / `rocm_get_rev_count()`, the only paths reaching
`git rev-list --count HEAD`, have no callers anywhere in the ROCm org.

## Issue Tracking

GitHub issue: https://github.com/ROCm/TheRock/issues/7170

## Test Plan

The change is to CI configuration, so this PR's own CI run is the test: all four affected workflows
run here, and the `Fetch sources` step in each should complete well inside its 30-minute budget with
shallow submodule clones. Reviewers should confirm the built artifacts and packages are unchanged
apart from the `PROJECT_VERSION_TWEAK` note above.

Static verification done before proposing it is the audit in Technical Details — every git call
against a subproject repo enumerated, plus a check of each submodule's own build system.

## Test Result

To be filled in from this PR's CI run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---

<sub>AI tool use disclosure, per CONTRIBUTING.md: the git-call audit and this description were
prepared with Claude (Anthropic). Each cited file, line and job timestamp was verified by hand
before posting; the change and the recommendation are mine.</sub>
