### PR TITLE
test(rocprofiler-sdk): synchronize before pausing in roctx-pause-resume

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
@@ -184,6 +184,8 @@ main()
             pc_sampling_kernel<<<num_blocks, threads_per_block>>>(threads_per_block);
             // Check for kernel launch errors
             checkHipErrors(hipGetLastError());
+            // Kernel launches are asynchronous; keep the profiler resumed until they complete.
+            checkHipErrors(hipDeviceSynchronize());
             roctxProfilerPause(tid);
         }
     }


### PR DESCRIPTION
## Motivation

`roctx-pause-resume-pc-sampling` collects zero PC samples and fails its `len(samples) > 0` assertion. The cause is in the test application rather than rocprofiler-sdk: the resume window covers kernel *launch* rather than kernel *execution*, so the sampler is disarmed before the sampled kernels run.

## Technical Details

Everything between `roctxProfilerResume` and `roctxProfilerPause` in `tests/bin/roctx-pause-resume/roctx-pause-resume.cpp` is non-blocking — two kernel launches plus `hipGetLastError()`, none of which wait for completion. Measured from the marker and kernel-dispatch traces, the resume windows average ~88 us against ~4.5 ms mean kernel execution, and 7 of 8 kernel dispatches fall outside any window. PC sampling records what is executing, not what has been launched, so the sampled kernels contribute nothing.

Synchronizing before the pause makes the window cover execution. This binary is shared with `roctx-pause-resume-tracing` and `roctx-pause-resume-nested-tracing`, so the change was checked against both.

## Issue Tracking

JIRA ID: ROCM-29593

## Test Plan

Ran the three tests built on this binary on gfx950, before and after the change: `rocprofv3-test-roctx-pause-resume-pc-sampling`, `rocprofv3-test-roctx-pause-resume-tracing`, and `rocprofv3-test-roctx-pause-resume-nested-tracing`.

## Test Result

PC sample count goes from 0 to 5,406 with no rocprofiler-sdk change. The sibling tests pass identically before and after — `test_kernel_data` and `test_counter_collection_data` for tracing, `test_kernel_data` for nested. Note that `roctx-pause-resume-pc-sampling` skips rather than fails unless `ROCPROFILER_PC_SAMPLING_BETA_ENABLED` is set, so CI may report it green without exercising this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.