### PR TITLE
fix(rocSHMEM): correct string size for socket, ignore libhsa in ASAN

### DIFF
--- a/projects/rocshmem/scripts/lsan-suppressions.txt
+++ b/projects/rocshmem/scripts/lsan-suppressions.txt
@@ -3,3 +3,4 @@ leak:hwloc.so
 leak:open-pal.so
 leak:ucs.so
 leak:uct.so
+leak:libhsa-runtime64.so

--- a/projects/rocshmem/src/bootstrap/bootstrap.cpp
+++ b/projects/rocshmem/src/bootstrap/bootstrap.cpp
@@ -292,7 +292,7 @@ void TcpBootstrap::Impl::initialize(const rocshmem_uniqueid_t& uniqueId, int64_t
     bootstrapCreateRoot();
   }
 
-  char line[MAX_IF_NAME_SIZE + 1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   SocketToString(&uniqueId_.addr, line);
   LOG_INFO("rank %d nranks %d - connecting to %s", rank_, nRanks_, line);
   establishConnections(timeoutSec);


### PR DESCRIPTION
## Motivation

- Using the correct size for char buffer.
- Add libhsa runtime to suppression list to remove leak noise.