### PR TITLE
[rocjitsu][CI] Exclude ROCr race from daemon HIP memcpy test

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -247,14 +247,15 @@ jobs:
             # async-event bookkeeping, outside rocjitsu-owned code.
             "HsaTranslateTest\.TranslateAndDispatchVectorAdd"
             "HsaTranslateTest\.TranslateAndDispatchMfma16x16"
-            # Direct HIP test discovery initializes the instrumented ROCr client,
-            # which reports a ConcurrentAsyncEvents race; vector add also exposes
-            # unsynchronized simulator/client buffer access. The daemon variants
-            # use the separately synchronized RPC path and remain enabled.
+            # HIP test discovery initializes the instrumented ROCr client, which
+            # reports a ConcurrentAsyncEvents race. The device-to-device case also
+            # reaches that ROCr race through the daemon client; vector add exposes
+            # unsynchronized simulator/client buffer access as well.
             "HipMemcpyTest\.RoundTripFloat"
             "HipMemcpyTest\.RoundTripInt"
             "HipMemcpyTest\.DeviceToDevice"
             "HipVectorAddTest\.CorrectResult"
+            "DaemonTest\.HipMemcpyDeviceToDevice"
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"


### PR DESCRIPTION
DaemonTest.HipMemcpyDeviceToDevice completes its functional check, but the instrumented HIP client can report a data race while ROCr’s asynchronous-event worker drains ConcurrentAsyncEvents during client teardown. The report contains no RocJITsu access frame, and the direct HIP cases are already excluded for the same external-runtime limitation.

Add the daemon device-to-device case to TSAN_EXCLUDED_TESTS only. Keep it in release and ASan+UBSan, and retain the other daemon HIP cases in TSan.