### PR TITLE
[rocjitsu] Quick fix for building probes with recent therock build

### DIFF
--- a/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
@@ -48,9 +48,16 @@ endfunction()
 # Unlike rj_add_device_kernel above (which compiles a __global__ kernel into a
 # host object carrying a .hip_fatbin), this is for a lone __device__ function
 # with no kernel. The normal fatbin path drops such a function, so this:
-#   1. compiles device-only with -fgpu-rdc into a Clang offload bundle, then
+#   1. compiles device-only into a Clang offload bundle, then
 #   2. unbundles the device code object into a raw device ELF that Executable /
 #      AmdGpuCodeObject can load directly.
+#
+# NOTE: The source must keep the __device__ function alive on its own (see
+# tests/kernels/rj_nop_probe.hip). -fgpu-rdc would also do that, but it is
+# incompatible with step 2 once the toolchain defaults to --offload-new-driver:
+# `-fgpu-rdc --cuda-device-only` then emits raw LLVM bitcode rather than an
+# offload bundle, and the unbundle fails with "Can't find bundles for
+# hipv4-amdgcn-amd-amdhsa--<arch>". Observed with TheRock 10.1.0a nightlies.
 #
 # AMDCXX, ROCM_PATH, CLANG_OFFLOAD_BUNDLER, and KERNEL_OUTPUT_DIR must be set
 # before calling this function.
@@ -75,14 +82,12 @@ function(rj_add_probe_object name offload_arch)
     set(bundle ${KERNEL_OUTPUT_DIR}/${output_name}.bundle)
     set(hsaco ${KERNEL_OUTPUT_DIR}/${output_name}.hsaco)
 
-    # Step 1: device-only compile to a Clang offload bundle. -fgpu-rdc keeps the
-    # used/noinline device function from being internalized away.
+    # Step 1: device-only compile to a Clang offload bundle.
     add_custom_command(
         OUTPUT ${bundle}
         COMMAND
             ${AMDCXX} -x hip --offload-arch=${offload_arch}
-            --rocm-path=${ROCM_PATH} -fgpu-rdc --cuda-device-only -O2 -o
-            ${bundle} ${src}
+            --rocm-path=${ROCM_PATH} --cuda-device-only -O2 -o ${bundle} ${src}
         DEPENDS ${src}
         COMMENT
             "Compiling probe object (device-only): ${output_name} (${offload_arch})"

--- a/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hotswap_rocjitsu_unit_test.cpp
@@ -1280,28 +1280,26 @@ TEST_F(HsaHotswapMemoTest, RepeatedLoadsOfOneObjectTranslateOnce) {
   EXPECT_EQ(rj_test_translation_memo_bytes(), source.size() + first_output.size());
 }
 
-// Identity is exact. Two objects that a sampled fingerprint could plausibly place
-// in the same bucket -- same size, differing in one interior byte -- must not be
-// mistaken for each other, because the consequence is running the wrong code.
-TEST_F(HsaHotswapMemoTest, ObjectsDifferingInOneInteriorByteAreNotConfused) {
+// Identity is exact. Two objects the sampling cannot tell apart -- same size, same
+// fingerprint, different bytes -- must not be mistaken for each other, because the
+// consequence is running the wrong code. The count is the whole check: a confused
+// pair is served from the memo and never reaches a second translation.
+TEST_F(HsaHotswapMemoTest, ObjectsInOneFingerprintBucketAreNotConfused) {
   ASSERT_TRUE(OnLoad(&api.table, 0, 0, nullptr));
   const std::vector<uint8_t> base = read_translation_fixture();
   ASSERT_FALSE(base.empty()) << GFX1250_B0_TO_A0_FIXTURE;
 
   std::vector<uint8_t> altered = base;
-  ASSERT_GT(altered.size(), 2048u);
-  altered[altered.size() / 2] = static_cast<uint8_t>(altered[altered.size() / 2] ^ 0xff);
+  altered.resize(base.size() + 4096, 0);
+  const std::vector<uint8_t> twin = make_fingerprint_twin(base);
+  ASSERT_FALSE(twin.empty()) << "no colliding twin found; the sampling changed";
+  ASSERT_EQ(altered.size(), twin.size());
+  ASSERT_NE(altered, twin);
+  ASSERT_EQ(rj_test_sample_fingerprint(altered.data(), altered.size()),
+            rj_test_sample_fingerprint(twin.data(), twin.size()));
 
-  ASSERT_EQ(load_through_new_reader(base), HSA_STATUS_SUCCESS);
-  const std::vector<uint8_t> base_output = g_loaded_bytes;
-
-  g_loaded_bytes.clear();
-  const hsa_status_t altered_status = load_through_new_reader(altered);
-  // Whatever the altered object translates to, it must not be served the entry
-  // that belongs to the original.
-  if (altered_status == HSA_STATUS_SUCCESS) {
-    EXPECT_NE(g_loaded_bytes, base_output);
-  }
+  ASSERT_EQ(load_through_new_reader(altered), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load_through_new_reader(twin), HSA_STATUS_SUCCESS);
   EXPECT_EQ(rj_test_translation_count(), 2u);
 }
 

--- a/emulation/rocjitsu/tests/kernels/rj_nop_probe.hip
+++ b/emulation/rocjitsu/tests/kernels/rj_nop_probe.hip
@@ -18,3 +18,16 @@
 // `s_setpc_b64 s[30:31]` (a return through the s[30:31] link pair).
 //
 extern "C" __device__ __attribute__((noinline, used, visibility("default"))) void rj_nop_probe() {}
+
+// Keeps rj_nop_probe in the emitted code object. A device-only compile of a
+// translation unit with no kernel and no device global drops the function
+// entirely: `used` survives IR-level DCE, but Clang's HIP device-internalize
+// pass then marks the hidden symbol internal and the device linker discards it.
+// Taking its address from a device global is what forces it out of line and
+// keeps it in .text. -fgpu-rdc would also do this, but it is incompatible with
+// the unbundle step -- see rj_add_probe_object in
+// cmake/rj_add_device_kernel.cmake.
+//
+// The pointer is never read; only the probe's own body is copied out of the
+// object by the instrumentor.
+__device__ void (*rj_nop_probe_keepalive)() = rj_nop_probe;


### PR DESCRIPTION

## Motivation

Probes stopped building with the most recent builds of TheRock. Recent versions have made the offload driver default, but for the probes we just want the LLVM bitcode, not the bundle. 

## Technical Details

Before, we used `-fgpu-rdc` to force an empty probe to be emitted (for testing purposes), but this is incompatible with the offload driver default. Rather than play with build options, this change forces the empty probe to be emitted by creating a function pointer to it.

NOTE: There are two side issues that are out of scope for this PR. 1) Moving these to simulator. 2) Related failing tests that existed prior to this change, which is all the more reason to move them to the simulator.

## Change to HsaHotswapMemoTest.ObjectsInOneFingerprintBucketAreNotConfused

This test started to fail after the quick fix because the fixture it was reading changed slightly. After investigating the failure, I believe that the test was no longer a good representation of what it was trying to test.

**The goal of the test** It's my understanding that the test was attempting to take two different objects that have the same fingerprint and verify that they are still considered different objects.

**The original test** The original test did this by creating an `altered` object by making a copy of `base` and flipping a bit outside the fingerprint range. Then, it would translate both. IF the `altered` translation was actually successful, then it would double-check that the translations were not the same. Finally, it would check two see that there were two different translations.

**What changed** On my system with rocm7.2, this test never gets to the sanity check because the flipped bit makes it untranslatable. Removing `-fgpu-rdc` changes the object so that the flipped bit makes it translatable. But, that flipped bit ends up in dead code that doesn't end up in the translation, so the final `altered` translation ends up being equivalent to the `base` translation. Hence, the unit test failing. My understanding is that this is okay and expected behavior, and thus the sanity check is no longer sane.

**Refactor** Since the check for two different translations seems to satisfy the condition that they are two different objects, we can just remove the sanity check. While trying to understand the test and looking over the rest of the test suite, there was some fingerprint helpers that seemed to do what the goal was trying to do so I refactored it to use those helpers.

## Issue Tracking

N/A (Issue was reported offline)

## Test Plan / Result

Reproduced error found by @kuhar with [TheRock nightly build from 08/19/2026](rocm_sdk_devel-10.1.0a20260819-py3-none-linux_x86_64.whl). The error disappears with this fix.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
