### PR TITLE
Prevent a deadlock between hipEventSynchronize and hipMallocAsync

### DIFF
--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -339,7 +339,12 @@ void MemoryPool::ReleaseAllMemory() {
 
 // ================================================================================================
 void MemoryPool::ReleaseFreedMemory() {
-  std::scoped_lock lock(lock_pool_ops_);
+  // Do not block if the lock cannot be acquired, to avoid a deadlock if a different thread holds
+  // the pool lock and tries to acquire the device lock, e.g. hipMallocAsync requesting new memory.
+  std::unique_lock lock(lock_pool_ops_, std::try_to_lock);
+  if (! lock.owns_lock()) {
+    return;
+  }
 
   free_heap_.ReleaseAllMemory();
 }


### PR DESCRIPTION
## Motivation

`hipMallocAsync` may try to acquire the device lock while it holds the memory pool lock, if the pool needs to allocate more memory.

`hipEventSynchronize` will try to acquire the memory pool lock while holding the device lock, to free the unused memory in the pool.

This may cause a deadlock if the two operations happen on different threads at the same time.

## Technical Details

This change makes `MemoryPool::ReleaseFreedMemory` (called by `hipEventSynchronize`) return immediately if it cannot acquire the pool lock.

## Issue Tracking

See https://github.com/ROCm/rocm-systems/issues/10529 .

## Test Plan

The change is being tested on top of ROCm 7.14.0 on an MI300X, by running the workflow that used to get stuck in a loop.

## Test Result

No processes have deadlocked after 50+ runs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
