### PR TITLE
test(rocrtst): skip core dump and trap abort tests on gfx110X

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
@@ -41,6 +41,26 @@ static const uint32_t kNumBufferElements = rocrtst::isEmuModeEnabled() ? 4 : 256
 // Convert core pattern to glob pattern, substituting known values
 // and using wildcards for unknowable values (timestamp, TID)
 namespace {
+// True if any GPU is gfx11 minor<5. The parent has no HSA runtime, so read
+// gfx_target_version (major*10000 + minor*100 + step) from KFD topology sysfs.
+bool AnyGpuIsGfx11BelowMinor5() {
+  for (int node = 0; node < 64; ++node) {
+    std::ifstream f("/sys/devices/virtual/kfd/kfd/topology/nodes/" +
+                    std::to_string(node) + "/properties");
+    if (!f.is_open()) break;
+    std::string key;
+    while (f >> key) {
+      if (key == "gfx_target_version") {
+        unsigned long ver = 0;
+        f >> ver;
+        if (ver / 10000 == 11 && (ver / 100) % 100 < 5) return true;
+        break;
+      }
+    }
+  }
+  return false;
+}
+
 std::string PatternToGlob(const std::string& pattern, pid_t child_pid) {
   std::string result;
 
@@ -169,6 +189,20 @@ bool GpuCoreDumpTest::CheckPrerequisites() {
 
 void GpuCoreDumpTest::SetUp(void) {
   if (!checkPlatformFiltering()) return;
+
+  // GPU core dump generation is gated off on gfx11 minor<5, 
+  // so no core dump is ever produced and these tests cannot
+  // pass. Skip rather than fail.
+  if (AnyGpuIsGfx11BelowMinor5()) {
+    std::string testName =
+        std::string(::testing::UnitTest::GetInstance()->current_test_info()->test_case_name()) +
+        "." + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::string reason = "GPU core dump is not supported on gfx11 (minor<5)";
+    std::cout << "[ SKIPPED ] " << reason << std::endl;
+    rocrtst::SkippedTestTracker::getInstance().recordSkip(testName, reason);
+    test_skipped_ = true;
+    return;
+  }
 
 #ifdef ROCRTST_ASAN
   // Under ASAN, these tests fork children (unsupported in ASAN) that trigger

--- a/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
@@ -41,6 +41,26 @@ static const uint32_t kNumBufferElements = rocrtst::isEmuModeEnabled() ? 4 : 256
 // Convert core pattern to glob pattern, substituting known values
 // and using wildcards for unknowable values (timestamp, TID)
 namespace {
+// True if any GPU is gfx11 minor<5. The parent has no HSA runtime, so read
+// gfx_target_version (major*10000 + minor*100 + step) from KFD topology sysfs.
+bool AnyGpuIsGfx11BelowMinor5() {
+  for (int node = 0; node < 64; ++node) {
+    std::ifstream f("/sys/devices/virtual/kfd/kfd/topology/nodes/" + std::to_string(node) +
+                    "/properties");
+    if (!f.is_open()) break;
+    std::string key;
+    while (f >> key) {
+      if (key == "gfx_target_version") {
+        unsigned long ver = 0;
+        f >> ver;
+        if (ver / 10000 == 11 && (ver / 100) % 100 < 5) return true;
+        break;
+      }
+    }
+  }
+  return false;
+}
+
 std::string PatternToGlob(const std::string& pattern, pid_t child_pid) {
   std::string result;
 
@@ -169,6 +189,20 @@ bool GpuCoreDumpTest::CheckPrerequisites() {
 
 void GpuCoreDumpTest::SetUp(void) {
   if (!checkPlatformFiltering()) return;
+
+  // GPU core dump generation is gated off on gfx11 minor<5,
+  // so no core dump is ever produced and these tests cannot
+  // pass. Skip rather than fail.
+  if (AnyGpuIsGfx11BelowMinor5()) {
+    std::string testName =
+        std::string(::testing::UnitTest::GetInstance()->current_test_info()->test_case_name()) +
+        "." + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::string reason = "GPU core dump is not supported on gfx11 (minor<5)";
+    std::cout << "[ SKIPPED ] " << reason << std::endl;
+    rocrtst::SkippedTestTracker::getInstance().recordSkip(testName, reason);
+    test_skipped_ = true;
+    return;
+  }
 
 #ifdef ROCRTST_ASAN
   // Under ASAN, these tests fork children (unsupported in ASAN) that trigger

--- a/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.cc
@@ -27,6 +27,7 @@
 #include "common/base_rocr_utils.h"
 #include "common/common.h"
 #include "common/helper_funcs.h"
+#include "common/platform_filter.h"
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
@@ -417,7 +418,8 @@ bool TrapHandlerTest::RunTrapTest(hsa_agent_t cpuAgent, hsa_agent_t gpuAgent,
 }
 
 void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t expected_status,
-                                       bool pass_null_ptr, int divisor_value) {
+                                       bool pass_null_ptr, int divisor_value,
+                                       bool skip_gfx11_below5) {
   hsa_status_t err;
 
   // Find all CPU agents
@@ -434,7 +436,18 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
 
   // Run test on each GPU
   uint32_t tests_failed_before = tests_failed_;
+  size_t gpus_tested = 0;
   for (size_t i = 0; i < gpus.size(); ++i) {
+    char gpu_name[64] = {0};
+    hsa_agent_get_info(gpus[i], HSA_AGENT_INFO_NAME, gpu_name);
+    // gfx110X does not service s_trap 2 (abort), so the callback never fires.
+    if (skip_gfx11_below5 && std::string(gpu_name).compare(0, 6, "gfx110") == 0) {
+      std::cout << "  Testing " << kernel_name << " on " << gpu_name
+                << "... SKIPPED (gfx110X)" << std::endl;
+      continue;
+    }
+
+    ++gpus_tested;
     bool passed =
         RunTrapTest(cpus[0], gpus[i], kernel_name, expected_status, pass_null_ptr, divisor_value);
     if (passed) {
@@ -444,6 +457,19 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
     }
   }
 
+  // If every present GPU was skipped, record the skip so the test is reported
+  // as SKIPPED rather than PASSED. The bundled gtest predates GTEST_SKIP(), so
+  // use the same SkippedTestTracker mechanism as the core dump tests.
+  if (skip_gfx11_below5 && gpus_tested == 0) {
+    const ::testing::TestInfo* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    std::string testName = std::string(info->test_case_name()) + "." + info->name();
+    std::string reason =
+        std::string(kernel_name) + " is not supported on any present GPU (gfx110X)";
+    std::cout << "[ SKIPPED ] " << reason << std::endl;
+    rocrtst::SkippedTestTracker::getInstance().recordSkip(testName, reason);
+    return;
+  }
+
   // Fail the gtest if any GPU failed this test
   EXPECT_EQ(tests_failed_, tests_failed_before)
       << "Test " << kernel_name << " failed on one or more GPUs";
@@ -451,7 +477,8 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
 
 void TrapHandlerTest::TestTrapAbort() {
   std::cout << "\n--- Test: S_TRAP Abort (s_trap 2) ---" << std::endl;
-  RunTestOnAllGPUs("trap_abort", HSA_STATUS_ERROR_EXCEPTION);
+  RunTestOnAllGPUs("trap_abort", HSA_STATUS_ERROR_EXCEPTION, false /* pass_null_ptr */,
+                   1 /* divisor_value */, true /* skip_gfx11_below5 */);
 }
 
 void TrapHandlerTest::TestTrapDebugger() {

--- a/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.cc
@@ -27,6 +27,7 @@
 #include "common/base_rocr_utils.h"
 #include "common/common.h"
 #include "common/helper_funcs.h"
+#include "common/platform_filter.h"
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
@@ -417,7 +418,7 @@ bool TrapHandlerTest::RunTrapTest(hsa_agent_t cpuAgent, hsa_agent_t gpuAgent,
 }
 
 void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t expected_status,
-                                       bool pass_null_ptr, int divisor_value) {
+                                       bool pass_null_ptr, int divisor_value, bool skip_gfx110x) {
   hsa_status_t err;
 
   // Find all CPU agents
@@ -434,7 +435,18 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
 
   // Run test on each GPU
   uint32_t tests_failed_before = tests_failed_;
+  size_t gpus_tested = 0;
   for (size_t i = 0; i < gpus.size(); ++i) {
+    char gpu_name[64] = {0};
+    hsa_agent_get_info(gpus[i], HSA_AGENT_INFO_NAME, gpu_name);
+    // gfx110X does not service s_trap 2 (abort), so the callback never fires.
+    if (skip_gfx110x && std::string(gpu_name).compare(0, 6, "gfx110") == 0) {
+      std::cout << "  Testing " << kernel_name << " on " << gpu_name << "... SKIPPED (gfx110X)"
+                << std::endl;
+      continue;
+    }
+
+    ++gpus_tested;
     bool passed =
         RunTrapTest(cpus[0], gpus[i], kernel_name, expected_status, pass_null_ptr, divisor_value);
     if (passed) {
@@ -444,6 +456,20 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
     }
   }
 
+  // If every present GPU was skipped, record the skip so it isn't silently
+  // counted as a pass. The bundled gtest predates GTEST_SKIP(), so this uses the
+  // same SkippedTestTracker summary mechanism as the core dump tests; gtest
+  // itself still reports the test as passed.
+  if (skip_gfx110x && gpus_tested == 0) {
+    const ::testing::TestInfo* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    std::string testName = std::string(info->test_case_name()) + "." + info->name();
+    std::string reason =
+        std::string(kernel_name) + " is not supported on any present GPU (gfx110X)";
+    std::cout << "[ SKIPPED ] " << reason << std::endl;
+    rocrtst::SkippedTestTracker::getInstance().recordSkip(testName, reason);
+    return;
+  }
+
   // Fail the gtest if any GPU failed this test
   EXPECT_EQ(tests_failed_, tests_failed_before)
       << "Test " << kernel_name << " failed on one or more GPUs";
@@ -451,7 +477,8 @@ void TrapHandlerTest::RunTestOnAllGPUs(const char* kernel_name, hsa_status_t exp
 
 void TrapHandlerTest::TestTrapAbort() {
   std::cout << "\n--- Test: S_TRAP Abort (s_trap 2) ---" << std::endl;
-  RunTestOnAllGPUs("trap_abort", HSA_STATUS_ERROR_EXCEPTION);
+  RunTestOnAllGPUs("trap_abort", HSA_STATUS_ERROR_EXCEPTION, false /* pass_null_ptr */,
+                   1 /* divisor_value */, true /* skip_gfx110x */);
 }
 
 void TrapHandlerTest::TestTrapDebugger() {

--- a/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.h
@@ -147,7 +147,8 @@ class TrapHandlerTest : public TestBase {
    * @param divisor_value Divisor for math test
    */
   void RunTestOnAllGPUs(const char* kernel_name, hsa_status_t expected_status,
-                        bool pass_null_ptr = false, int divisor_value = 1);
+                        bool pass_null_ptr = false, int divisor_value = 1,
+                        bool skip_gfx11_below5 = false);
 
   // Test results tracking
   int tests_passed_{0};

--- a/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/trap_handler_test.h
@@ -147,7 +147,8 @@ class TrapHandlerTest : public TestBase {
    * @param divisor_value Divisor for math test
    */
   void RunTestOnAllGPUs(const char* kernel_name, hsa_status_t expected_status,
-                        bool pass_null_ptr = false, int divisor_value = 1);
+                        bool pass_null_ptr = false, int divisor_value = 1,
+                        bool skip_gfx110x = false);
 
   // Test results tracking
   int tests_passed_{0};


### PR DESCRIPTION
GPU core dump generation and the s_trap 2 abort path are gated off in the runtime on gfx110X, so these tests can never pass. Detect the arch and skip the affected tests instead of failing them. Other architectures are unaffected.

Validated on gfx1102: affected tests reported as SKIPPED, all others pass.

## Motivation

On gfx110X the `GpuCoreDump_*` tests and `TrapHandler_Abort` fail in nightly CI because the underlying features are intentionally disabled in the runtime (`amd_aql_queue.cpp` / `runtime.cpp`, gated on `major==11 && minor<5`). No core dump is ever produced and the abort callback never fires, so the tests cannot pass. Skipping them keeps the suite green on gfx110X without hiding real failures on other architectures.

## Technical Details

- `gpu_coredump.cc`: the parent process has no HSA runtime, so a small file-local helper reads `gfx_target_version` from KFD topology sysfs (`/sys/devices/virtual/kfd/kfd/topology/...`) and skips the fixture when a gfx11 minor<5 GPU is present. The condition mirrors the runtime gate exactly.
- `trap_handler_test.cc`: reuses the HSA agent name the test already queries (`HSA_AGENT_INFO_NAME`) and skips gfx110X per-agent for the abort test.
- Skips are recorded via `SkippedTestTracker` since the bundled gtest predates `GTEST_SKIP()`.
- Depends on #10180 (which re-enables the trap tests); this PR should be rebased after that merges. The two changes touch disjoint files, so there is no conflict.

## Issue Tracking

GitHub issue: #9971

## Test Plan

Built rocrtst and ran `GpuCoreDump_*` and `TrapHandler_{Abort,NoTrap,Generic}` on gfx1102 (gfx110X), gfx942, and gfx1036, including a run with the trap tests enabled to mirror the post-#10180 state.

## Test Result

- gfx1102 (gfx110X): all `GpuCoreDump_*` and `TrapHandler_Abort` reported SKIPPED; `TrapHandler_NoTrap`/`Generic` pass; full suite EXIT 0 (69 pass / 0 fail).
- gfx942 / gfx1036: nothing over-skipped — coredump and trap tests run and pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
