### PR TITLE
refactor(rocprofiler-systems): Remove tim::fopen()

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -3386,20 +3386,6 @@ tmp_file::open(std::ios::openmode _mode)
 }
 
 bool
-tmp_file::fopen(const char* _mode)
-{
-    LOG_DEBUG("Opening temporary file '{}'...", filename);
-
-    touch();
-
-    m_pid = getpid();
-    file  = filepath::fopen(filename, _mode);
-    if(file) fd = ::fileno(file);
-
-    return (file != nullptr && fd > 0);
-}
-
-bool
 tmp_file::flush()
 {
     if(m_pid != getpid()) return false;
@@ -3407,18 +3393,6 @@ tmp_file::flush()
     if(stream.is_open())
     {
         stream.flush();
-    }
-    else if(file != nullptr)
-    {
-        int _ret = fflush(file);
-        int _cnt = 0;
-        while(_ret == EAGAIN || _ret == EINTR)
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds{ 100 });
-            _ret = fflush(file);
-            if(++_cnt > 10) break;
-        }
-        return (_ret == 0);
     }
     else if(fd > 0)
     {
@@ -3447,16 +3421,6 @@ tmp_file::close()
     {
         stream.close();
         return !stream.is_open();
-    }
-    else if(file != nullptr)
-    {
-        auto _ret = fclose(file);
-        if(_ret == 0)
-        {
-            file = nullptr;
-            fd   = -1;
-        }
-        return (_ret == 0);
     }
     else if(fd > 0)
     {
@@ -3489,9 +3453,7 @@ tmp_file::remove()
 
 tmp_file::operator bool() const
 {
-    return (m_pid == getpid()) &&
-           ((stream.is_open() && stream.good()) || (file != nullptr && fd > 0) ||
-            (file == nullptr && fd > 0));
+    return (m_pid == getpid()) && ((stream.is_open() && stream.good()) || fd > 0);
 }
 
 std::shared_ptr<tmp_file>

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -426,7 +426,6 @@ struct tmp_file
 
     bool open(int, int);
     bool open(std::ios::openmode = std::ios::binary | std::ios::in | std::ios::out);
-    bool fopen(const char* = "r+");
     bool flush();
     bool close();
     bool remove();
@@ -435,7 +434,6 @@ struct tmp_file
 
     std::string  filename = {};
     std::fstream stream   = {};
-    FILE*        file     = nullptr;
     int          fd       = -1;
 
 private:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR is part of a PR series to remove the dependency on Timemory filepath utilities.
This particular PR removes dependency on `tim::filepath::fopen()` function.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

`tim::filepath::fopen()` was only used in `tmp_file::fopen()`, which, in turn, was never used. So `tmp_file::fopen()` is removed.
This removal also makes `file` member of `tmp_file` unused, so this member is also removed together with corresponding logic.

So, all the changes in this PR are just removing dead code - no change in behavior is introduced.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Existing ctest suite should pass.
No change in behavior is introduced.

## Test Result

<!-- Briefly summarize test outcomes. -->

Existing ctest suite passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
