### PR TITLE
[kpack] Make fat-binary detection idempotent across a split

### DIFF
--- a/shared/kpack/python/rocm_kpack/__init__.py
+++ b/shared/kpack/python/rocm_kpack/__init__.py
@@ -32,6 +32,7 @@ from .kpack_transform import (
     kpack_offload_binary,
     read_kpack_ref_marker,
     is_fat_binary,
+    is_kpack_processed,
     NotFatBinaryError,
 )
 
@@ -45,5 +46,6 @@ __all__ = [
     "kpack_offload_binary",
     "read_kpack_ref_marker",
     "is_fat_binary",
+    "is_kpack_processed",
     "NotFatBinaryError",
 ]

--- a/shared/kpack/python/rocm_kpack/artifact_utils.py
+++ b/shared/kpack/python/rocm_kpack/artifact_utils.py
@@ -106,6 +106,14 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
     the shape of a separated debug file produced by `objcopy --only-keep-debug`
     (TheRock's `*_dbg` artifacts), which carries no device code to split.
 
+    A binary that already carries a kpack marker section (.rocm_kpack_ref for
+    ELF, .kpackrf for COFF) is likewise *not* a fat binary: its device code has
+    already been moved into a .kpack archive. Such a binary keeps its
+    .hip_fatbin/.hip_fat section header, so the name check alone would send it
+    back through the splitter and `add_section()` would then fail with
+    "Section '.rocm_kpack_ref' already exists". Reporting False here is what
+    makes re-splitting an already-split tree a no-op instead of a hard error.
+
     Args:
         file_path: Path to the file to check
         toolchain: Toolchain instance with readelf path
@@ -133,12 +141,17 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
 
     if fmt == "elf":
         surgery = ElfSurgery.load(file_path)
+        if surgery.find_section(".rocm_kpack_ref") is not None:
+            return False
         section = surgery.find_section(".hip_fatbin")
         if section is None:
             return False
         return not section.header.is_nobits
     else:
         surgery = CoffSurgery.load(file_path)
+        # .kpackrf is the 8-char PE spelling of .rocm_kpack_ref.
+        if surgery.find_section(".kpackrf") is not None:
+            return False
         return surgery.find_section(".hip_fat") is not None
 
 

--- a/shared/kpack/python/rocm_kpack/coff/surgery.py
+++ b/shared/kpack/python/rocm_kpack/coff/surgery.py
@@ -181,7 +181,23 @@ class CoffSurgery:
 
     @staticmethod
     def has_fatbin_section(file_path: Path) -> bool:
-        """Fast check for .hip_fat section without loading the full binary.
+        """Fast check for .hip_fat section without loading the full binary."""
+        return CoffSurgery._has_section_named(file_path, b".hip_fat")
+
+    @staticmethod
+    def has_kpack_ref_section(file_path: Path) -> bool:
+        """Fast check for the .kpackrf marker without loading the full binary.
+
+        Its presence means the binary has already been through
+        kpack_offload_binary(): the device code lives in a .kpack archive and
+        the .hip_fat section header that remains is a leftover, not splittable
+        content.
+        """
+        return CoffSurgery._has_section_named(file_path, b".kpackrf")
+
+    @staticmethod
+    def _has_section_named(file_path: Path, target: bytes) -> bool:
+        """Scan the PE section header table for an 8-byte section name.
 
         Reads only the DOS header, PE signature, COFF header, and section
         headers — a few KB total even for large binaries.
@@ -215,8 +231,6 @@ class CoffSurgery:
             if len(section_data) < num_sections * SECTION_HEADER_SIZE:
                 return False
 
-            # Check each section name for ".hip_fat"
-            target = b".hip_fat"
             for i in range(num_sections):
                 name = section_data[
                     i * SECTION_HEADER_SIZE : i * SECTION_HEADER_SIZE + 8

--- a/shared/kpack/python/rocm_kpack/elf/surgery.py
+++ b/shared/kpack/python/rocm_kpack/elf/surgery.py
@@ -254,6 +254,17 @@ class ElfSurgery:
         return ElfSurgery._section_location(file_path, ".hip_fatbin") is not None
 
     @staticmethod
+    def has_kpack_ref_section(file_path: Path) -> bool:
+        """Fast check for .rocm_kpack_ref without loading the full binary.
+
+        Its presence means the binary has already been through
+        kpack_offload_binary(): the device code lives in a .kpack archive and
+        the .hip_fatbin section header that remains is a leftover, not
+        splittable content.
+        """
+        return ElfSurgery._section_location(file_path, ".rocm_kpack_ref") is not None
+
+    @staticmethod
     def read_section(file_path: Path, section_name: str) -> bytes | None:
         """Read one ELF section without retaining the rest of the ELF image."""
         location = ElfSurgery._section_location(file_path, section_name)

--- a/shared/kpack/python/rocm_kpack/kpack_transform.py
+++ b/shared/kpack/python/rocm_kpack/kpack_transform.py
@@ -126,11 +126,49 @@ def read_kpack_ref_marker(binary_path: Path) -> dict | None:
         return coff_impl(binary_path)
 
 
+def is_kpack_processed(binary_path: Path) -> bool:
+    """Check if a binary already carries a kpack marker section.
+
+    A marker (.rocm_kpack_ref for ELF, .kpackrf for COFF) is added by
+    kpack_offload_binary(), so its presence means the device code has already
+    been moved out into a .kpack archive. The .hip_fatbin/.hip_fat section
+    header is left behind by that transformation, so callers must not use the
+    section name alone to decide there is still something to split.
+
+    Fast-path: reads only headers, not the full binary.
+
+    Args:
+        binary_path: Path to binary
+
+    Returns:
+        True if the binary has already been kpack-processed, False otherwise
+        (including non-ELF/non-PE files).
+    """
+    try:
+        fmt = detect_binary_format(binary_path)
+    except UnsupportedBinaryFormat:
+        return False
+
+    if fmt == "elf":
+        from .elf.surgery import ElfSurgery
+
+        return ElfSurgery.has_kpack_ref_section(binary_path)
+    else:
+        from .coff.surgery import CoffSurgery
+
+        return CoffSurgery.has_kpack_ref_section(binary_path)
+
+
 def is_fat_binary(binary_path: Path) -> bool:
     """Check if a binary contains HIP fat binary sections.
 
     Fast-path: reads only headers (ELF section header table or PE section
     headers), not the full binary. Works for both ELF and PE/COFF.
+
+    An already kpack-processed binary reports False: it keeps its
+    .hip_fatbin/.hip_fat section header, but the device code has moved to a
+    .kpack archive and re-processing it would fail with
+    "Section '.rocm_kpack_ref' already exists".
 
     Args:
         binary_path: Path to binary
@@ -147,8 +185,12 @@ def is_fat_binary(binary_path: Path) -> bool:
     if fmt == "elf":
         from .elf.surgery import ElfSurgery
 
+        if ElfSurgery.has_kpack_ref_section(binary_path):
+            return False
         return ElfSurgery.has_fatbin_section(binary_path)
     else:
         from .coff.surgery import CoffSurgery
 
+        if CoffSurgery.has_kpack_ref_section(binary_path):
+            return False
         return CoffSurgery.has_fatbin_section(binary_path)

--- a/shared/kpack/tests/common/test_kpack_transform.py
+++ b/shared/kpack/tests/common/test_kpack_transform.py
@@ -13,6 +13,7 @@ from rocm_kpack import (
     kpack_offload_binary,
     read_kpack_ref_marker,
     is_fat_binary,
+    is_kpack_processed,
     detect_binary_format,
     NotFatBinaryError,
 )
@@ -34,6 +35,34 @@ class TestFormatDetection:
     def test_is_fat_binary_false(self, host_only_exe: Path):
         """Test that host-only binaries are not fat binaries."""
         assert is_fat_binary(host_only_exe) is False
+
+    def test_is_kpack_processed_false_before_transform(self, single_arch_exe: Path):
+        """An untouched fat binary carries no kpack marker."""
+        assert is_kpack_processed(single_arch_exe) is False
+
+    def test_is_kpack_processed_false_for_host_only(self, host_only_exe: Path):
+        """A host-only binary carries no kpack marker."""
+        assert is_kpack_processed(host_only_exe) is False
+
+    def test_kpack_processed_binary_is_not_a_fat_binary(
+        self, single_arch_exe: Path, tmp_path: Path
+    ):
+        """Detection must be idempotent across a kpack_offload_binary() pass.
+
+        The transform leaves the .hip_fatbin/.hip_fat section header behind, so
+        a name-only check keeps reporting the output as splittable and a second
+        pass fails with "Section '.rocm_kpack_ref' already exists".
+        """
+        output = tmp_path / "processed.exe"
+        kpack_offload_binary(
+            input_path=single_arch_exe,
+            output_path=output,
+            kpack_search_paths=["kernels.kpack"],
+            kernel_name="test_kernel",
+        )
+
+        assert is_kpack_processed(output) is True
+        assert is_fat_binary(output) is False
 
 
 class TestKpackOffloadBinary:

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -19,6 +19,7 @@ from rocm_kpack.artifact_splitter import (
     ExtractedKernel,
     base_arch,
 )
+from elf_test_utils import patch_hip_fatbin_size
 from rocm_kpack.artifact_utils import read_artifact_manifest, write_artifact_manifest
 from rocm_kpack.coff.kpack_transform import HIPF_MAGIC as COFF_HIPF_MAGIC
 from rocm_kpack.coff.kpack_transform import HIPK_MAGIC as COFF_HIPK_MAGIC
@@ -265,6 +266,119 @@ class TestArtifactSplitterIntegration:
         verifier = ArtifactVerifier(output_dir, toolchain, verbose=False)
         all_checks_passed = verifier.run_all_checks()
         assert all_checks_passed, "Artifact verification should pass all checks"
+
+    @staticmethod
+    def _make_single_binary_artifact(
+        tmp_path: Path, binary_relpath: str, source: Path
+    ) -> tuple[Path, str]:
+        """Build a one-binary artifact tree and return (artifact_dir, prefix)."""
+        artifact_dir = tmp_path / "input_artifact"
+        prefix = "test/lib/stage"
+        (artifact_dir / prefix).mkdir(parents=True)
+        write_artifact_manifest(artifact_dir, [prefix])
+
+        dest = artifact_dir / prefix / binary_relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+        return artifact_dir, prefix
+
+    @staticmethod
+    def _split(toolchain, input_dir: Path, output_dir: Path) -> None:
+        ArtifactSplitter(
+            artifact_prefix="test_lib",
+            toolchain=toolchain,
+            database_handlers=[],
+            verbose=False,
+        ).split(input_dir, output_dir)
+
+    def test_resplit_of_already_split_elf_artifact_is_a_noop(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Re-driving the splitter over an already-split ELF tree does nothing.
+
+        Populating a build tree from previously split outputs, or simply
+        re-running the split step, feeds the splitter binaries it has already
+        processed. Those keep their .hip_fatbin section header, so the second
+        pass used to re-enter kpack_offload_binary() and abort with
+        "Section '.rocm_kpack_ref' already exists".
+
+        The .hip_fatbin here is patched below one page so that
+        conservative_zero_page() declines and the section stays SHT_PROGBITS.
+        That isolates this from the separated-debug-file case: the SHT_NOBITS
+        guard cannot classify this binary, only the .rocm_kpack_ref marker can.
+        """
+        source = patch_hip_fatbin_size(
+            test_assets_dir / "bundled_binaries/linux/cov5/libtest_kernel_single.so",
+            tmp_path / "libsmall.so",
+            new_size=3000,
+        )
+        input_dir, prefix = self._make_single_binary_artifact(
+            tmp_path, "lib/libtest.so", source
+        )
+
+        first_output = tmp_path / "output_pass1"
+        self._split(toolchain, input_dir, first_output)
+
+        first_generic = first_output / "test_lib_generic"
+        split_binary = first_generic / prefix / "lib/libtest.so"
+        surgery = ElfSurgery.load(split_binary)
+        assert surgery.find_section(".rocm_kpack_ref") is not None
+        assert not surgery.find_section(".hip_fatbin").header.is_nobits, (
+            "fixture must keep .hip_fatbin PROGBITS so this test covers the "
+            "already-split case rather than the SHT_NOBITS case"
+        )
+        assert list(first_output.glob("test_lib_gfx*")), "pass 1 must split something"
+
+        # Second pass over the already-split generic artifact must not raise.
+        second_output = tmp_path / "output_pass2"
+        self._split(toolchain, first_generic, second_output)
+
+        assert (
+            list(second_output.glob("test_lib_gfx*")) == []
+        ), "re-split must not produce per-arch artifacts; the device code is gone"
+        assert (
+            second_output / "test_lib_generic" / prefix / "lib/libtest.so"
+        ).read_bytes() == split_binary.read_bytes(), (
+            "binary must pass through unchanged"
+        )
+
+    def test_resplit_of_already_split_coff_artifact_is_a_noop(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Same idempotency guarantee for PE/COFF, keyed off .kpackrf.
+
+        No zero-paging happens on the COFF path, so .hip_fat always survives
+        the transform with its contents and every re-split failed.
+        """
+        source = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.dll"
+        )
+        self._require_materialized_binary(source, b"MZ")
+        input_dir, prefix = self._make_single_binary_artifact(
+            tmp_path, "bin/test.dll", source
+        )
+
+        first_output = tmp_path / "output_pass1"
+        self._split(toolchain, input_dir, first_output)
+
+        first_generic = first_output / "test_lib_generic"
+        split_binary = first_generic / prefix / "bin/test.dll"
+        surgery = CoffSurgery.load(split_binary)
+        assert surgery.find_section(".kpackrf") is not None
+        assert surgery.find_section(".hip_fat") is not None
+        assert list(first_output.glob("test_lib_gfx*")), "pass 1 must split something"
+
+        second_output = tmp_path / "output_pass2"
+        self._split(toolchain, first_generic, second_output)
+
+        assert (
+            list(second_output.glob("test_lib_gfx*")) == []
+        ), "re-split must not produce per-arch artifacts; the device code is gone"
+        assert (
+            second_output / "test_lib_generic" / prefix / "bin/test.dll"
+        ).read_bytes() == split_binary.read_bytes(), (
+            "binary must pass through unchanged"
+        )
 
     def test_artifact_with_database_files(
         self, create_test_artifact, toolchain, tmp_path

--- a/shared/kpack/tests/test_artifact_utils.py
+++ b/shared/kpack/tests/test_artifact_utils.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from elf_test_utils import patch_hip_fatbin_to_nobits
+from elf_test_utils import patch_hip_fatbin_size, patch_hip_fatbin_to_nobits
 from rocm_kpack.artifact_utils import (
     read_artifact_manifest,
     write_artifact_manifest,
@@ -21,6 +21,9 @@ from rocm_kpack.artifact_utils import (
     extract_architecture_from_target,
 )
 from rocm_kpack.binutils import Toolchain
+from rocm_kpack.coff.surgery import CoffSurgery
+from rocm_kpack.elf.surgery import ElfSurgery
+from rocm_kpack.kpack_transform import kpack_offload_binary
 
 
 class TestArtifactManifest:
@@ -338,6 +341,79 @@ class TestIsFatBinary:
         assert (
             is_fat_binary(debug_copy, toolchain) is False
         ), "SHT_NOBITS .hip_fatbin must not be treated as device code"
+
+    def test_is_fat_binary_elf_already_kpack_processed(
+        self, test_assets_dir, tmp_path, toolchain
+    ):
+        """An already-split ELF is not a fat binary, even while PROGBITS.
+
+        kpack_offload_binary() leaves the .hip_fatbin section header in place,
+        so a second splitter pass over an already-split tree used to re-enter
+        the transform and die with "Section '.rocm_kpack_ref' already exists".
+
+        The fixture pins the case that the SHT_NOBITS guard cannot catch: a
+        .hip_fatbin smaller than one page makes conservative_zero_page()
+        decline (no full pages to remove), so the section stays SHT_PROGBITS
+        after processing and only the .rocm_kpack_ref marker distinguishes it.
+        """
+        source = patch_hip_fatbin_size(
+            test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe",
+            tmp_path / "small_fatbin.exe",
+            new_size=3000,
+        )
+        assert is_fat_binary(source, toolchain) is True
+
+        processed = tmp_path / "small_fatbin_processed.exe"
+        kpack_offload_binary(
+            input_path=source,
+            output_path=processed,
+            kpack_search_paths=[".kpack/test_@GFXARCH@.kpack"],
+            kernel_name="lib/small_fatbin.exe",
+        )
+
+        surgery = ElfSurgery.load(processed)
+        assert surgery.find_section(".rocm_kpack_ref") is not None
+        fatbin = surgery.find_section(".hip_fatbin")
+        assert fatbin is not None, ".hip_fatbin header is expected to survive"
+        assert (
+            not fatbin.header.is_nobits
+        ), "fixture must keep .hip_fatbin PROGBITS, else the NOBITS guard masks this"
+
+        assert (
+            is_fat_binary(processed, toolchain) is False
+        ), "a binary carrying .rocm_kpack_ref has nothing left to split"
+
+    def test_is_fat_binary_coff_already_kpack_processed(
+        self, test_assets_dir, tmp_path, toolchain
+    ):
+        """An already-split PE/COFF binary is not a fat binary.
+
+        The COFF marker is the 8-char name .kpackrf. Nothing zero-pages
+        .hip_fat on this path, so re-splitting a PE tree always failed.
+        """
+        source = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.dll"
+        )
+        assert source.exists(), f"Test asset not found: {source}"
+        assert is_fat_binary(source, toolchain) is True
+
+        processed = tmp_path / "test_kernel_single_processed.dll"
+        kpack_offload_binary(
+            input_path=source,
+            output_path=processed,
+            kpack_search_paths=[".kpack/test_@GFXARCH@.kpack"],
+            kernel_name="bin/test_kernel_single.dll",
+        )
+
+        surgery = CoffSurgery.load(processed)
+        assert surgery.find_section(".kpackrf") is not None
+        assert (
+            surgery.find_section(".hip_fat") is not None
+        ), ".hip_fat header is expected to survive"
+
+        assert (
+            is_fat_binary(processed, toolchain) is False
+        ), "a binary carrying .kpackrf has nothing left to split"
 
 
 class TestExtractArchitectureFromTarget:


### PR DESCRIPTION
## Motivation

Running the artifact splitter twice over the same tree fails instead of being a
no-op:

```
Error: Section '.rocm_kpack_ref' already exists
```

`kpack_offload_binary()` **leaves the `.hip_fatbin` (ELF) / `.hip_fat` (COFF)
section header in place** — it adds `.rocm_kpack_ref`, maps it to a new
`PT_LOAD`, rewrites the wrapper magic and zero-pages the fatbin, but does not
remove the section header. So an already-split binary still answers "yes" to
`is_fat_binary()`, gets handed back to `kpack_offload_binary()`, and
`add_section()` finds the marker it wrote on the first pass.

Re-driving the splitter over already-split output is a legitimate workflow —
repopulating a build tree from previously split artifacts, re-running the split
step, or any scan of an install tree that cannot know whether it has already
been processed. Idempotency is the expectation; today it is a hard failure.

## Relationship to #10060

**This PR is stacked on #10060** (GitHub stack #10497) and its base branch is
`users/pmclean/kpack-skip-nobits-fatbin`, so the diff shown here is only the
incremental already-split half — one commit. GitHub will retarget this to
`develop` when #10060 merges. Both PRs touch the same three lines of
`is_fat_binary()`, so stacking avoids a guaranteed conflict, and it keeps this
branch free of #10060's commit for anyone consuming it as a cherry-pick range.

```
develop
 └── users/pmclean/kpack-skip-nobits-fatbin   → #10060  (SHT_NOBITS half)
      └── users/pmclean/kpack-idempotent-resplit → this PR (already-split half)
```

#10060 is the *separated debug file* case (`objcopy --only-keep-debug`, section
header survives, contents were never in the file). This is the *already-split*
case (the splitter itself left the header behind). They overlap only by
accident, and #10060's `SHT_NOBITS` guard does **not** cover this one:
zero-paging is best-effort and `conservative_zero_page()` returns
`success=True, bytes_saved=0` **without** setting `SHT_NOBITS` when the section
is smaller than one page, or ends exactly on a page boundary with one page left.
Small fat binaries hit the first of those routinely. And nothing zero-pages
`.hip_fat` on the PE/COFF path at all.

All three shapes are the same defect, all exit 1 on `develop`:

| input shape | error today | covered by #10060 |
|---|---|---|
| ELF, `.hip_fatbin` left `SHT_PROGBITS` | `Section '.rocm_kpack_ref' already exists` | no |
| ELF, `.hip_fatbin` zero-paged to `SHT_NOBITS` | `Unrecognized fatbin format: first 4 bytes are b'\x7fELF'` | incidentally |
| PE/COFF (`.hip_fat` always survives) | `Unrecognized fatbin format: ...` | no |

## Technical Details

The decidable fact is the marker section the splitter itself writes:
`.rocm_kpack_ref` for ELF, `.kpackrf` for COFF
(`coff/kpack_transform.py:SECTION_KPACK_REF`, the 8-char PE spelling). If it is
present, the device code is in the `.kpack` archive and there is nothing left to
split, whatever the leftover fatbin section header says.

### Changes

- `artifact_utils.is_fat_binary()` — return `False` for a binary carrying the
  marker, on both the ELF and COFF branches. This is the splitter's gate
  (`artifact_splitter.py`, `FileClassificationVisitor.visit_file`), so the binary
  is simply copied into the generic artifact and the pass is a no-op. #10060's
  `SHT_NOBITS` behaviour is untouched.
- `kpack_transform.is_fat_binary()` — same guard on the header-scan fast path,
  which is the wheel splitter's scanner (`wheel_splitter._scan_fat_binaries`) and
  has the identical name-only check.
- New `kpack_transform.is_kpack_processed()` (exported from `rocm_kpack`), plus
  `ElfSurgery.has_kpack_ref_section()` / `CoffSurgery.has_kpack_ref_section()`
  fast-path helpers backing it. The COFF one is a two-line extraction of the
  existing `has_fatbin_section()` body into `_has_section_named()`.

### Deliberately not changed

`ElfSurgery.has_fatbin_section()` and `BundledBinary._detect_binary_type()` keep
their present, purely structural meaning ("does this file have readable fatbin
section content"). Folding the marker check in there would reclassify an
already-split binary as `STANDALONE` for `bulk_unbundle` too, which is a
behaviour change nobody asked for — and it is unnecessary, because the
`is_fat_binary()` gate runs first and the binary never reaches `BundledBinary`.

`kpack_offload_binary()` still raises on a second application. It is a low-level
primitive; the classifier deciding what to feed it is what needed fixing.

## Test Plan

Five new tests (10 instances — `tests/common/` is parameterized over ELF and
COFF). All four of the new non-parameterized tests fail on this branch's parent
and pass here; verified by reverting only the `python/` changes.

- `tests/test_artifact_utils.py::TestIsFatBinary`
  - `test_is_fat_binary_elf_already_kpack_processed` — asserts the fixture keeps
    `.hip_fatbin` **`SHT_PROGBITS`** after processing, so the test genuinely
    covers what the `SHT_NOBITS` guard cannot. Built with the repo's existing
    `patch_hip_fatbin_size(..., new_size=3000)` helper, which puts the section
    under one page and makes `conservative_zero_page()` decline.
  - `test_is_fat_binary_coff_already_kpack_processed` — natural test asset, no
    patching; asserts `.hip_fat` survives and `.kpackrf` is present.
- `tests/common/test_kpack_transform.py::TestFormatDetection` — three tests over
  the generic API, parameterized ELF/COFF: `is_kpack_processed()` is `False`
  before the transform and for host-only binaries, `True` after, and
  `is_fat_binary()` flips to `False` across a `kpack_offload_binary()` pass.
- `tests/test_artifact_splitter_integration.py` — end-to-end, one per format:
  `test_resplit_of_already_split_{elf,coff}_artifact_is_a_noop`. Split once, then
  split the resulting generic artifact again; assert the second pass does not
  raise, creates **no** per-arch artifacts, and passes the binary through
  byte-identically.

### Public repro (in-repo test assets only; no GPU, no HIP compile)

```bash
cd shared/kpack
export PYTHONPATH=$PWD/python
BUNDLER=$(command -v clang-offload-bundler)
SPLIT="python3 python/rocm_kpack/tools/split_artifacts.py"

rm -rf /tmp/kpack-idem && mkdir -p /tmp/kpack-idem/art/demo/stage/bin
cp test_assets/bundled_binaries/windows/cov5/test_kernel_single.dll \
   /tmp/kpack-idem/art/demo/stage/bin/
echo demo/stage > /tmp/kpack-idem/art/artifact_manifest.txt

$SPLIT --artifact-dir /tmp/kpack-idem/art --output-dir /tmp/kpack-idem/out1 \
       --artifact-prefix demo_lib --clang-offload-bundler "$BUNDLER"
$SPLIT --artifact-dir /tmp/kpack-idem/out1/demo_lib_generic \
       --output-dir /tmp/kpack-idem/out2 \
       --artifact-prefix demo_lib --clang-offload-bundler "$BUNDLER"
```

The ELF `SHT_PROGBITS` variant is in the issue; it uses
`tests/elf_test_utils.patch_hip_fatbin_size` to shrink `.hip_fatbin` below one
page.

## Test Result

`shared/kpack` suite, Python 3.12, same container:

| | result |
|---|---|
| parent commit (#10060 head) | `4 failed, 544 passed, 4 skipped` |
| this branch | `4 failed, 554 passed, 4 skipped` |

The 10 extra passes are the tests added here. The 4 failures are pre-existing,
identical on the parent commit, and untouched by this change:

- `tests/elf/test_surgery.py::TestVerifyAll::test_verify_all_valid_binary` —
  `gdb not found` in this container.
- three in `tests/test_wheel_splitter.py`
  (`test_gfx11_sub_family_level`, `test_sub_family_level`,
  `test_chain_with_gfx110x_wheel`) — these come from `rocm-bootstrap 0.1.0`
  installed from PyPI raising in `rocm_bootstrap/targets.py`; they are an
  environment/version mismatch on my side, not a kpack failure, and I could not
  reproduce whatever version CI pins. **I could not verify the wheel-splitter
  path end-to-end for this reason** — the `kpack_transform.is_fat_binary()`
  change is covered only by the new parameterized unit tests, not by a wheel
  round-trip.

End-to-end, parent → this branch, both repro cases plus the zero-paged ELF case:

```
COFF re-split         Unrecognized fatbin format          → exit 0, no-op, byte-identical output
ELF PROGBITS re-split Section '.rocm_kpack_ref' already exists → exit 0, no-op, byte-identical output
ELF NOBITS re-split   Unrecognized fatbin format          → exit 0, no-op, byte-identical output
```

`black` (26.5.1, the pinned pre-commit rev) reports all eight touched files
unchanged.

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10494

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

---

*AI tool use disclosure: this change was developed with the assistance of Claude
(Anthropic). The root cause, the zero-paging behaviour that makes the `SHT_NOBITS`
guard insufficient, the test results and the end-to-end verification above were
all run and checked by hand.*
