### PR TITLE
fix(rocjitsu): Fix gfx1250 DS_LOAD_TR8_B64 transpose selection and swmmac layouts

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -554,6 +554,16 @@ class IsaProfile(ABC):
         return False
 
     @property
+    def ds_b8_transpose_kind(self) -> int:
+        """Cross-lane routing used by 8-bit B64 DS transpose loads.
+
+        CDNA4 and older targets use the MFMA-oriented B64_TR_B8 routing.
+        Architectures with the 16x16 WMMA routing override this property so
+        opcode aliases cannot acquire different behavior from their spelling.
+        """
+        return 3
+
+    @property
     def cmpx_writes_vcc(self) -> bool:
         """True if V_CMPX instructions write both EXEC and VCC.
 
@@ -1980,6 +1990,10 @@ class Rdna4Profile(_AmdgpuProfileBase):
         )
 
     @property
+    def ds_b8_transpose_kind(self) -> int:
+        return 6
+
+    @property
     def waitcnt_lgkmcnt_mask(self) -> str:
         # RDNA4 removed S_WAITCNT; this property is unused but kept for
         # completeness. Returns 0x3F as a safe no-op default.
@@ -2153,6 +2167,12 @@ class Cdna5Profile(Rdna4Profile):
     @property
     def cpp_namespace(self) -> str | None:
         return 'cdna5'
+
+    @property
+    def ds_b8_transpose_kind(self) -> int:
+        # gfx1250 opcode 0xfd retains the B64_TR_B8 routing. All of its
+        # mnemonic aliases must resolve through this one profile value.
+        return 3
 
     @property
     def semantic_overrides(self) -> dict[str, tuple[str, ...]]:

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -17,6 +17,7 @@ import re
 
 if TYPE_CHECKING:
     from amdisa.gpuisa import IsaSpec
+    from amdisa.isa_profile import IsaProfile
 
 
 @dataclass
@@ -1821,17 +1822,20 @@ _TRANSPOSE_LOAD_MAP: dict[str, tuple[str, int, int, int]] = {
     # suffix -> (semantic suffix, elem_size, num_elems, transpose kind)
     # elem_size/num_elems describe the raw VGPR result size in dwords.
     # transpose kind is amdgpu::TransposeKind: TR_B4=1, TR_B6=2,
-    # B64_TR_B8=3 (CDNA4 MFMA layout), TR16_B128=4, B64_TR_B16=5,
-    # WMMA_TR_B8=6 (CDNA5/RDNA4 16x16 matrix layout).
+    # B64_TR_B8=3 (CDNA4 MFMA / CDNA5 DS layout), TR16_B128=4,
+    # B64_TR_B16=5,
+    # WMMA_TR_B8=6 (RDNA4 16x16 matrix layout). All textual aliases use the
+    # same default here; instruction-family and ISA-profile overrides below
+    # select the architecture's routing.
     'B64_TR_B4': ('b4', 4, 2, 1),
     'B96_TR_B6': ('b6', 4, 3, 2),
     'B64_TR_B8': ('b8', 4, 2, 3),
     'B64_TR_B16': ('b16', 4, 2, 5),
     'TR4_B64': ('b4', 4, 2, 1),
     'TR6_B96': ('b6', 4, 3, 2),
-    'TR8_B64': ('b8', 4, 2, 6),
+    'TR8_B64': ('b8', 4, 2, 3),
     'TR16_B128': ('b16', 4, 4, 4),
-    'TR_B64': ('b8', 4, 2, 6),
+    'TR_B64': ('b8', 4, 2, 3),
     'TR_B128': ('b16', 4, 4, 4),
 }
 
@@ -2039,7 +2043,9 @@ def _derive_flat(name: str) -> InstructionSemantics | None:
             if prefix == 'GLOBAL_LOAD_':
                 transpose_info = _derive_transpose_load_info(upper)
                 if transpose_info:
-                    _, esz, ne, transpose_kind = transpose_info
+                    kind, esz, ne, transpose_kind = transpose_info
+                    if kind == 'b8':
+                        transpose_kind = 6
                     return InstructionSemantics(
                         name,
                         'flat_load',
@@ -2584,7 +2590,9 @@ _ENC_DERIVE = {
 }
 
 
-def derive_semantics(name: str, enc_name: str) -> InstructionSemantics | None:
+def derive_semantics(
+    name: str, enc_name: str, profile: IsaProfile | None = None
+) -> InstructionSemantics | None:
     """Derive execution semantics for an instruction from its name and encoding.
 
     The encoding format name selects a format-specific derivation function
@@ -2594,6 +2602,7 @@ def derive_semantics(name: str, enc_name: str) -> InstructionSemantics | None:
     Args:
         name: Instruction mnemonic (e.g. ``S_ADD_I32``).
         enc_name: Encoding format name (e.g. ``ENC_SOP2``, ``VOP3A``).
+        profile: Optional ISA profile for architecture-specific semantic data.
 
     Returns:
         InstructionSemantics if the instruction could be classified, or
@@ -2620,6 +2629,13 @@ def derive_semantics(name: str, enc_name: str) -> InstructionSemantics | None:
             sem = fallback(name)
             if sem is not None:
                 break
+
+    if (
+        sem is not None
+        and profile is not None
+        and sem.semantic_class == 'ds_read_tr_b8'
+    ):
+        sem = replace(sem, transpose_kind=profile.ds_b8_transpose_kind)
 
     return sem
 
@@ -2660,7 +2676,7 @@ def derive_all_semantics(isa_spec: IsaSpec) -> SemanticsSpec:
                     data_type=data_type or None,
                 )
                 continue
-            sem = derive_semantics(inst.name, enc.enc_name)
+            sem = derive_semantics(inst.name, enc.enc_name, isa_spec.profile)
             if sem is not None:
                 semantic_class = class_overrides.get(inst.name)
                 if semantic_class is not None:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -254,6 +254,39 @@ def test_gfx1250_profile_scopes_special_ds_semantics() -> None:
 
 
 @pytest.mark.parametrize(
+    ('profile', 'expected_kind'),
+    [
+        (Cdna4Profile(), 3),
+        (Rdna4Profile(), 6),
+        (Cdna5Profile(), 3),
+    ],
+)
+def test_b8_transpose_aliases_share_profile_routing(profile, expected_kind) -> None:
+    names = ('DS_LOAD_TR8_B64', 'DS_LOAD_B64_TR_B8', 'DS_LOAD_TR_B64')
+    spec = SimpleNamespace(
+        profile=profile,
+        inst_encodings=[
+            SimpleNamespace(
+                enc_name='ENC_VDS',
+                insts=[SimpleNamespace(name=name) for name in names],
+            )
+        ],
+    )
+
+    semantics = derive_all_semantics(spec)
+
+    assert {semantics[name].transpose_kind for name in names} == {expected_kind}
+
+
+def test_gfx1250_ds_b8_transpose_uses_profile_routing(
+    gfx1250_generated_root: Path,
+) -> None:
+    vds = (gfx1250_generated_root / 'vds_exec.cpp').read_text()
+    body = _generated_method_body(vds, 'DsLoadTr8B64Vds', 'DsLoadB96Vds')
+    assert 'd->transpose = 3;' in body
+
+
+@pytest.mark.parametrize(
     ('name', 'elem_size', 'scale', 'dst_dwords'),
     [
         ('DS_STOREXCHG_2ADDR_RTN_B32', 4, '4U', 1),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from amdisa.isa_profile import Cdna5Profile
 from amdisa.semantics import derive_semantics
 from amdisa.sema_ast import (
     ExecModel,
@@ -2038,7 +2039,7 @@ class TestDeriveFlatLoad:
         ],
     )
     def test_gfx1250_global_transpose_loads(self, name, num_elems, transpose_kind):
-        sem = derive_semantics(name, 'ENC_VGLOBAL')
+        sem = derive_semantics(name, 'ENC_VGLOBAL', Cdna5Profile())
         assert sem is not None
         assert sem.semantic_class == 'flat_load'
         assert sem.elem_size == 4
@@ -2234,8 +2235,8 @@ class TestDeriveDsRead:
         [
             ('DS_LOAD_TR4_B64', 'ds_read_tr_b4', 2, 1),
             ('DS_LOAD_TR6_B96', 'ds_read_tr_b6', 3, 2),
-            ('DS_LOAD_TR8_B64', 'ds_read_tr_b8', 2, 6),
-            ('DS_LOAD_TR_B64', 'ds_read_tr_b8', 2, 6),
+            ('DS_LOAD_TR8_B64', 'ds_read_tr_b8', 2, 3),
+            ('DS_LOAD_TR_B64', 'ds_read_tr_b8', 2, 3),
             ('DS_LOAD_TR16_B128', 'ds_read_tr_b16', 4, 4),
             ('DS_LOAD_TR_B128', 'ds_read_tr_b16', 4, 4),
             ('DS_READ_B64_TR_B16', 'ds_read_tr_b16', 2, 5),
@@ -2244,7 +2245,7 @@ class TestDeriveDsRead:
     def test_gfx1250_ds_transpose_loads(
         self, name, semantic_class, num_elems, transpose_kind
     ):
-        sem = derive_semantics(name, 'ENC_DS')
+        sem = derive_semantics(name, 'ENC_DS', Cdna5Profile())
         assert sem is not None
         assert sem.semantic_class == semantic_class
         assert sem.elem_size == 4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
@@ -3243,7 +3243,7 @@ void DsLoadTr8B64Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->num_elems = 2;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  d->transpose = 6;
+  d->transpose = 3;
   ds_calculate_addresses_all_lanes(inst_, wf, *d);
   set_data(std::move(d));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
@@ -11,8 +11,8 @@
 /// cross-lane shuffle to produce the transposed matrix layout expected by
 /// matrix instructions.
 ///
-/// B64_TR_B8 is the CDNA4 MFMA byte transpose with groups of 4 consecutive
-/// lanes. WMMA_TR_B8 is the CDNA5/RDNA4 16x16 byte-matrix transpose.
+/// B64_TR_B8 is the CDNA4 MFMA and CDNA5 DS byte transpose with groups of 4
+/// consecutive lanes. WMMA_TR_B8 is used by RDNA4 and CDNA5 global loads.
 /// TR16_B128 (gfx1250 ds/global_load_tr16_b128, RDNA4 global_load_tr_b128)
 /// transposes 16-bit elements within groups of 8 consecutive lanes.
 /// B64_TR_B16 (CDNA4 ds_read_b64_tr_b16) is a 4x16-lane halfword transpose
@@ -37,7 +37,7 @@ enum class TransposeKind : uint8_t {
   WMMA_TR_B8 = 6,
 };
 
-/// @brief CDNA4 B64 byte-level MFMA transpose (B64_TR_B8 only).
+/// @brief CDNA4 MFMA / CDNA5 DS B64 byte-level transpose (B64_TR_B8 only).
 ///
 /// Groups of 4 source lanes, 8 byte iterations per group.
 /// Each iteration packs one byte from each of 4 source lanes into a dword
@@ -81,7 +81,7 @@ inline void transpose_b64_tr_b8(std::vector<uint8_t> &response_data, uint32_t nu
   response_data = std::move(output);
 }
 
-/// @brief CDNA5/RDNA4 16x16 8-bit WMMA transpose-load layout.
+/// @brief RDNA4 and CDNA5 global-load 16x16 8-bit WMMA transpose layout.
 ///
 /// Each of source lanes 0..31 reads eight adjacent matrix rows for one K
 /// coordinate. Wave32 writes two VGPRs per lane. RDNA4 Wave64 consumes the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -270,8 +270,10 @@ inline InputLoc wmma_input_loc(uint32_t dim, uint32_t K, uint32_t i, uint32_t k,
 
   if (dim == 16 && K >= 32) {
     uint32_t block_elems = elems_per_group / 2;
-    if (data_bits == 8)
-      block_elems = 8;
+    // CDNA5 K=128 dense WMMA uses 16-element K blocks. Do not change the
+    // pre-existing K=64 family, which uses the default 16-element blocks too.
+    if (data_bits == 8 && K == 128)
+      block_elems = 16;
     if (data_bits == 4 && K == 128)
       block_elems = 16;
     if (block_elems != 0) {
@@ -525,14 +527,6 @@ struct SwmmacIndexLoc {
 
 inline SwmmacIndexLoc swmmac_index_loc(uint32_t M, uint32_t K, uint32_t elem_bits, uint32_t row,
                                        uint32_t compressed_k, uint32_t index_entries) {
-  // CDNA5 K=128 8-bit sparse A follows the ordinary 16x64 8-bit layout.
-  // Its index fields occupy the same physical lane/slot as the corresponding
-  // compressed A element.
-  if (M == 16 && K == 128 && elem_bits == 8 && index_entries == 32) {
-    const uint32_t lane = row + 16u * ((compressed_k >> 3) & 1u);
-    const uint32_t slot = (compressed_k & 7u) + 8u * (compressed_k >> 4);
-    return {lane, slot};
-  }
   // RDNA4 K=32 SWMMAC uses the gfx12 builtin layout: each row's 16 sparse
   // 2-bit entries are split across two lanes. f16/bf16 split by pairs of
   // K-groups; fp8/bf8/iu8 split linearly by the low/high K=16 block.
@@ -565,11 +559,6 @@ inline SwmmacIndexLoc swmmac_index_loc(uint32_t wave_size, uint32_t M, uint32_t 
 
 inline InputLoc swmmac_a_input_loc(uint32_t M, uint32_t K, uint32_t row, uint32_t compressed_k,
                                    uint32_t elem_bits) {
-  if (M == 16 && K == 128 && elem_bits == 8) {
-    const uint32_t lane = row + 16u * ((compressed_k >> 3) & 1u);
-    const uint32_t slot = (compressed_k & 7u) + 8u * (compressed_k >> 4);
-    return wmma_packed_input_loc(lane, slot, elem_bits);
-  }
   if (M == 16 && K == 32) {
     const uint32_t group = compressed_k / 2u;
     const uint32_t slot = compressed_k & 1u;
@@ -606,8 +595,10 @@ inline InputLoc swmmac_a_input_loc(uint32_t wave_size, uint32_t M, uint32_t K, u
 inline InputLoc swmmac_b_input_loc(uint32_t N, uint32_t K, uint32_t col, uint32_t dense_k,
                                    uint32_t elem_bits) {
   if (N == 16 && K == 128 && elem_bits == 8) {
-    const uint32_t lane = col + 16u * ((dense_k >> 4) & 1u);
-    const uint32_t slot = (dense_k & 15u) + 16u * (dense_k >> 5);
+    // K=128 SWMMAC keeps the sparse instruction's 32-element B ordering;
+    // it is not the dense K=128 WMMA operand layout.
+    const uint32_t lane = col + 16u * ((dense_k >> 5) & 1u);
+    const uint32_t slot = (dense_k & 31u) + 32u * (dense_k >> 6);
     return wmma_packed_input_loc(lane, slot, elem_bits);
   }
   if (N == 16 && K == 32) {

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -1641,14 +1641,16 @@ TEST(Gfx1250ExecutionTest, SwmmacIu8K128MatchesIndependentSparseLayoutOracle) {
         const uint32_t ck = 2u * group + which;
         const uint8_t value = static_cast<uint8_t>(1u + ((row * 3u + group + which * 2u) % 7u));
         compressed_a[row][ck] = value;
-        const uint32_t lane = row + 16u * ((ck >> 3) & 1u);
-        const uint32_t slot = (ck & 7u) + 8u * (ck >> 4);
-        write_byte(kA, lane, slot, value);
+        const uint32_t a_lane = row + 16u * ((ck >> 4) & 1u);
+        const uint32_t a_slot = (ck & 15u) + 16u * (ck >> 5);
+        write_byte(kA, a_lane, a_slot, value);
 
-        const uint32_t word = slot / 16;
-        const uint32_t shift = 2u * (slot % 16);
-        const uint32_t old = cu.read_vgpr(base + kIndex + word, lane);
-        cu.write_vgpr(base + kIndex + word, lane, old | ((pair[which] & 3u) << shift));
+        const uint32_t index_lane = row + 16u * (ck / 32u);
+        const uint32_t index_slot = ck % 32u;
+        const uint32_t word = index_slot / 16;
+        const uint32_t shift = 2u * (index_slot % 16);
+        const uint32_t old = cu.read_vgpr(base + kIndex + word, index_lane);
+        cu.write_vgpr(base + kIndex + word, index_lane, old | ((pair[which] & 3u) << shift));
       }
     }
 
@@ -1656,8 +1658,8 @@ TEST(Gfx1250ExecutionTest, SwmmacIu8K128MatchesIndependentSparseLayoutOracle) {
     for (uint32_t col = 0; col < 16; ++col) {
       const uint8_t value = static_cast<uint8_t>(1u + ((k * 5u + col * 3u) % 11u));
       dense_b[col][k] = value;
-      const uint32_t lane = col + 16u * ((k >> 4) & 1u);
-      const uint32_t slot = (k & 15u) + 16u * (k >> 5);
+      const uint32_t lane = col + 16u * ((k >> 5) & 1u);
+      const uint32_t slot = (k & 31u) + 32u * (k >> 6);
       write_byte(kB, lane, slot, value);
     }
 

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -2597,11 +2597,11 @@ TEST(Cdna4Permlane16SwapExecutionTest, Wave64SwapsAllFourGroups) {
     wf->halt();
 }
 
-uint32_t wmma64_ab_lane(uint32_t row_or_col, uint32_t k) {
-  return row_or_col + 16u * ((k >> 3) & 1u);
+uint32_t gfx1250_fp8_ab_lane(uint32_t row_or_col, uint32_t k) {
+  return row_or_col + 16u * ((k >> 4) & 1u);
 }
 
-uint32_t wmma64_ab_index(uint32_t k) { return (k & 7u) + 8u * (k >> 4); }
+uint32_t gfx1250_fp8_ab_index(uint32_t k) { return (k & 15u) + 16u * (k >> 5); }
 
 TEST(Gfx1250WmmaTest, Fp8K128PhysicalLayoutMatchesCdna5Anchors) {
   struct LayoutAnchor {
@@ -2610,8 +2610,8 @@ TEST(Gfx1250WmmaTest, Fp8K128PhysicalLayoutMatchesCdna5Anchors) {
     uint32_t slot;
   };
   constexpr LayoutAnchor anchors[] = {
-      {0, 0, 0},   {7, 0, 7},   {8, 1, 0},   {15, 1, 7},   {16, 0, 8},
-      {63, 1, 31}, {64, 0, 32}, {72, 1, 32}, {127, 1, 63},
+      {0, 0, 0},   {15, 0, 15}, {16, 1, 0},  {31, 1, 15},  {32, 0, 16},
+      {63, 1, 31}, {64, 0, 32}, {80, 1, 32}, {127, 1, 63},
   };
   constexpr uint32_t row_or_col = 3;
 
@@ -2625,8 +2625,8 @@ TEST(Gfx1250WmmaTest, Fp8K128PhysicalLayoutMatchesCdna5Anchors) {
       EXPECT_EQ(loc.sub_element, anchor.slot % 4u);
       EXPECT_EQ(loc.data_bits, 8u);
     }
-    EXPECT_EQ(wmma64_ab_lane(row_or_col, anchor.k), row_or_col + 16u * anchor.lane_half);
-    EXPECT_EQ(wmma64_ab_index(anchor.k), anchor.slot);
+    EXPECT_EQ(gfx1250_fp8_ab_lane(row_or_col, anchor.k), row_or_col + 16u * anchor.lane_half);
+    EXPECT_EQ(gfx1250_fp8_ab_index(anchor.k), anchor.slot);
   }
 }
 
@@ -2699,15 +2699,15 @@ TEST(Gfx1250WmmaTest, F16Fp8K64MatchesReferenceLayout) {
 
   for (uint32_t row = 0; row < 16; ++row) {
     for (uint32_t k = 0; k < 64; ++k) {
-      const uint32_t idx = wmma64_ab_index(k);
-      write_packed_byte(*cu, a_base + idx / 4u, wmma64_ab_lane(row, k), idx % 4u,
+      const uint32_t idx = gfx1250_fp8_ab_index(k);
+      write_packed_byte(*cu, a_base + idx / 4u, gfx1250_fp8_ab_lane(row, k), idx % 4u,
                         util::f32_to_fp8_e4m3_rne(wmma_test_a(row, k)));
     }
   }
   for (uint32_t k = 0; k < 64; ++k) {
     for (uint32_t col = 0; col < 16; ++col) {
-      const uint32_t idx = wmma64_ab_index(k);
-      write_packed_byte(*cu, b_base + idx / 4u, wmma64_ab_lane(col, k), idx % 4u,
+      const uint32_t idx = gfx1250_fp8_ab_index(k);
+      write_packed_byte(*cu, b_base + idx / 4u, gfx1250_fp8_ab_lane(col, k), idx % 4u,
                         util::f32_to_fp8_e4m3_rne(wmma_test_b(k, col)));
     }
   }

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -396,16 +396,15 @@ TEST(MfmaExecTest, Gfx11WmmaIu8InputLocReplicatesKAcrossHalfwaves) {
   EXPECT_EQ(g1k15.sub_element, 3u);
 }
 
-TEST(MfmaExecTest, Gfx1250WmmaIu8InputLocMatchesEightElementKBlocks) {
+TEST(MfmaExecTest, Gfx1250WmmaIu8K64PreservesSixteenElementKBlocks) {
   struct Anchor {
     uint32_t k;
     uint32_t lane;
     uint32_t slot;
   };
   constexpr std::array anchors{
-      Anchor{0, 3, 0},   Anchor{7, 3, 7},    Anchor{8, 19, 0},   Anchor{15, 19, 7},
-      Anchor{16, 3, 8},  Anchor{24, 19, 8},  Anchor{32, 3, 16},  Anchor{40, 19, 16},
-      Anchor{48, 3, 24}, Anchor{56, 19, 24}, Anchor{63, 19, 31},
+      Anchor{0, 3, 0},   Anchor{15, 3, 15}, Anchor{16, 19, 0},  Anchor{31, 19, 15},
+      Anchor{32, 3, 16}, Anchor{47, 3, 31}, Anchor{48, 19, 16}, Anchor{63, 19, 31},
   };
   for (const auto &anchor : anchors) {
     const auto loc = amdgpu::wmma_input_loc(16, 64, /*i=*/3, anchor.k, 8);
@@ -494,21 +493,21 @@ TEST(MfmaExecTest, SwmmacK32InputLocUsesSparseHardwareLayout) {
 
 TEST(MfmaExecTest, Gfx1250SwmmacK128Iu8LocationsMatchSparseManual) {
   for (uint32_t ck = 0; ck < 64; ++ck) {
-    const uint32_t expected_lane = 5u + 16u * ((ck >> 3) & 1u);
-    const uint32_t expected_slot = (ck & 7u) + 8u * (ck >> 4);
+    const uint32_t expected_a_lane = 5u + 16u * ((ck >> 4) & 1u);
+    const uint32_t expected_a_slot = (ck & 15u) + 16u * (ck >> 5);
     const auto a = amdgpu::swmmac_a_input_loc(16, 128, /*row=*/5, ck, 8);
-    EXPECT_EQ(a.lane, expected_lane) << ck;
-    EXPECT_EQ(a.vgpr_offset, expected_slot / 4) << ck;
-    EXPECT_EQ(a.sub_element, expected_slot % 4) << ck;
+    EXPECT_EQ(a.lane, expected_a_lane) << ck;
+    EXPECT_EQ(a.vgpr_offset, expected_a_slot / 4) << ck;
+    EXPECT_EQ(a.sub_element, expected_a_slot % 4) << ck;
 
     const auto index = amdgpu::swmmac_index_loc(16, 128, 8, /*row=*/5, ck, /*index_entries=*/32);
-    EXPECT_EQ(index.lane, expected_lane) << ck;
-    EXPECT_EQ(index.local_compressed_k, expected_slot) << ck;
+    EXPECT_EQ(index.lane, 5u + 16u * (ck / 32u)) << ck;
+    EXPECT_EQ(index.local_compressed_k, ck % 32u) << ck;
   }
 
   for (uint32_t k = 0; k < 128; ++k) {
-    const uint32_t expected_lane = 7u + 16u * ((k >> 4) & 1u);
-    const uint32_t expected_slot = (k & 15u) + 16u * (k >> 5);
+    const uint32_t expected_lane = 7u + 16u * ((k >> 5) & 1u);
+    const uint32_t expected_slot = (k & 31u) + 32u * (k >> 6);
     const auto b = amdgpu::swmmac_b_input_loc(16, 128, /*col=*/7, k, 8);
     EXPECT_EQ(b.lane, expected_lane) << k;
     EXPECT_EQ(b.vgpr_offset, expected_slot / 4) << k;
@@ -878,9 +877,8 @@ TEST(MfmaExecTest, WmmaF8f6f4K128InputLocMatchesManualLayoutsExhaustively) {
         uint32_t expected_lane;
         uint32_t expected_slot;
         if (data_bits == 8) {
-          // CDNA5 defines K=128 as two consecutive K=64 matrices.
-          expected_lane = index + 16u * ((k >> 3u) & 1u);
-          expected_slot = (k & 7u) + 8u * (k >> 4u);
+          expected_lane = index + 16u * ((k >> 4u) & 1u);
+          expected_slot = (k & 15u) + 16u * (k >> 5u);
         } else {
           expected_lane = index + 16u * ((k >> 2u) & 1u);
           const uint32_t expected_reg = ((k >> 1u) & 1u) + 2u * ((k >> 3u) & 1u) +


### PR DESCRIPTION
Fixing regressions caused by #10447 
Github Issue: https://github.com/ROCm/rocm-systems/issues/10522