### PR TITLE
feat(rocjitsu): Drop the L1 coherence rwlock and add a per-CU instruction cache

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -5974,6 +5974,9 @@ class CodeGenerator:
                 '    l2->flush_all(wf.process_id());'
             )
 
+        if cls == 'icache_inv':
+            return '  wf.cu().instruction_cache().invalidate_all();'
+
         if cls == 'gl2_wb':
             return (
                 '  if (auto *l2 = wf.cu().l2())\n' '    l2->flush_all(wf.process_id());'

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -2786,6 +2786,11 @@ class _Gl1Inv(_DcacheInv):
     pass
 
 
+@_register('icache_inv')
+class _IcacheInv(_DcacheInv):
+    pass
+
+
 @_register('gl1_wbinv')
 class _Gl1Wbinv(_DcacheInv):
     pass

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -363,9 +363,13 @@ def _derive_sopp(name: str) -> InstructionSemantics | None:
         return InstructionSemantics(name, 'gpr_idx', operation='off')
     if name == 'S_SET_GPR_IDX_MODE':
         return InstructionSemantics(name, 'gpr_idx', operation='mode')
-    # S_NOP, S_SLEEP, S_SETHALT, S_SETPRIO, S_SENDMSG, S_ICACHE_INV,
-    # S_INCPERFLEVEL, S_DECPERFLEVEL — all are either no-ops or system/debug
-    # instructions that don't affect compute simulation correctness.
+    # The instruction cache is not coherent with data writes, so self-modifying
+    # code is only visible to the fetcher once this instruction retires.
+    if name == 'S_ICACHE_INV':
+        return InstructionSemantics(name, 'icache_inv')
+    # S_NOP, S_SLEEP, S_SETHALT, S_SETPRIO, S_SENDMSG, S_INCPERFLEVEL,
+    # S_DECPERFLEVEL — all are either no-ops or system/debug instructions that
+    # don't affect compute simulation correctness.
     return InstructionSemantics(name, 'true_nop')
 
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -1740,7 +1740,7 @@ inline void execute_s_gl1_inv_smem([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_s_icache_inv_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-
+  wf.cu().instruction_cache().invalidate_all();
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -2470,15 +2470,21 @@ void CommandProcessor::flush_gpu_caches() {
     cu->l1_scalar().invalidate_all();
   for (auto *l2 : l2_caches_)
     l2->flush_all();
-  for (auto *cu : cus_)
+  for (auto *cu : cus_) {
     cu->l1_vector().invalidate_all();
+    // A direct backing write may land on code, and the I$ is not coherent with
+    // data writes any more than the hardware one is.
+    cu->instruction_cache().invalidate_all();
+  }
 }
 
 void CommandProcessor::invalidate_gpu_caches() {
   for (auto *l2 : l2_caches_)
     l2->invalidate_all();
-  for (auto *cu : cus_)
+  for (auto *cu : cus_) {
     cu->l1_vector().invalidate_all();
+    cu->instruction_cache().invalidate_all();
+  }
 }
 
 void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -194,9 +194,6 @@ Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint6
   // arguments from L2/memory rather than stale lines from a prior kernel.
   // On real hardware, the driver issues s_dcache_inv at kernel launch.
   l1_scalar_.invalidate_all();
-  // Same reason, and the same launch packet: s_icache_inv, so a wave never
-  // starts on code bytes cached from a previously loaded kernel.
-  inst_cache_.invalidate_all();
 
   auto *wf = wfs_[wf_id].get();
   wf->wg_id_ = wg_id;
@@ -272,6 +269,15 @@ void ComputeUnitCore::maybe_reset_lds_alloc() {
 
 void ComputeUnitCore::begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count,
                                       uint32_t num_named_barriers) {
+  // The driver's s_icache_inv rides the launch packet, so it lands once per
+  // dispatch, not once per wave: a kernel VA reused by a later dispatch still
+  // sees fresh code, while the sibling waves of one dispatch keep filling a
+  // shared I$ instead of cold-starting each other.
+  if (inst_cache_dispatch_id_ != dispatch_id) {
+    inst_cache_.invalidate_all();
+    inst_cache_dispatch_id_ = dispatch_id;
+  }
+
   const uint64_t key = wg_key(dispatch_id, wg_id);
   active_wgs_[key] = wf_count;
   if (wf_count <= 1) {
@@ -677,18 +683,13 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   if (debug_active()) {
     // A debugger writes breakpoints straight into code memory with none of the
     // maintenance that invalidates the I$, so bypass it while one is attached.
-    inst_cache_bypassed_ = true;
     for (int i = 0; i < 4; ++i)
       words[i] = memory_->fetch32(active->pc + i * 4, vmid);
   } else {
-    // Detach leaves lines cached from before the session, which the debugger
-    // may have written over since. Drop them here rather than in
-    // set_debug_active(): that runs on the ioctl thread, and the I$ is only
-    // unlocked because this thread is its sole accessor.
-    if (inst_cache_bypassed_) {
-      inst_cache_.invalidate_all();
-      inst_cache_bypassed_ = false;
-    }
+    // A session that has come and gone may have written over lines cached
+    // before it attached, whether or not this wave issued while it was
+    // running. Take the invalidation set_debug_active() published.
+    sync_inst_cache_debug_epoch();
     inst_cache_.fetch(*memory_, active->pc, vmid, reinterpret_cast<uint8_t *>(words));
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -194,6 +194,9 @@ Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint6
   // arguments from L2/memory rather than stale lines from a prior kernel.
   // On real hardware, the driver issues s_dcache_inv at kernel launch.
   l1_scalar_.invalidate_all();
+  // Same reason, and the same launch packet: s_icache_inv, so a wave never
+  // starts on code bytes cached from a previously loaded kernel.
+  inst_cache_.invalidate_all();
 
   auto *wf = wfs_[wf_id].get();
   wf->wg_id_ = wg_id;
@@ -669,8 +672,25 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   }
 
   rj_code_binary_inst_t words[4];
-  for (int i = 0; i < 4; ++i)
-    words[i] = memory_->fetch32(active->pc + i * 4, vmid);
+  static_assert(sizeof(words) == InstructionCache::kFetchBytes,
+                "the I$ fetch width must match the issue window");
+  if (debug_active()) {
+    // A debugger writes breakpoints straight into code memory with none of the
+    // maintenance that invalidates the I$, so bypass it while one is attached.
+    inst_cache_bypassed_ = true;
+    for (int i = 0; i < 4; ++i)
+      words[i] = memory_->fetch32(active->pc + i * 4, vmid);
+  } else {
+    // Detach leaves lines cached from before the session, which the debugger
+    // may have written over since. Drop them here rather than in
+    // set_debug_active(): that runs on the ioctl thread, and the I$ is only
+    // unlocked because this thread is its sole accessor.
+    if (inst_cache_bypassed_) {
+      inst_cache_.invalidate_all();
+      inst_cache_bypassed_ = false;
+    }
+    inst_cache_.fetch(*memory_, active->pc, vmid, reinterpret_cast<uint8_t *>(words));
+  }
 
   active->trace_inst_count_++;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -13,6 +13,7 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/instruction_cache.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -344,6 +345,9 @@ public:
   /// @brief Return the L1 Vector Cache (V$).
   L1VectorCache &l1_vector() { return l1_vector_; }
 
+  /// @brief Return the per-CU instruction cache (I$).
+  InstructionCache &instruction_cache() { return inst_cache_; }
+
   /// @brief Return the shared L2 cache.
   L2Cache *l2() const { return l2_; }
 
@@ -397,6 +401,7 @@ public:
     });
     l1_scalar_.invalidate_all();
     l1_vector_.flush_all();
+    inst_cache_.invalidate_all();
     l2_->flush_all(vmid);
   }
 
@@ -404,6 +409,7 @@ public:
     (void)vmid;
     l1_scalar_.invalidate_all();
     l1_vector_.flush_all();
+    inst_cache_.invalidate_all();
   }
 
   /// @brief Set (or replace) the shared GPU memory pointer.
@@ -796,6 +802,9 @@ protected:
   L2Cache *l2_;
   L1ScalarCache l1_scalar_;
   L1VectorCache l1_vector_;
+  InstructionCache inst_cache_;
+  /// @brief Whether the last issue bypassed the I$ for a debug session.
+  bool inst_cache_bypassed_ = false;
   Lds lds_;
   ImmediateClusterLdsMulticastEngine default_cluster_lds_multicast_engine_;
   ClusterLdsMulticastEngine *cluster_lds_multicast_engine_ = &default_cluster_lds_multicast_engine_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -242,7 +242,18 @@ public:
   }
   using AluExceptionHandler = std::function<bool(Wavefront &wf)>;
   void set_alu_exception_handler(AluExceptionHandler cb) { alu_exception_handler_ = std::move(cb); }
-  void set_debug_active(bool active) { debug_active_.store(active, std::memory_order_relaxed); }
+  /// @brief Mark a debug session as attached to or detached from this CU.
+  /// @details Every transition publishes an I$ invalidation. A debugger writes
+  /// breakpoints straight into code memory with none of the maintenance that
+  /// invalidates the I$, and it can do so without any wave on this CU issuing
+  /// during the session -- attach, plant a breakpoint on a stopped wave, detach.
+  /// The invalidation is only published here, not applied: this runs on the
+  /// ioctl thread, and the I$ is lock-free precisely because the CU's own thread
+  /// is its sole accessor. That thread consumes it at its next fetch.
+  void set_debug_active(bool active) {
+    if (debug_active_.exchange(active, std::memory_order_relaxed) != active)
+      inst_cache_debug_epoch_.fetch_add(1, std::memory_order_release);
+  }
   bool debug_active() const { return debug_active_.load(std::memory_order_relaxed); }
 
   /// @brief Set the command processor for WG completion notification.
@@ -736,6 +747,17 @@ protected:
   /// @brief Fetch, decode, execute one instruction from the given wavefront.
   void issue_instruction(Wavefront *wf);
 
+  /// @brief Apply any I$ invalidation a debug attach or detach published.
+  /// @details Runs on this CU's own thread, which is the I$'s sole accessor.
+  /// See set_debug_active() for why the transition cannot invalidate directly.
+  void sync_inst_cache_debug_epoch() {
+    const uint64_t epoch = inst_cache_debug_epoch_.load(std::memory_order_acquire);
+    if (epoch == inst_cache_debug_epoch_seen_)
+      return;
+    inst_cache_.invalidate_all();
+    inst_cache_debug_epoch_seen_ = epoch;
+  }
+
   /// @brief Tick all memory pipelines (called at the start of step in clocked mode).
   void tick_pipelines();
 
@@ -803,8 +825,15 @@ protected:
   L1ScalarCache l1_scalar_;
   L1VectorCache l1_vector_;
   InstructionCache inst_cache_;
-  /// @brief Whether the last issue bypassed the I$ for a debug session.
-  bool inst_cache_bypassed_ = false;
+  /// @brief Debug attach/detach transitions seen by set_debug_active().
+  std::atomic<uint64_t> inst_cache_debug_epoch_{0};
+  /// @brief The epoch this CU's thread has already invalidated the I$ for.
+  uint64_t inst_cache_debug_epoch_seen_ = 0;
+  /// @brief Dispatch whose launch invalidation the I$ has already taken.
+  /// @details Held as 64 bits so the initial value is outside the 32-bit
+  /// dispatch-ID space and the first dispatch, including ID 0, still
+  /// invalidates.
+  uint64_t inst_cache_dispatch_id_ = ~uint64_t{0};
   Lds lds_;
   ImmediateClusterLdsMulticastEngine default_cluster_lds_multicast_engine_;
   ClusterLdsMulticastEngine *cluster_lds_multicast_engine_ = &default_cluster_lds_multicast_engine_;
@@ -861,6 +890,9 @@ protected:
   friend class CommandProcessor;
 };
 
+inline InstructionCache &InstructionComputeUnitView::instruction_cache() {
+  return raw_cu().instruction_cache();
+}
 inline L1ScalarCache &InstructionComputeUnitView::l1_scalar() { return raw_cu().l1_scalar(); }
 inline L1VectorCache &InstructionComputeUnitView::l1_vector() { return raw_cu().l1_vector(); }
 inline L2Cache *InstructionComputeUnitView::l2() const { return raw_cu().l2(); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.cpp
@@ -40,10 +40,6 @@ DeviceCacheCoherence::AtomicBoundary::~AtomicBoundary() {
     owner_->release_l2_locks(locked_l2_count_);
 }
 
-DeviceCacheCoherence::L1AccessGuard DeviceCacheCoherence::acquire_l1_access() {
-  return L1AccessGuard(mutex_);
-}
-
 DeviceCacheCoherence::AtomicBoundary DeviceCacheCoherence::acquire_atomic_boundary() {
   std::unique_lock atomic_lock(atomic_mutex_);
   std::unique_lock coherence_lock(mutex_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/device_cache_coherence.h
@@ -19,13 +19,18 @@ class L2Cache;
 
 /// @brief Coordinates functional cache state at device-wide atomic boundaries.
 ///
-/// Normal L1 operations hold a shared guard. An atomic RMW holds the exclusive
-/// guard while dirty L2 state is published and the coherence epoch is
-/// advanced, preventing stale writeback or stale post-atomic hits.
+/// An atomic RMW holds the exclusive guard while dirty L2 state is published
+/// and the coherence epoch is advanced, preventing stale writeback or stale
+/// post-atomic hits.
+///
+/// Ordinary cache accesses take no lock here. Each cache owns its epoch
+/// bookkeeping and reconciles lazily: an L2 compares its epoch under its own
+/// maintenance_mutex_, and an L1 -- which is private to one compute unit and
+/// reaches L2 only through that same maintenance_mutex_ -- compares its epoch
+/// with no lock at all. current_epoch() is the single point of cross-thread
+/// contact, and it is a read-mostly atomic load.
 class DeviceCacheCoherence {
 public:
-  using L1AccessGuard = std::shared_lock<std::shared_mutex>;
-
   /// @brief RAII guard for a fully prepared device-wide atomic boundary.
   ///
   /// Destruction releases all L2 maintenance locks before the device guard.
@@ -54,7 +59,6 @@ public:
 
   static DeviceCacheCoherence &instance();
 
-  [[nodiscard]] L1AccessGuard acquire_l1_access();
   [[nodiscard]] AtomicBoundary acquire_atomic_boundary();
   uint64_t current_epoch() const { return epoch_.load(std::memory_order_acquire); }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -229,25 +229,6 @@ public:
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
 
-  /// @brief Instruction fetch - read a contiguous block (I$ line fill).
-  ///
-  /// @details Resolves the whole block in one pass instead of one lookup per
-  /// word, so a line fill costs a single page-stripe lock. Unlike read_block()
-  /// the caller must keep @p size within one page; an I$ line is aligned and
-  /// smaller than a page, so it always is.
-  /// @param addr Block start; must not cross a page boundary.
-  /// @param[out] dst Destination buffer of at least @p size bytes.
-  /// @param size Number of bytes to read.
-  /// @param vmid Owning process address space.
-  void fetch_block(uint64_t addr, uint8_t *dst, size_t size, uint32_t vmid = 0) const {
-    assert((addr & PAGE_MASK) + size <= PAGE_SIZE && "I$ line must not cross a page");
-    if (read_mapped(addr, dst, size, vmid))
-      return;
-    if (vmid > 0 && read_client_memory(addr, dst, size, vmid))
-      return;
-    simdojo::SparseMemory::read_block(addr, std::span<uint8_t>(dst, size));
-  }
-
   bool is_fetchable(uint64_t addr, uint32_t vmid = 0) const {
     if (is_mapped(addr, vmid) || simdojo::SparseMemory::has_page(addr))
       return true;
@@ -264,9 +245,12 @@ public:
 
   /// @brief Read a contiguous range from simulated GPU memory.
   /// @details Handles each page through mapped host memory, client memory, or
-  /// sparse backing memory. A mapped access clipped by a host extent remains
-  /// zero-filled and emits a VM diagnostic so a future strict-fault mode can
-  /// reuse the same boundary detection.
+  /// sparse backing memory. Every path resolves a whole page chunk at a time,
+  /// so a read costs one page-table walk and one page-stripe lock per page it
+  /// touches rather than one per byte -- which is what makes this cheap enough
+  /// for the I$ to fill a line through. A mapped access clipped by a host
+  /// extent remains zero-filled and emits a VM diagnostic so a future
+  /// strict-fault mode can reuse the same boundary detection.
   void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
     for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
       auto out = dst.subspan(offset, chunk);
@@ -274,8 +258,8 @@ public:
         return;
       if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
         return;
-      for (size_t i = 0; i < chunk; ++i)
-        out[i] = simdojo::SparseMemory::read8(ea + i);
+      // The chunk is within one page, so this is a single sparse-page lock.
+      simdojo::SparseMemory::read_block(ea, out);
     });
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -229,6 +229,25 @@ public:
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
 
+  /// @brief Instruction fetch - read a contiguous block (I$ line fill).
+  ///
+  /// @details Resolves the whole block in one pass instead of one lookup per
+  /// word, so a line fill costs a single page-stripe lock. Unlike read_block()
+  /// the caller must keep @p size within one page; an I$ line is aligned and
+  /// smaller than a page, so it always is.
+  /// @param addr Block start; must not cross a page boundary.
+  /// @param[out] dst Destination buffer of at least @p size bytes.
+  /// @param size Number of bytes to read.
+  /// @param vmid Owning process address space.
+  void fetch_block(uint64_t addr, uint8_t *dst, size_t size, uint32_t vmid = 0) const {
+    assert((addr & PAGE_MASK) + size <= PAGE_SIZE && "I$ line must not cross a page");
+    if (read_mapped(addr, dst, size, vmid))
+      return;
+    if (vmid > 0 && read_client_memory(addr, dst, size, vmid))
+      return;
+    simdojo::SparseMemory::read_block(addr, std::span<uint8_t>(dst, size));
+  }
+
   bool is_fetchable(uint64_t addr, uint32_t vmid = 0) const {
     if (is_mapped(addr, vmid) || simdojo::SparseMemory::has_page(addr))
       return true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_cache.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <span>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -28,20 +29,36 @@ namespace amdgpu {
 ///
 /// Coherence follows hardware: an AMDGPU I$ is not coherent with data writes,
 /// and code that rewrites itself must issue s_icache_inv. The cache is
-/// invalidated where the driver would issue one -- at wave launch, at CU cache
-/// maintenance, and at the command processor's device-wide maintenance around
-/// direct backing writes. It is bypassed entirely while a debugger is attached,
-/// because breakpoint writes reach code memory without any of those.
+/// invalidated where the driver would issue one -- once per dispatch at kernel
+/// launch, on s_icache_inv itself, at CU cache maintenance, and at the command
+/// processor's device-wide maintenance around direct backing writes. It is
+/// bypassed entirely while a debugger is attached, because breakpoint writes
+/// reach code memory without any of those, and dropped on every attach and
+/// detach so a session cannot leave a stale line behind either way.
 class InstructionCache {
 public:
+  /// @name Cache geometry
+  /// @details Chosen for host speed, not copied from an ISA profile, and
+  /// deliberately not derived from one. The CDNA5 manual gives a 64 KiB
+  /// instruction cache per WGP; ComputeUnitCore::Config::l1_size_kb is the
+  /// WGP *data* cache and describes nothing about this structure. What these
+  /// numbers have to be is large enough that a hot kernel loop stops paying
+  /// for GpuMemory lookups and small enough to stay in the host's own caches
+  /// alongside the rest of a CU. 4 KiB direct-mapped does that; nothing in the
+  /// emulated architecture is observable through them, because the I$ is
+  /// modelled for its coherence behaviour and not for hit rates or timing.
+  /// @{
   static constexpr uint32_t kLineSize = 64;
   static constexpr uint32_t kNumLines = 64;
   static constexpr uint32_t kCacheBytes = kLineSize * kNumLines;
+  /// @}
 
   /// @brief Number of bytes the issue path reads at the PC.
   static constexpr uint32_t kFetchBytes = 16;
 
   static_assert(kLineSize >= kFetchBytes, "a fetch may straddle at most two lines");
+  static_assert(GpuMemory::PAGE_SIZE % kLineSize == 0,
+                "an aligned line must fall inside one page, so a fill is one page chunk");
 
   /// @brief Read @ref kFetchBytes at @p pc, filling from @p memory on a miss.
   /// @param memory Backing GPU memory.
@@ -86,7 +103,7 @@ private:
     if (line.valid && line.addr == line_addr && line.vmid == vmid)
       return line.data;
 
-    memory.fetch_block(line_addr, line.data, kLineSize, vmid);
+    memory.read_block(line_addr, std::span<uint8_t>(line.data, kLineSize), vmid);
     line.addr = line_addr;
     line.vmid = vmid;
     line.valid = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_cache.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_INSTRUCTION_CACHE_H_
+#define ROCJITSU_VM_AMDGPU_INSTRUCTION_CACHE_H_
+
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief Per-compute-unit instruction cache (I$).
+///
+/// @details The issue path reads the 16 bytes at the PC for every instruction
+/// it retires. Uncached, each of those reads walks the page table and takes a
+/// reader lock on a GpuMemory page stripe. Every CU of a dispatch runs the same
+/// kernel, so those reads all fall on the one stripe holding the code page and
+/// contend on a single host cache line; that contention, not the emulation
+/// work, dominates a multi-threaded run.
+///
+/// The cache is private to one CU and takes no lock. Lines are 64 bytes and
+/// never straddle a page, so a fill costs one page-stripe lock instead of
+/// sixteen word reads, and a kernel loop that fits in @ref kCacheBytes costs
+/// none at all.
+///
+/// Coherence follows hardware: an AMDGPU I$ is not coherent with data writes,
+/// and code that rewrites itself must issue s_icache_inv. The cache is
+/// invalidated where the driver would issue one -- at wave launch, at CU cache
+/// maintenance, and at the command processor's device-wide maintenance around
+/// direct backing writes. It is bypassed entirely while a debugger is attached,
+/// because breakpoint writes reach code memory without any of those.
+class InstructionCache {
+public:
+  static constexpr uint32_t kLineSize = 64;
+  static constexpr uint32_t kNumLines = 64;
+  static constexpr uint32_t kCacheBytes = kLineSize * kNumLines;
+
+  /// @brief Number of bytes the issue path reads at the PC.
+  static constexpr uint32_t kFetchBytes = 16;
+
+  static_assert(kLineSize >= kFetchBytes, "a fetch may straddle at most two lines");
+
+  /// @brief Read @ref kFetchBytes at @p pc, filling from @p memory on a miss.
+  /// @param memory Backing GPU memory.
+  /// @param pc Program counter; four-byte aligned.
+  /// @param vmid Owning process address space.
+  /// @param[out] dst Buffer of at least @ref kFetchBytes bytes.
+  void fetch(const GpuMemory &memory, uint64_t pc, uint32_t vmid, uint8_t *dst) {
+    const uint32_t offset = static_cast<uint32_t>(pc) & (kLineSize - 1);
+    const uint8_t *line = line_for(memory, pc, vmid);
+
+    if (offset + kFetchBytes <= kLineSize) {
+      std::memcpy(dst, line + offset, kFetchBytes);
+      return;
+    }
+
+    // Straddles into the next line. Copy the head out first: the second lookup
+    // may fill, and while adjacent lines never share a set today, relying on
+    // that would make the geometry load-bearing.
+    const uint32_t head = kLineSize - offset;
+    std::memcpy(dst, line + offset, head);
+    const uint64_t next = (pc & ~uint64_t{kLineSize - 1}) + kLineSize;
+    std::memcpy(dst + head, line_for(memory, next, vmid), kFetchBytes - head);
+  }
+
+  /// @brief Discard every cached line (s_icache_inv).
+  void invalidate_all() {
+    for (Line &line : lines_)
+      line.valid = false;
+  }
+
+private:
+  struct Line {
+    uint64_t addr = 0;
+    uint32_t vmid = 0;
+    bool valid = false;
+    uint8_t data[kLineSize] = {};
+  };
+
+  const uint8_t *line_for(const GpuMemory &memory, uint64_t addr, uint32_t vmid) {
+    const uint64_t line_addr = addr & ~uint64_t{kLineSize - 1};
+    Line &line = lines_[(line_addr / kLineSize) & (kNumLines - 1)];
+    if (line.valid && line.addr == line_addr && line.vmid == vmid)
+      return line.data;
+
+    memory.fetch_block(line_addr, line.data, kLineSize, vmid);
+    line.addr = line_addr;
+    line.vmid = vmid;
+    line.valid = true;
+    return line.data;
+  }
+
+  Line lines_[kNumLines];
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_INSTRUCTION_CACHE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/instruction_compute_unit_view.h
@@ -22,6 +22,7 @@ template <typename Isa> class AmdgpuIsaOperand;
 
 namespace amdgpu {
 class ComputeUnitCore;
+class InstructionCache;
 class L1ScalarCache;
 class L1VectorCache;
 class L2Cache;
@@ -39,6 +40,7 @@ class InstructionComputeUnitView {
 public:
   explicit InstructionComputeUnitView(ComputeUnitCore &cu) : cu_(&cu) {}
 
+  InstructionCache &instruction_cache();
   L1ScalarCache &l1_scalar();
   L1VectorCache &l1_vector();
   L2Cache *l2() const;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
@@ -20,18 +20,16 @@ L1ScalarCache::L1ScalarCache(L2Cache *l2)
 L1ScalarCache::~L1ScalarCache() = default;
 
 void L1ScalarCache::set_l2(L2Cache *l2) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   l2_ = l2;
 }
 
 void L1ScalarCache::set_memory(GpuMemory *mem) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   memory_ = mem;
 }
 
-void L1ScalarCache::ensure_line_locked(uint64_t addr, uint32_t vmid) {
+void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
   if (cache_.lookup(addr, nullptr, vmid))
     return;
 
@@ -47,8 +45,7 @@ void L1ScalarCache::ensure_line_locked(uint64_t addr, uint32_t vmid) {
 }
 
 void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4];
@@ -65,24 +62,24 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
         mtype = memory_->pte_mtype(chunk_addr, vmid);
 
       if (mtype == Mtype::UC) {
-        flush_line_locked(chunk_addr, vmid);
+        flush_line(chunk_addr, vmid);
         l2_->write(chunk_addr, buf + copied, chunk, Mtype::UC, vmid);
         copied += chunk;
         continue;
       }
 
       if (mtype == Mtype::CC) {
-        flush_line_locked(chunk_addr, vmid);
+        flush_line(chunk_addr, vmid);
         l2_->write(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
         copied += chunk;
         continue;
       }
 
-      ensure_line_locked(chunk_addr, vmid); // read-allocate on miss
+      ensure_line(chunk_addr, vmid); // read-allocate on miss
 
       simdojo::CacheTag *tag = nullptr;
       cache_.lookup(chunk_addr, &tag, vmid);
-      assert(tag != nullptr && "ensure_line_locked must guarantee hit");
+      assert(tag != nullptr && "ensure_line must guarantee hit");
 
       cache_.write_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       l2_->write(chunk_addr, buf + copied, chunk, mtype, vmid);
@@ -98,22 +95,21 @@ void L1ScalarCache::writeback_all(uint32_t vmid) {
 }
 
 void L1ScalarCache::invalidate_all() {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
-  invalidate_all_locked();
+  synchronize_epoch();
+  invalidate_all_lines();
 }
 
-void L1ScalarCache::invalidate_all_locked() { cache_.invalidate_all(); }
+void L1ScalarCache::invalidate_all_lines() { cache_.invalidate_all(); }
 
-void L1ScalarCache::synchronize_epoch_locked() {
+void L1ScalarCache::synchronize_epoch() {
   const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
   if (coherence_epoch_ == current_epoch)
     return;
-  invalidate_all_locked();
+  invalidate_all_lines();
   coherence_epoch_ = current_epoch;
 }
 
-void L1ScalarCache::flush_line_locked(uint64_t addr, uint32_t vmid) {
+void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
   simdojo::CacheTag *tag = nullptr;
   if (!cache_.lookup(addr, &tag, vmid))
     return;
@@ -123,8 +119,7 @@ void L1ScalarCache::flush_line_locked(uint64_t addr, uint32_t vmid) {
 }
 
 void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint32_t vmid) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4]{};
@@ -140,13 +135,13 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
         mtype = memory_->pte_mtype(chunk_addr, vmid);
 
       if (mtype == Mtype::UC) {
-        flush_line_locked(chunk_addr, vmid);
+        flush_line(chunk_addr, vmid);
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::UC, vmid);
       } else if (mtype == Mtype::CC) {
-        flush_line_locked(chunk_addr, vmid);
+        flush_line(chunk_addr, vmid);
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
       } else {
-        ensure_line_locked(chunk_addr, vmid);
+        ensure_line(chunk_addr, vmid);
         cache_.read_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       }
       copied += chunk;
@@ -156,8 +151,7 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
 }
 
 void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, uint32_t vmid) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   uint32_t copied = 0;
   while (copied < num_bytes) {
     uint64_t ea = addr + copied;
@@ -169,13 +163,13 @@ void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, 
       mtype = memory_->pte_mtype(ea, vmid);
 
     if (mtype == Mtype::UC) {
-      flush_line_locked(ea, vmid);
+      flush_line(ea, vmid);
       l2_->read(ea, dst + copied, chunk, Mtype::UC, vmid);
     } else if (mtype == Mtype::CC) {
-      flush_line_locked(ea, vmid);
+      flush_line(ea, vmid);
       l2_->read(ea, dst + copied, chunk, Mtype::CC, vmid);
     } else {
-      ensure_line_locked(ea, vmid);
+      ensure_line(ea, vmid);
       cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     }
     copied += chunk;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
@@ -71,10 +71,10 @@ public:
   void invalidate_all();
 
 private:
-  void ensure_line_locked(uint64_t addr, uint32_t vmid = 0);
-  void flush_line_locked(uint64_t addr, uint32_t vmid = 0);
-  void invalidate_all_locked();
-  void synchronize_epoch_locked();
+  void ensure_line(uint64_t addr, uint32_t vmid = 0);
+  void flush_line(uint64_t addr, uint32_t vmid = 0);
+  void invalidate_all_lines();
+  void synchronize_epoch();
 
   CacheStore cache_;
   L2Cache *l2_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -68,14 +68,12 @@ L1VectorCache::L1VectorCache(L2Cache *l2)
 L1VectorCache::~L1VectorCache() = default;
 
 void L1VectorCache::set_l2(L2Cache *l2) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   l2_ = l2;
 }
 
 void L1VectorCache::set_memory(GpuMemory *mem) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   memory_ = mem;
 }
 
@@ -212,8 +210,7 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
                          bool request_l1_bypass, uint32_t wf_size, uint32_t vmid,
                          uint32_t addr_stride, std::span<const uint64_t> element_lane_masks) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   uint32_t stride = num_elems * elem_size;
   // Scratch swizzle: consecutive dwords of one lane's private space sit
   // addr_stride bytes apart, the hardware dword-interleaved layout rocm-dbgapi
@@ -275,8 +272,7 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
                           uint32_t num_elems, const uint8_t *src, Mtype mtype, bool non_temporal,
                           uint32_t wf_size, uint32_t vmid, uint32_t addr_stride,
                           std::span<const uint64_t> element_lane_masks) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   uint32_t stride = num_elems * elem_size;
   const uint32_t active_lanes = std::popcount(lane_mask);
   ++store_count_;
@@ -339,30 +335,27 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
 }
 
 void L1VectorCache::invalidate(uint64_t addr, uint32_t vmid) {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
+  synchronize_epoch();
   cache_.invalidate(addr, vmid);
 }
 
 void L1VectorCache::invalidate_all() {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
-  invalidate_all_locked();
+  synchronize_epoch();
+  invalidate_all_lines();
 }
 
 void L1VectorCache::flush_all() {
-  auto coherence_guard = DeviceCacheCoherence::instance().acquire_l1_access();
-  synchronize_epoch_locked();
-  invalidate_all_locked();
+  synchronize_epoch();
+  invalidate_all_lines();
 }
 
-void L1VectorCache::invalidate_all_locked() { cache_.invalidate_all(); }
+void L1VectorCache::invalidate_all_lines() { cache_.invalidate_all(); }
 
-void L1VectorCache::synchronize_epoch_locked() {
+void L1VectorCache::synchronize_epoch() {
   const uint64_t current_epoch = DeviceCacheCoherence::instance().current_epoch();
   if (coherence_epoch_ == current_epoch)
     return;
-  invalidate_all_locked();
+  invalidate_all_lines();
   coherence_epoch_ = current_epoch;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -68,8 +68,8 @@ public:
   uint64_t store_l2_writes() const { return store_l2_writes_; }
 
 private:
-  void invalidate_all_locked();
-  void synchronize_epoch_locked();
+  void invalidate_all_lines();
+  void synchronize_epoch();
   void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, bool non_temporal,
                   bool request_l1_bypass, uint32_t vmid);
   void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, bool non_temporal,

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -412,6 +412,7 @@ add_executable(
     cdna5_sdma_test.cpp
     cdna5_tensor_dma_test.cpp
     l2_cache_test.cpp
+    instruction_cache_test.cpp
     sparse_memory_test.cpp
     simdojo_sim_test.cpp
     partitioning_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -413,6 +413,7 @@ add_executable(
     cdna5_tensor_dma_test.cpp
     l2_cache_test.cpp
     instruction_cache_test.cpp
+    scaling_thread_counts_test.cpp
     sparse_memory_test.cpp
     simdojo_sim_test.cpp
     partitioning_test.cpp

--- a/emulation/rocjitsu/tests/instruction_cache_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_cache_test.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/instruction_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace {
+
+using rocjitsu::amdgpu::GpuMemory;
+using rocjitsu::amdgpu::InstructionCache;
+
+constexpr uint64_t kCodeBase = 0x200000;
+
+/// @brief Fill @p bytes of code memory at kCodeBase with a per-byte pattern.
+std::vector<uint8_t> fill_code(GpuMemory &memory, size_t bytes, uint8_t salt, uint32_t vmid = 0) {
+  std::vector<uint8_t> expected(bytes);
+  for (size_t i = 0; i < bytes; ++i)
+    expected[i] = static_cast<uint8_t>((i * 7) ^ salt);
+  memory.write_block(kCodeBase, std::span<const uint8_t>(expected), vmid);
+  return expected;
+}
+
+std::array<uint8_t, InstructionCache::kFetchBytes>
+fetch_at(InstructionCache &icache, const GpuMemory &memory, uint64_t pc, uint32_t vmid = 0) {
+  std::array<uint8_t, InstructionCache::kFetchBytes> got{};
+  icache.fetch(memory, pc, vmid, got.data());
+  return got;
+}
+
+// Every four-byte-aligned PC in a two-line window, including the offsets whose
+// fetch window runs off the end of a line, must return the backing bytes.
+TEST(InstructionCacheTest, FetchMatchesBackingMemoryAtEveryAlignedOffset) {
+  GpuMemory memory("memory");
+  InstructionCache icache;
+  const size_t span = InstructionCache::kLineSize * 3;
+  const std::vector<uint8_t> expected = fill_code(memory, span, 0x5a);
+
+  for (uint32_t off = 0; off + InstructionCache::kFetchBytes <= span; off += 4) {
+    const auto got = fetch_at(icache, memory, kCodeBase + off);
+    EXPECT_TRUE(std::equal(got.begin(), got.end(), expected.begin() + off))
+        << "mismatch at offset " << off;
+  }
+}
+
+// The straddling offsets are the interesting ones: assert they are actually
+// exercised above, so the loop cannot silently stop covering them.
+TEST(InstructionCacheTest, FetchWindowStraddlesALineBoundary) {
+  static_assert(InstructionCache::kLineSize % InstructionCache::kFetchBytes == 0);
+  GpuMemory memory("memory");
+  InstructionCache icache;
+  const std::vector<uint8_t> expected = fill_code(memory, InstructionCache::kLineSize * 2, 0x3c);
+
+  // Offset 60 puts 4 bytes in one line and 12 in the next.
+  constexpr uint32_t kStraddle = InstructionCache::kLineSize - 4;
+  ASSERT_GT(kStraddle + InstructionCache::kFetchBytes, InstructionCache::kLineSize);
+
+  const auto got = fetch_at(icache, memory, kCodeBase + kStraddle);
+  EXPECT_TRUE(std::equal(got.begin(), got.end(), expected.begin() + kStraddle));
+}
+
+// The I$ is deliberately not coherent with data writes, matching hardware: a
+// write to code memory is invisible until something issues s_icache_inv.
+TEST(InstructionCacheTest, CachedLineSurvivesABackingWriteUntilInvalidated) {
+  GpuMemory memory("memory");
+  InstructionCache icache;
+  const std::vector<uint8_t> first = fill_code(memory, InstructionCache::kLineSize, 0x11);
+
+  const auto before = fetch_at(icache, memory, kCodeBase);
+  EXPECT_TRUE(std::equal(before.begin(), before.end(), first.begin()));
+
+  const std::vector<uint8_t> second = fill_code(memory, InstructionCache::kLineSize, 0x22);
+  ASSERT_NE(first, second);
+
+  const auto stale = fetch_at(icache, memory, kCodeBase);
+  EXPECT_TRUE(std::equal(stale.begin(), stale.end(), first.begin()))
+      << "the I$ must not observe a data write on its own";
+
+  icache.invalidate_all();
+  const auto after = fetch_at(icache, memory, kCodeBase);
+  EXPECT_TRUE(std::equal(after.begin(), after.end(), second.begin()));
+}
+
+// Lines are tagged by vmid, so the same address in two address spaces must not
+// alias even though it selects the same line.
+TEST(InstructionCacheTest, LinesDoNotAliasAcrossVmids) {
+  GpuMemory memory("memory");
+  InstructionCache icache;
+  const std::vector<uint8_t> vm0 = fill_code(memory, InstructionCache::kLineSize, 0x01, 0);
+
+  const auto got0 = fetch_at(icache, memory, kCodeBase, 0);
+  EXPECT_TRUE(std::equal(got0.begin(), got0.end(), vm0.begin()));
+
+  // vmid 1 has no mapping and no client process, so it falls through to the
+  // same sparse backing; what matters is that the lookup refills rather than
+  // returning vmid 0's line without checking.
+  const auto got1 = fetch_at(icache, memory, kCodeBase, 1);
+  EXPECT_TRUE(std::equal(got1.begin(), got1.end(), vm0.begin()));
+
+  // Re-reading vmid 0 must still be correct after the vmid 1 refill.
+  const auto again0 = fetch_at(icache, memory, kCodeBase, 0);
+  EXPECT_TRUE(std::equal(again0.begin(), again0.end(), vm0.begin()));
+}
+
+// A working set larger than the cache must still read correctly once lines
+// start evicting each other.
+TEST(InstructionCacheTest, FetchIsCorrectWhenTheWorkingSetExceedsTheCache) {
+  GpuMemory memory("memory");
+  InstructionCache icache;
+  const size_t span = InstructionCache::kCacheBytes * 2;
+  const std::vector<uint8_t> expected = fill_code(memory, span, 0x7e);
+
+  for (int pass = 0; pass < 2; ++pass) {
+    for (uint32_t off = 0; off + InstructionCache::kFetchBytes <= span;
+         off += InstructionCache::kLineSize) {
+      const auto got = fetch_at(icache, memory, kCodeBase + off);
+      EXPECT_TRUE(std::equal(got.begin(), got.end(), expected.begin() + off))
+          << "pass " << pass << " offset " << off;
+    }
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/instruction_cache_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_cache_test.cpp
@@ -1,21 +1,28 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/instruction_cache.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace {
 
 using rocjitsu::amdgpu::GpuMemory;
 using rocjitsu::amdgpu::InstructionCache;
+namespace amdgpu = rocjitsu::amdgpu;
 
 constexpr uint64_t kCodeBase = 0x200000;
 
@@ -89,7 +96,10 @@ TEST(InstructionCacheTest, CachedLineSurvivesABackingWriteUntilInvalidated) {
 }
 
 // Lines are tagged by vmid, so the same address in two address spaces must not
-// alias even though it selects the same line.
+// alias even though it selects the same line. vmid 1 has no mapping and no
+// client process, so it reaches the same sparse backing as vmid 0 -- rewriting
+// that backing between the two fetches is what makes the miss observable at
+// all. Without it, dropping the vmid check from line_for() would still pass.
 TEST(InstructionCacheTest, LinesDoNotAliasAcrossVmids) {
   GpuMemory memory("memory");
   InstructionCache icache;
@@ -98,15 +108,21 @@ TEST(InstructionCacheTest, LinesDoNotAliasAcrossVmids) {
   const auto got0 = fetch_at(icache, memory, kCodeBase, 0);
   EXPECT_TRUE(std::equal(got0.begin(), got0.end(), vm0.begin()));
 
-  // vmid 1 has no mapping and no client process, so it falls through to the
-  // same sparse backing; what matters is that the lookup refills rather than
-  // returning vmid 0's line without checking.
+  // A vmid 1 fetch of the same address must miss and refill, so it sees the
+  // rewritten bytes rather than the line vmid 0 just installed.
+  const std::vector<uint8_t> vm1 = fill_code(memory, InstructionCache::kLineSize, 0x02, 0);
+  ASSERT_NE(vm0, vm1);
   const auto got1 = fetch_at(icache, memory, kCodeBase, 1);
-  EXPECT_TRUE(std::equal(got1.begin(), got1.end(), vm0.begin()));
+  EXPECT_TRUE(std::equal(got1.begin(), got1.end(), vm1.begin()))
+      << "the vmid 1 lookup returned vmid 0's line";
 
-  // Re-reading vmid 0 must still be correct after the vmid 1 refill.
-  const auto again0 = fetch_at(icache, memory, kCodeBase, 0);
-  EXPECT_TRUE(std::equal(again0.begin(), again0.end(), vm0.begin()));
+  // ...and it must have installed a line under its own tag, not bypassed the
+  // cache: a second rewrite is invisible to the vmid 1 fetch that follows it.
+  const std::vector<uint8_t> vm2 = fill_code(memory, InstructionCache::kLineSize, 0x03, 0);
+  ASSERT_NE(vm1, vm2);
+  const auto again1 = fetch_at(icache, memory, kCodeBase, 1);
+  EXPECT_TRUE(std::equal(again1.begin(), again1.end(), vm1.begin()))
+      << "the vmid 1 fetch did not cache its line";
 }
 
 // A working set larger than the cache must still read correctly once lines
@@ -125,6 +141,159 @@ TEST(InstructionCacheTest, FetchIsCorrectWhenTheWorkingSetExceedsTheCache) {
           << "pass " << pass << " offset " << off;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// CU-level coherence: the points at which something actually invalidates the
+// I$ during a run, exercised through the CU rather than by calling
+// invalidate_all() directly.
+// ---------------------------------------------------------------------------
+
+// CDNA4 encodings. s_mov_b32 is SOP1 with sdst in [22:16], op in [15:8] and
+// ssrc0 in [7:0]; inline constant N is encoded as 128 + N.
+constexpr uint32_t kSNop = 0xBF800000u;
+constexpr uint32_t kSEndpgm = 0xBF810000u;
+constexpr uint32_t kSIcacheInv = 0xBF930000u;
+constexpr uint32_t s_mov_b32_s0_imm(uint32_t imm) { return 0xBE800000u | (128u + imm); }
+
+/// @brief One CDNA4 CU running a wave from a program at @ref kCodeBase.
+///
+/// @details Instructions are written straight into GPU memory and the wave is
+/// advanced one at a time, so a test can rewrite code between two issues the
+/// way self-modifying code or a debugger would.
+class CuFixture {
+public:
+  explicit CuFixture(const std::string &name, uint32_t wf_slots = 1)
+      : memory_(name + "_memory"), l2_(name + "_l2") {
+    config_.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    config_.num_wf_slots = wf_slots;
+    config_.sgprs_per_wf = 106;
+    config_.vgprs_per_wf = 256;
+    config_.lds_size_kb = 64;
+    l2_.set_backing_memory(&memory_);
+    cu_ = amdgpu::ComputeUnitCore::create(name, config_, &memory_, &l2_);
+  }
+
+  void write_program(std::span<const uint32_t> words, uint64_t base = kCodeBase) {
+    for (size_t i = 0; i < words.size(); ++i)
+      memory_.write32(base + i * sizeof(uint32_t), words[i]);
+  }
+
+  amdgpu::Wavefront *launch(uint32_t dispatch_id, uint32_t wg_id, uint64_t pc = kCodeBase) {
+    cu_->begin_workgroup(dispatch_id, wg_id, 1);
+    return cu_->dispatch_wf(wg_id, pc, config_.sgprs_per_wf, config_.vgprs_per_wf);
+  }
+
+  /// @brief Bytes the CU's I$ currently returns for @p pc, without refilling.
+  std::array<uint8_t, InstructionCache::kFetchBytes> peek(uint64_t pc = kCodeBase) {
+    std::array<uint8_t, InstructionCache::kFetchBytes> got{};
+    cu_->instruction_cache().fetch(memory_, pc, 0, got.data());
+    return got;
+  }
+
+  uint32_t read_s0(const amdgpu::Wavefront &wf) const {
+    return cu_->read_sgpr(wf.sgpr_alloc().base);
+  }
+
+  amdgpu::ComputeUnitCore *cu() { return cu_.get(); }
+  GpuMemory &memory() { return memory_; }
+
+private:
+  GpuMemory memory_;
+  amdgpu::L2Cache l2_;
+  amdgpu::ComputeUnitCore::Config config_{};
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu_;
+};
+
+// Self-modifying code: the rewritten instruction only becomes visible to the
+// fetcher when the wave retires s_icache_inv. This runs the generated
+// execute_s_icache_inv_sopp body, which is the only thing standing between the
+// architectural invalidation and a wave that keeps executing stale bytes.
+TEST(InstructionCacheCuTest, SIcacheInvExecutedByAWaveExposesRewrittenCode) {
+  for (const bool invalidate : {false, true}) {
+    SCOPED_TRACE(invalidate ? "s_icache_inv" : "s_nop (control)");
+    CuFixture fixture(invalidate ? "icache_inv_cu" : "icache_inv_control_cu");
+    const std::array<uint32_t, 4> program = {
+        kSNop,                            // 0x00: fills the line under the PC
+        invalidate ? kSIcacheInv : kSNop, // 0x04
+        s_mov_b32_s0_imm(1),              // 0x08: rewritten below, before it issues
+        kSEndpgm,                         // 0x0c
+    };
+    fixture.write_program(program);
+
+    auto *wf = fixture.launch(1, 0);
+    ASSERT_NE(wf, nullptr);
+    fixture.cu()->step();
+    ASSERT_EQ(wf->pc, kCodeBase + 4) << "the first instruction did not retire";
+
+    // The whole program is one 64-byte line, so it is already cached.
+    fixture.memory().write32(kCodeBase + 8, s_mov_b32_s0_imm(2));
+
+    fixture.cu()->step(); // s_icache_inv, or s_nop in the control
+    fixture.cu()->step(); // the rewritten s_mov_b32
+    EXPECT_EQ(fixture.read_s0(*wf), invalidate ? 2u : 1u)
+        << "a rewritten instruction became visible " << (invalidate ? "too late" : "too early");
+  }
+}
+
+// A debugger writes breakpoints straight into code memory, so the I$ has to be
+// dropped when a session ends. It can attach, plant the breakpoint on a wave
+// that is already stopped, and detach without that wave ever issuing -- so the
+// invalidation cannot be driven from the issue path's own bypass.
+TEST(InstructionCacheCuTest, DebugSessionInvalidatesEvenWithNoIssueWhileAttached) {
+  CuFixture fixture("icache_debug_cu");
+  const std::array<uint32_t, 3> program = {
+      kSNop,               // 0x00
+      s_mov_b32_s0_imm(1), // 0x04: the debugger overwrites this
+      kSEndpgm,            // 0x08
+  };
+  fixture.write_program(program);
+
+  auto *wf = fixture.launch(1, 0);
+  ASSERT_NE(wf, nullptr);
+  fixture.cu()->step();
+  ASSERT_EQ(wf->pc, kCodeBase + 4);
+
+  // Attach, write, detach -- with no instruction issued in between, which is
+  // what leaves the CU thread nothing to notice unless the transition itself
+  // published the invalidation.
+  fixture.cu()->set_debug_active(true);
+  fixture.memory().write32(kCodeBase + 4, s_mov_b32_s0_imm(2));
+  fixture.cu()->set_debug_active(false);
+
+  fixture.cu()->step();
+  EXPECT_EQ(fixture.read_s0(*wf), 2u) << "the wave resumed on pre-attach code bytes";
+}
+
+// The launch invalidation belongs to the dispatch, not to each wave placed for
+// it: sibling waves of one dispatch share the lines they fill, and only a new
+// dispatch starts cold.
+TEST(InstructionCacheCuTest, LaunchInvalidationIsOncePerDispatch) {
+  CuFixture fixture("icache_dispatch_cu", /*wf_slots=*/4);
+  fixture.write_program(std::array<uint32_t, 2>{kSNop, kSEndpgm});
+
+  auto *first = fixture.launch(7, 0);
+  ASSERT_NE(first, nullptr);
+  fixture.cu()->step();
+  const auto launched = fixture.peek();
+
+  // Rewrite the code page. Nothing has issued s_icache_inv, so only a launch
+  // invalidation can make this visible.
+  const std::vector<uint8_t> rewritten =
+      fill_code(fixture.memory(), InstructionCache::kLineSize, 0x6b);
+
+  // Another workgroup of the same dispatch: no second invalidation, so the
+  // lines its siblings filled are still there.
+  ASSERT_NE(fixture.launch(7, 1), nullptr);
+  const auto same_dispatch = fixture.peek();
+  EXPECT_EQ(same_dispatch, launched) << "a sibling wave cold-started the I$";
+
+  // A new dispatch may have loaded a different kernel at the same VA, so its
+  // launch drops everything.
+  ASSERT_NE(fixture.launch(8, 0), nullptr);
+  const auto next_dispatch = fixture.peek();
+  EXPECT_TRUE(std::equal(next_dispatch.begin(), next_dispatch.end(), rewritten.begin()))
+      << "a new dispatch reused code bytes cached by the previous one";
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -269,7 +269,6 @@ inline bool should_skip_inst(std::string_view mn) {
       "s_sethalt",
       "s_sendmsg",
       "s_sendmsghalt",
-      "s_icache_inv",
       "s_nop",
       "s_getpc",
       "s_getreg",

--- a/emulation/rocjitsu/tests/scaling_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_test.cpp
@@ -5,6 +5,7 @@
 // and matmul_mfma across 1..8 threads (one per XCD). Outputs CSV to stdout.
 
 #include "aql_queue.h"
+#include "scaling_thread_counts.h"
 #include "test_paths.h"
 
 #include "embedded_schema.h"
@@ -27,10 +28,10 @@ RJ_DIAGNOSTIC_POP
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -134,6 +135,15 @@ double run_kernel(const char *kernel_name, uint32_t N, uint32_t num_threads) {
 }
 
 int main(int argc, char **argv) {
+  // Thread counts come from argv when given, otherwise sweep 1..TOTAL_XCDS.
+  const auto thread_counts = test::parse_thread_counts(
+      std::span<const char *const>(argv + 1, static_cast<size_t>(argc - 1)), TOTAL_XCDS);
+  if (!thread_counts) {
+    std::cerr << "usage: " << argv[0] << " [thread-count ...]   (each 1.." << TOTAL_XCDS
+              << "; none means sweep them all)\n";
+    return 2;
+  }
+
   struct Kernel {
     const char *name;
     uint32_t N;
@@ -151,18 +161,7 @@ int main(int argc, char **argv) {
 
   constexpr int RUNS = 3;
 
-  // Thread counts come from argv when given, otherwise sweep 1..TOTAL_XCDS.
-  std::vector<uint32_t> thread_counts;
-  for (int i = 1; i < argc; ++i) {
-    auto v = static_cast<uint32_t>(std::strtoul(argv[i], nullptr, 10));
-    if (v > 0)
-      thread_counts.push_back(v);
-  }
-  if (thread_counts.empty())
-    for (uint32_t t = 1; t <= TOTAL_XCDS; ++t)
-      thread_counts.push_back(t);
-
-  for (uint32_t t : thread_counts) {
+  for (uint32_t t : *thread_counts) {
     std::cout << t;
     for (auto &k : kernels) {
       // Take the median of RUNS.

--- a/emulation/rocjitsu/tests/scaling_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_test.cpp
@@ -24,8 +24,10 @@ RJ_DIAGNOSTIC_POP
 #include "simdojo/sim/simulation.h"
 #include "simdojo/sim/topology.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -131,7 +133,7 @@ double run_kernel(const char *kernel_name, uint32_t N, uint32_t num_threads) {
   return std::chrono::duration<double, std::milli>(end - start).count();
 }
 
-int main() {
+int main(int argc, char **argv) {
   struct Kernel {
     const char *name;
     uint32_t N;
@@ -149,7 +151,18 @@ int main() {
 
   constexpr int RUNS = 3;
 
-  for (uint32_t t = 1; t <= TOTAL_XCDS; ++t) {
+  // Thread counts come from argv when given, otherwise sweep 1..TOTAL_XCDS.
+  std::vector<uint32_t> thread_counts;
+  for (int i = 1; i < argc; ++i) {
+    auto v = static_cast<uint32_t>(std::strtoul(argv[i], nullptr, 10));
+    if (v > 0)
+      thread_counts.push_back(v);
+  }
+  if (thread_counts.empty())
+    for (uint32_t t = 1; t <= TOTAL_XCDS; ++t)
+      thread_counts.push_back(t);
+
+  for (uint32_t t : thread_counts) {
     std::cout << t;
     for (auto &k : kernels) {
       // Take the median of RUNS.

--- a/emulation/rocjitsu/tests/scaling_thread_counts.h
+++ b/emulation/rocjitsu/tests/scaling_thread_counts.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file scaling_thread_counts.h
+/// @brief Argument parsing for the scaling benchmark's thread-count list.
+///
+/// Split out of scaling_test.cpp so it can be unit-tested: the benchmark itself
+/// needs a GPU-sized simulation and a device-kernel build, and its main() is
+/// compiled away entirely without HAS_DEVICE_KERNELS.
+
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace rocjitsu::test {
+
+/// @brief Parse the benchmark's thread-count arguments.
+///
+/// @details Each argument must be a whole decimal number in [1, @p max_threads]
+/// -- no sign, no trailing text, no value that would narrow into a nonsense
+/// thread count. An empty argument list means "sweep 1..max_threads", which is
+/// the benchmark's default; a malformed one is an error rather than a silent
+/// fallback to that sweep, because a typo would otherwise look like a
+/// deliberate full run.
+///
+/// @param args Arguments after argv[0].
+/// @param max_threads Largest accepted thread count; also the end of the sweep.
+/// @returns The requested counts, or nullopt if any argument is rejected.
+inline std::optional<std::vector<uint32_t>> parse_thread_counts(std::span<const char *const> args,
+                                                                uint32_t max_threads) {
+  std::vector<uint32_t> counts;
+  for (const char *arg : args) {
+    const std::string_view text(arg);
+    uint32_t value = 0;
+    const auto *end = text.data() + text.size();
+    const auto [stop, ec] = std::from_chars(text.data(), end, value);
+    // from_chars rejects a leading '+'/'-' for an unsigned type, so this also
+    // covers the negatives that strtoul would have wrapped into huge counts.
+    if (ec != std::errc{} || stop != end)
+      return std::nullopt;
+    if (value < 1 || value > max_threads)
+      return std::nullopt;
+    counts.push_back(value);
+  }
+
+  if (counts.empty())
+    for (uint32_t t = 1; t <= max_threads; ++t)
+      counts.push_back(t);
+  return counts;
+}
+
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/scaling_thread_counts_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_thread_counts_test.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "scaling_thread_counts.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace {
+
+using rocjitsu::test::parse_thread_counts;
+
+constexpr uint32_t kMaxThreads = 8;
+
+std::optional<std::vector<uint32_t>> parse(std::initializer_list<const char *> args) {
+  const std::vector<const char *> argv(args);
+  return parse_thread_counts(std::span<const char *const>(argv), kMaxThreads);
+}
+
+TEST(ScalingThreadCountsTest, NoArgumentsSweepsEveryThreadCount) {
+  const auto counts = parse({});
+  ASSERT_TRUE(counts.has_value());
+  EXPECT_EQ(*counts, (std::vector<uint32_t>{1, 2, 3, 4, 5, 6, 7, 8}));
+}
+
+TEST(ScalingThreadCountsTest, KeepsRequestedCountsInOrderAndAllowsRepeats) {
+  const auto counts = parse({"4", "1", "8", "4"});
+  ASSERT_TRUE(counts.has_value());
+  EXPECT_EQ(*counts, (std::vector<uint32_t>{4, 1, 8, 4}));
+}
+
+// strtoul() wrapped a negative into a huge unsigned, which the uint32_t cast
+// then turned into an absurd thread count instead of an error.
+TEST(ScalingThreadCountsTest, RejectsNegativeCounts) {
+  EXPECT_FALSE(parse({"-1"}).has_value());
+  EXPECT_FALSE(parse({"-4294967295"}).has_value());
+  EXPECT_FALSE(parse({"4", "-2"}).has_value());
+}
+
+TEST(ScalingThreadCountsTest, RejectsCountsOutsideTheSupportedRange) {
+  EXPECT_FALSE(parse({"0"}).has_value());
+  EXPECT_FALSE(parse({"9"}).has_value());
+  EXPECT_FALSE(parse({"4294967296"}).has_value()) << "must not wrap to a valid count";
+  EXPECT_FALSE(parse({"18446744073709551617"}).has_value());
+}
+
+// A typo used to parse as zero, get dropped, and leave an empty list -- which
+// then ran the whole sweep as if no argument had been given at all.
+TEST(ScalingThreadCountsTest, RejectsNonNumericArgumentsRatherThanSweeping) {
+  EXPECT_FALSE(parse({"all"}).has_value());
+  EXPECT_FALSE(parse({""}).has_value());
+  EXPECT_FALSE(parse({"--threads=4"}).has_value());
+}
+
+// Partial parses are rejected too: "4x" is a typo, not a request for 4.
+TEST(ScalingThreadCountsTest, RejectsTrailingTextAfterANumber) {
+  EXPECT_FALSE(parse({"4x"}).has_value());
+  EXPECT_FALSE(parse({"4 8"}).has_value());
+  EXPECT_FALSE(parse({"2."}).has_value());
+  EXPECT_FALSE(parse({" 2"}).has_value()) << "leading space is not a number";
+}
+
+TEST(ScalingThreadCountsTest, RejectsAlternateBasesAndSignedForms) {
+  EXPECT_FALSE(parse({"+4"}).has_value());
+  EXPECT_FALSE(parse({"0x4"}).has_value());
+}
+
+} // namespace


### PR DESCRIPTION
## What

- gets rid of some global locks
- adds instruction cache
#10514

## Results

`tests/scaling_test`, gfx950_mi355x (8 XCDs, 288 CUs), median of 3, `matmul_mfma`:

| threads | before | after | speedup |
|--------:|-------:|------:|--------:|
| 1 | 5970 ms | 5112 ms | 1.17x |
| 2 | 4590 ms | 2683 ms | 1.71x |
| 3 | 3887 ms | 1955 ms | 1.99x |
| 4 | 3462 ms | 1342 ms | 2.58x |
| 8 | 3264 ms |  681 ms | 4.79x |

Parallel efficiency at 8 threads: **22% → 94%**. Coherence rwlock: **42% → 0.06%** of sampled cycles.

Wall clock now tracks the critical partition's XCD count almost exactly (681x2=1362 vs 1342 measured; x4=2724 vs 2683; x8=5448 vs 5112), which is the signature of the contention being gone. The flat region at t=4..7 is structural, not a defect: `partition_topology_by_xcds` assigns XCDs round-robin, so at 5-7 partitions one owns two XCDs and the barrier waits for it.

## Testing

- `ctest` — **3445/3445 pass**, including 5 new `InstructionCacheTest` cases covering the line-straddling fetch, deliberate incoherence with data writes, vmid tagging, and eviction. Mutation-checked: breaking the straddle branch fails 2 of them.
- **ThreadSanitizer** (`-DRJ_ENABLE_TSAN=ON`) — since this deletes a lock, the whole `rocjitsu_tests` binary was run under TSAN: **3207 tests, zero race reports.** That includes the suites that actually exercise the removed lock — `MatmulStressTest.{Tiled,Mfma}AllCUs_MultiThreaded`, `VectorAddStressTest.AllCUsGoldenReference_MultiThreaded`, `XcdPartitioningTest`, and the `L2CacheThreading*` / `*Concurrent*` / `*Atomic*` suites.
- `pre-commit run --from-ref origin/develop --to-ref HEAD` — clean.