### PR TITLE
fix(ci): forward rocm_deb/rpm_package_version in nightly workflow

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-nightly.yml
@@ -112,6 +112,8 @@ jobs:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
+      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       # Empty string triggers full test run in downstream workflow

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -161,6 +161,8 @@ jobs:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
+      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       # Empty string when run_all_tests=true triggers full test run in downstream workflow


### PR DESCRIPTION
## Problem

  The **TheRock Multi-Arch Nightly CI** `Build RPM/DEB Packages` jobs have been failing on every run with:

```  ValueError: Version string '' does not have major.minor versions```

  Failing run: https://github.com/ROCm/rocm-systems/actions/runs/32343456245/job/96364810140
  ## Root Cause

  `setup_multi_arch.yml` correctly computes and exposes three version outputs:
  - `rocm_package_version` (wheels)
  - `rocm_deb_package_version` (native DEB packages)
  - `rocm_rpm_package_version` (native RPM packages)

  However, `therock-multi-arch-ci-nightly.yml` only forwarded `rocm_package_version`  to `multi_arch_ci_linux.yml`. The `rocm_deb_package_version` and `rocm_rpm_package_version` inputs were left unset (defaulting to `""`), which
  propagated as `--rocm-version ""` into `build_package.py`, causing the crash.
This was a gap introduced when the split deb/rpm version outputs were added to `setup_multi_arch.yml` — the nightly workflow was never updated to forward them.

## Fix
  Add the two missing `with:` inputs to `linux_build_and_test` in `therock-multi-arch-ci-nightly.yml`:
  ```yaml
  rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
  rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
```

## Issue Tracking
GitHub issue:  https://github.com/ROCm/rocm-libraries/issues/11106

## Test Result
  - [ ] Verify nightly CI run completes the Build RPM Packages and Build DEB Packages steps without error after this change
  - [ ] Confirm produced RPM/DEB version strings match the expected `<rocm-version>~<YYYYMMDD>g<sha>` format for ci release type

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
