### PR TITLE
fix(rocrtst): guard 1.31 HSA enums so tests build against older HSA headers

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/queue_create.cc
@@ -285,6 +285,9 @@ void QueueCreateTest::SdmaQueueCreateDestroyTest() {
   ASSERT_SUCCESS(rocrtst::SetDefaultAgents(this));
   ASSERT_SUCCESS(rocrtst::SetPoolsTypical(this));
 
+  // HSA_AMD_QUEUE_INFO_READ_POINTER / _WRITE_POINTER are HSA enum constants added
+  // in hsa_ext_amd.h interface 1.31.
+#if HSA_AMD_INTERFACE_VERSION_MINOR >= 31
   auto create_and_destroy = [&](uint16_t flags, const char* label) {
     hsa_amd_queue_create_desc_t desc = {};
     desc.version = HSA_AMD_QUEUE_CREATE_DESC_VERSION;
@@ -345,6 +348,12 @@ void QueueCreateTest::SdmaQueueCreateDestroyTest() {
   create_and_destroy(HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF |
                          HSA_AMD_QUEUE_CREATE_DEVICE_MEM_QUEUE_DESCRIPTOR,
                      "device ring buffer and descriptor");
+#else
+  // The gtest vendored under rocrtst/ predates GTEST_SKIP(); use the standard
+  // [ SKIPPED ] marker instead.
+  fprintf(stdout, "[ SKIPPED ] SdmaQueueCreateDestroyTest: HSA headers predate "
+                  "queue read/write pointer queries\n");
+#endif
 }
 
 void QueueCreateTest::InvalidArgsTest() {

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -66,6 +66,17 @@
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 
+// HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED is an HSA enum constant (in
+// hsa.h) first available at hsa_ext_amd.h interface 1.31.
+static hsa_status_t QueryHostAllocDmaBufSupported(bool* supported) {
+#if HSA_AMD_INTERFACE_VERSION_MINOR >= 31
+  return hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED, supported);
+#else
+  *supported = false;
+  return HSA_STATUS_SUCCESS;
+#endif
+}
+
 // Wrap printf to add first or second process indicator
 #define PROCESS_LOG(format, ...)                                                                   \
   {                                                                                                \
@@ -161,8 +172,7 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   // Query whether the system supports host memory DMA-BUF allocation via vmem APIs
   const bool is_cpu_pool = (ag_type == HSA_DEVICE_TYPE_CPU);
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test for CPU pools if host memory DMA-BUF is not supported
   if (is_cpu_pool && !vmem_host_supported) {
@@ -424,8 +434,7 @@ void VirtMemoryTestBasic::TestRefCount(hsa_agent_t agent, hsa_amd_memory_pool_t 
 
   // Query whether this system supports host memory allocation via vmem APIs
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test for CPU pools if host memory allocation is not supported
   if (ag_type == HSA_DEVICE_TYPE_CPU && !vmem_host_supported) {
@@ -521,8 +530,7 @@ void VirtMemoryTestBasic::TestPartialMapping(hsa_agent_t agent, hsa_amd_memory_p
 
   // Query whether this system supports host memory DMA-BUF allocation via vmem APIs
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test for CPU pools if host memory DMA-BUF is not supported
   if (ag_type == HSA_DEVICE_TYPE_CPU && !vmem_host_supported) {
@@ -1350,8 +1358,7 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(hsa_agent_t agent, hsa_amd_memory
 
   // Query whether this system supports host memory allocation via vmem APIs
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test for CPU pools if host memory is not supported
   if (!vmem_host_supported) {
@@ -1772,8 +1779,7 @@ void VirtMemoryTestBasic::NonContiguousChunks(hsa_agent_t agent, hsa_amd_memory_
   if (ag_type != HSA_DEVICE_TYPE_CPU) return;
 
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test for CPU pools if host memory allocation is not supported
   if (!vmem_host_supported) {
@@ -2327,8 +2333,7 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
                                                                hsa_amd_memory_pool_t cpu_pool) {
   // Query whether this system supports host memory DMA-BUF allocation via vmem APIs
   bool vmem_host_supported = false;
-  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED,
-                                     &vmem_host_supported));
+  ASSERT_SUCCESS(QueryHostAllocDmaBufSupported(&vmem_host_supported));
 
   // Skip test if host memory is not supported
   if (!vmem_host_supported) {


### PR DESCRIPTION
## Motivation

`rocrtst` fails to compile when built against HSA headers older than interface
1.31, which blocks the **entire** ROCR test suite from running (0 cases execute).
This happens on the QA source-rebuild path that builds `develop` `rocrtst`
against an older SDK (e.g. an RC3 SDK): the tests reference HSA enum constants
that those headers do not define.

## Technical Details

Two test files reference enum constants introduced at `hsa_ext_amd.h` interface
1.31:

- `queue_create.cc` — `HSA_AMD_QUEUE_INFO_READ_POINTER` / `HSA_AMD_QUEUE_INFO_WRITE_POINTER`
- `virtual_memory.cc` — `HSA_AMD_SYSTEM_INFO_HOST_ALLOC_DMA_BUF_SUPPORTED` (declared in `hsa.h`, 6 call sites)

These are **enum constants, not `#define`s**, so `#if defined(...)` cannot detect
them. Both are guarded on `#if HSA_AMD_INTERFACE_VERSION_MINOR >= 31` (the real
macro in `hsa_ext_amd.h`, bumped to 31 in the same commit that added the queue
pointer enums). Older headers are `MINOR <= 30`, so the guard is a safe lower
bound for both features.

On older headers:
- `queue_create.cc` emits the standard `[ SKIPPED ]` marker (the gtest vendored
  under `rocrtst/` predates `GTEST_SKIP()`).
- `virtual_memory.cc` routes the query through a small helper that reports host
  DMA-BUF as unsupported, so the dependent sub-tests skip.

No behavior change when built against current headers (`MINOR >= 31`): the real
queries run exactly as before.

## Issue Tracking

<!-- JIRA ID: -->
ROCM-29836

## Test Plan

Compiled both files with the real `rocrtst` build flags against:
1. Reconstructed older HSA headers (interface 1.30, both enums absent) — mimics the RC3 SDK.
2. Current `develop` HSA headers (interface 1.31).

Both the unmodified (baseline) and modified sources were compiled to confirm the
guard flips correctly.

## Test Result

- Baseline vs. old headers: **fails** with the exact reported errors (both files) — reproduces the issue.
- Fixed vs. old headers: **compiles** (skip/unsupported paths taken).
- Fixed vs. current `develop` headers: **compiles**, real queries retained (no regression).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.