### PR TITLE
[rocjitsu] Suppress the external ROCr TSan race in HIP memcpy tests.

### DIFF
--- a/emulation/rocjitsu/tests/hip_memcpy_test.cpp
+++ b/emulation/rocjitsu/tests/hip_memcpy_test.cpp
@@ -13,6 +13,15 @@
 
 #include <cstdlib>
 
+// ROCR serializes its async-event pool with rocr::HybridMutex, an atomic CAS
+// spinlock. The external HSA runtime is not instrumented, so ThreadSanitizer
+// cannot observe that happens-before edge and reports the pool's heap reuse as
+// a race. Ignore only interceptors called from the HSA runtime while retaining
+// ThreadSanitizer coverage for rocjitsu and this test executable.
+extern "C" const char *__tsan_default_suppressions() {
+  return "called_from_lib:libhsa-runtime64.so\n";
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   int rc = RUN_ALL_TESTS();


### PR DESCRIPTION
Under parallel load, ROCr's uninstrumented async-event synchronization can produce an allocator-interceptor data-race report in ConcurrentAsyncEvents after HipMemcpyTest.RoundTripInt has passed. This external false positive makes the child exit 66 and flakes the daemon wrapper.

A focused serial run passed. An eight-worker reproducer then ran 25 iterations per worker with a unique ROCJITSU_RUNTIME_DIR for each process. It reproduced the failure 3 times in 200 runs, a 1.5% hit rate. All 200 child correctness checks passed; the three wrapper failures each contained the same ConcurrentAsyncEvents TSan report and exit code 66, with no rocJitsu-owned memory-access frame.

Add the same called_from_lib suppression already used by the vector-add HIP test to the memcpy child. Scope it to libhsa-runtime64 so rocJitsu and the test executable remain covered by TSan. The same eight-worker, 200-run reproducer then passed 200 times with no TSan report or exit code 66, and all three daemon memcpy functional tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
