### PR TITLE
docs(rccl): Fixed old ROCm/rccl references in docs files (#8117)

### DIFF
--- a/projects/rccl/README.md
+++ b/projects/rccl/README.md
@@ -5,7 +5,7 @@ ROCm Communication Collectives Library
 [![RCCL](https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/status%2Frccl?repoName=ROCm%2Frccl&branchName=develop)](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/latest?definitionId=107&repoName=ROCm%2Frccl&branchName=develop)
 [![TheRock CI](https://github.com/ROCm/rccl/actions/workflows/therock-ci.yml/badge.svg?branch=develop&event=push)](https://github.com/ROCm/rccl/actions/workflows/therock-ci.yml)
 
-> **Note:** The published documentation is available at [RCCL](https://rocm.docs.amd.com/projects/rccl/en/latest/index.html) in an organized easy-to-read format that includes a table of contents and search functionality. The documentation source files reside in the [rccl/docs](https://github.com/ROCm/rccl/tree/develop/docs) folder in this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
+> **Note:** The published documentation is available at [RCCL](https://rocm.docs.amd.com/projects/rccl/en/latest/index.html) in an organized easy-to-read format that includes a table of contents and search functionality. The documentation source files reside in the [rccl/docs](https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl/docs) folder in this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
 ## Introduction
 

--- a/projects/rccl/bindings/nccl4py/DESCRIPTION.rst
+++ b/projects/rccl/bindings/nccl4py/DESCRIPTION.rst
@@ -2,7 +2,7 @@
 nccl4py: Pythonic RCCL Communication for GPU Clusters
 **************************************************
 
-`nccl4py <https://github.com/ROCm/rccl>`_ provides a Pythonic interface to the
+`nccl4py <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl/bindings/nccl4py>`_ provides a Pythonic interface to the
 ROCm Communication Collectives Library (RCCL), AMD's drop-in replacement for
 NVIDIA NCCL on ROCm. It bridges Python's simplicity with RCCL's GPU-accelerated
 multi-GPU and multi-node communication primitives, so distributed Python
@@ -16,7 +16,7 @@ shim, RCCL-only collective wrappers (``ncclAllReduceWithBias``,
 ``nccl4py`` is deliberately kept so that code written against the upstream
 bindings runs unchanged on ROCm.
 
-* `Homepage <https://github.com/ROCm/rccl>`_
+* `Homepage <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`_
 * `Repository <https://github.com/ROCm/rocm-systems>`_
 * `Documentation <https://rocm.docs.amd.com/projects/rccl/en/latest/>`_
 * `Issue tracker <https://github.com/ROCm/rocm-systems/issues>`_

--- a/projects/rccl/bindings/nccl4py/README.md
+++ b/projects/rccl/bindings/nccl4py/README.md
@@ -1,7 +1,7 @@
 # nccl4py: Python Bindings for RCCL
 
 Python bindings for the [ROCm Communication Collectives Library
-(RCCL)](https://github.com/ROCm/rccl), AMD's drop-in replacement for
+(RCCL)](https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl), AMD's drop-in replacement for
 NVIDIA NCCL on ROCm. This package is a fork of the upstream NVIDIA
 [nccl4py](https://github.com/NVIDIA/nccl/tree/master/bindings/nccl4py)
 v0.2.0 and provides both low-level Cython bindings and a high-level

--- a/projects/rccl/docker/README.md
+++ b/projects/rccl/docker/README.md
@@ -34,7 +34,7 @@ If using ROCm 6.4.0 or later
 $ mpirun --allow-run-as-root -np 8 --mca pml ucx --mca btl ^openib -x NCCL_DEBUG=VERSION /workspace/rccl-tests/build/all_reduce_perf -b 1 -e 16G -f 2 -g 1
 ```
 
-For more information on rccl-tests options, refer to the [Usage](https://github.com/ROCm/rccl-tests#usage) section of rccl-tests.
+For more information on rccl-tests options, refer to the [Usage](https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl-tests#usage) section of rccl-tests.
 
 
 ## Copyright

--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -39,7 +39,7 @@ Quick start RCCL build
 RCCL directly depends on the HIP runtime plus the HIP-Clang compiler, which are part of the ROCm software stack.
 For ROCm installation instructions, see the :doc:`rocm:install/rocm`.
 
-Use the `install.sh helper script <https://github.com/ROCm/rccl/blob/develop/install.sh>`_,
+Use the `install.sh helper script <https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/install.sh>`_,
 located in the root directory of the RCCL repository,
 to build and install RCCL with a single command. It uses hard-coded configurations that can be specified directly
 when using cmake. However, it's a great way to get started quickly and provides an

--- a/projects/rccl/docs/install/docker-install.rst
+++ b/projects/rccl/docs/install/docker-install.rst
@@ -49,4 +49,4 @@ To build the Docker image and run the container, follow these steps.
 
       mpirun --allow-run-as-root -np 8 --mca pml ucx --mca btl ^openib -x NCCL_DEBUG=VERSION -x HSA_NO_SCRATCH_RECLAIM=1 /workspace/rccl-tests/build/all_reduce_perf -b 1 -e 16G -f 2 -g 1
 
-For more information on the rccl-tests options, see the `Usage guidelines <https://github.com/ROCm/rccl-tests#usage>`_ in the GitHub repository.
+For more information on the rccl-tests options, see the `Usage guidelines <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl-tests#usage>`_ in the GitHub repository.


### PR DESCRIPTION
Port of #8117 to `docs/7.14.0`.

## Motivation

RCCL was migrated from ROCm/rccl repo to ROCm/rocm-systems super-repo. Docs required update.

## Technical Details

Updates stale ROCm/rccl repository references in RCCL documentation and packaging files to point to the rocm-systems super-repo paths.

Cherry-picked from commit 9a31416f9350ba0b7db232a1b705f4f93952d964.

## JIRA ID

JIRA ID: ROCM-27388

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Made with [Cursor](https://cursor.com)