### PR TITLE
hip-tests catch tags.

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/callback.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/callback.yaml
@@ -7,7 +7,7 @@ callback:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: []
+    tags: [P0]
   Unit_hipGetStreamDeviceId_Negative_Parameters: *level_2
   Unit_hipKernelNameRef_Positive_Basic:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -2,91 +2,91 @@
 device:
   Unit_hipChooseDevice_ValidateDevId:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipChooseDevice_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceComputeCapability_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceComputeCapability_ValidateVersion:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetByPCIBusId_Functional:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetByPCIBusId_NegativeNullChk:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetByPCIBusId_NegativeInputString:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetByPCIBusId_WrongBusID:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetName_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetName_CheckPropName:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetName_PartialFill:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetPCIBusId_Negative_PartialFill:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetPCIBusId_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceSetCacheConfig_Positive_Basic:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceSetCacheConfig_Positive_Carveout:
     <<: *level_2
-    tags: [config]
+    tags: [config, P1]
   Unit_hipDeviceGetCacheConfig_Positive_Default:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceSynchronize_Positive_Empty_Streams:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceSynchronize_Positive_Nullstream:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
     disabled: [nvidia_windows]
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipDeviceSynchronize_Functional:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
     disabled: [nvidia_windows]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceTotalMem_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceTotalMem_ValidateTotalMem:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceTotalMem_NonSelectedDevice:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P0]
   Unit_hipGetDeviceAttribute_CheckAttrValues:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetAttribute_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipGetDeviceAttribute_hipDeviceAttributeGPUDirectRDMAWithHipVMMSupported:
     <<: *level_2
     tags: [query]
@@ -95,75 +95,75 @@ device:
     tags: [query]
   Unit_hipGetDeviceCount_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipGetDeviceCount_HideDevices:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P0]
   Unit_hipGetDeviceProperties_ArchPropertiesTst:
     <<: *level_2
-    tags: [query, smoke]
+    tags: [query, smoke, P0]
   Unit_hipGetDeviceProperties_NegTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipRuntimeGetVersion_Positive:
     <<: *level_2
-    tags: [init, smoke]
+    tags: [init, smoke, P0]
   Unit_hipRuntimeGetVersion_Negative:
     <<: *level_2
-    tags: [init]
+    tags: [init, P0]
   Unit_hipGetSetDeviceFlags_NullptrFlag:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipGetSetDeviceFlags_ValidFlag:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipGetSetDeviceFlags_SetThenGet:
     <<: *level_2
-    tags: [config, smoke]
+    tags: [config, smoke, P0]
   Unit_hipGetSetDeviceFlags_Threaded:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipGetDeviceFlags_Positive_Context:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
     # (amd_wsl) Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [config]
+    tags: [config, P0]
   Unit_hipGetSetDeviceFlags_InvalidFlag:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipSetDevice_BasicSetGet:
     <<: *level_2
-    tags: [query, smoke]
+    tags: [query, smoke, P0]
   Unit_hipGetSetDevice_MultiThreaded:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipSetGetDevice_Positive_Threaded_Basic:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P0]
   Unit_hipSetGetDevice_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGet_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetUuid_Positive:
     <<: *level_2
     # (amd_windows) Note: UUID returned empty on some windows nodes
     # (amd_wsl) Note: UUID returned empty on some windows nodes
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetUuid_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetUuid_From_RocmInfo:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetLuid_Positive:
     <<: *level_2
     tags: [query]
@@ -177,45 +177,45 @@ device:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P0]
   Unit_UUID_setEnv_Thread:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows, amd_wsl]
-    tags: [query, multigpu]
+    tags: [query, multigpu, P0]
   Unit_hipDeviceAPUCheck:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetDefaultMemPool_Positive_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceGetDefaultMemPool_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceCanAccessPeer_positive:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipDeviceCanAccessPeer_negative:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipDeviceEnableDisablePeerAccess_positive:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipDeviceEnablePeerAccess_negative:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipDeviceDisablePeerAccess_negative:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipDeviceSetLimit_Positive_StackSize:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceSetLimit_Positive_PrintfFifoSize:
     <<: *level_2
     tags: [config]
@@ -232,12 +232,12 @@ device:
     <<: *level_2
     # Below 2 tests are disabled due to defect EXSWHTEC-342
     disabled: [nvidia_windows]
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetLimit_Negative_Parameters:
     <<: *level_2
     # Below 2 tests are disabled due to defect EXSWHTEC-342
     disabled: [nvidia_windows]
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetSetLimit_Scratch_Negative:
     <<: *level_2
     tags: [config]
@@ -264,67 +264,67 @@ device:
     tags: [config]
   Unit_hipDeviceSetSharedMemConfig_Positive_Basic:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceSetSharedMemConfig_Negative_Parameters:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetSharedMemConfig_Positive_Default:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetSharedMemConfig_Positive_Basic:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
     # (amd_wsl) Note: Linux disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetSharedMemConfig_Positive_Threaded:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
     # (amd_wsl) Note: Linux disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetSharedMemConfig_Negative_Parameters:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceReset_Positive_Basic:
     <<: *level_2
     # (amd_wsl) Note: Windows disabled
     # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
     disabled: [amd_wsl, nvidia_windows]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceReset_Positive_Threaded:
     <<: *level_2
     # (amd_wsl) Note: Windows disabled
     # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
     disabled: [amd_wsl, nvidia_windows]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceSetMemPool_Positive_Basic:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceSetMemPool_Negative_Parameters:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetMemPool_Positive_Default:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetMemPool_Positive_Basic:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetMemPool_Positive_Threaded:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipDeviceGetMemPool_Negative_Parameters:
     <<: *level_2
-    tags: [config]
+    tags: [config, P0]
   Unit_hipInit_Positive:
     <<: *level_2
-    tags: [init, smoke]
+    tags: [init, smoke, P0]
   Unit_hipInit_Negative:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
     # (amd_wsl) Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [init]
+    tags: [init, P0]
   Unit_hipInitDevice_Positive_Basic:
     <<: *level_2
     tags: [init, smoke]
@@ -345,10 +345,10 @@ device:
     tags: [init]
   Unit_hipDriverGetVersion_Positive:
     <<: *level_2
-    tags: [init, smoke]
+    tags: [init, smoke, P0]
   Unit_hipDriverGetVersion_Negative:
     <<: *level_2
-    tags: [init]
+    tags: [init, P0]
   Unit_hipSetValidDevices_Negative:
     <<: *level_2
     tags: [config]
@@ -373,13 +373,15 @@ device:
   Unit_hipSetValidDevices_with_hipMemcpyPeer:
     <<: *level_2
     tags: [config, multigpu]
-  Unit_hipGetProcAddress_ValidateDeviceApis: *level_2
+  Unit_hipGetProcAddress_ValidateDeviceApis:
+    <<: *level_2
+    tags: [P0]
   Unit_hipGetProcAddress_PeerDeviceAccessAPIs:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipGetProcAddress_SetGetMemPoolAPIs:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P0]
   Unit_hipGetDriverEntryPoint_Positive: *level_2
   Unit_hipGetDriverEntryPoint_Negative: *level_2
   Unit_hipGetDriverEntryPoint_spt_Positive: *level_2
@@ -391,26 +393,35 @@ device:
     disabled: [amd_windows, amd_wsl, amd_linux]
   Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process:
     <<: *level_2
+    tags: [P0]
     # Note: Windows disabled
     disabled: [amd_wsl]
   Unit_hipIpcOpenMemHandle_Negative_Open_In_Two_Contexts_Same_Device:
     <<: *level_2
+    tags: [P0]
     # (amd_linux) SWDEV-511679 : Below tests fail in stress test
     # (amd_wsl) Note: hsa_amd_ipc_ is dummy
     disabled: [amd_linux, amd_wsl]
   Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations:
     <<: *level_2
+    tags: [P0]
     # Note: Test disabled due to defect - EXSWHTEC-207
     disabled: [amd_wsl]
-  Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory: *level_2
-  Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer: *level_2
+  Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory:
+    <<: *level_2
+    tags: [P0]
+  Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer:
+    <<: *level_2
+    tags: [P0]
   Unit_hipIpcCloseMemHandle_Positive_Reference_Counting:
     <<: *level_2
+    tags: [P0]
     # (amd_linux) SWDEV-511679 : Below tests fail in stress test
     # (amd_wsl) Note: hsa_amd_ipc_ is dummy
     disabled: [amd_linux, amd_wsl]
   Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process:
     <<: *level_2
+    tags: [P0]
     # Note: Windows disabled
     disabled: [amd_wsl]
   Unit_hipIpcOpenMemHandle_Multiproc: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -2,48 +2,48 @@
 deviceLib:
   Unit_deviceFunctions_CompileTest:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_AnyAll_CompileTest:
     <<: *level_2
-    tags: [warp]
+    tags: [warp, P0]
   Unit_ballot:
     <<: *level_2
-    tags: [warp]
+    tags: [warp, P0]
   Unit_clz:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_ffs:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_funnelshift:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_brev:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_popc:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_ldg:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_threadfence_system:
     <<: *level_2
-    tags: []
+    tags: [P0]
   Unit_syncthreads_and:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_syncthreads_count:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_syncthreads_or:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType:
     <<: *level_2
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocation_ComplexDataType:
     <<: *level_2
     # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
@@ -61,13 +61,13 @@ deviceLib:
     # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
     # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocation_New_PerThread_Graph:
     <<: *level_2
     # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
     # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocation_DeviceFunc:
     <<: *level_2
     # Note: devicelib hangs and failures
@@ -77,7 +77,7 @@ deviceLib:
     <<: *level_2
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocation_SingKernels_MulThreads:
     <<: *level_2
     tags: [memory]
@@ -85,208 +85,208 @@ deviceLib:
     <<: *level_2
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocation_New_MulCodeObj:
     <<: *level_2
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_deviceAllocationFollowedByDeviceReset:
     <<: *level_2
     tags: [memory]
   Unit_AtomicFunctions_Inc:
     <<: *level_2
-    tags: [atomics]
+    tags: [atomics, P0]
   Unit_AtomicFunctions_Dec:
     <<: *level_2
-    tags: [atomics]
+    tags: [atomics, P0]
   Unit_DoublePrecisionIntrinsics:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_DoublePrecisionMathDevice:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_DoublePrecisionMathHost:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_IntegerIntrinsics:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_SinglePrecisionIntrinsics:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_SinglePrecisionMathDevice:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_SinglePrecisionMathHost:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_SimpleAtomicsTest:
     <<: *level_2
-    tags: [atomics]
+    tags: [atomics, P0]
   Unit_hipTestAtomicAdd:
     <<: *level_2
-    tags: [atomics]
+    tags: [atomics, P0]
   Unit_StdComplex:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hipTestClock:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_kernel_trigger:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_ToAndFroMemCpyToDevice:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
   Unit_TestIncludeMathPreciseFloat:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_hipTestDotFunctions:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_hipMemcpyToSymbolAsync_ToNFrom:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipGetSymbolAddressAndSize_Validation:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipGetSymbolAddress_Negative:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipGetSymbolSize_Negative:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipTest_DeviceNewOperator:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipThreadFence:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceTrigFunc_Float:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipTestDeviceLimit_Basic:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hipTrigDeviceFunc_Double:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_TestDevice_DoublePrecisionMathFunc:
     <<: *level_2
-    tags: [misc]
+    tags: [misc, P0]
   Unit_hadd_int_varaint:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_rhadd_int_varaint:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_uhadd_int_varaint:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_urhadd_int_varaint:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_unsafeAtomicAdd:
     <<: *level_2
-    tags: [atomics]
+    tags: [atomics, P0]
   Unit_mbcnt:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_bitExtract:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_bitInsert:
     <<: *level_2
-    tags: [bitops]
+    tags: [bitops, P0]
   Unit_floatTM:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_abs_int64_Verification:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_pown_Verification:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_hmax_hmin_Tsts:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hmax_hmin_Tsts_Negative:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hmax_hmin_Tsts_With_Array:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hipBfloat16:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hipVectorTypes_test_on_host:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hipVectorTypes_test_on_device:
     <<: *level_2
     # SWDEV-444987 - Below tests fail in stress testing on 25/01/2023
     disabled: [amd_windows, amd_wsl]
-    tags: [types]
+    tags: [types, P0]
   Unit_hipTestHalf:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_TestMathFuncComplex:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_hipTestFMA:
     <<: *level_2
-    tags: [math]
+    tags: [math, P0]
   Unit_hipTestNativeHalf:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_Test_makechar_functionality:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_basic:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_conversion_to_integral_type:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf162_basic:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_operators_host:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf162_operators_host:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_bf162_convert_tests:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_shfl:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf162_shfl:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_value_ops:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf16_floor_ceil:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_bf162_floor_ceil:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_AtomicsWithRandomActiveLanesInWavefront:
     <<: *level_2
     tags: [atomics]
   Unit_fp16_arith:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp162_arith:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp16_host_operations:
     <<: *level_2
     tags: [types]
@@ -307,28 +307,28 @@ deviceLib:
     tags: [atomics, types]
   Unit_fp8_ocp_bool_host:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_all_fp8_ocp_vector_cvt:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp8_ocp_correctness:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp8_ocp_vector_basic_conversions:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp8_fnuz_bool_host:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_all_fp8_fnuz_vector_cvt:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp8_fnuz_correctness:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit_fp8_fnuz_vector_basic_conversions:
     <<: *level_2
-    tags: [types]
+    tags: [types, P0]
   Unit__hip_cvt_bfloat16raw_to_e8m0:
     <<: *level_2
     tags: [types]

--- a/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
@@ -2,11 +2,11 @@
 errorHandling:
   Unit_hipGetErrorName_Positive_Basic:
     <<: *level_2
-    tags: [smoke]
+    tags: [smoke, P0]
   Unit_hipGetErrorName_Negative_Parameters: *level_2
   Unit_hipGetErrorString_Positive_Basic:
     <<: *level_2
-    tags: [smoke]
+    tags: [smoke, P0]
   Unit_hipGetErrorString_Negative_Parameters: *level_2
   Unit_hipDrvGetErrorName_Positive_Basic: *level_2
   Unit_hipDrvGetErrorName_Negative_Parameters: *level_2
@@ -14,7 +14,7 @@ errorHandling:
   Unit_hipDrvGetErrorString_Negative_Parameters: *level_2
   Unit_hipGetLastError_Positive_Basic:
     <<: *level_2
-    tags: [smoke]
+    tags: [smoke, P0]
   Unit_hipGetLastError_Positive_Threaded: *level_2
   Unit_hipGetLastError_with_hipMemcpyPeerAsync:
     <<: *level_2
@@ -52,7 +52,7 @@ errorHandling:
   Unit_hipGetLastError_Kernel_Invalid_Config: *level_2
   Unit_hipPeekAtLastError_Positive_Basic:
     <<: *level_2
-    tags: [smoke]
+    tags: [smoke, P0]
   Unit_hipPeekAtLastError_Positive_Threaded: *level_2
   Unit_hipPeekAtLastError_Positive: *level_2
   Unit_hipPeekAtLastError_Chk_Updated_Status: *level_2
@@ -69,7 +69,9 @@ errorHandling:
     <<: *level_2
     # Test causes error state in the runtime and prevents resource cleanup.
     disabled: [asan]
-  Unit_hipExtGetLastError_Positive_Basic: *level_2
+  Unit_hipExtGetLastError_Positive_Basic:
+    <<: *level_2
+    tags: [P0]
   Unit_hipExtGetLastError_Positive_Threaded: *level_2
   Unit_hipExtGetLastError_with_hipMemcpyPeerAsync:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -2,59 +2,59 @@
 event:
   Unit_hipEventCreate_NullCheck:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_NullCheck:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreate_IncompatibleFlags:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventSynchronize_NullCheck:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventQuery_NullCheck:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventDestroy_NullCheck:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEvent:
     <<: *level_2
     # SWDEV-411303 fails in WSL. Profiling not support in WSL
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipEventElapsedTime_NullCheck:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventElapsedTime_DisableTiming:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventElapsedTime_DifferentDevices:
     <<: *level_2
-    tags: [multigpu, synchronization]
+    tags: [multigpu, synchronization, P1]
   Unit_hipEventElapsedTime_NotReady_Negative:
     <<: *level_2
     # SWDEV-411303 fails in WSL. Profiling not support in WSL
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventElapsedTime:
     <<: *level_2
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipEventElapsedTime_Verify_Capture:
     <<: *level_2
     tags: [synchronization]
   Unit_hipEventRecord:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipEventRecord_Negative:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventIpc:
     <<: *level_2
     # (amd_wsl) Below tests fail in stress test on 24/07/23
     disabled: [amd_windows, amd_wsl]
-    tags: [ipc]
+    tags: [ipc, P1]
   Unit_hipEventIpc_DestroyNonBlocking:
     <<: *level_2
     tags: [ipc, lifecycle]
@@ -62,79 +62,79 @@ event:
     <<: *level_2
     # SWDEV-411303 fails in WSL. Profiling not support in WSL
     disabled: [amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipEventDestroy_WithWaitingStream:
     <<: *level_2
     # SWDEV-402054 fails in external github build
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventDestroy_Negative:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventDestroy_Verify_Capture:
     <<: *level_2
     tags: [lifecycle]
   Unit_hipEventCreate_Positive:
     <<: *level_2
-    tags: [lifecycle, smoke]
+    tags: [lifecycle, smoke, P0]
   Unit_hipEventCreate_Verify_Capture:
     <<: *level_2
     tags: [lifecycle]
   Unit_hipEventCreateWithFlags_Positive:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipEventCreateWithFlags_DisableSystemFence_HstVisMem:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_DefaultFlg_HstVisMem:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipEventCreateWithFlags_DisableSystemFence_NonCohHstMem:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_DefaultFlg_NonCohHstMem:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_DisableSystemFence_CohHstMem:
     <<: *level_2
     # (amd_linux) SWDEV-470751 : Fine Grain memory is MTYPE_NC due to HW bug.
     # (amd_windows) Note: intermittent Seg fault failure
     disabled: [gfx1200, gfx1201, amdgcnspirv, amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_DefaultFlg_CohHstMem:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipEventCreateWithFlags_Verify_Capture:
     <<: *level_2
     tags: [lifecycle]
   Unit_hipEventSynchronize_Default_Positive:
     <<: *level_2
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipEventSynchronize_NoEventRecord_Positive:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipEventMGpuMThreads_1:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipEventMGpuMThreads_2:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
   Unit_hipEventMGpuMThreads_3:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
   Unit_hipEventQuery_DifferentDevice:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipEventIpc_shm_cleanup:
     <<: *level_2
     tags: [ipc]

--- a/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
@@ -94,7 +94,7 @@ executionControl:
     tags: [attributes, kernel]
   Unit_hipFuncSetCacheConfig_Positive_VerifyCarveoutMapping:
     <<: *level_2
-    tags: [attributes, kernel]
+    tags: [attributes, kernel, P1]
   Unit_hipFuncSetSharedMemConfig_Positive_Basic:
     <<: *level_2
     # Note: intermittent Seg fault failure

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -59,6 +59,7 @@ executionctx:
     <<: *level_2
   Unit_hipExecutionCtxRecordWaitEvent_Sanity:
     <<: *level_2
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExecutionCtxRecordEventFunctional:
     <<: *level_2
   Unit_hipExecutionCtxRecordWait_Blocking:

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -82,7 +82,7 @@ graph:
     tags: [node]
   Unit_hipGraph_BasicFunctional:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipGraph_SimpleGraphWithKernel:
     <<: *level_2
     tags: [exec]
@@ -344,7 +344,7 @@ graph:
     tags: [node]
   Unit_hipGraphAddMemcpyNode1D_Positive_Basic:
     <<: *level_2
-    tags: [node]
+    tags: [node, P0]
   Unit_hipGraphAddMemcpyNode1D_Negative_Parameters:
     <<: *level_2
     tags: [node]
@@ -617,7 +617,7 @@ graph:
     tags: [capture]
   Unit_hipStreamBeginCapture_Positive_Basic:
     <<: *level_2
-    tags: [capture]
+    tags: [capture, P0]
   Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags:
     <<: *level_2
     tags: [capture]
@@ -782,7 +782,7 @@ graph:
     tags: [capture]
   Unit_hipStreamIsCapturing_Positive_Basic:
     <<: *level_2
-    tags: [capture]
+    tags: [capture, P0]
   Unit_hipStreamIsCapturing_Positive_Functional:
     <<: *level_2
     tags: [capture]
@@ -931,6 +931,7 @@ graph:
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree:
     <<: *level_2
+    disabled: [amd_linux]
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams:
     <<: *level_2
@@ -978,7 +979,7 @@ graph:
     tags: [capture]
   Unit_hipStreamEndCapture_Positive_GraphDestroy:
     <<: *level_2
-    tags: [capture]
+    tags: [capture, P0]
   Unit_hipStreamEndCapture_Negative_Thread:
     <<: *level_2
     tags: [capture]
@@ -1053,7 +1054,7 @@ graph:
     tags: [node]
   Unit_hipGraphAddKernelNode_Negative:
     <<: *level_2
-    tags: [node]
+    tags: [node, P0]
   Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph:
     <<: *level_2
     tags: [node]
@@ -1108,7 +1109,7 @@ graph:
     tags: [exec]
   Unit_hipGraphLaunch_Positive:
     <<: *level_2
-    tags: [exec, smoke]
+    tags: [exec, smoke, P0]
   Unit_hipGraphLaunch_Negative_Parameters:
     <<: *level_2
     tags: [exec]
@@ -1237,6 +1238,7 @@ graph:
     tags: [capture]
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
+    tags: [capture]
     # Hangs on Windows (PAL), hitting CI timeout; passes on Linux.
     # https://github.com/ROCm/rocm-systems/issues/7148
     disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/kernel.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/kernel.yaml
@@ -2,51 +2,51 @@
 kernel:
   Unit_hipMemFaultStackAllocation_Check:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P1]
   Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check:
     <<: *level_2
-    tags: [attributes]
+    tags: [attributes, P1]
   Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check:
     <<: *level_2
-    tags: [attributes]
+    tags: [attributes, P1]
   Unit_hipDynamicShared:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
+    tags: [memory, P0]
   Unit_hipDynamicShared2:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
   Unit_hipEmptyKernel:
     <<: *level_2
-    tags: [language, smoke]
+    tags: [language, smoke, P0]
   Unit_hipGridLaunch:
     <<: *level_2
-    tags: [launch, smoke]
+    tags: [launch, smoke, P0]
   Unit_hipLanguageExtensions:
     <<: *level_2
-    tags: [language]
+    tags: [language, P1]
   Unit_hipLaunchParm:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipLaunchParmFunctor:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_kernel_chkConstantViaKernel:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
   Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
   Unit_kernel_MemoryOperationsViaKernels:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
   Unit_kernel_LaunchBounds_Functional:
     <<: *level_2
-    tags: [attributes, smoke]
+    tags: [attributes, smoke, P0]
   Unit_kernel_Assign_threadIdx_to_auto:
     <<: *level_2
-    tags: [language]
+    tags: [language, P0]
   Unit_hipLaunchKernelExC_NegetiveTsts:
     <<: *level_2
     tags: [launch]
@@ -55,7 +55,7 @@ kernel:
     tags: [launch]
   Unit_hipLaunchKernelEx_Functional:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipLaunchKernelEx_With_Different_Kernels:
     <<: *level_2
     tags: [launch]
@@ -67,40 +67,41 @@ kernel:
     tags: [launch]
   Unit_kernel_ChkPrintf:
     <<: *level_2
-    tags: [language]
+    tags: [language, P0]
   Unit_hipExtLaunchKernelGGL:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipSetupArgument_Simple:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipSetupArgument_Execute_Kernel_And_Check_Result:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P0]
   Unit_ConfigureCall:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_ConfigureCall_CheckParams:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipGridLaunch_ExceedMaxGridDim_Negative:
     <<: *level_2
     disabled: [amd_windows, amd_linux, amd_wsl]
     tags: [launch]
   Unit_hipExtDynDataPrefetch_NegativeTests:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipExtDynDataPrefetch_FunctionalDaxpy:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipExtDynDataPrefetch_SingleRegion:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_hipExtDynDataPrefetch_TemporalHints:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P1]
   Unit_KernelStackSize:
     <<: *level_2
+    tags: [P0]
     disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Validate_User_Sgpr_Count:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -2,128 +2,128 @@
 memory:
   Unit_hipMemcpy2DToArray_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArray_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArray_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     # Disabling tests tracked with SWDEV-389647..
     disabled: [amd_wsl]
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy3D_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpy3D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3D_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3D_Positive_Array:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy3D_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_multiDevice_Negative:
     <<: *level_2
-    tags: [multigpu, image]
+    tags: [multigpu, image, P1]
   Unit_hipMemcpy3DAsync_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3DAsync_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3DAsync_Positive_Array:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy3DAsync_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3DAsync_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_multiDevice_Negative:
     <<: *level_2
-    tags: [multigpu, image]
+    tags: [multigpu, image, P1]
   Unit_hipMemcpy3DAsync_multiDevice_DiffStream:
     <<: *level_2
-    tags: [multigpu, image]
+    tags: [multigpu, image, P1]
   Unit_hipMemcpyParam2D_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2D_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2D_Positive_Array:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyParam2D_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
@@ -131,270 +131,282 @@ memory:
   Unit_hipMemcpyParam2DAsync_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2DAsync_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2DAsync_Positive_Array:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyParam2DAsync_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyParam2DAsync_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpy2D_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpy2D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2D_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2D_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_H2D_D2D_D2H:
     <<: *level_2
+    tags: [P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset:
     <<: *level_2
+    tags: [P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_H2D_D2D_D2H_Managed_WithOffset:
     <<: *level_2
+    tags: [P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_multiDevice_Basic_Size_Test:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DAsync_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DAsync_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DAsync_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DAsync_Capture:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
   Unit_hipMemcpy2DAsync_Host_N_PinnedMem:
     <<: *level_2
+    tags: [P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
   Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DFromArray_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArray_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArray_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DFromArray_multiDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     # SWDEV-396963
     disabled: [amd_wsl]
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy2DFromArrayAsync_Capture:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyAtoD_Basic:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P0]
   Unit_hipMemcpyAtoH_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P0]
   Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyAtoH_Positive_ZeroCount:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyAtoH_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyAtoH_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyAtoHAsync_Basic:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyAtoHAsync_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyDtoA_Basic:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMemcpyDtoA_Negative:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyDtoA_BasicPositive:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpyHtoA_Positive_Default:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P0]
   Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyHtoA_Positive_ZeroCount:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyHtoA_Negative_Parameters:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyHtoA_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyHtoAAsync_Basic:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMemcpyHtoAAsync_Negative:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyHtoAAsync_MultiDevice:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_HipMemcpyHtoAAsync_Capture:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyAtoA_Basic:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipMemcpy_Negative:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_NullCheck:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_HalfMemCopy:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_MultiThread_AllAPIs:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: []
+    tags: [P1]
   Unit_hipMemcpy_DynamicQueueChurn_StagedCopies:
     <<: *level_2
     tags: [multigpu, transfer]
   Unit_hipHostRegister_ReferenceFromKernelandhipMemset:
     <<: *level_2
     # disabling due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
-    tags: []
+    tags: [P1]
     disabled: [amd_linux, amd_wsl]
-  Unit_hipHostRegister_DirectReferenceFromKernel: *level_2
+  Unit_hipHostRegister_DirectReferenceFromKernel:
+    <<: *level_2
+    tags: [P1]
   Unit_hipHostRegister_DirectReferenceMultGpu:
     <<: *level_2
-    tags: []
+    tags: [P1]
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
   Unit_hipHostRegister_SameChunkRepeat:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostRegister_Chunks_SingleAttempt:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostRegister_Chunks_RoundRobin:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostRegister_Perform_hipMemset:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipHostRegister_Perform_hipMemcpy:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
     # disabled due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
     disabled: [amd_linux, amd_wsl]
   Unit_hipHostRegister_AsyncApis:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostRegister_Graphs:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostRegister_MemAdvise_SetGet:
     <<: *level_2
-    tags: [alloc]
-  Unit_hipHostRegister_Memcpy: *level_2
-  Unit_hipHostRegister_Flags: *level_2
+    tags: [alloc, P1]
+  Unit_hipHostRegister_Memcpy:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipHostRegister_Flags:
+    <<: *level_2
+    tags: [P1]
   Unit_hipHostRegister_Negative:
     <<: *level_2
+    tags: [P1]
     # Tests behaviour after free which throws off the sanitizer
     disabled: [asan]
   Unit_hipHostRegister_DuplicateAndDisjoint:
@@ -414,16 +426,16 @@ memory:
     tags: [alloc]
   Unit_hipHostUnregister_NullPtr:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostUnregister_NotRegisteredPointer:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostUnregister_AlreadyUnregisteredPointer:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostUnregister_Capture:
     <<: *level_2
     tags: [alloc]
@@ -431,15 +443,15 @@ memory:
     <<: *level_2
     # Note: CONFIG_NUMA disabled
     disabled: [amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipHostGetFlags_DifferentThreads:
     <<: *level_2
     # Note: CONFIG_NUMA disabled
     disabled: [amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipHostGetFlags_InvalidArgs:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipHostGetFlags_Capture:
     <<: *level_2
     tags: [query]
@@ -447,10 +459,10 @@ memory:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/96
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipHostGetDevicePointer_UseCase:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipHostGetDevicePointer_Capture:
     <<: *level_2
     tags: [query]
@@ -459,51 +471,51 @@ memory:
     tags: [alloc]
   Unit_hipMallocHost_DataValidation:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMallocHost_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocHost_Capture:
     <<: *level_2
     tags: [alloc]
   Unit_hipMemAllocHost_Positive:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemAllocHost_DataValidation:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemAllocHost_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemAllocHost_VerifyAccess:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemAllocHost_Capture:
     <<: *level_2
     tags: [alloc]
   Unit_hipMallocManaged_HostDeviceConcurrent:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MultiChunkSingleDevice:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MultiChunkMultiDevice:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocManaged_OverSubscription:
     <<: *level_2
     # Huge memory usage, no point enabling it with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_TwoPointers:
     <<: *level_2
-    tags: []
+    tags: [P1]
   Unit_hipMallocManaged_DeviceContextChange:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
   Unit_hipManagedMultiGpuVaConsistency_MultiDevice:
@@ -514,54 +526,54 @@ memory:
     tags: [alloc, multigpu]
   Unit_hipMemset_Negative_InvalidPtr:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset_Negative_OutOfBoundsSize:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset_Negative_OutOfBoundsPtr:
     <<: *level_2
     # Out of bounds access is caught by the sanitizer
     disabled: [asan]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2D_Negative_InvalidPtr:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2D_Negative_InvalidSizes:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2D_Negative_OutOfBoundsPtr:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_Negative_InvalidPtr:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_Negative_ModifiedPtr:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_Negative_InvalidSizes:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_Negative_OutOfBounds:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset_SetMemoryWithOffset:
     <<: *level_2
-    tags: [memset, smoke]
+    tags: [memset, smoke, P0]
   Unit_hipMemsetAsync_SetMemoryWithOffset:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P0]
   Unit_hipMemset_SmallBufferSizes:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset_2AsyncOperations:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset_UnalignedKernelCornerCases:
     <<: *level_2
     tags: [memset, fillBuffer, unaligned]
@@ -570,241 +582,241 @@ memory:
   Unit_hipMemset3D_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_capturehipMemset3DAsync:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
   Unit_hipMemset2D_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2DAsync_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P0]
   Unit_hipMemset2D_UniqueWidthHeight:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2DAsync_capturehipMemset2DAsync:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
   Unit_hipHostMalloc_ArgValidation:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemset3D_MemsetWithExtent:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_MemsetWithExtent:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_MemsetMaxValue:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_MemsetMaxValue:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_SeekSetSlice:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_SeekSetSlice:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_SeekSetArrayPortion:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_SeekSetArrayPortion:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3D_RegressInLoop:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_RegressInLoop:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DAsync_ConcurrencyMthread:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMallocManaged_FlgParam:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_AccessMultiStream:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPrefetchAsyncAdviseFlgTst:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
   Unit_hipMemPrefetchAsyncAccsdByTst:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
   Unit_hipMemPrefetchAsyncNegativeTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPrefetchAsync_NonPageSz:
     <<: *level_2
     # Disabling below tests temporarily due to change in API behavior
     disabled: [amd_windows, amd_wsl, amd_linux]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_MmapMem:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMallocManaged_Basic:
     <<: *level_2
-    tags: [alloc, smoke]
+    tags: [alloc, smoke, P0]
   Unit_hipMallocManaged_Advanced:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_Large:
     <<: *level_2
     # Huge memory usage, no point enabling it with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic:
     <<: *level_2
     # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_linux, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range:
     <<: *level_2
     # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_linux, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
   Unit_hipMemRangeGetAttribute_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_TstCountParam:
     <<: *level_2
     # Huge memory usage, no point enabling it with ASAN
     disabled: [asan]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_AccessedBy1:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttribute_4:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipHostMalloc_CoherentTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipMallocManaged_CoherentTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipMallocManaged_CoherentTstWthAdvise:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMalloc_CoherentTst:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P0]
   Unit_hipExtMallocWithFlags_CoherentTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemsetD32_ValidBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32_InvalidArg:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32_KernelBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32_Capture: *level_2
   Unit_hipMemsetD16_ValidBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16_InvalidArg:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16_KernelBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16_Capture: *level_2
   Unit_hipMemsetD16Async_ValidBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16Async_InvalidArg:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16Async_KernelBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32Async_ValidBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32Async_InvalidArg:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD32Async_KernelBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD8Async_ValidBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD8Async_InvalidArg:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD8Async_KernelBuffer:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetD16_UnalignedPatternFill:
     <<: *level_2
     tags: [memset]
@@ -819,10 +831,10 @@ memory:
     tags: [memset]
   Unit_hipMemcpy2DArrayToArray_Negative:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DArrayToArray_Positive:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipMemcpy2DArrayToArray_BasicPositive:
     <<: *level_2
     tags: [transfer, image]
@@ -873,15 +885,21 @@ memory:
   Unit_hipMemcpyBatchAsync_Attrs_Negative:
     <<: *level_2
     tags: [transfer]
-  Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_H2D_Functional:
+    <<: *level_2
+    tags: [transfer, P1]
   Unit_hipMemcpyBatchAsync_H2D_Pageable_DuringApiCall_SourceAccess:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_H2D_Pageable_Stream_SourceAccess:
     <<: *level_2
     tags: [transfer, stream]
-  Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
-  Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_D2H_Functional:
+    <<: *level_2
+    tags: [transfer, P1]
+  Unit_hipMemcpyBatchAsync_H2H_Functional:
+    <<: *level_2
+    tags: [transfer, P1]
   Unit_hipMemcpyBatchAsync_Mixed_Functional:
     <<: *level_2
     tags: [transfer]
@@ -991,163 +1009,188 @@ memory:
     tags: [transfer, image]
   Unit_hipMemPoolExportPointer_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolExportToShareableHandle_SameProc:
     <<: *level_2
-    tags: [alloc]
+    disabled: [amd_linux, amd_windows, amd_wsl]
+    tags: [alloc, P1]
   Unit_hipMemPoolExportToShareableHandle_ChldUseHdl:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolExportToShareableHandle_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolImportFromShareableHandle_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolImportPointer_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPtrGetInfo_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipMemPtrGetInfo_SizeZeroAllocation:
     <<: *level_2
     tags: [query]
   Unit_hipPointerGetAttributes_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P0]
   Unit_hipPointerGetAttributes_ClusterAlloc:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttributes_TinyClusterAlloc:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttributes_MultiThread:
     <<: *level_2
     tags: []
   Unit_hipPointerGetAttributes_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttributes_GpuIter:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttributes_GpuIter_Managed__Memory:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipExtMallocWithFlags_Positive_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipExtMallocWithFlags_Positive_Zero_Size:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipExtMallocWithFlags_Positive_Alignment:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipExtMallocWithFlags_Negative_Parameters:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MultiThread:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MGpuMThread:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocManaged_MultiKrnlComnHmm:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MultiKrnlComnMalloc:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_MultiThrdMultiStrm:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocManaged_TwoKrnlsComnHmmMem:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemVmm_Basic:
     <<: *level_2
     # SWDEV-396616 hipMemMap returns invalid error
     # AIRUNTIME-2291: temporarily disabled (hangs in CI 942)
     disabled: [amd_windows, amd_wsl, amd_linux]
-    tags: [virtualMemoryManagement]
+    tags: [virtualMemoryManagement, P1]
   Unit_hipMemVmm_Uncached:
     <<: *level_2
     tags: [alloc]
   Unit_hipArray_Valid:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P0]
   Unit_hipArray_Invalid:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray_Nullptr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray_DoubleFree:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray_TrippleDestroy:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray_DoubleNullptr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray_DoubleInvalid:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipGetProcAddress_MemoryApisMallocFree:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
-  Unit_hipGetProcAddress_MemoryApisRegisterUnReg: *level_2
+  Unit_hipGetProcAddress_MemoryApisRegisterUnReg:
+    <<: *level_2
+    tags: [P1]
   Unit_hipGetProcAddress_MemoryApisArrayRelated:
     <<: *level_2
-    tags: [image]
-  Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes: *level_2
-  Unit_hipGetProcAddress_MemoryApisMemCopy: *level_2
-  Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams: *level_2
-  Unit_hipGetProcAddress_MemoryApisMemset: *level_2
+    tags: [image, P1]
+  Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipGetProcAddress_MemoryApisMemCopy:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipGetProcAddress_MemoryApisMemset:
+    <<: *level_2
+    tags: [P1]
   Unit_hipGetProcAddress_MemoryApisMemset2D3D:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
-  Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated: *level_2
+  Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated:
+    <<: *level_2
+    tags: [P1]
   Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
   Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated_Array:
     <<: *level_2
     tags: [image]
   Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
-  Unit_hipGetProcAddress_MemoryApisAddressRelated: *level_2
-  Unit_hipGetProcAddress_MemoryApisManagedMemory: *level_2
-  Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory: *level_2
+  Unit_hipGetProcAddress_MemoryApisAddressRelated:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipGetProcAddress_MemoryApisManagedMemory:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory:
+    <<: *level_2
+    tags: [P1]
   Unit_hipGetProcAddress_MemoryApisPeerToPeer:
     <<: *level_2
-    tags: [multigpu]
-  Unit_hipGetSymbolSizeAddress_Positive_Basic: *level_2
+    tags: [multigpu, P1]
+  Unit_hipGetSymbolSizeAddress_Positive_Basic:
+    <<: *level_2
+    tags: [query, P0]
   Unit_hipGetSymbolAddress_Negative_Parameters: *level_2
   Unit_hipGetSymbolSize_Negative_Parameters: *level_2
   Unit_hipMemPrefetchAsync_v2_Device_Host:
@@ -1174,106 +1217,106 @@ memory:
     <<: *level_2
     # Below test is disabled due to defect EXSWHTEC-347
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerSetAttribute_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemcpyFromToSymbol_Negative:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyToFromSymbol_SyncAndAsync:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpyToFromSymbol_Capture:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipPtrGetAttribute_Simple:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPoolApi_Basic:
     <<: *level_2
-    tags: [stream]
+    tags: [stream, P1]
   Unit_hipMemPoolApi_BasicAlloc:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolApi_BasicTrim:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolApi_BasicReuse:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolApi_Opportunistic:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolApi_Default:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceGetMemPool_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceGetMemPool_Functional:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceGetMemPool_Multidevice:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceGetDefaultMemPool_Functional:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceSetMemPool_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceSetMemPool_DestroyCurrentMempool:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceSetMemPool_functional:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipDeviceSetMemPool_functionalAttribute:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetGetAccess_Positive_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemPoolSetGetAccess_Positive_P2P:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMemPoolSetAccess_Negative_Parameters:
     <<: *level_2
     # SWDEV-435667: Below tests failing randomly in stress test on 08/12/23
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetAccess_SetAccess:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMemPoolSetAccess_NegTst:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAccess_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAccess_SetGet:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetGetAttribute_Positive_Default:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetGetAttribute_Positive_MemBasic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetAttribute_Opportunistic:
     <<: *level_2
     tags: [alloc]
@@ -1281,211 +1324,211 @@ memory:
     <<: *level_2
     # mlsejenkins_Window_Failures_on_gfx1201
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetAttribute_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolSetAttribute_ResetMemHighAttr:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_SetGet:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_UsedMem:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_ReservedMem:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_UsageStatistics:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolGetAttribute_CheckDefaultValues:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolCreate_Negative_Parameter:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolCreate_With_maxSize:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolCreate_Without_maxSize:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolCreate_DeviceTest:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMemPoolDestroy_Negative_Parameter:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolMaxAlloc:
     <<: *level_2
     tags: [alloc]
   Unit_hipMemPoolTrimTo_Negative_Parameter:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolTrimTo_Positive_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMemPoolTrimTo_VaryingMinBytesToHold:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMemPoolTrimTo_Multithreaded:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_Basic_OneAlloc:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMallocFromPoolAsync_Basic_TwoAllocs:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_Basic_Reuse:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_Negative_Parameters:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_ReleaseThreshold:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_NullStream:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_hipStreamPerThread:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_Multidevice_Concurrent:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocFromPoolAsync_Multidevice_MultiStream:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocFromPoolAsync_MThread_DefaultThresh:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MThread_MaxThresh:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [amd_windows, amd_wsl, asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [amd_windows, amd_wsl, asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MultStream_Sync:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_MultStream_UserStreams:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemcpyPeer_Positive_Default:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeer_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeer_Positive_ZeroSize:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
     # Disabling test tracked SWDEV-391555
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpyPeer_Negative_Parameters:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeerAsync_Positive_Default:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeerAsync_Positive_ZeroSize:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
     # Disabling test tracked SWDEV-391555
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpyPeerAsync_Negative_Parameters:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyPeerAsync_Capture:
     <<: *level_2
     tags: [multigpu, transfer]
   Unit_hipMemcpyPeerAsync_StreamOnDiffDevice:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyWithStream_TestwithTwoStream:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyWithStream_TestkindDtoH:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyWithStream_TestkindHtoH:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyWithStream_TestkindDtoD:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyWithStream_TestkindDefault:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyWithStream_TestkindDefaultForDtoD:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyWithStream_TestDtoDonSameDevice:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpy_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_Negative_Parameters:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyWithStream_Capture:
     <<: *level_2
     tags: [transfer]
@@ -1493,234 +1536,240 @@ memory:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemsetAsync_VerifyExecutionWithKernel:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2DAsync_WithKernel:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset2DAsync_MultiThread:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemcpyDtoD_Basic:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyDtoDAsync_Basic:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipMemcpyDtoDAsync_Capture:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipHostMalloc_Basic:
     <<: *level_2
-    tags: [alloc, smoke]
+    tags: [alloc, smoke, P0]
   Unit_hipHostMalloc_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostMalloc_NonCoherent:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostMalloc_Coherent:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostMalloc_Default:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipHostMalloc_Capture:
     <<: *level_2
     tags: [alloc]
-  Unit_hipMemcpy_KernelLaunch: *level_2
+  Unit_hipMemcpy_KernelLaunch:
+    <<: *level_2
+    tags: [P0]
   Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem:
     <<: *level_2
-    tags: []
+    tags: [P1]
   Unit_hipMemcpy_MultiThreadWithSerialization:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy_PinnedRegMemWithKernelLaunch:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
   Unit_hipMemcpyDtoH_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoH_Negative_Parameters:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoD_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoD_Negative_Parameters:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoD_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P0]
   Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoD_Negative_Parameters:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyAsync_Positive_Basic:
     <<: *level_2
-    tags: [transfer, smoke]
+    tags: [transfer, smoke, P0]
   Unit_hipMemcpyAsync_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyAsync_Negative_Parameters:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyAsync_Capture:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem:
     <<: *level_2
-    tags: []
-  Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread: *level_2
-  Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream: *level_2
+    tags: [P1]
+  Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream:
+    <<: *level_2
+    tags: [P1]
   Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch:
     <<: *level_2
-    tags: [multigpu]
+    tags: [multigpu, P1]
   Unit_hipMemcpyDtoHAsync_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoHAsync_Negative_Parameters:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoDAsync_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoDAsync_Negative_Parameters:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoDAsync_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoDAsync_Negative_Parameters:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyDtoHAsync_Capture:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpyHtoDAsync_Capture:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemsetFunctional_ZeroValue_hipMemset:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroValue_hipMemsetD32:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroValue_hipMemsetD16:
     <<: *level_2
     # Below tests soft hang in stress test on 13/09/23
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroValue_hipMemsetD8:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_hipMemset:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_hipMemsetD32:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_hipMemsetD16:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_hipMemsetD8:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_hipMemset:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_hipMemsetD32:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_hipMemsetD16:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_hipMemsetD8:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_PartialSet_1D:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroValue_2D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_2D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_2D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_PartialSet_2D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroValue_3D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_SmallSize_3D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_ZeroSize_3D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemsetFunctional_PartialSet_3D:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMalloc_Positive_Basic:
     <<: *level_2
-    tags: [alloc, smoke]
+    tags: [alloc, smoke, P0]
   Unit_hipMalloc_Positive_Zero_Size:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMalloc_Positive_Alignment:
     <<: *level_2
-    tags: [alloc, smoke]
+    tags: [alloc, smoke, P0]
   Unit_hipMalloc_Negative_Parameters:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMalloc_Allocate90PercentOfDeviceMemory:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     # Huge memory usage, no point enabling it with ASAN
     disabled: [amd_windows, amd_wsl, asan]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMalloc_Positive_APU_LargeAllocSpill:
     <<: *level_2
     tags: [alloc]
@@ -1732,257 +1781,259 @@ memory:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMemAllocPitch_ValidatePitch:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_ValidatePitch:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMalloc3D_Negative:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_Zero_Dims:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMemAllocPitch_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_SmallandBigChunks:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_Memcpy2D:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
   Unit_hipMallocPitch_MultiThread:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocPitch_KernelLaunch:
     <<: *level_2
+    tags: [P1]
     disabled: [amd_wsl]
   Unit_hipMalloc3D_Basic:
     <<: *level_2
     # hipMemGetInfo doesnt report updated memory immediately after hipFree in ASAN
     disabled: [amd_wsl, asan]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMalloc3D_SmallandBigChunks:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMalloc3D_MultiThread:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMalloc3DArray_DiffSizes:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_MultiThread:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_happy:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMalloc3DArray_MaxTexture:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMalloc3DArray_Negative_NullArrayPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_NullDescPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_ZeroWidth:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_ZeroHeight:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_InvalidFlags:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_InvalidFormat:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_BadChannelLayout:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_8BitFloat:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_DifferentChannelSizes:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_BadChannelSize:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_NumericLimit:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMalloc3DArray_Negative_Non2DTextureGather:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArray3DCreate_happy:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArray3DCreate_MaxTexture:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArray3DCreate_Negative_NullArrayPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_NullDescPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_ZeroWidth:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_ZeroHeight:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_InvalidFormat:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_NumChannels:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_InvalidFlags:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_NumericLimit:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipArray3DCreate_Negative_Non2DTextureGather:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipDrvMemcpy3D_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows, amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3D_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3D_Positive_Array:
     <<: *level_2
     # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipDrvMemcpy3D_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3D_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_MultipleDataTypes:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipDrvMemcpy3D_HosttoDevice:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipDrvMemcpy3D_Negative:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipDrvMemcpy3D_ExtentValidation:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipDrvMemcpy3D_H2DDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipDrvMemcpy3DAsync_Positive_Basic:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3DAsync_Positive_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3DAsync_Positive_Array:
     <<: *level_2
     # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_windows, amd_wsl]
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipDrvMemcpy3DAsync_Negative_Parameters:
     <<: *level_2
     disabled: [amd_wsl]
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy3DAsync_Capture:
     <<: *level_2
     disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer]
+    tags: [multigpu, transfer, P1]
   Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange:
     <<: *level_2
-    tags: [multigpu, transfer, image]
+    tags: [multigpu, transfer, image, P1]
   Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test:
     <<: *level_2
-    tags: [transfer, image]
+    tags: [transfer, image, P1]
   Unit_hipPointerGetAttribute_MemoryTypes:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P0]
   Unit_hipPointerGetAttribute_DeferredManagedVar:
     <<: *level_2
     tags: [query]
   Unit_hipPointerGetAttribute_KernelUpdation:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttribute_PeerGPU:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
   Unit_hipPointerGetAttribute_BufferID:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttribute_HostDeviceOrdinal:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttribute_MappedMem:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttribute_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipPointerGetAttribute_ipc_capable:
     <<: *level_2
     disabled: [amd_wsl]
@@ -1992,10 +2043,10 @@ memory:
     tags: [query, image]
   Unit_hipDrvPtrGetAttributes_Negative:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipDrvPtrGetAttributes_Functional:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPrefetchAsync_Basic_AllDevices:
     <<: *level_2
     # AIRUNTIME-2337: temporarily disabled (intermittent failure in CI)
@@ -2003,13 +2054,13 @@ memory:
     tags: []
   Unit_hipMemPrefetchAsync_Sync_Behavior:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPrefetchAsync_Rounding_Behavior:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPrefetchAsync_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemPrefetchBatchAsync_SingleOperationSingleLocation:
     <<: *level_2
     # AIRUNTIME-2337: temporarily disabled (intermittent failure in CI)
@@ -2068,357 +2119,370 @@ memory:
   Unit_hipDrvMemDiscardAndPrefetchBatchAsync_SingleBuffer: *level_2
   Unit_hipMemGetInfo_FreeLessThanTotal:
     <<: *level_2
-    tags: [query]
+    disabled: [amd_linux]
+    tags: [query, P0]
   Unit_hipFreeImplicitSyncDev:
     <<: *level_2
     # Note: TDR
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipFreeImplicitSyncHost:
     <<: *level_2
     # Note: TDR
     disabled: [amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeImplicitSyncArray:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipFreeNegativeDev:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeNegativeHost:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeNegativeArray:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeDoubleDevice:
     <<: *level_2
     # Tests double free which throws off the sanitizer
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeDoubleHost:
     <<: *level_2
     # Tests double free which throws off the sanitizer
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeDoubleArrayFree:
     <<: *level_2
     tags: [alloc]
   Unit_hipFreeDoubleArrayDestroy: *level_2
   Unit_hipFreeDoubleArray:
     <<: *level_2
-    tags: [alloc, image]
-  Unit_hipFreeMultiTDev: *level_2
-  Unit_hipFreeMultiTHost: *level_2
+    tags: [alloc, image, P1]
+  Unit_hipFreeMultiTDev:
+    <<: *level_2
+    tags: [P1]
+  Unit_hipFreeMultiTHost:
+    <<: *level_2
+    tags: [P1]
   Unit_hipFreeMultiTArray:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipFreeArray_DifferentSizes:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipFreeArray_NegativeArray:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeArray_DoubleFree:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipFreeArray_MultiThreaded:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipHostFree_InvalidMemory:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostFree_DoubleFree:
     <<: *level_2
     # Tests double free which throws off the sanitizer
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostFree_Multithreading:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipHostFree_Capture:
     <<: *level_2
     tags: [alloc]
   Unit_hipMemcpySync:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy2DSync:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemcpy3DSync:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipMemsetSync:
     <<: *level_2
     # Note: TDR (random fail)
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P0]
   Unit_hipMemsetDSync:
     <<: *level_2
+    tags: [P1]
     # Note: TDR (random fail)
     disabled: [amd_wsl]
   Unit_hipMemset2DSync:
     <<: *level_2
     # SWDEV-398977 fails in stress tests
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P0]
   Unit_hipMemset3DSync:
     <<: *level_2
     # Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_wsl]
-    tags: [memset]
+    tags: [memset, P0]
   Unit_hipMemsetASyncMulti:
     <<: *level_2
-    tags: [memset]
-  Unit_hipMemsetDASyncMulti: *level_2
+    tags: [memset, P1]
+  Unit_hipMemsetDASyncMulti:
+    <<: *level_2
+    tags: [P1]
   Unit_hipMemset2DASyncMulti:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemset3DASyncMulti:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, P1]
   Unit_hipMemAdvise_TstAccessedByPeer:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
   Unit_hipMemAdvise_TstAccessedByFlg2:
     <<: *level_2
-    tags: [query, multigpu]
+    tags: [query, multigpu, P1]
   Unit_hipMemAdvise_TstAccessedByFlg3:
     <<: *level_2
-    tags: [query, multigpu]
+    tags: [query, multigpu, P1]
   Unit_hipMemAdvise_TstAccessedByFlg4:
     <<: *level_2
     # Note: Windows disabled
     # AIRUNTIME-2291: temporarily disabled (hangs in CI 942)
     disabled: [amd_windows, amd_wsl, amd_linux]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_TstAlignedAllocMem:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_TstAlignedAllocMem_XNACK:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_ReadMosltyMgpuTst:
     <<: *level_2
-    tags: [multigpu, query]
+    tags: [multigpu, query, P1]
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
   Unit_hipMemAdvise_Set_Unset_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_No_Flag_Interference:
     <<: *level_2
     # (amd_linux) NOTE: The following test is disabled due to defect - EXSWHTEC-244
     # (amd_windows) Note: intermittent Seg fault failure
     # (amd_wsl) Note: intermittent Seg fault failure
     disabled: [amd_linux, amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_Rounding:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_Read_Write_After_Advise:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_Prefetch_After_Advise:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_AccessedBy_All_Devices:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemAdvise_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttributes_Positive_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemRangeGetAttributes_Negative_Parameters:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipFreeAsync_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeAsync_capturehipFreeAsync:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipFreeHost_InvalidMemory:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeHost_DoubleFree:
     <<: *level_2
     # Tests double free which throws off the sanitizer
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipFreeHost_Multithreading:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_Basic_OneAlloc:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMallocAsync_Basic_TwoAllocs:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMallocAsync_Basic_Reuse:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipMallocAsync_Negative_Parameters:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_Multistream_Concurrent:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_StreamEvent_CrissCross:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_Multidevice:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_Multidevice_Concurrent:
     <<: *level_2
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocAsync_Multidevice_MultiStream:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc, multigpu]
+    tags: [alloc, multigpu, P1]
   Unit_hipMallocAsync_ByUsinghipMalloc:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_ByUsinghipFree:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_MThread_ThreadLocalStream:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_MThread_ThreadSharedStream:
     <<: *level_2
     # Does not play well with ASAN
     disabled: [asan]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocAsync_DefaultStreams_Concurrent:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipStreamAttachMemAsync_Positive_Basic:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipStreamAttachMemAsync_Positive_Pageable:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipStreamAttachMemAsync_Positive_AttachGlobal:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipStreamAttachMemAsync_Positive_AttachHost:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipStreamAttachMemAsync_Positive_AttachSingle:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipStreamAttachMemAsync_Negative_Parameters:
     <<: *level_2
     # Below tests soft hang in stress test on 13/09/23
     # Asan test disabled temporarily until PR #5287 is merged
     disabled: [amd_wsl, asan]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemGetAddressRange_Positive:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMemGetAddressRange_Negative:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_wsl]
-    tags: [query]
+    tags: [query, P1]
   Unit_hipMallocMipmappedArray_DiffSizes:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_MultiThread:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-  Unit_hipMallocMipmappedArray_happy: *level_2
+  Unit_hipMallocMipmappedArray_happy:
+    <<: *level_2
+    tags: [P1]
   Unit_hipMallocMipmappedArray_Negative_NullArrayPtr:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_NullDescPtr:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_ZeroWidth:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_ZeroHeight:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_InvalidFlags:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_InvalidFormat:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_BadChannelLayout:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_8BitFloat:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_BadChannelSize:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_NumericLimit:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMallocMipmappedArray_Negative_NumLevels:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipGetMipmappedArrayLevel_Negative:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
-  Unit_hipFreeMipmappedArrayImplicitSyncArray: *level_2
+    tags: [alloc, P1]
+  Unit_hipFreeMipmappedArrayImplicitSyncArray:
+    <<: *level_2
+    tags: [P1]
   Unit_hipFreeMipmappedArray_Negative_Nullptr:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipFreeMipmappedArrayMultiTArray:
     <<: *level_2
+    tags: [P1]
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
   Unit_hipFreeMipmappedArray_NoLeakAfterGetLevel:
@@ -2432,171 +2496,173 @@ memory:
     tags: [alloc]
   Unit_hipMallocArray_DiffSizes:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P0]
   Unit_hipMallocArray_MultiThread:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_happy:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMallocArray_MaxTexture_Default:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipMallocArray_Negative_DifferentChannelSizes:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_ZeroWidth:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_NullArrayPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_NullDescPtr:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_BadFlags:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_8bitFloat:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
   Unit_hipMallocArray_Negative_BadNumberOfBits:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_3ChannelElement:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_ChannelAfterZeroChannel:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_InvalidChannelFormat:
     <<: *level_2
     # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
     disabled: [nvidia_windows]
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipMallocArray_Negative_NumericLimit:
     <<: *level_2
-    tags: [alloc, image]
+    tags: [alloc, image, P1]
   Unit_hipHostAlloc_Positive:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P0]
   Unit_hipHostAlloc_DataValidation:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Negative:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Basic:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Default:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Negative_NonCoherent:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Negative_Coherent:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Negative_NumaUser:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
     disabled: [amd_windows, amd_wsl]
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_ArgValidation:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, P1]
   Unit_hipHostAlloc_Capture:
     <<: *level_2
     tags: [alloc]
   Unit_hipDrvMemcpy2DUnaligned_NegTst:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy2DUnaligned_FuncTst:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy2DUnaligned_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, P1]
   Unit_hipArrayGetInfo_Positive_Basic:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayGetInfo_Negative_Parameters:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayCreate_DiffSizes:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_MultiThread:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_happy:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_maxTexture:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_ZeroWidth:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_Nullptr:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_BadNumberChannelElement:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayCreate_BadChannelFormat:
     <<: *level_2
-    tags: [image]
+    tags: [image, P1]
   Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayGetDescriptor_Host2Array_Array2Host:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayGetDescriptor_Negative_Scenarios:
     <<: *level_2
-    tags: [query]
+    tags: [query, P1]
   Unit_hipArrayGetDescriptor_Positive_Basic:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArrayGetDescriptor_Negative_Parameters:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArray3DGetDescriptor_Positive_Basic:
     <<: *level_2
-    tags: [query, image]
+    tags: [query, image, P1]
   Unit_hipArray3DGetDescriptor_Negative_Parameters:
     <<: *level_2
-    tags: [query, image]
-  Unit_hipMemcpyToFromSymbol_GlobalConstVar: *level_2
+    tags: [query, image, P1]
+  Unit_hipMemcpyToFromSymbol_GlobalConstVar:
+    <<: *level_2
+    tags: [P1]
   Unit_svm_byte_granularity:
     <<: *level_2
     tags: []

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -4,7 +4,7 @@ module:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows, amd_wsl]
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
@@ -22,7 +22,7 @@ module:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows, amd_wsl]
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipModuleLaunchKernel_Positive_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
@@ -73,7 +73,7 @@ module:
     tags: [function, multigpu]
   Unit_hipModuleGetFunction_Positive_Basic:
     <<: *level_2
-    tags: [function]
+    tags: [function, P0]
   Unit_hipModuleGetFunction_Negative_Parameters:
     <<: *level_2
     tags: [function]
@@ -103,7 +103,7 @@ module:
     tags: [function]
   Unit_hipHccModuleLaunchKernel_basic:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipHccModuleLaunchKernel_NegTst:
     <<: *level_2
     tags: [launch]
@@ -118,7 +118,7 @@ module:
     tags: [launch]
   Unit_hipDrvLaunchKernelEx_Functional:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipDrvLaunchKernelEx_With_Different_Kernels:
     <<: *level_2
     tags: [launch]
@@ -140,7 +140,7 @@ module:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
-    tags: [load]
+    tags: [load, P0]
   Unit_hipModuleLoadData_Negative_Parameters:
     <<: *level_2
     # Below tests tests fail in PSDB
@@ -153,7 +153,7 @@ module:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
-    tags: [load]
+    tags: [load, P0]
   Unit_hipModuleLoad_Negative_Parameters:
     <<: *level_2
     tags: [load]
@@ -184,7 +184,7 @@ module:
     tags: [load]
   Unit_hipModuleUnload_basic:
     <<: *level_2
-    tags: [load]
+    tags: [load, P0]
   Unit_hipModuleGetFunctionCount_Functional:
     <<: *level_2
     # (amd_linux) Rock_Linux_Failures_on_gfx94X
@@ -282,7 +282,7 @@ module:
     tags: [resource, image]
   Unit_hipFuncSetAttribute_Basic:
     <<: *level_2
-    tags: [function]
+    tags: [function, P0]
   Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr:
     <<: *level_2
     tags: [launch]
@@ -308,7 +308,7 @@ module:
     <<: *level_2
     # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
     disabled: [amd_windows, amd_wsl]
-    tags: [launch]
+    tags: [launch, P0]
   Unit_hipExtModuleLaunchKernel_AnyOrder:
     <<: *level_2
     tags: [launch]

--- a/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
@@ -2,34 +2,34 @@
 multiThread:
   Unit_hipMemsetAsync_QueueJobsMultithreaded:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P1]
     # AIRUNTIME-2291: temporarily disabled (hangs in CI 942)
     disabled: [amd_windows, amd_wsl, amd_linux]
   Unit_hipMultiThreadDevice_Streams:
     <<: *level_2
-    tags: [device_mgmt]
+    tags: [device_mgmt, P0]
   Unit_hipMultiThreadDevice_SerialPyramid:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [device_mgmt]
+    tags: [device_mgmt, P1]
   Unit_hipMultiThreadDevice_ParallelPyramid:
     <<: *level_2
-    tags: [device_mgmt]
+    tags: [device_mgmt, P1]
   Unit_hipMultiThreadDevice_NearZero:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [device_mgmt]
+    tags: [device_mgmt, P1]
   Unit_hipMultiThreadStreams1_AsyncSync:
     <<: *level_2
-    tags: [stream]
+    tags: [stream, P0]
   Unit_hipMultiThreadStreams1_AsyncAsync:
     <<: *level_2
-    tags: [stream]
+    tags: [stream, P0]
   Unit_hipMultiThreadStreams1_AsyncSame:
     <<: *level_2
-    tags: [stream]
+    tags: [stream, P0]
   Unit_hipMultiThreadStreams2:
     <<: *level_2
-    tags: [stream]
+    tags: [stream, P0]

--- a/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
@@ -4,10 +4,14 @@ occupancy:
     <<: *level_2
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
-  Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation: *level_2
+  Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
+    <<: *level_2
+    tags: [P0]
   Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation: *level_2
   Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters: *level_2
-  Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation: *level_2
+  Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation:
+    <<: *level_2
+    tags: [P0]
   Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation: *level_2
   Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters:
     <<: *level_2
@@ -31,6 +35,7 @@ occupancy:
     disabled: [amd_windows, amd_wsl]
   Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
     <<: *level_2
+    tags: [P0]
     # SWDEV-434878: Below tests failed in stress test on 24/11/23
     disabled: [amd_windows, amd_wsl]
   Unit_OccupancyAPIs_StreamCapture: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -2,40 +2,40 @@
 stream:
   Unit_hipStreamCreate_default:
     <<: *level_2
-    tags: [lifecycle, smoke]
+    tags: [lifecycle, smoke, P0]
   Unit_hipStreamCreate_Negative:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamGetFlags_Basic:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P0]
   Unit_hipStreamGetFlags_Negative:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetFlags_StreamsCreatedWithCUMask:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetPriority_happy:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P0]
   Unit_hipStreamGetPriority_nullptr_nullptr:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetPriority_stream_nullptr:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetPriority_nullptr_priority:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetPriority_stream_priority:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetPriority_StreamsWithCUMask:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipMultiStream_sameDevice:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipMultiStream_SharedHwQueuePacketOrdering:
     # Uses wall_clock64(), so the test is only compiled on AMD.
     <<: *level_2
@@ -43,19 +43,19 @@ stream:
     tags: [synchronization]
   Unit_hipMultiStream_multimeDevice:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamAddCallback_ParamTst_Positive:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P0]
   Unit_hipStreamAddCallback_ParamTst_Negative:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipStreamAddCallback_WithDefaultStream:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipStreamAddCallback_WithCreatedStream:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P0]
   Unit_hipStreamAttachMemAsync_Negative:
     <<: *level_2
     # Asan test disabled temporarily until PR #5287 is merged
@@ -63,45 +63,45 @@ stream:
     tags: [memory]
   Unit_hipStreamAttachMemAsync_UseCase:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P0]
     # disabled due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
     disabled: [amd_linux, amd_wsl]
   Unit_hipStreamCreateWithFlags_Negative_NullStream:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithFlags_Negative_InvalidFlag:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithFlags_Default:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipStreamCreateWithFlags_DefaultStreamInteraction:
     <<: *level_2
     # (amd_windows) Disabling below tests temporarily due to change in API behavior
     # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipStreamCreateWithPriority_MulthreadDefaultflag:
     <<: *level_2
     # SWDEV-398981 fails in stress test
     # Does not play well with ASAN
     disabled: [amd_wsl, asan]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag:
     <<: *level_2
     # Disabling test tracked SWDEV-394199
     # Does not play well with ASAN
     disabled: [amd_windows, amd_wsl, asan]
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithPriority_NegTst:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithPriority_CheckPriorityVal:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamCreateWithPriority_VerifyKernelResults:
     <<: *level_2
     # Below tests fail in stress test on 24/07/23
@@ -109,7 +109,7 @@ stream:
     tags: [lifecycle]
   Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamPriorityAqlLog_ChildWorkload:
     <<: *level_2
     # Internal helper, only invoked by the parent test via re-exec (by exact
@@ -135,29 +135,29 @@ stream:
     tags: [synchronization]
   Unit_hipStreamDestroy_Default:
     <<: *level_2
-    tags: [lifecycle, smoke]
+    tags: [lifecycle, smoke, P0]
   Unit_hipStreamDestroy_Negative_NullStream:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamDestroy_WithFinishedWork:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipStreamDestroy_WithPendingWork:
     <<: *level_2
     # Note: TDR
     disabled: [amd_wsl]
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem:
     <<: *level_2
     tags: [memory]
   Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipMemPrefetchAsync_Basic:
     <<: *level_2
     # AIRUNTIME-2337: temporarily disabled (intermittent failure in CI)
     disabled: [amd_windows, amd_wsl, amd_linux]
-    tags: [memory]
+    tags: [memory, P1]
   Unit_hipMemPoolApi_hipStreamLegacy_Basic:
     <<: *level_2
     tags: [memory]
@@ -165,171 +165,171 @@ stream:
     <<: *level_2
     # Below tests fail in stress test on 30/06/23
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamValue_Negative_InvalidMemory:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamWriteValue_Default:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamWaitValue_Default:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamSynchronize_EmptyStream:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamSynchronize_FinishWork:
     <<: *level_2
     # Note: TDR (pass)
     disabled: [amd_wsl]
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipStreamSynchronize_NullStreamSynchronization:
     <<: *level_2
     # (amd_windows) mlsejenkins_Window_Failures_on_gfx1201
     # (amd_wsl) Note: TDR (pass)
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamSynchronize_NullStreamAndStreamPerThread:
     <<: *level_2
     # Note: needs to be enabled when streamPerThread issues are fixed
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamKilledWorkerThread:
     <<: *level_2
     disabled: [amd_linux]
     tags: [synchronization]
   Unit_hipStreamQuery_WithNoWork:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipStreamQuery_WithFinishedWork:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream:
     <<: *level_2
     # Note: TDR (pass)
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamQuery_NullStreamQuery:
     <<: *level_2
     # Note: TDR (pass)
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamQuery_WithPendingWork:
     <<: *level_2
     # (amd_linux) Rock_Linux_Failures_on_gfx94X
     # (amd_wsl) Note: TDR (pass)
     disabled: [amd_linux, amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P0]
   Unit_hipDeviceGetStreamPriorityRange_Default:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamAddCallback_StrmSyncTiming:
     <<: *level_2
     # (amd_windows) SWDEV-400049 tdr intermittently
     # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_basic:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P0]
   Unit_hipLaunchHostFunc_Negative:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_streams:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_multistreams:
     <<: *level_2
     # SWDEV-430116:Below tests failed in stress test on 27/10/23
     disabled: [amd_wsl]
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_KernelHost:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_multidevice:
     <<: *level_2
-    tags: [callback, multigpu]
+    tags: [callback, multigpu, P1]
   Unit_hipLaunchHostFunc_Samepriority:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_Diffpriority:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipLaunchHostFunc_Graph:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipStreamGetDevice_Negative:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetDevice_Usecase:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P0]
   Unit_hipStreamGetDevice_MThread:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamGetDevice_SetDiffDevice:
     <<: *level_2
-    tags: [properties, multigpu]
+    tags: [properties, multigpu, P1]
   Unit_hipStreamGetDevice_NullStream:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamLegacy_WithBlockingStream:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipStreamLegacy_MultipleThreads:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamLegacy_NegetiveCase:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamLegacy_WithNonBlockingStream:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamLegacy_WithStreamPerThread:
     <<: *level_2
-    tags: [streamperthread]
+    tags: [streamperthread, P1]
   Unit_hipStreamLegacy_MultiDevice:
     <<: *level_2
-    tags: [lifecycle, multigpu]
+    tags: [lifecycle, multigpu, P1]
   Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default:
     <<: *level_2
-    tags: [memory]
+    tags: [memory, P1]
   Unit_hipStreamLegacy_MultiDeviceMultiOperation:
     <<: *level_2
-    tags: [lifecycle, multigpu]
+    tags: [lifecycle, multigpu, P1]
   Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation:
     <<: *level_2
-    tags: [lifecycle, multigpu]
+    tags: [lifecycle, multigpu, P1]
   Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation:
     <<: *level_2
-    tags: [lifecycle, multigpu]
+    tags: [lifecycle, multigpu, P1]
   Unit_hipStreamLegacy_InChildProcess:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P1]
   Unit_hipStreamLegacy_WithKernel:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, P0]
   Unit_hipStreamLegacy_hipStreamSynchronize:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamLegacy_WithSptCompilerOption:
     <<: *level_2
-    tags: [streamperthread]
+    tags: [streamperthread, P1]
   Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption:
     <<: *level_2
-    tags: [streamperthread]
+    tags: [streamperthread, P1]
   Unit_hipStreamGetId_Negative:
     <<: *level_2
     tags: [properties]
@@ -350,87 +350,87 @@ stream:
     tags: [properties]
   Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipExtStreamGetCUMask_Negative:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipExtStreamCreateWithCUMask_Functionality:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipExtStreamCreateWithCUMask_AllCUsMasked:
     <<: *level_2
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipExtStreamCreateWithCUMask_NegTst:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
     disabled: [amd_linux, amd_wsl]
-    tags: [properties]
+    tags: [properties, P1]
   Unit_hipStreamAddCallback_MultipleThreads:
     <<: *level_2
-    tags: [callback]
+    tags: [callback, P1]
   Unit_hipStreamWaitEvent_Negative:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamWaitEvent_Default:
     <<: *level_2
-    tags: [synchronization, smoke]
+    tags: [synchronization, smoke, P0]
   Unit_hipStreamWaitEvent_DifferentStreams:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamGetFlags_spt_Basic:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamGetFlags_spt_Negative:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamGetPriority_spt_BasicTst:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamGetPriority_spt_NegativeCases:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamGetPriority_spt_StreamsWithCUMask:
     <<: *level_2
-    tags: [properties, streamperthread]
+    tags: [properties, streamperthread, P1]
   Unit_hipStreamQuery_spt_WithNoWork:
     <<: *level_2
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamQuery_spt_WithFinishedWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamQuery_spt_NegativeCases:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamQuery_spt_WithPendingWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamSynchronize_spt_EmptyStream:
     <<: *level_2
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamSynchronize_spt_FinishWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization, streamperthread]
+    tags: [synchronization, streamperthread, P1]
   Unit_hipStreamBatchMemOp_Negative_Tests:
     <<: *level_2
     tags: [memory]
@@ -474,10 +474,10 @@ stream:
     tags: [properties]
   Unit_hipStreamValue_Negative_StreamAndFlag:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamValue_Wait_Blocking:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, P1]
   Unit_hipStreamWriteValue_Decrement_Default:
     <<: *level_2
     tags: [synchronization]

--- a/projects/hip-tests/catch/config/configs/unit/texture.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/texture.yaml
@@ -249,6 +249,7 @@ texture:
     tags: [texobj, image]
   Unit_TexObjectCreate_TypePitch2D_EdgeCases:
     <<: *level_2
+    disabled: [amd_windows]
     tags: [texobj, image]
   Unit_hipGetTexObjectResourceDesc_positive:
     <<: *level_2


### PR DESCRIPTION
## Summary

JIRA ID : AIRUNTIME-2687

hip-tests catch tags.

- Adds 314 `P0` and 702 `P1` tags, plus a handful of `amd_linux`/`amd_windows`/`amd_wsl` platform `disabled` selectors. All added selectors are public.

## Test plan

- [x] Codegen-header regen verified the edits reach the generated header: baseline 0 → 314 P0 / 702 P1 tags (catch-config YAMLs compile into generated headers at build; confirms not a no-op).
- [x] Confidentiality scan on added lines only: 0 non-public token hits.
- [x] CI hip-tests build and suite run on target hardware.

🤖 Claude Code 🤖
