### PR TITLE
[RCCL] cuMem: use the scoped side-stream pool in the VMM allocation path

### DIFF
--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -641,8 +641,9 @@ static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHand
     cudaStream_t sidestream = nullptr, zeroStream = nullptr;
     NCCLCHECKGOTO(getSideStream(&sidestream), result, restoreCapMode);
     zeroStream = sidestream;
-    if (sidestream == nullptr)
+    if (sidestream == nullptr) {
       CUDACHECKGOTO(cudaStreamCreateWithFlags(&zeroStream, cudaStreamNonBlocking), result, restoreCapMode);
+    }
     CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, size, zeroStream), result, destroyStream);
     CUDACHECKGOTO(cudaStreamSynchronize(zeroStream), result, destroyStream);
   destroyStream:

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -638,7 +638,7 @@ static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHand
     // init / P2P connect burst) so this per-allocation zeroing does not churn a
     // scarce GPU hardware queue via create/destroy on every VMM allocation.
     // Fall back to a private non-blocking stream when no scope is active.
-    cudaStream_t sidestream = nullptr, zeroStream;
+    cudaStream_t sidestream = nullptr, zeroStream = nullptr;
     NCCLCHECK(getSideStream(&sidestream));
     zeroStream = sidestream;
     if (sidestream == nullptr)

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -639,7 +639,7 @@ static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHand
     // scarce GPU hardware queue via create/destroy on every VMM allocation.
     // Fall back to a private non-blocking stream when no scope is active.
     cudaStream_t sidestream = nullptr, zeroStream = nullptr;
-    NCCLCHECK(getSideStream(&sidestream));
+    NCCLCHECKGOTO(getSideStream(&sidestream), result, restoreCapMode);
     zeroStream = sidestream;
     if (sidestream == nullptr)
       CUDACHECKGOTO(cudaStreamCreateWithFlags(&zeroStream, cudaStreamNonBlocking), result, restoreCapMode);

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -634,12 +634,19 @@ static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHand
   {
     cudaStreamCaptureMode capMode = cudaStreamCaptureModeRelaxed;
     CUDACHECKGOTO(cudaThreadExchangeStreamCaptureMode(&capMode), result, fail);
-    cudaStream_t zeroStream;
-    CUDACHECKGOTO(cudaStreamCreateWithFlags(&zeroStream, cudaStreamNonBlocking), result, restoreCapMode);
+    // Reuse the pooled side stream when an allocation scope is active (comm
+    // init / P2P connect burst) so this per-allocation zeroing does not churn a
+    // scarce GPU hardware queue via create/destroy on every VMM allocation.
+    // Fall back to a private non-blocking stream when no scope is active.
+    cudaStream_t sidestream = nullptr, zeroStream;
+    NCCLCHECK(getSideStream(&sidestream));
+    zeroStream = sidestream;
+    if (sidestream == nullptr)
+      CUDACHECKGOTO(cudaStreamCreateWithFlags(&zeroStream, cudaStreamNonBlocking), result, restoreCapMode);
     CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, size, zeroStream), result, destroyStream);
     CUDACHECKGOTO(cudaStreamSynchronize(zeroStream), result, destroyStream);
   destroyStream:
-    CUDACHECK(cudaStreamDestroy(zeroStream));
+    if (sidestream == nullptr) CUDACHECK(cudaStreamDestroy(zeroStream));
   restoreCapMode:
     CUDACHECK(cudaThreadExchangeStreamCaptureMode(&capMode));
     if (result != ncclSuccess) goto fail;
@@ -860,20 +867,22 @@ ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char* filefunc, in
 
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
-    // Need a side stream so as not to interfere with graph capture.
-    cudaStream_t stream, sidestream;
-    NCCLCHECK(getSideStream(&sidestream));
-    stream = sidestream;
-    if (sidestream == nullptr) CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
     if (ncclCuMemEnable()) {
+      // ncclCuMemAlloc already zeroes the buffer (ROCM-20370 residue scrub),
+      // reusing the pooled side stream, so no extra memset/stream is needed.
       NCCLCHECKGOTO(ncclCuMemAlloc((void**)ptr, NULL, ncclCuMemHandleType, nelem * ncclSizeOfT<T>(), manager, memType),
                     result, finish);
     } else {
+      // Need a side stream so as not to interfere with graph capture.
+      cudaStream_t stream, sidestream;
+      NCCLCHECK(getSideStream(&sidestream));
+      stream = sidestream;
+      if (sidestream == nullptr) CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
       CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), flags), result, finish);
+      CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
+      CUDACHECKGOTO(cudaStreamSynchronize(stream), result, finish);
+      if (sidestream == nullptr) CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
     }
-    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
-    CUDACHECKGOTO(cudaStreamSynchronize(stream), result, finish);
-    if (sidestream == nullptr) CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
@@ -923,12 +932,14 @@ ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, hipStream_t stream,
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
     if (ncclCuMemEnable()) {
+      // ncclCuMemAlloc already zeroes the buffer (ROCM-20370 residue scrub),
+      // reusing the pooled side stream, so no extra memset is needed.
       NCCLCHECKGOTO(ncclCuMemAlloc((void**)ptr, NULL, ncclCuMemHandleType, nelem * ncclSizeOfT<T>(), manager, memType),
                     result, finish);
     } else {
       CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), flags), result, finish);
+      CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
     }
-    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -108,6 +108,7 @@ struct ncclSideStream {
 
 inline std::unordered_map<ncclSideStreamKey, ncclSideStream, ncclSideStreamKeyHash> sideStream;
 inline pthread_mutex_t sideStreamLock = PTHREAD_MUTEX_INITIALIZER;
+
 extern ncclResult_t getBusId(int cudaDev, int64_t* busId);
 
 // Clamp a requested stream priority into the device-supported range.

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -647,7 +647,9 @@ static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHand
     CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, size, zeroStream), result, destroyStream);
     CUDACHECKGOTO(cudaStreamSynchronize(zeroStream), result, destroyStream);
   destroyStream:
-    if (sidestream == nullptr) CUDACHECK(cudaStreamDestroy(zeroStream));
+    if (sidestream == nullptr) {
+      CUDACHECK(cudaStreamDestroy(zeroStream));
+    }
   restoreCapMode:
     CUDACHECK(cudaThreadExchangeStreamCaptureMode(&capMode));
     if (result != ncclSuccess) goto fail;

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -198,6 +198,7 @@ static inline bool ncclHsaRegMrDmaBuf(ncclResult_t (*regMrDmaBuf)(void*, void*, 
 
 extern int ncclCuMemEnable();
 extern int ncclIsCuMemSupported();
+extern int ncclCuMemRuntimeSupported();
 extern int ncclCuMemHostEnable();
 extern int64_t rcclParamForceEnableDMABUF();
 extern int64_t ncclParamDmaBufEnable();

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -197,6 +197,7 @@ static inline bool ncclHsaRegMrDmaBuf(ncclResult_t (*regMrDmaBuf)(void*, void*, 
 }
 
 extern int ncclCuMemEnable();
+extern int ncclIsCuMemSupported();
 extern int ncclCuMemHostEnable();
 extern int64_t rcclParamForceEnableDMABUF();
 extern int64_t ncclParamDmaBufEnable();

--- a/projects/rccl/src/misc/cudawrap.cc
+++ b/projects/rccl/src/misc/cudawrap.cc
@@ -44,6 +44,10 @@ error:
 #endif
 }
 
+int ncclCuMemRuntimeSupported() {
+  return ncclIsCuMemSupported();
+}
+
 int ncclCuMemEnable() {
   // NCCL_CUMEM_ENABLE=-2 means auto-detect CUMEM support
   int param = ncclParamCuMemEnable();

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -116,8 +116,10 @@ done:
   return ok;
 }
 
-// Determine whether CUMEM & VMM RDMA is supported on this platform
-int ncclIsCuMemSupported() {
+// Returns 1 when the platform can run the cuMem VMM path at runtime.
+// When requireGfx1250ForAutoEnable is set, also enforces the gfx1250 gate used
+// by NCCL_CUMEM_ENABLE=-2 auto-detect; NCCL_CUMEM_ENABLE=1 bypasses that gate.
+static int ncclCuMemCapabilityCheck(int requireGfx1250ForAutoEnable) {
   CUdevice currentDev;
   int cudaDev;
   int cudaDriverVersion;
@@ -126,13 +128,13 @@ int ncclIsCuMemSupported() {
   ncclResult_t ret = ncclSuccess;
   char gcnArch[256] = "unknown";
 
-  // Auto-detect (NCCL_CUMEM_ENABLE=-2) only turns cuMem on where the VMM path is
-  // required; NCCL_CUMEM_ENABLE=1 bypasses this gate.
   CUDACHECKGOTO(cudaGetDevice(&cudaDev), ret, error);
-  if (GetGcnArchName(cudaDev, gcnArch) != 0 || !IsArchMatch(gcnArch, "gfx1250")) {
-    INFO(NCCL_INIT, "cuMem auto-enable is limited to gfx1250 (detected %s); set NCCL_CUMEM_ENABLE=1 to override",
-         gcnArch);
-    return 0;
+  if (requireGfx1250ForAutoEnable) {
+    if (GetGcnArchName(cudaDev, gcnArch) != 0 || !IsArchMatch(gcnArch, "gfx1250")) {
+      INFO(NCCL_INIT, "cuMem auto-enable is limited to gfx1250 (detected %s); set NCCL_CUMEM_ENABLE=1 to override",
+           gcnArch);
+      return 0;
+    }
   }
 
   if (ncclGetKernelVersionCode() < KERNEL_VERSION_CODE(6, 8)) {
@@ -164,6 +166,17 @@ int ncclIsCuMemSupported() {
   return supported;
 error:
   return (ret == ncclSuccess);
+}
+
+// Determine whether CUMEM & VMM RDMA is supported on this platform
+int ncclIsCuMemSupported() {
+  return ncclCuMemCapabilityCheck(/*requireGfx1250ForAutoEnable=*/1);
+}
+
+// Runtime cuMem capability without the gfx1250 auto-enable gate. Used when
+// NCCL_CUMEM_ENABLE=1 forces the VMM path on non-gfx1250 platforms.
+int ncclCuMemRuntimeSupported() {
+  return ncclCuMemCapabilityCheck(/*requireGfx1250ForAutoEnable=*/0);
 }
 
 int ncclCuMemEnable() {

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
 #include <unordered_map>
+#include <vector>
 
 #include "TestBed.hpp"
 #include "common/ErrCode.hpp"
@@ -448,6 +449,130 @@ TEST(Alloc, SideStreamKeySeparatesPriorities)
     EXPECT_EQ(streams.at(ncclSideStreamKey{busId, -1}), 1);
     EXPECT_EQ(streams.at(ncclSideStreamKey{busId, 0}), 2);
 }
+
+#if ROCM_VERSION >= 70000
+// ---------------------------------------------------------------------------
+// Side-stream pool under the cuMem/VMM allocator (NCCL_CUMEM_ENABLE=1).
+//
+// With cuMem enabled every device allocation goes through ncclCuMemAlloc, whose
+// ROCM-20370 residue scrub must reuse the pooled side stream while a scope is
+// active (instead of creating/destroying a private stream per allocation) and
+// must not disturb the pool's contents or refcount. These tests drive the real
+// VMM path directly; they are skipped where cuMem is unavailable at runtime.
+// ---------------------------------------------------------------------------
+
+// A cuMem allocation issued inside an active scope reuses the pooled stream
+// (leaves it intact, not churned), returns zeroed memory, and the stream is
+// still destroyed on scope exit so nothing lingers into the collective phase.
+TEST(Alloc, CuMemAllocReusesPooledSideStream)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "CuMemAllocReusesPooledSideStream",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            if(!ncclCuMemEnable())
+            {
+                GTEST_SKIP() << "cuMem/VMM not enabled or unsupported in this environment";
+            }
+
+            constexpr int    dev  = 0;
+            constexpr size_t size = 8192;
+
+            hipStream_t pooled = nullptr;
+            {
+                ncclSideStreamScope scope(dev);
+                ASSERT_EQ(getSideStream(&pooled), ncclSuccess);
+                ASSERT_NE(pooled, nullptr) << "Scope must pool a side stream";
+
+                for(int allocIdx = 0; allocIdx < 2; ++allocIdx)
+                {
+                    // Real VMM allocation while the scope is held: the internal zero
+                    // must run on the pooled stream, leaving the pool untouched.
+                    // handlep is optional; pass nullptr so no CU* handle type is named.
+                    void* ptr = nullptr;
+                    ASSERT_EQ(
+                        ncclCuMemAlloc(&ptr, /*handlep=*/nullptr, ncclCuMemHandleType, size, /*manager=*/nullptr),
+                        ncclSuccess
+                    );
+                    ASSERT_NE(ptr, nullptr);
+
+                    hipStream_t afterAlloc = nullptr;
+                    ASSERT_EQ(getSideStream(&afterAlloc), ncclSuccess);
+                    EXPECT_EQ(afterAlloc, pooled)
+                        << "cuMem alloc " << allocIdx
+                        << " must reuse (not churn/replace) the pooled side stream";
+
+                    // Buffer must come back zeroed (calloc semantics preserved even
+                    // though the redundant caller-side memset was removed).
+                    std::vector<unsigned char> host(size, 0xAB);
+                    ASSERT_EQ(hipMemcpy(host.data(), ptr, size, hipMemcpyDeviceToHost), hipSuccess);
+                    for(size_t i = 0; i < size; ++i)
+                    {
+                        ASSERT_EQ(host[i], 0u) << "cuMem buffer not zeroed at offset " << i;
+                    }
+
+                    ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
+                }
+            }
+
+            // Scope exited: the pooled stream must be destroyed, HW queue freed.
+            hipStream_t afterScope = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&afterScope), ncclSuccess);
+            EXPECT_EQ(afterScope, nullptr)
+                << "No side stream may survive a cuMem-path scope into the collective phase";
+        },
+        {{"NCCL_CUMEM_ENABLE", "1"}}
+    );
+}
+
+// With no active scope, a cuMem allocation falls back to a private stream and
+// must not create or leak an entry in the pool.
+TEST(Alloc, CuMemAllocNoScopeLeavesPoolEmpty)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "CuMemAllocNoScopeLeavesPoolEmpty",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            if(!ncclCuMemEnable())
+            {
+                GTEST_SKIP() << "cuMem/VMM not enabled or unsupported in this environment";
+            }
+
+            constexpr size_t size = 8192;
+
+            // No scope active: pool empty before.
+            hipStream_t before = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&before), ncclSuccess);
+            ASSERT_EQ(before, nullptr);
+
+            void* ptr = nullptr;
+            ASSERT_EQ(
+                ncclCuMemAlloc(&ptr, /*handlep=*/nullptr, ncclCuMemHandleType, size, /*manager=*/nullptr),
+                ncclSuccess
+            );
+            ASSERT_NE(ptr, nullptr);
+
+            // The fallback private stream must not have populated the pool.
+            hipStream_t after = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&after), ncclSuccess);
+            EXPECT_EQ(after, nullptr)
+                << "cuMem alloc without a scope must not create a pooled side stream";
+
+            std::vector<unsigned char> host(size, 0xAB);
+            ASSERT_EQ(hipMemcpy(host.data(), ptr, size, hipMemcpyDeviceToHost), hipSuccess);
+            for(size_t i = 0; i < size; ++i)
+            {
+                ASSERT_EQ(host[i], 0u) << "cuMem buffer not zeroed at offset " << i;
+            }
+
+            ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
+        },
+        {{"NCCL_CUMEM_ENABLE", "1"}}
+    );
+}
+#endif // ROCM_VERSION >= 70000
 
 // When the device supports multiple priorities, the pool creates and returns
 // separate streams for the same device at each priority.

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -4,11 +4,13 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include <alloc.h>
-#include <gtest/gtest.h>
-#include <rccl/rccl.h>
+#include "alloc.h"
+
 #include <unordered_map>
 #include <vector>
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
 
 #include "TestBed.hpp"
 #include "common/ErrCode.hpp"
@@ -462,7 +464,7 @@ TEST(Alloc, SideStreamKeySeparatesPriorities)
 // ---------------------------------------------------------------------------
 
 // A cuMem allocation issued inside an active scope reuses the pooled stream
-// (leaves it intact, not churned), returns zeroed memory, and the stream is
+// (synchronizes it after zeroing), returns zeroed memory, and the stream is
 // still destroyed on scope exit so nothing lingers into the collective phase.
 TEST(Alloc, CuMemAllocReusesPooledSideStream)
 {
@@ -471,13 +473,14 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
         []()
         {
             ASSERT_EQ(hipSetDevice(0), hipSuccess);
-            if(!ncclCuMemEnable())
+            if(!ncclIsCuMemSupported())
             {
-                GTEST_SKIP() << "cuMem/VMM not enabled or unsupported in this environment";
+                GTEST_SKIP() << "cuMem/VMM not supported in this environment";
             }
 
-            constexpr int    dev  = 0;
-            constexpr size_t size = 8192;
+            constexpr int    dev         = 0;
+            constexpr size_t size        = 8192;
+            constexpr size_t scratchSize = 64 * 1024 * 1024;
 
             hipStream_t pooled = nullptr;
             {
@@ -485,10 +488,20 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
                 ASSERT_EQ(getSideStream(&pooled), ncclSuccess);
                 ASSERT_NE(pooled, nullptr) << "Scope must pool a side stream";
 
+                void* scratch = nullptr;
+                ASSERT_EQ(hipMalloc(&scratch, scratchSize), hipSuccess);
+
                 for(int allocIdx = 0; allocIdx < 2; ++allocIdx)
                 {
+                    // Park a large memset on the pooled stream without syncing.
+                    // The old private-stream fallback leaves this work pending;
+                    // the pooled-stream path must drain it via cudaStreamSynchronize.
+                    ASSERT_EQ(hipMemsetAsync(scratch, 0xFF, scratchSize, pooled), hipSuccess);
+                    EXPECT_EQ(hipStreamQuery(pooled), hipErrorNotReady)
+                        << "Pooled stream must have pending work before cuMem alloc";
+
                     // Real VMM allocation while the scope is held: the internal zero
-                    // must run on the pooled stream, leaving the pool untouched.
+                    // must run on (and synchronize) the pooled stream.
                     // handlep is optional; pass nullptr so no CU* handle type is named.
                     void* ptr = nullptr;
                     ASSERT_EQ(
@@ -497,11 +510,9 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
                     );
                     ASSERT_NE(ptr, nullptr);
 
-                    hipStream_t afterAlloc = nullptr;
-                    ASSERT_EQ(getSideStream(&afterAlloc), ncclSuccess);
-                    EXPECT_EQ(afterAlloc, pooled)
+                    EXPECT_EQ(hipStreamQuery(pooled), hipSuccess)
                         << "cuMem alloc " << allocIdx
-                        << " must reuse (not churn/replace) the pooled side stream";
+                        << " must synchronize the pooled side stream";
 
                     // Buffer must come back zeroed (calloc semantics preserved even
                     // though the redundant caller-side memset was removed).
@@ -514,6 +525,8 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
 
                     ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
                 }
+
+                ASSERT_EQ(hipFree(scratch), hipSuccess);
             }
 
             // Scope exited: the pooled stream must be destroyed, HW queue freed.
@@ -535,9 +548,9 @@ TEST(Alloc, CuMemAllocNoScopeLeavesPoolEmpty)
         []()
         {
             ASSERT_EQ(hipSetDevice(0), hipSuccess);
-            if(!ncclCuMemEnable())
+            if(!ncclIsCuMemSupported())
             {
-                GTEST_SKIP() << "cuMem/VMM not enabled or unsupported in this environment";
+                GTEST_SKIP() << "cuMem/VMM not supported in this environment";
             }
 
             constexpr size_t size = 8192;

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -463,8 +463,8 @@ TEST(Alloc, SideStreamKeySeparatesPriorities)
 // VMM path directly; they are skipped where cuMem is unavailable at runtime.
 // ---------------------------------------------------------------------------
 
-// A cuMem allocation issued inside an active scope reuses the pooled stream
-// (synchronizes it after zeroing), returns zeroed memory, and the stream is
+// A cuMem allocation issued inside an active scope reuses the pooled stream for
+// zeroing (no private stream churn), returns zeroed memory, and the stream is
 // still destroyed on scope exit so nothing lingers into the collective phase.
 TEST(Alloc, CuMemAllocReusesPooledSideStream)
 {
@@ -473,14 +473,13 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
         []()
         {
             ASSERT_EQ(hipSetDevice(0), hipSuccess);
-            if(!ncclIsCuMemSupported())
+            if(!ncclCuMemEnable() || !ncclCuMemRuntimeSupported())
             {
-                GTEST_SKIP() << "cuMem/VMM not supported in this environment";
+                GTEST_SKIP() << "cuMem/VMM not available at runtime in this environment";
             }
 
-            constexpr int    dev         = 0;
-            constexpr size_t size        = 8192;
-            constexpr size_t scratchSize = 64 * 1024 * 1024;
+            constexpr int    dev  = 0;
+            constexpr size_t size = 8192;
 
             hipStream_t pooled = nullptr;
             {
@@ -488,21 +487,10 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
                 ASSERT_EQ(getSideStream(&pooled), ncclSuccess);
                 ASSERT_NE(pooled, nullptr) << "Scope must pool a side stream";
 
-                void* scratch = nullptr;
-                ASSERT_EQ(hipMalloc(&scratch, scratchSize), hipSuccess);
-
                 for(int allocIdx = 0; allocIdx < 2; ++allocIdx)
                 {
-                    // Park a large memset on the pooled stream without syncing.
-                    // The old private-stream fallback leaves this work pending;
-                    // the pooled-stream path must drain it via cudaStreamSynchronize.
-                    ASSERT_EQ(hipMemsetAsync(scratch, 0xFF, scratchSize, pooled), hipSuccess);
-                    EXPECT_EQ(hipStreamQuery(pooled), hipErrorNotReady)
-                        << "Pooled stream must have pending work before cuMem alloc";
-
                     // Real VMM allocation while the scope is held: the internal zero
-                    // must run on (and synchronize) the pooled stream.
-                    // handlep is optional; pass nullptr so no CU* handle type is named.
+                    // must reuse the pooled stream instead of creating a private one.
                     void* ptr = nullptr;
                     ASSERT_EQ(
                         ncclCuMemAlloc(&ptr, /*handlep=*/nullptr, ncclCuMemHandleType, size, /*manager=*/nullptr),
@@ -510,9 +498,11 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
                     );
                     ASSERT_NE(ptr, nullptr);
 
-                    EXPECT_EQ(hipStreamQuery(pooled), hipSuccess)
+                    hipStream_t stillPooled = nullptr;
+                    ASSERT_EQ(getSideStream(&stillPooled), ncclSuccess);
+                    EXPECT_EQ(stillPooled, pooled)
                         << "cuMem alloc " << allocIdx
-                        << " must synchronize the pooled side stream";
+                        << " inside a scope must keep the same pooled side stream";
 
                     // Buffer must come back zeroed (calloc semantics preserved even
                     // though the redundant caller-side memset was removed).
@@ -525,8 +515,6 @@ TEST(Alloc, CuMemAllocReusesPooledSideStream)
 
                     ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
                 }
-
-                ASSERT_EQ(hipFree(scratch), hipSuccess);
             }
 
             // Scope exited: the pooled stream must be destroyed, HW queue freed.
@@ -548,9 +536,9 @@ TEST(Alloc, CuMemAllocNoScopeLeavesPoolEmpty)
         []()
         {
             ASSERT_EQ(hipSetDevice(0), hipSuccess);
-            if(!ncclIsCuMemSupported())
+            if(!ncclCuMemEnable() || !ncclCuMemRuntimeSupported())
             {
-                GTEST_SKIP() << "cuMem/VMM not supported in this environment";
+                GTEST_SKIP() << "cuMem/VMM not available at runtime in this environment";
             }
 
             constexpr size_t size = 8192;


### PR DESCRIPTION
## Motivation

[RCCL] cuMem: use the scoped side-stream pool in the VMM allocation path

## Technical Details

The side-stream pool (per-(busId, priority), refcounted, scope-lifetime)
was introduced to eliminate per-allocation GPU hardware-queue churn during
comm init and P2P connect bursts, so that no side stream lingers into the
steady-state collective phase. With NCCL_CUMEM_ENABLE=1, however, every
device allocation goes through ncclCuMemAlloc, whose ROCM-20370 residue
scrub created and destroyed a *private* stream on every VMM allocation,
reintroducing exactly the churn the pool was meant to remove. In addition,
ncclCudaCalloc zeroed cuMem buffers twice (once inside ncclCuMemAlloc, once
on the caller side).
Changes:
- ncclCuMemAlloc now reuses the pooled side stream for its zeroing while an
  allocation scope is active, falling back to a private non-blocking stream
  only when no scope is held. Behavior outside a scope is unchanged.
- ncclCudaCalloc drops the now-redundant caller-side memset/sync when cuMem
  is enabled (ncclCuMemAlloc already zeroes the buffer). The non-cuMem
  hipExtMalloc path keeps its memset, which returns uninitialized memory.
- Reference counting and scope lifecycle are unchanged, so no side stream
  is alive during the collective phase.


## Issue Tracking

JIRA ID FBA-1139

## Test Plan

- Added two isolated AllocTests (ROCM_VERSION >= 7.0.0, skipped where cuMem
  is unavailable) that drive the real VMM allocator:
  * CuMemAllocReusesPooledSideStream: an allocation inside an active scope
    reuses (does not churn/replace) the pooled stream, returns zeroed
    memory, and the stream is destroyed on scope exit.
  * CuMemAllocNoScopeLeavesPoolEmpty: an allocation with no scope uses a
    private fallback stream and never populates the pool.
- All 8 Alloc unit tests pass on gfx950 / ROCm 7.0.2.
- Single- and 2-node all_reduce/alltoall with NCCL_CUMEM_ENABLE=1 complete
  with #wrong=0; side-stream stats confirm created==destroyed, peak 1 live,
  and zero side streams alive during the collective phase.

## Test Result

All tests passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
