### PR TITLE
fix(rocprofiler-sdk): emit invalid PC sampling records for host-trap samples

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/pc_record_interface.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/pc_record_interface.cpp
@@ -188,18 +188,6 @@ emplace_records_in_buffer(rocprofiler::buffer::instance*        buff,
                           rocprofiler_pc_sampling_record_kind_t record_kind)
 {
     for(size_t i = 0; i < num_samples; i++)
-        buff->emplace(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING, record_kind, samples[i]);
-}
-
-template <>
-inline void
-emplace_records_in_buffer<rocprofiler_pc_sampling_record_stochastic_v0_t>(
-    rocprofiler::buffer::instance*                        buff,
-    const rocprofiler_pc_sampling_record_stochastic_v0_t* samples,
-    size_t                                                num_samples,
-    rocprofiler_pc_sampling_record_kind_t                 record_kind)
-{
-    for(size_t i = 0; i < num_samples; i++)
     {
         if(samples[i].size == 0)
         {


### PR DESCRIPTION
## Motivation

Host-trap PC sampling emits samples with a non-zero `Correlation_Id` but an undecodable instruction, breaking the "`Correlation_Id` is 0 `iff` the instruction is decoded" invariant asserted by the `exec_mask_manipulation` validators (`csv.py:104`, `json.py:137`). Observed on gfx950 at roughly one bad sample per 250,000. Stochastic sampling is unaffected.

## Technical Details

`size == 0` is the PC sampling parser's internal marker for an invalid sample. `add_upcoming_samples()` sets it when a sample's PC cannot be resolved to a loaded code object, but assigns `correlation_id` and `dispatch_id` first, so the condemned record still points at a real kernel.

`emplace_records_in_buffer()` converts marked samples into `ROCPROFILER_PC_SAMPLING_RECORD_INVALID_SAMPLE`, but that conversion lived only in the `rocprofiler_pc_sampling_record_stochastic_v0_t` specialization. Host-trap records used the unfiltered generic template and were emitted verbatim.

This moves the check into the generic template and deletes the specialization, whose only remaining purpose was that check. `host_trap_v0` and `stochastic_v0` are the only types that can instantiate it — the function is defined solely in `pc_record_interface.cpp` and reached only through the `protected` four-argument `generate_upcoming_pc_record`, which has exactly two explicit specializations — so stochastic behaviour is unchanged.

## Issue Tracking

JIRA ID: ROCM-29593

## Test Plan

`ctest -R "pcs|pc_sampling|parser"`, a full same-revision `ctest` A/B, and a 20-run A/B on bare-metal MI350X (gfx950) running `rocprofv3 --pc-sampling-method host_trap` over `exec-mask-manipulation`, checking every output row for the invariant.

## Test Result

65/65 unit tests pass. Without the fix, 1-3 of every 20 runs produced a violating row; with it, 0 in 32 runs. Samples per run unchanged (~256k), so no valid data is dropped. The full `ctest` A/B produced identical failure sets in both arms, i.e. no regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.