### PR TITLE
feat(rdc): add CU occupancy fields sourced from amdsmi process list

### DIFF
--- a/projects/rdc/common/rdc_field.data
+++ b/projects/rdc/common/rdc_field.data
@@ -93,6 +93,8 @@ FLD_DESC_ENT(RDC_FI_GPU_GTT_FREE,        "Free GTT memory in bytes",            
 FLD_DESC_ENT(RDC_FI_GPU_GFX_BUSY_INST,   "Instantaneous GFX busy percentage",           "GFX_BUSY_INST",    true)
 FLD_DESC_ENT(RDC_FI_GPU_VCN_BUSY_INST,   "Instantaneous VCN busy percentage",           "VCN_BUSY_INST",    true)
 FLD_DESC_ENT(RDC_FI_GPU_JPEG_BUSY_INST,  "Instantaneous JPEG busy percentage",          "JPEG_BUSY_INST",   true)
+FLD_DESC_ENT(RDC_FI_GPU_CU_OCCUPANCY,    "Compute units occupied by all processes",     "CU_OCCUPANCY",     true)
+FLD_DESC_ENT(RDC_FI_GPU_CU_OCCUPANCY_PERCENT, "Percent of compute units occupied",      "CU_OCCUPANCY_PERCENT", true)
 FLD_DESC_ENT(RDC_FI_GPU_PAGE_RETRIED,    "Retried page of the GPU instance",            "GPU_PAGE_RETRIED", true)
 
 // ECC totals

--- a/projects/rdc/include/rdc/rdc.h
+++ b/projects/rdc/include/rdc/rdc.h
@@ -243,6 +243,11 @@ typedef enum {
   RDC_FI_GPU_GFX_BUSY_INST,         //!< Instantaneous GFX busy percentage
   RDC_FI_GPU_VCN_BUSY_INST,         //!< Instantaneous VCN busy percentage
   RDC_FI_GPU_JPEG_BUSY_INST,        //!< Instantaneous JPEG busy percentage
+  RDC_FI_GPU_CU_OCCUPANCY,          //!< Compute units occupied, summed over all processes on the
+                                    // GPU. Instantaneous wave-count snapshot from KFD, not a
+                                    // time average - see the note in the user guide.
+  RDC_FI_GPU_CU_OCCUPANCY_PERCENT,  //!< RDC_FI_GPU_CU_OCCUPANCY as a percentage of the GPU's
+                                    // compute units. Matches `amd-smi monitor --process` CU%.
 
   /**
    * @brief GPU page related fields

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -986,6 +986,60 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
       }
       break;
     }
+    case RDC_FI_GPU_CU_OCCUPANCY:
+    case RDC_FI_GPU_CU_OCCUPANCY_PERCENT: {
+      // Unlike gfx_activity, CU occupancy is only exposed per process, so the
+      // per-GPU value is the sum over every process holding this device.
+      //
+      // Two caveats worth knowing before acting on this field. It is an
+      // instantaneous wave-count snapshot taken by KFD at read time with no
+      // averaging, so a duty-cycled workload reads low unless sampled fast.
+      // And on gfx942 the kernel derives it from XCC0 alone and scales by the
+      // XCC count, so it is exact only when workgroups divide evenly across
+      // XCCs and biased high otherwise.
+      value->type = INTEGER;
+
+      uint32_t num_proc = 0;
+      value->status = amdsmi_get_gpu_process_list(processor_handle, &num_proc, nullptr);
+      if (value->status != AMDSMI_STATUS_SUCCESS) {
+        break;
+      }
+
+      int64_t cu_sum = 0;
+      if (num_proc > 0) {
+        std::vector<amdsmi_proc_info_t> procs(num_proc);
+        value->status = amdsmi_get_gpu_process_list(processor_handle, &num_proc, procs.data());
+        if (value->status != AMDSMI_STATUS_SUCCESS) {
+          break;
+        }
+        // num_proc is updated to what was actually written; do not trust the
+        // original request size.
+        for (uint32_t i = 0; i < num_proc && i < procs.size(); ++i) {
+          // KFD reports 0xFFFFFFFF when the stats file is absent for a device.
+          if (procs[i].cu_occupancy == UINT32_MAX) {
+            continue;
+          }
+          cu_sum += static_cast<int64_t>(procs[i].cu_occupancy);
+        }
+      }
+
+      if (field_id == RDC_FI_GPU_CU_OCCUPANCY) {
+        value->value.l_int = cu_sum;
+        break;
+      }
+
+      amdsmi_asic_info_t asic_info = {};
+      value->status = amdsmi_get_gpu_asic_info(processor_handle, &asic_info);
+      if (value->status != AMDSMI_STATUS_SUCCESS) {
+        break;
+      }
+      if (asic_info.num_of_compute_units == 0xFFFFFFFF || asic_info.num_of_compute_units == 0) {
+        value->status = AMDSMI_STATUS_NOT_SUPPORTED;
+        break;
+      }
+      value->value.l_int = (cu_sum * 100) / static_cast<int64_t>(asic_info.num_of_compute_units);
+      break;
+    }
     case RDC_FI_DEV_NAME: {
       // source values from asic_info
       amdsmi_asic_info_t asic_info;

--- a/projects/rdc/rdc_libs/rdc/src/RdcSmiLib.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcSmiLib.cc
@@ -164,6 +164,7 @@ rdc_status_t RdcSmiLib::rdc_telemetry_fields_query(uint32_t field_ids[MAX_NUM_FI
       RDC_FI_GPU_VIS_VRAM_TOTAL,       RDC_FI_GPU_VIS_VRAM_USED,      RDC_FI_GPU_VIS_VRAM_FREE,
       RDC_FI_GPU_GTT_TOTAL,            RDC_FI_GPU_GTT_USED,           RDC_FI_GPU_GTT_FREE,
       RDC_FI_GPU_GFX_BUSY_INST,        RDC_FI_GPU_VCN_BUSY_INST,      RDC_FI_GPU_JPEG_BUSY_INST,
+      RDC_FI_GPU_CU_OCCUPANCY,         RDC_FI_GPU_CU_OCCUPANCY_PERCENT,
       RDC_FI_ECC_CORRECT_TOTAL,        RDC_FI_ECC_UNCORRECT_TOTAL,
       RDC_FI_ECC_SDMA_CE,              RDC_FI_ECC_SDMA_UE,            RDC_FI_ECC_GFX_CE,
       RDC_FI_ECC_GFX_UE,               RDC_FI_ECC_MMHUB_CE,           RDC_FI_ECC_MMHUB_UE,

--- a/projects/rdc/tests/unit/CMakeLists.txt
+++ b/projects/rdc/tests/unit/CMakeLists.txt
@@ -53,7 +53,9 @@ include(GoogleTest)
 # would abort the process before main(); keeping these tests out of that library
 # lets them run on GPU-less CI and satisfy the unit-test gate anywhere. Uses
 # gtest_main since it needs no custom setup.
-add_executable(${RDC_CODEC_TESTS} ${SRC_DIR}/test_entity_codec.cc ${SRC_DIR}/test_afid_field.cc)
+add_executable(
+    ${RDC_CODEC_TESTS} ${SRC_DIR}/test_entity_codec.cc ${SRC_DIR}/test_afid_field.cc
+                       ${SRC_DIR}/test_cu_occupancy_field.cc)
 target_include_directories(
     ${RDC_CODEC_TESTS}
     PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/include

--- a/projects/rdc/tests/unit/test_cu_occupancy_field.cc
+++ b/projects/rdc/tests/unit/test_cu_occupancy_field.cc
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2025 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Pure-logic tests for RDC_FI_GPU_CU_OCCUPANCY and its percentage companion,
+// which report how many compute units are occupied by processes on a GPU
+// (sourced from amdsmi's per-process cu_occupancy, itself from KFD sysfs).
+// These need no hardware: they lock down the field registration contract that
+// the daemon and `rdci dmon -e CU_OCCUPANCY` depend on. A field missing from
+// rdc_field.data / rdc_fields_supported becomes silently unqueryable, so these
+// guard the wiring. The value itself needs a GPU with a running process and is
+// covered by the hardware integration tests.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "common/rdc_fields_supported.h"
+#include "rdc/rdc.h"
+
+namespace {
+
+// Both fields must be registered and valid, or the telemetry layer rejects them.
+TEST(CuOccupancyField, IsValid) {
+  EXPECT_TRUE(amd::rdc::is_field_valid(RDC_FI_GPU_CU_OCCUPANCY));
+  EXPECT_TRUE(amd::rdc::is_field_valid(RDC_FI_GPU_CU_OCCUPANCY_PERCENT));
+}
+
+// The descriptor table must carry both with enum name, label and description,
+// and mark them for display (rdci dmon -l relies on all of these).
+TEST(CuOccupancyField, DescriptorMetadata) {
+  auto& table = amd::rdc::get_field_id_description_from_id();
+
+  auto raw = table.find(static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY));
+  ASSERT_NE(raw, table.end()) << "RDC_FI_GPU_CU_OCCUPANCY missing from descriptor table";
+  EXPECT_EQ(raw->second.enum_name, "RDC_FI_GPU_CU_OCCUPANCY");
+  EXPECT_EQ(raw->second.label, "CU_OCCUPANCY");
+  EXPECT_FALSE(raw->second.description.empty());
+  EXPECT_TRUE(raw->second.do_display);
+
+  auto pct = table.find(static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY_PERCENT));
+  ASSERT_NE(pct, table.end()) << "RDC_FI_GPU_CU_OCCUPANCY_PERCENT missing from descriptor table";
+  EXPECT_EQ(pct->second.enum_name, "RDC_FI_GPU_CU_OCCUPANCY_PERCENT");
+  EXPECT_EQ(pct->second.label, "CU_OCCUPANCY_PERCENT");
+  EXPECT_FALSE(pct->second.description.empty());
+  EXPECT_TRUE(pct->second.do_display);
+}
+
+// Name -> id resolution must work by enum name, since the CLI accepts that form.
+TEST(CuOccupancyField, NameLookupResolvesToId) {
+  rdc_field_t id = RDC_FI_INVALID;
+
+  ASSERT_TRUE(amd::rdc::get_field_id_from_name("RDC_FI_GPU_CU_OCCUPANCY", &id));
+  EXPECT_EQ(id, RDC_FI_GPU_CU_OCCUPANCY);
+
+  id = RDC_FI_INVALID;
+  ASSERT_TRUE(amd::rdc::get_field_id_from_name("RDC_FI_GPU_CU_OCCUPANCY_PERCENT", &id));
+  EXPECT_EQ(id, RDC_FI_GPU_CU_OCCUPANCY_PERCENT);
+
+  // The C wrapper used by the CLI must agree.
+  EXPECT_EQ(get_field_id_from_name("RDC_FI_GPU_CU_OCCUPANCY"), RDC_FI_GPU_CU_OCCUPANCY);
+}
+
+// field_id_string() (used throughout logging and the CLI) must return the label.
+TEST(CuOccupancyField, FieldIdStringReturnsLabel) {
+  EXPECT_STREQ(field_id_string(RDC_FI_GPU_CU_OCCUPANCY), "CU_OCCUPANCY");
+  EXPECT_STREQ(field_id_string(RDC_FI_GPU_CU_OCCUPANCY_PERCENT), "CU_OCCUPANCY_PERCENT");
+}
+
+// Both belong to the GPU-usage block that starts at RDC_FI_GPU_UTIL = 500 and
+// must stay below the page block at 550. They were appended after the existing
+// members so no previously published id shifts.
+TEST(CuOccupancyField, IdsInGpuUsageBlock) {
+  EXPECT_GT(static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY),
+            static_cast<uint32_t>(RDC_FI_GPU_JPEG_BUSY_INST));
+  EXPECT_LT(static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY_PERCENT),
+            static_cast<uint32_t>(RDC_FI_GPU_PAGE_RETRIED));
+  EXPECT_EQ(static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY_PERCENT),
+            static_cast<uint32_t>(RDC_FI_GPU_CU_OCCUPANCY) + 1);
+}
+
+// Appending must not have shifted the ids that are already published.
+TEST(CuOccupancyField, ExistingUsageIdsUnchanged) {
+  EXPECT_EQ(static_cast<uint32_t>(RDC_FI_GPU_UTIL), 500u);
+  EXPECT_EQ(static_cast<uint32_t>(RDC_FI_GPU_BUSY_PERCENT), 508u);
+  EXPECT_EQ(static_cast<uint32_t>(RDC_FI_GPU_JPEG_BUSY_INST), 521u);
+  EXPECT_EQ(static_cast<uint32_t>(RDC_FI_GPU_PAGE_RETRIED), 550u);
+}
+
+}  // namespace

--- a/projects/rdc/tools/dme_rdc_metric_mapping.json
+++ b/projects/rdc/tools/dme_rdc_metric_mapping.json
@@ -130,7 +130,7 @@
     {"dme": "GPU_AFID_ERRORS", "rdc": null, "status": "missing", "reason": "P3: needs investigation"},
     {"dme": "GPU_VIOLATION_LOW_UTILIZATION_ACCUMULATED", "rdc": null, "status": "missing", "reason": "P3: needs investigation"},
     {"dme": "GPU_VIOLATION_LOW_UTILIZATION_PERCENTAGE", "rdc": null, "status": "missing", "reason": "P3: needs investigation"},
-    {"dme": "GPU_PROCESS_CU_OCCUPANCY", "rdc": null, "status": "missing", "reason": "P3: needs investigation"},
+    {"dme": "GPU_PROCESS_CU_OCCUPANCY", "rdc": "RDC_FI_GPU_CU_OCCUPANCY", "status": "mapped", "note": "RDC aggregates per-GPU (sum over processes); DME reports per process"},
     {"dme": "GPU_PROF_CPC_CPC_STAT_BUSY", "rdc": "RDC_FI_PROF_CPC_CPC_STAT_BUSY", "status": "mapped"},
     {"dme": "GPU_PROF_CPC_CPC_STAT_IDLE", "rdc": "RDC_FI_PROF_CPC_CPC_STAT_IDLE", "status": "mapped"},
     {"dme": "GPU_PROF_CPC_CPC_STAT_STALL", "rdc": "RDC_FI_PROF_CPC_CPC_STAT_STALL", "status": "mapped"},


### PR DESCRIPTION
## Summary

RDC had no way to report compute-unit occupancy — `tools/dme_rdc_metric_mapping.json` tracked
`GPU_PROCESS_CU_OCCUPANCY` as `"status": "missing"`. This adds two fields that answer "how much of
this GPU is occupied":

| id | field | meaning |
| --- | --- | --- |
| 522 | `RDC_FI_GPU_CU_OCCUPANCY` | CUs occupied, summed over the GPU's processes |
| 523 | `RDC_FI_GPU_CU_OCCUPANCY_PERCENT` | the same as a percent of the device's compute units, matching `amd-smi monitor --process` CU% |

`cu_occupancy` is only exposed per process, so the per-GPU value is the sum over
`amdsmi_get_gpu_process_list()`. This follows the same `RdcSmiLib` pattern `GPU_UTIL` uses
(`processor_handle` -> amdsmi call): **no performance counters and no PTL interaction**, so it does
not take the counter lock or disturb a PTL-enabled node the way the rocprofiler-backed
`RDC_FI_PROF_OCCUPANCY_PERCENT` (800) does.

Both ids are appended after `RDC_FI_GPU_JPEG_BUSY_INST` (521), so no published id shifts.

Two properties are documented at the call site because they change how the field should be read:
it is an instantaneous KFD wave-count snapshot with no averaging, so a duty-cycled workload reads
low unless sampled fast; and on gfx942 the kernel derives it from XCC0 alone and scales by the XCC
count, so it is exact only when workgroups divide evenly across XCCs and biased high otherwise.

### Known dependency

`amdsmi_proc_info_t::cu_occupancy` is only populated by **amd_smi >= 27.0.0**. On amd_smi 26.2.2
(what ROCm 7.2.4 ships) the field stays 0 and every process is attributed to every GPU, so these
fields read 0 there. `develop` already gates on `find_package(amd_smi 27.0.0 ... REQUIRED)`, so
this is satisfied on `develop`; flagging it because it matters for any backport.

## Test plan

Built and tested against the versions `develop` gates on — amd_smi 27.0.0 and gRPC 1.78.1 — on a
ROCm 7.2.4 base image.

- [x] Configure + build clean, no new warnings in the touched files
- [x] `ctest`: 3/3 suites pass
- [x] 6 new `CuOccupancyField.*` tests (field validity, descriptor metadata, name/id round-trip,
      label lookup, ids land in the GPU-usage block, existing ids unchanged); `rdc_codec_tests`
      17/17
- [x] `rdci dmon -l` advertises `522 RDC_FI_GPU_CU_OCCUPANCY` and `523 ..._PERCENT`
- [x] End-to-end on an MI308X (gfx942, 80 CU): a persistent kernel held 25/50/75/100 % of the
      wave slots resident; `rdci dmon -e 522,523` returned 20/40/60/80 CU and 25/50/75/100 %,
      matching the KFD `cu_occupancy` sum exactly at every point
- [x] Multi-process: two concurrent 25 % processes each report 20, field 522 reports 40, so it
      aggregates rather than reporting one process
- [x] Cross-checked the same workload against NVIDIA DCGM `SM_OCCUPANCY` (field 1003) on an A100
      and against rocprof-compute `Wavefront Occupancy` on the same MI308X; all three agree with
      the predicted occupancy (DCGM exact, rocprof-compute within 0.05 pp, the residual being
      dispatch ramp-up that an integrating metric sees and a sampled one cannot)

Signed-off-by: Brian Chang <brichang@amd.com>