### PR TITLE
fix(rocprofiler-systems): pause recording, not init, under region filtering

### DIFF
--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -73,9 +73,32 @@ target_link_libraries(
 add_executable(mpi-example mpi.cpp)
 target_link_libraries(mpi-example PRIVATE mpi-cxx-interface-library)
 
+find_library(
+    ROCTX_LIBRARY
+    NAMES rocprofiler-sdk-roctx
+    PATHS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64 /opt/rocm/lib
+)
+find_path(
+    ROCTX_INCLUDE_DIR
+    NAMES rocprofiler-sdk-roctx/roctx.h
+    PATHS ${ROCM_PATH}/include /opt/rocm/include
+)
+
+if(ROCTX_LIBRARY AND ROCTX_INCLUDE_DIR)
+    add_executable(mpi-roctx-regions roctx-regions.cpp)
+    target_include_directories(mpi-roctx-regions PRIVATE ${ROCTX_INCLUDE_DIR})
+    target_link_libraries(
+        mpi-roctx-regions
+        PRIVATE mpi-cxx-interface-library ${ROCTX_LIBRARY}
+    )
+else()
+    message(STATUS "roctx could not be found. Cannot build the mpi-roctx-regions target")
+endif()
+
 if(ROCPROFSYS_INSTALL_EXAMPLES)
     set(MPI_EXAMPLES
         mpi-example
+        mpi-roctx-regions
         mpi-allgather
         mpi-bcast
         mpi-all2all

--- a/projects/rocprofiler-systems/examples/mpi/README.md
+++ b/projects/rocprofiler-systems/examples/mpi/README.md
@@ -14,6 +14,7 @@ This example benchmarks various MPI communication patterns including point-to-po
 - `reduce.c` - MPI_Reduce example
 - `scatter-gather.c` - MPI_Scatter/MPI_Gather example
 - `send-recv.c` - MPI_Send/MPI_Recv example
+- `roctx-regions.cpp` - roctx region-filtering example (`ROCPROFSYS_SELECTED_REGIONS`)
 
 ## Prerequisites
 

--- a/projects/rocprofiler-systems/examples/mpi/roctx-regions.cpp
+++ b/projects/rocprofiler-systems/examples/mpi/roctx-regions.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Exercises ROCPROFSYS_SELECTED_REGIONS against MPI tracing. MPI_Allreduce is only
+// ever called inside "TracedRegion" and MPI_Bcast only ever outside it, so a filtered
+// trace must contain the former and none of the latter.
+
+#include <mpi.h>
+#include <rocprofiler-sdk-roctx/roctx.h>
+
+#include <cstdio>
+
+namespace
+{
+constexpr int CALLS_PER_PHASE = 8;
+
+void
+run_untraced_phase()
+{
+    int value = 0;
+    for(int i = 0; i < CALLS_PER_PHASE; ++i)
+        MPI_Bcast(&value, 1, MPI_INT, 0, MPI_COMM_WORLD);
+}
+
+void
+run_traced_phase()
+{
+    roctxRangePushA("TracedRegion");
+    for(int i = 0; i < CALLS_PER_PHASE; ++i)
+    {
+        int local = 1;
+        int total = 0;
+        MPI_Allreduce(&local, &total, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    }
+    roctxRangePop();
+}
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+
+    int rank = 0;
+    int size = 1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    run_untraced_phase();
+    run_traced_phase();
+    run_untraced_phase();
+
+    if(rank == 0) printf("mpi-roctx-regions completed on %d rank(s)\n", size);
+
+    MPI_Finalize();
+    return 0;
+}

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -39,6 +39,7 @@
 #include "library/components/exit_gotcha.hpp"
 #include "library/components/fork_gotcha.hpp"
 #include "library/components/mpi_gotcha.hpp"
+#include "library/components/mpip.hpp"
 #include "library/components/numa_gotcha.hpp"
 #include "library/components/pthread_gotcha.hpp"
 #include "library/components/shmem_gotcha_policy.hpp"
@@ -677,7 +678,7 @@ rocprofsys_init_tooling_hidden(void)
                 LOG_DEBUG("Pause callback...");
                 rocprofiler_sdk::pause();
                 sampling::pause();
-                component::mpi_gotcha::pause();
+                component::pause_mpip();
                 component::ucx_gotcha<rocprofsys::DefaultUCXPolicy>::pause();
                 component::shmem_gotcha<rocprofsys::DefaultSHMEMPolicy>::pause();
                 component::vaapi_gotcha::pause();
@@ -691,7 +692,7 @@ rocprofsys_init_tooling_hidden(void)
                 LOG_DEBUG("Resume callback...");
                 rocprofiler_sdk::resume();
                 sampling::resume();
-                component::mpi_gotcha::resume();
+                component::resume_mpip();
                 component::ucx_gotcha<rocprofsys::DefaultUCXPolicy>::resume();
                 component::shmem_gotcha<rocprofsys::DefaultSHMEMPolicy>::resume();
                 component::vaapi_gotcha::resume();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -33,6 +33,13 @@ namespace component
 namespace
 {
 using mpip_bundle_t = tim::component_tuple<category_region<category::mpi>, comm_data>;
+using mpip_gotcha_t = mpip_handle<mpip_bundle_t, project::rocprofsys>::mpip_gotcha_t;
+
+// set_ready() only writes wrappers that are already installed, and the MPI wrappers are
+// installed from the MPI_Init audit, which runs after the initial pause. Remember the
+// requested state so activation can adopt it.
+std::mutex s_mpip_mutex;
+bool       s_mpip_paused = false;  // guarded by s_mpip_mutex
 
 struct comm_rank_data
 {
@@ -195,20 +202,20 @@ mpi_gotcha::shutdown()
     update();
 }
 
-std::mutex mpi_gotcha::s_mutex = {};
-
 void
-mpi_gotcha::pause()
+pause_mpip()
 {
-    const std::scoped_lock<std::mutex> _lk{ s_mutex };
-    mpi_gotcha_t::set_ready(false);
+    const std::scoped_lock<std::mutex> _lk{ s_mpip_mutex };
+    s_mpip_paused = true;
+    mpip_gotcha_t::set_ready(false);
 }
 
 void
-mpi_gotcha::resume()
+resume_mpip()
 {
-    const std::scoped_lock<std::mutex> _lk{ s_mutex };
-    mpi_gotcha_t::set_ready(true);
+    const std::scoped_lock<std::mutex> _lk{ s_mpip_mutex };
+    s_mpip_paused = false;
+    mpip_gotcha_t::set_ready(true);
 }
 
 bool
@@ -353,6 +360,9 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
             configure_mpip<mpip_bundle_t, project::rocprofsys>(permit_bindings,
                                                                reject_bindings);
             mpip_index = activate_mpip<mpip_bundle_t, project::rocprofsys>();
+
+            const std::scoped_lock<std::mutex> _lk{ s_mpip_mutex };
+            mpip_gotcha_t::set_ready(!s_mpip_paused);
         }
 
         const auto_lock_t _lk{ type_mutex<mpi_gotcha>() };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -28,9 +28,6 @@ struct mpi_gotcha : comp::base<mpi_gotcha, void>
     static void configure();
     static void shutdown();
 
-    static void pause();
-    static void resume();
-
     // called right before MPI_Init with that functions arguments
     static void audit(const gotcha_data_t& _data, audit::incoming, int*, char***);
 
@@ -70,8 +67,6 @@ private:
 
     static std::mutex                                           s_on_init_callbacks_mutex;
     static std::vector<std::function<void(int rank, int size)>> s_on_init_callbacks;
-
-    static std::mutex s_mutex;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
@@ -63,6 +63,14 @@ TIMEMORY_NOINLINE std::uint64_t deactivate_mpip(std::uint64_t);
 //
 //--------------------------------------------------------------------------------------//
 //
+void
+pause_mpip();
+
+void
+resume_mpip();
+//
+//--------------------------------------------------------------------------------------//
+//
 template <typename Toolset, typename Tag>
 struct mpip_handle : base<mpip_handle<Toolset, Tag>, void>
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -151,6 +151,23 @@ std::vector<collectors::collector_slice> g_collector_slices;
 
 std::atomic<bool> g_reinit_pending{ false };
 
+// Timestamp of a pause whose zero-valued sample could not be written because the
+// sampling thread held the AMD SMI lock. Zero means nothing is outstanding.
+std::atomic<std::int64_t> g_pending_pause_ts{ 0 };
+
+// Requires type_mutex<category::amd_smi> to be held.
+void
+write_pause_samples(std::int64_t timestamp)
+{
+    for(auto& slice : g_collector_slices)
+    {
+        slice.pause(timestamp);
+    }
+#if ROCPROFILER_VERSION >= 600
+    if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->pause(timestamp);
+#endif
+}
+
 // Tears down the AMD SMI collector slices and marks the sampler uninitialized.
 // This is the only teardown performed on the post-fork reinit path: that reinit
 // exists solely to refresh AMD SMI device handles in the child.
@@ -330,6 +347,37 @@ post_process()
 void
 pause()
 {
+    const auto timestamp =
+        static_cast<std::int64_t>(tim::get_clock_real_now<size_t, std::nano>());
+
+    // sample() holds this lock for a whole AMD SMI sweep, and the caller is an
+    // application thread leaving a traced region. Hand the timestamp to the
+    // sampling thread rather than waiting for the sweep to finish.
+    std::unique_lock _lk{ type_mutex<category::amd_smi>(), std::try_to_lock };
+
+    if(!_lk.owns_lock())
+    {
+        g_pending_pause_ts.store(timestamp, std::memory_order_release);
+        return;
+    }
+
+    if(pmc::get_state() != state::process::Active || !is_initialized())
+    {
+        return;
+    }
+
+    write_pause_samples(timestamp);
+}
+
+void
+flush_pending_pause()
+{
+    const auto timestamp = g_pending_pause_ts.exchange(0, std::memory_order_acq_rel);
+    if(timestamp == 0)
+    {
+        return;
+    }
+
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
 
     if(pmc::get_state() != state::process::Active || !is_initialized())
@@ -337,16 +385,7 @@ pause()
         return;
     }
 
-    auto timestamp =
-        static_cast<std::int64_t>(tim::get_clock_real_now<size_t, std::nano>());
-
-    for(auto& slice : g_collector_slices)
-    {
-        slice.pause(timestamp);
-    }
-#if ROCPROFILER_VERSION >= 600
-    if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->pause(timestamp);
-#endif
+    write_pause_samples(timestamp);
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.hpp
@@ -40,6 +40,9 @@ void
 pause();
 
 void
+flush_pending_pause();
+
+void
 postfork_child_cleanup();
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
@@ -88,7 +88,15 @@ sampler::poll(std::atomic<state::process::State>* _state, nsec_t _interval,
         if(_state->load() != state::process::Active) continue;
         if(state::process::get() >= state::process::Finalized) break;
         if(state::process::get() != state::process::Active) continue;
-        if(sampler_paused.load(std::memory_order_relaxed)) continue;
+
+        for(auto& itr : instances)
+            itr->flush_pending_pause();
+
+        if(sampler_paused.load(std::memory_order_relaxed))
+        {
+            _now = std::chrono::steady_clock::now() + _interval;
+            continue;
+        }
         get_sampler_is_sampling().store(true);
         for(auto& itr : instances)
             itr->sample();
@@ -127,13 +135,14 @@ sampler::setup()
     shutdown();
 
     LOG_DEBUG("Setting up PMC sampling.");
-    auto& _pmc         = instances.emplace_back(std::make_unique<instance>());
-    _pmc->setup        = []() { pmc::setup(); };
-    _pmc->shutdown     = []() { pmc::shutdown(); };
-    _pmc->post_process = []() { pmc::post_process(); };
-    _pmc->config       = []() { pmc::config(); };
-    _pmc->sample       = []() { pmc::sample(); };
-    _pmc->pause        = []() { pmc::pause(); };
+    auto& _pmc                = instances.emplace_back(std::make_unique<instance>());
+    _pmc->setup               = []() { pmc::setup(); };
+    _pmc->shutdown            = []() { pmc::shutdown(); };
+    _pmc->post_process        = []() { pmc::post_process(); };
+    _pmc->config              = []() { pmc::config(); };
+    _pmc->sample              = []() { pmc::sample(); };
+    _pmc->pause               = []() { pmc::pause(); };
+    _pmc->flush_pending_pause = []() { pmc::flush_pending_pause(); };
 
     for(auto& itr : instances)
         itr->setup();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.hpp
@@ -24,12 +24,13 @@ namespace process_sampler
 {
 struct instance
 {
-    std::function<void()> setup        = []() {};
-    std::function<void()> shutdown     = []() {};
-    std::function<void()> config       = []() {};
-    std::function<void()> sample       = []() {};
-    std::function<void()> post_process = []() {};
-    std::function<void()> pause        = []() {};
+    std::function<void()> setup               = []() {};
+    std::function<void()> shutdown            = []() {};
+    std::function<void()> config              = []() {};
+    std::function<void()> sample              = []() {};
+    std::function<void()> post_process        = []() {};
+    std::function<void()> pause               = []() {};
+    std::function<void()> flush_pending_pause = []() {};
 };
 //
 struct sampler

--- a/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
@@ -429,3 +429,63 @@ class TestSelectiveRegionNoMarker(RocprofsysTest):
             pass_regex=["CodeBlock_B", "CodeBlock_C", "CodeBlock_D", "CodeBlock_F"],
             fail_regex=["CodeBlock_A", "CodeBlock_E", "CodeBlock_G"],
         )
+
+
+# =============================================================================
+# Test Class: Region filtering vs MPI tracing
+# =============================================================================
+
+
+@pytest.mark.class_name("mpi-roctx-regions")
+class TestSelectiveRegionMPI(RocprofsysTest):
+    """Regression: region filtering must not switch MPI tracing off entirely.
+
+    ROCPROFSYS_SELECTED_REGIONS used to pause the gotcha that intercepts MPI_Init,
+    which is also what installs the MPI wrappers, so no MPI call was ever traced.
+
+    Code flow:
+        MPI_Bcast x8 (outside),
+        TracedRegion: MPI_Allreduce x8,
+        MPI_Bcast x8 (outside)
+    """
+
+    def test_no_filter(self, selective_region_env):
+        """No ROCPROFSYS_SELECTED_REGIONS — both phases traced."""
+        result = self.run_test(
+            "sys_run",
+            "mpi-roctx-regions",
+            env=selective_region_env,
+            launcher="mpi",
+            num_procs=2,
+        )
+        self.assert_regex(result)
+        self.assert_perfetto(
+            result,
+            subtest_name="All MPI calls present",
+            categories=["mpi"],
+            pass_regex=["MPI_Allreduce", "MPI_Bcast"],
+        )
+
+    def test_region_filter(self, selective_region_env):
+        """ROCPROFSYS_SELECTED_REGIONS='TracedRegion'.
+
+        MPI_Allreduce present proves the MPI wrappers were installed at all;
+        MPI_Bcast absent proves they are gated to the selected region.
+        """
+        env = selective_region_env.copy()
+        env["ROCPROFSYS_SELECTED_REGIONS"] = "TracedRegion"
+        result = self.run_test(
+            "sys_run",
+            "mpi-roctx-regions",
+            env=env,
+            launcher="mpi",
+            num_procs=2,
+        )
+        self.assert_regex(result)
+        self.assert_perfetto(
+            result,
+            subtest_name="Only in-region MPI calls traced",
+            categories=["mpi"],
+            pass_regex=["MPI_Allreduce"],
+            fail_regex=["MPI_Bcast"],
+        )


### PR DESCRIPTION
## Motivation

The reported issue contained 2 defects that were easily reproduced when using `ROCTx` region filtering feature.

- A stall in the application appeared between the first and second selected region, and an unfiltered run of the same workload has no mid-loop gap.
- Every MPI call vanished from the trace.
-Both come from the same root cause: pause was being used to suppress one-time initialization rather than recording.

## Technical Details

- `pmc::sample()` holds `type_mutex<category::amd_smi>` for a whole sensor sweep, and `pmc::pause()` took that mutex blocking. With region filtering, `force_initial_pause()` keeps the sampler idle from process start, so its first (cold, most expensive) sweep begins when the first region opens and is still running when that region closes - the application thread then blocks for the remainder. 
- `pause()` now captures the timestamp before the lock, uses `try_to_lock`, and on contention publishes the timestamp for the sampler thread to drain via `pmc::flush_pending_pause()`. 
- The timestamp move also fixes the sentinel, which previously carried the lock-acquisition instant rather than the pause instant. The paused branch of the poll loop now advances its wake time instead of spinning.
- The pause subscription was attached to `mpi_gotcha`, which wraps `MPI_Init`/`Finalize`/`Comm_rank`/`Comm_size`. Its `MPI_Init` audit is what calls `activate_mpip()` to install the ~500 MPI wrappers, and what publishes rank/size and selects
the output suffix. 
- `force_initial_pause()` runs before the application calls `MPI_Init`, so the audit never fired and the wrappers were never installed. 
- The subscription moves to `mpip_gotcha_t`, the gotcha that actually produces `category::mpi` records. Because `gotcha::set_ready()` only writes wrappers that are already installed, and MPIP's are installed later, the requested state is remembered and applied immediately after `activate_mpip()`.

## Issue Tracking

JIRA ID: ROCM-29862

## Test Plan

- New example `examples/mpi/roctx-regions.cpp` (target `mpi-roctx-regions`): `MPI_Allreduce` is called only inside `TracedRegion`, `MPI_Bcast` only outside it, so one workload discriminates both halves without any temporal assertion. Built only when roctx is found.

- New `TestSelectiveRegionMPI` in `tests/pytest/test_selective_regions.py`, `launcher="mpi"`, `num_procs=2`:

- `test_no_filter` - control, both call names present.
- `test_region_filter` - `MPI_Allreduce` present (wrappers installed at all), `MPI_Bcast`
  absent (wrappers gated to the region).

## Test Result

- `rocprof-sys-unit-tests` all passed
- `test_selective_regions.py`: 58 passed, 152 subtests.
- Reported workload, 2 ranks, `SELECTED_REGIONS=step_3,step_4,step_5`: 
    - `mpi` slices 0 -> 36 with none outside the regions; first inter-region gap 0.89-2.0 ms -> 8.4 us; 
    - pause sentinel lag after region end 7.6 us;
    -  output naming `perfetto-trace-<pid>.proto` -> `perfetto-trace-0/1.proto`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
