### PR TITLE
style(rccl): clang-format src/** with clang-format 22.1.0

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -190,8 +190,8 @@ RCCL_PARAM_DECLARE(ForceCeAllReduce);
 // eligibility, etc). This helper does not re-derive CE eligibility itself: threading the same boolean
 // through both the early CE return and this guard keeps the two decisions from silently drifting apart
 // as CE AllReduce's own eligibility rules evolve.
-bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclDataType_t datatype,
-                                    bool symEligible, bool ceAllReduceAllowed) {
+bool rcclAllReduceShouldTakeDdaPath(const ncclComm* comm, size_t count, ncclDataType_t datatype, bool symEligible,
+                                    bool ceAllReduceAllowed) {
   const size_t msgBytes = count * ncclTypeSize(datatype);
   // gfx1250 DDA fabric AR is bounded by rcclDdaEnabled (RCCL_DDA_THRESHOLD) and the per-tier
   // thresholds, so it may claim the full range regardless of CE eligibility -- ddaFabricArch1250
@@ -334,7 +334,8 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
 
   switch (decision.algo) {
   case RCCL_DDA_FABRIC_LL:
-    INFO(NCCL_COLL, "AllGather: taking DDA fabric LL path: nRanks=%d nNodes=%d sendcount=%zu datatype=%d totalBytes=%zu",
+    INFO(NCCL_COLL,
+         "AllGather: taking DDA fabric LL path: nRanks=%d nNodes=%d sendcount=%zu datatype=%d totalBytes=%zu",
          comm->nRanks, comm->nNodes, sendcount, (int)datatype, msgSize);
     NCCLCHECK(ncclAllGatherDdaFabricLL(sendbuff, recvbuff, sendcount, datatype, comm, stream));
     return ncclSuccess;
@@ -425,9 +426,8 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
     }
 #endif // ENABLE_ROCSHMEM
     // alltoall does not need symEligible check as symmetric kernel is not supported for alltoall
-    if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype),
-                       kDdaAlltoAllGfx942ThresholdBytes, kDdaAlltoAllGfx950ThresholdBytes,
-                       kDdaAlltoAllGfx1250ThresholdBytes)) {
+    if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype), kDdaAlltoAllGfx942ThresholdBytes,
+                       kDdaAlltoAllGfx950ThresholdBytes, kDdaAlltoAllGfx1250ThresholdBytes)) {
       if (IsArchMatch(comm->archName, "gfx1250")) {
         const size_t a2aBytes = comm->nRanks * count * ncclTypeSize(datatype);
         const int64_t llThresh = rcclParamDdaLLThreshold();
@@ -937,7 +937,8 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
     NCCLCHECK(ncclReduceScatterDdaFabricLL128(sendbuff, recvbuff, recvcount, datatype, op, comm, stream));
     return ncclSuccess;
   case RCCL_DDA_FABRIC_VMM:
-    INFO(NCCL_COLL, "ReduceScatter: taking DDA fabric (VMM) path: nRanks=%d nNodes=%d recvcount=%zu datatype=%d bytes=%zu",
+    INFO(NCCL_COLL,
+         "ReduceScatter: taking DDA fabric (VMM) path: nRanks=%d nNodes=%d recvcount=%zu datatype=%d bytes=%zu",
          comm->nRanks, comm->nNodes, recvcount, (int)datatype, recvcount * ncclTypeSize(datatype));
     NCCLCHECK(ncclReduceScatterDdaFabric(sendbuff, recvbuff, recvcount, datatype, op, comm, stream));
     return ncclSuccess;

--- a/projects/rccl/src/dda_alltoall_fabric.cu
+++ b/projects/rccl/src/dda_alltoall_fabric.cu
@@ -61,16 +61,16 @@ static ncclResult_t ncclAllToAllDdaFabricTyped(const void* sendbuff, void* recvb
 
   switch (nRanks) {
   case 4:
-    meta::comms::ddaAllToAllFabric<T, 4><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
+    meta::comms::ddaAllToAllFabric<T, 4>
+      <<<grid, block, 0, stream>>>(d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
     break;
   case 8:
-    meta::comms::ddaAllToAllFabric<T, 8><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
+    meta::comms::ddaAllToAllFabric<T, 8>
+      <<<grid, block, 0, stream>>>(d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
     break;
   default:
-    meta::comms::ddaAllToAllFabric<T, 0><<<grid, block, 0, stream>>>(
-      d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
+    meta::comms::ddaAllToAllFabric<T, 0>
+      <<<grid, block, 0, stream>>>(d_ipcbuffs, static_cast<T*>(recvbuff), count, comm->rank, nRanks, barrierHost);
     break;
   }
 

--- a/projects/rccl/src/dda_alltoall_ipc.cu
+++ b/projects/rccl/src/dda_alltoall_ipc.cu
@@ -56,11 +56,11 @@ static ncclResult_t ncclAllToAllDdaIpcTyped(const void* sendbuff, void* recvbuff
 
   if (meta::comms::ddaAlltoAllSingleBlockGrid(count, sizeof(T))) {
     meta::comms::ddaAllToAllIpc<T, kDdaNranks, false, true><<<grid, block, 0, stream>>>(
-        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
+      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
   } else {
     CUDACHECK(cudaMemcpyAsync(comm->ddaScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
     meta::comms::ddaAllToAllIpc<T, kDdaNranks, false, false><<<grid, block, 0, stream>>>(
-        d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
+      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
   }
   CUDACHECK(cudaGetLastError());
 

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -383,8 +383,7 @@ static ncclResult_t symMemoryImportAndMapSegmentsForRank(struct ncclComm* comm, 
   uintptr_t addr = base + r * devr->bigSize + bigOffset;
   for (int segment = 0; segment < numSegments; segment++) {
     symLsaMessage* msg = messages + r * maxSegments + segment;
-    bool reuseLocal =
-      (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
+    bool reuseLocal = (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && ncclSymIsHostSegment(msg->type));
     CUmemGenericAllocationHandle handle = reuseLocal ? memHandles[segment] : (CUmemGenericAllocationHandle)0ULL;
     NCCLCHECKGOTO(symMemoryImportAndMapSegmentHandle(comm, r, reinterpret_cast<CUdeviceptr>(addr), msg, handle,
                                                      reuseLocal),
@@ -1347,9 +1346,10 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
     CUmemAllocationProp prop;
     CUCHECKGOTO(cuMemGetAllocationPropertiesFromHandle(&prop, memHandles[segment]), ret, fail_locReg);
     if (!ncclSymIsHostSegment(prop.location.type) && prop.location.type != CU_MEM_LOCATION_TYPE_DEVICE) {
-      WARN("Segment %d has unsupported location type %d. Symmetric memory currently only supports "
-           "host (CU_MEM_LOCATION_TYPE_HOST_NUMA, or CU_MEM_LOCATION_TYPE_HOST on AMD) and CU_MEM_LOCATION_TYPE_DEVICE.",
-           segment, (int)prop.location.type);
+      WARN(
+        "Segment %d has unsupported location type %d. Symmetric memory currently only supports "
+        "host (CU_MEM_LOCATION_TYPE_HOST_NUMA, or CU_MEM_LOCATION_TYPE_HOST on AMD) and CU_MEM_LOCATION_TYPE_DEVICE.",
+        segment, (int)prop.location.type);
       ret = ncclInvalidArgument;
       goto fail_locReg;
     }
@@ -1801,8 +1801,8 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
   // Must use this devComm's own resource window (win->userPtr), not
   // devr->winSorted[0] which may belong to a different devComm (e.g. symk).
   if (devr->ginEnabled && ginSignalTotal > 0 && outDevComm->resourceWindow != nullptr) {
-    NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win->userPtr, ginAnvilNetSignalsOffset,
-                                                        nGinContextsTotal, ginSignalTotal),
+    NCCLCHECKGOTO(ncclGinAnvilBindResourceWindowSignals(comm, win->userPtr, ginAnvilNetSignalsOffset, nGinContextsTotal,
+                                                        ginSignalTotal),
                   ret, fail_stream_mem_win);
   }
 #endif

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -48,9 +48,9 @@ __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct 
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0, false, RCCL_METADATA_EMPTY, 0, 0, UserRegMode>
-      prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex,
-            work->connIndex, work);
+    Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0, false, RCCL_METADATA_EMPTY, 0, 0, UserRegMode> prims(
+      tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex,
+      work->connIndex, work);
 
     for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
       offset = gridOffset + elemOffset;

--- a/projects/rccl/src/device/ce_reduce.cc
+++ b/projects/rccl/src/device/ce_reduce.cc
@@ -126,17 +126,28 @@ ncclResult_t ncclCeLaunchPersistentReduce(const void* in, void* out, int nRanks,
 int ncclCeLocalReduceBlocks(ncclDataType_t datatype, size_t chunkElems) {
   if (chunkElems == 0) return 0;
   switch (datatype) {
-  case ncclFloat32:  return ncclCeLocalReduceBlocks_f32(chunkElems);
-  case ncclFloat64:  return ncclCeLocalReduceBlocks_f64(chunkElems);
-  case ncclFloat16:  return ncclCeLocalReduceBlocks_f16(chunkElems);
-  case ncclBfloat16: return ncclCeLocalReduceBlocks_bf16(chunkElems);
-  case ncclInt32:    return ncclCeLocalReduceBlocks_i32(chunkElems);
-  case ncclUint32:   return ncclCeLocalReduceBlocks_u32(chunkElems);
-  case ncclInt64:    return ncclCeLocalReduceBlocks_i64(chunkElems);
-  case ncclUint64:   return ncclCeLocalReduceBlocks_u64(chunkElems);
-  case ncclInt8:     return ncclCeLocalReduceBlocks_i8(chunkElems);
-  case ncclUint8:    return ncclCeLocalReduceBlocks_u8(chunkElems);
+  case ncclFloat32:
+    return ncclCeLocalReduceBlocks_f32(chunkElems);
+  case ncclFloat64:
+    return ncclCeLocalReduceBlocks_f64(chunkElems);
+  case ncclFloat16:
+    return ncclCeLocalReduceBlocks_f16(chunkElems);
+  case ncclBfloat16:
+    return ncclCeLocalReduceBlocks_bf16(chunkElems);
+  case ncclInt32:
+    return ncclCeLocalReduceBlocks_i32(chunkElems);
+  case ncclUint32:
+    return ncclCeLocalReduceBlocks_u32(chunkElems);
+  case ncclInt64:
+    return ncclCeLocalReduceBlocks_i64(chunkElems);
+  case ncclUint64:
+    return ncclCeLocalReduceBlocks_u64(chunkElems);
+  case ncclInt8:
+    return ncclCeLocalReduceBlocks_i8(chunkElems);
+  case ncclUint8:
+    return ncclCeLocalReduceBlocks_u8(chunkElems);
   // fp8 (e4m3/e5m2) not currently supported for CE AR.
-  default:           return 0;
+  default:
+    return 0;
   }
 }

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -273,10 +273,13 @@ __device__ __forceinline__ void loadWorkBatchToShmem(int tid, int tn, struct ncc
     // the nextExtends warp rotation stays correct. alignas(16) keeps bcastPacks >= 1.
     static_assert(sizeof(struct ncclDevWorkBcast) % 16 == 0 && sizeof(struct ncclDevWorkBcast) >= 16,
                   "ncclDevWorkBcast must be a non-zero multiple of the 16B pack size");
-    constexpr int bcastPacks = sizeof(struct ncclDevWorkBcast)/16; // 3 packs/work
+    constexpr int bcastPacks = sizeof(struct ncclDevWorkBcast) / 16; // 3 packs/work
     bool isBcast = batch.workType == (int)ncclDevWorkTypeBcast;
     for (int pk = tid; pk < nPacks; pk += tn) {
-      if (isBcast) { dstWork = pk/bcastPacks; packInWork = pk - dstWork*bcastPacks; }
+      if (isBcast) {
+        dstWork = pk / bcastPacks;
+        packInWork = pk - dstWork * bcastPacks;
+      }
       int srcWork = fnsOfBitset[dstWork]; // find n'th set bit in batch.offsetBitset
       ulonglong2 tmp;
       // The loads done in these two cases must be kept separate since we are
@@ -315,7 +318,7 @@ __device__ __forceinline__ void loadWorkBatchToShmem(int tid, int tn, struct ncc
 
     if (batch.nextExtends) {
       batchIx += batch.nextJump;
-      tid -= 2*WARP_SIZE; // Rotate threads so we use the next two warps for next batch struct.
+      tid -= 2 * WARP_SIZE; // Rotate threads so we use the next two warps for next batch struct.
       if (tid < 0) tid += tn;
     } else {
       if (tid == 0) {

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -306,10 +306,11 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     for (int g = 0; g < WordPerThread / 2; g++) {
       int ix = g * WARP_SIZE - LineSkip * (g / 2) + wid - (g % 2) * (wid / (LineElems / 2));
       if (!flagThread || g % 2 == 0) {
-        if (misalignment == 0 && (ix + 1) * EltPer16B <= eltN)
+        if (misalignment == 0 && (ix + 1) * EltPer16B <= eltN) {
           storeUser128((uint64_t*)(dst + ix * EltPer16B), regs[2 * g + 0], regs[2 * g + 1]);
-        else
+        } else {
           storeShmem128(shm8 + 2 * ix, regs[2 * g + 0], regs[2 * g + 1]);
+        }
       }
     }
     __syncwarp();

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -89,57 +89,57 @@ __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct 
     }
   }
 #ifdef ENABLE_WARP_SPEED
-    int warp = threadIdx.x / WARP_SIZE;
-    ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
+  int warp = threadIdx.x / WARP_SIZE;
+  ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
 #else
-    ncclRing* ring = &ncclShmem.channel.ring;
+  ncclRing* ring = &ncclShmem.channel.ring;
 #endif
-    int const* ringRanks = ring->userRanks;
-    const int nranks = ncclShmem.comm.nRanks;
-    size_t count;
-    size_t gridOffset;
-    size_t channelCount;
-    size_t chunkCount;
+  int const* ringRanks = ring->userRanks;
+  const int nranks = ncclShmem.comm.nRanks;
+  size_t count;
+  size_t gridOffset;
+  size_t channelCount;
+  size_t chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount,
-                    &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount,
+                  &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
 #endif
-    size_t offset;
-    size_t dataOffset;
-    uint32_t nelem;
-    int rankDest;
+  size_t offset;
+  size_t dataOffset;
+  uint32_t nelem;
+  int rankDest;
 
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims(tid, nthreads, &ring->prev,
-                                                                                 &ring->next, work->sendbuff,
-                                                                                 work->recvbuff, work->redOpArg, 0,
-                                                                                 work->connIndex, work->connIndex);
+  Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims(tid, nthreads, &ring->prev, &ring->next,
+                                                                               work->sendbuff, work->recvbuff,
+                                                                               work->redOpArg, 0, work->connIndex,
+                                                                               work->connIndex);
 
-    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-      nelem = min(chunkCount, channelCount - elemOffset);
+  for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+    nelem = min(chunkCount, channelCount - elemOffset);
 
-      dataOffset = gridOffset + elemOffset;
+    dataOffset = gridOffset + elemOffset;
         /////////////// begin ReduceScatter steps ///////////////
         // step 0: push data to next GPU
-      rankDest = ringRanks[nranks - 1];
-      offset = dataOffset + rankDest * count;
-      prims.send(offset, nelem);
+    rankDest = ringRanks[nranks - 1];
+    offset = dataOffset + rankDest * count;
+    prims.send(offset, nelem);
         // k-2 steps: reduce and copy to next GPU
-      for (int j = 2; j < nranks; ++j) {
-        rankDest = ringRanks[nranks - j];
-        offset = dataOffset + rankDest * count;
-        prims.recvReduceSend(offset, nelem);
-      }
+    for (int j = 2; j < nranks; ++j) {
+      rankDest = ringRanks[nranks - j];
+      offset = dataOffset + rankDest * count;
+      prims.recvReduceSend(offset, nelem);
+    }
 
         // step k-1: reduce this buffer and data, which will produce the final result
-      rankDest = ringRanks[0];
-      offset = dataOffset + rankDest * count;
-      prims.recvReduceCopy(offset, dataOffset, nelem, /*postOp=*/true);
-    }
+    rankDest = ringRanks[0];
+    offset = dataOffset + rankDest * count;
+    prims.recvReduceCopy(offset, dataOffset, nelem, /*postOp=*/true);
+  }
 }
 } // namespace
 

--- a/projects/rccl/src/device/tdm/asyncCopy.h
+++ b/projects/rccl/src/device/tdm/asyncCopy.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "syncPolicy.h"   // shared SyncPolicy encoding (same as tdmCopy.h)
 
 #ifndef __has_include
-#  define __has_include(x) 0
+#define __has_include(x) 0
 #endif
 // The TileMover wrappers at the bottom of this header are built on the gfx1250 TDM
 // descriptor types, so they need the SDK's descriptor header. Use the same
@@ -39,18 +39,18 @@ THE SOFTWARE.
 // so adding one here would force this to 0 for every host caller and make the
 // host-side capability queries report unsupported on real gfx1250 hardware.
 #ifndef TDM_TOOLCHAIN_AVAILABLE
-#  if __has_include(<hip/amd_detail/amd_gfx1250_TDM.h>)
-#    define TDM_TOOLCHAIN_AVAILABLE 1
-#  else
-#    define TDM_TOOLCHAIN_AVAILABLE 0
-#  endif
+#if __has_include(<hip/amd_detail/amd_gfx1250_TDM.h>)
+#define TDM_TOOLCHAIN_AVAILABLE 1
+#else
+#define TDM_TOOLCHAIN_AVAILABLE 0
+#endif
 #endif
 #if TDM_TOOLCHAIN_AVAILABLE
-#  include <hip/amd_detail/amd_gfx1250_TDM.h>   // gfx1250_TDM_GROUP0/1 descriptor types
+#include <hip/amd_detail/amd_gfx1250_TDM.h>   // gfx1250_TDM_GROUP0/1 descriptor types
 #endif
 
 #ifndef __has_builtin
-#  define __has_builtin(x) 0
+#define __has_builtin(x) 0
 #endif
 
 // Capability macros for the two builtin families this header wraps. Unlike
@@ -62,22 +62,20 @@ THE SOFTWARE.
 // a hard error -- so every body that emits one has to be gated on these.
 #if defined(__gfx1250__) && __has_builtin(__builtin_amdgcn_global_load_async_to_lds_b128)
                                   /* extend: || (defined(__gfxNNNN__) && ...) */
-#  define ASYNC_COPY_SUPPORTED 1
+#define ASYNC_COPY_SUPPORTED 1
 #else
-#  define ASYNC_COPY_SUPPORTED 0
+#define ASYNC_COPY_SUPPORTED 0
 #endif
 
 // Same condition as tdmCopy.h's copy, kept #ifndef-guarded so the two headers can
 // be included together in either order.
 #ifndef TDM_SUPPORTED
-#  if defined(__gfx1250__) && \
-      __has_builtin(__builtin_amdgcn_tensor_load_to_lds) && \
-      TDM_TOOLCHAIN_AVAILABLE
+#if defined(__gfx1250__) && __has_builtin(__builtin_amdgcn_tensor_load_to_lds) && TDM_TOOLCHAIN_AVAILABLE
                                   /* extend: || (defined(__gfxNNNN__) && ...) */
-#    define TDM_SUPPORTED 1
-#  else
-#    define TDM_SUPPORTED 0
-#  endif
+#define TDM_SUPPORTED 1
+#else
+#define TDM_SUPPORTED 0
+#endif
 #endif
 
 // ============================================================================
@@ -101,11 +99,11 @@ THE SOFTWARE.
 // namespace-scope entry point in this header -- the one-way asyncLoadToLDS()/asyncStoreFromLDS()
 // primitives and asyncWait() as well as the async:: parity API.
 #if ASYNC_COPY_SUPPORTED
-#  define ASYNC_API      inline
-#  define ASYNC_DELETED
+#define ASYNC_API inline
+#define ASYNC_DELETED
 #else
-#  define ASYNC_API
-#  define ASYNC_DELETED  = delete
+#define ASYNC_API
+#define ASYNC_DELETED = delete
 #endif
 
 // Used for setting TDM descriptor fields and arguments to the async load/store builtins
@@ -117,12 +115,12 @@ using __rccl_int32x8 = int32_t __attribute__((__vector_size__(32)));
 // compile-time constant.  We always pass a zero immediate and instead apply the per-lane offset directly to
 // the src/dst pointers, which lets every lane target a different chunk of the transfer.
 namespace {
-  constexpr int32_t ZERO_OFFSET = 0;
+constexpr int32_t ZERO_OFFSET = 0;
 }
 
 // Waits until at most WAIT_CNT outstanding async-to/from-LDS transfers remain in flight.  The count
 // is baked into the hardware instruction, so it must be a compile-time constant.
-template<int WAIT_CNT = 0>
+template <int WAIT_CNT = 0>
 __device__ ASYNC_API void asyncWait() ASYNC_DELETED;
 
 /* Async load/Store APIs */
@@ -133,13 +131,12 @@ __device__ ASYNC_API void asyncWait() ASYNC_DELETED;
 
 // Warp-level async copy from global memory into LDS.  The entire warp calls this with the same arguments.
 // Set Aligned=true only when globalSrc and ldsDst are known to be 128-byte aligned (skips the peel).
-template<SyncPolicy sp = SyncPolicy::Async, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
-__device__ ASYNC_API void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst,
-                                         size_t sizeInBytes) ASYNC_DELETED;
+template <SyncPolicy sp = SyncPolicy::Async, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
+__device__ ASYNC_API void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst, size_t sizeInBytes) ASYNC_DELETED;
 
 // Warp-level async copy from LDS into global memory.  The entire warp calls this with the same arguments.
 // Set Aligned=true only when globalDst and ldsSrc are known to be 128-byte aligned (skips the peel).
-template<SyncPolicy sp = SyncPolicy::Async, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
+template <SyncPolicy sp = SyncPolicy::Async, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
 __device__ ASYNC_API void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst,
                                             size_t sizeInBytes) ASYNC_DELETED;
 
@@ -161,62 +158,64 @@ namespace async_detail {
 
 // Direction of the transfer.  In both cases the first pointer is the global-memory side and the second is the
 // LDS side, which keeps the per-width helpers below symmetric.
-enum struct AsyncDir { Load, Store };
+enum struct AsyncDir {
+  Load,
+  Store
+};
 
-using __rccl_global_char     = __attribute__((address_space(1))) char;
-using __rccl_lds_char        = __attribute__((address_space(3))) char;
-using __rccl_global_int32    = __attribute__((address_space(1))) int32_t;
-using __rccl_lds_int32       = __attribute__((address_space(3))) int32_t;
-using __rccl_global_int32x2  = __attribute__((address_space(1))) __rccl_int32x2;
-using __rccl_lds_int32x2     = __attribute__((address_space(3))) __rccl_int32x2;
-using __rccl_global_int32x4  = __attribute__((address_space(1))) __rccl_int32x4;
-using __rccl_lds_int32x4     = __attribute__((address_space(3))) __rccl_int32x4;
+using __rccl_global_char = __attribute__((address_space(1))) char;
+using __rccl_lds_char = __attribute__((address_space(3))) char;
+using __rccl_global_int32 = __attribute__((address_space(1))) int32_t;
+using __rccl_lds_int32 = __attribute__((address_space(3))) int32_t;
+using __rccl_global_int32x2 = __attribute__((address_space(1))) __rccl_int32x2;
+using __rccl_lds_int32x2 = __attribute__((address_space(3))) __rccl_int32x2;
+using __rccl_global_int32x4 = __attribute__((address_space(1))) __rccl_int32x4;
+using __rccl_lds_int32x4 = __attribute__((address_space(3))) __rccl_int32x4;
 
 // One b8 access (1 byte) for a single lane.
-template<AsyncDir DIR, CachePolicy cp>
-__device__ inline void asyncCopyB8(const uint8_t* global, uint8_t* lds){
+template <AsyncDir DIR, CachePolicy cp>
+__device__ inline void asyncCopyB8(const uint8_t* global, uint8_t* lds) {
   if constexpr (DIR == AsyncDir::Load) {
-    __builtin_amdgcn_global_load_async_to_lds_b8(
-        (__rccl_global_char*)global, (__rccl_lds_char*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_load_async_to_lds_b8((__rccl_global_char*)global, (__rccl_lds_char*)lds, ZERO_OFFSET, cp);
   } else {
-    __builtin_amdgcn_global_store_async_from_lds_b8(
-        (__rccl_global_char*)global, (__rccl_lds_char*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_store_async_from_lds_b8((__rccl_global_char*)global, (__rccl_lds_char*)lds, ZERO_OFFSET,
+                                                    cp);
   }
 }
 
 // One b32 access (4 bytes) for a single lane.
-template<AsyncDir DIR, CachePolicy cp>
-__device__ inline void asyncCopyB32(const uint8_t* global, uint8_t* lds){
+template <AsyncDir DIR, CachePolicy cp>
+__device__ inline void asyncCopyB32(const uint8_t* global, uint8_t* lds) {
   if constexpr (DIR == AsyncDir::Load) {
-    __builtin_amdgcn_global_load_async_to_lds_b32(
-        (__rccl_global_int32*)global, (__rccl_lds_int32*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_load_async_to_lds_b32((__rccl_global_int32*)global, (__rccl_lds_int32*)lds, ZERO_OFFSET,
+                                                  cp);
   } else {
-    __builtin_amdgcn_global_store_async_from_lds_b32(
-        (__rccl_global_int32*)global, (__rccl_lds_int32*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_store_async_from_lds_b32((__rccl_global_int32*)global, (__rccl_lds_int32*)lds, ZERO_OFFSET,
+                                                     cp);
   }
 }
 
 // One b64 access (8 bytes) for a single lane.
-template<AsyncDir DIR, CachePolicy cp>
-__device__ inline void asyncCopyB64(const uint8_t* global, uint8_t* lds){
+template <AsyncDir DIR, CachePolicy cp>
+__device__ inline void asyncCopyB64(const uint8_t* global, uint8_t* lds) {
   if constexpr (DIR == AsyncDir::Load) {
-    __builtin_amdgcn_global_load_async_to_lds_b64(
-        (__rccl_global_int32x2*)global, (__rccl_lds_int32x2*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_load_async_to_lds_b64((__rccl_global_int32x2*)global, (__rccl_lds_int32x2*)lds, ZERO_OFFSET,
+                                                  cp);
   } else {
-    __builtin_amdgcn_global_store_async_from_lds_b64(
-        (__rccl_global_int32x2*)global, (__rccl_lds_int32x2*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_store_async_from_lds_b64((__rccl_global_int32x2*)global, (__rccl_lds_int32x2*)lds,
+                                                     ZERO_OFFSET, cp);
   }
 }
 
 // One b128 access (16 bytes) for a single lane.
-template<AsyncDir DIR, CachePolicy cp>
-__device__ inline void asyncCopyB128(const uint8_t* global, uint8_t* lds){
+template <AsyncDir DIR, CachePolicy cp>
+__device__ inline void asyncCopyB128(const uint8_t* global, uint8_t* lds) {
   if constexpr (DIR == AsyncDir::Load) {
-    __builtin_amdgcn_global_load_async_to_lds_b128(
-        (__rccl_global_int32x4*)global, (__rccl_lds_int32x4*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_load_async_to_lds_b128((__rccl_global_int32x4*)global, (__rccl_lds_int32x4*)lds,
+                                                   ZERO_OFFSET, cp);
   } else {
-    __builtin_amdgcn_global_store_async_from_lds_b128(
-        (__rccl_global_int32x4*)global, (__rccl_lds_int32x4*)lds, ZERO_OFFSET, cp);
+    __builtin_amdgcn_global_store_async_from_lds_b128((__rccl_global_int32x4*)global, (__rccl_lds_int32x4*)lds,
+                                                      ZERO_OFFSET, cp);
   }
 }
 
@@ -225,7 +224,7 @@ constexpr size_t BYTES_PER_LANE_B128 = 16;
 // The hot loop must start on a 128-byte boundary, so the peel aligns the global pointer to this.
 constexpr size_t NATURAL_ALIGNMENT_BYTES = 128;
 // How many b128 iterations the hot loop unrolls at a time.
-constexpr int    HOT_LOOP_UNROLL     = 4;
+constexpr int HOT_LOOP_UNROLL = 4;
 
 // Warp-cooperative byte copy between global memory and LDS.  The whole warp must call this with identical
 // `global`, `lds`, and `sizeInBytes` arguments -- the per-lane work distribution is derived internally.
@@ -244,11 +243,11 @@ constexpr int    HOT_LOOP_UNROLL     = 4;
 // boundary, the phase-1 peel is provably a no-op.  Compiling it out removes the peel branches and lets the
 // hot loop start at offset 0 with folded, compile-time-known strides.  Callers must only pass Aligned=true
 // after checking the runtime pointers (see async::detail::issue).
-template<AsyncDir DIR, CachePolicy cp, bool Aligned = false>
-__device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t sizeInBytes){
-  const unsigned lane      = __lane_id();
-  const size_t   laneCount = (size_t)__builtin_amdgcn_wavefrontsize();
-  const size_t   laneByte  = (size_t)lane * BYTES_PER_LANE_B128;
+template <AsyncDir DIR, CachePolicy cp, bool Aligned = false>
+__device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t sizeInBytes) {
+  const unsigned lane = __lane_id();
+  const size_t laneCount = (size_t)__builtin_amdgcn_wavefrontsize();
+  const size_t laneByte = (size_t)lane * BYTES_PER_LANE_B128;
 
   size_t offset = 0;
 
@@ -256,9 +255,8 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
     // Phase 1a: peel leading bytes until `global` is 16-byte aligned, one byte per lane.
     const size_t misalign = (uintptr_t)global & (BYTES_PER_LANE_B128 - 1);
     if (misalign != 0) {
-      const size_t head = (BYTES_PER_LANE_B128 - misalign) < sizeInBytes
-                              ? (BYTES_PER_LANE_B128 - misalign)
-                              : sizeInBytes;
+      const size_t head =
+        (BYTES_PER_LANE_B128 - misalign) < sizeInBytes ? (BYTES_PER_LANE_B128 - misalign) : sizeInBytes;
       if (lane < head) {
         asyncCopyB8<DIR, cp>(global + lane, lds + lane);
       }
@@ -268,9 +266,9 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
     // Phase 1b: peel whole 16-byte chunks until `global + offset` reaches 128-byte alignment, one b128 per
     // leading lane.  `global + offset` is already 16-byte aligned, so the number of bytes left to the next
     // 128-byte boundary is a multiple of 16 (at most 112 -> 7 chunks, well within a warp).
-    const size_t align128    = ((uintptr_t)global + offset) & (NATURAL_ALIGNMENT_BYTES - 1);
+    const size_t align128 = ((uintptr_t)global + offset) & (NATURAL_ALIGNMENT_BYTES - 1);
     const size_t bytesToLine = (NATURAL_ALIGNMENT_BYTES - align128) & (NATURAL_ALIGNMENT_BYTES - 1);
-    size_t       peelChunks  = bytesToLine / BYTES_PER_LANE_B128;
+    size_t peelChunks = bytesToLine / BYTES_PER_LANE_B128;
     const size_t availChunks = (sizeInBytes - offset) / BYTES_PER_LANE_B128;
     if (peelChunks > availChunks) peelChunks = availChunks;
     if (lane < peelChunks) {
@@ -282,12 +280,12 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
 
   // Phase 2: hot unrolled loop of full-warp b128 transfers, now starting on a 128-byte boundary.
   const size_t bytesPerIter = laneCount * BYTES_PER_LANE_B128;
-  size_t remaining          = sizeInBytes - offset;
-  #pragma unroll HOT_LOOP_UNROLL
+  size_t remaining = sizeInBytes - offset;
+#pragma unroll HOT_LOOP_UNROLL
   while (remaining >= bytesPerIter) {
     const size_t laneOff = offset + laneByte;
     asyncCopyB128<DIR, cp>(global + laneOff, lds + laneOff);
-    offset    += bytesPerIter;
+    offset += bytesPerIter;
     remaining -= bytesPerIter;
   }
 
@@ -298,7 +296,7 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
     const size_t laneOff = offset + laneByte;
     asyncCopyB128<DIR, cp>(global + laneOff, lds + laneOff);
   }
-  offset    += full128 * BYTES_PER_LANE_B128;
+  offset += full128 * BYTES_PER_LANE_B128;
   remaining -= full128 * BYTES_PER_LANE_B128;  // now < 16 bytes
 
   if (remaining == 0) return;   // common case after a 16B-multiple chunk: nothing left to drain
@@ -310,14 +308,14 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
     if (lane == 0) {
       asyncCopyB64<DIR, cp>(global + offset, lds + offset);
     }
-    offset    += 8;
+    offset += 8;
     remaining -= 8;
   }
   if (remaining >= 4) {
     if (lane == 0) {
       asyncCopyB32<DIR, cp>(global + offset, lds + offset);
     }
-    offset    += 4;
+    offset += 4;
     remaining -= 4;
   }
   // Final 1..3 bytes, one b8 per lane.
@@ -328,32 +326,31 @@ __device__ inline void warpAsyncCopy(const uint8_t* global, uint8_t* lds, size_t
 
 } // namespace async_detail
 
-template<int WAIT_CNT>
-__device__ inline void asyncWait(){
+template <int WAIT_CNT>
+__device__ inline void asyncWait() {
   __builtin_amdgcn_s_wait_asynccnt(WAIT_CNT);
 }
 
-template<SyncPolicy sp, CachePolicy cp, bool Aligned>
-__device__ inline void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst, size_t sizeInBytes){
+template <SyncPolicy sp, CachePolicy cp, bool Aligned>
+__device__ inline void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst, size_t sizeInBytes) {
   async_detail::warpAsyncCopy<async_detail::AsyncDir::Load, cp, Aligned>(globalSrc, ldsDst, sizeInBytes);
   if constexpr (sp == SyncPolicy::Sync) {
     asyncWait<0>();
   }
 }
 
-template<SyncPolicy sp, CachePolicy cp, bool Aligned>
-__device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst, size_t sizeInBytes){
+template <SyncPolicy sp, CachePolicy cp, bool Aligned>
+__device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst, size_t sizeInBytes) {
   // warpAsyncCopy shares one non-const `lds` parameter across load and store; the store path only reads from
   // it, so dropping const here is safe.
-  async_detail::warpAsyncCopy<async_detail::AsyncDir::Store, cp, Aligned>(globalDst, const_cast<uint8_t*>(ldsSrc), sizeInBytes);
+  async_detail::warpAsyncCopy<async_detail::AsyncDir::Store, cp, Aligned>(globalDst, const_cast<uint8_t*>(ldsSrc),
+                                                                          sizeInBytes);
   if constexpr (sp == SyncPolicy::Sync) {
     asyncWait<0>();
   }
 }
 
 #endif // ASYNC_COPY_SUPPORTED
-
-
 
 /* TDM APIs */
 // setTransferSize and TileMover name the TDM descriptor types directly, so they only
@@ -363,7 +360,7 @@ __device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalD
 #if TDM_TOOLCHAIN_AVAILABLE
 // Higher productivity async copy wrappers on top of TDM header, which is lower level.
 // The TDM API does not have a function to set the transfer size, so we need to do it manually.
-__device__ static void setTransferSize(gfx1250_TDM_GROUP1& group1, int numElements){
+__device__ static void setTransferSize(gfx1250_TDM_GROUP1& group1, int numElements) {
   group1.tensorDim0(numElements);
   group1.tensorDim0Stride(numElements);
   group1.tileDim0(numElements);
@@ -373,8 +370,8 @@ __device__ static void setTransferSize(gfx1250_TDM_GROUP1& group1, int numElemen
 // Warp-level tile copier built on top of the async-to/from-LDS builtins.  Exposes the same interface as
 // TileMover so the two can be used interchangeably as the TileMoverType of a copy kernel.  An entire warp
 // makes each call, and the shmem/global pointers must be uniform across the warp (no per-lane offsets).
-template<typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
-struct AsyncDataCopier{
+template <typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
+struct AsyncDataCopier {
   size_t sizeInBytes_{0};
   T* shmemPtr_{nullptr};
 
@@ -383,38 +380,36 @@ struct AsyncDataCopier{
 // slipped through gets a compile error at the call site instead of a silent no-op copy.
 #if ASYNC_COPY_SUPPORTED
   // An entire warp makes this call.  The shmemPtr and srcPtr should be the same across all lanes in the warp.
-  __device__ void loadTile(T* shmemPtr, const T* srcPtr, int numElementsToProcess){
+  __device__ void loadTile(T* shmemPtr, const T* srcPtr, int numElementsToProcess) {
     sizeInBytes_ = static_cast<size_t>(numElementsToProcess) * sizeof(T);
     shmemPtr_ = shmemPtr;
     asyncLoadToLDS<SyncPolicy::Async, cp>(reinterpret_cast<const uint8_t*>(srcPtr),
-                                          reinterpret_cast<uint8_t*>(shmemPtr),
-                                          sizeInBytes_);
+                                          reinterpret_cast<uint8_t*>(shmemPtr), sizeInBytes_);
   }
 
   // An entire warp makes this call.  The dstPtr should be the same across all lanes in the warp.
-  __device__ void storeTile(T* dstPtr){
+  __device__ void storeTile(T* dstPtr) {
     asyncStoreFromLDS<SyncPolicy::Async, cp>(reinterpret_cast<const uint8_t*>(shmemPtr_),
-                                             reinterpret_cast<uint8_t*>(dstPtr),
-                                             sizeInBytes_);
+                                             reinterpret_cast<uint8_t*>(dstPtr), sizeInBytes_);
   }
 
-  template<int WAIT_CNT = 0>
-  __device__ void waitTile(){
+  template <int WAIT_CNT = 0>
+  __device__ void waitTile() {
     asyncWait<WAIT_CNT>();
   }
 #else
   __device__ void loadTile(T* shmemPtr, const T* srcPtr, int numElementsToProcess) = delete;
   __device__ void storeTile(T* dstPtr) = delete;
-  template<int WAIT_CNT = 0>
+  template <int WAIT_CNT = 0>
   __device__ void waitTile() = delete;
 #endif
 };
 
 #if TDM_TOOLCHAIN_AVAILABLE
-// Warp-level data copier.  Moves whole 1D tiles in between global memory and LDS using the TDM.  Both pointers ideally should be a multiple of 128-byte aligned 
+// Warp-level data copier.  Moves whole 1D tiles in between global memory and LDS using the TDM.  Both pointers ideally should be a multiple of 128-byte aligned
 // for maximum performance.
-template<typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
-struct TileMover{
+template <typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
+struct TileMover {
   gfx1250_TDM_GROUP0 group0;
   gfx1250_TDM_GROUP1 group1;
 
@@ -423,9 +418,11 @@ struct TileMover{
 // reasoning as AsyncDataCopier. The enclosing TDM_TOOLCHAIN_AVAILABLE guard keeps this
 // type nameable in the host pass, where TDM_SUPPORTED is always 0.
 #if TDM_SUPPORTED
-  __device__ TileMover(){
+  __device__ TileMover() {
     constexpr int log2DataSize = __builtin_ctzll(sizeof(T));
-    static_assert(log2DataSize <= 3, "Datatype must be 1, 2, 4, or 8 bytes in width"); // TODO(breslow): Replace with C++ concepts when we migrate to C++20
+    static_assert(
+      log2DataSize <= 3,
+      "Datatype must be 1, 2, 4, or 8 bytes in width"); // TODO(breslow): Replace with C++ concepts when we migrate to C++20
     group1.dataSize(log2DataSize);
   }
 
@@ -434,28 +431,30 @@ struct TileMover{
     group0.ldsAddr((uintptr_t)shmemPtr);
     group0.globalAddr((uintptr_t)srcPtr);
     setTransferSize(group1, numElementsToProcess);
-    __builtin_amdgcn_tensor_load_to_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{}, __rccl_int32x8{}, cp);
+    __builtin_amdgcn_tensor_load_to_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{},
+                                        __rccl_int32x8{}, cp);
   }
 
   // An entire warp makes this call.  The dstPtr should be the same across all lanes in the warp.  Do not pass in per-lane offsets for addresses.
   __device__ void storeTile(T* dstPtr) {
     group0.globalAddr((uintptr_t)dstPtr);
-    __builtin_amdgcn_tensor_store_from_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{}, __rccl_int32x8{}, cp);
+    __builtin_amdgcn_tensor_store_from_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{},
+                                           __rccl_int32x8{}, cp);
   }
 
-  template<int WAIT_CNT = 0> // Needs to be a template parameter because the count is baked into the hardware instruction
-  __device__ void waitTile(){
+  template <
+    int WAIT_CNT = 0> // Needs to be a template parameter because the count is baked into the hardware instruction
+  __device__ void waitTile() {
     __builtin_amdgcn_s_wait_tensorcnt(WAIT_CNT);
   }
 #else
   __device__ void loadTile(T* shmemPtr, const T* srcPtr, int numElementsToProcess) = delete;
   __device__ void storeTile(T* dstPtr) = delete;
-  template<int WAIT_CNT = 0>
+  template <int WAIT_CNT = 0>
   __device__ void waitTile() = delete;
 #endif
 };
 #endif // TDM_TOOLCHAIN_AVAILABLE
-
 
 namespace async {
 
@@ -464,16 +463,19 @@ namespace async {
 /// \see tdm::IsTdmCopySupported for the identical query on the TDM library.
 __host__ __device__ inline bool IsTdmCopySupported(int deviceId = 0) {
 #if defined(__HIP_DEVICE_COMPILE__)
-    (void)deviceId;
-    return ASYNC_COPY_SUPPORTED;              // compile-time constant for this arch pass
+  (void)deviceId;
+  return ASYNC_COPY_SUPPORTED; // compile-time constant for this arch pass
 #else
-    hipDeviceProp_t prop;
-    if (hipGetDeviceProperties(&prop, deviceId) != hipSuccess) return false;
+  hipDeviceProp_t prop;
+  if (hipGetDeviceProperties(&prop, deviceId) != hipSuccess) return false;
     // gcnArchName looks like "gfx1250:sramecc+:xnack-"; match the arch prefix.
-    const char* arch = prop.gcnArchName;
-    const char* p    = "gfx1250";
-    while (*p && *arch == *p) { ++arch; ++p; }
-    return (*p == '\0');
+  const char* arch = prop.gcnArchName;
+  const char* p = "gfx1250";
+  while (*p && *arch == *p) {
+    ++arch;
+    ++p;
+  }
+  return (*p == '\0');
 #endif
 }
 
@@ -489,10 +491,10 @@ constexpr uint32_t WINDOW_GRAIN = 128;
 // area is too small to hold even a single window (the vector fallback, mirroring
 // tdm::detail::warpVecCopy's role). Byte granularity keeps it correct for any
 // source/destination alignment.
-template<CachePolicy cp>
-__device__ inline void warpGlobalCopy(const uint8_t* s, uint8_t* d, size_t n,
-                                      uint32_t warpThread, uint32_t warpThreads) {
-    for (size_t i = warpThread; i < n; i += warpThreads) d[i] = s[i];
+template <CachePolicy cp>
+__device__ inline void warpGlobalCopy(const uint8_t* s, uint8_t* d, size_t n, uint32_t warpThread,
+                                      uint32_t warpThreads) {
+  for (size_t i = warpThread; i < n; i += warpThreads) d[i] = s[i];
 }
 
 // Stage [myStart, myStart+myBytes) HBM->LDS->HBM through this warp's single `window`-byte LDS buffer.
@@ -501,14 +503,14 @@ __device__ inline void warpGlobalCopy(const uint8_t* s, uint8_t* d, size_t n,
 // caller and templated in here rather than branched per iteration. The Sync policy waits after the load
 // (RAW: the store must see the filled LDS) and after the store (WAR: the next load must not overwrite LDS
 // that is still draining).
-template<CachePolicy cp, bool LoadAligned, bool StoreAligned>
-__device__ inline void stageLoop(const uint8_t* s, uint8_t* d, uint8_t* myLds,
-                                 size_t myStart, size_t myBytes, uint32_t window) {
-    for (size_t o = 0; o < myBytes; o += window) {
-        const size_t chunk = (myBytes - o < window) ? (myBytes - o) : window;
-        asyncLoadToLDS  <SyncPolicy::Sync, cp, LoadAligned >(s + myStart + o, myLds, chunk);
-        asyncStoreFromLDS<SyncPolicy::Sync, cp, StoreAligned>(myLds, d + myStart + o, chunk);
-    }
+template <CachePolicy cp, bool LoadAligned, bool StoreAligned>
+__device__ inline void stageLoop(const uint8_t* s, uint8_t* d, uint8_t* myLds, size_t myStart, size_t myBytes,
+                                 uint32_t window) {
+  for (size_t o = 0; o < myBytes; o += window) {
+    const size_t chunk = (myBytes - o < window) ? (myBytes - o) : window;
+    asyncLoadToLDS<SyncPolicy::Sync, cp, LoadAligned>(s + myStart + o, myLds, chunk);
+    asyncStoreFromLDS<SyncPolicy::Sync, cp, StoreAligned>(myLds, d + myStart + o, chunk);
+  }
 }
 
 // core: partition + issue the whole copy for the team [start, stop). Work + LDS
@@ -518,84 +520,77 @@ __device__ inline void stageLoop(const uint8_t* s, uint8_t* d, uint8_t* myLds,
 // tile already drains its own load/store (RAW/WAR) inside the loop, so nothing
 // is left in flight on return; async::tdmWait() below is therefore a no-op guard
 // kept for API parity with tdm::tdmWait().
-template<CachePolicy cp>
-__device__ inline void issue(void* dst, const void* src, size_t sizeBytes,
-                             void* ldsBuffer, size_t ldsBufferBytes,
+template <CachePolicy cp>
+__device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes,
                              uint32_t startWarpId, uint32_t stopWarpId) {
-    const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
-    uint8_t*       d = reinterpret_cast<uint8_t*>(dst);
-    uint8_t*       lds      = reinterpret_cast<uint8_t*>(ldsBuffer);
-    const uint32_t ldsBytes = static_cast<uint32_t>(ldsBufferBytes);   // LDS is small
+  const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
+  uint8_t* d = reinterpret_cast<uint8_t*>(dst);
+  uint8_t* lds = reinterpret_cast<uint8_t*>(ldsBuffer);
+  const uint32_t ldsBytes = static_cast<uint32_t>(ldsBufferBytes); // LDS is small
 
-    const uint32_t W          = warpSize;
-    const uint32_t nThreads   = blockDim.x * blockDim.y * blockDim.z;
-    const uint32_t tid        = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x
-                                + threadIdx.x;
-    const uint32_t warpThread = tid % W;               // thread index within its warp
-    const uint32_t warpId     = tid / W;
-    const uint32_t nWarps     = (nThreads + W - 1) / W;
+  const uint32_t W = warpSize;
+  const uint32_t nThreads = blockDim.x * blockDim.y * blockDim.z;
+  const uint32_t tid = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
+  const uint32_t warpThread = tid % W; // thread index within its warp
+  const uint32_t warpId = tid / W;
+  const uint32_t nWarps = (nThreads + W - 1) / W;
 
-    // --- team membership: this warp participates iff in [start, stop) --------
-    const uint32_t teamStop = (stopWarpId > nWarps) ? nWarps : stopWarpId;
-    if (startWarpId >= teamStop || warpId < startWarpId || warpId >= teamStop)
-        return;                                        // not on this team
-    const uint32_t rank      = warpId - startWarpId;    // rank within the team
-    const uint32_t teamWarps = teamStop - startWarpId;  // >= 1
+  // --- team membership: this warp participates iff in [start, stop) --------
+  const uint32_t teamStop = (stopWarpId > nWarps) ? nWarps : stopWarpId;
+  if (startWarpId >= teamStop || warpId < startWarpId || warpId >= teamStop) return; // not on this team
+  const uint32_t rank = warpId - startWarpId; // rank within the team
+  const uint32_t teamWarps = teamStop - startWarpId; // >= 1
 
-    // active threads in THIS warp (handles partial final warp); stride for the
-    // byte fallback below.
-    const uint32_t warpThreads = (nThreads - warpId * W < W) ? (nThreads - warpId * W) : W;
+  // active threads in THIS warp (handles partial final warp); stride for the
+  // byte fallback below.
+  const uint32_t warpThreads = (nThreads - warpId * W < W) ? (nThreads - warpId * W) : W;
 
-    if (sizeBytes == 0) return;
+  if (sizeBytes == 0) return;
 
-    // --- tiny-LDS fallback: not enough LDS for a single window ---------------
-    if (ldsBytes < WINDOW_GRAIN) {
-        if (rank == 0) warpGlobalCopy<cp>(s, d, sizeBytes, warpThread, warpThreads);
-        return;
-    }
+  // --- tiny-LDS fallback: not enough LDS for a single window ---------------
+  if (ldsBytes < WINDOW_GRAIN) {
+    if (rank == 0) warpGlobalCopy<cp>(s, d, sizeBytes, warpThread, warpThreads);
+    return;
+  }
 
-    // --- give each issuing warp a 128B-multiple LDS window -------------------
-    uint32_t maxIssuers = ldsBytes / WINDOW_GRAIN;      // #warps we can give a window
-    uint32_t issuers    = teamWarps < maxIssuers ? teamWarps : maxIssuers;
-    uint32_t window     = (ldsBytes / issuers) & ~(WINDOW_GRAIN - 1);  // per-warp 128B-multiple
-    if (rank >= issuers) return;                        // this warp doesn't issue
+  // --- give each issuing warp a 128B-multiple LDS window -------------------
+  uint32_t maxIssuers = ldsBytes / WINDOW_GRAIN; // #warps we can give a window
+  uint32_t issuers = teamWarps < maxIssuers ? teamWarps : maxIssuers;
+  uint32_t window = (ldsBytes / issuers) & ~(WINDOW_GRAIN - 1); // per-warp 128B-multiple
+  if (rank >= issuers) return; // this warp doesn't issue
 
-    // Distribute the byte range across issuers in contiguous, 128B-aligned blocks. Splitting on whole
-    // WINDOW_GRAIN (128B) grains -- rather than raw sizeBytes/issuers -- keeps every issuing warp's start a
-    // multiple of 128B, so `s + myStart` and `d + myStart` inherit the base pointers' alignment and stay
-    // aligned across chunks (the stride `window` is a 128B multiple). The sub-128B remainder is appended to
-    // the last issuing warp so coverage remains contiguous and gap-free.
-    const size_t grain   = WINDOW_GRAIN;
-    const size_t nGrains = sizeBytes / grain;
-    const size_t tail    = sizeBytes - nGrains * grain;         // 0..127 trailing bytes
+  // Distribute the byte range across issuers in contiguous, 128B-aligned blocks. Splitting on whole
+  // WINDOW_GRAIN (128B) grains -- rather than raw sizeBytes/issuers -- keeps every issuing warp's start a
+  // multiple of 128B, so `s + myStart` and `d + myStart` inherit the base pointers' alignment and stay
+  // aligned across chunks (the stride `window` is a 128B multiple). The sub-128B remainder is appended to
+  // the last issuing warp so coverage remains contiguous and gap-free.
+  const size_t grain = WINDOW_GRAIN;
+  const size_t nGrains = sizeBytes / grain;
+  const size_t tail = sizeBytes - nGrains * grain; // 0..127 trailing bytes
 
-    const size_t baseG  = nGrains / issuers;
-    const size_t extraG = nGrains % issuers;
-    const size_t myG    = baseG + (rank < extraG ? 1u : 0u);
-    const size_t startG = rank * baseG + (rank < extraG ? rank : extraG);
+  const size_t baseG = nGrains / issuers;
+  const size_t extraG = nGrains % issuers;
+  const size_t myG = baseG + (rank < extraG ? 1u : 0u);
+  const size_t startG = rank * baseG + (rank < extraG ? rank : extraG);
 
-    size_t myStart = startG * grain;                            // 128B-aligned
-    size_t myBytes = myG * grain;
-    if (rank == issuers - 1) myBytes += tail;                   // last warp mops up the < 128B tail
-    if (myBytes == 0) return;
+  size_t myStart = startG * grain; // 128B-aligned
+  size_t myBytes = myG * grain;
+  if (rank == issuers - 1) myBytes += tail; // last warp mops up the < 128B tail
+  if (myBytes == 0) return;
 
-    uint8_t* myLds = lds + static_cast<size_t>(rank) * window;
+  uint8_t* myLds = lds + static_cast<size_t>(rank) * window;
 
-    // Pick the peel-free fast path per direction (load reads src, store writes dst). myStart and window are
-    // both 128B multiples, so each side's alignment is loop-invariant and computed once here.
-    const uintptr_t mask    = WINDOW_GRAIN - 1;
-    const bool ldsAligned   = ((uintptr_t)myLds & mask) == 0;
-    const bool loadAligned  = ldsAligned && (((uintptr_t)(s + myStart) & mask) == 0);
-    const bool storeAligned = ldsAligned && (((uintptr_t)(d + myStart) & mask) == 0);
+  // Pick the peel-free fast path per direction (load reads src, store writes dst). myStart and window are
+  // both 128B multiples, so each side's alignment is loop-invariant and computed once here.
+  const uintptr_t mask = WINDOW_GRAIN - 1;
+  const bool ldsAligned = ((uintptr_t)myLds & mask) == 0;
+  const bool loadAligned = ldsAligned && (((uintptr_t)(s + myStart) & mask) == 0);
+  const bool storeAligned = ldsAligned && (((uintptr_t)(d + myStart) & mask) == 0);
 
-    if (loadAligned && storeAligned)
-        stageLoop<cp, true,  true >(s, d, myLds, myStart, myBytes, window);
-    else if (loadAligned)
-        stageLoop<cp, true,  false>(s, d, myLds, myStart, myBytes, window);
-    else if (storeAligned)
-        stageLoop<cp, false, true >(s, d, myLds, myStart, myBytes, window);
-    else
-        stageLoop<cp, false, false>(s, d, myLds, myStart, myBytes, window);
+  if (loadAligned && storeAligned) stageLoop<cp, true, true>(s, d, myLds, myStart, myBytes, window);
+  else if (loadAligned) stageLoop<cp, true, false>(s, d, myLds, myStart, myBytes, window);
+  else if (storeAligned) stageLoop<cp, false, true>(s, d, myLds, myStart, myBytes, window);
+  else stageLoop<cp, false, false>(s, d, myLds, myStart, myBytes, window);
 }
 
 } // namespace detail
@@ -608,60 +603,58 @@ __device__ ASYNC_API void tdmWait() ASYNC_DELETED;
 
 /// \brief Non-blocking block-collective copy: issue and return.
 /// \see tdm::tdmCopyAsync.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ ASYNC_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes,
-                                       void* ldsBuffer, size_t ldsBufferBytes) ASYNC_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ ASYNC_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                       size_t ldsBufferBytes) ASYNC_DELETED;
 
 /// \brief Blocking block-collective copy of [0, sizeBytes): dst <- src.
 /// \see tdm::tdmCopy.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ ASYNC_API void tdmCopy(void* dst, const void* src, size_t sizeBytes,
-                                  void* ldsBuffer, size_t ldsBufferBytes) ASYNC_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ ASYNC_API void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                  size_t ldsBufferBytes) ASYNC_DELETED;
 
 /// \brief Non-blocking WARP-SPECIALIZED copy by one contiguous warp team.
 /// \see tdm::tdmCopyAsyncByTeam.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ ASYNC_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes,
-                                             void* ldsBuffer, size_t ldsBufferBytes,
-                                             uint32_t startWarpId, uint32_t stopWarpId) ASYNC_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ ASYNC_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                             size_t ldsBufferBytes, uint32_t startWarpId,
+                                             uint32_t stopWarpId) ASYNC_DELETED;
 
 /// \brief Blocking WARP-SPECIALIZED copy by one contiguous warp team.
 /// \see tdm::tdmCopyByTeam.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ ASYNC_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes,
-                                        void* ldsBuffer, size_t ldsBufferBytes,
-                                        uint32_t startWarpId, uint32_t stopWarpId) ASYNC_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ ASYNC_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                        size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) ASYNC_DELETED;
 
 #if ASYNC_COPY_SUPPORTED
 
-__device__ inline void tdmWait() { asyncWait<0>(); }
-
-template<CachePolicy cp>
-__device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes,
-                                    void* ldsBuffer, size_t ldsBufferBytes) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+__device__ inline void tdmWait() {
+  asyncWait<0>();
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes,
-                               void* ldsBuffer, size_t ldsBufferBytes) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
-    tdmWait();
+template <CachePolicy cp>
+__device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                    size_t ldsBufferBytes) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes,
-                                          void* ldsBuffer, size_t ldsBufferBytes,
-                                          uint32_t startWarpId, uint32_t stopWarpId) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+template <CachePolicy cp>
+__device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  tdmWait();
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes,
-                                     void* ldsBuffer, size_t ldsBufferBytes,
-                                     uint32_t startWarpId, uint32_t stopWarpId) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
-    tdmWait();   // no-op on any warp that issued nothing / is off-team
+template <CachePolicy cp>
+__device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                          size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+}
+
+template <CachePolicy cp>
+__device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                     size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  tdmWait(); // no-op on any warp that issued nothing / is off-team
 }
 
 #endif // ASYNC_COPY_SUPPORTED
@@ -670,6 +663,5 @@ __device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeByte
 
 #undef ASYNC_API
 #undef ASYNC_DELETED
-
 
 #endif // __ASYNCCOPY_H

--- a/projects/rccl/src/device/tdm/cachePolicy.h
+++ b/projects/rccl/src/device/tdm/cachePolicy.h
@@ -43,24 +43,25 @@ THE SOFTWARE.
 using CachePolicy = uint32_t;
 
 enum struct MemScope : uint32_t {
-    WGP = 0,    // Workgroup processor scope - warps running on the same WGP should be able to see the effect of the operation
-    SE,         // Shader engine a.k.a cluster scope
-    DEV,        // Device scope
-    SYS,        // System scope
+  WGP =
+    0, // Workgroup processor scope - warps running on the same WGP should be able to see the effect of the operation
+  SE, // Shader engine a.k.a cluster scope
+  DEV, // Device scope
+  SYS, // System scope
 };
 
 enum struct TemporalHint : uint32_t {
-    RT = 0, // Regular temporal (nothing special)
-    NT,     // Not temporal
-    HT,     // High temporal
-    LU,     // Last use
-    NT_RT,
-    RT_NT,
-    NT_HT,
+  RT = 0, // Regular temporal (nothing special)
+  NT, // Not temporal
+  HT, // High temporal
+  LU, // Last use
+  NT_RT,
+  RT_NT,
+  NT_HT,
 };
 
 __host__ __device__ constexpr CachePolicy createCachePolicy(TemporalHint temporal, MemScope scope) noexcept {
-    return static_cast<CachePolicy>(scope) << 3 | static_cast<CachePolicy>(temporal);
+  return static_cast<CachePolicy>(scope) << 3 | static_cast<CachePolicy>(temporal);
 }
 
 static_assert(createCachePolicy(TemporalHint::RT, MemScope::WGP) == 0);

--- a/projects/rccl/src/device/tdm/syncPolicy.h
+++ b/projects/rccl/src/device/tdm/syncPolicy.h
@@ -36,8 +36,8 @@ THE SOFTWARE.
 /// Whether a transfer primitive drains before returning (Sync) or leaves the
 /// transfer in flight for the caller to wait on later (Async).
 enum struct SyncPolicy : uint32_t {
-    Async,
-    Sync,
+  Async,
+  Sync,
 };
 
 constexpr SyncPolicy DEFAULT_SYNC_POLICY = SyncPolicy::Async;

--- a/projects/rccl/src/device/tdm/tdmCopy.h
+++ b/projects/rccl/src/device/tdm/tdmCopy.h
@@ -82,10 +82,10 @@ THE SOFTWARE.
 // applies that guard uniformly to every declaration.
 // ============================================================================
 #ifndef __has_builtin
-#  define __has_builtin(x) 0
+#define __has_builtin(x) 0
 #endif
 #ifndef __has_include
-#  define __has_include(x) 0
+#define __has_include(x) 0
 #endif
 // Host-evaluable toolchain capability. TDM_SUPPORTED (below) keys on device arch
 // macros (e.g. __gfx1250__) that are never defined during the host pass, so it is
@@ -96,27 +96,25 @@ THE SOFTWARE.
 // Without this host gate, a build whose device pass fell back to the no-op TDM stub
 // would still report support on gfx1250 hardware and silently dispatch a no-op copy.
 #if __has_include(<hip/amd_detail/amd_gfx1250_TDM.h>)
-#  define TDM_TOOLCHAIN_AVAILABLE 1
+#define TDM_TOOLCHAIN_AVAILABLE 1
 #else
-#  define TDM_TOOLCHAIN_AVAILABLE 0
+#define TDM_TOOLCHAIN_AVAILABLE 0
 #endif
 
-#if defined(__gfx1250__) && \
-    __has_builtin(__builtin_amdgcn_tensor_load_to_lds) && \
-    TDM_TOOLCHAIN_AVAILABLE
+#if defined(__gfx1250__) && __has_builtin(__builtin_amdgcn_tensor_load_to_lds) && TDM_TOOLCHAIN_AVAILABLE
                                   /* extend: || (defined(__gfxNNNN__) && ...) */
-#  define TDM_SUPPORTED 1
+#define TDM_SUPPORTED 1
 #else
-#  define TDM_SUPPORTED 0
+#define TDM_SUPPORTED 0
 #endif
 
 #if TDM_SUPPORTED
-#  include <hip/amd_detail/amd_gfx1250_TDM.h>   // D# descriptor types for the target's TDM
-#  define TDM_API      inline     // normal inline declaration (defined below)
-#  define TDM_DELETED             //   ... and not deleted
+#include <hip/amd_detail/amd_gfx1250_TDM.h>   // D# descriptor types for the target's TDM
+#define TDM_API inline     // normal inline declaration (defined below)
+#define TDM_DELETED             //   ... and not deleted
 #else
-#  define TDM_API                 // no linkage keyword on a deleted declaration
-#  define TDM_DELETED  = delete   // unsupported target: any call is a compile error
+#define TDM_API                 // no linkage keyword on a deleted declaration
+#define TDM_DELETED = delete   // unsupported target: any call is a compile error
 #endif
 
 namespace tdm {
@@ -147,20 +145,23 @@ namespace tdm {
 /// \endcode
 __host__ __device__ inline bool IsTdmCopySupported(int deviceId = 0) {
 #if defined(__HIP_DEVICE_COMPILE__)
-    (void)deviceId;
-    return TDM_SUPPORTED;                 // compile-time constant for this arch pass
+  (void)deviceId;
+  return TDM_SUPPORTED;                 // compile-time constant for this arch pass
 #else
-    hipDeviceProp_t prop;
-    if (hipGetDeviceProperties(&prop, deviceId) != hipSuccess) return false;
+  hipDeviceProp_t prop;
+  if (hipGetDeviceProperties(&prop, deviceId) != hipSuccess) return false;
     // gcnArchName looks like "gfx1250:sramecc+:xnack-"; match the arch prefix.
     // Keep this list in sync with the TDM_SUPPORTED arch condition above.
-    const char* arch = prop.gcnArchName;
-    const char* p    = "gfx1250";
-    while (*p && *arch == *p) { ++arch; ++p; }
+  const char* arch = prop.gcnArchName;
+  const char* p = "gfx1250";
+  while (*p && *arch == *p) {
+    ++arch;
+    ++p;
+  }
     // Require BOTH a TDM-capable arch AND a toolchain that actually built TDM
     // (otherwise the device pass emitted a no-op stub and enabling the path here
     // would silently produce wrong results).
-    return TDM_TOOLCHAIN_AVAILABLE && (*p == '\0');
+  return TDM_TOOLCHAIN_AVAILABLE && (*p == '\0');
 #endif
 }
 
@@ -186,9 +187,9 @@ __host__ __device__ inline bool IsTdmCopySupported(int deviceId = 0) {
 /// \warning \p src and \p dst must be GLOBAL (HBM) pointers. Passing a shared /
 ///          LDS pointer compiles (it decays to void*) but is undefined at run
 ///          time -- the address is programmed into the descriptor's global field.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ TDM_API void tdmCopy(void* dst, const void* src, size_t sizeBytes,
-                                void* ldsBuffer, size_t ldsBufferBytes) TDM_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ TDM_API void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                size_t ldsBufferBytes) TDM_DELETED;
 
 /// \brief Non-blocking variant of tdmCopy(): issue and return.
 ///
@@ -198,9 +199,9 @@ __device__ TDM_API void tdmCopy(void* dst, const void* src, size_t sizeBytes,
 ///
 /// \see tdmCopy for parameter meanings (including the \p cp cache policy).
 /// \see tdmWait to complete the copy.
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ TDM_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes,
-                                     void* ldsBuffer, size_t ldsBufferBytes) TDM_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ TDM_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                     size_t ldsBufferBytes) TDM_DELETED;
 
 /// \brief Blocking WARP-SPECIALIZED copy performed by one contiguous warp team.
 ///
@@ -233,18 +234,17 @@ __device__ TDM_API void tdmCopyAsync(void* dst, const void* src, size_t sizeByte
 ///       /* compute -- use LDS past the team's window */;
 ///   __syncthreads();
 /// \endcode
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ TDM_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes,
-                                      void* ldsBuffer, size_t ldsBufferBytes,
-                                      uint32_t startWarpId, uint32_t stopWarpId) TDM_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ TDM_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                      size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) TDM_DELETED;
 
 /// \brief Non-blocking variant of tdmCopyByTeam(): issue and return.
 /// \see tdmCopyByTeam for parameter meanings and team semantics (incl. \p cp).
 /// \see tdmWait to complete the copy (called by each participating warp).
-template<CachePolicy cp = DEFAULT_CACHE_POLICY>
-__device__ TDM_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes,
-                                           void* ldsBuffer, size_t ldsBufferBytes,
-                                           uint32_t startWarpId, uint32_t stopWarpId) TDM_DELETED;
+template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+__device__ TDM_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                           size_t ldsBufferBytes, uint32_t startWarpId,
+                                           uint32_t stopWarpId) TDM_DELETED;
 
 /// \brief Drain the CALLING WARP's outstanding TDM ops (TENSORcnt -> 0).
 ///
@@ -293,24 +293,19 @@ __device__ TDM_API void tdmWait() TDM_DELETED;
 ///          (the head is peeled against the global pointer and the same offset
 ///          is applied to the LDS side). RCCL's LDS staging buffers are
 ///          128-byte aligned, which satisfies this for an aligned source.
-template<SyncPolicy sp = DEFAULT_SYNC_POLICY, CachePolicy cp = DEFAULT_CACHE_POLICY,
-         bool Aligned = false>
-__device__ TDM_API void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst,
-                                       size_t sizeInBytes) TDM_DELETED;
+template <SyncPolicy sp = DEFAULT_SYNC_POLICY, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
+__device__ TDM_API void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst, size_t sizeInBytes) TDM_DELETED;
 
 /// \brief Warp-level transfer of \p sizeInBytes from LDS out to global memory.
 /// \see asyncLoadToLDS for the calling convention, template parameters and the
 ///      matching-alignment requirement (peeled against \p globalDst here).
-template<SyncPolicy sp = DEFAULT_SYNC_POLICY, CachePolicy cp = DEFAULT_CACHE_POLICY,
-         bool Aligned = false>
-__device__ TDM_API void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst,
-                                          size_t sizeInBytes) TDM_DELETED;
+template <SyncPolicy sp = DEFAULT_SYNC_POLICY, CachePolicy cp = DEFAULT_CACHE_POLICY, bool Aligned = false>
+__device__ TDM_API void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst, size_t sizeInBytes) TDM_DELETED;
 
 } // namespace tdm
 
 #undef TDM_API
 #undef TDM_DELETED
-
 
 // ############################################################################
 // #                                                                          #
@@ -364,10 +359,10 @@ namespace tdm {
 namespace detail {
 
 constexpr uint32_t WIDTH = 256;          // bytes per TDM row (first tile dim)
-constexpr uint32_t ELT   = 4;            // dword
-constexpr uint32_t DS4   = 2;            // data_size code for 4-byte
-constexpr uint32_t DS1   = 0;            // data_size code for 1-byte
-constexpr uint32_t TD0   = WIDTH / ELT;  // 64 elements per row
+constexpr uint32_t ELT = 4;            // dword
+constexpr uint32_t DS4 = 2;            // data_size code for 4-byte
+constexpr uint32_t DS1 = 0;            // data_size code for 1-byte
+constexpr uint32_t TD0 = WIDTH / ELT;  // 64 elements per row
 
 // ---- instruction emission (the only arch-specific piece) -------------------
 // The tensor DMA is a single builtin taking the FULL descriptor: five register
@@ -387,38 +382,33 @@ using u32x8 = __attribute__((ext_vector_type(8))) uint32_t;   // D1, D4
 // The cache policy is baked into the instruction as its immediate cpol operand,
 // so it must be a compile-time constant -- hence a template parameter (mirroring
 // how asyncCopy.h passes its cache policy to the async builtins).
-template<CachePolicy cp>
-__device__ inline void load(const gfx1250_TDM_GROUP0& g0,
-                            const gfx1250_TDM_GROUP1& g1) {
-    __builtin_amdgcn_tensor_load_to_lds(
-        g0.m_bitfield,               // D0  addresses
-        g1.m_bitfield,               // D1  2D shape
-        u32x4{}, u32x4{}, u32x8{},   // D2/D3/D4  higher dims: unused (zero)
-        /*cpol=*/cp);
+template <CachePolicy cp>
+__device__ inline void load(const gfx1250_TDM_GROUP0& g0, const gfx1250_TDM_GROUP1& g1) {
+  __builtin_amdgcn_tensor_load_to_lds(g0.m_bitfield,               // D0  addresses
+                                      g1.m_bitfield,               // D1  2D shape
+                                      u32x4{}, u32x4{}, u32x8{},   // D2/D3/D4  higher dims: unused (zero)
+                                      /*cpol=*/cp);
 }
-template<CachePolicy cp>
-__device__ inline void store(const gfx1250_TDM_GROUP0& g0,
-                             const gfx1250_TDM_GROUP1& g1) {
-    __builtin_amdgcn_tensor_store_from_lds(
-        g0.m_bitfield,
-        g1.m_bitfield,
-        u32x4{}, u32x4{}, u32x8{},
-        /*cpol=*/cp);
+template <CachePolicy cp>
+__device__ inline void store(const gfx1250_TDM_GROUP0& g0, const gfx1250_TDM_GROUP1& g1) {
+  __builtin_amdgcn_tensor_store_from_lds(g0.m_bitfield, g1.m_bitfield, u32x4{}, u32x4{}, u32x8{},
+                                         /*cpol=*/cp);
 }
-__device__ inline void waitTensor0() { __builtin_amdgcn_s_wait_tensorcnt(0); }
+__device__ inline void waitTensor0() {
+  __builtin_amdgcn_s_wait_tensorcnt(0);
+}
 
 // ---- cooperative vector copy of a small byte range, by one warp ------------
 // All threads of the calling warp participate. Dword-wide where possible; the
 // (<4 byte) ragged end is finished by the warp's first thread.
-__device__ inline void warpVecCopy(const uint8_t* s, uint8_t* d, size_t n,
-                                   uint32_t warpThread, uint32_t warpThreads) {
-    size_t nd = n >> 2;
-    const uint32_t* s32 = reinterpret_cast<const uint32_t*>(s);
-    uint32_t*       d32 = reinterpret_cast<uint32_t*>(d);
-    for (size_t i = warpThread; i < nd; i += warpThreads) d32[i] = s32[i];
-    uint32_t rem = static_cast<uint32_t>(n & 3u);
-    if (rem && warpThread == 0)
-        for (uint32_t b = 0; b < rem; ++b) d[nd * 4 + b] = s[nd * 4 + b];
+__device__ inline void warpVecCopy(const uint8_t* s, uint8_t* d, size_t n, uint32_t warpThread, uint32_t warpThreads) {
+  size_t nd = n >> 2;
+  const uint32_t* s32 = reinterpret_cast<const uint32_t*>(s);
+  uint32_t* d32 = reinterpret_cast<uint32_t*>(d);
+  for (size_t i = warpThread; i < nd; i += warpThreads) d32[i] = s32[i];
+  uint32_t rem = static_cast<uint32_t>(n & 3u);
+  if (rem && warpThread == 0)
+    for (uint32_t b = 0; b < rem; ++b) d[nd * 4 + b] = s[nd * 4 + b];
 }
 
 // ---- issue one chunk of whole 256B rows (2D tile) through ONE LDS window. ---
@@ -429,79 +419,91 @@ __device__ inline void warpVecCopy(const uint8_t* s, uint8_t* d, size_t n,
 //   * load -> wait: the store reads the LDS the load just wrote (RAW hazard).
 //   * store -> wait: the caller reuses this same window next iteration; the next
 //     load must not overwrite LDS the store is still draining (WAR hazard).
-template<CachePolicy cp>
-__device__ inline void issueRows(uint64_t src, uint32_t lds, uint64_t dst,
-                                 uint32_t rows) {
-    gfx1250_TDM_GROUP1 g1;
-    g1.dataSize(DS4);
-    g1.tileDim0(TD0);   g1.tileDim1(rows);
-    g1.tensorDim0(TD0); g1.tensorDim1(rows);
-    g1.tensorDim0Stride(TD0);                // rows back-to-back (contiguous)
+template <CachePolicy cp>
+__device__ inline void issueRows(uint64_t src, uint32_t lds, uint64_t dst, uint32_t rows) {
+  gfx1250_TDM_GROUP1 g1;
+  g1.dataSize(DS4);
+  g1.tileDim0(TD0);
+  g1.tileDim1(rows);
+  g1.tensorDim0(TD0);
+  g1.tensorDim1(rows);
+  g1.tensorDim0Stride(TD0);                // rows back-to-back (contiguous)
 
     // Higher dims (D2/D3/D4) are unused for this 2D tile -> passed as zero inside
     // load()/store(), matching known-good example usage.
-    gfx1250_TDM_GROUP0 g0l(lds, src);
-    load<cp>(g0l, g1);   waitTensor0();       // RAW: fill LDS before store reads it
-    gfx1250_TDM_GROUP0 g0s(lds, dst);
-    store<cp>(g0s, g1);  waitTensor0();       // WAR: drain store before window reuse
+  gfx1250_TDM_GROUP0 g0l(lds, src);
+  load<cp>(g0l, g1);
+  waitTensor0();       // RAW: fill LDS before store reads it
+  gfx1250_TDM_GROUP0 g0s(lds, dst);
+  store<cp>(g0s, g1);
+  waitTensor0();       // WAR: drain store before window reuse
 }
 
 // ---- issue a sub-row tail (<256B) as a 1-D tile at BYTE granularity. ---------
 // Same single-buffered LDS window and the same required RAW/WAR waits as above.
-template<CachePolicy cp>
-__device__ inline void issueRow1d(uint64_t src, uint32_t lds, uint64_t dst,
-                                  uint32_t nbytes) {
-    gfx1250_TDM_GROUP1 g1;
-    g1.dataSize(DS1);                        // 1-byte elements: exact length
-    g1.tileDim0(nbytes);   g1.tileDim1(1);
-    g1.tensorDim0(nbytes); g1.tensorDim1(1);
-    g1.tensorDim0Stride(nbytes);
+template <CachePolicy cp>
+__device__ inline void issueRow1d(uint64_t src, uint32_t lds, uint64_t dst, uint32_t nbytes) {
+  gfx1250_TDM_GROUP1 g1;
+  g1.dataSize(DS1);                        // 1-byte elements: exact length
+  g1.tileDim0(nbytes);
+  g1.tileDim1(1);
+  g1.tensorDim0(nbytes);
+  g1.tensorDim1(1);
+  g1.tensorDim0Stride(nbytes);
 
-    gfx1250_TDM_GROUP0 g0l(lds, src);        // unused higher dims -> zero (see load())
-    load<cp>(g0l, g1);   waitTensor0();       // RAW: fill LDS before store reads it
-    gfx1250_TDM_GROUP0 g0s(lds, dst);
-    store<cp>(g0s, g1);  waitTensor0();       // WAR: drain store before window reuse
+  gfx1250_TDM_GROUP0 g0l(lds, src);        // unused higher dims -> zero (see load())
+  load<cp>(g0l, g1);
+  waitTensor0();       // RAW: fill LDS before store reads it
+  gfx1250_TDM_GROUP0 g0s(lds, dst);
+  store<cp>(g0s, g1);
+  waitTensor0();       // WAR: drain store before window reuse
 }
 
 // ---- one-way global <-> LDS transfer of a byte range, by ONE warp -----------
 // Direction of a single leg: the first pointer is always the global-memory side
 // and the second the LDS side, which keeps the tile helpers below symmetric.
-enum struct LdsDir { Load, Store };
+enum struct LdsDir {
+  Load,
+  Store
+};
 
 constexpr uint32_t TILE_DIM_MAX = 0xFFFFu;   // tile_dim0/tile_dim1 are 16-bit fields
-constexpr uint32_t LINE         = 128;       // alignment the head peel targets
+constexpr uint32_t LINE = 128;       // alignment the head peel targets
 
-template<LdsDir DIR, CachePolicy cp>
-__device__ inline void ldsIssue(const gfx1250_TDM_GROUP0& g0,
-                                const gfx1250_TDM_GROUP1& g1) {
-    if constexpr (DIR == LdsDir::Load) load<cp>(g0, g1);
-    else                               store<cp>(g0, g1);
+template <LdsDir DIR, CachePolicy cp>
+__device__ inline void ldsIssue(const gfx1250_TDM_GROUP0& g0, const gfx1250_TDM_GROUP1& g1) {
+  if constexpr (DIR == LdsDir::Load) load<cp>(g0, g1);
+  else store<cp>(g0, g1);
 }
 
 // One 1-D tile at BYTE granularity, for the ragged head/tail. Exact length, so
 // it works at any alignment; `nbytes` must be <= TILE_DIM_MAX.
-template<LdsDir DIR, CachePolicy cp>
+template <LdsDir DIR, CachePolicy cp>
 __device__ inline void ldsTileBytes(uint64_t global, uint32_t lds, uint32_t nbytes) {
-    gfx1250_TDM_GROUP1 g1;
-    g1.dataSize(DS1);
-    g1.tileDim0(nbytes);   g1.tileDim1(1);
-    g1.tensorDim0(nbytes); g1.tensorDim1(1);
-    g1.tensorDim0Stride(nbytes);
-    gfx1250_TDM_GROUP0 g0(lds, global);
-    ldsIssue<DIR, cp>(g0, g1);
+  gfx1250_TDM_GROUP1 g1;
+  g1.dataSize(DS1);
+  g1.tileDim0(nbytes);
+  g1.tileDim1(1);
+  g1.tensorDim0(nbytes);
+  g1.tensorDim1(1);
+  g1.tensorDim0Stride(nbytes);
+  gfx1250_TDM_GROUP0 g0(lds, global);
+  ldsIssue<DIR, cp>(g0, g1);
 }
 
 // One 2-D tile of `rows` back-to-back 256B rows -- the bulk shape, chosen for
 // bandwidth exactly as in issueRows(). `rows` must be <= TILE_DIM_MAX.
-template<LdsDir DIR, CachePolicy cp>
+template <LdsDir DIR, CachePolicy cp>
 __device__ inline void ldsTileRows(uint64_t global, uint32_t lds, uint32_t rows) {
-    gfx1250_TDM_GROUP1 g1;
-    g1.dataSize(DS4);
-    g1.tileDim0(TD0);   g1.tileDim1(rows);
-    g1.tensorDim0(TD0); g1.tensorDim1(rows);
-    g1.tensorDim0Stride(TD0);                // rows back-to-back (contiguous)
-    gfx1250_TDM_GROUP0 g0(lds, global);
-    ldsIssue<DIR, cp>(g0, g1);
+  gfx1250_TDM_GROUP1 g1;
+  g1.dataSize(DS4);
+  g1.tileDim0(TD0);
+  g1.tileDim1(rows);
+  g1.tensorDim0(TD0);
+  g1.tensorDim1(rows);
+  g1.tensorDim0Stride(TD0);                // rows back-to-back (contiguous)
+  gfx1250_TDM_GROUP0 g0(lds, global);
+  ldsIssue<DIR, cp>(g0, g1);
 }
 
 // Split [0, sizeInBytes) into [head][ aligned 256B rows ][tail], mirroring the
@@ -515,150 +517,142 @@ __device__ inline void ldsTileRows(uint64_t global, uint32_t lds, uint32_t rows)
 // only when the two pointers start with the same sub-128B offset -- the contract
 // documented on the public entry points. `Aligned` asserts that offset is zero
 // for both and compiles the peel out entirely.
-template<LdsDir DIR, CachePolicy cp, bool Aligned>
+template <LdsDir DIR, CachePolicy cp, bool Aligned>
 __device__ inline void warpLdsCopy(uint64_t global, uint32_t lds, size_t sizeInBytes) {
-    if (sizeInBytes == 0) return;            // a zero-extent tile is not a valid descriptor
+  if (sizeInBytes == 0) return;            // a zero-extent tile is not a valid descriptor
 
-    size_t off = 0;
-    if constexpr (!Aligned) {
-        uint32_t head = static_cast<uint32_t>((LINE - (global & (LINE - 1))) & (LINE - 1));
-        if (head > sizeInBytes) head = static_cast<uint32_t>(sizeInBytes);
-        if (head) {
-            ldsTileBytes<DIR, cp>(global, lds, head);
-            off = head;
-        }
+  size_t off = 0;
+  if constexpr (!Aligned) {
+    uint32_t head = static_cast<uint32_t>((LINE - (global & (LINE - 1))) & (LINE - 1));
+    if (head > sizeInBytes) head = static_cast<uint32_t>(sizeInBytes);
+    if (head) {
+      ldsTileBytes<DIR, cp>(global, lds, head);
+      off = head;
     }
+  }
 
     // Bulk: whole 256B rows, split across as many tiles as the 16-bit row count needs.
-    size_t rows = (sizeInBytes - off) / WIDTH;
-    while (rows) {
-        const uint32_t chunk = rows < TILE_DIM_MAX ? static_cast<uint32_t>(rows) : TILE_DIM_MAX;
-        ldsTileRows<DIR, cp>(global + off, lds + static_cast<uint32_t>(off), chunk);
-        off  += static_cast<size_t>(chunk) * WIDTH;
-        rows -= chunk;
-    }
+  size_t rows = (sizeInBytes - off) / WIDTH;
+  while (rows) {
+    const uint32_t chunk = rows < TILE_DIM_MAX ? static_cast<uint32_t>(rows) : TILE_DIM_MAX;
+    ldsTileRows<DIR, cp>(global + off, lds + static_cast<uint32_t>(off), chunk);
+    off += static_cast<size_t>(chunk) * WIDTH;
+    rows -= chunk;
+  }
 
     // Tail: the < 256B sub-row remainder, again at byte granularity.
-    const uint32_t tail = static_cast<uint32_t>(sizeInBytes - off);
-    if (tail) ldsTileBytes<DIR, cp>(global + off, lds + static_cast<uint32_t>(off), tail);
+  const uint32_t tail = static_cast<uint32_t>(sizeInBytes - off);
+  if (tail) ldsTileBytes<DIR, cp>(global + off, lds + static_cast<uint32_t>(off), tail);
 }
 
 // ---- core: partition + issue the whole copy for the team [start, stop). -----
 // NO final wait. Work + LDS partition by rank within the team (warpId - start),
 // so each team indexes its own `ldsBuffer` from zero. Safe to call collectively
 // (warps outside the range return immediately) or only from the team's warps.
-template<CachePolicy cp>
-__device__ inline void issue(void* dst, const void* src, size_t sizeBytes,
-                             void* ldsBuffer, size_t ldsBufferBytes,
+template <CachePolicy cp>
+__device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes,
                              uint32_t startWarpId, uint32_t stopWarpId) {
-    const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
-    uint8_t*       d = reinterpret_cast<uint8_t*>(dst);
-    const uint32_t ldsBase  = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(ldsBuffer));
-    const uint32_t ldsBytes = static_cast<uint32_t>(ldsBufferBytes);  // LDS is small
+  const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
+  uint8_t* d = reinterpret_cast<uint8_t*>(dst);
+  const uint32_t ldsBase = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(ldsBuffer));
+  const uint32_t ldsBytes = static_cast<uint32_t>(ldsBufferBytes);  // LDS is small
 
-    const uint32_t W          = warpSize;
-    const uint32_t nThreads   = blockDim.x * blockDim.y * blockDim.z;
-    const uint32_t tid        = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x
-                                + threadIdx.x;
-    const uint32_t warpThread = tid % W;               // thread index within its warp
-    const uint32_t warpId     = tid / W;
-    const uint32_t nWarps     = (nThreads + W - 1) / W;
+  const uint32_t W = warpSize;
+  const uint32_t nThreads = blockDim.x * blockDim.y * blockDim.z;
+  const uint32_t tid = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
+  const uint32_t warpThread = tid % W;               // thread index within its warp
+  const uint32_t warpId = tid / W;
+  const uint32_t nWarps = (nThreads + W - 1) / W;
 
     // --- team membership: this warp participates iff in [start, stop) --------
-    const uint32_t teamStop = (stopWarpId > nWarps) ? nWarps : stopWarpId;
-    if (startWarpId >= teamStop || warpId < startWarpId || warpId >= teamStop)
-        return;                                        // not on this team
-    const uint32_t rank      = warpId - startWarpId;    // rank within the team
-    const uint32_t teamWarps = teamStop - startWarpId;  // >= 1
+  const uint32_t teamStop = (stopWarpId > nWarps) ? nWarps : stopWarpId;
+  if (startWarpId >= teamStop || warpId < startWarpId || warpId >= teamStop) return; // not on this team
+  const uint32_t rank = warpId - startWarpId; // rank within the team
+  const uint32_t teamWarps = teamStop - startWarpId; // >= 1
 
-    // active threads in THIS warp (handles partial final warp); stride for vector.
-    const uint32_t warpThreads = (nThreads - warpId * W < W) ? (nThreads - warpId * W) : W;
+  // active threads in THIS warp (handles partial final warp); stride for vector.
+  const uint32_t warpThreads = (nThreads - warpId * W < W) ? (nThreads - warpId * W) : W;
 
-    // --- split the range: [head][ aligned 256B rows ][tail] ------------------
-    uint64_t sAddr = reinterpret_cast<uint64_t>(s);
-    uint32_t head  = static_cast<uint32_t>((128u - (sAddr & 127u)) & 127u);
-    if (head > sizeBytes) head = static_cast<uint32_t>(sizeBytes);
-    size_t   bulk     = sizeBytes - head;              // starts 128B-aligned
-    size_t   rows     = bulk / WIDTH;                  // whole 256B rows
-    size_t   tdmBytes = rows * WIDTH;
-    size_t   tailOff  = head + tdmBytes;
-    uint32_t tail     = static_cast<uint32_t>(sizeBytes - tailOff);   // < 256B
+  // --- split the range: [head][ aligned 256B rows ][tail] ------------------
+  uint64_t sAddr = reinterpret_cast<uint64_t>(s);
+  uint32_t head = static_cast<uint32_t>((128u - (sAddr & 127u)) & 127u);
+  if (head > sizeBytes) head = static_cast<uint32_t>(sizeBytes);
+  size_t bulk = sizeBytes - head; // starts 128B-aligned
+  size_t rows = bulk / WIDTH; // whole 256B rows
+  size_t tdmBytes = rows * WIDTH;
+  size_t tailOff = head + tdmBytes;
+  uint32_t tail = static_cast<uint32_t>(sizeBytes - tailOff); // < 256B
 
-    // --- edges (team's FIRST warp = rank 0): vector head, TDM tail -----------
-    if (rank == 0 && head) warpVecCopy(s, d, head, warpThread, warpThreads);
-    if (rank == 0 && tail) {
-        if (ldsBytes >= tail)                          // stage tail in rank 0's window
-            issueRow1d<cp>(reinterpret_cast<uint64_t>(s + tailOff), ldsBase,
-                           reinterpret_cast<uint64_t>(d + tailOff), tail);
-        else
-            warpVecCopy(s + tailOff, d + tailOff, tail, warpThread, warpThreads);
-    }
+  // --- edges (team's FIRST warp = rank 0): vector head, TDM tail -----------
+  if (rank == 0 && head) warpVecCopy(s, d, head, warpThread, warpThreads);
+  if (rank == 0 && tail) {
+    if (ldsBytes >= tail) // stage tail in rank 0's window
+      issueRow1d<cp>(reinterpret_cast<uint64_t>(s + tailOff), ldsBase, reinterpret_cast<uint64_t>(d + tailOff), tail);
+    else warpVecCopy(s + tailOff, d + tailOff, tail, warpThread, warpThreads);
+  }
 
-    // --- aligned bulk via TDM ------------------------------------------------
-    if (rows == 0) return;                             // no aligned bulk (edges done)
-    uint32_t maxByLds = ldsBytes / WIDTH;              // #warps we can give a window
-    if (maxByLds == 0) {                               // LDS < 256B: vector fallback
-        if (rank == 0)
-            warpVecCopy(s + head, d + head, tdmBytes, warpThread, warpThreads);
-        return;
-    }
-    uint32_t issuers = teamWarps < maxByLds ? teamWarps : maxByLds;
-    uint32_t window  = (ldsBytes / issuers) & ~(WIDTH - 1);   // per-warp 256B-multiple
-    uint32_t rowsPerChunk = window / WIDTH;
+  // --- aligned bulk via TDM ------------------------------------------------
+  if (rows == 0) return; // no aligned bulk (edges done)
+  uint32_t maxByLds = ldsBytes / WIDTH; // #warps we can give a window
+  if (maxByLds == 0) { // LDS < 256B: vector fallback
+    if (rank == 0) warpVecCopy(s + head, d + head, tdmBytes, warpThread, warpThreads);
+    return;
+  }
+  uint32_t issuers = teamWarps < maxByLds ? teamWarps : maxByLds;
+  uint32_t window = (ldsBytes / issuers) & ~(WIDTH - 1); // per-warp 256B-multiple
+  uint32_t rowsPerChunk = window / WIDTH;
 
-    if (rank >= issuers) return;                       // this warp doesn't issue
+  if (rank >= issuers) return; // this warp doesn't issue
 
-    // distribute `rows` across issuers by team rank (contiguous row blocks)
-    size_t base    = rows / issuers;
-    size_t extra   = rows % issuers;
-    size_t myRows  = base + (rank < extra ? 1u : 0u);
-    size_t myStart = rank * base + (rank < extra ? rank : extra);
-    if (myRows == 0) return;
+  // distribute `rows` across issuers by team rank (contiguous row blocks)
+  size_t base = rows / issuers;
+  size_t extra = rows % issuers;
+  size_t myRows = base + (rank < extra ? 1u : 0u);
+  size_t myStart = rank * base + (rank < extra ? rank : extra);
+  if (myRows == 0) return;
 
-    uint32_t myLds = ldsBase + rank * window;
-    uint64_t sBase = reinterpret_cast<uint64_t>(s + head) + (uint64_t)myStart * WIDTH;
-    uint64_t dBase = reinterpret_cast<uint64_t>(d + head) + (uint64_t)myStart * WIDTH;
+  uint32_t myLds = ldsBase + rank * window;
+  uint64_t sBase = reinterpret_cast<uint64_t>(s + head) + (uint64_t)myStart * WIDTH;
+  uint64_t dBase = reinterpret_cast<uint64_t>(d + head) + (uint64_t)myStart * WIDTH;
 
-    for (size_t r = 0; r < myRows; r += rowsPerChunk) {
-        uint32_t chunkRows = (myRows - r < rowsPerChunk)
-                             ? static_cast<uint32_t>(myRows - r) : rowsPerChunk;
-        uint64_t off = (uint64_t)r * WIDTH;
-        issueRows<cp>(sBase + off, myLds, dBase + off, chunkRows);
-    }
+  for (size_t r = 0; r < myRows; r += rowsPerChunk) {
+    uint32_t chunkRows = (myRows - r < rowsPerChunk) ? static_cast<uint32_t>(myRows - r) : rowsPerChunk;
+    uint64_t off = (uint64_t)r * WIDTH;
+    issueRows<cp>(sBase + off, myLds, dBase + off, chunkRows);
+  }
 }
 
 } // namespace detail
 
 // ---- public API definitions (declared at the top of this file) -------------
 
-__device__ inline void tdmWait() { detail::waitTensor0(); }
-
-template<CachePolicy cp>
-__device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes,
-                                    void* ldsBuffer, size_t ldsBufferBytes) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+__device__ inline void tdmWait() {
+  detail::waitTensor0();
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes,
-                               void* ldsBuffer, size_t ldsBufferBytes) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
-    tdmWait();
+template <CachePolicy cp>
+__device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                    size_t ldsBufferBytes) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes,
-                                          void* ldsBuffer, size_t ldsBufferBytes,
-                                          uint32_t startWarpId, uint32_t stopWarpId) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+template <CachePolicy cp>
+__device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  tdmWait();
 }
 
-template<CachePolicy cp>
-__device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes,
-                                     void* ldsBuffer, size_t ldsBufferBytes,
-                                     uint32_t startWarpId, uint32_t stopWarpId) {
-    detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
-    tdmWait();   // no-op on any warp that issued nothing / is off-team
+template <CachePolicy cp>
+__device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                          size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+}
+
+template <CachePolicy cp>
+__device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
+                                     size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
+  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  tdmWait(); // no-op on any warp that issued nothing / is off-team
 }
 
 // The TDM descriptor holds the LDS side as a 32-bit address. A generic pointer
@@ -667,24 +661,22 @@ __device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeByte
 // copy path uses for its ldsBuffer argument.
 namespace detail {
 __device__ inline uint32_t ldsAddrOf(const void* p) {
-    return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(p));
+  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(p));
 }
-}  // namespace detail
+} // namespace detail
 
-template<SyncPolicy sp, CachePolicy cp, bool Aligned>
-__device__ inline void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst,
-                                      size_t sizeInBytes) {
-    detail::warpLdsCopy<detail::LdsDir::Load, cp, Aligned>(
-        reinterpret_cast<uint64_t>(globalSrc), detail::ldsAddrOf(ldsDst), sizeInBytes);
-    if constexpr (sp == SyncPolicy::Sync) tdmWait();
+template <SyncPolicy sp, CachePolicy cp, bool Aligned>
+__device__ inline void asyncLoadToLDS(const uint8_t* globalSrc, uint8_t* ldsDst, size_t sizeInBytes) {
+  detail::warpLdsCopy<detail::LdsDir::Load, cp, Aligned>(reinterpret_cast<uint64_t>(globalSrc),
+                                                         detail::ldsAddrOf(ldsDst), sizeInBytes);
+  if constexpr (sp == SyncPolicy::Sync) tdmWait();
 }
 
-template<SyncPolicy sp, CachePolicy cp, bool Aligned>
-__device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst,
-                                         size_t sizeInBytes) {
-    detail::warpLdsCopy<detail::LdsDir::Store, cp, Aligned>(
-        reinterpret_cast<uint64_t>(globalDst), detail::ldsAddrOf(ldsSrc), sizeInBytes);
-    if constexpr (sp == SyncPolicy::Sync) tdmWait();
+template <SyncPolicy sp, CachePolicy cp, bool Aligned>
+__device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalDst, size_t sizeInBytes) {
+  detail::warpLdsCopy<detail::LdsDir::Store, cp, Aligned>(reinterpret_cast<uint64_t>(globalDst),
+                                                          detail::ldsAddrOf(ldsSrc), sizeInBytes);
+  if constexpr (sp == SyncPolicy::Sync) tdmWait();
 }
 
 #endif // TDM_SUPPORTED
@@ -692,4 +684,3 @@ __device__ inline void asyncStoreFromLDS(const uint8_t* ldsSrc, uint8_t* globalD
 // so there is nothing to define here -- any call is a compile-time error.
 
 } // namespace tdm
-

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -174,8 +174,8 @@ static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
 // packs traffic into, so rcclGetCollImplInfo reports the channels that actually run
 // rather than the tuning cap. Mirrors the native-kernel packer (channelId=0,
 // currentTraffic=0): for one coll, 1+nMid+(cellsHi!=0) reduces to divUp(cells,cellsPerChannel).
-rccl_static int rcclKernelPackedChannels(struct ncclComm* comm, ncclFunc_t func, size_t count,
-                                         ncclDataType_t datatype, int protocol, int nMaxChannels) {
+rccl_static int rcclKernelPackedChannels(struct ncclComm* comm, ncclFunc_t func, size_t count, ncclDataType_t datatype,
+                                         int protocol, int nMaxChannels) {
   if (nMaxChannels <= 0 || count == 0) return nMaxChannels;
   constexpr size_t MinTrafficPerChannel = 16 << 10;
   size_t elementSize = ncclTypeSize(datatype);
@@ -497,7 +497,8 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     if (ncclDevFuncIsLL128RegVariant(task->func, task->protocol)) {
       int accFlag = (task->func == ncclFuncAllReduce && task->acc != nullptr) ? 1 : 0;
       int regMode = (devWork.regUsed || devWork.netRegUsed) ? 1 : 2;
-      int id = ncclDevFuncId(task->func, task->opDev.op, task->datatype, task->algorithm, task->protocol, accFlag, task->pipeline, regMode);
+      int id = ncclDevFuncId(task->func, task->opDev.op, task->datatype, task->algorithm, task->protocol, accFlag,
+                             task->pipeline, regMode);
       if (id >= 0) task->devFuncId = id;
     }
 
@@ -1088,8 +1089,7 @@ static ncclResult_t scheduleCollTasksToPlan(struct ncclComm* comm, struct ncclKe
       }
 #endif
       INFO(NCCL_TUNING, "%s: %ld Bytes -> Algo %s proto %s channel{Lo..Hi}={%d..%d}", ncclFuncToString(task->func),
-           task->count * ncclTypeSize(task->datatype), algoStr,
-           ncclProtoToString(task->protocol), chLo, chHi);
+           task->count * ncclTypeSize(task->datatype), algoStr, ncclProtoToString(task->protocol), chLo, chHi);
 
       if (task->isCollnet) {
         TRACE(NCCL_COLL,
@@ -1227,9 +1227,8 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
   //     available on network connections.
   //   - gfx942/gfx950: the only archs whose LL128 send/recv kernel is generated.
 #if defined(ENABLE_LL128)
-  bool useLL128SendRecv = comm->allocP2pNetLLBuffers &&
-                          comm->topo->ll128Enabled &&
-                          (comm->cudaArch == 940 || comm->cudaArch == 950);
+  bool useLL128SendRecv =
+    comm->allocP2pNetLLBuffers && comm->topo->ll128Enabled && (comm->cudaArch == 940 || comm->cudaArch == 950);
 #else
   bool useLL128SendRecv = false; // LL128 kernels not built (e.g. HIP < 6.1.33591)
 #endif
@@ -1307,8 +1306,8 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
     // Emit the selected protocol so tests (and NCCL_DEBUG=INFO) can confirm the latency protocol
     // was actually chosen rather than silently falling back to SIMPLE.
     if (bytes[dir] != -1)
-      INFO(NCCL_INIT, "RCCL P2P SendRecv protocol=%s dir=%s bytes=%ld nChannels=%d",
-           ncclProtoStr[protocol[dir]], dir ? "send" : "recv", (long)bytes[dir], nChannels[dir]);
+      INFO(NCCL_INIT, "RCCL P2P SendRecv protocol=%s dir=%s bytes=%ld nChannels=%d", ncclProtoStr[protocol[dir]],
+           dir ? "send" : "recv", (long)bytes[dir], nChannels[dir]);
 
     stepSize[dir] = comm->buffSizes[protocol[dir]] / NCCL_STEPS;
     if (protocol[dir] == NCCL_PROTO_SIMPLE) stepSize[dir] = comm->p2pChunkSize;
@@ -3429,7 +3428,8 @@ static ncclResult_t collTaskAppend(struct ncclComm* comm, struct ncclInfo* info,
 
   if (info->coll == ncclFuncBroadcast && ncclParamAllgathervEnable() && !comm->ccEnable) {
     // Must be in thread local group before tasks can be alloc'd in `comm->memScoped`.
-    struct ncclTaskBcast* t = ncclMemoryPoolAlloc<struct ncclTaskBcast>(&comm->memPool_ncclTaskBcast, &comm->memPermanent);
+    struct ncclTaskBcast* t =
+      ncclMemoryPoolAlloc<struct ncclTaskBcast>(&comm->memPool_ncclTaskBcast, &comm->memPermanent);
     t->func = ncclFuncAllGatherV;
     t->sendbuff = info->sendbuff;
     t->recvbuff = info->recvbuff;
@@ -3448,49 +3448,48 @@ static ncclResult_t collTaskAppend(struct ncclComm* comm, struct ncclInfo* info,
     ncclIntruQueueEnqueue(&planner->peers[info->root].bcastQueue, t);
     planner->nTasksBcast += 1;
     comm->opCount++;
-  }
-  else {
-  struct ncclTaskColl* t = ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
-  // RCCL: ncclMemoryPoolAlloc does not zero-initialize; default to 0 so
-  // scheduleCollTasksToPlan overwrites with the correct value and the inspector plugin
-  // never sees garbage in eDescr->coll.nChannels.
-  t->nChannels = 0;
-  t->func = info->coll;
-  t->sendbuff = info->sendbuff;
-  t->recvbuff = info->recvbuff;
-  t->count = info->count;
-  t->root = info->root;
-  t->datatype = info->datatype;
+  } else {
+    struct ncclTaskColl* t = ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
+    // RCCL: ncclMemoryPoolAlloc does not zero-initialize; default to 0 so
+    // scheduleCollTasksToPlan overwrites with the correct value and the inspector plugin
+    // never sees garbage in eDescr->coll.nChannels.
+    t->nChannels = 0;
+    t->func = info->coll;
+    t->sendbuff = info->sendbuff;
+    t->recvbuff = info->recvbuff;
+    t->count = info->count;
+    t->root = info->root;
+    t->datatype = info->datatype;
 
 #ifdef ENABLE_ROCSHMEM
-  if (t->func == ncclFuncAlltoAllvGda && info->sizes != nullptr) {
-    size_t nSizes = 4 * comm->nRanks;
-    CUDACHECK(hipMallocManaged((void**)&t->sizes, nSizes * sizeof(size_t)));
-    ncclCommPushCudaFree(comm, t->sizes);
-    memcpy(t->sizes, info->sizes, nSizes * sizeof(size_t));
-  }
+    if (t->func == ncclFuncAlltoAllvGda && info->sizes != nullptr) {
+      size_t nSizes = 4 * comm->nRanks;
+      CUDACHECK(hipMallocManaged((void**)&t->sizes, nSizes * sizeof(size_t)));
+      ncclCommPushCudaFree(comm, t->sizes);
+      memcpy(t->sizes, info->sizes, nSizes * sizeof(size_t));
+    }
 #endif
 
-  size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot ||
-      t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
-    t->count *= elementSize;
-    t->datatype = ncclInt8;
-    elementSize = 1;
-  }
-  t->trafficBytes = t->count * elementSize * ncclFuncTrafficPerByte(t->func, comm->nRanks);
-  t->opHost = info->op;
-  t->opDev = opDev; // C++ struct assignment
-  t->chunkSteps = info->chunkSteps;
-  t->sliceSteps = info->sliceSteps;
-  t->eActivationMask = ncclProfilerApiState.eActivationMask;
-  t->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
-  t->collApiEventHandle = ncclProfilerApiState.collApiEventHandle;
-  t->opCount = comm->opCount;
-  t->acc = info->acc;
+    size_t elementSize = ncclTypeSize(t->datatype);
+    if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot ||
+        t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
+      t->count *= elementSize;
+      t->datatype = ncclInt8;
+      elementSize = 1;
+    }
+    t->trafficBytes = t->count * elementSize * ncclFuncTrafficPerByte(t->func, comm->nRanks);
+    t->opHost = info->op;
+    t->opDev = opDev; // C++ struct assignment
+    t->chunkSteps = info->chunkSteps;
+    t->sliceSteps = info->sliceSteps;
+    t->eActivationMask = ncclProfilerApiState.eActivationMask;
+    t->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
+    t->collApiEventHandle = ncclProfilerApiState.collApiEventHandle;
+    t->opCount = comm->opCount;
+    t->acc = info->acc;
 
-  planner->nTasksColl += 1;
-  ncclTaskCollSorterInsert(&planner->collSorter, t, t->trafficBytes);
+    planner->nTasksColl += 1;
+    ncclTaskCollSorterInsert(&planner->collSorter, t, t->trafficBytes);
   }
   ncclProfilerStopCollApiEvent();
   return ncclSuccess;
@@ -3865,7 +3864,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
       bool ceAvailable = !ceCapturing && ncclCeAvailable(comm, info->coll, info->op, info->datatype, winRegType);
       // Hierarchical CE (sync feature) rides the same symmetric-window ceCollTaskAppend
       // path; keep it graph-capture-safe by gating on !ceCapturing like ceAvailable.
-      bool hierCeAvailable = !ceCapturing && ncclHierCeAvailable(comm, info->coll, info->op, info->datatype, winRegType);
+      bool hierCeAvailable =
+        !ceCapturing && ncclHierCeAvailable(comm, info->coll, info->op, info->datatype, winRegType);
       if (info->coll == ncclFuncAllReduce) {
         const bool ceAllReduceOpSupported =
           (info->op == ncclSum || info->op == ncclProd || info->op == ncclMin || info->op == ncclMax);
@@ -3913,7 +3913,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
         }
         // hierCeAvailable is AllGather/AlltoAll-only (ncclHierCeAvailable rejects
         // AllReduce), so it never affects this AllReduce branch.
-      } else if (((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) && (ceAvailable || hierCeAvailable) && !hasSysmemSegment) ||
+      } else if (((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) && (ceAvailable || hierCeAvailable) &&
+                  !hasSysmemSegment) ||
                  ceArSymRegistered) {
         INFO(NCCL_INIT, "Taking CE collective path with symmetric registered windows for user buffers");
         NCCLCHECK(ceCollTaskAppend(comm, info, sendWin, recvWin, /*ddaRecvBase=*/nullptr, /*ddaPeerBases=*/nullptr,

--- a/projects/rccl/src/fabric_init.cu
+++ b/projects/rccl/src/fabric_init.cu
@@ -67,8 +67,8 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
 
   // Right-sized from the DDA thresholds and nRanks (env-overridable) instead of
   // a fixed 10 GiB. RCCL_DDA_FABRIC_BUFFER_SIZE=0 disables the fabric DDA path.
-  size_t bytes = ddaFabricScratchSizing(nRanks, fabricScratchOverride, rcclParamDdaEnable(),
-                                        simpleThresh, llEnabled, ll128Enabled);
+  size_t bytes =
+    ddaFabricScratchSizing(nRanks, fabricScratchOverride, rcclParamDdaEnable(), simpleThresh, llEnabled, ll128Enabled);
   if (bytes == 0) {
     return ncclSuccess;
   }
@@ -160,13 +160,12 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   comm->ddaFabricMaxBlocks = nBlocksMax;
   comm->ddaLLEpochDev = epochDev;
   comm->ddaLLEpochLen = (int)epochLen;
-  INFO(
-    NCCL_INIT,
-    "ncclDdaFabricCommInit: nRanks %d, scratch %zu bytes (vmm, gfx1250 fabric path; derived from RCCL DDA params; "
-    "RCCL_DDA_FABRIC_BUFFER_SIZE=%lld), LL enabled=%lld threshold=%lld, "
-    "LL128 enabled=%lld threshold=%lld, Simple threshold=%lld, FabricGpuBarrier nBlocks=%d, peer table on device",
-    nRanks, bytes, (long long)fabricScratchOverride, (long long)llEnabled, (long long)llThresh,
-    (long long)ll128Enabled, (long long)ll128Thresh, (long long)simpleThresh, nBlocksMax);
+  INFO(NCCL_INIT,
+       "ncclDdaFabricCommInit: nRanks %d, scratch %zu bytes (vmm, gfx1250 fabric path; derived from RCCL DDA params; "
+       "RCCL_DDA_FABRIC_BUFFER_SIZE=%lld), LL enabled=%lld threshold=%lld, "
+       "LL128 enabled=%lld threshold=%lld, Simple threshold=%lld, FabricGpuBarrier nBlocks=%d, peer table on device",
+       nRanks, bytes, (long long)fabricScratchOverride, (long long)llEnabled, (long long)llThresh,
+       (long long)ll128Enabled, (long long)ll128Thresh, (long long)simpleThresh, nBlocksMax);
   return ncclSuccess;
 
 fail:

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
@@ -38,14 +38,10 @@ __launch_bounds__(512)
     // cudaMemcpyAsync launch overhead on ROCm.
     const size_t copyCount = count * NRANKS;
     copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
-    barrier.syncOnSameBlockIdx<
-        true /* hasPreviousMemAccess */,
-        true /* hasSubsequentMemAccess */>();
+    barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
   } else {
     // Large messages: host enqueues cudaMemcpyAsync into ddaScratch before launch.
-    barrier.syncOnSameBlockIdx<
-        false /* hasPreviousMemAccess */,
-        true /* hasSubsequentMemAccess */>();
+    barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
   }
 
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda_fabric.h
@@ -24,9 +24,8 @@ template <typename T, int NRANKS_CT>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-  __global__
-  void ddaAllToAllFabric(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count, int selfRank,
-                         int nRanks, FabricGpuBarrier barrier) {
+  __global__ void ddaAllToAllFabric(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                    int selfRank, int nRanks, FabricGpuBarrier barrier) {
   barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
   // use uint4 to do 16-byte loads to maximize memory efficiency. We assume

--- a/projects/rccl/src/include/alltoallv_meta.h
+++ b/projects/rccl/src/include/alltoallv_meta.h
@@ -38,8 +38,7 @@ static inline size_t* ncclAlltoAllvRecvDispls(size_t* gathered, int rank, int nR
 }
 
 static inline void ncclAlltoAllvPackLocalSizes(size_t* sizes, int nRanks, const size_t* sendcounts,
-                                                 const size_t* sdispls, const size_t* recvcounts,
-                                                 const size_t* rdispls) {
+                                               const size_t* sdispls, const size_t* recvcounts, const size_t* rdispls) {
   for (int i = 0; i < nRanks; ++i) {
     sizes[i] = sendcounts[i];
     sizes[nRanks + i] = sdispls[i];

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -85,7 +85,7 @@ struct ncclCeColl {
   struct ncclDevrWindow* signalWin;
   // Global counter barrier for regular launch: [0]=arrival, [1]=completed generation.
   uint32_t* d_barrierSync;
-  cudaStream_t scatterStream; 
+  cudaStream_t scatterStream;
   cudaEvent_t synceEvent;  // join scatterStream back onto the caller's stream
   // Latched while this comm has live graph-captured plans. CE 2-shot AllReduce
   // can deadlock on eager calls that share a graph-mode comm, so we disable CE

--- a/projects/rccl/src/include/dda_init_detail.h
+++ b/projects/rccl/src/include/dda_init_detail.h
@@ -37,7 +37,7 @@ constexpr int kDdaLL128DataElems = 15;                // payload words per 128B 
 // Derive slot stride from max per-rank bytes.
 constexpr size_t kDdaLLSlotStridePkts = kDdaLLMaxPerRankBytes / 8;  // 16384 pkts (16B lines)
 constexpr size_t kDdaLL128SlotStrideLines =
-    (kDdaLL128MaxPerRankBytes / 8 + kDdaLL128DataElems - 1) / kDdaLL128DataElems;  // 4370 lines
+  (kDdaLL128MaxPerRankBytes / 8 + kDdaLL128DataElems - 1) / kDdaLL128DataElems;  // 4370 lines
 
 // Compute the fabric scratch allocation from the runtime configuration.
 // An explicit buffer-size override takes precedence over derived sizing.
@@ -50,8 +50,8 @@ constexpr size_t kDdaLL128SlotStrideLines =
 // Collectives that need more scratch (e.g., LL128 AR with large messages) are
 // bounded by the eligibility check (scratchNeeded > ddaScratchBytes), which
 // causes them to fall through to Simple path.
-inline size_t ddaFabricScratchSizing(int nRanks, int64_t overrideBytes, int64_t ddaEnabled,
-                                     int64_t ddaThreshold, int64_t llEnabled, int64_t ll128Enabled) {
+inline size_t ddaFabricScratchSizing(int nRanks, int64_t overrideBytes, int64_t ddaEnabled, int64_t ddaThreshold,
+                                     int64_t llEnabled, int64_t ll128Enabled) {
   if (overrideBytes >= 0) {
     return overrideBytes > 0 ? (size_t)overrideBytes : 0;
   }

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -849,8 +849,7 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
     // (0 = legacy LL, 1 = LL128). reg=0 preserves the historical coll-only key.
     key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT) |
           ((uint64_t)(reg & RCCL_FUNC_ID_MASK) << RCCL_REG_SHIFT);
-  } else if (coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda ||
-             coll == ncclFuncAlltoAllvGda) {
+  } else if (coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda || coll == ncclFuncAlltoAllvGda) {
     key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT);
   } else {
     key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT) |

--- a/projects/rccl/src/include/nccl_device/core.h
+++ b/projects/rccl/src/include/nccl_device/core.h
@@ -210,9 +210,8 @@ static_assert(offsetof(ncclCommProperties_t, ginType) == 36,
 static_assert(offsetof(ncclCommProperties_t, railedGinType) == 48,
               "ncclCommProperties_t.railedGinType offset changed; update nccl4py's "
               "cynccl.pxd and bindings/nccl4py/tests/test_comm_properties_abi.py to match");
-static_assert(sizeof(ncclCommProperties_t) == 56,
-              "ncclCommProperties_t size changed; update nccl4py's cynccl.pxd and "
-              "bindings/nccl4py/tests/test_comm_properties_abi.py to match");
+static_assert(sizeof(ncclCommProperties_t) == 56, "ncclCommProperties_t size changed; update nccl4py's cynccl.pxd and "
+                                                  "bindings/nccl4py/tests/test_comm_properties_abi.py to match");
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* props);
 NCCL_EXTERN_C __host__ ncclResult_t ncclDevCommCreate(ncclComm_t comm, ncclDevCommRequirements_t const* reqs,

--- a/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
+++ b/projects/rccl/src/include/nccl_device/gin/anvil_sdma/gin_anvil_sdma.h
@@ -28,7 +28,6 @@ NCCL_DEVICE_INLINE bool anvilCtxValid(ncclGinAnvilSdmaGPUContext* rsCtx) {
   return rsCtx != nullptr && loadConst(&rsCtx->layoutMagic) == NCCL_GIN_ANVIL_SDMA_LAYOUT_MAGIC;
 }
 
-
 NCCL_DEVICE_INLINE void* resolveRemotePeerVa(ncclGinAnvilSdmaGPUContext* rsCtx, ncclGinAnvilSdmaMemHandle* mh, int peer,
                                              size_t off) {
   ptrdiff_t stride = loadConst(&mh->vmmStride);
@@ -380,8 +379,8 @@ struct ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 template <>
 struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor, cuda::memory_order ord, uint32_t* abortFlag) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
+                                      cuda::memory_order ord, uint32_t* abortFlag) {
     (void)hasDescriptor;
     (void)descriptor;
     (void)ord;
@@ -425,25 +424,23 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
 template <>
 struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t,
-                                      ncclGinWindow_t, size_t, size_t, bool,
-                                      ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t, ncclGinWindow_t, size_t, size_t,
+                                      bool, ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool,
-                                      ncclGinDescriptorSmem*, uint32_t) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool, ncclGinDescriptorSmem*, uint32_t) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_ANVIL_SDMA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool,
-                                      ncclGinDescriptorSmem*, cuda::memory_order, uint32_t*) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool, ncclGinDescriptorSmem*, cuda::memory_order,
+                                      uint32_t*) {
     __builtin_trap();
   }
 };

--- a/projects/rccl/src/include/nccl_device/gin/gin_device_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/gin_device_common.h
@@ -39,7 +39,6 @@
 #endif
 #endif
 
-
 // GIN rocshmem device templates (GDA, SDMA) gate on ENABLE_ROCSHMEM_GIN.
 #ifndef NCCL_GIN_ROCSHMEM_GDA_ENABLE
 #if defined(__HIP_PLATFORM_AMD__) && defined(ENABLE_ROCSHMEM_GIN)

--- a/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/gin_rocshmem_gda.h
+++ b/projects/rccl/src/include/nccl_device/gin/rocshmem_gda/gin_rocshmem_gda.h
@@ -141,8 +141,8 @@ struct ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
 template <>
 struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor, cuda::memory_order ord, uint32_t* abortFlag) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
+                                      cuda::memory_order ord, uint32_t* abortFlag) {
     (void)hasDescriptor;
     (void)descriptor;
     (void)ord;
@@ -161,25 +161,23 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
 template <>
 struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t,
-                                      ncclGinWindow_t, size_t, size_t, bool,
-                                      ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop, int, ncclGinWindow_t, size_t, ncclGinWindow_t, size_t, size_t,
+                                      bool, ncclGinDescriptorSmem*, uint32_t = ncclGinOptFlagsDefault) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool,
-                                      ncclGinDescriptorSmem*, uint32_t) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, int, ncclGinRequest_t*, bool, ncclGinDescriptorSmem*, uint32_t) {
     __builtin_trap();
   }
 };
 
 template <>
 struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA> {
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool,
-                                      ncclGinDescriptorSmem*, cuda::memory_order, uint32_t*) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, ncclGinRequest_t&, bool, ncclGinDescriptorSmem*, cuda::memory_order,
+                                      uint32_t*) {
     __builtin_trap();
   }
 };

--- a/projects/rccl/src/include/nccl_device/impl/vector__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/vector__funcs.h
@@ -768,8 +768,7 @@ NCCL_DEVICE_INLINE EltPack<int8_t, 4> reducePack(OpSum<int8_t> const& /* red */,
   bb.pack = b;
 #if defined(NCCL_HIP_PLATFORM) || defined(__HIP_PLATFORM_AMD__)
 #pragma unroll
-  for (int i = 0; i < 4; ++i)
-    out.pack.elts()[i] = static_cast<int8_t>(aa.pack.elts()[i] + bb.pack.elts()[i]);
+  for (int i = 0; i < 4; ++i) out.pack.elts()[i] = static_cast<int8_t>(aa.pack.elts()[i] + bb.pack.elts()[i]);
 #else
   out.word = __vadd4(aa.word, bb.word);
 #endif

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -196,8 +196,7 @@ bool rcclUseAlltoAllGda(struct ncclComm* comm);
 // Returns true when the CE AllReduce path should be used instead of the standard ring/tree kernels.
 // Pass the bias buffer as acc (nullptr when the caller is plain AllReduce).
 // Does NOT check ceARTmpBuf initialization; the caller is responsible.
-bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t datatype, ncclRedOp_t op,
-                        const void* acc);
+bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t datatype, ncclRedOp_t op, const void* acc);
 // Updates the CE AllReduce graph latch from this call's capture state.
 // Invoke once per collective (any type) at each CE AR decision point.
 void rcclCeAllReduceGraphLatchTick(struct ncclComm* comm, bool ceCapturing);
@@ -242,8 +241,8 @@ constexpr size_t kDdaAlltoAllGfx1250ThresholdBytes = 4194304;
 // Returns true when the DDA fast path should be attempted for a collective.
 // Per-arch defaults cap the threshold; when 0, gfx950/gfx1250 fall back to
 // the user-configurable RCCL_DDA_THRESHOLD env var.
-bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default,
-                    size_t gfx950Default = 0, size_t gfx1250Default = 0);
+bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default, size_t gfx950Default = 0,
+                    size_t gfx1250Default = 0);
 
 int getFirmwareVersion();
 bool rcclIsArchSupportedForFunc(struct ncclTaskColl* info, char const* archName);

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -68,8 +68,7 @@
 // asserted in unit tests; the gate itself is this build's instantiation.
 #define NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(probe, v) ((probe) && NCCL_CUMEM_VERSION_SUPPORTED(v))
 
-#define NCCL_CUMEM_DMABUF_EXPORT_GATE \
-  NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION)
+#define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_DMABUF_EXPORT_GATE_FOR(NCCL_CUMEM_DMABUF_EXPORT_PROBE, HIP_VERSION)
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).

--- a/projects/rccl/src/include/scheduler.h
+++ b/projects/rccl/src/include/scheduler.h
@@ -16,12 +16,15 @@
 // Host-callable equivalent of device.h's __device__ ncclProtoGrainSize().
 static inline int rcclProtoGrainSize(int proto, ncclComm* comm) {
   switch (proto) {
-    case NCCL_PROTO_LL: return 16;
-    case NCCL_PROTO_LL128:
-      return comm->WarpSize * NCCL_LL128_SHMEM_ELEMS_PER_THREAD * comm->ll128DataElems * sizeof(uint64_t) /
-             comm->ll128LineElems;
-    case NCCL_PROTO_SIMPLE: return 512;
-    default: return -1;
+  case NCCL_PROTO_LL:
+    return 16;
+  case NCCL_PROTO_LL128:
+    return comm->WarpSize * NCCL_LL128_SHMEM_ELEMS_PER_THREAD * comm->ll128DataElems * sizeof(uint64_t) /
+           comm->ll128LineElems;
+  case NCCL_PROTO_SIMPLE:
+    return 512;
+  default:
+    return -1;
   }
 }
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1801,12 +1801,11 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4 / ringGraph->nChannels);
   if (ringGraph->nChannels > MAXCHANNELS / 2) allGather3Data[rank].nc = 1;
   // cheap fence is only safe with cache bypassing load/store availability in kernel.
-  comm->cheapPostSendFenceOff = rcclComputeCheapPostSendFenceOff(
-      comm->cudaArch, rcclParamCheapPostSendFenceOff(),
+  comm->cheapPostSendFenceOff = rcclComputeCheapPostSendFenceOff(comm->cudaArch, rcclParamCheapPostSendFenceOff(),
 #ifdef HIP_UNCACHED_MEMORY
-      true);
+                                                                 true);
 #else
-      false);
+                                                                 false);
 #endif
   INFO(NCCL_INIT, "Cheap post-send fence is %s", comm->cheapPostSendFenceOff ? "OFF" : "ON");
   // RCCL: Only use one slice per primitive on some single node gfx9xx systems, only currently enabled for AllReduce, ReduceScatter, and AllGather
@@ -2767,7 +2766,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     NCCLCHECK(ncclMemAlloc((void**)&comm->localSizes, nLocal * sizeof(size_t)));
     NCCLCHECK(ncclMemAlloc((void**)&comm->gatheredSizes, nGather * sizeof(size_t)));
   }
-  
+
   // Initialize hierarchical sub-communicators and temp buffers
   if (!job->parent && !comm->isGrow && comm->nNodes >= 8 && comm->maxLocalRanks > 1 &&
       (rcclParamHierarchicalAllGather() == 1 || rcclParamHierarchicalReduceScatter() == 1)) {

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -72,27 +72,24 @@ static int ncclCuMemFunctionalProbe(CUdevice dev, int devOrdinal) {
   prop.requestedHandleTypes = ncclCuMemHandleType;
 
   // Smallest legal allocation: one granularity unit.
-  if (CUPFN(cuMemGetAllocationGranularity(&granularity, &prop,
-            CU_MEM_ALLOC_GRANULARITY_MINIMUM)) != hipSuccess || granularity == 0)
+  if (CUPFN(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM)) != hipSuccess ||
+      granularity == 0)
     goto done;
 
   if (CUPFN(cuMemCreate(&handle, granularity, &prop, 0)) != hipSuccess)
-    goto done;                       // 7.0.2.2-without-backport fails here
+    goto done; // 7.0.2.2-without-backport fails here
   created = true;
 
-  if (CUPFN(cuMemAddressReserve(&ptr, granularity, granularity, 0, 0)) != hipSuccess)
-    goto cleanup;
+  if (CUPFN(cuMemAddressReserve(&ptr, granularity, granularity, 0, 0)) != hipSuccess) goto cleanup;
   reserved = true;
 
-  if (CUPFN(cuMemMap(ptr, granularity, 0, handle, 0)) != hipSuccess)
-    goto cleanup;
+  if (CUPFN(cuMemMap(ptr, granularity, 0, handle, 0)) != hipSuccess) goto cleanup;
   mapped = true;
 
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   accessDesc.location.id = devOrdinal;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  if (CUPFN(cuMemSetAccess(ptr, granularity, &accessDesc, 1)) != hipSuccess)
-    goto cleanup;
+  if (CUPFN(cuMemSetAccess(ptr, granularity, &accessDesc, 1)) != hipSuccess) goto cleanup;
 
   // register.cc queries: LEGACY_IPC is the op 7.0.2.2 rejects even though alloc/map above succeed.
   {
@@ -100,25 +97,22 @@ static int ncclCuMemFunctionalProbe(CUdevice dev, int devOrdinal) {
     size_t baseSize = 0;
     CUmemorytype memType;
     int legacyIpcCap = 0;
-    if (CUPFN(cuMemGetAddressRange(&base, &baseSize, ptr)) != hipSuccess)
-      goto cleanup;
-    if (CUPFN(cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, ptr)) != hipSuccess)
-      goto cleanup;
-    if (CUPFN(cuPointerGetAttribute((void*)&legacyIpcCap,
-              CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE, base)) != hipSuccess)
+    if (CUPFN(cuMemGetAddressRange(&base, &baseSize, ptr)) != hipSuccess) goto cleanup;
+    if (CUPFN(cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, ptr)) != hipSuccess) goto cleanup;
+    if (CUPFN(cuPointerGetAttribute((void*)&legacyIpcCap, CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE, base)) !=
+        hipSuccess)
       goto cleanup;
   }
 
   ok = 1;
 
 cleanup:
-  if (mapped)   CUCHECKIGNORE(cuMemUnmap(ptr, granularity));
+  if (mapped) CUCHECKIGNORE(cuMemUnmap(ptr, granularity));
   if (reserved) CUCHECKIGNORE(cuMemAddressFree(ptr, granularity));
-  if (created)  CUCHECKIGNORE(cuMemRelease(handle));
-  (void)hipGetLastError();           // clear any sticky error from the probe
+  if (created) CUCHECKIGNORE(cuMemRelease(handle));
+  (void)hipGetLastError(); // clear any sticky error from the probe
 done:
-  if (!ok)
-    INFO(NCCL_INIT, "cuMem functional probe failed on device %d; disabling cuMem", devOrdinal);
+  if (!ok) INFO(NCCL_INIT, "cuMem functional probe failed on device %d; disabling cuMem", devOrdinal);
   return ok;
 }
 
@@ -165,8 +159,7 @@ int ncclIsCuMemSupported() {
   }
 
   // Cheap gates passed — confirm the driver actually implements the VMM path at runtime.
-  if (supported && !ncclCuMemFunctionalProbe(currentDev, cudaDev))
-    supported = 0;
+  if (supported && !ncclCuMemFunctionalProbe(currentDev, cudaDev)) supported = 0;
 
   return supported;
 error:
@@ -275,9 +268,9 @@ static void initOnceFunc() {
   INFO(NCCL_INIT, "ROCr version %d.%d", version_major, version_minor);
 
   // if (hsaDriverVersion < ROCR_DRIVER_MIN_VERSION) {
-    // WARN("ROCr Driver version found is %d. Minimum requirement is %d", hsaDriverVersion, ROCR_DRIVER_MIN_VERSION);
-    // Silently ignore version check mismatch for backwards compatibility
-    // goto error;
+  // WARN("ROCr Driver version found is %d. Minimum requirement is %d", hsaDriverVersion, ROCR_DRIVER_MIN_VERSION);
+  // Silently ignore version check mismatch for backwards compatibility
+  // goto error;
   //}
 
   // Determine whether we support the cuMem APIs or not

--- a/projects/rccl/src/plugin/gin.cc
+++ b/projects/rccl/src/plugin/gin.cc
@@ -185,7 +185,7 @@ static ncclResult_t ncclGinPluginAssignToComm(struct ncclComm* comm, int pluginI
     // Honor NCCL_GIN_ENABLE: when disabled, keep ginType NONE so globalGinSupport
     // resolves to NONE and GIN bring-up is cleanly rejected downstream.
     comm->sharedRes->ginState.ginType =
-        ncclParamGinEnable() ? static_cast<ncclGinType_t>(props.netDeviceType) : NCCL_GIN_TYPE_NONE;
+      ncclParamGinEnable() ? static_cast<ncclGinType_t>(props.netDeviceType) : NCCL_GIN_TYPE_NONE;
     comm->ginPluginIndex = pluginIndex;
 
     ncclGinProperties_t ginProperties;
@@ -326,7 +326,7 @@ static ncclResult_t ncclGinPluginFinalize(struct ncclComm* comm, int pluginIndex
 
 ncclResult_t ncclGinInit(struct ncclComm* comm) {
   if (ncclParamGinEnable() == 0) {
-    INFO(NCCL_INIT|NCCL_NET, "GIN disabled by NCCL_GIN_ENABLE=0; skipping GIN plugin init");
+    INFO(NCCL_INIT | NCCL_NET, "GIN disabled by NCCL_GIN_ENABLE=0; skipping GIN plugin init");
     return ncclSuccess;
   }
 #if !defined(__HIP_PLATFORM_AMD__)

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -386,8 +386,8 @@ void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclT
 
 extern ncclResult_t getAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* task, int collNetSupport, int nvlsSupport,
                                 int numPipeOps, ncclSimInfo_t* simInfo = NULL);
-extern int rcclKernelPackedChannels(struct ncclComm* comm, ncclFunc_t func, size_t count,
-                                    ncclDataType_t datatype, int protocol, int nMaxChannels);
+extern int rcclKernelPackedChannels(struct ncclComm* comm, ncclFunc_t func, size_t count, ncclDataType_t datatype,
+                                    int protocol, int nMaxChannels);
 
 ncclResult_t rcclHierarchicalAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
                                       int* algo, int* protocol, int* maxChannels) {
@@ -508,7 +508,8 @@ ncclResult_t rcclGetCollImplInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_
 
   if (coll == ncclFuncReduceScatter) {
     struct rcclCollDecision decision;
-    NCCLCHECK(rcclSelectReduceScatter(comm, sendbuff, recvbuff, (size_t)count, dataType, op, /*query=*/true, &decision));
+    NCCLCHECK(rcclSelectReduceScatter(comm, sendbuff, recvbuff, (size_t)count, dataType, op, /*query=*/true,
+                                      &decision));
     *algo = decision.algo;
     *protocol = decision.protocol;
     *maxChannels = decision.nMaxChannels;
@@ -642,8 +643,8 @@ ncclResult_t rcclGetProtocolName(int protocol, const char** protocolName) {
   return ncclSuccess;
 }
 
-bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default,
-                    size_t gfx950Default, size_t gfx1250Default) {
+bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default, size_t gfx950Default,
+                    size_t gfx1250Default) {
   if (!rcclParamDdaEnable() || ncclParamLaunchOrderImplicit() || ncclGroupDepth != 0) {
     return false;
   }
@@ -760,8 +761,7 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
   return (comm->enableCustColl && (msgSize <= threshold) && (threshold != -1) && !rankMultiple);
 }
 
-bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t datatype, ncclRedOp_t op,
-                        const void* acc) {
+bool rcclUseCeAllReduce(struct ncclComm* comm, size_t count, ncclDataType_t datatype, ncclRedOp_t op, const void* acc) {
   static int enabled = rcclParamCeAllReduce();
   static int force = rcclParamForceCeAllReduce();
   if (!enabled) {
@@ -871,9 +871,8 @@ ncclResult_t rcclSelectAllReduce(struct ncclComm* comm, const void* sendbuff, vo
 
   // (1) Symmetric-window kernel eligibility takes priority over CE / DDA, exactly
   // as the pre-refactor collectives.cc path did.
-  const bool symEligible =
-    (op == ncclSum) &&
-    isSymmetricKernelRequested(comm, ncclFuncAllReduce, (int)ncclDevSum, datatype, count, sendbuff, recvbuff);
+  const bool symEligible = (op == ncclSum) && isSymmetricKernelRequested(comm, ncclFuncAllReduce, (int)ncclDevSum,
+                                                                         datatype, count, sendbuff, recvbuff);
 
   // (2) CE AllReduce graph state. CE is graph-unsafe, so capture disables it.
   //  - Live dispatch (query=false): probe the real stream and tick the graph
@@ -903,8 +902,7 @@ ncclResult_t rcclSelectAllReduce(struct ncclComm* comm, const void* sendbuff, vo
   struct ncclDevrWindow* recvWin = nullptr;
   ncclDevrFindWindow(comm, sendbuff, &sendWin);
   ncclDevrFindWindow(comm, recvbuff, &recvWin);
-  const bool hasSysmemSegment =
-    ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
+  const bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
   ncclSymRegType_t winRegType;
   NCCLCHECK(ncclGetSymRegType(sendWin, recvWin, &winRegType));
 
@@ -1013,8 +1011,7 @@ ncclResult_t rcclSelectAllReduce(struct ncclComm* comm, const void* sendbuff, vo
     decision->protocol = task.protocol;
     // Report the traffic-packed channel count the kernel actually runs on, not the
     // tuning cap (task.nMaxChannels), matching the enqueue.cc channel{Lo..Hi} log.
-    int packed = rcclKernelPackedChannels(comm, ncclFuncAllReduce, count, datatype, task.protocol,
-                                          task.nMaxChannels);
+    int packed = rcclKernelPackedChannels(comm, ncclFuncAllReduce, count, datatype, task.protocol, task.nMaxChannels);
 #ifdef ENABLE_WARP_SPEED
     // WarpSpeed reports as RING* with channels scaled by nWarps, matching rcclGetAlgoInfo.
     decision->nMaxChannels = task.useWarpSpeed ? task.nMaxChannels / task.nWarps : packed;
@@ -1131,8 +1128,7 @@ ncclResult_t rcclSelectAllGather(struct ncclComm* comm, const void* sendbuff, vo
     struct ncclDevrWindow* recvWin = nullptr;
     ncclDevrFindWindow(comm, sendbuff, &sendWin);
     ncclDevrFindWindow(comm, recvbuff, &recvWin);
-    const bool hasSysmemSegment =
-      ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
+    const bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(sendWin) || ncclDevrWindowHasSysmemSegment(recvWin);
     ncclSymRegType_t winRegType;
     NCCLCHECK(ncclGetSymRegType(sendWin, recvWin, &winRegType));
     // Branch #2: FORCE_CE via DDA scratch (unregistered windows).
@@ -1190,8 +1186,8 @@ ncclResult_t rcclSelectAllGather(struct ncclComm* comm, const void* sendbuff, vo
     decision->protocol = task.protocol;
     // Report the traffic-packed channel count the kernel actually runs on, not the
     // tuning cap (task.nMaxChannels), matching the enqueue.cc channel{Lo..Hi} log.
-    int packed = rcclKernelPackedChannels(comm, ncclFuncAllGather, sendcount, datatype, task.protocol,
-                                          task.nMaxChannels);
+    int packed =
+      rcclKernelPackedChannels(comm, ncclFuncAllGather, sendcount, datatype, task.protocol, task.nMaxChannels);
 #ifdef ENABLE_WARP_SPEED
     // WarpSpeed reports as RING* with channels scaled by nWarps, matching rcclGetAlgoInfo.
     decision->nMaxChannels = task.useWarpSpeed ? task.nMaxChannels / task.nWarps : packed;
@@ -1221,9 +1217,8 @@ ncclResult_t rcclSelectReduceScatter(struct ncclComm* comm, const void* sendbuff
   // (1) Symmetric eligibility (sum/avg). Reported last but gates DDA IPC / Direct here.
   const bool symEligible =
     (op == ncclSum || op == ncclAvg) &&
-    isSymmetricKernelRequested(comm, ncclFuncReduceScatter,
-                               (op == ncclAvg) ? (int)ncclDevSumPostDiv : (int)ncclDevSum, datatype, recvcount,
-                               sendbuff, recvbuff);
+    isSymmetricKernelRequested(comm, ncclFuncReduceScatter, (op == ncclAvg) ? (int)ncclDevSumPostDiv : (int)ncclDevSum,
+                               datatype, recvcount, sendbuff, recvbuff);
 
   // (2) DDA fast paths. gfx1250 fabric may win over symmetric (cross-rank identical
   // state); IPC keeps the strict !symEligible guard. No Blocks helpers -> nMaxChannels 0.
@@ -1304,8 +1299,8 @@ ncclResult_t rcclSelectReduceScatter(struct ncclComm* comm, const void* sendbuff
     decision->protocol = task.protocol;
     // Report the traffic-packed channel count the kernel actually runs on, not the
     // tuning cap (task.nMaxChannels), matching the enqueue.cc channel{Lo..Hi} log.
-    int packed = rcclKernelPackedChannels(comm, ncclFuncReduceScatter, recvcount, datatype, task.protocol,
-                                          task.nMaxChannels);
+    int packed =
+      rcclKernelPackedChannels(comm, ncclFuncReduceScatter, recvcount, datatype, task.protocol, task.nMaxChannels);
 #ifdef ENABLE_WARP_SPEED
     // WarpSpeed reports as RING* with channels scaled by nWarps, matching rcclGetAlgoInfo.
     decision->nMaxChannels = task.useWarpSpeed ? task.nMaxChannels / task.nWarps : packed;
@@ -1539,8 +1534,8 @@ ncclResult_t rcclSetWarpSpeedAuto(struct ncclComm* comm, struct ncclTaskColl* in
       // nChannels to MAXCHANNELS) instead of failing. Force-enable still errors below.
       if (!rcclWarpSpeedChannelCountSupported(comm)) {
         if (comm->rank == 0)
-          INFO(NCCL_TUNING, "RCCL WarpSpeed auto-disabled: %d channels exceeds max %d supported",
-               comm->nChannels, MAXCHANNELS / 2);
+          INFO(NCCL_TUNING, "RCCL WarpSpeed auto-disabled: %d channels exceeds max %d supported", comm->nChannels,
+               MAXCHANNELS / 2);
       } else {
         info->nWarps = 4;
         info->useWarpSpeed = true;

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -379,8 +379,8 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t s
       props_tmp.ptrSupport &= ~NCCL_PTR_DMABUF;
     }
 #endif
-    NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclRma, rmaProxyState->rmaComms[n], props_tmp, address,
-                                   size, NCCL_PTR_CUDA, 0, &rmaHostWins[n], true));
+    NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclRma, rmaProxyState->rmaComms[n], props_tmp, address, size,
+                                   NCCL_PTR_CUDA, 0, &rmaHostWins[n], true));
     if (rmaHostWins[n] == NULL) {
       WARN("rank %d - RMA Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
       return ncclSystemError;

--- a/projects/rccl/src/scheduler/allgatherv_sched.cc
+++ b/projects/rccl/src/scheduler/allgatherv_sched.cc
@@ -17,8 +17,8 @@ static int agvChannelCount(struct ncclComm* comm, int tunedChannels) {
 #ifdef ENABLE_WARP_SPEED
   if (comm->warpSpeedChannelMultiplier > 1) {
     int channels = std::max(1, tunedChannels / comm->warpSpeedChannelMultiplier);
-    INFO(NCCL_COLL, "AllGatherV: WarpSpeed not supported; channels %d -> %d (multiplier %d)",
-         tunedChannels, channels, comm->warpSpeedChannelMultiplier);
+    INFO(NCCL_COLL, "AllGatherV: WarpSpeed not supported; channels %d -> %d (multiplier %d)", tunedChannels, channels,
+         comm->warpSpeedChannelMultiplier);
     return channels;
   }
 #endif
@@ -81,7 +81,6 @@ ncclResult_t ncclScheduleBcastTasksToPlan(struct ncclComm* comm, struct ncclKern
     size_t grainSize = rcclProtoGrainSize(proto, comm);
     nChannels = agvChannelCount(comm, tcoll.nMaxChannels);
     chunkSize = chunkSize / grainSize * grainSize;
-
 
     // Determine thread count per block
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -1326,8 +1326,8 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       } else // FALL-THROUGH to the HSA DMA-BUF export path
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
-      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
-          pfn_hsa_amd_portable_export_dmabuf) {
+        if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
+            pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
         HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd,
@@ -1578,8 +1578,8 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       } else // FALL-THROUGH to the HSA DMA-BUF export path
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
-      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
-          pfn_hsa_amd_portable_export_dmabuf) {
+        if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
+            pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
         HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd,

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -613,8 +613,8 @@ static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element
 static_assert(sizeof(struct ncclIbSendFifo) <= 64, "struct ncclIbSendFifo should fit one cache line");
 static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0,
               "ncclIbSendFifoCtsInline element size must be 32-byte aligned");
-static_assert((sizeof(struct ncclIbSendFifoCtsInline) <=32),
-               "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
+static_assert((sizeof(struct ncclIbSendFifoCtsInline) <= 32),
+              "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
 

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1469,7 +1469,8 @@ ib_recv:
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p) && !remMeta.isRMA;
   rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
   INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d isRMA=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",
-       remMeta.isP2p, remMeta.isRMA, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
+       remMeta.isP2p, remMeta.isRMA, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(),
+       rComm->base.recvMatchingScheme);
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
   if (remMeta.isRMA) {
     rComm->base.nqps = 1;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -553,7 +553,8 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // CTS Offload and CTS Inline are mutually dependent — both must be
       // enabled for either to function. Disable both if either is missing.
       if (IbCastOffloadEnabled && !IbCastUseInline) {
-        INFO(NCCL_INIT|NCCL_NET, "NET/IB : IB Use Inline is disabled and CTS Offload is enabled - enabling IB Use Inline Data");
+        INFO(NCCL_INIT | NCCL_NET,
+             "NET/IB : IB Use Inline is disabled and CTS Offload is enabled - enabling IB Use Inline Data");
         IbCastUseInline = true;
       }
       if (IbCastOffloadEnabled && rcclUseIbCastQpSched()) {
@@ -568,10 +569,8 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: %s; GDR Flush: %s",
-           IbCastAinicCtsInlineData ? "Enabled": "Disabled",
-           IbCastOffloadEnabled ? "Enabled": "Disabled",
-           IbCastUseInline ? "Enabled": "Disabled",
-           IbCastGdrFlushDisable ? "Disabled": "Enabled");
+           IbCastAinicCtsInlineData ? "Enabled" : "Disabled", IbCastOffloadEnabled ? "Enabled" : "Disabled",
+           IbCastUseInline ? "Enabled" : "Disabled", IbCastGdrFlushDisable ? "Disabled" : "Enabled");
     }
   }
 exit:
@@ -584,9 +583,8 @@ exit:
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
-    INFO(NCCL_INIT | NCCL_NET,
-         "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload, Inline Data "
-         "(not compatible with resiliency)");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload, Inline Data "
+                               "(not compatible with resiliency)");
     IbCastOffloadEnabled = false;
     IbCastUseInline = false;
     IbCastAinicCtsInlineData = false;
@@ -640,7 +638,7 @@ ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->maxComms = ibDev->maxQp;
   // AINIC with CTS offload enabled supports max of 1 recv only.
   if (IbCastOffloadEnabled && !rcclParamIbCastP2pDisableCts()) {
-    props->maxRecvs = 1; 
+    props->maxRecvs = 1;
   } else {
     props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
   }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -370,15 +370,15 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
   volatile void* slots = (volatile void*)comm->ctsFifo[slot];
 
   if (!comm->useCtsOffload) {
-    uint32_t idx = (uint32_t)(comm->base.fifoHead+1);
+    uint32_t idx = (uint32_t)(comm->base.fifoHead + 1);
     if (ctsFifoIdx(slots, 0) != idx) {
       *request = NULL;
       return ncclSuccess;
     }
     nreqs = ctsFifoNreqs(slots, 0);
     // Wait until all data has arrived
-    for (int r=1; r<nreqs; r++)
-      while(ctsFifoIdx(slots, r) != idx);
+    for (int r = 1; r < nreqs; r++)
+      while (ctsFifoIdx(slots, r) != idx);
     std::atomic_thread_fence(std::memory_order_seq_cst); // order the nreqsPtr load against tag/rkey/addr loads below
   }
 
@@ -393,9 +393,9 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         ncclSocketGetAddr(&comm->base.sock, &addr);
-        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-             r, nreqs, tag, ncclSocketToString(&addr, line), ctsFifoSize(slots, r),
-             ctsFifoAddr(slots, r), ctsFifoRkey(slots, r, 0));
+        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
+             tag, ncclSocketToString(&addr, line), ctsFifoSize(slots, r), ctsFifoAddr(slots, r),
+             ctsFifoRkey(slots, r, 0));
         return ncclInternalError;
       }
     }
@@ -513,16 +513,14 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.sg_list[0].length = MAX_INLINE_DATA_SIZE;
   } else {
     wr.sg_list[0].length =
-      n * (IbCastAinicCtsInlineData ?
-             sizeof(struct ncclIbSendFifoCtsInline) :
-             sizeof(struct ncclIbSendFifo));
+      n * (IbCastAinicCtsInlineData ? sizeof(struct ncclIbSendFifoCtsInline) : sizeof(struct ncclIbSendFifo));
   }
   wr.num_sge = 1;
 
   wr.opcode = IBV_WR_RDMA_WRITE;
   wr.send_flags = comm->remCtsFifo.flags; // IBV_SEND_INLINE
-  // for multi-receive requests, reset inline flag in send_flags as 
-  // QP max_inline_data attribute limits the inline data to 1 request. 
+  // for multi-receive requests, reset inline flag in send_flags as
+  // QP max_inline_data attribute limits the inline data to 1 request.
   if (IbCastAinicCtsInlineData && n > 1) {
     wr.send_flags &= ~(IBV_SEND_INLINE);
   }
@@ -676,7 +674,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       localElemInline[i].nreqs = (uint8_t)n;
       localElemInline[i].size = sizes[i]; // Sanity/Debugging
       localElemInline[i].tag = (uint16_t)tags[i];
-      localElemInline[i].idx = (uint32_t)(comm->base.fifoHead+1);
+      localElemInline[i].idx = (uint32_t)(comm->base.fifoHead + 1);
       localElemInline[i].rxReqIndex = (uint8_t)rxReqIndex;
     } else {
       localElem[i].addr = (uint64_t)data[i];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
@@ -59,13 +59,11 @@ static inline ncclResult_t IbCastRequestRetrieveAsIndex(ncclIbRequest* reqs, uin
 
 // --- Field accessors (layout-aware, row-based) ---
 static inline uint32_t ctsFifoNreqs(volatile void* slotBase, uint32_t rxReqId) {
-  if (IbCastAinicCtsInlineData)
-    return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].nreqs;
+  if (IbCastAinicCtsInlineData) return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].nreqs;
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].nreqs;
 }
 static inline uint64_t ctsFifoAddr(volatile void* slotBase, uint32_t rxReqId) {
-  if (IbCastAinicCtsInlineData)
-    return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].addr;
+  if (IbCastAinicCtsInlineData) return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].addr;
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].addr;
 }
 static inline uint16_t ctsFifoRxReqIndex(volatile void* slotBase, uint32_t rxReqId) {
@@ -80,18 +78,15 @@ static inline uint32_t ctsFifoRkey(volatile void* slotBase, uint32_t rxReqId, in
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].rkeys[devIdx];
 }
 static inline uint32_t ctsFifoIdx(volatile void* slotBase, uint32_t rxReqId) {
-  if (IbCastAinicCtsInlineData)
-    return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].idx;
+  if (IbCastAinicCtsInlineData) return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].idx;
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].idx;
 }
 static inline size_t ctsFifoSize(volatile void* slotBase, uint32_t rxReqId) {
-  if (IbCastAinicCtsInlineData)
-    return (size_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].size;
+  if (IbCastAinicCtsInlineData) return (size_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].size;
   return (size_t)((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].size;
 }
 static inline uint32_t ctsFifoTag(volatile void* slotBase, uint32_t rxReqId) {
-  if (IbCastAinicCtsInlineData)
-    return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].tag;
+  if (IbCastAinicCtsInlineData) return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].tag;
   return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].tag;
 }
 

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -1454,9 +1454,11 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
   }
   assert(sizeof(void*) == respSize);
 
-  INFO(NCCL_REG, "Proxy rank %d register reqBuff %p size %ld offset %ld legacyIpcCap %d sameProcess %d totalSize %zu numSegments %d",
-       proxyState->tpRank, reqBuff, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap,
-       connection->sameProcess, totalSize, numSegments);
+  INFO(
+    NCCL_REG,
+    "Proxy rank %d register reqBuff %p size %ld offset %ld legacyIpcCap %d sameProcess %d totalSize %zu numSegments %d",
+    proxyState->tpRank, reqBuff, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap,
+    connection->sameProcess, totalSize, numSegments);
 
   // request peer passes all necessary buffer info to import. The proxy thread would register
   // the buffer locally and return register addr back
@@ -1467,7 +1469,8 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
     regAddr = (void*)((uintptr_t)regAddr + ipcExpInfo->offset);
   } else {
 #if ROCM_VERSION >= 70000
-    CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)&regAddr, totalSize, /* alignment */ 0, /* addr */ 0, /* flags */ 0), ret, fail);
+    CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)&regAddr, totalSize, /* alignment */ 0, /* addr */ 0, /* flags */ 0),
+                ret, fail);
     size_t offset = 0;
     for (int segment = 0; segment < numSegments; segment++) {
       // cuMem import
@@ -1476,14 +1479,20 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
         memcpy(&segmentHandles[segment], &ipcExpInfo[segment].ipcDesc.memHandle, sizeof(CUmemGenericAllocationHandle));
       } else {
         if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
-          CUCHECKGOTO(cuMemImportFromShareableHandle(&segmentHandles[segment], (void*)(uintptr_t)ipcExpInfo[segment].impFd, ncclCuMemHandleType), ret, fail);
+          CUCHECKGOTO(cuMemImportFromShareableHandle(&segmentHandles[segment],
+                                                     (void*)(uintptr_t)ipcExpInfo[segment].impFd, ncclCuMemHandleType),
+                      ret, fail);
           SYSCHECKGOTO(close(ipcExpInfo[segment].impFd), "close", ret, fail);
         } else {
-          CUCHECKGOTO(cuMemImportFromShareableHandle(&segmentHandles[segment], (void*)&ipcExpInfo[segment].ipcDesc.cuDesc, ncclCuMemHandleType), ret, fail);
+          CUCHECKGOTO(cuMemImportFromShareableHandle(&segmentHandles[segment],
+                                                     (void*)&ipcExpInfo[segment].ipcDesc.cuDesc, ncclCuMemHandleType),
+                      ret, fail);
         }
       }
       imported[segment] = true;
-      CUCHECKGOTO(cuMemMap((CUdeviceptr)((char*)regAddr + offset), ipcExpInfo[segment].size, /* offset */ 0, segmentHandles[segment], /* flags */ 0), ret, fail);
+      CUCHECKGOTO(cuMemMap((CUdeviceptr)((char*)regAddr + offset), ipcExpInfo[segment].size, /* offset */ 0,
+                           segmentHandles[segment], /* flags */ 0),
+                  ret, fail);
       offset += ipcExpInfo[segment].size;
       mapped[segment] = true;
     }
@@ -1496,8 +1505,11 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
     regAddr = (void*)((uintptr_t)regAddr + ipcExpInfo[0].offset);
 #endif
   }
-  INFO(NCCL_REG, "Proxy rank %d register success regAddr %p totalSize %zu offset %ld legacyIpcCap %d sameProcess %d numSegments %d",
-       proxyState->tpRank, regAddr, totalSize, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap, connection->sameProcess, numSegments);
+  INFO(
+    NCCL_REG,
+    "Proxy rank %d register success regAddr %p totalSize %zu offset %ld legacyIpcCap %d sameProcess %d numSegments %d",
+    proxyState->tpRank, regAddr, totalSize, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap, connection->sameProcess,
+    numSegments);
 
 exit:
   if (regAddr) {


### PR DESCRIPTION
## Summary

Applies the pinned **clang-format 22.1.0** across `projects/rccl/src/**`, making the
tree clean for the new rccl `pre-commit` check. Mechanical formatting only — **no
logic changes**.

## Why

RCCL's `maint/run-clang-format.sh` (inherited from NCCL) mandates clang-format **>= 22**,
and the new `projects/rccl/.pre-commit-config.yaml` (added in #9888) pins
`mirrors-clang-format` to `v22.1.0`. `src/**` was not fully v22-clean, so PRs touching
those files would otherwise hit surprise formatting failures on pre-existing code.
This bulk-formats them once, using the same `.clang-format` + `.clang-format-ignore`
the script and the hook use, so results are identical.

## Notes

- 42 files, produced verbatim by `pre-commit run clang-format` at `rev: v22.1.0`.
- Pairs with #9888 (the rccl pre-commit config/CI plumbing).
- Formatting-only: no `test_*` file, so the "Unit Test" policy needs a maintainer waiver.

JIRA ID: AITESTAUTO-6995