### PR TITLE
fix(rccl): apply --offload-compress to reduce librccl.so size by ~90%

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -60,9 +60,11 @@ set(SPECIALIZED_DIR  "${GEN_DIR}/specialized")
 # Dropped here: flags selecting the compilation model (each command sets its
 # own -x hip / --offload-arch, and --offload-host-only would suppress the very
 # device code these commands exist to produce), -parallel-jobs (would
-# oversubscribe an already parallel build), --offload-compress (packaging, see
-# ENABLE_COMPRESS below) and diagnostics (generated sources are compiled
-# quietly by design, and some need -w).
+# oversubscribe an already parallel build), and diagnostics (generated sources
+# are compiled quietly by design, and some need -w).  --offload-compress is
+# also filtered out of the rccl target copy below and re-appended when
+# ENABLE_COMPRESS is on, so every command using ${DL_INHERITED_FLAGS} picks it
+# up consistently.
 #
 # Also dropped are options that are only meaningful to something other than the
 # amdclang++ invocations below: SHELL: is an escaping prefix CMake expands only
@@ -82,6 +84,9 @@ if(_rccl_copts)
     endif()
     list(APPEND DL_INHERITED_FLAGS "${_opt}")
   endforeach()
+endif()
+if(ENABLE_COMPRESS AND ROCM_VERSION VERSION_GREATER_EQUAL "60200")
+  list(APPEND DL_INHERITED_FLAGS "--offload-compress")
 endif()
 message(STATUS "Device Linker: inherited compile options: ${DL_INHERITED_FLAGS}")
 
@@ -458,11 +463,6 @@ add_custom_command(
 # ===========================================================================
 set(COMMON_FAT_OBJ "${DEVICE_BUILD_DIR}/common.o")
 
-set(DL_HOST_COMPRESS "")
-if(ENABLE_COMPRESS)
-  set(DL_HOST_COMPRESS "--offload-compress")
-endif()
-
 # Gather include flags for host compile (same paths as device)
 set(_host_inc_flags "")
 if(_dev_includes)
@@ -491,7 +491,6 @@ add_custom_command(
     ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
-    ${DL_HOST_COMPRESS}
     -c -o ${COMMON_FAT_OBJ}
     ${HIPIFY_DIR}/src/device/common.cu.cpp
   DEPENDS ${DEVICE_HIPFB} ${HIPIFY_DIR}/src/device/common.cu.cpp
@@ -702,6 +701,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -721,6 +721,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -790,6 +791,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -809,6 +811,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -848,6 +851,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -867,6 +871,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -886,6 +891,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -905,6 +911,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_INHERITED_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -943,6 +950,7 @@ foreach(_ce_reduce_src IN LISTS _ce_reduce_srcs)
       ${_link_def_flags}
       ${_host_inc_flags}
       ${DL_OPT_FLAGS}
+      ${DL_INHERITED_FLAGS}
       -std=c++17
       -fPIC
       -w

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1038,10 +1038,14 @@ if (HAVE_PARALLEL_JOBS)
   target_compile_options(rccl PRIVATE -parallel-jobs=12)
 endif()
 
-if (ROCM_VERSION VERSION_GREATER_EQUAL "60200")
-  target_compile_options(rccl PRIVATE --offload-compress)    # Compress GPU code at compile time.
+if (ROCM_VERSION VERSION_GREATER_EQUAL "60200" AND ENABLE_COMPRESS)
+  if(NOT ENABLE_DEVICE_LINKER)
+    target_compile_options(rccl PRIVATE --offload-compress)  # Compress GPU code at compile time.
+  endif()
   target_link_libraries(rccl PRIVATE --offload-compress)     # Compress GPU code at link time.
   message(STATUS "--offload-compress enabled - ROCm version >= 6.2.0")
+elseif(ROCM_VERSION VERSION_GREATER_EQUAL "60200")
+  message(STATUS "--offload-compress disabled - ENABLE_COMPRESS=OFF")
 else()
   message(STATUS "--offload-compress disabled - ROCm version < 6.2.0")
 endif()


### PR DESCRIPTION
## Summary

JIRA ID : ROCM-30068 

- Forward `--offload-compress` through `DL_INHERITED_FLAGS` so every device-linker fat-object compile (onerank, collectives, DDA, CE reduce, symmetric kernels, etc.) produces compressed GPU bundles in `librccl.so`.
- Add `${DL_INHERITED_FLAGS}` to fabric LL and CE-reduce compiles that previously missed inherited options (including kernarg preload).
- Skip the unused compile-time `--offload-compress` on host-only `rccl` sources when `ENABLE_DEVICE_LINKER` is enabled; keep link-time compression gated on `ENABLE_COMPRESS`.

Compression remains **on by default** via `ENABLE_COMPRESS=ON` (ROCm >= 6.2). Disable with `-DENABLE_COMPRESS=OFF` or `./install.sh --cmake-options "-DENABLE_COMPRESS=OFF"`.

<img width="545" height="231" alt="image" src="https://github.com/user-attachments/assets/551e138b-eb47-4894-a583-06799d044aba" />


## Test plan
- [x] Reconfigured with `ENABLE_COMPRESS=ON`; all 87 device fat-object rules include `--offload-compress`
- [x] Spot-checked rebuilt objects (`onerank.o`, `ce_reduce_f32_Sum.o`, `dda_all_reduce_fabric_ll.o`) — all emit `CCOB` compressed bundles
- [x] Full multi-arch `librccl.so`: 85 compressed bundles, 0 uncompressed (181.75 MiB compressed vs 2.1 GiB with `ENABLE_COMPRESS=OFF`)


Made with [Cursor](https://cursor.com)