### PR TITLE
adding windows legacy dlls for msi installer packaging

### DIFF
--- a/shared/amdgpu-windows-interop/legacy/.gitignore
+++ b/shared/amdgpu-windows-interop/legacy/.gitignore
@@ -1,0 +1,2 @@
+/amdhip64_6.dll
+/amd_comgr_2.dll

--- a/shared/amdgpu-windows-interop/legacy/amd_comgr_2.dll.dvc
+++ b/shared/amdgpu-windows-interop/legacy/amd_comgr_2.dll.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6b03e0c82aaeb2a2249c1eda5c264fd8
-  size: 121159576
+- md5: c4e138002e5c9bb280f5b20deca82400
+  size: 115276040
   hash: md5
   path: amd_comgr_2.dll

--- a/shared/amdgpu-windows-interop/legacy/amd_comgr_2.dll.dvc
+++ b/shared/amdgpu-windows-interop/legacy/amd_comgr_2.dll.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6b03e0c82aaeb2a2249c1eda5c264fd8
+  size: 121159576
+  hash: md5
+  path: amd_comgr_2.dll

--- a/shared/amdgpu-windows-interop/legacy/amdhip64_6.dll.dvc
+++ b/shared/amdgpu-windows-interop/legacy/amdhip64_6.dll.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6f58fd02a6aff3fb8742aef23374d67a
+  size: 17740696
+  hash: md5
+  path: amdhip64_6.dll

--- a/shared/amdgpu-windows-interop/legacy/amdhip64_6.dll.dvc
+++ b/shared/amdgpu-windows-interop/legacy/amdhip64_6.dll.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6f58fd02a6aff3fb8742aef23374d67a
-  size: 17740696
+- md5: e6032cb755c10a2501ecce7309840d51
+  size: 18794760
   hash: md5
   path: amdhip64_6.dll


### PR DESCRIPTION
## Motivation

Add legacy Windows DLLs (amdhip64_6.dll and amd_comgr_2.dll) as DVC-tracked artifacts under shared/amdgpu-windows-interop/legacy/ to support MSI installer packaging for Windows (https://github.com/ROCm/TheRock/pull/4803
https://github.com/ROCm/TheRock/pull/3973).

## Technical Details

 - Added DVC pointer files for amdhip64_6.dll and amd_comgr_2.dll in shared/amdgpu-windows-interop/legacy/
 - Added .gitignore to exclude the actual DLL binaries from git tracking (managed via DVC)
 - These are legacy DLL versions required by the Windows MSI packaging pipeline

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
