### PR TITLE
NetIbMPI tests multithread mode for connection and multi-QP

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -372,12 +372,12 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
     std::vector<size_t> testSizes = {1, 64, 256, 1024, 4096, 16384, 65536};
 
     if (nThreads > 1) {
-        const RdmaResourceCounts before = CaptureRdmaResources();
         // Pinned, unlike SimpleSendRecv: this test's claim is the shared per-device MR
         // cache, and spreading workers across NICs gives each its own cache, so at two
         // and four workers on a four-NIC host the contention would not exist at all.
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads,
+            "threaded SendRecvMultipleSizes",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 // One pattern per worker across the whole ladder. Folding the size into
@@ -391,8 +391,6 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded SendRecvMultipleSizes");
         return;
     }
 
@@ -794,18 +792,16 @@ TEST_F(NetIbMPITest, LargeTransfer) {
     const int nThreads = MPIEnvironment::nThreads;
 
     if (nThreads > 1) {
-        const RdmaResourceCounts before = CaptureRdmaResources();
         // Pinned for the same reason: several large registrations live on one device is
         // the claim, which spreading would defeat.
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads,
+            "threaded LargeTransfer",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 return WorkerHostTransfer(rank, pair, kLargeBufferSize, 400,
                                           WorkerSeed(threadIdx, kBaseSeedOffset),
                                           kLargeTransferTimeout);
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LargeTransfer");
         return;
     }
 

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -280,7 +280,7 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
         ThreadResult result;
         const size_t bufferSize = kSmallBufferSize;
         const int tag = 42;
-        const int seed = senderRank + threadIdx * 97;
+        const int seed = WorkerSeed(threadIdx, senderRank);
 
         void* buffer = malloc(bufferSize);
         if (!buffer) { result.ok = false; result.msg = "malloc failed"; return result; }
@@ -354,6 +354,9 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
     AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded SimpleSendRecv");
 }
 
+// Parameterized by MPIEnvironment::nThreads. Concurrent workers each sweep the
+// same size ladder on an independent connection, so registrations of many
+// different sizes hit the shared per-device MR cache at once.
 TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit))
@@ -363,12 +366,39 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
     AssertInitAndGetDevices(&ndev);
 
     const int rank = MPIEnvironment::world_rank;
-    ConnectionPair pair;
-    NetConnectionGuard connGuard(net_);
-    SetupConnectionWithGuard(0, pair, connGuard);
+    const int nThreads = MPIEnvironment::nThreads;
 
     // Test various sizes
     std::vector<size_t> testSizes = {1, 64, 256, 1024, 4096, 16384, 65536};
+
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        // Pinned, unlike SimpleSendRecv: this test's claim is the shared per-device MR
+        // cache, and spreading workers across NICs gives each its own cache, so at two
+        // and four workers on a four-NIC host the contention would not exist at all.
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Fixed(0), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                // One pattern per worker across the whole ladder. Folding the size into
+                // the seed put different workers on the same bytes at different sizes;
+                // a payload arriving from the wrong connection at the wrong size is
+                // caught by the size check, and at the right size by the pattern.
+                const int seed = WorkerSeed(threadIdx, kMultiSizeSeedOffset);
+                for (size_t size : testSizes) {
+                    result = WorkerHostTransfer(rank, pair, size, 100, seed);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded SendRecvMultipleSizes");
+        return;
+    }
+
+    ConnectionPair pair;
+    NetConnectionGuard connGuard(net_);
+    SetupConnectionWithGuard(0, pair, connGuard);
 
     for (size_t size : testSizes) {
         const int tag = 100;
@@ -682,9 +712,15 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
 
         NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
 
+        // One pattern for this worker, held across all of its transfers. A per-iteration
+        // seed reduces modulo 256 into another worker's space -- at sixteen workers
+        // thread 0's iteration 66 and thread 2's iteration 0 produce the same bytes --
+        // and these transfers are not synchronized between workers, so a payload
+        // crossing connections could verify clean. The tag still changes per iteration,
+        // which is what the plugin matches on.
+        const int seed = WorkerSeed(threadIdx, kBaseSeedOffset);
         for (int i = 0; i < numTransfers; i++) {
             const int tag = kTransferTagBase + i;
-            const int seed = kBaseSeedOffset + threadIdx * 10000 + i;
             void* request = nullptr;
             bool postOk = true;
 
@@ -743,6 +779,9 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
     AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MultipleSequentialTransfers");
 }
 
+// Parameterized by MPIEnvironment::nThreads. Concurrent 16 MB transfers put
+// several large registrations in the per-device MR cache simultaneously and
+// keep the NIC saturated while every worker verifies its own payload.
 TEST_F(NetIbMPITest, LargeTransfer) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit))
@@ -752,6 +791,24 @@ TEST_F(NetIbMPITest, LargeTransfer) {
     AssertInitAndGetDevices(&ndev);
 
     const int rank = MPIEnvironment::world_rank;
+    const int nThreads = MPIEnvironment::nThreads;
+
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        // Pinned for the same reason: several large registrations live on one device is
+        // the claim, which spreading would defeat.
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Fixed(0), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                return WorkerHostTransfer(rank, pair, kLargeBufferSize, 400,
+                                          WorkerSeed(threadIdx, kBaseSeedOffset),
+                                          kLargeTransferTimeout);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LargeTransfer");
+        return;
+    }
+
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
     SetupConnectionWithGuard(0, pair, connGuard);

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -800,7 +800,7 @@ TEST_F(NetIbMPITest, LargeTransfer) {
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 return WorkerHostTransfer(rank, pair, kLargeBufferSize, 400,
                                           WorkerSeed(threadIdx, kBaseSeedOffset),
-                                          kLargeTransferTimeout);
+                                          kLargeTransferTimeoutMs);
             });
         return;
     }
@@ -837,7 +837,7 @@ TEST_F(NetIbMPITest, LargeTransfer) {
     // Wait for completion with longer timeout for large transfer
     int sizes[1] = {0};
     ASSERT_NE(request, nullptr) << "Request must be non-NULL before waiting";
-    ASSERT_EQ(WaitForCompletion(request, sizes, kLargeTransferTimeout), ncclSuccess);
+    ASSERT_EQ(WaitForCompletion(request, sizes, kLargeTransferTimeoutMs), ncclSuccess);
 
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Large transfer size mismatch";

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1123,9 +1123,14 @@ protected:
     // caller gets without saying anything is unchanged.
     static constexpr int kSlotWaitDefaultMs = kMaxRetryAttempts * kPollIntervalMs;
 
+    // nullRetries, when given, counts how many times isend came back without a
+    // request. That count is evidence for a test whose subject is backpressure --
+    // FifoPressureSenderFast asserts on it -- and without it such a test has to
+    // reimplement this loop to see it.
     ThreadResult WorkerPostSend(void* sendComm, void* data, size_t size, int tag,
                                 void* mhandle, void** request, bool busyPoll = false,
-                                int timeoutMs = kSlotWaitDefaultMs) {
+                                int timeoutMs = kSlotWaitDefaultMs,
+                                int* nullRetries = nullptr) {
         ThreadResult result;
         const auto deadline =
             std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
@@ -1136,6 +1141,7 @@ protected:
                 return result;
             }
             if (*request != nullptr) break;
+            if (nullRetries) (*nullRetries)++;
             if (std::chrono::steady_clock::now() >= deadline) {
                 result.ok = false;
                 result.msg = "isend kept returning a NULL request for "
@@ -1390,6 +1396,15 @@ protected:
     // the receive buffer is cleared to.
     static constexpr int kWorkerSeedBase   = 55;
     static constexpr int kWorkerSeedStride = 100001;
+    // An odd stride gives every worker a distinct pattern only while the worker
+    // index stays below 256; past that two workers share one modulo 256 and a
+    // payload delivered on the wrong connection would verify clean. Fail the build
+    // rather than the verification if the cap is ever raised that far.
+    static_assert(MPIEnvironment::kMaxThreads < 256,
+                  "WorkerSeed patterns alias once the worker cap reaches 256; widen the "
+                  "pattern before raising it");
+    static_assert(kWorkerSeedStride % 2 == 1,
+                  "WorkerSeed stride must be odd, or workers a power of two apart collide");
     static int WorkerSeed(int threadIdx, int seq) {
         return kWorkerSeedBase + threadIdx * kWorkerSeedStride + seq;
     }
@@ -1579,10 +1594,15 @@ protected:
     // them moves on, which the start gates cannot express: they only synchronize
     // entry into the body. Bounded so a worker that failed earlier cannot hang
     // its siblings; the caller reports the timeout as its own failure.
-    static bool WorkerRendezvous(std::atomic<int>& arrived, int expected, int pollIterations) {
+    // aborted, when given, releases the wait early: a worker that failed before
+    // arriving never increments the counter, so without it the siblings spin out the
+    // whole budget and report "only K of N", which hides the failure that caused it.
+    static bool WorkerRendezvous(std::atomic<int>& arrived, int expected, int pollIterations,
+                                 const std::atomic<bool>* aborted = nullptr) {
         arrived.fetch_add(1, std::memory_order_release);
         for (int poll = 0; poll < pollIterations; poll++) {
             if (arrived.load(std::memory_order_acquire) >= expected) return true;
+            if (aborted && aborted->load(std::memory_order_acquire)) return false;
             usleep(kPollIntervalUs);
         }
         return false;

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1260,6 +1260,57 @@ protected:
         return result;
     }
 
+    // Post a whole batch of equal-sized slots carved out of one registered buffer,
+    // then drain and verify every one. Both slot-pressure bodies did exactly this,
+    // differing only in how they labelled a failure, so the label is the parameter.
+    //
+    // Slot identity rests on the tag, not the payload: with the whole batch in
+    // flight at once a per-slot seed would alias into another worker's patterns
+    // modulo 256, so every slot carries this worker's single pattern and a payload
+    // arriving on the wrong connection is a mismatch rather than a clean pass.
+    ThreadResult WorkerBatchPostDrain(int rank, ConnectionPair& pair, void* buffer,
+                                      size_t slotSize, int slots, void* mhandle, int pattern,
+                                      const std::string& where) {
+        ThreadResult result;
+        std::vector<void*> requests(slots, nullptr);
+        for (int i = 0; i < slots; i++) {
+            char* slot = static_cast<char*>(buffer) + i * slotSize;
+            if (rank == 0) {
+                memset(slot, 0, slotSize);
+                result = WorkerPostRecv(pair.recvComm, slot, slotSize, i, mhandle, &requests[i]);
+            } else {
+                fillHostBufferWithPattern<uint8_t>(slot, slotSize, makeBytePattern(pattern));
+                // kStressTimeoutMs rather than the default slot wait: this post has
+                // to outlast the peer rank publishing all of its own slots under
+                // N-way contention on one NIC, which the drain below also budgets for.
+                result = WorkerPostSend(pair.sendComm, slot, slotSize, i, mhandle, &requests[i],
+                                        /*busyPoll=*/false, kStressTimeoutMs);
+            }
+            if (!result.ok) return result;
+        }
+        for (int i = 0; i < slots; i++) {
+            int sizes[1] = {0};
+            result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+            if (!result.ok) return result;
+            if (rank != 0) continue;
+            const char* slot = static_cast<const char*>(buffer) + i * slotSize;
+            if (sizes[0] != static_cast<int>(slotSize)) {
+                result.ok = false;
+                result.msg = where + "slot " + std::to_string(i) + ": received "
+                             + std::to_string(sizes[0]) + " of " + std::to_string(slotSize)
+                             + " bytes";
+                return result;
+            }
+            if (!verifyHostBufferData<uint8_t>(slot, slotSize, makeBytePattern(pattern))) {
+                result.ok = false;
+                result.msg = where + "slot " + std::to_string(i)
+                             + ": payload is not this worker's pattern";
+                return result;
+            }
+        }
+        return result;
+    }
+
     // A worker's registered host buffer, kept alive as one movable value: the
     // allocation and its registration, released registration-first when this
     // dies because mhandleGuard is declared after bufferGuard. Returning it lets

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1124,9 +1124,11 @@ protected:
     static constexpr int kSlotWaitDefaultMs = kMaxRetryAttempts * kPollIntervalMs;
 
     // nullRetries, when given, counts how many times isend came back without a
-    // request. That count is evidence for a test whose subject is backpressure --
-    // FifoPressureSenderFast asserts on it -- and without it such a test has to
-    // reimplement this loop to see it.
+    // request. FifoPressureSenderFast reports that count in its failure message
+    // rather than asserting on it: nothing orders the sender's attempt against the
+    // receiver publishing a slot, so a descheduled sender can legitimately see
+    // none. Without the count a test whose subject is backpressure would have to
+    // reimplement this loop just to observe it.
     ThreadResult WorkerPostSend(void* sendComm, void* data, size_t size, int tag,
                                 void* mhandle, void** request, bool busyPoll = false,
                                 int timeoutMs = kSlotWaitDefaultMs,

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1396,12 +1396,13 @@ protected:
     // the receive buffer is cleared to.
     static constexpr int kWorkerSeedBase   = 55;
     static constexpr int kWorkerSeedStride = 100001;
-    // An odd stride gives every worker a distinct pattern only while the worker
-    // index stays below 256; past that two workers share one modulo 256 and a
-    // payload delivered on the wrong connection would verify clean. Fail the build
-    // rather than the verification if the cap is ever raised that far.
-    static_assert(MPIEnvironment::kMaxThreads < 256,
-                  "WorkerSeed patterns alias once the worker cap reaches 256; widen the "
+    // With an odd stride the 256 indices a cap of 256 permits still land on 256
+    // distinct values modulo 256, one each. Worker 256 would be the first to share
+    // a pattern with worker 0, and a payload delivered on the wrong connection would
+    // then verify clean, so the cap is what the build refuses to let past 256 -- not
+    // the count of usable indices below it.
+    static_assert(MPIEnvironment::kMaxThreads <= 256,
+                  "WorkerSeed patterns alias once the worker cap exceeds 256; widen the "
                   "pattern before raising it");
     static_assert(kWorkerSeedStride % 2 == 1,
                   "WorkerSeed stride must be odd, or workers a power of two apart collide");

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1221,6 +1221,61 @@ protected:
         return result;
     }
 
+    // One transfer plus host-side payload check: the sender fills a seeded
+    // pattern, the receiver clears its buffer first and verifies afterwards. A
+    // distinct seed per worker turns any cross-connection delivery into a data
+    // failure rather than a silent pass.
+    ThreadResult WorkerSendRecvPattern(int rank, ConnectionPair& pair, void* buffer, size_t size,
+                                       int tag, void* mhandle, int seed,
+                                       int timeoutMs = kDefaultTimeoutMs) {
+        if (rank == 0) {
+            memset(buffer, 0, size);
+        } else {
+            fillHostBufferWithPattern<uint8_t>(buffer, size, makeBytePattern(seed));
+        }
+
+        int received = 0;
+        ThreadResult result = WorkerSendRecvRaw(rank, pair, buffer, size, tag, mhandle,
+                                               timeoutMs, &received);
+        if (!result.ok) return result;
+
+        if (rank == 0) {
+            if (received != (int)size) {
+                result.ok = false;
+                result.msg = "received size mismatch";
+                return result;
+            }
+            if (size > 0
+                && !verifyHostBufferData<uint8_t>(buffer, size, makeBytePattern(seed))) {
+                result.ok = false;
+                result.msg = "data validation failed";
+            }
+        }
+        return result;
+    }
+
+    // Composite: allocate a host buffer, register it, run one seeded transfer,
+    // and release both. Covers the common single-transfer worker body.
+    ThreadResult WorkerHostTransfer(int rank, ConnectionPair& pair, size_t size, int tag,
+                                    int seed, int timeoutMs = kDefaultTimeoutMs) {
+        ThreadResult result;
+        void* buffer = malloc(size ? size : 1);
+        if (!buffer) {
+            result.ok = false;
+            result.msg = "malloc failed";
+            return result;
+        }
+        auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        void* mhandle = nullptr;
+        result = WorkerRegister(comm, buffer, size ? size : 1, NCCL_PTR_HOST, &mhandle);
+        if (!result.ok) return result;
+        NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
+
+        return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+    }
+
     ncclResult_t InitNetIbCtx(void** ctxOut) {
         ncclNetCommConfig_t commConfig = {};
         commConfig.trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
@@ -1335,6 +1390,10 @@ protected:
     // the receive buffer is cleared to.
     static constexpr int kWorkerSeedBase   = 55;
     static constexpr int kWorkerSeedStride = 100001;
+    static int WorkerSeed(int threadIdx, int seq) {
+        return kWorkerSeedBase + threadIdx * kWorkerSeedStride + seq;
+    }
+
     // Plugin-visible indices of physical (non-merged) devices. devices() also
     // reports virtual NICs created by earlier tests, and a deduped 1-device vNIC
     // reuses an existing physical index, so dedupe on vProps.devs[0].
@@ -1516,6 +1575,19 @@ protected:
         return physical[slotIdx % physical.size()];
     }
 
+    // Bounded rendezvous for workers that must all reach a point before any of
+    // them moves on, which the start gates cannot express: they only synchronize
+    // entry into the body. Bounded so a worker that failed earlier cannot hang
+    // its siblings; the caller reports the timeout as its own failure.
+    static bool WorkerRendezvous(std::atomic<int>& arrived, int expected, int pollIterations) {
+        arrived.fetch_add(1, std::memory_order_release);
+        for (int poll = 0; poll < pollIterations; poll++) {
+            if (arrived.load(std::memory_order_acquire) >= expected) return true;
+            usleep(kPollIntervalUs);
+        }
+        return false;
+    }
+
     // Mirrors the normal rccl-tests -t execution model: contexts and
     // communicators are established by the main thread, then workers drive
     // independent comms concurrently. MPI is used only between phases.
@@ -1624,6 +1696,76 @@ protected:
     // The threaded branch has to match whichever its serial body does, or it
     // quietly covers less.
     enum class SweepRegistration { Once, PerSize };
+
+    // Threaded size sweep: every worker walks the list on its own connection with
+    // a per-worker payload seed, so a transfer delivered on the wrong connection
+    // fails verification. Wraps the run in an RDMA resource leak check.
+    void RunThreadedSizeSweep(ThreadDevPolicy policy, int nThreads,
+                              const std::vector<size_t>& sizes, int repeats,
+                              const char* label,
+                              SweepRegistration registration = SweepRegistration::Once) {
+        const int rank = MPIEnvironment::world_rank;
+        size_t maxSize = 1;
+        for (size_t size : sizes) maxSize = std::max(maxSize, size);
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            policy, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(maxSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                const bool perSize = (registration == SweepRegistration::PerSize);
+
+                void* wholeMhandle = nullptr;
+                if (!perSize) {
+                    result = WorkerRegister(comm, buffer, maxSize, NCCL_PTR_HOST, &wholeMhandle);
+                    if (!result.ok) return result;
+                }
+                NetMHandleWorkerGuard wholeGuard(wholeMhandle,
+                                                 NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern for this worker across the whole sweep. Varying it per
+                // step aliased modulo 256 -- WorkerSeed(0, 8) and WorkerSeed(8, 0) are
+                // the same byte -- and workers walk the ladder independently, so in a
+                // sweep that mixes sizes a 256-byte send misrouted into another
+                // worker's 1-byte receive would be clamped and then pass both the size
+                // and the payload check. The tag and the expected size identify the
+                // step; the payload identifies the worker.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                int tag = 0;
+                for (size_t size : sizes) {
+                    void* sizeMhandle = nullptr;
+                    if (perSize) {
+                        result = WorkerRegister(comm, buffer, size, NCCL_PTR_HOST, &sizeMhandle);
+                        if (!result.ok) return result;
+                    }
+                    // Released at the end of this size, so the next one registers
+                    // again, as the serial body does.
+                    NetMHandleWorkerGuard sizeGuard(sizeMhandle,
+                                                    NetMHandleWorkerDeleter(net_, comm));
+                    void* mhandle = perSize ? sizeMhandle : wholeMhandle;
+
+                    for (int repeat = 0; repeat < repeats; repeat++) {
+                        const int timeout = (size > 1024 * 1024) ? kLargeTransferTimeoutMs
+                                                                 : kDefaultTimeoutMs;
+                        result = WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle,
+                                                       workerPattern, timeout);
+                        if (!result.ok) return result;
+                        tag++;
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), label);
+    }
 
     // ===============================================================
     // Stress test infrastructure

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1260,26 +1260,52 @@ protected:
         return result;
     }
 
-    // Composite: allocate a host buffer, register it, run one seeded transfer,
-    // and release both. Covers the common single-transfer worker body.
-    ThreadResult WorkerHostTransfer(int rank, ConnectionPair& pair, size_t size, int tag,
-                                    int seed, int timeoutMs = kDefaultTimeoutMs) {
+    // A worker's registered host buffer, kept alive as one movable value: the
+    // allocation and its registration, released registration-first when this
+    // dies because mhandleGuard is declared after bufferGuard. Returning it lets
+    // a body that needs the handle for a loop hold both without re-pasting the
+    // preamble, and keeps the guard order one reviewed fact rather than one per
+    // call site. On failure `result.ok` is false and the guards are empty no-ops.
+    struct WorkerHostBuffer {
         ThreadResult result;
-        void* buffer = malloc(size ? size : 1);
-        if (!buffer) {
-            result.ok = false;
-            result.msg = "malloc failed";
-            return result;
+        void* buffer = nullptr;
+        void* mhandle = nullptr;
+        HostBufferAutoGuard bufferGuard;
+        NetMHandleWorkerGuard mhandleGuard;
+    };
+
+    // The allocate-and-register preamble on its own: malloc(size, floored to 1),
+    // register it on this rank's comm, and hand back both guards live. A zero
+    // size still yields a one-byte registered buffer, as the transfer helpers
+    // expect.
+    WorkerHostBuffer WorkerSetupHostBuffer(int rank, ConnectionPair& pair, size_t size) {
+        WorkerHostBuffer h;
+        const size_t allocSize = size ? size : 1;
+        h.buffer = malloc(allocSize);
+        if (!h.buffer) {
+            h.result.ok = false;
+            h.result.msg = "malloc failed";
+            return h;
         }
-        auto bufferGuard = makeHostBufferAutoGuard(buffer);
+        h.bufferGuard = makeHostBufferAutoGuard(h.buffer);
 
         void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-        void* mhandle = nullptr;
-        result = WorkerRegister(comm, buffer, size ? size : 1, NCCL_PTR_HOST, &mhandle);
-        if (!result.ok) return result;
-        NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
+        h.result = WorkerRegister(comm, h.buffer, allocSize, NCCL_PTR_HOST, &h.mhandle);
+        if (!h.result.ok) return h;
+        h.mhandleGuard = NetMHandleWorkerGuard(h.mhandle, NetMHandleWorkerDeleter(net_, comm));
+        return h;
+    }
 
-        return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+    // Composite: allocate a host buffer, register it, run one seeded transfer,
+    // and release both. Covers the common single-transfer worker body. The
+    // holder outlives the transfer, so the buffer is deregistered and freed only
+    // after WorkerSendRecvPattern has returned.
+    ThreadResult WorkerHostTransfer(int rank, ConnectionPair& pair, size_t size, int tag,
+                                    int seed, int timeoutMs = kDefaultTimeoutMs) {
+        WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, size);
+        if (!h.result.ok) return h.result;
+
+        return WorkerSendRecvPattern(rank, pair, h.buffer, size, tag, h.mhandle, seed, timeoutMs);
     }
 
     ncclResult_t InitNetIbCtx(void** ctxOut) {
@@ -1710,28 +1736,31 @@ protected:
         RunMultiThreadedIndependent(ThreadDevPolicy::Fixed(dev), nThreads, body);
     }
 
-    // How a threaded size sweep registers memory. Some serial bodies register the
-    // whole buffer once, others register exactly the current size on every step;
-    // on a fused device that second shape is the point of the test, since each
-    // registration fans out across both members' protection domains and caches.
-    // The threaded branch has to match whichever its serial body does, or it
-    // quietly covers less.
-    enum class SweepRegistration { Once, PerSize };
+    // The envelope every threaded test body shares: snapshot the RDMA resource
+    // counts, run the workers, barrier so no rank captures its "after" while a
+    // peer is still releasing, and fail if anything leaked. Held here so the
+    // load-bearing barrier is not retyped by hand at each site.
+    void RunThreadedBody(ThreadDevPolicy policy, int nThreads, const char* label,
+                         std::function<ThreadResult(int, ConnectionPair&)> body) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(policy, nThreads, std::move(body));
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), label);
+    }
 
     // Threaded size sweep: every worker walks the list on its own connection with
     // a per-worker payload seed, so a transfer delivered on the wrong connection
-    // fails verification. Wraps the run in an RDMA resource leak check.
+    // fails verification. Registers the whole buffer once and reuses that handle
+    // for every size. Wraps the run in an RDMA resource leak check.
     void RunThreadedSizeSweep(ThreadDevPolicy policy, int nThreads,
                               const std::vector<size_t>& sizes, int repeats,
-                              const char* label,
-                              SweepRegistration registration = SweepRegistration::Once) {
+                              const char* label) {
         const int rank = MPIEnvironment::world_rank;
         size_t maxSize = 1;
         for (size_t size : sizes) maxSize = std::max(maxSize, size);
 
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
-            policy, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+        RunThreadedBody(
+            policy, nThreads, label, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 void* buffer = malloc(maxSize);
                 if (!buffer) {
@@ -1742,15 +1771,10 @@ protected:
                 auto bufferGuard = makeHostBufferAutoGuard(buffer);
 
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                const bool perSize = (registration == SweepRegistration::PerSize);
-
-                void* wholeMhandle = nullptr;
-                if (!perSize) {
-                    result = WorkerRegister(comm, buffer, maxSize, NCCL_PTR_HOST, &wholeMhandle);
-                    if (!result.ok) return result;
-                }
-                NetMHandleWorkerGuard wholeGuard(wholeMhandle,
-                                                 NetMHandleWorkerDeleter(net_, comm));
+                void* mhandle = nullptr;
+                result = WorkerRegister(comm, buffer, maxSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
 
                 // One pattern for this worker across the whole sweep. Varying it per
                 // step aliased modulo 256 -- WorkerSeed(0, 8) and WorkerSeed(8, 0) are
@@ -1762,17 +1786,6 @@ protected:
                 const int workerPattern = WorkerSeed(threadIdx, 0);
                 int tag = 0;
                 for (size_t size : sizes) {
-                    void* sizeMhandle = nullptr;
-                    if (perSize) {
-                        result = WorkerRegister(comm, buffer, size, NCCL_PTR_HOST, &sizeMhandle);
-                        if (!result.ok) return result;
-                    }
-                    // Released at the end of this size, so the next one registers
-                    // again, as the serial body does.
-                    NetMHandleWorkerGuard sizeGuard(sizeMhandle,
-                                                    NetMHandleWorkerDeleter(net_, comm));
-                    void* mhandle = perSize ? sizeMhandle : wholeMhandle;
-
                     for (int repeat = 0; repeat < repeats; repeat++) {
                         const int timeout = (size > 1024 * 1024) ? kLargeTransferTimeoutMs
                                                                  : kDefaultTimeoutMs;
@@ -1784,8 +1797,6 @@ protected:
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), label);
     }
 
     // ===============================================================

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1153,6 +1153,61 @@ protected:
         return result;
     }
 
+    // One transfer plus host-side payload check: the sender fills a seeded
+    // pattern, the receiver clears its buffer first and verifies afterwards. A
+    // distinct seed per worker turns any cross-connection delivery into a data
+    // failure rather than a silent pass.
+    ThreadResult WorkerSendRecvPattern(int rank, ConnectionPair& pair, void* buffer, size_t size,
+                                       int tag, void* mhandle, int seed,
+                                       int timeoutMs = kDefaultTimeoutMs) {
+        if (rank == 0) {
+            memset(buffer, 0, size);
+        } else {
+            fillHostBufferWithPattern<uint8_t>(buffer, size, makeBytePattern(seed));
+        }
+
+        int received = 0;
+        ThreadResult result = WorkerSendRecvRaw(rank, pair, buffer, size, tag, mhandle,
+                                               timeoutMs, &received);
+        if (!result.ok) return result;
+
+        if (rank == 0) {
+            if (received != (int)size) {
+                result.ok = false;
+                result.msg = "received size mismatch";
+                return result;
+            }
+            if (size > 0
+                && !verifyHostBufferData<uint8_t>(buffer, size, makeBytePattern(seed))) {
+                result.ok = false;
+                result.msg = "data validation failed";
+            }
+        }
+        return result;
+    }
+
+    // Composite: allocate a host buffer, register it, run one seeded transfer,
+    // and release both. Covers the common single-transfer worker body.
+    ThreadResult WorkerHostTransfer(int rank, ConnectionPair& pair, size_t size, int tag,
+                                    int seed, int timeoutMs = kDefaultTimeoutMs) {
+        ThreadResult result;
+        void* buffer = malloc(size ? size : 1);
+        if (!buffer) {
+            result.ok = false;
+            result.msg = "malloc failed";
+            return result;
+        }
+        auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        void* mhandle = nullptr;
+        result = WorkerRegister(comm, buffer, size ? size : 1, NCCL_PTR_HOST, &mhandle);
+        if (!result.ok) return result;
+        NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
+
+        return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+    }
+
     ncclResult_t InitNetIbCtx(void** ctxOut) {
         ncclNetCommConfig_t commConfig = {};
         commConfig.trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
@@ -1267,6 +1322,10 @@ protected:
     // the receive buffer is cleared to.
     static constexpr int kWorkerSeedBase   = 55;
     static constexpr int kWorkerSeedStride = 100001;
+    static int WorkerSeed(int threadIdx, int seq) {
+        return kWorkerSeedBase + threadIdx * kWorkerSeedStride + seq;
+    }
+
     // Plugin-visible indices of physical (non-merged) devices. devices() also
     // reports virtual NICs created by earlier tests, and a deduped 1-device vNIC
     // reuses an existing physical index, so dedupe on vProps.devs[0].
@@ -1322,6 +1381,19 @@ protected:
                          int slotIdx) {
         if (!policy.spread) return policy.dev;
         return physical[slotIdx % physical.size()];
+    }
+
+    // Bounded rendezvous for workers that must all reach a point before any of
+    // them moves on, which the start gates cannot express: they only synchronize
+    // entry into the body. Bounded so a worker that failed earlier cannot hang
+    // its siblings; the caller reports the timeout as its own failure.
+    static bool WorkerRendezvous(std::atomic<int>& arrived, int expected, int pollIterations) {
+        arrived.fetch_add(1, std::memory_order_release);
+        for (int poll = 0; poll < pollIterations; poll++) {
+            if (arrived.load(std::memory_order_acquire) >= expected) return true;
+            usleep(kPollIntervalUs);
+        }
+        return false;
     }
 
     // Mirrors the normal rccl-tests -t execution model: contexts and
@@ -1432,6 +1504,76 @@ protected:
     // The threaded branch has to match whichever its serial body does, or it
     // quietly covers less.
     enum class SweepRegistration { Once, PerSize };
+
+    // Threaded size sweep: every worker walks the list on its own connection with
+    // a per-worker payload seed, so a transfer delivered on the wrong connection
+    // fails verification. Wraps the run in an RDMA resource leak check.
+    void RunThreadedSizeSweep(ThreadDevPolicy policy, int nThreads,
+                              const std::vector<size_t>& sizes, int repeats,
+                              const char* label,
+                              SweepRegistration registration = SweepRegistration::Once) {
+        const int rank = MPIEnvironment::world_rank;
+        size_t maxSize = 1;
+        for (size_t size : sizes) maxSize = std::max(maxSize, size);
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            policy, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(maxSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                const bool perSize = (registration == SweepRegistration::PerSize);
+
+                void* wholeMhandle = nullptr;
+                if (!perSize) {
+                    result = WorkerRegister(comm, buffer, maxSize, NCCL_PTR_HOST, &wholeMhandle);
+                    if (!result.ok) return result;
+                }
+                NetMHandleWorkerGuard wholeGuard(wholeMhandle,
+                                                 NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern for this worker across the whole sweep. Varying it per
+                // step aliased modulo 256 -- WorkerSeed(0, 8) and WorkerSeed(8, 0) are
+                // the same byte -- and workers walk the ladder independently, so in a
+                // sweep that mixes sizes a 256-byte send misrouted into another
+                // worker's 1-byte receive would be clamped and then pass both the size
+                // and the payload check. The tag and the expected size identify the
+                // step; the payload identifies the worker.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                int tag = 0;
+                for (size_t size : sizes) {
+                    void* sizeMhandle = nullptr;
+                    if (perSize) {
+                        result = WorkerRegister(comm, buffer, size, NCCL_PTR_HOST, &sizeMhandle);
+                        if (!result.ok) return result;
+                    }
+                    // Released at the end of this size, so the next one registers
+                    // again, as the serial body does.
+                    NetMHandleWorkerGuard sizeGuard(sizeMhandle,
+                                                    NetMHandleWorkerDeleter(net_, comm));
+                    void* mhandle = perSize ? sizeMhandle : wholeMhandle;
+
+                    for (int repeat = 0; repeat < repeats; repeat++) {
+                        const int timeout = (size > 1024 * 1024) ? kLargeTransferTimeoutMs
+                                                                 : kDefaultTimeoutMs;
+                        result = WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle,
+                                                       workerPattern, timeout);
+                        if (!result.ok) return result;
+                        tag++;
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), label);
+    }
 
     // ===============================================================
     // Stress test infrastructure

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -241,7 +241,6 @@ protected:
     static constexpr int kTransferTagBase = 300;
 
     // Timeout constants
-    static constexpr int kLargeTransferTimeout = 30000;
 
     ncclNet_t* net_;
     int numDevices_;
@@ -1276,6 +1275,22 @@ protected:
                                       const std::string& where) {
         ThreadResult result;
         std::vector<void*> requests(slots, nullptr);
+
+        // One deadline for the whole batch rather than kStressTimeoutMs per slot. Each
+        // slot taking its own 60 s is 32 minutes across a full batch, and the suite's
+        // own 300 s timeout kills the process long before the loop returns, so the
+        // readable failure below never gets printed. Every slot is still waited on,
+        // with what is left of the budget and a floor so a drain that starts past the
+        // deadline still gets a chance to retire its work.
+        const auto deadline = std::chrono::steady_clock::now()
+                              + std::chrono::milliseconds(kStressTimeoutMs);
+        auto budgetMs = [&](int floorMs) {
+            const auto left = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  deadline - std::chrono::steady_clock::now()).count();
+            return std::max(static_cast<int>(left), floorMs);
+        };
+
+        int posted = 0;
         for (int i = 0; i < slots; i++) {
             char* slot = static_cast<char*>(buffer) + i * slotSize;
             if (rank == 0) {
@@ -1283,23 +1298,27 @@ protected:
                 result = WorkerPostRecv(pair.recvComm, slot, slotSize, i, mhandle, &requests[i]);
             } else {
                 fillHostBufferWithPattern<uint8_t>(slot, slotSize, makeBytePattern(pattern));
-                // kStressTimeoutMs rather than the default slot wait: this post has
-                // to outlast the peer rank publishing all of its own slots under
-                // N-way contention on one NIC, which the drain below also budgets for.
+                // The batch budget rather than the default slot wait: this post has to
+                // outlast the peer rank publishing all of its own slots under N-way
+                // contention on one NIC.
                 result = WorkerPostSend(pair.sendComm, slot, slotSize, i, mhandle, &requests[i],
-                                        /*busyPoll=*/false, kStressTimeoutMs);
+                                        /*busyPoll=*/false, budgetMs(/*floorMs=*/1000));
             }
-            if (!result.ok) return result;
+            if (!result.ok) break;
+            posted = i + 1;
         }
-        // Every slot is waited on even after one of them fails. Returning at the first
-        // failure left the rest of the batch outstanding, and the caller's
-        // WorkerHostBuffer then deregistered the memory and freed it while the device
-        // could still be writing into those slots -- a crash in teardown instead of a
-        // readable failure. The first failure is what gets reported.
+        // A failed post is not a reason to return either: the slots already posted are
+        // in flight, and the caller's WorkerHostBuffer would deregister the memory and
+        // free it while the device can still be writing into them -- a crash in teardown
+        // instead of a readable failure. Reached when a peer worker stalls, not only on a
+        // misbehaving plugin. So the posted prefix is drained below whatever happened,
+        // and every slot is waited on even after one of them fails. The first failure is
+        // what gets reported.
         ThreadResult firstFailure;
-        for (int i = 0; i < slots; i++) {
+        if (!result.ok) firstFailure = result;
+        for (int i = 0; i < posted; i++) {
             int sizes[1] = {0};
-            const ThreadResult waited = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+            const ThreadResult waited = WorkerWait(requests[i], sizes, budgetMs(/*floorMs=*/1000));
             if (!waited.ok) {
                 if (firstFailure.ok) firstFailure = waited;
                 continue;
@@ -1823,8 +1842,23 @@ protected:
                               const std::vector<size_t>& sizes, int repeats,
                               const char* label) {
         const int rank = MPIEnvironment::world_rank;
+
+        // Capped by worker count, the way MemoryRegistrationStorm holds its own
+        // aggregate near the serial body's: this registers the largest step once per
+        // worker, so a ladder topping out at 64 MB means 1 GB of registered host memory
+        // per rank at sixteen workers where the serial body holds 64 MB. Steps above the
+        // per-worker share are dropped rather than every step being shrunk, so the sizes
+        // that do run are sizes the serial body runs too.
+        static constexpr size_t kSweepRegBudget = 64 * 1024 * 1024;
+        const size_t perWorker = std::max<size_t>(kSweepRegBudget / std::max(nThreads, 1), 1);
+        std::vector<size_t> steps;
+        for (size_t size : sizes)
+            if (size <= perWorker) steps.push_back(size);
+        if (steps.empty() && !sizes.empty())
+            steps.push_back(*std::min_element(sizes.begin(), sizes.end()));
+
         size_t maxSize = 1;
-        for (size_t size : sizes) maxSize = std::max(maxSize, size);
+        for (size_t size : steps) maxSize = std::max(maxSize, size);
 
         RunThreadedBody(
             policy, nThreads, label, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
@@ -1843,7 +1877,7 @@ protected:
                 // step; the payload identifies the worker.
                 const int workerPattern = WorkerSeed(threadIdx, 0);
                 int tag = 0;
-                for (size_t size : sizes) {
+                for (size_t size : steps) {
                     for (int repeat = 0; repeat < repeats; repeat++) {
                         const int timeout = (size > 1024 * 1024) ? kLargeTransferTimeoutMs
                                                                  : kDefaultTimeoutMs;

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1127,8 +1127,9 @@ protected:
     // request. FifoPressureSenderFast reports that count in its failure message
     // rather than asserting on it: nothing orders the sender's attempt against the
     // receiver publishing a slot, so a descheduled sender can legitimately see
-    // none. Without the count a test whose subject is backpressure would have to
-    // reimplement this loop just to observe it.
+    // none. The count is not forwarded by WorkerSendRecvRaw or
+    // WorkerSendRecvPattern, so a test that wants it posts through this helper
+    // directly and drives its own wait and verify, as that one does.
     ThreadResult WorkerPostSend(void* sendComm, void* data, size_t size, int tag,
                                 void* mhandle, void** request, bool busyPoll = false,
                                 int timeoutMs = kSlotWaitDefaultMs,
@@ -1290,27 +1291,40 @@ protected:
             }
             if (!result.ok) return result;
         }
+        // Every slot is waited on even after one of them fails. Returning at the first
+        // failure left the rest of the batch outstanding, and the caller's
+        // WorkerHostBuffer then deregistered the memory and freed it while the device
+        // could still be writing into those slots -- a crash in teardown instead of a
+        // readable failure. The first failure is what gets reported.
+        ThreadResult firstFailure;
         for (int i = 0; i < slots; i++) {
             int sizes[1] = {0};
-            result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
-            if (!result.ok) return result;
+            const ThreadResult waited = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+            if (!waited.ok) {
+                if (firstFailure.ok) firstFailure = waited;
+                continue;
+            }
             if (rank != 0) continue;
             const char* slot = static_cast<const char*>(buffer) + i * slotSize;
             if (sizes[0] != static_cast<int>(slotSize)) {
-                result.ok = false;
-                result.msg = where + "slot " + std::to_string(i) + ": received "
-                             + std::to_string(sizes[0]) + " of " + std::to_string(slotSize)
-                             + " bytes";
-                return result;
+                if (firstFailure.ok) {
+                    firstFailure.ok = false;
+                    firstFailure.msg = where + "slot " + std::to_string(i) + ": received "
+                                       + std::to_string(sizes[0]) + " of "
+                                       + std::to_string(slotSize) + " bytes";
+                }
+                continue;
             }
             if (!verifyHostBufferData<uint8_t>(slot, slotSize, makeBytePattern(pattern))) {
-                result.ok = false;
-                result.msg = where + "slot " + std::to_string(i)
-                             + ": payload is not this worker's pattern";
-                return result;
+                if (firstFailure.ok) {
+                    firstFailure.ok = false;
+                    firstFailure.msg = where + "slot " + std::to_string(i)
+                                       + ": payload is not this worker's pattern";
+                }
+                continue;
             }
         }
-        return result;
+        return firstFailure;
     }
 
     // A worker's registered host buffer, kept alive as one movable value: the
@@ -1814,20 +1828,11 @@ protected:
 
         RunThreadedBody(
             policy, nThreads, label, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, maxSize);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mhandle = h.mhandle;
                 ThreadResult result;
-                void* buffer = malloc(maxSize);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mhandle = nullptr;
-                result = WorkerRegister(comm, buffer, maxSize, NCCL_PTR_HOST, &mhandle);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
 
                 // One pattern for this worker across the whole sweep. Varying it per
                 // step aliased modulo 256 -- WorkerSeed(0, 8) and WorkerSeed(8, 0) are

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -726,7 +726,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
 
     // Extended timeout for 16MB transfer across doubled QPs.
     int sizes[1] = {0};
-    ASSERT_EQ(WaitForCompletion(request, sizes, kLargeTransferTimeout), ncclSuccess);
+    ASSERT_EQ(WaitForCompletion(request, sizes, kLargeTransferTimeoutMs), ncclSuccess);
 
     // Full 64MB byte-by-byte verification
     // ncclIbMultiSend would corrupt data at QP split points.
@@ -801,7 +801,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
         MPI_Barrier(MPI_COMM_WORLD);
 
         int sizes[1] = {0};
-        int timeout = (size > 1024 * 1024) ? kLargeTransferTimeout : kDefaultTimeoutMs;
+        int timeout = (size > 1024 * 1024) ? kLargeTransferTimeoutMs : kDefaultTimeoutMs;
         ASSERT_EQ(WaitForCompletion(request, sizes, timeout), ncclSuccess);
 
         // Prevent request reuse race between iterations.

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -17,6 +17,27 @@
 
 #ifdef MPI_TESTS_ENABLED
 
+// Size ladders shared by the threaded and serial bodies of the tests below. Held
+// here because each was written out once per body, and a size added to one copy
+// while the other kept its own list would quietly narrow half the coverage.
+static const std::vector<size_t> kBarrageSizes = {
+    1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
+    1023, 1024, 4095, 4096, 8191, 8192, 8193,
+    16384, 32768, 65536, 131072,
+    1048576,   // 1 MB
+    4194304,   // 4 MB
+    16777216,  // 16 MB
+    67108864   // 64 MB
+};
+
+// Alignment boundaries either side of the 128B split threshold and the page and
+// 64K marks, for both multi-QP bodies.
+static const std::vector<size_t> kMultiQpAlignmentSizes = {
+    127, 128, 129, 255, 256, 257,
+    1023, 1024, 1025, 4095, 4096, 4097,
+    65535, 65536, 65537
+};
+
 // =====================================================================
 //  Group E: Branch-coverage (2-rank)
 // =====================================================================
@@ -276,7 +297,7 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
                 // One pattern per worker, held for the whole loop, rather than one
                 // per iteration. makeBytePattern sees the seed modulo 256, and
                 // WorkerSeed only guarantees distinctness between workers at the
-                // same sequence number -- across 16 workers and 25 unsynchronized
+                // same sequence number -- across 16 workers and 50 unsynchronized
                 // iterations half the byte patterns are shared by some pair of
                 // different workers, so a payload delivered on the wrong connection
                 // could still verify. Holding the seed constant makes any
@@ -407,13 +428,6 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
-    static const std::vector<size_t> kBarrageSizes = {
-        1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
-        1023, 1024, 4095, 4096, 8191, 8192, 8193,
-        16384, 32768, 65536, 131072,
-        1048576, 4194304, 16777216, 67108864
-    };
-
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         RunThreadedSizeSweep(ThreadDevPolicy::Spread(), nThreads, kBarrageSizes,
@@ -434,18 +448,8 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
     ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
-    const size_t sizes[] = {
-        1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
-        1023, 1024, 4095, 4096, 8191, 8192, 8193,
-        16384, 32768, 65536, 131072,
-        1048576,   // 1 MB
-        4194304,   // 4 MB
-        16777216,  // 16 MB
-        67108864   // 64 MB
-    };
-
     int tag = 0;
-    for (size_t sz : sizes) {
+    for (size_t sz : kBarrageSizes) {
         int timeout = (sz > 1024 * 1024) ? kLargeTransferTimeoutMs : kDefaultTimeoutMs;
         DoSendRecv(cp.sendComm, cp.recvComm,
                    buf.get(), buf.get(), sz,
@@ -495,17 +499,18 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                 if (!result.ok) return result;
                 NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
 
+                // One pattern per worker, held for the whole run rather than
+                // varying per message. makeBytePattern sees the seed modulo 256
+                // and these workers advance independently, so a per-message seed
+                // aliases across them -- worker 0 at message 8 and worker 8 at
+                // message 0 land on the same byte, and a delivery to the wrong
+                // worker's communicator would verify clean. The tag identifies
+                // the message; the pattern identifies the worker.
+                const int seed = WorkerSeed(threadIdx, 0);
+
                 int nullCount = 0;
                 for (int i = 0; i < kThreadedMsgs; i++) {
                     void* request = nullptr;
-                    // One pattern per worker, held for the whole run rather than
-                    // varying per message. makeBytePattern sees the seed modulo 256
-                    // and these workers advance independently, so a per-message seed
-                    // aliases across them -- worker 0 at message 8 and worker 8 at
-                    // message 0 land on the same byte, and a delivery to the wrong
-                    // worker's communicator would verify clean. The tag identifies
-                    // the message; the pattern identifies the worker.
-                    const int seed = WorkerSeed(threadIdx, 0);
                     if (rank == 0) {
                         if (i > 0) usleep(kThreadedRecvDelayUs);
                         memset(buffer, 0, sz);
@@ -770,7 +775,7 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
 //      in various patterns to stress the MR cache.
 //      Parameterized by MPIEnvironment::nThreads: the MR cache is per physical
 //      device behind a single mutex, so concurrent storms are the only way to
-//      race its insert, lookup and eviction paths against each other.
+//      race its insert, lookup and release paths against each other.
 TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -813,9 +818,13 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
                 // every later test. deregisterOrder nulls what it releases, so this
                 // only ever sees leftovers.
                 auto handleCleanup = makeScopeGuard([&]() {
+                    // Through the same deleter the guards use, so a deregMr refused
+                    // on this path lands in g_workerDeregFailures rather than being
+                    // dropped -- this is the path the guard was added for.
+                    NetMHandleWorkerDeleter release(net_, comm);
                     for (auto*& h : handles) {
                         if (h) {
-                            DeregisterMemory(comm, h);
+                            release(h);
                             h = nullptr;
                         }
                     }
@@ -1302,9 +1311,7 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     // single-worker body already covers.
     if (MPIEnvironment::nThreads > 1) {
         RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
-                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
-                              4095, 4096, 4097, 65535, 65536, 65537},
-                             /*repeats=*/2, "threaded MultiQpSplitDataStress");
+                             kMultiQpAlignmentSizes, /*repeats=*/2, "threaded MultiQpSplitDataStress");
         return;
     }
 
@@ -1321,16 +1328,9 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
-    // Alignment boundary sizes (128B is the split threshold)
-    const size_t sizes[] = {
-        127, 128, 129, 255, 256, 257,
-        1023, 1024, 1025, 4095, 4096, 4097,
-        65535, 65536, 65537
-    };
-
     static constexpr int kRepeats = 10;
     int tag = 0;
-    for (size_t sz : sizes) {
+    for (size_t sz : kMultiQpAlignmentSizes) {
         for (int r = 0; r < kRepeats; r++) {
             DoSendRecv(cp.sendComm, cp.recvComm,
                        buf.get(), buf.get(), sz,
@@ -1357,9 +1357,7 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
     // and pinned to one device for the same reason as the split variant.
     if (MPIEnvironment::nThreads > 1) {
         RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
-                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
-                              4095, 4096, 4097, 65535, 65536, 65537},
-                             /*repeats=*/2, "threaded MultiQpNoSplitStress");
+                             kMultiQpAlignmentSizes, /*repeats=*/2, "threaded MultiQpNoSplitStress");
         return;
     }
 
@@ -1376,15 +1374,9 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
     ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
-    const size_t sizes[] = {
-        127, 128, 129, 255, 256, 257,
-        1023, 1024, 1025, 4095, 4096, 4097,
-        65535, 65536, 65537
-    };
-
     static constexpr int kRepeats = 10;
     int tag = 0;
-    for (size_t sz : sizes) {
+    for (size_t sz : kMultiQpAlignmentSizes) {
         for (int r = 0; r < kRepeats; r++) {
             DoSendRecv(cp.sendComm, cp.recvComm,
                        buf.get(), buf.get(), sz,

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1935,6 +1935,17 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
                     if (!result.ok) return result;
                     NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
 
+                    // hipMalloc can hand back recycled memory, and the pattern is the
+                    // same seed every cycle for this worker: an untouched receive
+                    // buffer that already holds a prior transfer's bytes would verify
+                    // clean without this transfer ever landing. Clear it first, as the
+                    // other GPU receive tests do.
+                    if (rank == 0 && hipMemset(devBuf, 0, sz) != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "GPU buffer clear failed";
+                        return result;
+                    }
+
                     if (rank == 1
                         && initializeBufferWithPattern<uint8_t>(devBuf, sz,
                                                                 makeBytePattern(seed))

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -498,11 +498,14 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                 int nullCount = 0;
                 for (int i = 0; i < kThreadedMsgs; i++) {
                     void* request = nullptr;
-                    // Per-worker payload, verified by the receiver: backpressure is
-                    // what this test is about, but without a distinct pattern a
-                    // completion delivered to the wrong worker's communicator would
-                    // pass here just as it would anywhere else.
-                    const int seed = WorkerSeed(threadIdx, i);
+                    // One pattern per worker, held for the whole run rather than
+                    // varying per message. makeBytePattern sees the seed modulo 256
+                    // and these workers advance independently, so a per-message seed
+                    // aliases across them -- worker 0 at message 8 and worker 8 at
+                    // message 0 land on the same byte, and a delivery to the wrong
+                    // worker's communicator would verify clean. The tag identifies
+                    // the message; the pattern identifies the worker.
+                    const int seed = WorkerSeed(threadIdx, 0);
                     if (rank == 0) {
                         if (i > 0) usleep(kThreadedRecvDelayUs);
                         memset(buffer, 0, sz);

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -625,18 +625,32 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// A2.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
-//      then drain all via matching sends, then verify slots are recycled.
+// A2.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs, then
+//      drain all via matching sends. The serial body establishes that much: 32
+//      operations in flight on one comm.
 //      Parameterized by MPIEnvironment::nThreads: request pools are per-comm, so
 //      the point is N x 32 requests in flight on one NIC and the confirmation
-//      that completion routing never crosses communicators.
+//      that completion routing never crosses communicators. The threaded body
+//      also cycles more than a whole pool through each comm, which is what makes
+//      recycling assertable rather than assumed -- see kRounds below.
 TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
-    static constexpr int kMaxReqsPerComm = 32; // NCCL_NET_MAX_REQUESTS
+    // 32 is the API's cap on operations in flight per comm, not the size of the
+    // plugin's request pool: NET_IB_MAX_REQUESTS is NCCL_NET_MAX_REQUESTS *
+    // NCCL_NET_IB_MAX_RECVS = 256 entries per comm, and ncclIbGetRequest returns
+    // the first unused one (src/transport/net_ib/common.h:308, p2p.cc:37).
+    static constexpr int kMaxReqsPerComm = 32;      // NCCL_NET_MAX_REQUESTS
+    static constexpr int kReqPoolPerComm = 32 * 8;  // NET_IB_MAX_REQUESTS
+    // One batch is an eighth of that pool, so on its own it shows 32 requests can
+    // be outstanding but says nothing about completed ones coming back: a plugin
+    // that stopped freeing them would still find room and pass. Cycling more than
+    // the whole pool through one comm separates the two -- without recycling there
+    // is nothing left to allocate on the ninth round and the post fails.
+    static constexpr int kRounds = kReqPoolPerComm / kMaxReqsPerComm + 1;  // 288 > 256
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         RunThreadedBody(
@@ -663,11 +677,15 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
                 // the failure this test is pointed at. Slot identity rests on the tag
                 // instead, which is what the plugin matches on.
                 const int workerPattern = WorkerSeed(threadIdx, 0);
-                result = WorkerBatchPostDrain(rank, pair, buffer, sz, kMaxReqsPerComm, mh,
-                                              workerPattern, /*where=*/"");
-                if (!result.ok) return result;
+                for (int round = 0; round < kRounds; round++) {
+                    result = WorkerBatchPostDrain(rank, pair, buffer, sz, kMaxReqsPerComm, mh,
+                                                  workerPattern,
+                                                  "round " + std::to_string(round) + " ");
+                    if (!result.ok) return result;
+                }
 
-                // Slots must be recycled: another round on the same comm.
+                // And ordinary traffic still works on a comm whose whole request
+                // pool has been cycled through.
                 for (int i = 0; i < 4; i++) {
                     result = WorkerSendRecvPattern(rank, pair, buffer, sz, 100 + i, mh,
                                                    workerPattern, kStressTimeoutMs);

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -71,30 +71,43 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
         // next one ran, and the refcount would never climb past the two that the
         // serial body already covers.
         std::atomic<int> bothHeld{0};
+        // Set by whichever worker fails before arriving, so the others stop waiting
+        // for a worker that is never coming and the reported cause stays the real
+        // one rather than "only K of N".
+        std::atomic<bool> registerFailed{false};
         static constexpr int kRendezvousPolls = 3000;  // 3000 * 10ms = 30s
 
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 (void)threadIdx;
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
                 void* mh1 = nullptr;
                 void* mh2 = nullptr;
                 ThreadResult result = WorkerRegister(comm, shared.get(), sharedSz,
                                                      NCCL_PTR_HOST, &mh1);
-                if (!result.ok) return result;
+                if (!result.ok) {
+                    registerFailed.store(true, std::memory_order_release);
+                    return result;
+                }
                 result = WorkerRegister(comm, shared.get(), sharedSz, NCCL_PTR_HOST, &mh2);
                 if (!result.ok) {
+                    registerFailed.store(true, std::memory_order_release);
                     DeregisterMemory(comm, mh1);
                     return result;
                 }
-                if (!WorkerRendezvous(bothHeld, nThreads, kRendezvousPolls)) {
+                if (!WorkerRendezvous(bothHeld, nThreads, kRendezvousPolls, &registerFailed)) {
                     DeregisterMemory(comm, mh1);
                     DeregisterMemory(comm, mh2);
                     result.ok = false;
-                    result.msg = "only " + std::to_string(bothHeld.load()) + " of "
-                                 + std::to_string(nThreads)
-                                 + " workers reached the point where all hold two registrations";
+                    result.msg =
+                        registerFailed.load(std::memory_order_acquire)
+                            ? "another worker failed to register before all workers held two "
+                              "registrations; its own message is the cause"
+                            : "only " + std::to_string(bothHeld.load()) + " of "
+                                  + std::to_string(nThreads)
+                                  + " workers reached the point where all hold two registrations";
                     return result;
                 }
                 // Both, not short-circuited: if the first deregMr fails, || would
@@ -464,7 +477,8 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
         static constexpr int kThreadedRecvDelayUs = 50000; // 50ms
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 const size_t sz = kSmallBufferSize;
                 void* buffer = malloc(sz);
@@ -484,34 +498,45 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                 int nullCount = 0;
                 for (int i = 0; i < kThreadedMsgs; i++) {
                     void* request = nullptr;
+                    // Per-worker payload, verified by the receiver: backpressure is
+                    // what this test is about, but without a distinct pattern a
+                    // completion delivered to the wrong worker's communicator would
+                    // pass here just as it would anywhere else.
+                    const int seed = WorkerSeed(threadIdx, i);
                     if (rank == 0) {
                         if (i > 0) usleep(kThreadedRecvDelayUs);
+                        memset(buffer, 0, sz);
                         result = WorkerPostRecv(pair.recvComm, buffer, sz, i, mh, &request);
                     } else {
-                        fillHostBufferWithPattern<uint8_t>(buffer, sz, makeBytePattern(i));
-                        int attempts = 0;
-                        do {
-                            if (PostSend(pair.sendComm, buffer, sz, i, mh, &request)
-                                != ncclSuccess) {
-                                result.ok = false;
-                                result.msg = "isend failed";
-                                return result;
-                            }
-                            if (request) break;
-                            nullCount++;
-                            usleep(1000);
-                            if (++attempts > kMaxRetryAttempts) {
-                                result.ok = false;
-                                result.msg = "isend never got a FIFO slot";
-                                return result;
-                            }
-                        } while (!request);
+                        fillHostBufferWithPattern<uint8_t>(buffer, sz, makeBytePattern(seed));
+                        // The shared helper, with the retry count handed back: it
+                        // carries the same deadline semantics as every other post in
+                        // the suite, and the count is the backpressure evidence this
+                        // test asserts on below.
+                        result = WorkerPostSend(pair.sendComm, buffer, sz, i, mh, &request,
+                                                /*busyPoll=*/false, kStressTimeoutMs,
+                                                &nullCount);
                     }
                     if (!result.ok) return result;
 
                     int sizes[1] = {0};
                     result = WorkerWait(request, sizes, kStressTimeoutMs);
                     if (!result.ok) return result;
+
+                    if (rank != 0) continue;
+                    if (sizes[0] != static_cast<int>(sz)) {
+                        result.ok = false;
+                        result.msg = "message " + std::to_string(i) + " received "
+                                     + std::to_string(sizes[0]) + " of " + std::to_string(sz)
+                                     + " bytes";
+                        return result;
+                    }
+                    if (!verifyHostBufferData<uint8_t>(buffer, sz, makeBytePattern(seed))) {
+                        result.ok = false;
+                        result.msg = "message " + std::to_string(i)
+                                     + " is not this worker's pattern";
+                        return result;
+                    }
                 }
 
                 // The slow receiver guarantees the sender saw backpressure.
@@ -604,7 +629,7 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     if (nThreads > 1) {
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 const size_t sz = 256;
                 void* buffer = malloc(sz * kMaxReqsPerComm);
@@ -760,7 +785,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
         static constexpr size_t kThreadedBufSz = 4096;
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
 
@@ -1910,7 +1935,7 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
         static constexpr int kThreadedCycles = 3;
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 const size_t cycleSizes[kThreadedCycles] = {512 * 1024, 1024 * 1024,
                                                             2 * 1024 * 1024};
@@ -2063,7 +2088,7 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
         static constexpr int kThreadedBatch  = 32;
         const RdmaResourceCounts before = CaptureRdmaResources();
         RunMultiThreadedIndependent(
-            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 const size_t sz = 256;
                 void* buffer = malloc(sz * kThreadedBatch);

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -104,6 +104,10 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 (void)threadIdx;
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                // The unwind paths below release through this rather than calling
+                // deregMr directly, so a refusal while already failing still lands
+                // in g_workerDeregFailures instead of resurfacing later as a leak.
+                NetMHandleWorkerDeleter release(net_, comm);
                 void* mh1 = nullptr;
                 void* mh2 = nullptr;
                 ThreadResult result = WorkerRegister(comm, shared.get(), sharedSz,
@@ -115,12 +119,12 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
                 result = WorkerRegister(comm, shared.get(), sharedSz, NCCL_PTR_HOST, &mh2);
                 if (!result.ok) {
                     registerFailed.store(true, std::memory_order_release);
-                    DeregisterMemory(comm, mh1);
+                    release(mh1);
                     return result;
                 }
                 if (!WorkerRendezvous(bothHeld, nThreads, kRendezvousPolls, &registerFailed)) {
-                    DeregisterMemory(comm, mh1);
-                    DeregisterMemory(comm, mh2);
+                    release(mh1);
+                    release(mh2);
                     result.ok = false;
                     result.msg =
                         registerFailed.load(std::memory_order_acquire)
@@ -525,10 +529,34 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                     }
                 }
 
-                // The slow receiver guarantees the sender saw backpressure.
-                if (rank != 0 && nullCount == 0) {
-                    result.ok = false;
-                    result.msg = "expected at least one NULL request (FIFO backpressure)";
+                // The 50 ms receiver delay puts the sender under backpressure in
+                // practice and nullCount records it, but nothing orders the sender's
+                // attempt inside that window: a descheduled sender can find every
+                // slot already published and count no NULL at all, which is not a
+                // defect. Asserting on the count would fail a correct plugin under
+                // load, so the assertion rests on a case the scheduler cannot change.
+                //
+                // The loop is a strict ping-pong, so every slot the receiver
+                // published has been consumed by the time it ends, and it posts
+                // nothing further. One more isend therefore has no slot to take and
+                // must come back without a request -- which is the contract this test
+                // exists to check.
+                if (rank != 0) {
+                    void* probe = nullptr;
+                    if (PostSend(pair.sendComm, buffer, sz, /*tag=*/kThreadedMsgs, mh, &probe)
+                        != ncclSuccess) {
+                        result.ok = false;
+                        result.msg = "the backpressure probe send failed outright after "
+                                     + std::to_string(nullCount) + " NULL requests in the loop";
+                        return result;
+                    }
+                    if (probe != nullptr) {
+                        result.ok = false;
+                        result.msg = "isend handed back a request with no receive posted, so "
+                                     "FIFO backpressure is not being reported ("
+                                     + std::to_string(nullCount)
+                                     + " NULL requests during the loop)";
+                    }
                 }
                 return result;
             });
@@ -635,40 +663,9 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
                 // the failure this test is pointed at. Slot identity rests on the tag
                 // instead, which is what the plugin matches on.
                 const int workerPattern = WorkerSeed(threadIdx, 0);
-                std::vector<void*> requests(kMaxReqsPerComm, nullptr);
-                for (int i = 0; i < kMaxReqsPerComm; i++) {
-                    char* slot = static_cast<char*>(buffer) + i * sz;
-                    if (rank == 0) {
-                        memset(slot, 0, sz);
-                        result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
-                    } else {
-                        fillHostBufferWithPattern<uint8_t>(slot, sz,
-                                                           makeBytePattern(workerPattern));
-                        result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
-                    }
-                    if (!result.ok) return result;
-                }
-                for (int i = 0; i < kMaxReqsPerComm; i++) {
-                    int sizes[1] = {0};
-                    result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
-                    if (!result.ok) return result;
-                    if (rank != 0) continue;
-                    const char* slot = static_cast<char*>(buffer) + i * sz;
-                    if (sizes[0] != (int)sz) {
-                        result.ok = false;
-                        result.msg = "slot " + std::to_string(i) + " completed with size "
-                                     + std::to_string(sizes[0]) + " instead of "
-                                     + std::to_string(sz);
-                        return result;
-                    }
-                    if (!verifyHostBufferData<uint8_t>(slot, sz,
-                                                       makeBytePattern(workerPattern))) {
-                        result.ok = false;
-                        result.msg = "slot " + std::to_string(i)
-                                     + " holds another worker's payload";
-                        return result;
-                    }
-                }
+                result = WorkerBatchPostDrain(rank, pair, buffer, sz, kMaxReqsPerComm, mh,
+                                              workerPattern, /*where=*/"");
+                if (!result.ok) return result;
 
                 // Slots must be recycled: another round on the same comm.
                 for (int i = 0; i < 4; i++) {
@@ -2045,47 +2042,10 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
                 // per-slot seed would alias into another worker's patterns modulo 256.
                 const int workerPattern = WorkerSeed(threadIdx, 0);
                 for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
-                    std::vector<void*> requests(kThreadedBatch, nullptr);
-                    for (int i = 0; i < kThreadedBatch; i++) {
-                        char* slot = static_cast<char*>(buffer) + i * sz;
-                        // Per-worker payloads, so a completion or a payload routed
-                        // to another worker's communicator is a data failure here.
-                        // Draining and checking only that requests complete would
-                        // pass on exactly the misrouting this test is pointed at,
-                        // and every worker posting the same bytes would hide it.
-                        if (rank == 0) {
-                            memset(slot, 0, sz);
-                            result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
-                        } else {
-                            fillHostBufferWithPattern<uint8_t>(slot, sz,
-                                                               makeBytePattern(workerPattern));
-                            result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
-                        }
-                        if (!result.ok) return result;
-                    }
-                    for (int i = 0; i < kThreadedBatch; i++) {
-                        int sizes[1] = {0};
-                        result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
-                        if (!result.ok) return result;
-                        if (rank != 0) continue;
-                        const char* slot = static_cast<const char*>(buffer) + i * sz;
-                        if (sizes[0] != static_cast<int>(sz)) {
-                            result.ok = false;
-                            result.msg = "cycle " + std::to_string(cycle) + " slot "
-                                         + std::to_string(i) + ": received "
-                                         + std::to_string(sizes[0]) + " of "
-                                         + std::to_string(sz) + " bytes";
-                            return result;
-                        }
-                        if (!verifyHostBufferData<uint8_t>(slot, sz,
-                                                          makeBytePattern(workerPattern))) {
-                            result.ok = false;
-                            result.msg = "cycle " + std::to_string(cycle) + " slot "
-                                         + std::to_string(i)
-                                         + ": payload is not this worker's pattern";
-                            return result;
-                        }
-                    }
+                    result = WorkerBatchPostDrain(rank, pair, buffer, sz, kThreadedBatch, mh,
+                                                  workerPattern,
+                                                  "cycle " + std::to_string(cycle) + " ");
+                    if (!result.ok) return result;
                 }
                 return result;
             });

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -50,11 +50,69 @@ TEST_F(NetIbMPITest, InvalidRecvCount) {
 // E1.  MrCacheRefCount — registers the same host buffer twice on the same
 //      comm: cache hit bumps refs to 2, two Dereg calls bring it back to 0
 //      (covers the refs>0 branch in ncclIbDeregMrInternal).
+//      Parameterized by MPIEnvironment::nThreads: every worker registers the
+//      SAME address from its own communicator, so all of them contend on one
+//      cache entry's refcount rather than merely on the cache mutex.
 TEST_F(NetIbMPITest, MrCacheRefCount) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const size_t sharedSz = 4096;
+        auto shared = makeHostBufferAutoGuard(malloc(sharedSz));
+        ASSERT_NE(shared.get(), nullptr);
+
+        // Every worker must be holding both of its registrations before any of
+        // them starts releasing. The body gate only synchronizes entry, so
+        // without this a worker could register twice and release both before the
+        // next one ran, and the refcount would never climb past the two that the
+        // serial body already covers.
+        std::atomic<int> bothHeld{0};
+        static constexpr int kRendezvousPolls = 3000;  // 3000 * 10ms = 30s
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                (void)threadIdx;
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh1 = nullptr;
+                void* mh2 = nullptr;
+                ThreadResult result = WorkerRegister(comm, shared.get(), sharedSz,
+                                                     NCCL_PTR_HOST, &mh1);
+                if (!result.ok) return result;
+                result = WorkerRegister(comm, shared.get(), sharedSz, NCCL_PTR_HOST, &mh2);
+                if (!result.ok) {
+                    DeregisterMemory(comm, mh1);
+                    return result;
+                }
+                if (!WorkerRendezvous(bothHeld, nThreads, kRendezvousPolls)) {
+                    DeregisterMemory(comm, mh1);
+                    DeregisterMemory(comm, mh2);
+                    result.ok = false;
+                    result.msg = "only " + std::to_string(bothHeld.load()) + " of "
+                                 + std::to_string(nThreads)
+                                 + " workers reached the point where all hold two registrations";
+                    return result;
+                }
+                // Both, not short-circuited: if the first deregMr fails, || would
+                // skip the second and turn a plugin error into a leaked reference
+                // that every later test in this process inherits.
+                const bool dereg1 = DeregisterMemory(comm, mh1) == ncclSuccess;
+                const bool dereg2 = DeregisterMemory(comm, mh2) == ncclSuccess;
+                if (!dereg1 || !dereg2) {
+                    result.ok = false;
+                    result.msg = std::string("deregMr failed while unwinding the cache refcount (")
+                                 + (dereg1 ? "" : "first ") + (dereg2 ? "" : "second ") + "handle)";
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MrCacheRefCount");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -170,11 +228,61 @@ TEST_F(NetIbMPITest, NullCommClose) {
 // E4.  TagZeroReuse — 50 messages all sent with tag=0.
 //      Verifies FIFO ordering: messages arrive in send order because
 //      the FIFO is a strict ring (slot = fifoHead % MAX_REQUESTS).
+//      Parameterized by MPIEnvironment::nThreads: with every worker reusing
+//      tag 0 on its own connection, a completion routed to the wrong comm shows
+//      up as a data mismatch instead of passing silently.
 TEST_F(NetIbMPITest, TagZeroReuse) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kTagZeroIters = 50;
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Spread(), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern per worker, held for the whole loop, rather than one
+                // per iteration. makeBytePattern sees the seed modulo 256, and
+                // WorkerSeed only guarantees distinctness between workers at the
+                // same sequence number -- across 16 workers and 25 unsynchronized
+                // iterations half the byte patterns are shared by some pair of
+                // different workers, so a payload delivered on the wrong connection
+                // could still verify. Holding the seed constant makes any
+                // cross-worker delivery a mismatch whatever iteration it came from,
+                // which is what this test claims to catch. Two iterations of the
+                // same worker are indistinguishable as a result, but that is a
+                // property of one connection's own ordering, which the
+                // single-worker body covers with its FIFO check.
+                const int seed = WorkerSeed(threadIdx, 0);
+                for (int i = 0; i < kTagZeroIters; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, /*tag=*/0, mh, seed);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded TagZeroReuse");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -277,11 +385,28 @@ TEST_F(NetIbMPITest, InlineSendBoundary) {
 // E7.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
 //      Exercises alignment boundaries, AR threshold, inline paths, and
 //      large-MR registration.
+//      Parameterized by MPIEnvironment::nThreads: concurrent workers sweep the
+//      whole ladder at once, so alignment and chunking paths run under real
+//      bandwidth pressure with several 64 MB registrations live per device.
 TEST_F(NetIbMPITest, MixedSizeBarrage) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static const std::vector<size_t> kBarrageSizes = {
+        1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
+        1023, 1024, 4095, 4096, 8191, 8192, 8193,
+        16384, 32768, 65536, 131072,
+        1048576, 4194304, 16777216, 67108864
+    };
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Spread(), nThreads, kBarrageSizes,
+                             /*repeats=*/1, "threaded MixedSizeBarrage");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -324,11 +449,82 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
 // A1.  FifoPressureSenderFast — receiver deliberately slow, sender in
 //      tight loop.  Verifies that isend returns *request==NULL when the
 //      FIFO slot is not ready (backpressure).
+//      Parameterized by MPIEnvironment::nThreads: N slow receivers against N
+//      tight senders replace an idle fabric with genuine queue contention, while
+//      the backpressure assertion stays per-connection.
 TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedMsgs = 20;
+        static constexpr int kThreadedRecvDelayUs = 50000; // 50ms
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                int nullCount = 0;
+                for (int i = 0; i < kThreadedMsgs; i++) {
+                    void* request = nullptr;
+                    if (rank == 0) {
+                        if (i > 0) usleep(kThreadedRecvDelayUs);
+                        result = WorkerPostRecv(pair.recvComm, buffer, sz, i, mh, &request);
+                    } else {
+                        fillHostBufferWithPattern<uint8_t>(buffer, sz, makeBytePattern(i));
+                        int attempts = 0;
+                        do {
+                            if (PostSend(pair.sendComm, buffer, sz, i, mh, &request)
+                                != ncclSuccess) {
+                                result.ok = false;
+                                result.msg = "isend failed";
+                                return result;
+                            }
+                            if (request) break;
+                            nullCount++;
+                            usleep(1000);
+                            if (++attempts > kMaxRetryAttempts) {
+                                result.ok = false;
+                                result.msg = "isend never got a FIFO slot";
+                                return result;
+                            }
+                        } while (!request);
+                    }
+                    if (!result.ok) return result;
+
+                    int sizes[1] = {0};
+                    result = WorkerWait(request, sizes, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+
+                // The slow receiver guarantees the sender saw backpressure.
+                if (rank != 0 && nullCount == 0) {
+                    result.ok = false;
+                    result.msg = "expected at least one NULL request (FIFO backpressure)";
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded FifoPressureSenderFast");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -394,11 +590,98 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
 
 // A2.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
 //      then drain all via matching sends, then verify slots are recycled.
+//      Parameterized by MPIEnvironment::nThreads: request pools are per-comm, so
+//      the point is N x 32 requests in flight on one NIC and the confirmation
+//      that completion routing never crosses communicators.
 TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kMaxReqsPerComm = 32; // NCCL_NET_MAX_REQUESTS
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = 256;
+                void* buffer = malloc(sz * kMaxReqsPerComm);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz * kMaxReqsPerComm, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // No rank handshake here: the sender's retry loop waits for the
+                // receiver's FIFO slots instead of a barrier the worker cannot use.
+                // Per-worker seeds, checked on arrival: with the slot index alone
+                // every worker would send the same bytes for a slot, and a
+                // completion delivered to the wrong worker's request would satisfy
+                // the wait unnoticed.
+                // One pattern for this worker, not one per slot. makeBytePattern
+                // reduces the seed modulo 256 and WorkerSeed only separates workers
+                // at the same sequence number, so with all 32 requests in flight at
+                // once thread 0 slot 8 and thread 8 slot 0 collide -- a payload or
+                // completion crossing between those two would verify clean, which is
+                // the failure this test is pointed at. Slot identity rests on the tag
+                // instead, which is what the plugin matches on.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                std::vector<void*> requests(kMaxReqsPerComm, nullptr);
+                for (int i = 0; i < kMaxReqsPerComm; i++) {
+                    char* slot = static_cast<char*>(buffer) + i * sz;
+                    if (rank == 0) {
+                        memset(slot, 0, sz);
+                        result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
+                    } else {
+                        fillHostBufferWithPattern<uint8_t>(slot, sz,
+                                                           makeBytePattern(workerPattern));
+                        result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
+                    }
+                    if (!result.ok) return result;
+                }
+                for (int i = 0; i < kMaxReqsPerComm; i++) {
+                    int sizes[1] = {0};
+                    result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                    if (rank != 0) continue;
+                    const char* slot = static_cast<char*>(buffer) + i * sz;
+                    if (sizes[0] != (int)sz) {
+                        result.ok = false;
+                        result.msg = "slot " + std::to_string(i) + " completed with size "
+                                     + std::to_string(sizes[0]) + " instead of "
+                                     + std::to_string(sz);
+                        return result;
+                    }
+                    if (!verifyHostBufferData<uint8_t>(slot, sz,
+                                                       makeBytePattern(workerPattern))) {
+                        result.ok = false;
+                        result.msg = "slot " + std::to_string(i)
+                                     + " holds another worker's payload";
+                        return result;
+                    }
+                }
+
+                // Slots must be recycled: another round on the same comm.
+                for (int i = 0; i < 4; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, 100 + i, mh,
+                                                   workerPattern, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RequestSlotExhaustion");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -457,11 +740,102 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
 
 // A3.  MemoryRegistrationStorm — register/deregister 512 unique buffers
 //      in various patterns to stress the MR cache.
+//      Parameterized by MPIEnvironment::nThreads: the MR cache is per physical
+//      device behind a single mutex, so concurrent storms are the only way to
+//      race its insert, lookup and eviction paths against each other.
 TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        // Keep the aggregate registration count near the serial test's 512 rather
+        // than multiplying it by the worker count. What is under test is
+        // contention on the one per-device cache, and a per-worker storm that
+        // grows with N only spreads the workers apart in time until the
+        // verification transfer outlives any sane timeout.
+        const int kThreadedBufs = std::max(16, 512 / nThreads);
+        static constexpr size_t kThreadedBufSz = 4096;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+
+                std::vector<void*> bufs(kThreadedBufs, nullptr);
+                auto bufCleanup = makeScopeGuard([&]() {
+                    for (auto* p : bufs) free(p);
+                });
+                for (int i = 0; i < kThreadedBufs; i++) {
+                    bufs[i] = malloc(kThreadedBufSz);
+                    if (!bufs[i]) {
+                        result.ok = false;
+                        result.msg = "malloc failed";
+                        return result;
+                    }
+                }
+
+                std::vector<void*> handles(kThreadedBufs, nullptr);
+                // Registrations outlive the buffers otherwise: any early return
+                // below -- a failed registerAll partway through, or a failed
+                // deregisterOrder -- would free memory the device still has
+                // registered, leaving the shared cache holding stale entries for
+                // every later test. deregisterOrder nulls what it releases, so this
+                // only ever sees leftovers.
+                auto handleCleanup = makeScopeGuard([&]() {
+                    for (auto*& h : handles) {
+                        if (h) {
+                            DeregisterMemory(comm, h);
+                            h = nullptr;
+                        }
+                    }
+                });
+                auto registerAll = [&]() {
+                    for (int i = 0; i < kThreadedBufs; i++) {
+                        result = WorkerRegister(comm, bufs[i], kThreadedBufSz, NCCL_PTR_HOST,
+                                                &handles[i]);
+                        if (!result.ok) return false;
+                    }
+                    return true;
+                };
+                auto deregisterOrder = [&](const std::vector<int>& order) {
+                    for (int idx : order) {
+                        if (DeregisterMemory(comm, handles[idx]) != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "deregMr failed";
+                            return false;
+                        }
+                        handles[idx] = nullptr;
+                    }
+                    return true;
+                };
+
+                std::vector<int> reverse(kThreadedBufs);
+                for (int i = 0; i < kThreadedBufs; i++) reverse[i] = kThreadedBufs - 1 - i;
+                std::vector<int> shuffled(kThreadedBufs);
+                for (int i = 0; i < kThreadedBufs; i++) shuffled[i] = i;
+                for (int i = kThreadedBufs - 1; i > 0; i--) {
+                    int j = (i * 42 + 17 + threadIdx) % (i + 1);
+                    std::swap(shuffled[i], shuffled[j]);
+                }
+
+                if (!registerAll()) return result;
+                if (!deregisterOrder(reverse)) return result;
+                if (!registerAll()) return result;
+                if (!deregisterOrder(shuffled)) return result;
+
+                // The connection must still work after the storm. The peer's
+                // worker may be several hundred registrations behind, so this
+                // transfer waits on the stress budget rather than the default.
+                return WorkerHostTransfer(rank, pair, kThreadedBufSz, 0,
+                                          WorkerSeed(threadIdx, 999), kStressTimeoutMs);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MemoryRegistrationStorm");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -890,6 +1264,22 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent workers multiply the
+    // QPs in flight per device while each one checks its own split payloads.
+    //
+    // Pinned to one device rather than spread. Spreading is right where the shared
+    // state is per device -- the MR cache, the protection domain -- but here the
+    // point is the QPs a single device carries: with four workers over four NICs
+    // every device would end up with one connection again, which is what the
+    // single-worker body already covers.
+    if (MPIEnvironment::nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
+                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
+                              4095, 4096, 4097, 65535, 65536, 65537},
+                             /*repeats=*/2, "threaded MultiQpSplitDataStress");
+        return;
+    }
+
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
@@ -934,6 +1324,16 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    // Parameterized by MPIEnvironment::nThreads: same sweep on the nDataQps path,
+    // and pinned to one device for the same reason as the split variant.
+    if (MPIEnvironment::nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
+                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
+                              4095, 4096, 4097, 65535, 65536, 65537},
+                             /*repeats=*/2, "threaded MultiQpNoSplitStress");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -1406,11 +1806,52 @@ TEST_F(NetIbMPITest, BidirectionalSaturation) {
 
 // F1.  LongRunningEndurance — 10000 transfers on a single connection,
 //      tag cycling, RDMA checkpoints.
+//      Parameterized by MPIEnvironment::nThreads. The leak checkpoints move to
+//      the main thread around the whole run: an in-loop snapshot would see the
+//      other workers' live QPs and report a false leak.
 TEST_F(NetIbMPITest, LongRunningEndurance) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedIters = 2000;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Spread(), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // Worker-constant pattern, for the same reason as the slot test: a
+                // per-iteration seed reduces modulo 256 into another worker's space.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                for (int i = 0; i < kThreadedIters; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, i % 1000, mh,
+                                                   workerPattern, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LongRunningEndurance");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -1460,6 +1901,83 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
         GTEST_SKIP() << "No GPU Direct RDMA support";
     }
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent GPU registrations
+    // drive the peer-memory path into the same per-device MR cache. Workers
+    // inherit this rank's HIP device from the harness, since the current device
+    // is thread-local.
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedCycles = 3;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t cycleSizes[kThreadedCycles] = {512 * 1024, 1024 * 1024,
+                                                            2 * 1024 * 1024};
+                // Worker-constant, not per cycle: workers are at different cycles
+                // at the same moment, and a per-cycle seed folds into another
+                // worker's pattern modulo 256.
+                const int seed = WorkerSeed(threadIdx, 0);
+                for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
+                    const size_t sz = cycleSizes[cycle];
+
+                    void* devBuf = nullptr;
+                    if (hipMalloc(&devBuf, sz) != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "hipMalloc failed";
+                        return result;
+                    }
+                    auto devGuard = makeDeviceBufferAutoGuard(devBuf);
+
+                    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                    void* mh = nullptr;
+                    result = WorkerRegister(comm, devBuf, sz, NCCL_PTR_CUDA, &mh);
+                    if (!result.ok) return result;
+                    NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                    if (rank == 1
+                        && initializeBufferWithPattern<uint8_t>(devBuf, sz,
+                                                                makeBytePattern(seed))
+                               != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "GPU buffer initialization failed";
+                        return result;
+                    }
+
+                    result = WorkerSendRecvRaw(rank, pair, devBuf, sz, cycle, mh,
+                                               kLargeTransferTimeoutMs);
+                    if (!result.ok) return result;
+
+                    if (rank == 0) {
+                        void* flushRequest = nullptr;
+                        int flushSize = static_cast<int>(sz);
+                        // A null request means the flush was a no-op; an error
+                        // return means the flush itself failed.
+                        if (FlushRecv(pair.recvComm, 1, &devBuf, &flushSize, &mh, &flushRequest)
+                            != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "FlushRecv failed at cycle " + std::to_string(cycle);
+                            return result;
+                        }
+                        if (flushRequest) {
+                            int flushed[1] = {0};
+                            result = WorkerWait(flushRequest, flushed, kLargeTransferTimeoutMs);
+                            if (!result.ok) return result;
+                        }
+                        if (!verifyBufferData<uint8_t>(devBuf, sz, makeBytePattern(seed))) {
+                            result.ok = false;
+                            result.msg = "GPU data mismatch";
+                            return result;
+                        }
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded GpuMemoryTransferStress");
+        return;
+    }
+
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
@@ -1501,6 +2019,7 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
             void* flushReq = nullptr;
             int flushSz = static_cast<int>(sz);
             ncclResult_t fr = FlushRecv(cp.recvComm, 1, &devBuf, &flushSz, &mh, &flushReq);
+            EXPECT_EQ(fr, ncclSuccess) << "FlushRecv failed at cycle " << cycle;
             if (fr == ncclSuccess && flushReq) {
                 int fsz = 0;
                 EXPECT_EQ(WaitForCompletion(flushReq, &fsz, kLargeTransferTimeoutMs), ncclSuccess);
@@ -1518,11 +2037,90 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
 // =====================================================================
 
 // J1.  RapidRecvPostDrain — 100 cycles of post-32-recv → send-32 → drain.
+//      Parameterized by MPIEnvironment::nThreads: batches from all workers are
+//      in flight on one NIC at once, so recycling has to hold up while other
+//      communicators are draining their own batches.
 TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedCycles = 25;
+        static constexpr int kThreadedBatch  = 32;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = 256;
+                void* buffer = malloc(sz * kThreadedBatch);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz * kThreadedBatch, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern per worker: the whole batch is in flight at once, so a
+                // per-slot seed would alias into another worker's patterns modulo 256.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
+                    std::vector<void*> requests(kThreadedBatch, nullptr);
+                    for (int i = 0; i < kThreadedBatch; i++) {
+                        char* slot = static_cast<char*>(buffer) + i * sz;
+                        // Per-worker payloads, so a completion or a payload routed
+                        // to another worker's communicator is a data failure here.
+                        // Draining and checking only that requests complete would
+                        // pass on exactly the misrouting this test is pointed at,
+                        // and every worker posting the same bytes would hide it.
+                        if (rank == 0) {
+                            memset(slot, 0, sz);
+                            result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
+                        } else {
+                            fillHostBufferWithPattern<uint8_t>(slot, sz,
+                                                               makeBytePattern(workerPattern));
+                            result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
+                        }
+                        if (!result.ok) return result;
+                    }
+                    for (int i = 0; i < kThreadedBatch; i++) {
+                        int sizes[1] = {0};
+                        result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+                        if (!result.ok) return result;
+                        if (rank != 0) continue;
+                        const char* slot = static_cast<const char*>(buffer) + i * sz;
+                        if (sizes[0] != static_cast<int>(sz)) {
+                            result.ok = false;
+                            result.msg = "cycle " + std::to_string(cycle) + " slot "
+                                         + std::to_string(i) + ": received "
+                                         + std::to_string(sizes[0]) + " of "
+                                         + std::to_string(sz) + " bytes";
+                            return result;
+                        }
+                        if (!verifyHostBufferData<uint8_t>(slot, sz,
+                                                          makeBytePattern(workerPattern))) {
+                            result.ok = false;
+                            result.msg = "cycle " + std::to_string(cycle) + " slot "
+                                         + std::to_string(i)
+                                         + ": payload is not this worker's pattern";
+                            return result;
+                        }
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RapidRecvPostDrain");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -98,9 +98,9 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
         std::atomic<bool> registerFailed{false};
         static constexpr int kRendezvousPolls = 3000;  // 3000 * 10ms = 30s
 
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads,
+            "threaded MrCacheRefCount",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 (void)threadIdx;
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
@@ -143,8 +143,6 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MrCacheRefCount");
         return;
     }
 
@@ -274,25 +272,16 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
     static constexpr int kTagZeroIters = 50;
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Spread(), nThreads,
+            "threaded TagZeroReuse",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
-                ThreadResult result;
                 const size_t sz = kSmallBufferSize;
-                void* buffer = malloc(sz);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mh = nullptr;
-                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mh = h.mhandle;
+                ThreadResult result;
 
                 // One pattern per worker, held for the whole loop, rather than one
                 // per iteration. makeBytePattern sees the seed modulo 256, and
@@ -313,8 +302,6 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded TagZeroReuse");
         return;
     }
 
@@ -479,25 +466,16 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     if (nThreads > 1) {
         static constexpr int kThreadedMsgs = 20;
         static constexpr int kThreadedRecvDelayUs = 50000; // 50ms
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads,
+            "threaded FifoPressureSenderFast",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
-                ThreadResult result;
                 const size_t sz = kSmallBufferSize;
-                void* buffer = malloc(sz);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mh = nullptr;
-                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mh = h.mhandle;
+                ThreadResult result;
 
                 // One pattern per worker, held for the whole run rather than
                 // varying per message. makeBytePattern sees the seed modulo 256
@@ -554,8 +532,6 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded FifoPressureSenderFast");
         return;
     }
 
@@ -635,24 +611,15 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     static constexpr int kMaxReqsPerComm = 32; // NCCL_NET_MAX_REQUESTS
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
-            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
-                ThreadResult result;
+        RunThreadedBody(
+            ThreadDevPolicy::Fixed(0), nThreads, "threaded RequestSlotExhaustion",
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 const size_t sz = 256;
-                void* buffer = malloc(sz * kMaxReqsPerComm);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mh = nullptr;
-                result = WorkerRegister(comm, buffer, sz * kMaxReqsPerComm, NCCL_PTR_HOST, &mh);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz * kMaxReqsPerComm);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mh = h.mhandle;
+                ThreadResult result;
 
                 // No rank handshake here: the sender's retry loop waits for the
                 // receiver's FIFO slots instead of a barrier the worker cannot use.
@@ -711,8 +678,6 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RequestSlotExhaustion");
         return;
     }
 
@@ -791,9 +756,9 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
         // verification transfer outlives any sane timeout.
         const int kThreadedBufs = std::max(16, 512 / nThreads);
         static constexpr size_t kThreadedBufSz = 4096;
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
-            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+        RunThreadedBody(
+            ThreadDevPolicy::Fixed(0), nThreads, "threaded MemoryRegistrationStorm",
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
 
@@ -869,8 +834,6 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
                 return WorkerHostTransfer(rank, pair, kThreadedBufSz, 0,
                                           WorkerSeed(threadIdx, 999), kStressTimeoutMs);
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MemoryRegistrationStorm");
         return;
     }
 
@@ -1838,25 +1801,16 @@ TEST_F(NetIbMPITest, LongRunningEndurance) {
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         static constexpr int kThreadedIters = 2000;
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
+        RunThreadedBody(
             ThreadDevPolicy::Spread(), nThreads,
+            "threaded LongRunningEndurance",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
-                ThreadResult result;
                 const size_t sz = kSmallBufferSize;
-                void* buffer = malloc(sz);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mh = nullptr;
-                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mh = h.mhandle;
+                ThreadResult result;
 
                 // Worker-constant pattern, for the same reason as the slot test: a
                 // per-iteration seed reduces modulo 256 into another worker's space.
@@ -1868,8 +1822,6 @@ TEST_F(NetIbMPITest, LongRunningEndurance) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LongRunningEndurance");
         return;
     }
 
@@ -1928,9 +1880,9 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         static constexpr int kThreadedCycles = 3;
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
-            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+        RunThreadedBody(
+            ThreadDevPolicy::Fixed(0), nThreads, "threaded GpuMemoryTransferStress",
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
                 const size_t cycleSizes[kThreadedCycles] = {512 * 1024, 1024 * 1024,
                                                             2 * 1024 * 1024};
@@ -2004,8 +1956,6 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded GpuMemoryTransferStress");
         return;
     }
 
@@ -2081,24 +2031,15 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     if (nThreads > 1) {
         static constexpr int kThreadedCycles = 25;
         static constexpr int kThreadedBatch  = 32;
-        const RdmaResourceCounts before = CaptureRdmaResources();
-        RunMultiThreadedIndependent(
-            ThreadDevPolicy::Fixed(0), nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
-                ThreadResult result;
+        RunThreadedBody(
+            ThreadDevPolicy::Fixed(0), nThreads, "threaded RapidRecvPostDrain",
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 const size_t sz = 256;
-                void* buffer = malloc(sz * kThreadedBatch);
-                if (!buffer) {
-                    result.ok = false;
-                    result.msg = "malloc failed";
-                    return result;
-                }
-                auto bufferGuard = makeHostBufferAutoGuard(buffer);
-
-                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
-                void* mh = nullptr;
-                result = WorkerRegister(comm, buffer, sz * kThreadedBatch, NCCL_PTR_HOST, &mh);
-                if (!result.ok) return result;
-                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz * kThreadedBatch);
+                if (!h.result.ok) return h.result;
+                void* buffer = h.buffer;
+                void* mh = h.mhandle;
+                ThreadResult result;
 
                 // One pattern per worker: the whole batch is in flight at once, so a
                 // per-slot seed would alias into another worker's patterns modulo 256.
@@ -2148,8 +2089,6 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
                 }
                 return result;
             });
-        MPI_Barrier(MPI_COMM_WORLD);
-        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RapidRecvPostDrain");
         return;
     }
 

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -48,11 +48,69 @@ TEST_F(NetIbMPITest, InvalidRecvCount) {
 // E1.  MrCacheRefCount — registers the same host buffer twice on the same
 //      comm: cache hit bumps refs to 2, two Dereg calls bring it back to 0
 //      (covers the refs>0 branch in ncclIbDeregMrInternal).
+//      Parameterized by MPIEnvironment::nThreads: every worker registers the
+//      SAME address from its own communicator, so all of them contend on one
+//      cache entry's refcount rather than merely on the cache mutex.
 TEST_F(NetIbMPITest, MrCacheRefCount) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const size_t sharedSz = 4096;
+        auto shared = makeHostBufferAutoGuard(malloc(sharedSz));
+        ASSERT_NE(shared.get(), nullptr);
+
+        // Every worker must be holding both of its registrations before any of
+        // them starts releasing. The body gate only synchronizes entry, so
+        // without this a worker could register twice and release both before the
+        // next one ran, and the refcount would never climb past the two that the
+        // serial body already covers.
+        std::atomic<int> bothHeld{0};
+        static constexpr int kRendezvousPolls = 3000;  // 3000 * 10ms = 30s
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                (void)threadIdx;
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh1 = nullptr;
+                void* mh2 = nullptr;
+                ThreadResult result = WorkerRegister(comm, shared.get(), sharedSz,
+                                                     NCCL_PTR_HOST, &mh1);
+                if (!result.ok) return result;
+                result = WorkerRegister(comm, shared.get(), sharedSz, NCCL_PTR_HOST, &mh2);
+                if (!result.ok) {
+                    DeregisterMemory(comm, mh1);
+                    return result;
+                }
+                if (!WorkerRendezvous(bothHeld, nThreads, kRendezvousPolls)) {
+                    DeregisterMemory(comm, mh1);
+                    DeregisterMemory(comm, mh2);
+                    result.ok = false;
+                    result.msg = "only " + std::to_string(bothHeld.load()) + " of "
+                                 + std::to_string(nThreads)
+                                 + " workers reached the point where all hold two registrations";
+                    return result;
+                }
+                // Both, not short-circuited: if the first deregMr fails, || would
+                // skip the second and turn a plugin error into a leaked reference
+                // that every later test in this process inherits.
+                const bool dereg1 = DeregisterMemory(comm, mh1) == ncclSuccess;
+                const bool dereg2 = DeregisterMemory(comm, mh2) == ncclSuccess;
+                if (!dereg1 || !dereg2) {
+                    result.ok = false;
+                    result.msg = std::string("deregMr failed while unwinding the cache refcount (")
+                                 + (dereg1 ? "" : "first ") + (dereg2 ? "" : "second ") + "handle)";
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MrCacheRefCount");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -168,11 +226,61 @@ TEST_F(NetIbMPITest, NullCommClose) {
 // E4.  TagZeroReuse — 50 messages all sent with tag=0.
 //      Verifies FIFO ordering: messages arrive in send order because
 //      the FIFO is a strict ring (slot = fifoHead % MAX_REQUESTS).
+//      Parameterized by MPIEnvironment::nThreads: with every worker reusing
+//      tag 0 on its own connection, a completion routed to the wrong comm shows
+//      up as a data mismatch instead of passing silently.
 TEST_F(NetIbMPITest, TagZeroReuse) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kTagZeroIters = 50;
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Spread(), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern per worker, held for the whole loop, rather than one
+                // per iteration. makeBytePattern sees the seed modulo 256, and
+                // WorkerSeed only guarantees distinctness between workers at the
+                // same sequence number -- across 16 workers and 25 unsynchronized
+                // iterations half the byte patterns are shared by some pair of
+                // different workers, so a payload delivered on the wrong connection
+                // could still verify. Holding the seed constant makes any
+                // cross-worker delivery a mismatch whatever iteration it came from,
+                // which is what this test claims to catch. Two iterations of the
+                // same worker are indistinguishable as a result, but that is a
+                // property of one connection's own ordering, which the
+                // single-worker body covers with its FIFO check.
+                const int seed = WorkerSeed(threadIdx, 0);
+                for (int i = 0; i < kTagZeroIters; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, /*tag=*/0, mh, seed);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded TagZeroReuse");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -275,11 +383,28 @@ TEST_F(NetIbMPITest, InlineSendBoundary) {
 // E7.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
 //      Exercises alignment boundaries, AR threshold, inline paths, and
 //      large-MR registration.
+//      Parameterized by MPIEnvironment::nThreads: concurrent workers sweep the
+//      whole ladder at once, so alignment and chunking paths run under real
+//      bandwidth pressure with several 64 MB registrations live per device.
 TEST_F(NetIbMPITest, MixedSizeBarrage) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static const std::vector<size_t> kBarrageSizes = {
+        1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
+        1023, 1024, 4095, 4096, 8191, 8192, 8193,
+        16384, 32768, 65536, 131072,
+        1048576, 4194304, 16777216, 67108864
+    };
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Spread(), nThreads, kBarrageSizes,
+                             /*repeats=*/1, "threaded MixedSizeBarrage");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -322,11 +447,82 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
 // A1.  FifoPressureSenderFast — receiver deliberately slow, sender in
 //      tight loop.  Verifies that isend returns *request==NULL when the
 //      FIFO slot is not ready (backpressure).
+//      Parameterized by MPIEnvironment::nThreads: N slow receivers against N
+//      tight senders replace an idle fabric with genuine queue contention, while
+//      the backpressure assertion stays per-connection.
 TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedMsgs = 20;
+        static constexpr int kThreadedRecvDelayUs = 50000; // 50ms
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                int nullCount = 0;
+                for (int i = 0; i < kThreadedMsgs; i++) {
+                    void* request = nullptr;
+                    if (rank == 0) {
+                        if (i > 0) usleep(kThreadedRecvDelayUs);
+                        result = WorkerPostRecv(pair.recvComm, buffer, sz, i, mh, &request);
+                    } else {
+                        fillHostBufferWithPattern<uint8_t>(buffer, sz, makeBytePattern(i));
+                        int attempts = 0;
+                        do {
+                            if (PostSend(pair.sendComm, buffer, sz, i, mh, &request)
+                                != ncclSuccess) {
+                                result.ok = false;
+                                result.msg = "isend failed";
+                                return result;
+                            }
+                            if (request) break;
+                            nullCount++;
+                            usleep(1000);
+                            if (++attempts > kMaxRetryAttempts) {
+                                result.ok = false;
+                                result.msg = "isend never got a FIFO slot";
+                                return result;
+                            }
+                        } while (!request);
+                    }
+                    if (!result.ok) return result;
+
+                    int sizes[1] = {0};
+                    result = WorkerWait(request, sizes, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+
+                // The slow receiver guarantees the sender saw backpressure.
+                if (rank != 0 && nullCount == 0) {
+                    result.ok = false;
+                    result.msg = "expected at least one NULL request (FIFO backpressure)";
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded FifoPressureSenderFast");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -392,11 +588,98 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
 
 // A2.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
 //      then drain all via matching sends, then verify slots are recycled.
+//      Parameterized by MPIEnvironment::nThreads: request pools are per-comm, so
+//      the point is N x 32 requests in flight on one NIC and the confirmation
+//      that completion routing never crosses communicators.
 TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kMaxReqsPerComm = 32; // NCCL_NET_MAX_REQUESTS
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = 256;
+                void* buffer = malloc(sz * kMaxReqsPerComm);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz * kMaxReqsPerComm, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // No rank handshake here: the sender's retry loop waits for the
+                // receiver's FIFO slots instead of a barrier the worker cannot use.
+                // Per-worker seeds, checked on arrival: with the slot index alone
+                // every worker would send the same bytes for a slot, and a
+                // completion delivered to the wrong worker's request would satisfy
+                // the wait unnoticed.
+                // One pattern for this worker, not one per slot. makeBytePattern
+                // reduces the seed modulo 256 and WorkerSeed only separates workers
+                // at the same sequence number, so with all 32 requests in flight at
+                // once thread 0 slot 8 and thread 8 slot 0 collide -- a payload or
+                // completion crossing between those two would verify clean, which is
+                // the failure this test is pointed at. Slot identity rests on the tag
+                // instead, which is what the plugin matches on.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                std::vector<void*> requests(kMaxReqsPerComm, nullptr);
+                for (int i = 0; i < kMaxReqsPerComm; i++) {
+                    char* slot = static_cast<char*>(buffer) + i * sz;
+                    if (rank == 0) {
+                        memset(slot, 0, sz);
+                        result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
+                    } else {
+                        fillHostBufferWithPattern<uint8_t>(slot, sz,
+                                                           makeBytePattern(workerPattern));
+                        result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
+                    }
+                    if (!result.ok) return result;
+                }
+                for (int i = 0; i < kMaxReqsPerComm; i++) {
+                    int sizes[1] = {0};
+                    result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                    if (rank != 0) continue;
+                    const char* slot = static_cast<char*>(buffer) + i * sz;
+                    if (sizes[0] != (int)sz) {
+                        result.ok = false;
+                        result.msg = "slot " + std::to_string(i) + " completed with size "
+                                     + std::to_string(sizes[0]) + " instead of "
+                                     + std::to_string(sz);
+                        return result;
+                    }
+                    if (!verifyHostBufferData<uint8_t>(slot, sz,
+                                                       makeBytePattern(workerPattern))) {
+                        result.ok = false;
+                        result.msg = "slot " + std::to_string(i)
+                                     + " holds another worker's payload";
+                        return result;
+                    }
+                }
+
+                // Slots must be recycled: another round on the same comm.
+                for (int i = 0; i < 4; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, 100 + i, mh,
+                                                   workerPattern, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RequestSlotExhaustion");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -455,11 +738,102 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
 
 // A3.  MemoryRegistrationStorm — register/deregister 512 unique buffers
 //      in various patterns to stress the MR cache.
+//      Parameterized by MPIEnvironment::nThreads: the MR cache is per physical
+//      device behind a single mutex, so concurrent storms are the only way to
+//      race its insert, lookup and eviction paths against each other.
 TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        // Keep the aggregate registration count near the serial test's 512 rather
+        // than multiplying it by the worker count. What is under test is
+        // contention on the one per-device cache, and a per-worker storm that
+        // grows with N only spreads the workers apart in time until the
+        // verification transfer outlives any sane timeout.
+        const int kThreadedBufs = std::max(16, 512 / nThreads);
+        static constexpr size_t kThreadedBufSz = 4096;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+
+                std::vector<void*> bufs(kThreadedBufs, nullptr);
+                auto bufCleanup = makeScopeGuard([&]() {
+                    for (auto* p : bufs) free(p);
+                });
+                for (int i = 0; i < kThreadedBufs; i++) {
+                    bufs[i] = malloc(kThreadedBufSz);
+                    if (!bufs[i]) {
+                        result.ok = false;
+                        result.msg = "malloc failed";
+                        return result;
+                    }
+                }
+
+                std::vector<void*> handles(kThreadedBufs, nullptr);
+                // Registrations outlive the buffers otherwise: any early return
+                // below -- a failed registerAll partway through, or a failed
+                // deregisterOrder -- would free memory the device still has
+                // registered, leaving the shared cache holding stale entries for
+                // every later test. deregisterOrder nulls what it releases, so this
+                // only ever sees leftovers.
+                auto handleCleanup = makeScopeGuard([&]() {
+                    for (auto*& h : handles) {
+                        if (h) {
+                            DeregisterMemory(comm, h);
+                            h = nullptr;
+                        }
+                    }
+                });
+                auto registerAll = [&]() {
+                    for (int i = 0; i < kThreadedBufs; i++) {
+                        result = WorkerRegister(comm, bufs[i], kThreadedBufSz, NCCL_PTR_HOST,
+                                                &handles[i]);
+                        if (!result.ok) return false;
+                    }
+                    return true;
+                };
+                auto deregisterOrder = [&](const std::vector<int>& order) {
+                    for (int idx : order) {
+                        if (DeregisterMemory(comm, handles[idx]) != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "deregMr failed";
+                            return false;
+                        }
+                        handles[idx] = nullptr;
+                    }
+                    return true;
+                };
+
+                std::vector<int> reverse(kThreadedBufs);
+                for (int i = 0; i < kThreadedBufs; i++) reverse[i] = kThreadedBufs - 1 - i;
+                std::vector<int> shuffled(kThreadedBufs);
+                for (int i = 0; i < kThreadedBufs; i++) shuffled[i] = i;
+                for (int i = kThreadedBufs - 1; i > 0; i--) {
+                    int j = (i * 42 + 17 + threadIdx) % (i + 1);
+                    std::swap(shuffled[i], shuffled[j]);
+                }
+
+                if (!registerAll()) return result;
+                if (!deregisterOrder(reverse)) return result;
+                if (!registerAll()) return result;
+                if (!deregisterOrder(shuffled)) return result;
+
+                // The connection must still work after the storm. The peer's
+                // worker may be several hundred registrations behind, so this
+                // transfer waits on the stress budget rather than the default.
+                return WorkerHostTransfer(rank, pair, kThreadedBufSz, 0,
+                                          WorkerSeed(threadIdx, 999), kStressTimeoutMs);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded MemoryRegistrationStorm");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -888,6 +1262,22 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent workers multiply the
+    // QPs in flight per device while each one checks its own split payloads.
+    //
+    // Pinned to one device rather than spread. Spreading is right where the shared
+    // state is per device -- the MR cache, the protection domain -- but here the
+    // point is the QPs a single device carries: with four workers over four NICs
+    // every device would end up with one connection again, which is what the
+    // single-worker body already covers.
+    if (MPIEnvironment::nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
+                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
+                              4095, 4096, 4097, 65535, 65536, 65537},
+                             /*repeats=*/2, "threaded MultiQpSplitDataStress");
+        return;
+    }
+
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
@@ -932,6 +1322,16 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    // Parameterized by MPIEnvironment::nThreads: same sweep on the nDataQps path,
+    // and pinned to one device for the same reason as the split variant.
+    if (MPIEnvironment::nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
+                             {127, 128, 129, 255, 256, 257, 1023, 1024, 1025,
+                              4095, 4096, 4097, 65535, 65536, 65537},
+                             /*repeats=*/2, "threaded MultiQpNoSplitStress");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -1404,11 +1804,52 @@ TEST_F(NetIbMPITest, BidirectionalSaturation) {
 
 // F1.  LongRunningEndurance — 10000 transfers on a single connection,
 //      tag cycling, RDMA checkpoints.
+//      Parameterized by MPIEnvironment::nThreads. The leak checkpoints move to
+//      the main thread around the whole run: an in-loop snapshot would see the
+//      other workers' live QPs and report a false leak.
 TEST_F(NetIbMPITest, LongRunningEndurance) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedIters = 2000;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            ThreadDevPolicy::Spread(), nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = kSmallBufferSize;
+                void* buffer = malloc(sz);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // Worker-constant pattern, for the same reason as the slot test: a
+                // per-iteration seed reduces modulo 256 into another worker's space.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                for (int i = 0; i < kThreadedIters; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, sz, i % 1000, mh,
+                                                   workerPattern, kStressTimeoutMs);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LongRunningEndurance");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
@@ -1458,6 +1899,83 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
         GTEST_SKIP() << "No GPU Direct RDMA support";
     }
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent GPU registrations
+    // drive the peer-memory path into the same per-device MR cache. Workers
+    // inherit this rank's HIP device from the harness, since the current device
+    // is thread-local.
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedCycles = 3;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t cycleSizes[kThreadedCycles] = {512 * 1024, 1024 * 1024,
+                                                            2 * 1024 * 1024};
+                // Worker-constant, not per cycle: workers are at different cycles
+                // at the same moment, and a per-cycle seed folds into another
+                // worker's pattern modulo 256.
+                const int seed = WorkerSeed(threadIdx, 0);
+                for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
+                    const size_t sz = cycleSizes[cycle];
+
+                    void* devBuf = nullptr;
+                    if (hipMalloc(&devBuf, sz) != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "hipMalloc failed";
+                        return result;
+                    }
+                    auto devGuard = makeDeviceBufferAutoGuard(devBuf);
+
+                    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                    void* mh = nullptr;
+                    result = WorkerRegister(comm, devBuf, sz, NCCL_PTR_CUDA, &mh);
+                    if (!result.ok) return result;
+                    NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                    if (rank == 1
+                        && initializeBufferWithPattern<uint8_t>(devBuf, sz,
+                                                                makeBytePattern(seed))
+                               != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "GPU buffer initialization failed";
+                        return result;
+                    }
+
+                    result = WorkerSendRecvRaw(rank, pair, devBuf, sz, cycle, mh,
+                                               kLargeTransferTimeoutMs);
+                    if (!result.ok) return result;
+
+                    if (rank == 0) {
+                        void* flushRequest = nullptr;
+                        int flushSize = static_cast<int>(sz);
+                        // A null request means the flush was a no-op; an error
+                        // return means the flush itself failed.
+                        if (FlushRecv(pair.recvComm, 1, &devBuf, &flushSize, &mh, &flushRequest)
+                            != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "FlushRecv failed at cycle " + std::to_string(cycle);
+                            return result;
+                        }
+                        if (flushRequest) {
+                            int flushed[1] = {0};
+                            result = WorkerWait(flushRequest, flushed, kLargeTransferTimeoutMs);
+                            if (!result.ok) return result;
+                        }
+                        if (!verifyBufferData<uint8_t>(devBuf, sz, makeBytePattern(seed))) {
+                            result.ok = false;
+                            result.msg = "GPU data mismatch";
+                            return result;
+                        }
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded GpuMemoryTransferStress");
+        return;
+    }
+
     ConnectionPair cp;
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
@@ -1499,6 +2017,7 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
             void* flushReq = nullptr;
             int flushSz = static_cast<int>(sz);
             ncclResult_t fr = FlushRecv(cp.recvComm, 1, &devBuf, &flushSz, &mh, &flushReq);
+            EXPECT_EQ(fr, ncclSuccess) << "FlushRecv failed at cycle " << cycle;
             if (fr == ncclSuccess && flushReq) {
                 int fsz = 0;
                 EXPECT_EQ(WaitForCompletion(flushReq, &fsz, kLargeTransferTimeoutMs), ncclSuccess);
@@ -1516,11 +2035,90 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
 // =====================================================================
 
 // J1.  RapidRecvPostDrain — 100 cycles of post-32-recv → send-32 → drain.
+//      Parameterized by MPIEnvironment::nThreads: batches from all workers are
+//      in flight on one NIC at once, so recycling has to hold up while other
+//      communicators are draining their own batches.
 TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
+
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        static constexpr int kThreadedCycles = 25;
+        static constexpr int kThreadedBatch  = 32;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t sz = 256;
+                void* buffer = malloc(sz * kThreadedBatch);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mh = nullptr;
+                result = WorkerRegister(comm, buffer, sz * kThreadedBatch, NCCL_PTR_HOST, &mh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern per worker: the whole batch is in flight at once, so a
+                // per-slot seed would alias into another worker's patterns modulo 256.
+                const int workerPattern = WorkerSeed(threadIdx, 0);
+                for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
+                    std::vector<void*> requests(kThreadedBatch, nullptr);
+                    for (int i = 0; i < kThreadedBatch; i++) {
+                        char* slot = static_cast<char*>(buffer) + i * sz;
+                        // Per-worker payloads, so a completion or a payload routed
+                        // to another worker's communicator is a data failure here.
+                        // Draining and checking only that requests complete would
+                        // pass on exactly the misrouting this test is pointed at,
+                        // and every worker posting the same bytes would hide it.
+                        if (rank == 0) {
+                            memset(slot, 0, sz);
+                            result = WorkerPostRecv(pair.recvComm, slot, sz, i, mh, &requests[i]);
+                        } else {
+                            fillHostBufferWithPattern<uint8_t>(slot, sz,
+                                                               makeBytePattern(workerPattern));
+                            result = WorkerPostSend(pair.sendComm, slot, sz, i, mh, &requests[i]);
+                        }
+                        if (!result.ok) return result;
+                    }
+                    for (int i = 0; i < kThreadedBatch; i++) {
+                        int sizes[1] = {0};
+                        result = WorkerWait(requests[i], sizes, kStressTimeoutMs);
+                        if (!result.ok) return result;
+                        if (rank != 0) continue;
+                        const char* slot = static_cast<const char*>(buffer) + i * sz;
+                        if (sizes[0] != static_cast<int>(sz)) {
+                            result.ok = false;
+                            result.msg = "cycle " + std::to_string(cycle) + " slot "
+                                         + std::to_string(i) + ": received "
+                                         + std::to_string(sizes[0]) + " of "
+                                         + std::to_string(sz) + " bytes";
+                            return result;
+                        }
+                        if (!verifyHostBufferData<uint8_t>(slot, sz,
+                                                          makeBytePattern(workerPattern))) {
+                            result.ok = false;
+                            result.msg = "cycle " + std::to_string(cycle) + " slot "
+                                         + std::to_string(i)
+                                         + ": payload is not this worker's pattern";
+                            return result;
+                        }
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RapidRecvPostDrain");
+        return;
+    }
 
     ConnectionPair cp;
     NetConnectionGuard guard(net_);

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1933,6 +1933,17 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
                     if (!result.ok) return result;
                     NetMHandleWorkerGuard mhGuard(mh, NetMHandleWorkerDeleter(net_, comm));
 
+                    // hipMalloc can hand back recycled memory, and the pattern is the
+                    // same seed every cycle for this worker: an untouched receive
+                    // buffer that already holds a prior transfer's bytes would verify
+                    // clean without this transfer ever landing. Clear it first, as the
+                    // other GPU receive tests do.
+                    if (rank == 0 && hipMemset(devBuf, 0, sz) != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "GPU buffer clear failed";
+                        return result;
+                    }
+
                     if (rank == 1
                         && initializeBufferWithPattern<uint8_t>(devBuf, sz,
                                                                 makeBytePattern(seed))

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -559,6 +559,18 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
                                      "FIFO backpressure is not being reported ("
                                      + std::to_string(nullCount)
                                      + " NULL requests during the loop)";
+                        // The probe is in flight with no receive that can ever match it, so
+                        // returning straight away would let this worker's buffer be freed
+                        // under it and turn the contract violation this test reports into an
+                        // abort in teardown. Waited on first, and if it does not retire the
+                        // memory is kept rather than freed.
+                        int probeSizes[1] = {0};
+                        if (!WorkerWait(probe, probeSizes, kDefaultTimeoutMs).ok) {
+                            result.msg += "; the probe request never completed, so its buffer "
+                                          "and registration are retained";
+                            h.mhandleGuard.release();
+                            h.bufferGuard.release();
+                        }
                     }
                 }
                 return result;
@@ -1288,9 +1300,10 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     // point is the QPs a single device carries: with four workers over four NICs
     // every device would end up with one connection again, which is what the
     // single-worker body already covers.
-    if (MPIEnvironment::nThreads > 1) {
-        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads,
-                             kMultiQpAlignmentSizes, /*repeats=*/2, "threaded MultiQpSplitDataStress");
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(0), nThreads, kMultiQpAlignmentSizes,
+                             /*repeats=*/2, "threaded MultiQpSplitDataStress");
         return;
     }
 

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -412,7 +412,7 @@ TEST_F(NetIbMPITest, InlineSendBoundary) {
 //      large-MR registration.
 //      Parameterized by MPIEnvironment::nThreads: concurrent workers sweep the
 //      whole ladder at once, so alignment and chunking paths run under real
-//      bandwidth pressure with several 64 MB registrations live per device.
+//      bandwidth pressure.
 TEST_F(NetIbMPITest, MixedSizeBarrage) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -430,7 +430,10 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
 
-    const size_t maxSz = 64 * 1024 * 1024; // 64 MB
+    // From the shared ladder, not a constant beside it: a size added to
+    // kBarrageSizes would otherwise send DoSendRecv past the end of this buffer.
+    size_t maxSz = 1;
+    for (size_t sz : kBarrageSizes) maxSz = std::max(maxSz, sz);
     auto buf = makeHostBufferAutoGuard(malloc(maxSz));
     ASSERT_NE(buf.get(), nullptr);
 
@@ -700,20 +703,19 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     NetConnectionGuard guard(net_);
     SetupConnectionWithGuard(0, cp, guard);
 
-    static constexpr int kMaxReqs = 32; // NCCL_NET_MAX_REQUESTS
     const size_t sz = 256;
-    auto buf = makeHostBufferAutoGuard(malloc(sz * kMaxReqs));
+    auto buf = makeHostBufferAutoGuard(malloc(sz * kMaxReqsPerComm));
     ASSERT_NE(buf.get(), nullptr);
 
     void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
     void* mh = nullptr;
-    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kMaxReqs, NCCL_PTR_HOST, &mh), ncclSuccess);
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kMaxReqsPerComm, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
     if (rank == 0) {
         // Post all 32 irecvs
-        std::vector<void*> reqs(kMaxReqs, nullptr);
-        for (int i = 0; i < kMaxReqs; i++) {
+        std::vector<void*> reqs(kMaxReqsPerComm, nullptr);
+        for (int i = 0; i < kMaxReqsPerComm; i++) {
             char* p = static_cast<char*>(buf.get()) + i * sz;
             PostSingleRecv(cp.recvComm, p, sz, /*tag=*/i, mh, &reqs[i]);
         }
@@ -721,7 +723,7 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
         MPI_Barrier(MPI_COMM_WORLD);
 
         // Wait for all completions
-        for (int i = 0; i < kMaxReqs; i++) {
+        for (int i = 0; i < kMaxReqsPerComm; i++) {
             int rsz = 0;
             ASSERT_EQ(WaitForCompletion(reqs[i], &rsz, kStressTimeoutMs), ncclSuccess)
                 << "Completion failed for recv " << i;
@@ -731,7 +733,7 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
         MPI_Barrier(MPI_COMM_WORLD);
 
         // Send all 32
-        for (int i = 0; i < kMaxReqs; i++) {
+        for (int i = 0; i < kMaxReqsPerComm; i++) {
             char* p = static_cast<char*>(buf.get()) + i * sz;
             fillHostBufferWithPattern<uint8_t>(p, sz, makeBytePattern(i));
             void* req = nullptr;
@@ -762,6 +764,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
+    static constexpr size_t kRegStormBufSz = 4096;
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         // Keep the aggregate registration count near the serial test's 512 rather
@@ -770,7 +773,6 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
         // grows with N only spreads the workers apart in time until the
         // verification transfer outlives any sane timeout.
         const int kThreadedBufs = std::max(16, 512 / nThreads);
-        static constexpr size_t kThreadedBufSz = 4096;
         RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads, "threaded MemoryRegistrationStorm",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
@@ -782,7 +784,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
                     for (auto* p : bufs) free(p);
                 });
                 for (int i = 0; i < kThreadedBufs; i++) {
-                    bufs[i] = malloc(kThreadedBufSz);
+                    bufs[i] = malloc(kRegStormBufSz);
                     if (!bufs[i]) {
                         result.ok = false;
                         result.msg = "malloc failed";
@@ -811,7 +813,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
                 });
                 auto registerAll = [&]() {
                     for (int i = 0; i < kThreadedBufs; i++) {
-                        result = WorkerRegister(comm, bufs[i], kThreadedBufSz, NCCL_PTR_HOST,
+                        result = WorkerRegister(comm, bufs[i], kRegStormBufSz, NCCL_PTR_HOST,
                                                 &handles[i]);
                         if (!result.ok) return false;
                     }
@@ -846,7 +848,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
                 // The connection must still work after the storm. The peer's
                 // worker may be several hundred registrations behind, so this
                 // transfer waits on the stress budget rather than the default.
-                return WorkerHostTransfer(rank, pair, kThreadedBufSz, 0,
+                return WorkerHostTransfer(rank, pair, kRegStormBufSz, 0,
                                           WorkerSeed(threadIdx, 999), kStressTimeoutMs);
             });
         return;
@@ -859,12 +861,11 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
 
     static constexpr int kNumBufs = 512;
-    static constexpr size_t kBufSz = 4096;
 
     // Allocate all buffers
     std::vector<void*> bufs(kNumBufs);
     for (int i = 0; i < kNumBufs; i++) {
-        bufs[i] = malloc(kBufSz);
+        bufs[i] = malloc(kRegStormBufSz);
         ASSERT_NE(bufs[i], nullptr) << "malloc failed at buffer " << i;
     }
     auto bufCleanup = makeScopeGuard([&]() {
@@ -874,7 +875,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     // Phase 1: register all forward
     std::vector<void*> handles(kNumBufs, nullptr);
     for (int i = 0; i < kNumBufs; i++) {
-        ASSERT_EQ(RegisterMemory(comm, bufs[i], kBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
+        ASSERT_EQ(RegisterMemory(comm, bufs[i], kRegStormBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
             << "regMr failed at " << i;
     }
 
@@ -887,7 +888,7 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
 
     // Phase 3: re-register all forward
     for (int i = 0; i < kNumBufs; i++) {
-        ASSERT_EQ(RegisterMemory(comm, bufs[i], kBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
+        ASSERT_EQ(RegisterMemory(comm, bufs[i], kRegStormBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
             << "re-regMr failed at " << i;
     }
 
@@ -908,14 +909,14 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Phase 5: verify connection is still alive with one transfer
-    auto tbuf = makeHostBufferAutoGuard(malloc(kBufSz));
+    auto tbuf = makeHostBufferAutoGuard(malloc(kRegStormBufSz));
     ASSERT_NE(tbuf.get(), nullptr);
     void* mh = nullptr;
-    ASSERT_EQ(RegisterMemory(comm, tbuf.get(), kBufSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    ASSERT_EQ(RegisterMemory(comm, tbuf.get(), kRegStormBufSz, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
     DoSendRecv(cp.sendComm, cp.recvComm,
-               tbuf.get(), tbuf.get(), kBufSz,
+               tbuf.get(), tbuf.get(), kRegStormBufSz,
                /*tag=*/0, mh, mh, /*patternSeed=*/999);
 }
 
@@ -2042,15 +2043,15 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
+    static constexpr int kDrainBatch = 32;
     const int nThreads = MPIEnvironment::nThreads;
     if (nThreads > 1) {
         static constexpr int kThreadedCycles = 25;
-        static constexpr int kThreadedBatch  = 32;
         RunThreadedBody(
             ThreadDevPolicy::Fixed(0), nThreads, "threaded RapidRecvPostDrain",
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 const size_t sz = 256;
-                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz * kThreadedBatch);
+                WorkerHostBuffer h = WorkerSetupHostBuffer(rank, pair, sz * kDrainBatch);
                 if (!h.result.ok) return h.result;
                 void* buffer = h.buffer;
                 void* mh = h.mhandle;
@@ -2060,7 +2061,7 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
                 // per-slot seed would alias into another worker's patterns modulo 256.
                 const int workerPattern = WorkerSeed(threadIdx, 0);
                 for (int cycle = 0; cycle < kThreadedCycles; cycle++) {
-                    result = WorkerBatchPostDrain(rank, pair, buffer, sz, kThreadedBatch, mh,
+                    result = WorkerBatchPostDrain(rank, pair, buffer, sz, kDrainBatch, mh,
                                                   workerPattern,
                                                   "cycle " + std::to_string(cycle) + " ");
                     if (!result.ok) return result;
@@ -2075,29 +2076,28 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     SetupConnectionWithGuard(0, cp, guard);
 
     static constexpr int kCycles = 100;
-    static constexpr int kBatch  = 32;
     const size_t sz = 256;
 
-    auto buf = makeHostBufferAutoGuard(malloc(sz * kBatch));
+    auto buf = makeHostBufferAutoGuard(malloc(sz * kDrainBatch));
     ASSERT_NE(buf.get(), nullptr);
 
     void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
     void* mh = nullptr;
-    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kBatch, NCCL_PTR_HOST, &mh), ncclSuccess);
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kDrainBatch, NCCL_PTR_HOST, &mh), ncclSuccess);
     NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
 
     for (int cycle = 0; cycle < kCycles; cycle++) {
         if (rank == 0) {
             // Post all recvs
-            std::vector<void*> reqs(kBatch, nullptr);
-            for (int i = 0; i < kBatch; i++) {
+            std::vector<void*> reqs(kDrainBatch, nullptr);
+            for (int i = 0; i < kDrainBatch; i++) {
                 char* p = static_cast<char*>(buf.get()) + i * sz;
                 PostSingleRecv(cp.recvComm, p, sz, /*tag=*/i, mh, &reqs[i]);
             }
             // Signal sender
             MPI_Barrier(MPI_COMM_WORLD);
             // Drain all
-            for (int i = 0; i < kBatch; i++) {
+            for (int i = 0; i < kDrainBatch; i++) {
                 int rsz = 0;
                 ASSERT_EQ(WaitForCompletion(reqs[i], &rsz, kStressTimeoutMs), ncclSuccess)
                     << "Drain failed cycle=" << cycle << " msg=" << i;
@@ -2106,9 +2106,9 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
             // Wait for recvs to be posted
             MPI_Barrier(MPI_COMM_WORLD);
             // Send all
-            for (int i = 0; i < kBatch; i++) {
+            for (int i = 0; i < kDrainBatch; i++) {
                 char* p = static_cast<char*>(buf.get()) + i * sz;
-                fillHostBufferWithPattern<uint8_t>(p, sz, makeBytePattern(cycle * kBatch + i));
+                fillHostBufferWithPattern<uint8_t>(p, sz, makeBytePattern(cycle * kDrainBatch + i));
                 void* req = nullptr;
                 PostSendWithRetry(cp.sendComm, p, sz, /*tag=*/i, mh, &req);
                 int rsz = 0;

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -190,6 +190,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2749,6 +2786,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -446,6 +446,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -3965,6 +4002,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -446,6 +446,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -3942,6 +3979,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -173,6 +173,16 @@
           "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
         },
         {
+          "name": "A17_NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms contend on the shared per-device MR cache.",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "A17_NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount.",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
           "name": "A17_NetIB_MultiThread_ProgressDoesNotSerialize",
           "description": "Gate: concurrent workers must progress at the same time. Catches a lock held across a progress call, which functional tests pass straight through.",
           "test_filter": "NetIbMPITest.ThreadedProgressDoesNotSerialize"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -173,6 +173,16 @@
           "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
         },
         {
+          "name": "A17_NetIB_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent workers each walk the size ladder on an independent connection.",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "A17_NetIB_MultiThread_LongRunningEndurance",
+          "description": "Concurrent workers each run a long transfer loop, so a leak or a slow drift shows up.",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        },
+        {
           "name": "A17_NetIB_MultiThread_MemoryRegistrationStorm",
           "description": "Concurrent register/deregister storms contend on the shared per-device MR cache.",
           "test_filter": "NetIbMPITest.MemoryRegistrationStorm"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -209,6 +209,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -4270,6 +4307,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -196,6 +196,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2791,6 +2828,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -205,6 +205,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -3579,6 +3616,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -190,6 +190,43 @@
         "NCCL_DMABUF_ENABLE": "1"
       }
     },
+    "net_ib_multithread_independent": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
+          "description": "Concurrent workers each transfer on an independent NET/IB context and connection",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_MultiThread_IndependentSequentialTransfers",
+          "description": "Concurrent workers each run repeated transfers on an independent connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        },
+        {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder into the shared per-device MR cache",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2744,6 +2781,12 @@
       "name": "NET Transport - Ethernet (Multi-Node)",
       "description": "Network transport tests over Ethernet",
       "config": "net_transport_eth_multinode",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Independent Connections (4)",
+      "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
+      "config": "net_ib_multithread_independent",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1031,7 +1031,7 @@
         },
         {
           "name": "NetIB_MultiThread_MemoryRegistrationStorm",
-          "description": "Concurrent register/deregister storms race the insert, lookup and eviction paths of the per-device MR cache",
+          "description": "Concurrent register/deregister storms race the insert, lookup and release paths of the per-device MR cache",
           "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
         },
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1015,9 +1015,92 @@
           "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
         },
         {
+          "name": "NetIB_MultiThread_MultipleSizes",
+          "description": "Concurrent workers sweep the size ladder, filling the shared per-device MR cache with registrations of many sizes",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
           "name": "NetIB_MultiThread_ProgressDoesNotSerialize",
           "description": "Gate: the same transfer loop at one worker and at all of them, so a lock held across a progress call shows up as time that scales with the worker count. Skips below four workers",
           "test_filter": "NetIbMPITest.ThreadedProgressDoesNotSerialize"
+        },
+        {
+          "name": "NetIB_MultiThread_LargeTransfer",
+          "description": "Concurrent 16 MB transfers keep several large registrations live on one device",
+          "test_filter": "NetIbMPITest.LargeTransfer"
+        },
+        {
+          "name": "NetIB_MultiThread_MemoryRegistrationStorm",
+          "description": "Concurrent register/deregister storms race the insert, lookup and eviction paths of the per-device MR cache",
+          "test_filter": "NetIbMPITest.MemoryRegistrationStorm"
+        },
+        {
+          "name": "NetIB_MultiThread_MrCacheRefCount",
+          "description": "All workers register the same address, contending on one cache entry's refcount",
+          "test_filter": "NetIbMPITest.MrCacheRefCount"
+        },
+        {
+          "name": "NetIB_MultiThread_MixedSizeBarrage",
+          "description": "Concurrent workers walk 1 B to 64 MB, exercising alignment and chunking under bandwidth pressure",
+          "test_filter": "NetIbMPITest.MixedSizeBarrage"
+        },
+        {
+          "name": "NetIB_MultiThread_TagZeroReuse",
+          "description": "Every worker reuses tag 0 on its own connection, so a misrouted completion shows up as a data mismatch",
+          "test_filter": "NetIbMPITest.TagZeroReuse"
+        },
+        {
+          "name": "NetIB_MultiThread_RequestSlotExhaustion",
+          "description": "Concurrent workers hold 32 requests each in flight on one NIC and verify slot recycling",
+          "test_filter": "NetIbMPITest.RequestSlotExhaustion"
+        },
+        {
+          "name": "NetIB_MultiThread_RapidRecvPostDrain",
+          "description": "Concurrent post-and-drain batches, so recycling holds up while other communicators drain",
+          "test_filter": "NetIbMPITest.RapidRecvPostDrain"
+        },
+        {
+          "name": "NetIB_MultiThread_FifoPressure",
+          "description": "N slow receivers against N tight senders, with the backpressure assertion kept per connection",
+          "test_filter": "NetIbMPITest.FifoPressureSenderFast"
+        },
+        {
+          "name": "NetIB_MultiThread_LongRunningEndurance",
+          "description": "Sustained concurrent traffic with the RDMA leak check taken around the whole run",
+          "test_filter": "NetIbMPITest.LongRunningEndurance"
+        },
+        {
+          "name": "NetIB_MultiThread_GpuMemoryTransfer",
+          "description": "Concurrent GPU-buffer registrations drive the peer-memory path into the shared MR cache",
+          "test_filter": "NetIbMPITest.GpuMemoryTransferStress"
+        }
+      ]
+    },
+    "net_ib_multithread_multiqp": {
+      "extends": "net_ib_multithread_base",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_MultiQpSplitData",
+          "description": "Concurrent workers multiply the QPs in flight per device while each checks its own split payloads",
+          "test_filter": "NetIbMPITest.MultiQpSplitDataStress"
+        }
+      ]
+    },
+    "net_ib_multithread_multiqp_nosplit": {
+      "extends": "net_ib_multithread_base",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
+      },
+      "tests": [
+        {
+          "name": "NetIB_MultiThread_MultiQpNoSplit",
+          "description": "Same concurrent sweep on the nDataQps path",
+          "test_filter": "NetIbMPITest.MultiQpNoSplitStress"
         }
       ]
     },
@@ -1032,6 +1115,14 @@
     "net_ib_multithread_independent_16": {
       "extends": "net_ib_multithread_independent",
       "command_args": "--net_ib_nthreads=16"
+    },
+    "net_ib_multithread_multiqp_4": {
+      "extends": "net_ib_multithread_multiqp",
+      "command_args": "--net_ib_nthreads=4"
+    },
+    "net_ib_multithread_multiqp_nosplit_4": {
+      "extends": "net_ib_multithread_multiqp_nosplit",
+      "command_args": "--net_ib_nthreads=4"
     },
     "cast_wrr_split_long_interval": {
       "extends": "cast_base",
@@ -1359,6 +1450,18 @@
       "name": "NET IB - Multithread Independent Connections (16)",
       "description": "16 worker threads/rank, each using an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent_16",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Multi-QP Split (4)",
+      "description": "4 worker threads/rank with 4 QPs per connection and data split across QPs",
+      "config": "net_ib_multithread_multiqp_4",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Multithread Multi-QP NoSplit (4)",
+      "description": "4 worker threads/rank with 4 QPs per connection on the nDataQps path",
+      "config": "net_ib_multithread_multiqp_nosplit_4",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1003,6 +1003,7 @@
     },
     "net_ib_multithread_independent": {
       "extends": "net_ib_multithread_base",
+      "timeout": 600,
       "tests": [
         {
           "name": "NetIB_MultiThread_IndependentSimpleSendRecv",
@@ -1079,7 +1080,7 @@
     "net_ib_multithread_multiqp": {
       "extends": "net_ib_multithread_base",
       "env_variables": {
-        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_QPS_PER_CONNECTION": "8",
         "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
       },
       "tests": [

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1455,7 +1455,7 @@
     },
     {
       "name": "NET IB - Multithread Multi-QP Split (4)",
-      "description": "4 worker threads/rank with 4 QPs per connection and data split across QPs",
+      "description": "4 worker threads/rank with 8 QPs per connection and data split across QPs",
       "config": "net_ib_multithread_multiqp_4",
       "enabled": true
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -994,6 +994,7 @@
     },
     "net_ib_multithread_base": {
       "extends": "net_ib_base",
+      "timeout": 600,
       "timeout": 300,
       "description": "Shared environment for the threaded suites. Deliberately carries no tests: extends merges test lists rather than replacing them, so a threaded suite that extended a suite with tests would also run those tests, at whatever worker count it sets.",
       "env_variables": {
@@ -1003,7 +1004,6 @@
     },
     "net_ib_multithread_independent": {
       "extends": "net_ib_multithread_base",
-      "timeout": 600,
       "tests": [
         {
           "name": "NetIB_MultiThread_IndependentSimpleSendRecv",


### PR DESCRIPTION
## Motivation

Second of four stacked PRs, on the worker-safe harness. Thirteen data-path tests and the two multi-QP sweeps gain a threaded branch, picked where NET/IB shares state between independent plugin contexts: the per-device MR cache and its protection domain, the request pool, and completion routing.

Base: `users/ilkosare/netib-threaded-harness`.

## Technical Details

Each test keeps its single-worker body and gains a threaded branch, so both run the
same assertions and the diff shows what concurrency changes.

Worker seeds come from `WorkerSeed`, not `threadIdx` arithmetic. The obvious form,
`threadIdx * 100000 + tag`, collides once the byte pattern is taken modulo 256:
workers eight apart produce identical payloads, so at sixteen workers a
cross-connection delivery would verify clean.

## Issue Tracking

JIRA ID: AICOMNET-323

## Test Plan

### Enabled tests

Worker counts are 2, 4 and 16 unless stated otherwise.

Independent connections, host memory:

- `SendRecvMultipleSizes` — every worker sweeps the size ladder, so registrations
  of many sizes land in the shared per-device MR cache at once.
- `LargeTransfer` — concurrent 16 MB transfers keep several large registrations
  live and the NIC saturated.
- `MemoryRegistrationStorm` — register/deregister storms in forward, reverse and
  shuffled order race the cache's insert, lookup and eviction paths.
- `MrCacheRefCount` — all workers register the *same* address, contending on one
  cache entry's refcount rather than merely on the cache mutex.
- `MixedSizeBarrage` — the size ladder per worker, exercising alignment and chunking
  under bandwidth pressure. Each worker walks the steps that fit its share of the
  sweep's registration budget, so the top step falls as the worker count rises: 16 MB
  at 2 and 4 workers, 4 MB at 16. The serial arm covers the whole ladder to 64 MB, and
  the budget is what keeps sixteen workers from holding 1 GB of registered host memory
  per rank.
- `TagZeroReuse` — every worker reuses tag 0 on its own connection, so a misrouted
  completion shows up as a payload mismatch instead of passing.
- `RequestSlotExhaustion` — N x 32 requests in flight on one NIC, then slot
  recycling.
- `RapidRecvPostDrain` — post-and-drain batches while other communicators drain
  their own.
- `FifoPressureSenderFast` — N slow receivers against N tight senders; the
  backpressure assertion stays per connection.
- `LongRunningEndurance` — sustained concurrent traffic, with the RDMA leak check
  taken on the main thread around the whole run.

GPU buffers:

- `GpuMemoryTransferStress` — concurrent `NCCL_PTR_CUDA` registrations drive the
  peer-memory path into the same cache; workers inherit the rank's HIP device,
  since the current device is thread-local.

Multi-QP outside IB-CAST, four workers:

- `MultiQpSplitDataStress` — data split across QPs, multiplying the QPs per device.
- `MultiQpNoSplitStress` — the same sweep on the `nDataQps` path.

### Procedure

Hardware: mia1, AINIC/Pensando with RoCE on `rdma0..rdma3`, gfx950, host build,
two ranks.

- Rebuild `rccl-UnitTestsMPI` in a debug configuration with MPI tests enabled.
- Run this level's suites at 2, 4 and 16 workers plus the two multi-QP suites,
  together with everything the level below ships.
- Load every runner config through the runner's own resolver and compile the test
  sources with fault injection off and with MPI tests off.

## Test Result

mia1, gfx950, two ranks, on `develop` at `60030ad2f2`:

- Everything the stack runs at this level, rerun on this branch head: **48 PASS /
  0 FAIL / 0 HANG / 1 SKIP**,
  which is this level's fourteen tests at 2, 4 and 16 workers plus the shim guard
  and the four long-interval tests inherited from the base. The skip is the
  serialization gate declining two workers.
- No RDMA leaks: every threaded body takes the resource counts on the main thread
  around the whole run, `LongRunningEndurance` included.
- Configs combine through `TestConfigProcessor`; the translation units compile with
  fault injection off and with MPI tests off.

## Submission Checklist

- [x] Look over the contributing guidelines at
  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

