### PR TITLE
fix(rocprofiler-systems): throw on hierarchical JSON config files passed via ROCPROFSYS_CONFIG_FILE

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1421,12 +1421,12 @@ configure_settings(bool _init)
                             expanded_filename, TIMEMORY_PROJECT_NAME));
         }
 
-        // Timemory parses config files during static init before main(), outside our
-        // control (see timemory_library_constructor()->init_config()). Bad .json files
-        // fail to parse but Timemory error message is uninformative. Meanwhile, the
-        // suppress_config flag is always true in the launcher. So, to produce a proper
-        // diagnostic message for bad .json files, the above .json root check MUST stay
-        // above this 'continue' gate to run regardless of suppress_config flag.
+        // Timemory parses config files during static init before main() (see
+        // timemory_library_constructor()->init_config()). Bad .json files fail to parse
+        // but Timemory error message is uninformative. Meanwhile, the suppress_config
+        // flag is always true in the launcher. So, to produce a proper diagnostic message
+        // for bad .json files, the above .json root check MUST stay above this 'continue'
+        // gate to run regardless of suppress_config flag.
         if(_config->get_suppress_config()) continue;
 
         LOG_DEBUG("Reading config file {}", filename);

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1405,8 +1405,6 @@ configure_settings(bool _init)
     for(auto&& filename : rocprofsys::delimit(
             _config->get<std::string>(std::string{ env_vars::CONFIG_FILE }), ";:"))
     {
-        if(_config->get_suppress_config()) continue;
-
         const auto expanded_filename = settings::format(filename, _config->get_tag());
 
         // Prevent Timemory's read() silently dropping JSON config files without proper
@@ -1422,6 +1420,14 @@ configure_settings(bool _init)
                             "configuration, pass it via --preset instead.",
                             expanded_filename, TIMEMORY_PROJECT_NAME));
         }
+
+        // Timemory parses config files during static init before main(), outside our
+        // control (see timemory_library_constructor()->init_config()). Bad .json files
+        // fail to parse but Timemory error message is uninformative. Meanwhile, the
+        // suppress_config flag is always true in the launcher. So, to produce a proper
+        // diagnostic message for bad .json files, the above .json root check MUST stay
+        // above this 'continue' gate to run regardless of suppress_config flag.
+        if(_config->get_suppress_config()) continue;
 
         LOG_DEBUG("Reading config file {}", filename);
         validate_config_file_values(filename, _config->get_tag(), _config);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Hierarchical `.json` config files passed via `ROCPROFSYS_CONFIG_FILE` failed to parse (expected behavior) but produced no error message advising the user to use `--preset` for this file. This PR fixes this behavior - proper error message is now displayed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

**Root cause**:

Timemory tries to parse config files during static init before `main()`. Hierarchical `.json` files fail to parse but Timemory error message is uninformative.
In rocprofiler-systems code, there was a check if an input `.json` config file is hierarchical, but this check was gated on the `suppress_config` flag, and this flag is always true in the launcher. So the proper diagnostic message advising the user to use `--preset` for this `.json` file was never displayed.

**Fix**: `.json` check is now performed on every config file unconditionally.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-483

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Existing ctest suite should pass
- Expected error message should be displayed

## Test Result

<!-- Briefly summarize test outcomes. -->

- Existing ctest suite passes
- Expected error message is dispayed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
