### PR TITLE
NetIbMPI tests multithread mode for IB-CAST and NIC fusion

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/CastTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/CastTests.cpp
@@ -8,6 +8,11 @@
 #include "NetIbCastInspect.hpp"
 #include <initializer_list>
 
+// ThreadedCastAgreedNqps returns this when the connection uses one queue pair: real,
+// but the scheduler then returns before split selection and token accounting, so the
+// threaded branches skip rather than assert.
+static constexpr int kThreadedNqpsSingleQp = 1;
+
 #ifdef MPI_TESTS_ENABLED
 
 // =============================================================================
@@ -590,6 +595,71 @@ TEST_F(NetIbMPITest, CastSplitDataThresholdBoundary) {
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads. Scheduler state is per send
+    // communicator, so every worker arms and audits its own tokens while N
+    // schedulers run the boundary decision concurrently.
+    if (MPIEnvironment::nThreads > 1) {
+        // Token-delta assertions need the RTT-driven update suspended: with
+        // several workers the wall-clock gap between the before and after
+        // snapshots is wide enough for the timer to rewrite the ledger.
+        CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
+        // The live count, agreed across ranks: on a merged device the plugin creates
+        // the requested QPs per member, so an environment-derived threshold is wrong.
+        int nqps = 0;
+        // The helper reports failures itself; both ranks exit together. One queue pair
+        // is not a failure but bypasses split selection and token accounting.
+        const int nqpsStatus = ThreadedCastAgreedNqps(/*dev=*/0, &nqps);
+        if (nqpsStatus == kThreadedNqpsSingleQp)
+            GTEST_SKIP() << "the connection uses a single queue pair, which bypasses WRR and "
+                            "split selection; CastSingleQPBypassesWrr covers that case";
+        if (nqpsStatus != 0) return;
+        const size_t splitDataMin = GetSplitDataMin();
+        if (splitDataMin == 0)
+            GTEST_SKIP() << "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN=0: no WRR/split boundary exists";
+        const size_t threshold = splitDataMin * static_cast<size_t>(nqps);
+        // WorkerCastPrepareTokens warms up with 64 bytes, which a small threshold would
+        // otherwise put past the allocation.
+        const size_t bufSize = std::max<size_t>(64, threshold);
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(bufSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, bufSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                const int seed = WorkerSeed(threadIdx, 1599);
+                result = WorkerCastPrepareTokens(rank, pair, buffer, mhandle, nqps, 1599, seed);
+                if (!result.ok) return result;
+
+                // At the threshold the split path must leave WRR tokens alone.
+                result = WorkerCastTransferExpectTokens(rank, pair, buffer, threshold, 1600,
+                                                        mhandle, seed + 1, /*tokens=*/0);
+                if (!result.ok) return result;
+
+                // One byte below it, WRR must consume exactly one token.
+                return WorkerCastTransferExpectTokens(rank, pair, buffer, threshold - 1, 1601,
+                                                      mhandle, seed + 2, /*tokens=*/1);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(),
+                          "threaded CastSplitDataThresholdBoundary");
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1029,6 +1099,84 @@ TEST_F(NetIbMPITest, CastSendRecvMultipleSizes) {
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads: N schedulers sweep both sides of
+    // the WRR/split boundary at once, each auditing its own token ledger.
+    if (MPIEnvironment::nThreads > 1) {
+        // Token-delta assertions need the RTT-driven update suspended: with
+        // several workers the wall-clock gap between the before and after
+        // snapshots is wide enough for the timer to rewrite the ledger.
+        CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
+        // The live count, agreed across ranks, not the environment's request: on a
+        // merged device the plugin creates that many QPs per member, so a threshold
+        // derived from the environment sits on the wrong side of the split boundary.
+        int nqps = 0;
+        // The helper reports a failure itself; both ranks take this exit together. A
+        // single queue pair is not a failure but is not testable here either: the
+        // scheduler returns before split selection and token accounting, so the token
+        // deltas these branches expect never appear.
+        const int nqpsStatus = ThreadedCastAgreedNqps(/*dev=*/0, &nqps);
+        if (nqpsStatus == kThreadedNqpsSingleQp)
+            GTEST_SKIP() << "the connection uses a single queue pair, which bypasses WRR and "
+                            "split selection; CastSingleQPBypassesWrr covers that case";
+        if (nqpsStatus != 0) return;
+        const size_t splitDataMin = GetSplitDataMin();
+        if (splitDataMin == 0)
+            GTEST_SKIP() << "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN=0: no WRR/split boundary exists";
+        const size_t threshold = splitDataMin * static_cast<size_t>(nqps);
+        // Floored at the 64 bytes the token warm-up transfers, for the same reason.
+        const size_t bufSize = std::max<size_t>(64, threshold * 2);
+
+        std::vector<size_t> wrrSizes;
+        for (size_t size : std::initializer_list<size_t>{512, 4096, splitDataMin, threshold - 1})
+            if (size > 0 && size < threshold) wrrSizes.push_back(size);
+        wrrSizes.erase(std::unique(wrrSizes.begin(), wrrSizes.end()), wrrSizes.end());
+        const std::vector<size_t> splitSizes = {threshold, threshold * 2};
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(bufSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, bufSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                const int seedBase = WorkerSeed(threadIdx, 1999);
+                result = WorkerCastPrepareTokens(rank, pair, buffer, mhandle, nqps, 1999,
+                                                 seedBase);
+                if (!result.ok) return result;
+
+                int tag = 2000;
+                for (size_t size : wrrSizes) {
+                    result = WorkerCastTransferExpectTokens(rank, pair, buffer, size, tag++,
+                                                            mhandle, seedBase + tag,
+                                                            /*tokens=*/1);
+                    if (!result.ok) return result;
+                }
+                for (size_t size : splitSizes) {
+                    result = WorkerCastTransferExpectTokens(rank, pair, buffer, size, tag++,
+                                                            mhandle, seedBase + tag,
+                                                            /*tokens=*/0);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded CastSendRecvMultipleSizes");
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1140,6 +1288,59 @@ TEST_F(NetIbMPITest, CastLargeTransfer) {
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent 16 MB split-path
+    // transfers, each worker confirming its own scheduler stayed untouched.
+    if (MPIEnvironment::nThreads > 1) {
+        // Token-delta assertions need the RTT-driven update suspended: with
+        // several workers the wall-clock gap between the before and after
+        // snapshots is wide enough for the timer to rewrite the ledger.
+        CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
+        // The live count, agreed across ranks, not the environment's request: on a
+        // merged device the plugin creates that many QPs per member, so a threshold
+        // derived from the environment sits on the wrong side of the split boundary.
+        int nqps = 0;
+        // The helper reports a failure itself; both ranks take this exit together. A
+        // single queue pair is not a failure but is not testable here either: the
+        // scheduler returns before split selection and token accounting, so the token
+        // deltas these branches expect never appear.
+        const int nqpsStatus = ThreadedCastAgreedNqps(/*dev=*/0, &nqps);
+        if (nqpsStatus == kThreadedNqpsSingleQp)
+            GTEST_SKIP() << "the connection uses a single queue pair, which bypasses WRR and "
+                            "split selection; CastSingleQPBypassesWrr covers that case";
+        if (nqpsStatus != 0) return;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(kLargeBufferSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, kLargeBufferSize, NCCL_PTR_HOST,
+                                        &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                const int seed = WorkerSeed(threadIdx, 2099);
+                result = WorkerCastPrepareTokens(rank, pair, buffer, mhandle, nqps, 2099, seed);
+                if (!result.ok) return result;
+
+                return WorkerCastTransferExpectTokens(rank, pair, buffer, kLargeBufferSize,
+                                                      2100, mhandle, seed + 1, /*tokens=*/0);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded CastLargeTransfer");
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1205,6 +1406,59 @@ TEST_F(NetIbMPITest, CastSendRecvZeroSize) {
     CAST_ENV_CHECK_OR_SKIP();
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
+
+    // Parameterized by MPIEnvironment::nThreads: a zero-byte send must still take
+    // the WRR path on every worker's own scheduler.
+    if (MPIEnvironment::nThreads > 1) {
+        // Token-delta assertions need the RTT-driven update suspended: with
+        // several workers the wall-clock gap between the before and after
+        // snapshots is wide enough for the timer to rewrite the ledger.
+        CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
+        // The live count, agreed across ranks, not the environment's request: on a
+        // merged device the plugin creates that many QPs per member, so a threshold
+        // derived from the environment sits on the wrong side of the split boundary.
+        int nqps = 0;
+        // The helper reports a failure itself; both ranks take this exit together. A
+        // single queue pair is not a failure but is not testable here either: the
+        // scheduler returns before split selection and token accounting, so the token
+        // deltas these branches expect never appear.
+        const int nqpsStatus = ThreadedCastAgreedNqps(/*dev=*/0, &nqps);
+        if (nqpsStatus == kThreadedNqpsSingleQp)
+            GTEST_SKIP() << "the connection uses a single queue pair, which bypasses WRR and "
+                            "split selection; CastSingleQPBypassesWrr covers that case";
+        if (nqpsStatus != 0) return;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t regSize = 64;
+                void* buffer = malloc(regSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, regSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                const int seed = WorkerSeed(threadIdx, 2199);
+                result = WorkerCastPrepareTokens(rank, pair, buffer, mhandle, nqps, 2199, seed);
+                if (!result.ok) return result;
+
+                return WorkerCastTransferExpectTokens(rank, pair, buffer, 0, 2200, mhandle,
+                                                      seed + 1, /*tokens=*/1);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded CastSendRecvZeroSize");
+        return;
+    }
 
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
@@ -1279,6 +1533,119 @@ TEST_F(NetIbMPITest, CastStressMultiRoundTwoConns) {
     CAST_ENV_CHECK_OR_SKIP();
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
+
+    // Parameterized by MPIEnvironment::nThreads. The single-threaded body already
+    // drives many connections, but strictly one after another; here every worker
+    // owns a connection so the schedulers advance simultaneously. Each worker
+    // audits its own ledger: tokens are per send communicator.
+    if (MPIEnvironment::nThreads > 1) {
+        if (GetSplitDataMin() == 0)
+            GTEST_SKIP() << "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN=0: no WRR/split boundary exists";
+
+        // The live count, agreed across ranks, not the environment's request: on a
+        // merged device the plugin creates that many QPs per member, so a threshold
+        // derived from the environment sits on the wrong side of the split boundary.
+        int nqps = 0;
+        // The helper reports a failure itself; both ranks take this exit together. A
+        // single queue pair is not a failure but is not testable here either: the
+        // scheduler returns before split selection and token accounting, so the token
+        // deltas these branches expect never appear.
+        const int nqpsStatus = ThreadedCastAgreedNqps(/*dev=*/0, &nqps);
+        if (nqpsStatus == kThreadedNqpsSingleQp)
+            GTEST_SKIP() << "the connection uses a single queue pair, which bypasses WRR and "
+                            "split selection; CastSingleQPBypassesWrr covers that case";
+        if (nqpsStatus != 0) return;
+        const size_t splitDataMin = GetSplitDataMin();
+        // Split is taken when size / liveNqps >= splitDataMin, so the boundary scales
+        // with the live count; a ramp built from splitDataMin alone never crosses it.
+        const size_t threshold = splitDataMin * static_cast<size_t>(nqps);
+        if (threshold < 2)
+            GTEST_SKIP() << "live split threshold is " << threshold
+                         << " bytes: there is no WRR band below it to stress";
+        // One byte under the threshold and not floored: a 64-byte floor would push it
+        // past the threshold when the threshold is small. Only the buffer is floored.
+        const size_t msgSize = threshold - 1;
+        const std::vector<size_t> rampSizes = {threshold / 4, threshold / 2,
+                                               threshold, threshold * 2};
+        const size_t bufSize = std::max<size_t>(64, std::max(msgSize, threshold * 2));
+        static constexpr int kThreadedMsgs = 100;
+        static constexpr int kThreadedRampRounds = 5;
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* buffer = malloc(bufSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, bufSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                const int tagBase = 10000 + threadIdx * 200;
+                const int seedBase = WorkerSeed(threadIdx, 3999);
+                result = WorkerCastPrepareTokens(rank, pair, buffer, mhandle, nqps, tagBase,
+                                                 seedBase);
+                if (!result.ok) return result;
+
+                // Phase 1: small messages, all on the WRR path.
+                for (int i = 0; i < kThreadedMsgs; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, msgSize, tagBase + 1 + i,
+                                                   mhandle, seedBase + i);
+                    if (!result.ok) return result;
+                }
+
+                if (rank == 1) {
+                    struct ncclIbCastSchedState state = {};
+                    result = WorkerCastGetSchedState(pair.sendComm, &state);
+                    if (!result.ok) return result;
+                    if (!state.schedInit) {
+                        result.ok = false;
+                        result.msg = "scheduler never initialized after the WRR phase";
+                        return result;
+                    }
+                    int sum = 0;
+                    for (int qp = 0; qp < state.nqps; qp++) sum += state.activeQpTokens[qp];
+                    if (sum != state.activeTotTokens) {
+                        result.ok = false;
+                        result.msg = "per-QP tokens do not sum to activeTotTokens";
+                        return result;
+                    }
+                    if (state.activeTotTokens < 0
+                        || state.activeTotTokens > state.initTotTokens) {
+                        result.ok = false;
+                        result.msg = "activeTotTokens left the [0, initTotTokens] range";
+                        return result;
+                    }
+                }
+
+                // Phase 2: ramp across the WRR/split boundary.
+                int tag = tagBase + 1 + kThreadedMsgs;
+                for (int round = 0; round < kThreadedRampRounds; round++) {
+                    for (size_t size : rampSizes) {
+                        if (size == 0 || size > bufSize) continue;
+                        result = WorkerSendRecvPattern(rank, pair, buffer, size, tag++, mhandle,
+                                                       seedBase + tag,
+                                                       kLargeTransferTimeoutMs);
+                        if (!result.ok) return result;
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(),
+                          "threaded CastStressMultiRoundTwoConns");
+        return;
+    }
 
     constexpr int kNConns = 100;
     std::vector<void*> listenComms(kNConns, nullptr);

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1208,6 +1208,209 @@ protected:
         return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
     }
 
+    // ── Worker-safe IB-CAST scheduler inspection ─────────────────────
+    // Token and cursor state is per send communicator, so a worker can arm and
+    // read its own connection without disturbing the others.
+
+    ThreadResult WorkerCastSetTokens(void* sendComm, const std::vector<int>& tokens) {
+        ThreadResult result;
+        if (ncclIbCastSetTokens(sendComm, tokens.data(), (int)tokens.size()) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastSetTokens failed";
+        }
+        return result;
+    }
+
+    ThreadResult WorkerCastGetSchedState(void* sendComm, struct ncclIbCastSchedState* out) {
+        ThreadResult result;
+        memset(out, 0, sizeof(*out));
+        if (ncclIbCastGetSchedState(sendComm, out) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastGetSchedState failed";
+        }
+        return result;
+    }
+
+    // QPs the connection actually uses. NCCL_IB_QPS_PER_CONNECTION states only a
+    // request: on a merged device the plugin creates that many per member, so
+    // arming faults from the environment would leave the remaining QPs healthy
+    // and "the send must fail" would depend on which QP the scheduler picked.
+    // Valid once the scheduler is warm, which the first successful send does.
+    ThreadResult WorkerCastLiveNqps(void* sendComm, int* nqps) {
+        struct ncclIbCastSchedState state;
+        ThreadResult result = WorkerCastGetSchedState(sendComm, &state);
+        if (!result.ok) return result;
+        if (state.nqps <= 0) {
+            result.ok = false;
+            result.msg = "scheduler reports nqps=" + std::to_string(state.nqps);
+            return result;
+        }
+        *nqps = state.nqps;
+        return result;
+    }
+
+    // The connection's live QP count, agreed across ranks: on a merged device the plugin
+    // creates the requested QPs per member, so an environment-derived split threshold is
+    // wrong, and a worker cannot broadcast the real one.
+    // 0 usable, 1 single queue pair (caller skips), -1 failure (reported here).
+    int ThreadedCastAgreedNqps(int dev, int* nqps) {
+        void* listenComm = nullptr;
+        void* sendComm = nullptr;
+        void* recvComm = nullptr;
+
+        // The probe brings up its own connection rather than calling
+        // SetupCastConnection, which asserts fatally and sends the handle only after
+        // its assertions: a listen that fails on rank 0 leaves rank 1 waiting in
+        // MPI_Recv forever, which is a hang instead of the failure this helper
+        // promises. Here the handle carries a status word, so both ranks agree before
+        // either one waits on the other.
+        const int rank = MPIEnvironment::world_rank;
+        const int peer = 1 - rank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+        int localOk = 1;
+
+        // ncclNetHandle_t is a char array, so the handshake copies rather than assigns.
+        struct ProbeHandshake {
+            int             ok;
+            ncclNetHandle_t handle;
+        };
+
+        if (rank == 0) {
+            if (CreateListenComm(dev, &handle, &listenComm) != ncclSuccess || !listenComm)
+                localOk = 0;
+            ProbeHandshake msg{};
+            msg.ok = localOk;
+            memcpy(msg.handle, handle, sizeof(handle));
+            MPI_Send(&msg, sizeof(msg), MPI_BYTE, peer, 0, MPI_COMM_WORLD);
+            if (localOk) {
+                for (int i = 0; i < kMaxRetryAttempts && recvComm == nullptr; i++) {
+                    if (AcceptConnection(listenComm, &recvComm) != ncclSuccess) break;
+                    if (!recvComm) usleep(kPollIntervalUs);
+                }
+                if (!recvComm) localOk = 0;
+            }
+        } else {
+            ProbeHandshake msg{};
+            MPI_Recv(&msg, sizeof(msg), MPI_BYTE, peer, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            localOk = msg.ok;
+            if (localOk) {
+                memcpy(handle, msg.handle, sizeof(handle));
+                for (int i = 0; i < kMaxRetryAttempts && sendComm == nullptr; i++) {
+                    if (ConnectToRemote(dev, &handle, &sendComm) != ncclSuccess) break;
+                    if (!sendComm) usleep(kPollIntervalUs);
+                }
+                if (!sendComm) localOk = 0;
+            }
+        }
+
+        int bothUp = 0;
+        if (MPI_Allreduce(&localOk, &bothUp, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD) != MPI_SUCCESS)
+            bothUp = 0;
+        if (!bothUp) {
+            ADD_FAILURE() << "could not establish the probe connection used to agree the "
+                             "connection's live QP count";
+            TeardownConnection(recvComm, listenComm, sendComm, nullptr);
+            return -1;
+        }
+
+        void* comm = (rank == 0) ? recvComm : sendComm;
+        std::vector<char> probe(128, 0);
+        void* mhandle = nullptr;
+        const int registered =
+            RegisterMemory(comm, probe.data(), probe.size(), NCCL_PTR_HOST, &mhandle)
+                    == ncclSuccess
+                ? 1
+                : 0;
+        // Agreed before either side moves: a one-sided failure would otherwise send
+        // the failing rank into the teardown barrier while its peer waits inside
+        // GetActualNqps for traffic that is never coming, and the test would hang
+        // instead of reporting anything. TeardownConnection accepts a null handle.
+        int bothOk = 0;
+        if (MPI_Allreduce(&registered, &bothOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD)
+            != MPI_SUCCESS) {
+            bothOk = 0;
+        }
+        if (!bothOk) {
+            ADD_FAILURE() << "registering the probe buffer failed on at least one rank, so the "
+                             "connection's live QP count could not be agreed";
+            TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+            return -1;
+        }
+        *nqps = GetActualNqps(sendComm, recvComm, probe.data(), probe.size(), 1, mhandle);
+        TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+        // One queue pair is a legitimate configuration -- CastSingleQPBypassesWrr
+        // covers it -- but not one these branches can make claims about: the scheduler
+        // returns before split selection and token accounting when nqps is 1, so a
+        // token delta of 1 never appears and the split path is never taken. Reported
+        // separately from a failure so the caller can skip rather than fail.
+        if (*nqps == 1) return 1;
+        if (*nqps > 0) return 0;
+        ADD_FAILURE() << "the scheduler reported " << *nqps
+                      << " queue pairs after a successful warm-up transfer";
+        return -1;
+    }
+
+    // Warm the scheduler up (it initializes on the first send) and arm equal weights.
+    // nqps is the live count ThreadedCastAgreedNqps agreed on the main thread, so both
+    // ranks size their transfers the same way and merged devices work; the sender
+    // confirms its own connection reports the same count.
+    ThreadResult WorkerCastPrepareTokens(int rank, ConnectionPair& pair, void* buffer,
+                                         void* mhandle, int nqps, int tag, int seed) {
+        ThreadResult result = WorkerSendRecvPattern(rank, pair, buffer, 64, tag, mhandle, seed);
+        if (!result.ok || rank != 1) return result;
+
+        // The expectations are built from the agreed live count, so this checks that
+        // this worker's own connection reports the same thing; a mismatch means the
+        // expectations belong to a different connection than the one carrying data.
+        int liveNqps = 0;
+        result = WorkerCastLiveNqps(pair.sendComm, &liveNqps);
+        if (!result.ok) return result;
+        if (liveNqps != nqps) {
+            // Both ranks sized their buffers from the value the main thread agreed,
+            // so a worker's connection reporting something else means the
+            // expectations below are about a different connection than the one
+            // carrying the data.
+            result.ok = false;
+            result.msg = "this worker's connection reports nqps=" + std::to_string(liveNqps)
+                         + " but the run agreed on " + std::to_string(nqps);
+            return result;
+        }
+        return WorkerCastSetTokens(pair.sendComm, EqualTokens(liveNqps));
+    }
+
+    // Worker-safe CAST transfer with a token-consumption expectation. Only the
+    // sender owns scheduler state, so it checks the delta while the receiver
+    // verifies the payload. Pass a negative delta to skip the token check.
+    ThreadResult WorkerCastTransferExpectTokens(int rank, ConnectionPair& pair, void* buffer,
+                                                size_t size, int tag, void* mhandle, int seed,
+                                                int expectedTokenDelta,
+                                                int timeoutMs = kLargeTransferTimeoutMs) {
+        struct ncclIbCastSchedState before = {};
+        ThreadResult result;
+        if (rank == 1) {
+            result = WorkerCastGetSchedState(pair.sendComm, &before);
+            if (!result.ok) return result;
+        }
+
+        result = WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+        if (!result.ok) return result;
+
+        if (rank == 1 && expectedTokenDelta >= 0) {
+            struct ncclIbCastSchedState after = {};
+            result = WorkerCastGetSchedState(pair.sendComm, &after);
+            if (!result.ok) return result;
+            const int delta = before.activeTotTokens - after.activeTotTokens;
+            if (delta != expectedTokenDelta) {
+                result.ok = false;
+                result.msg = "expected a WRR token delta of "
+                             + std::to_string(expectedTokenDelta) + " at size "
+                             + std::to_string(size) + ", observed " + std::to_string(delta);
+            }
+        }
+        return result;
+    }
+
     ncclResult_t InitNetIbCtx(void** ctxOut) {
         ncclNetCommConfig_t commConfig = {};
         commConfig.trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -615,6 +615,55 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
         << "Failed to create fused vNIC from devices 0 and 1";
     ASSERT_GE(vdev, 0);
 
+    // Parameterized by MPIEnvironment::nThreads. Every regMr on a fused device
+    // fans out across both members' protection domains and MR caches, so
+    // concurrent cycling on one address doubles the contended surface. The vNIC
+    // itself is created once on the main thread: the merged-device table is
+    // process-global.
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads > 1) {
+        // One region, cycled by every worker so they contend on a single MR cache
+        // entry, but sliced for the traffic that follows: the serial body moves
+        // data through the address it just recycled, and a shared payload buffer
+        // would have the workers overwriting each other's verification.
+        const size_t slotSize   = kSmallBufferSize;
+        const size_t sharedSize = slotSize * nThreads;
+        auto shared = makeHostBufferAutoGuard(malloc(sharedSize));
+        ASSERT_NE(shared.get(), nullptr);
+
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            vdev, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                for (int i = 0; i < 50; i++) {
+                    void* mhandle = nullptr;
+                    result = WorkerRegister(workerComm, shared.get(), sharedSize,
+                                            NCCL_PTR_HOST, &mhandle);
+                    if (!result.ok) return result;
+                    if (DeregisterMemory(workerComm, mhandle) != ncclSuccess) {
+                        result.ok = false;
+                        result.msg = "deregMr failed during vNIC cache cycling";
+                        return result;
+                    }
+                }
+
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, shared.get(), sharedSize, NCCL_PTR_HOST,
+                                        &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                void* slot = static_cast<char*>(shared.get()) + threadIdx * slotSize;
+                return WorkerSendRecvPattern(rank, pair, slot, slotSize, 530, mhandle,
+                                             WorkerSeed(threadIdx, 0));
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded RegDeregCycling_VNic");
+        return;
+    }
+
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
     SetupConnectionWithGuard(vdev, pair, connGuard);
@@ -694,6 +743,27 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
         << "Failed to create fused vNIC from devices 0 and 1";
     ASSERT_GE(vdev, 0);
 
+    // Parameterized by MPIEnvironment::nThreads: several striped transfers run at
+    // once over the fused device. The per-worker size shrinks with the worker
+    // count: every registration on a fused device is pinned once per member, so
+    // 64 MB per worker exhausts registration resources at high worker counts
+    // while adding nothing to the striping coverage.
+    if (MPIEnvironment::nThreads > 1) {
+        const size_t threadedSize =
+            std::max<size_t>(4 * 1024 * 1024,
+                             (64 * 1024 * 1024) / MPIEnvironment::nThreads);
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            vdev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                return WorkerHostTransfer(rank, pair, threadedSize, 540,
+                                          WorkerSeed(threadIdx, 5400), kLargeTransferTimeout);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded LargeTransfer_VNic");
+        return;
+    }
+
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
     SetupConnectionWithGuard(vdev, pair, connGuard);
@@ -760,6 +830,20 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
     ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
         << "Failed to create fused vNIC from devices 0 and 1";
     ASSERT_GE(vdev, 0);
+
+    // Parameterized by MPIEnvironment::nThreads: the uneven-split ladder runs on
+    // every worker's own fused connection simultaneously.
+    if (MPIEnvironment::nThreads > 1) {
+        // Per-size registration, as the serial body does: on a fused device every
+        // regMr fans out across both members, and that churn is what this test is
+        // about.
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(vdev), MPIEnvironment::nThreads,
+                             {1, 3*1024*1024, 3, 5*1024*1024, 7, 7*1024*1024,
+                              64, 16*1024*1024, 1, 11*1024*1024, 4*1024*1024, 1},
+                             /*repeats=*/1, "threaded MixedSizes_VNic",
+                             SweepRegistration::PerSize);
+        return;
+    }
 
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
@@ -837,6 +921,16 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
     ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
         << "Failed to create fused vNIC from devices 0 and 1";
     ASSERT_GE(vdev, 0);
+
+    // Parameterized by MPIEnvironment::nThreads: concurrent workers hit the
+    // 128-byte striping boundary on both members of the fused device at once.
+    if (MPIEnvironment::nThreads > 1) {
+        RunThreadedSizeSweep(ThreadDevPolicy::Fixed(vdev), MPIEnvironment::nThreads,
+                             {127, 129, 255, 257, 511, 513},
+                             /*repeats=*/2, "threaded UnalignedSizeTransfer_VNic",
+                             SweepRegistration::PerSize);
+        return;
+    }
 
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
@@ -1057,6 +1151,90 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
     ASSERT_GE(vdev, 0);
 
     const int rank = MPIEnvironment::world_rank;
+
+    // Parameterized by MPIEnvironment::nThreads: concurrent GPU receives and
+    // flushes on one fused device. Workers inherit this rank's HIP device from
+    // the harness, since the current device is thread-local.
+    if (MPIEnvironment::nThreads > 1) {
+        static constexpr int kThreadedIters = 20;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            vdev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = kSmallBufferSize;
+                void* gpuBuffer = nullptr;
+                if (hipMalloc(&gpuBuffer, size) != hipSuccess) {
+                    result.ok = false;
+                    result.msg = "hipMalloc failed";
+                    return result;
+                }
+                auto gpuGuard = makeDeviceBufferAutoGuard(gpuBuffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(comm, gpuBuffer, size, NCCL_PTR_CUDA, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
+
+                // One pattern per worker: a per-iteration seed aliases modulo 256.
+                const int seed = WorkerSeed(threadIdx, 6000);
+                for (int iter = 0; iter < kThreadedIters; iter++) {
+                    if (rank == 1
+                        && initializeBufferWithPattern<uint8_t>(gpuBuffer, size,
+                                                                makeBytePattern(seed))
+                               != hipSuccess) {
+                        result.ok = false;
+                        result.msg = "GPU buffer initialization failed";
+                        return result;
+                    }
+
+                    // The size is checked: with one pattern per worker and no clearing
+                    // between iterations, a short receive would verify on a stale tail.
+                    int received = 0;
+                    result = WorkerSendRecvRaw(rank, pair, gpuBuffer, size, 600, mhandle,
+                                               kDefaultTimeoutMs, &received);
+                    if (!result.ok) return result;
+
+                    if (rank != 0) continue;
+                    if (received != static_cast<int>(size)) {
+                        result.ok = false;
+                        result.msg = "iteration " + std::to_string(iter) + " received "
+                                     + std::to_string(received) + " of "
+                                     + std::to_string(size) + " bytes";
+                        return result;
+                    }
+
+                    void* flushBuffers[1] = {gpuBuffer};
+                    int flushSizes[1] = {static_cast<int>(size)};
+                    void* flushHandles[1] = {mhandle};
+                    void* flushRequest = nullptr;
+                    // A null request means the flush was a no-op; an error
+                    // return means the flush itself failed.
+                    if (FlushRecv(pair.recvComm, 1, flushBuffers, flushSizes, flushHandles,
+                                  &flushRequest)
+                        != ncclSuccess) {
+                        result.ok = false;
+                        result.msg = "FlushRecv failed at iteration " + std::to_string(iter);
+                        return result;
+                    }
+                    if (flushRequest != nullptr) {
+                        result = WorkerWait(flushRequest, nullptr);
+                        if (!result.ok) return result;
+                    }
+                    if (!verifyBufferData<uint8_t>(gpuBuffer, size, makeBytePattern(seed))) {
+                        result.ok = false;
+                        result.msg = "GPU data verification failed after flush";
+                        return result;
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded FlushRepeated_VNic");
+        return;
+    }
+
     ConnectionPair pair;
     NetConnectionGuard connGuard(net_);
     SetupConnectionWithGuard(vdev, pair, connGuard);
@@ -1104,6 +1282,7 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
 
             ncclResult_t flushResult = FlushRecv(pair.recvComm, 1, flushBuffers, flushSizes,
                                                  flushHandles, &flushRequest);
+            EXPECT_EQ(flushResult, ncclSuccess) << "Iter " << iter << ": FlushRecv failed";
             if (flushResult == ncclSuccess && flushRequest != nullptr) {
                 ASSERT_EQ(WaitForCompletion(flushRequest, nullptr), ncclSuccess);
             }
@@ -1140,6 +1319,44 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
     ASSERT_GE(vdev, 0);
 
     const int rank = MPIEnvironment::world_rank;
+
+    // Parameterized by MPIEnvironment::nThreads: every worker reuses one
+    // registration across its iterations, so the fused device serves many
+    // long-lived MRs at once.
+    if (MPIEnvironment::nThreads > 1) {
+        static constexpr int kThreadedIters = 100;
+        const RdmaResourceCounts before = CaptureRdmaResources();
+        RunMultiThreadedIndependent(
+            vdev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = kSmallBufferSize;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(comm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle, NetMHandleWorkerDeleter(net_, comm));
+
+                // Worker-constant, as above.
+                const int seed = WorkerSeed(threadIdx, 7000);
+                for (int iter = 0; iter < kThreadedIters; iter++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, size, 700, mhandle, seed);
+                    if (!result.ok) return result;
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        AssertNoRdmaLeaks(before, CaptureRdmaResources(), "threaded SequentialTransfers_VNic");
+        return;
+    }
 
     // Single connection through the vNIC, reused across all 100 iterations.
     ConnectionPair pair;

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -227,6 +227,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2792,6 +2814,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -483,6 +483,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -3985,6 +4007,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -495,7 +495,7 @@
     { "config": "gin_ainic_backend",     "enabled": true },
     { "config": "bootstrap_socket_poll", "enabled": true, "smoke": true },
     { "config": "a_netib_multithread",   "enabled": true, "smoke": true },
-    { "config": "a_cast_multithread",    "enabled": true },
+    { "config": "a_cast_multithread",    "enabled": true, "smoke": true },
 
     { "config": "ib_baseline",           "enabled": true, "smoke": true },
     { "config": "cast_alltoall_full",    "enabled": true, "smoke": true },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -189,6 +189,22 @@
         }
       ]
     },
+    "a_cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "description": "A18: four worker threads per rank on independent IB-CAST connections, so several WRR schedulers advance at once.",
+      "tests": [
+        {
+          "name": "A18_Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent CAST connections, each auditing its own WRR token ledger.",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        }
+      ]
+    },
 
     "gin_proxy": {
       "extends": "gtest_base",
@@ -479,6 +495,7 @@
     { "config": "gin_ainic_backend",     "enabled": true },
     { "config": "bootstrap_socket_poll", "enabled": true, "smoke": true },
     { "config": "a_netib_multithread",   "enabled": true, "smoke": true },
+    { "config": "a_cast_multithread",    "enabled": true },
 
     { "config": "ib_baseline",           "enabled": true, "smoke": true },
     { "config": "cast_alltoall_full",    "enabled": true, "smoke": true },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -246,6 +246,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -4313,6 +4335,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -233,6 +233,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2834,6 +2856,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -242,6 +242,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -3622,6 +3644,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -227,6 +227,28 @@
         }
       ]
     },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Concurrent IB-CAST connections, each auditing its own WRR token ledger",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2787,6 +2809,12 @@
       "name": "NET IB - Multithread Independent Connections (4)",
       "description": "4 worker threads/rank, each on an independent NET/IB context and connection",
       "config": "net_ib_multithread_independent",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1073,6 +1073,36 @@
           "name": "NetIB_MultiThread_GpuMemoryTransfer",
           "description": "Concurrent GPU-buffer registrations drive the peer-memory path into the shared MR cache",
           "test_filter": "NetIbMPITest.GpuMemoryTransferStress"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicRegDeregCycling",
+          "description": "Concurrent register/deregister cycling on a fused device, fanning out across both members' protection domains",
+          "test_filter": "NetIbMPITest.RegDeregCycling_VNic"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicSequentialTransfers",
+          "description": "Concurrent long-lived registrations on one fused device",
+          "test_filter": "NetIbMPITest.SequentialTransfers_VNic"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicMixedSizes",
+          "description": "Concurrent uneven QP splits across a fused device",
+          "test_filter": "NetIbMPITest.MixedSizes_VNic"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicLargeTransfer",
+          "description": "Concurrent striped transfers over a fused device, 64 MB divided by the worker count so the registrations stay within the device limits",
+          "test_filter": "NetIbMPITest.LargeTransfer_VNic"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicUnalignedSizes",
+          "description": "Concurrent transfers at the 128-byte striping boundary of a fused device",
+          "test_filter": "NetIbMPITest.UnalignedSizeTransfer_VNic"
+        },
+        {
+          "name": "NetIB_MultiThread_VNicFlushRepeated",
+          "description": "Concurrent GPU receives and flushes on one fused device",
+          "test_filter": "NetIbMPITest.FlushRepeated_VNic"
         }
       ]
     },
@@ -1123,6 +1153,54 @@
     "net_ib_multithread_multiqp_nosplit_4": {
       "extends": "net_ib_multithread_multiqp_nosplit",
       "command_args": "--net_ib_nthreads=4"
+    },
+    "cast_multithread": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "10000000"
+      },
+      "tests": [
+        {
+          "name": "Cast_MultiThread_StressMultiRound",
+          "description": "Every worker drives its own CAST connection, so the WRR schedulers advance simultaneously instead of one after another",
+          "test_filter": "NetIbMPITest.CastStressMultiRoundTwoConns"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvMultipleSizes",
+          "description": "Concurrent schedulers sweep both sides of the WRR/split boundary, each auditing its own token ledger",
+          "test_filter": "NetIbMPITest.CastSendRecvMultipleSizes"
+        },
+        {
+          "name": "Cast_MultiThread_LargeTransfer",
+          "description": "Concurrent 16 MB split-path transfers, each confirming its scheduler consumed no tokens",
+          "test_filter": "NetIbMPITest.CastLargeTransfer"
+        },
+        {
+          "name": "Cast_MultiThread_SendRecvZeroSize",
+          "description": "Zero-byte sends still take the WRR path on every worker's scheduler",
+          "test_filter": "NetIbMPITest.CastSendRecvZeroSize"
+        },
+        {
+          "name": "Cast_MultiThread_SplitDataThresholdBoundary",
+          "description": "Concurrent schedulers decide the split boundary at the same time, each auditing its own tokens",
+          "test_filter": "NetIbMPITest.CastSplitDataThresholdBoundary"
+        }
+      ]
+    },
+    "cast_multithread_2": {
+      "extends": "cast_multithread",
+      "command_args": "--net_ib_nthreads=2"
+    },
+    "cast_multithread_4": {
+      "extends": "cast_multithread",
+      "command_args": "--net_ib_nthreads=4"
+    },
+    "cast_multithread_16": {
+      "extends": "cast_multithread",
+      "command_args": "--net_ib_nthreads=16"
     },
     "cast_wrr_split_long_interval": {
       "extends": "cast_base",
@@ -1462,6 +1540,24 @@
       "name": "NET IB - Multithread Multi-QP NoSplit (4)",
       "description": "4 worker threads/rank with 4 QPs per connection on the nDataQps path",
       "config": "net_ib_multithread_multiqp_nosplit_4",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (2)",
+      "description": "2 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread_2",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (4)",
+      "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread_4",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Multithread (16)",
+      "description": "16 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
+      "config": "cast_multithread_16",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

Third of four stacked PRs. IB-CAST keeps its token ledger per communicator, so the serial bodies already build several connections but drive them one after another; here the schedulers advance at the same time, each auditing its own ledger. Fused devices come with it because a vNIC is still the plain send/recv path — the difference is that every registration fans out across both members' protection domains and caches, doubling the contended surface for the same test body.

Base: `users/ilkosare/netib-threaded-independent`.

## Technical Details

The threaded CAST branches query the live QP count from the scheduler instead of
trusting `NCCL_IB_QPS_PER_CONNECTION`: that variable states a request, and on a
merged device the plugin creates that many per member, so an expectation built from
the environment would be wrong on exactly the configurations these tests care
about. The suites hold `RCCL_IB_QP_SCHED_UPDATE_INTERVAL` at 10 s so the RTT timer
cannot rewrite tokens mid-assertion.

The vNIC is created once on the main thread and its index handed to the workers,
since the device table is process-global.

## Issue Tracking

JIRA ID: AICOMNET-323

## Test Plan

### Enabled tests

Worker counts are 2, 4 and 16.

IB-CAST scheduler, with the RTT update suspended so token deltas are meaningful:

- `CastStressMultiRoundTwoConns` — the serial body builds many connections but
  drives them one at a time; here the schedulers advance simultaneously, each
  auditing its own ledger. Deliberately weaker in one respect: the serial body
  asserts that the RTT timer fired, which cannot hold at the 10 s interval the
  threaded branches need, so the threaded variant drops that assertion and keeps
  the ledger audit.
- `CastSendRecvMultipleSizes` — both sides of the WRR/split boundary.
- `CastLargeTransfer` — the 16 MB split path, no tokens consumed.
- `CastSendRecvZeroSize` — a zero-byte send still takes the WRR path.
- `CastSplitDataThresholdBoundary` — exactly at the threshold and one byte below.

Fused devices (vNIC created once on the main thread, its index handed to workers):

- `RegDeregCycling_VNic` — every registration fans out across both members'
  protection domains and caches, doubling the contended surface.
- `SequentialTransfers_VNic` — long-lived registrations, one per worker.
- `MixedSizes_VNic` — uneven QP splits across the fused device.
- `LargeTransfer_VNic` — striped transfers; the per-worker size scales down with
  the worker count, since each registration is pinned once per member.
- `UnalignedSizeTransfer_VNic` — the 128-byte striping boundary.
- `FlushRepeated_VNic` — concurrent GPU receives plus `iflush`.

### Procedure

Hardware: mia1, AINIC/Pensando with RoCE on `rdma0..rdma3`, gfx950, host build,
two ranks.

- Rebuild `rccl-UnitTestsMPI` in a debug configuration with MPI tests enabled.
- Run this level's CAST and fused-device suites at 2, 4 and 16 workers, together
  with everything the two levels below ship.
- Confirm the four scheduler-toggle tests still pass at the 10 s interval they now
  share with the threaded CAST branches.
- Load every runner config through the runner's own resolver and compile the test
  sources with fault injection off and with MPI tests off.

## Test Result

mia1, gfx950, two ranks, on `develop` at `60030ad2f2`:

- Everything the stack runs at this level, rerun on this branch head: **81 PASS /
  0 FAIL / 0 HANG / 1 SKIP**. The skip is the serialization gate declining two
  workers. The count is higher than it was when this PR was opened because the
  suites grew while the stack was under review, not because tests were re-counted.
- The four scheduler-toggle tests pass at the shared 10 s interval.
- Configs combine through `TestConfigProcessor`; the translation units compile with
  fault injection off and with MPI tests off.

## Submission Checklist

- [x] Look over the contributing guidelines at
  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
