### PR TITLE
feat(rocSHMEM): validate and propagate GPU_TARGETS feature suffixes, #AIROCSHMEM-497

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -307,7 +307,7 @@ if (NOT BUILD_TESTS_ONLY)
   endif()
 
   if (ASAN)
-    message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+    message(STATUS "Removing xnack- entries from GPU_TARGETS because they are invalid with AddressSanitizer (ASAN)")
     list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
     if(GPU_TARGETS_FULL)
       list(FILTER GPU_TARGETS_FULL EXCLUDE REGEX ".*:xnack-$")

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -312,6 +312,48 @@ if (NOT BUILD_TESTS_ONLY)
     if(GPU_TARGETS_FULL)
       list(FILTER GPU_TARGETS_FULL EXCLUDE REGEX ".*:xnack-$")
     endif()
+
+    # RDNA archs (gfx11xx/gfx12xx) have no xnack+ variant at all, so device
+    # ASAN can never be enabled for them - clang just ignores
+    # -fsanitize=address for that offload arch with a warning. Drop them
+    # instead of leaving a target in GPU_TARGETS that silently gets no
+    # instrumentation.
+    set(_ASAN_INCOMPATIBLE_ARCHS gfx1100 gfx1201 gfx1250)
+    foreach(_asan_incompatible_arch ${_ASAN_INCOMPATIBLE_ARCHS})
+      list(FILTER GPU_TARGETS EXCLUDE REGEX "^${_asan_incompatible_arch}(:.*)?$")
+      if(GPU_TARGETS_FULL)
+        list(FILTER GPU_TARGETS_FULL EXCLUDE REGEX "^${_asan_incompatible_arch}(:.*)?$")
+      endif()
+    endforeach()
+
+    if(NOT GPU_TARGETS)
+      message(FATAL_ERROR "ASAN requires a GPU target that supports xnack+ (e.g. gfx90a, gfx942, gfx950). "
+        "None of the requested/default GPU_TARGETS support it.")
+    endif()
+
+    # CDNA archs (gfx90a/gfx942/gfx950) only get ASAN instrumentation with the
+    # xnack+ feature explicitly enabled; a bare arch name compiles without it.
+    # Force :xnack+ onto any entry that doesn't already request it.
+    set(_ASAN_GPU_TARGETS "")
+    foreach(_asan_target ${GPU_TARGETS})
+      if(NOT _asan_target MATCHES "xnack\\+")
+        message(STATUS "ASAN: appending :xnack+ to GPU target '${_asan_target}'")
+        set(_asan_target "${_asan_target}:xnack+")
+      endif()
+      list(APPEND _ASAN_GPU_TARGETS "${_asan_target}")
+    endforeach()
+    set(GPU_TARGETS "${_ASAN_GPU_TARGETS}")
+
+    if(GPU_TARGETS_FULL)
+      set(_ASAN_GPU_TARGETS_FULL "")
+      foreach(_asan_target ${GPU_TARGETS_FULL})
+        if(NOT _asan_target MATCHES "xnack\\+")
+          set(_asan_target "${_asan_target}:xnack+")
+        endif()
+        list(APPEND _ASAN_GPU_TARGETS_FULL "${_asan_target}")
+      endforeach()
+      set(GPU_TARGETS_FULL "${_ASAN_GPU_TARGETS_FULL}")
+    endif()
   endif()
 
   # hip-config-amd.cmake caches GPU_BUILD_TARGETS without FORCE, so on a

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -75,14 +75,6 @@ option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
 option(ASAN "Enable AddressSanitizer" ${ASAN})
 
-if (ASAN)
-  execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libclang_rt.asan-x86_64.so
-    OUTPUT_VARIABLE ASAN_RUNTIME_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
-  get_filename_component(ASAN_RUNTIME_DIR "${ASAN_RUNTIME_PATH}" DIRECTORY)
-  message(STATUS "ASAN runtime directory: ${ASAN_RUNTIME_DIR}")
-endif()
-
 set(USE_EXTERNAL_MPI AUTO CACHE STRING "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5)")
 set_property(CACHE USE_EXTERNAL_MPI PROPERTY STRINGS AUTO ON OFF)
 
@@ -96,6 +88,17 @@ set(VERSION_STRING 3.7.0)
 message(STATUS "rocSHMEM Version: " "${VERSION_STRING}")
 
 project(rocshmem VERSION ${VERSION_STRING} LANGUAGES CXX)
+
+# Must run after project(... LANGUAGES CXX) so CMAKE_CXX_COMPILER is populated;
+# querying it any earlier silently returns an empty path here, which then
+# corrupts the -Wl,-rpath, link flag added for ASAN builds below.
+if (ASAN)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libclang_rt.asan-x86_64.so
+    OUTPUT_VARIABLE ASAN_RUNTIME_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  get_filename_component(ASAN_RUNTIME_DIR "${ASAN_RUNTIME_PATH}" DIRECTORY)
+  message(STATUS "ASAN runtime directory: ${ASAN_RUNTIME_DIR}")
+endif()
 
 find_package(ROCmCMakeBuildTools)
 include(ROCMCreatePackage)
@@ -197,25 +200,22 @@ set(DEFAULT_GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
 
 # When the user supplies GPU_TARGETS:
 #   - Normalise comma/semicolon separators
-#   - Build a base→full map so feature suffixes (e.g. gfx950:sramecc+:xnack-)
-#     can be restored after validation
-#   - Produce a bare-arch list for rocm_check_target_ids and HIP compilation,
-#     which both reject feature-suffixed entries in --offload-arch
+#   - Dedupe on the exact string, since the same base arch may legitimately
+#     appear more than once with different feature suffixes (e.g.
+#     gfx90a:xnack+;gfx90a:xnack-) to fat-binary both variants
+# rocm_check_target_ids validates each entry with a real compiler-flag check
+# (-xhip --offload-arch=<entry>), so feature-suffixed entries like
+# gfx950:sramecc+:xnack- are validated natively and echoed back verbatim on
+# success — no separate bare/full bookkeeping is needed.
 if(GPU_TARGETS)
   string(REPLACE "," ";" GPU_TARGETS "${GPU_TARGETS}")
-  set(_bare_targets "")
-  foreach(_t ${GPU_TARGETS})
-    string(REGEX REPLACE ":.*" "" _base "${_t}")
-    set(_USER_FULL_${_base} "${_t}")
-    list(APPEND _bare_targets "${_base}")
-  endforeach()
-  list(REMOVE_DUPLICATES _bare_targets)
+  list(REMOVE_DUPLICATES GPU_TARGETS)
 endif()
 
 if(COMMAND rocm_check_target_ids)
   if(GPU_TARGETS)
-    message(STATUS "Checking for ROCm support for GPU targets: " "${_bare_targets}")
-    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${_bare_targets})
+    message(STATUS "Checking for ROCm support for GPU targets: " "${GPU_TARGETS}")
+    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${GPU_TARGETS})
   else()
     message(STATUS "Checking for ROCm support for GPU targets: " "${DEFAULT_GPU_TARGETS}")
     rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${DEFAULT_GPU_TARGETS})
@@ -223,28 +223,20 @@ if(COMMAND rocm_check_target_ids)
 else()
   message(WARNING "Unable to check for supported GPU targets.")
   if(GPU_TARGETS)
-    set(SUPPORTED_GPUS ${_bare_targets})
+    set(SUPPORTED_GPUS ${GPU_TARGETS})
   else()
     set(SUPPORTED_GPUS ${DEFAULT_GPU_TARGETS})
   endif()
 endif()
 
-# GPU_TARGETS_FULL: validated arch strings with feature suffixes restored.
+# GPU_TARGETS_FULL: validated arch strings with feature suffixes intact.
 # Consumed by DeviceBitcode.cmake to embed correct amdhsa.target metadata in
-# HSACOs — HIP error 209 occurs if the suffix in the HSACO metadata does not
-# match the active feature configuration of the GPU.
+# the device bitcode — HIP error 209 occurs if the suffix in the bitcode
+# metadata does not match the active feature configuration of the GPU.
 # Explicitly cleared when GPU_TARGETS is not set so a stale cached value from a
 # previous -DGPU_TARGETS=... configure run cannot persist into the defaults path.
 if(GPU_TARGETS)
-  set(_full_validated "")
-  foreach(_base ${SUPPORTED_GPUS})
-    if(DEFINED _USER_FULL_${_base})
-      list(APPEND _full_validated "${_USER_FULL_${_base}}")
-    else()
-      list(APPEND _full_validated "${_base}")
-    endif()
-  endforeach()
-  set(GPU_TARGETS_FULL "${_full_validated}" CACHE STRING
+  set(GPU_TARGETS_FULL "${SUPPORTED_GPUS}" CACHE STRING
     "Validated GPU arch strings with feature suffixes (consumed by DeviceBitcode.cmake)" FORCE)
 else()
   unset(GPU_TARGETS_FULL CACHE)
@@ -313,6 +305,21 @@ if (NOT BUILD_TESTS_ONLY)
       message(FATAL_ERROR "External MPI support requested but MPI support not found. Build Aborted")
     endif()
   endif()
+
+  if (ASAN)
+    message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+    list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+    if(GPU_TARGETS_FULL)
+      list(FILTER GPU_TARGETS_FULL EXCLUDE REGEX ".*:xnack-$")
+    endif()
+  endif()
+
+  # hip-config-amd.cmake caches GPU_BUILD_TARGETS without FORCE, so on a
+  # reconfigure of an existing build directory it can retain a stale value
+  # (e.g. from before ASAN was enabled, or from a previous GPU_TARGETS) even
+  # though GPU_TARGETS itself was correctly refreshed above. Force it to match
+  # on every configure so hip::device's --offload-arch flags stay in sync.
+  set(GPU_BUILD_TARGETS "${GPU_TARGETS}" CACHE STRING "GPU targets to compile for" FORCE)
 
   find_package(hip REQUIRED)
   find_package(hsa-runtime64 REQUIRED)
@@ -464,9 +471,6 @@ if (NOT BUILD_TESTS_ONLY)
   )
 
   if (ASAN)
-    message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
-    list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
-
     # Add ASAN runtime directory to RPATH so executables can find libclang_rt.asan at runtime
     target_link_options(
       ${PROJECT_NAME}

--- a/projects/rocshmem/DEBUG.md
+++ b/projects/rocshmem/DEBUG.md
@@ -17,17 +17,10 @@ Refer to [General documentation for ASAN on AMD GPUs][1].
 
 ### Compiling with ASAN
 
-If this is a fresh build directory, simply add `-DASAN=ON` to the `cmake` invocation.
+Add `-DASAN=ON` to the `cmake` invocation, whether configuring a fresh build directory or reconfiguring an existing one.
   `cmake . <...> -DASAN=ON`
 
-If you are enabling ASAN in a previously used build directory, use `ccmake` to alter the CMake Cache
-  `ccmake .`
-
-In the `ccmake` interface:
-1. find and toggle `ASAN` ON
-2. find and delete `COMPILING_TARGETS` (keybind `d`)
-
-Do not forget to delete `COMPILING_TARGETS` again when disabling ASAN (otherwise xnack will remain required, causing failure in production runs).
+`xnack-` targets are silently invalid under ASAN (the compiler skips instrumenting device code for them without a hard error), so rocSHMEM automatically drops any `:xnack-` entries from `GPU_TARGETS` when `ASAN=ON`, and re-derives HIP's offload targets from the result on every configure. Simply toggling `-DASAN=ON`/`-DASAN=OFF` on an existing build directory is enough; no manual CMake cache surgery is required.
 
 ### Running with ASAN
 

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -208,8 +208,28 @@ endif()
 # all callers exist.  This mirrors the approach in CMakeDeviceBitcodeTester.cmake.
 set(ALL_BITCODE_OUTPUTS)
 foreach(gpu_arch ${BITCODE_GPU_ARCHS})
+  # Resolve the full arch string (with feature suffixes) for this base arch, so
+  # the compile step below embeds the correct amdhsa.target metadata. Mirrors
+  # the lookup in tests/functional_tests/CMakeDeviceBitcodeTester.cmake.
+  set(_FULL_ARCH "${gpu_arch}")
+  set(_FULL_ARCH_MATCHES "")
+  foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
+    string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
+    if("${_candidate_base}" STREQUAL "${gpu_arch}")
+      list(APPEND _FULL_ARCH_MATCHES "${_candidate}")
+    endif()
+  endforeach()
+  list(LENGTH _FULL_ARCH_MATCHES _n_full_arch_matches)
+  if(_n_full_arch_matches GREATER 0)
+    list(GET _FULL_ARCH_MATCHES 0 _FULL_ARCH)
+    if(_n_full_arch_matches GREATER 1)
+      message(STATUS "Multiple feature variants requested for ${gpu_arch} "
+        "(${_FULL_ARCH_MATCHES}); device bitcode will embed ${_FULL_ARCH}")
+    endif()
+  endif()
+
   # Per-source flags: -Xclang -disable-llvm-passes suppresses DCE.
-  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${gpu_arch}
+  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${_FULL_ARCH}
                      -Xclang -disable-llvm-passes)
   set(BITCODE_OBJECTS_${gpu_arch})
   foreach(src_file ${BITCODE_SOURCES})

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -80,10 +80,9 @@ set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING
 
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and clang backend compilation.
-# -fgpu-rdc marks each TU as part of a larger relocatable-device-code program,
-# so real per-TU -O3 never DCEs genuinely external-linkage device functions
-# even with zero in-TU callers (mirrors the flag already used to build
-# librocshmem.a itself in src/CMakeLists.txt).
+# -fgpu-rdc mirrors the flag used to build librocshmem.a in src/CMakeLists.txt.
+# -Xclang -disable-llvm-passes (added per-arch below) is what actually stops
+# per-TU DCE of these in-TU-uncalled __device__ functions.
 set(BITCODE_COMPILE_FLAGS_BASE
     -Wall
     -Wextra
@@ -186,12 +185,9 @@ endif()
 #
 # __device__ API functions (rocshmem_quiet, rocshmem_barrier_wg, etc.) have no
 # caller within their own TU -- they are public API for code that doesn't
-# exist yet at build time. BITCODE_COMPILE_FLAGS_BASE carries -fgpu-rdc, which
-# tells clang/LLVM this TU is part of a larger program, so real per-TU -O3
-# never strips genuinely external-linkage device functions. Each source is
-# compiled at real -O3, then all per-arch .bc files are merged with llvm-link
-# and reoptimized with opt -O3 once real cross-TU callers exist in the merged
-# module. This mirrors the approach in CMakeDeviceBitcodeTester.cmake.
+# exist yet at build time. -Xclang -disable-llvm-passes skips per-TU DCE so
+# these survive; -O3 optimization actually happens once, via opt -O3 below,
+# after llvm-link merges all per-arch .bc files. Mirrors CMakeDeviceBitcodeTester.cmake.
 set(ALL_BITCODE_OUTPUTS)
 foreach(gpu_arch ${BITCODE_GPU_ARCHS})
   # Resolve the full arch string (with feature suffixes) for this base arch, so
@@ -214,7 +210,8 @@ foreach(gpu_arch ${BITCODE_GPU_ARCHS})
     endif()
   endif()
 
-  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${_FULL_ARCH})
+  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${_FULL_ARCH}
+                     -Xclang -disable-llvm-passes)
   set(BITCODE_OBJECTS_${gpu_arch})
   foreach(src_file ${BITCODE_SOURCES})
     get_filename_component(src_name ${src_file} NAME_WE)

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -39,27 +39,6 @@ function(strip_arch_features targets_list out_var)
   set(${out_var} "${_result}" PARENT_SCOPE)
 endfunction()
 
-# Convert arch feature suffix to clang -Xclang -target-feature flags.
-# gfx950:sramecc+:xnack-  ->  "-Xclang;-target-feature;-Xclang;+sramecc;-Xclang;-target-feature;-Xclang;-xnack"
-# Caller passes the list directly to add_custom_command COMMAND.
-function(arch_features_to_target_feature_flags full_arch out_var)
-  string(REPLACE ":" ";" _all_tokens "${full_arch}")
-  list(LENGTH _all_tokens _ntokens)
-  set(_flags "")
-  if(_ntokens GREATER 1)
-    list(SUBLIST _all_tokens 1 -1 _feat_tokens)
-    foreach(_tok ${_feat_tokens})
-      if(_tok STREQUAL "")
-        continue()
-      endif()
-      # "sramecc+" -> "+sramecc", "xnack-" -> "-xnack"
-      string(REGEX REPLACE "([a-zA-Z0-9_]+)([+-])$" "\\2\\1" _feat "${_tok}")
-      list(APPEND _flags -Xclang -target-feature -Xclang ${_feat})
-    endforeach()
-  endif()
-  set(${out_var} "${_flags}" PARENT_SCOPE)
-endfunction()
-
 # Resolve the target arch list: GPU_TARGETS CMake var -> auto-detect local GPUs.
 # Both accept comma- or semicolon-separated lists.
 if(GPU_TARGETS)
@@ -101,6 +80,10 @@ set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING
 
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and clang backend compilation.
+# -fgpu-rdc marks each TU as part of a larger relocatable-device-code program,
+# so real per-TU -O3 never DCEs genuinely external-linkage device functions
+# even with zero in-TU callers (mirrors the flag already used to build
+# librocshmem.a itself in src/CMakeLists.txt).
 set(BITCODE_COMPILE_FLAGS_BASE
     -Wall
     -Wextra
@@ -110,6 +93,7 @@ set(BITCODE_COMPILE_FLAGS_BASE
     -emit-llvm
     -fvisibility=default
     -O3
+    -fgpu-rdc
     -Xclang -mcode-object-version=none
     -I${CMAKE_CURRENT_SOURCE_DIR}/include/rocshmem
     -I${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -200,12 +184,14 @@ endif()
 
 # Build bitcode for each GPU architecture
 #
-# __device__ API functions (rocshmem_quiet, rocshmem_barrier_wg, etc.) are DCE'd
-# by LLVM's -O3 passes when compiled per-TU: no amdgpu_kernel in the same TU
-# calls them, so the optimizer treats them as dead.  Fix: compile each source
-# with -Xclang -disable-llvm-passes (frontend runs at -O3, LLVM DCE is skipped,
-# all __device__ bodies are retained), then run opt -O3 over the merged BC where
-# all callers exist.  This mirrors the approach in CMakeDeviceBitcodeTester.cmake.
+# __device__ API functions (rocshmem_quiet, rocshmem_barrier_wg, etc.) have no
+# caller within their own TU -- they are public API for code that doesn't
+# exist yet at build time. BITCODE_COMPILE_FLAGS_BASE carries -fgpu-rdc, which
+# tells clang/LLVM this TU is part of a larger program, so real per-TU -O3
+# never strips genuinely external-linkage device functions. Each source is
+# compiled at real -O3, then all per-arch .bc files are merged with llvm-link
+# and reoptimized with opt -O3 once real cross-TU callers exist in the merged
+# module. This mirrors the approach in CMakeDeviceBitcodeTester.cmake.
 set(ALL_BITCODE_OUTPUTS)
 foreach(gpu_arch ${BITCODE_GPU_ARCHS})
   # Resolve the full arch string (with feature suffixes) for this base arch, so
@@ -228,9 +214,7 @@ foreach(gpu_arch ${BITCODE_GPU_ARCHS})
     endif()
   endif()
 
-  # Per-source flags: -Xclang -disable-llvm-passes suppresses DCE.
-  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${_FULL_ARCH}
-                     -Xclang -disable-llvm-passes)
+  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${_FULL_ARCH})
   set(BITCODE_OBJECTS_${gpu_arch})
   foreach(src_file ${BITCODE_SOURCES})
     get_filename_component(src_name ${src_file} NAME_WE)

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -337,6 +337,16 @@ and looking for the ``Name:`` field under each agent, for example
   may cause device bitcode load failures at runtime. Match the suffix to the actual
   configuration of the target system.
 
+.. note::
+
+  Requesting more than one feature variant of the same base architecture (for example
+  ``-DGPU_TARGETS="gfx90a:xnack+;gfx90a:xnack-"``) builds a fat binary containing both
+  variants into the main library. However, the installed device bitcode
+  (``librocshmem_device_gfx90a.bc``) is a single file and can only embed one variant's
+  feature metadata. The chosen variant is reported at configure time, for example:
+  ``Multiple feature variants requested for gfx90a (...); device bitcode will embed
+  gfx90a:xnack+``.
+
 Installation prefix
 ^^^^^^^^^^^^^^^^^^^
 

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -344,8 +344,7 @@ and looking for the ``Name:`` field under each agent, for example
   variants into the main library. However, the installed device bitcode
   (``librocshmem_device_gfx90a.bc``) is a single file and can only embed one variant's
   feature metadata. The chosen variant is reported at configure time, for example:
-  ``Multiple feature variants requested for gfx90a (...); device bitcode will embed
-  gfx90a:xnack+``.
+  ``Multiple feature variants requested for gfx90a (...); device bitcode will embed gfx90a:xnack+``.
 
 Installation prefix
 ^^^^^^^^^^^^^^^^^^^

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -59,21 +59,16 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
     endif()
   endforeach()
 
-  # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
-  # __device__ functions with no caller in their own TU.
-  # BITCODE_COMPILE_FLAGS_BASE (shared with DeviceBitcode.cmake) carries
-  # -fgpu-rdc, so real per-TU -O3 never DCEs genuinely external-linkage device
-  # functions -- no need to defer optimization via -Xclang
-  # -disable-llvm-passes (which also sidesteps the earlier -O0 AMDGPU backend
-  # register-class bug, since we stay at real -O3 throughout). The kernel BC
-  # and each device-source BC are compiled at real -O3, linked with
-  # llvm-link, then a final opt -O3 pass over the merged BC optimizes
-  # everything together (mirrors DeviceBitcode.cmake).
-  set(_TESTER_DEVICE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
-
-  # Compile the kernel and each device source into tester-private BCs.
-  set(_TESTER_BCS "")
-
+  # The kernel is compiled fresh (it stands in for an end user's own code),
+  # then linked directly against BITCODE_OUTPUT_${GPU_ARCH} -- the exact
+  # librocshmem_device_${GPU_ARCH}.bc that DeviceBitcode.cmake already built
+  # and ships to real users. This mirrors the real end-user distribution
+  # contract instead of independently recompiling BITCODE_SOURCES a second
+  # time. BITCODE_COMPILE_FLAGS_BASE carries -fgpu-rdc, so real per-TU -O3
+  # never DCEs genuinely external-linkage device functions even with zero
+  # in-TU callers, which is what makes it safe for both the kernel and the
+  # production bitcode to be compiled/optimized independently before being
+  # merged and re-optimized here.
   add_custom_command(
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}
@@ -85,34 +80,25 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
     COMMENT "device_bitcode_tester: compiling kernel for ${GPU_ARCH}"
     VERBATIM
   )
-  list(APPEND _TESTER_BCS ${KERNEL_BC})
-
-  foreach(_src ${BITCODE_SOURCES})
-    get_filename_component(_src_name "${_src}" NAME_WE)
-    set(_src_bc ${CMAKE_CURRENT_BINARY_DIR}/tester_device_${GPU_ARCH}_${_src_name}.bc)
-    add_custom_command(
-      OUTPUT ${_src_bc}
-      COMMAND ${LLVM_CLANG}
-        ${_TESTER_DEVICE_FLAGS}
-        --offload-arch=${_FULL_ARCH}
-        -c ${_src}
-        -o ${_src_bc}
-      DEPENDS ${_src}
-      COMMENT "device_bitcode_tester: compiling ${_src_name} for ${GPU_ARCH}"
-      VERBATIM
-    )
-    list(APPEND _TESTER_BCS ${_src_bc})
-  endforeach()
 
   set(_UNOPT_BC ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}_unopt.bc)
 
+  # rocshmem_device_bitcode is listed explicitly (in addition to the file
+  # itself) because the Unix Makefiles generator only resolves custom-command
+  # OUTPUT dependencies within the directory that defines them; a bare file
+  # dependency on BITCODE_OUTPUT_${GPU_ARCH} (produced in the top-level
+  # directory scope by DeviceBitcode.cmake) has no rule when recursed into
+  # from this directory's own generated Makefile on a clean build. Depending
+  # on the target instead gives a global build-order edge that works
+  # regardless of generator.
   add_custom_command(
     OUTPUT ${_UNOPT_BC}
     COMMAND ${LLVM_LINK}
-      ${_TESTER_BCS}
+      ${KERNEL_BC}
+      ${BITCODE_OUTPUT_${GPU_ARCH}}
       -o ${_UNOPT_BC}
-    DEPENDS ${_TESTER_BCS}
-    COMMENT "device_bitcode_tester: linking all device sources for ${GPU_ARCH}"
+    DEPENDS ${KERNEL_BC} ${BITCODE_OUTPUT_${GPU_ARCH}} rocshmem_device_bitcode
+    COMMENT "device_bitcode_tester: linking kernel against rocshmem device bitcode for ${GPU_ARCH}"
     VERBATIM
   )
 

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -44,9 +44,11 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(OBJ_FILE   ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.o)
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
 
-  # Find the full arch string (with feature suffixes) for this base arch so we can
-  # pass target-feature flags. Without features the amdhsa.target metadata in the
-  # HSACO omits the suffix, causing hipModuleLoadData error 209 on devices that
+  # Find the full arch string (with feature suffixes) for this base arch and
+  # pass it directly via --offload-arch= to the kernel/device-source compile
+  # steps below, so the frontend embeds the correct amdhsa.target metadata
+  # from the start. Without features the amdhsa.target metadata in the HSACO
+  # omits the suffix, causing hipModuleLoadData error 209 on devices that
   # report e.g. gfx950:sramecc+:xnack-.
   set(_FULL_ARCH "${GPU_ARCH}")
   foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
@@ -56,25 +58,18 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
       break()
     endif()
   endforeach()
-  arch_features_to_target_feature_flags("${_FULL_ARCH}" _CLANG_MATTR_FLAGS)
 
   # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
-  # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
-  # because no amdgpu_kernel in the same TU calls them. Compiling at -O0
-  # avoids DCE but produces unoptimized IR patterns that trigger an AMDGPU
-  # backend register-class bug (V_CMP_NE_U32 on $src_private_base).
-  #
-  # Solution: compile with -Xclang -disable-llvm-passes, which runs the
-  # frontend at -O3 (generating valid, structured IR) but skips the LLVM
-  # optimization and DCE passes. The resulting BC retains all device function
-  # bodies. After linking with the kernel (which provides callers), a final
-  # opt -O3 pass over the merged BC optimizes everything together.
-
-  # Device sources: suppress LLVM passes so DCE doesn't eliminate __device__
-  # functions that have no callers within the same TU. The kernel BC is compiled
-  # at plain -O3 (it has an amdgpu_kernel entry point, so nothing gets DCE'd).
+  # __device__ functions with no caller in their own TU.
+  # BITCODE_COMPILE_FLAGS_BASE (shared with DeviceBitcode.cmake) carries
+  # -fgpu-rdc, so real per-TU -O3 never DCEs genuinely external-linkage device
+  # functions -- no need to defer optimization via -Xclang
+  # -disable-llvm-passes (which also sidesteps the earlier -O0 AMDGPU backend
+  # register-class bug, since we stay at real -O3 throughout). The kernel BC
+  # and each device-source BC are compiled at real -O3, linked with
+  # llvm-link, then a final opt -O3 pass over the merged BC optimizes
+  # everything together (mirrors DeviceBitcode.cmake).
   set(_TESTER_DEVICE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
-  list(APPEND _TESTER_DEVICE_FLAGS -Xclang -disable-llvm-passes)
 
   # Compile the kernel and each device source into tester-private BCs.
   set(_TESTER_BCS "")
@@ -83,7 +78,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}
       ${BITCODE_COMPILE_FLAGS_BASE}
-      --offload-arch=${GPU_ARCH}
+      --offload-arch=${_FULL_ARCH}
       -c ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip
       -o ${KERNEL_BC}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip
@@ -99,7 +94,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
       OUTPUT ${_src_bc}
       COMMAND ${LLVM_CLANG}
         ${_TESTER_DEVICE_FLAGS}
-        --offload-arch=${GPU_ARCH}
+        --offload-arch=${_FULL_ARCH}
         -c ${_src}
         -o ${_src_bc}
       DEPENDS ${_src}
@@ -140,7 +135,6 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
     COMMAND ${LLVM_CLANG}
       -target amdgcn-amd-amdhsa
       -mcpu=${GPU_ARCH}
-      ${_CLANG_MATTR_FLAGS}
       -mllvm -amdgpu-internalize-symbols=false
       -x ir
       -c ${LINKED_BC}

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -62,13 +62,8 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   # The kernel is compiled fresh (it stands in for an end user's own code),
   # then linked directly against BITCODE_OUTPUT_${GPU_ARCH} -- the exact
   # librocshmem_device_${GPU_ARCH}.bc that DeviceBitcode.cmake already built
-  # and ships to real users. This mirrors the real end-user distribution
-  # contract instead of independently recompiling BITCODE_SOURCES a second
-  # time. BITCODE_COMPILE_FLAGS_BASE carries -fgpu-rdc, so real per-TU -O3
-  # never DCEs genuinely external-linkage device functions even with zero
-  # in-TU callers, which is what makes it safe for both the kernel and the
-  # production bitcode to be compiled/optimized independently before being
-  # merged and re-optimized here.
+  # and ships to real users -- instead of independently recompiling
+  # BITCODE_SOURCES a second time.
   add_custom_command(
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}


### PR DESCRIPTION
## Technical Details

- `CMakeLists.txt`: stopped stripping feature suffixes off `GPU_TARGETS` before validation — `rocm_check_target_ids` now validates and echoes back full suffixed strings (e.g. `gfx950:sramecc+:xnack-`) natively via its own compiler-flag check, removing the old bare-arch/full-arch bookkeeping (`_bare_targets`, `_USER_FULL_${_base}`) entirely
- `CMakeLists.txt`: `GPU_TARGETS` is now deduped on the exact string rather than base arch, so the same base arch can legitimately appear more than once with different feature suffixes (fat-binary case)
- `cmake/DeviceBitcode.cmake`: main device-bitcode compile loop now resolves the full feature-suffixed arch string (from `BITCODE_GPU_ARCHS_FULL`) per base arch and uses it for `--offload-arch=`, instead of the bare arch; when more than one suffix variant is requested for the same base arch, logs which one was chosen for embedding (only one variant's metadata can be embedded in the single installed `.bc` file)
- `docs/build.rst`: added a note documenting the multi-variant-per-base-arch fat-binary caveat and the configure-time log message that reports which variant's metadata gets embedded in the device bitcode
- `CMakeLists.txt`: relocated the ASAN `xnack-` filter (`list(FILTER GPU_TARGETS/GPU_TARGETS_FULL EXCLUDE REGEX ".*:xnack-$")`) to run before `find_package(hip REQUIRED)` instead of after — previously it only ever affected the separate device-bitcode build, never the main library's actual `hip::device` compile/link flags
- `CMakeLists.txt`: added an unconditional `set(GPU_BUILD_TARGETS "${GPU_TARGETS}" CACHE STRING ... FORCE)` immediately before `find_package(hip REQUIRED)`, so HIP's own non-`FORCE`d cache variable can no longer go stale across reconfigures (fixes both the ASAN case and the general case of changing `-DGPU_TARGETS=...` on an existing build directory)
- `CMakeLists.txt`: relocated `ASAN_RUNTIME_DIR` detection (`execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=...)`) to run after `project(... LANGUAGES CXX)` instead of before — previously `CMAKE_CXX_COMPILER` was unpopulated at that point, silently producing an empty path that corrupted the ASAN RPATH link flag (`-Wl,-rpath,`) and broke linking (`undefined symbol: main`) for every ASAN executable
- `DEBUG.md`: removed the obsolete manual `ccmake`/"delete `COMPILING_TARGETS`" workaround (a cache variable name that doesn't exist in this codebase); documents that toggling `-DASAN=ON`/`-DASAN=OFF` on an existing build directory now correctly and automatically refreshes GPU offload targets
- `cmake/DeviceBitcode.cmake`: replaced the per-source `-Xclang -disable-llvm-passes` DCE workaround with `-fgpu-rdc` added to `BITCODE_COMPILE_FLAGS_BASE`. Marking each TU as part of a larger relocatable-device-code program means real per-TU `-O3` no longer DCEs externally-visible `__device__` API functions that have no in-TU callers, so device sources now compile at genuine `-O3` throughout instead of deferring optimization to the merged bitcode (mirrors the flag already used to build `librocshmem.a` in `src/CMakeLists.txt`)
- `cmake/DeviceBitcode.cmake` and `tests/functional_tests/CMakeDeviceBitcodeTester.cmake`: removed the now-unnecessary `arch_features_to_target_feature_flags` helper and its `-Xclang -target-feature` flag generation — `--offload-arch=<full-arch-string>` (already resolved via `BITCODE_GPU_ARCHS_FULL`) carries the feature suffix into the frontend directly, so the tester's separate post-link `-mcpu=`+`-target-feature` pass is no longer needed
- `tests/functional_tests/CMakeDeviceBitcodeTester.cmake`: tester no longer independently recompiles `BITCODE_SOURCES` into tester-private bitcode; it now links its freshly-compiled kernel bitcode directly against the real `BITCODE_OUTPUT_${GPU_ARCH}` (the same `librocshmem_device_${arch}.bc` that `DeviceBitcode.cmake` builds and ships to users), so the test exercises the exact bitcode end users get rather than a parallel recompilation. Adds an explicit dependency on the `rocshmem_device_bitcode` target, since the Unix Makefiles generator doesn't resolve a custom-command `OUTPUT` dependency defined in a different directory scope otherwise
- Fixes in the main `CMakeLists.txt:L309-L353`: when ASAN=ON, the config now automatically drops gfx1100/gfx1201/gfx1250 (no `xnack+` variant exists) and appends `:xnack+` to any CDNA target (gfx90a/gfx942/gfx950) that doesn't already specify a feature suffix. Otherwise we get clang nagging about unsupported arch. Verified with a `configure+build against ROCm 7.14`. Now, no more manual `-DGPU_TARGETS="gfx950:xnack+"` needed

## Test Results:

- Verified via 6 build scenarios: default `GPU_TARGETS`, exact hardware-matching arch, non-matching arch, ASAN with mixed `xnack+`/`xnack-` targets, multi-variant fat binary (`gfx90a:xnack+;gfx90a:xnack-`), and `BUILD_LOCAL_GPU_TARGET_ONLY=ON` — all build clean with zero rocSHMEM warnings/errors
- Confirmed via `compile_commands.json` that ASAN builds no longer compile any `:xnack-` target into the main library
- Confirmed the "Multiple feature variants requested for gfx90a ..." log message fires correctly
- `device_bitcode` ctest suite (8 variants): passes on non-ASAN hardware-matching configurations, and correctly hard-fails (not silently skips) on non-matching configurations (`hipGetSymbolAddress: invalid kernel file`), which is expected/correct behavior

## Further Tests Plan

- [x] Re-verify the 6 build scenarios and `device_bitcode` ctest suite after the `-fgpu-rdc` / tester-reuse changes
- [ ] Verify all the above on older compilers, especially before ROCm 7.1
- [x] Verify ASAN on the supported archs

## Issue Tracking

JIRA ID: AIROCSHMEM-497
JIRA ID: AIROCSHMEM-502
