### PR TITLE
[rocclr] Populate ext-dispatch setup byte before AQL debug log

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1532,6 +1532,11 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   writePacketToRingBuffer(aql_loc, packet, header, rest, index & queueMask);
 
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
+    if constexpr (std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
+      // setup travels in `rest`, not in the local packet struct, so the log
+      // would otherwise print setup=0. Populate it before logging.
+      packet->setup = static_cast<uint8_t>((rest >> 8) & 0xFF);
+    }
     if (dev().settings().ext_dispatch_packet_) {
       logAqlDispatchPacketExtended(
           roc_device_, gpu_queue_, header,


### PR DESCRIPTION
## Motivation

When ext-dispatch packets are enabled, the HIP AQL debug log always prints `setup=0`, hiding the real setup byte. The dispatched packet is correct — this is a diagnostic-only logging bug.

## Technical Details

For an ext-dispatch packet the `setup` byte travels in the `rest` argument (committed to the ring buffer), not in the local packet struct passed to the logger, so the logger reads an uninitialized field. Populate `setup` from `rest` before the debug-log call. Guarded with `if constexpr`, so it is a no-op for the standard dispatch path and does not change the dispatched packet.

## Issue Tracking

JIRA ID: AIRUNTIME-2683

## Test Plan

Local rocclr build; inspected the HIP AQL debug log with ext-dispatch enabled. Diagnostic-only — dispatched packets are unaffected.

## Test Result

Debug log reports the actual `setup` byte instead of `0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.