### PR TITLE
test(rocjpeg): add CTests for jpegDecodeAsync and jpegDecodeBatchedAsync

### DIFF
--- a/projects/rocjpeg/test/CMakeLists.txt
+++ b/projects/rocjpeg/test/CMakeLists.txt
@@ -332,6 +332,54 @@ add_test(
 
 add_test(
   NAME
+    jpeg-decode-async-fmt-native
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+            --build-and-test "${ROCM_PATH}/share/rocjpeg/samples/jpegDecodeAsync"
+                              "${CMAKE_CURRENT_BINARY_DIR}/jpegDecodeAsync"
+            --build-generator "${CMAKE_GENERATOR}"
+            --test-command "jpegdecodeasync"
+            -i ${ROCM_PATH}/share/rocjpeg/images/
+)
+
+add_test(
+  NAME
+    jpeg-decode-async-fmt-rgb
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+            --build-and-test "${ROCM_PATH}/share/rocjpeg/samples/jpegDecodeAsync"
+                              "${CMAKE_CURRENT_BINARY_DIR}/jpegDecodeAsync"
+            --build-generator "${CMAKE_GENERATOR}"
+            --test-command "jpegdecodeasync"
+            -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb
+)
+
+add_test(
+  NAME
+    jpeg-decode-batch-async-fmt-native
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+            --build-and-test "${ROCM_PATH}/share/rocjpeg/samples/jpegDecodeBatchedAsync"
+                              "${CMAKE_CURRENT_BINARY_DIR}/jpegDecodeBatchedAsync"
+            --build-generator "${CMAKE_GENERATOR}"
+            --test-command "jpegdecodebatchedasync"
+            -i ${ROCM_PATH}/share/rocjpeg/images/
+)
+
+add_test(
+  NAME
+    jpeg-decode-batch-async-fmt-rgb
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+            --build-and-test "${ROCM_PATH}/share/rocjpeg/samples/jpegDecodeBatchedAsync"
+                              "${CMAKE_CURRENT_BINARY_DIR}/jpegDecodeBatchedAsync"
+            --build-generator "${CMAKE_GENERATOR}"
+            --test-command "jpegdecodebatchedasync"
+            -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb
+)
+
+add_test(
+  NAME
     jpeg-negative-api-tests
   COMMAND
     "${CMAKE_CTEST_COMMAND}"


### PR DESCRIPTION
## Motivation

Add CTests for jpegDecodeAsync and jpegDecodeBatchedAsync

## Technical Details

Updated the CTest suite to cover the newly added asynchronous APIs.

## Issue Tracking

JIRA ID: AICV-278

## Test Plan

rocjpeg ctest.

## Test Result

rocjpeg ctest should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
