### PR TITLE
chore(ci): Update TheRock hash to `b014dba` (2026-08-21)

### DIFF
--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 35ed46c376f22431411a497dac08db894060a522 # 2026-08-19
+          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Update therock workflows to commit `b014dba` (2026-08-21), the current tip of `ROCm/TheRock@main`.

Picks up ROCm/TheRock#7546, which renames the rocprofiler-compute torch trace gtest in the RPATH origin post-install hook.