### PR TITLE
NetIbMPI tests multithread mode for fault-injection and recovery

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2093,10 +2093,16 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
             mergedDev, MPIEnvironment::nThreads,
             [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
                 ThreadResult result;
-                // One message, not a run of them: with more, the two sides have been seen
-                // to drift a message apart. PostRecoveryPingPongHoldsSync carries that
-                // finding; one message here still proves traffic resumes.
-                static constexpr int kThreadedPostRecoveryMsgs = 1;
+                // Two messages, and the two do different jobs. The recovery thread
+                // publishes Recovered on its own, but activeQps is not restored until
+                // IbCastResiliencyProgress runs, and that runs only from a request poll
+                // (p2p.cc IbCastTest) -- ncclIbCastGetResiliencyState below merely reads
+                // the state and drives nothing. So message 0 is a progress kick, still
+                // posted on the failover queue pairs, and message 1 is the one that
+                // actually crosses the restored ones. Not more than two: beyond that the
+                // two sides have been seen to drift a message apart, which
+                // PostRecoveryPingPongHoldsSync carries as its own finding.
+                static constexpr int kThreadedPostRecoveryMsgs = 2;
                 static constexpr int kRecoveryPollIterations = 6000;  // 6000 * 10ms = 60s
                 // The receiver has no way to learn when the sender leaves the
                 // recovery poll: the serial body uses an MPI handshake, which a
@@ -2172,6 +2178,9 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
                         // it on its own would call the communicator recovered on a run where
                         // the injected failure was never observed -- and the traffic below
                         // would then prove nothing. recoveryCount separates the two.
+                        // Recovered means the recovery thread is done, not that the queue
+                        // pairs are back in rotation; the kick message below is what
+                        // finishes that, and the check after it is what confirms it.
                         if (lastState == kDevStateRecovered
                             || (lastState == kDevStateOk && recoveries > 0)) {
                             recovered = true;
@@ -2205,8 +2214,10 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
                         // in isolation, with both ranks bounded at their own budgets waiting for
                         // each other, so the device state at the moment of failure is what the
                         // next occurrence needs to be diagnosable.
-                        result.msg = "post-recovery traffic, message " + std::to_string(i) + ": "
-                                     + result.msg;
+                        result.msg = std::string("post-recovery traffic, ")
+                                     + ((i == 0) ? "progress kick" : "transfer on the restored "
+                                                                     "queue pairs")
+                                     + ": " + result.msg;
                         if (rank == 1) {
                             struct ncclIbCastResiliencyState state = {};
                             if (ncclIbCastGetResiliencyState(pair.sendComm, &state)
@@ -2219,6 +2230,30 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
                         // buffer and its registration outlive this worker.
                         return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
                                                                  &bufferGuard);
+                    }
+                    if (i == 0 && rank == 1) {
+                        // Polling message 0 to completion is what ran
+                        // IbCastResiliencyProgress, which restores activeQps and moves
+                        // device 0 from Recovered to Ok while counting the recovery. If
+                        // that has not happened by now, message 1 would go out on the
+                        // failover queue pairs as well and the test would report a
+                        // restored connection it never touched.
+                        struct ncclIbCastResiliencyState state = {};
+                        if (ncclIbCastGetResiliencyState(pair.sendComm, &state) != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "ncclIbCastGetResiliencyState failed after the "
+                                         "post-recovery progress kick";
+                            return result;
+                        }
+                        if (state.devState[0] != kDevStateOk || state.recoveryCount[0] < 1) {
+                            result.ok = false;
+                            result.msg = "recovery was not finalized by the first post-recovery "
+                                         "message, so the queue pairs were never restored: "
+                                         "devState[0]=" + std::to_string(state.devState[0])
+                                         + " recoveryCount[0]="
+                                         + std::to_string(state.recoveryCount[0]);
+                            return result;
+                        }
                     }
                 }
 

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -85,6 +85,68 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorIsFatal) {
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads. Injected error state lives in
+    // the communicator, so each worker breaks only its own connection and each
+    // one must observe the failure on its own send.
+    if (MPIEnvironment::nThreads > 1) {
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = 1024;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                // Warm the scheduler up before arming, as the serial body does.
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 300, mhandle,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                if (rank == 0) {
+                    // Posting this receive is what lets the peer reach the injected
+                    // error, and its send then fails before posting, so nothing will
+                    // complete this request. Flushing it keeps the work request from
+                    // outliving the memory region the worker must deregister.
+                    void* request = nullptr;
+                    result = WorkerPostRecv(pair.recvComm, buffer, size, 301, mhandle, &request);
+                    if (!result.ok) return result;
+                    if (WorkerDrainRecv(request, 100)) return result;
+                    return WorkerCastFlushAbandonedRecv(pair.recvComm, request);
+                }
+
+                int liveNqps = 0;
+                result = WorkerCastLiveNqps(pair.sendComm, &liveNqps);
+                if (!result.ok) return result;
+
+                result = WorkerCastFaultArmError(pair.sendComm, liveNqps);
+                if (!result.ok) return result;
+
+                const WorkerFaultSendOutcome outcome =
+                    WorkerCastFaultSend(pair.sendComm, buffer, size, 301, mhandle, 200);
+                if (outcome.sendRet == ncclSuccess && outcome.fatalCount <= 0) {
+                    result.ok = false;
+                    result.msg = "expected isend to fail or a fatal error to be counted after "
+                                 "arming every QP with error injection";
+                    return result;
+                }
+                return WorkerCastFaultClear(pair.sendComm);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -362,6 +424,56 @@ TEST_F(NetIbMPITest, FaultInjCastDelayDataIntegrity) {
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
+    // Parameterized by MPIEnvironment::nThreads: every worker slows down its own
+    // QP 0 and still has to deliver intact data while the other workers keep the
+    // device busy.
+    if (MPIEnvironment::nThreads > 1) {
+        RunMultiThreadedIndependent(
+            0, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                static constexpr int kThreadedMsgs = 20;
+                const size_t size = 8192;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 4999, mhandle,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                if (rank == 1) {
+                    result = WorkerCastFaultSetDelay(pair.sendComm, /*qpIdx=*/0,
+                                                     /*delayUs=*/2000);
+                    if (!result.ok) return result;
+                }
+
+                // One pattern per worker: the claim is whose data arrived, not which.
+                const int seed = WorkerSeed(threadIdx, 0);
+                for (int i = 0; i < kThreadedMsgs; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, size, 5000 + i, mhandle,
+                                                   seed, kLargeTransferTimeoutMs);
+                    if (!result.ok) return result;
+                }
+
+                if (rank == 1) return WorkerCastFaultClear(pair.sendComm);
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -573,6 +685,95 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
 
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
+
+    // Parameterized by MPIEnvironment::nThreads. Each worker owns two
+    // connections: it breaks the first, clears the fault, and then has to move
+    // data cleanly on the second, so leftover fault state cannot hide behind a
+    // quiet fabric.
+    if (MPIEnvironment::nThreads > 1) {
+        RunMultiThreadedIndependentGroups(
+            ThreadDevPolicy::Fixed(0), MPIEnvironment::nThreads, /*connsPerWorker=*/2,
+            [&](int threadIdx, std::vector<ConnectionPair*>& pairs) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = 1024;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                ConnectionPair& faulted = *pairs[0];
+                ConnectionPair& fresh   = *pairs[1];
+
+                void* faultedComm = (rank == 0) ? faulted.recvComm : faulted.sendComm;
+                void* faultedMh = nullptr;
+                result = WorkerRegister(faultedComm, buffer, size, NCCL_PTR_HOST, &faultedMh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard faultedGuard(faultedMh,
+                                                   NetMHandleWorkerDeleter(net_, faultedComm));
+
+                result = WorkerSendRecvPattern(rank, faulted, buffer, size, 500, faultedMh,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                if (rank == 0) {
+                    // Flushed rather than left hanging: phase 2 reuses this buffer,
+                    // and a work request from the broken connection must not still
+                    // be pointing at it.
+                    void* request = nullptr;
+                    result = WorkerPostRecv(faulted.recvComm, buffer, size, 501, faultedMh,
+                                            &request);
+                    if (!result.ok) return result;
+                    if (!WorkerDrainRecv(request, 100)) {
+                        result = WorkerCastFlushAbandonedRecv(faulted.recvComm, request);
+                        if (!result.ok) return result;
+                    }
+                } else {
+                    int liveNqps = 0;
+                    result = WorkerCastLiveNqps(faulted.sendComm, &liveNqps);
+                    if (!result.ok) return result;
+
+                    result = WorkerCastFaultArmError(faulted.sendComm, liveNqps);
+                    if (!result.ok) return result;
+
+                    const WorkerFaultSendOutcome outcome =
+                        WorkerCastFaultSend(faulted.sendComm, buffer, size, 501, faultedMh, 200);
+                    if (outcome.sendRet == ncclSuccess && outcome.fatalCount <= 0) {
+                        result.ok = false;
+                        result.msg = "phase 1 did not observe the injected fault";
+                        return result;
+                    }
+                    result = WorkerCastFaultClear(faulted.sendComm);
+                    if (!result.ok) return result;
+                }
+
+                // Phase 2: the fresh connection must be unaffected.
+                void* freshComm = (rank == 0) ? fresh.recvComm : fresh.sendComm;
+                void* freshMh = nullptr;
+                result = WorkerRegister(freshComm, buffer, size, NCCL_PTR_HOST, &freshMh);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard freshGuard(freshMh,
+                                                 NetMHandleWorkerDeleter(net_, freshComm));
+
+                result = WorkerSendRecvPattern(rank, fresh, buffer, size, 502, freshMh,
+                                               WorkerSeed(threadIdx, 7));
+                if (!result.ok) return result;
+
+                if (rank == 1) {
+                    const int fatalCount = WorkerCastFatalCount(fresh.sendComm);
+                    if (fatalCount != 0) {
+                        result.ok = false;
+                        result.msg = "the fresh connection reports fatal errors ("
+                                     + std::to_string(fatalCount) + ")";
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
 
     // ── Phase 1: inject fault on first connection ─────────────────────────
     void* listenComm1 = nullptr;
@@ -823,6 +1024,50 @@ TEST_F(NetIbMPITest, FailoverCqeErrorRecovered) {
     if (mergedDev < 0) {
         GTEST_SKIP() << "Failover requires NIC Fusion (ndevs >= 2). "
                      << "Found " << totalDevs << " physical devices.";
+    }
+
+    // Parameterized by MPIEnvironment::nThreads: N links fail at once, and each
+    // communicator still has to deliver its payload over the surviving device. The
+    // threaded suites run this with NCCL_IB_RESILIENCY_PORT_RECOVERY unset, which is
+    // its default, so what overlaps here is failover -- N failovers on one fused
+    // device, each rewriting its own per-communicator resiliency state. Concurrent
+    // recovery is a different claim and belongs to the suites that enable recovery;
+    // turning it on here would also race this test's own check that device 0 is no
+    // longer Ok, since recovery exists precisely to put it back.
+    if (MPIEnvironment::nThreads > 1) {
+        // Shared gate: staggered failures would not put several failovers on the
+        // device at the same time.
+        std::atomic<int> atFailure{0};
+        RunMultiThreadedIndependent(
+            mergedDev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = 8192;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 600, mhandle,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                return WorkerCastFailoverTransfer(rank, pair, buffer, size, 601, mhandle,
+                                                  WorkerSeed(threadIdx, 1), /*messages=*/1, &atFailure,
+                                                  MPIEnvironment::nThreads);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
     }
 
     void* listenComm = nullptr;
@@ -1227,6 +1472,47 @@ TEST_F(NetIbMPITest, FailoverLargeMessageDataIntegrity) {
         GTEST_SKIP() << "Requires NIC Fusion (ndevs >= 2). Need at least 2 IB devices.";
     }
 
+    // Parameterized by MPIEnvironment::nThreads: concurrent 64 KB messages must
+    // survive their own link failure byte for byte, which also keeps several
+    // retransmit paths active on one device at the same time.
+    if (MPIEnvironment::nThreads > 1) {
+        // Shared by the workers so every link fails at the same moment: the point of
+        // these threaded bodies is several failovers overlapping on one device, which
+        // staggered failures would not produce. Recovery is off here by default, so
+        // the recovery thread is not what this exercises.
+        std::atomic<int> atFailure{0};
+        RunMultiThreadedIndependent(
+            mergedDev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                const size_t size = 65536;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 900, mhandle,
+                                               WorkerSeed(threadIdx, 0), kLargeTransferTimeoutMs);
+                if (!result.ok) return result;
+
+                return WorkerCastFailoverTransfer(rank, pair, buffer, size, 901, mhandle,
+                                                  WorkerSeed(threadIdx, 1), /*messages=*/1, &atFailure,
+                                                  MPIEnvironment::nThreads);
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1498,6 +1784,70 @@ TEST_F(NetIbMPITest, FailoverMultiRequestInFlight) {
         GTEST_SKIP() << "Requires NIC Fusion (ndevs >= 2).";
     }
 
+    // Parameterized by MPIEnvironment::nThreads. What the threaded body establishes
+    // is the ordering and the outcome: every worker posts several messages, breaks
+    // its own QP 0, and then requires all of them to arrive intact with no fatal
+    // error, with the failures overlapping across communicators. It does not claim
+    // that a request was still on the wire at the transition -- the helper explains
+    // why that is not observable from a worker, and the repost count it returns is
+    // logged rather than asserted.
+    if (MPIEnvironment::nThreads > 1) {
+        // Shared by the workers so every link fails at the same moment: the point of
+        // these threaded bodies is several failovers overlapping on one device, which
+        // staggered failures would not produce. Recovery is off here by default, so
+        // the recovery thread is not what this exercises.
+        std::atomic<int> atFailure{0};
+        // Filled by the workers, logged here after they join.
+        std::vector<int> reposts(MPIEnvironment::nThreads, -1);
+        RunMultiThreadedIndependent(
+            mergedDev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                static constexpr int kThreadedReqs = 4;
+                // 16 MB, not the serial body's 4 KB: measured with the helper's own
+                // count, 4 KB left 0 of 4 requests outstanding and 1 MB left 0 to 1,
+                // because those finish before the batch is posted.
+                const size_t size = 16 * 1024 * 1024;
+                // One slice per in-flight message, plus one for the warmup.
+                const size_t bufSize = size * (kThreadedReqs + 1);
+                void* buffer = malloc(bufSize);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, bufSize, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 1200, mhandle,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                // This test is about requests already in flight when the link
+                // dies, so the fault lands after every message is posted.
+                // Both guards are handed over: a failure that cannot flush its requests
+                // keeps the buffer and its registration alive rather than freeing memory
+                // the device may still be writing into. The repost count comes back
+                // rather than being logged here, since a worker cannot call TEST_INFO.
+                return WorkerCastFailoverInFlight(rank, pair, buffer, size, 1210, mhandle,
+                                                  WorkerSeed(threadIdx, 1), kThreadedReqs,
+                                                  &atFailure, MPIEnvironment::nThreads,
+                                                  &mhandleGuard, &bufferGuard,
+                                                  &reposts[threadIdx]);
+            });
+        for (int t = 0; t < MPIEnvironment::nThreads; t++)
+            TEST_INFO("worker %d: messages posted before the QP error, repost count %d",
+                      t, reposts[t]);
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1730,6 +2080,164 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
         GTEST_SKIP() << "Requires NIC Fusion (ndevs >= 2). Found " << totalDevs << " physical devices.";
     }
 
+    // Parameterized by MPIEnvironment::nThreads. Recovery assertions stay
+    // per-communicator, but the recovery thread and its inbox are process-global,
+    // so N simultaneous failures are the only way to see it serve several
+    // connections. The poll budget is generous for exactly that reason.
+    if (MPIEnvironment::nThreads > 1) {
+        // Shared by the workers so every link fails at the same moment: the point
+        // of these threaded bodies is the one global recovery thread facing several
+        // broken communicators, which staggered failures would not produce.
+        std::atomic<int> atFailure{0};
+        RunMultiThreadedIndependent(
+            mergedDev, MPIEnvironment::nThreads,
+            [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+                ThreadResult result;
+                // One message, not a run of them: with more, the two sides have been seen
+                // to drift a message apart. PostRecoveryPingPongHoldsSync carries that
+                // finding; one message here still proves traffic resumes.
+                static constexpr int kThreadedPostRecoveryMsgs = 1;
+                static constexpr int kRecoveryPollIterations = 6000;  // 6000 * 10ms = 60s
+                // The receiver has no way to learn when the sender leaves the
+                // recovery poll: the serial body uses an MPI handshake, which a
+                // worker cannot call. So the first post-recovery message has to
+                // wait out the sender's whole poll budget on top of its own.
+                static constexpr int kFirstPostRecoveryTimeoutMs =
+                    kRecoveryPollIterations * (kPollIntervalUs / 1000) + kLargeTransferTimeoutMs;
+                const size_t size = 8192;
+                void* buffer = malloc(size);
+                if (!buffer) {
+                    result.ok = false;
+                    result.msg = "malloc failed";
+                    return result;
+                }
+                auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+                void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+                void* mhandle = nullptr;
+                result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+                if (!result.ok) return result;
+                NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                                   NetMHandleWorkerDeleter(net_, workerComm));
+
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 1300, mhandle,
+                                               WorkerSeed(threadIdx, 0));
+                if (!result.ok) return result;
+
+                // QP 0 is broken while the connection is idle: the serial body's
+                // in-flight break needs an MPI handshake a worker cannot make. Gated so
+                // the failures land together, which is the claim about the one global
+                // recovery thread.
+                if (!WorkerRendezvous(atFailure, MPIEnvironment::nThreads, 3000)) {
+                    result.ok = false;
+                    result.msg = "workers did not all reach the link failure together";
+                    return result;
+                }
+                result = WorkerTransferAcrossQpFailure(rank, pair, buffer, size, 1301, mhandle,
+                                                      WorkerSeed(threadIdx, 1),
+                                                      kLargeTransferTimeoutMs);
+                if (!result.ok) {
+                    result.msg = "failover transfer after the link failure: " + result.msg;
+                    return result;
+                }
+
+                if (rank == 1) {
+                    // Failover was supposed to absorb the QP error, as the serial
+                    // body asserts after its own phase 1.
+                    const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+                    if (fatalCount != 0) {
+                        result.ok = false;
+                        result.msg = "failover left " + std::to_string(fatalCount)
+                                     + " fatal errors on the connection";
+                        return result;
+                    }
+                }
+
+                if (rank == 1) {
+                    // Wait for the global recovery thread to bring device 0 back.
+                    bool recovered = false;
+                    int lastState = -1;
+                    int recoveries = 0;
+                    for (int poll = 0; poll < kRecoveryPollIterations; poll++) {
+                        struct ncclIbCastResiliencyState state = {};
+                        if (ncclIbCastGetResiliencyState(pair.sendComm, &state) != ncclSuccess) {
+                            result.ok = false;
+                            result.msg = "ncclIbCastGetResiliencyState failed while waiting for "
+                                         "recovery";
+                            return result;
+                        }
+                        lastState = state.devState[0];
+                        recoveries = state.recoveryCount[0];
+                        // Ok is also device 0's state before anything happened, so accepting
+                        // it on its own would call the communicator recovered on a run where
+                        // the injected failure was never observed -- and the traffic below
+                        // would then prove nothing. recoveryCount separates the two.
+                        if (lastState == kDevStateRecovered
+                            || (lastState == kDevStateOk && recoveries > 0)) {
+                            recovered = true;
+                            break;
+                        }
+                        if (lastState == kDevStateRecoveryFailed
+                            || lastState == kDevStateErrorPermanent) {
+                            break;
+                        }
+                        usleep(kPollIntervalUs);
+                    }
+                    if (!recovered) {
+                        result.ok = false;
+                        result.msg = "device 0 never reported a completed recovery; last "
+                                     "state was " + std::to_string(lastState)
+                                     + " with recoveryCount=" + std::to_string(recoveries);
+                        return result;
+                    }
+                }
+
+                // Traffic must flow again on the recovered connection.
+                // Per-message patterns, unlike the other threaded bodies: the drift is a
+                // one-message skew, so a stale message must not verify as its successor.
+                for (int i = 0; i < kThreadedPostRecoveryMsgs; i++) {
+                    result = WorkerSendRecvPattern(rank, pair, buffer, size, 1310 + i, mhandle,
+                                                   WorkerSeed(threadIdx, 10 + i),
+                                                   (i == 0) ? kFirstPostRecoveryTimeoutMs
+                                                            : kLargeTransferTimeoutMs);
+                    if (!result.ok) {
+                        // This phase has been seen to fail once in a full matrix run and never
+                        // in isolation, with both ranks bounded at their own budgets waiting for
+                        // each other, so the device state at the moment of failure is what the
+                        // next occurrence needs to be diagnosable.
+                        result.msg = "post-recovery traffic, message " + std::to_string(i) + ": "
+                                     + result.msg;
+                        if (rank == 1) {
+                            struct ncclIbCastResiliencyState state = {};
+                            if (ncclIbCastGetResiliencyState(pair.sendComm, &state)
+                                == ncclSuccess) {
+                                result.msg += "; devState[0]=" + std::to_string(state.devState[0])
+                                              + " devState[1]=" + std::to_string(state.devState[1]);
+                            }
+                        }
+                        // The wait timed out but did not cancel the request, so the
+                        // buffer and its registration outlive this worker.
+                        return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                                 &bufferGuard);
+                    }
+                }
+
+                if (rank == 1) {
+                    // Sustained traffic after recovery must stay clean too, which
+                    // is the serial body's closing assertion.
+                    const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+                    if (fatalCount != 0) {
+                        result.ok = false;
+                        result.msg = "post-recovery traffic reported " + std::to_string(fatalCount)
+                                     + " fatal errors";
+                    }
+                }
+                return result;
+            });
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
     void* listenComm = nullptr;
     void* sendComm   = nullptr;
     void* recvComm   = nullptr;
@@ -1921,6 +2429,177 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
     }
 
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
+// =============================================================================
+// Test: PostRecoveryPingPongHoldsSync
+//
+// Tracks an open finding: after QP 0 is driven to error on both sides and recovery
+// reports device 0 healthy, ten blocking ping-pong messages get the two ranks a
+// message apart -- the sender exhausting its FIFO-slot retries on message n+1 while
+// the receiver waits for n, both devices Ok. Not reproducible on demand, so no rate
+// is quoted; the figure from before the recoveryCount guard measured runs where
+// recovery never happened. Nightly only (suite "A20. Nightly - ..."), since it is
+// expected to fail some runs until the plugin side is understood.
+//
+// The serial body does not drift: its MPI handshakes resynchronize the two sides
+// between phases, which a worker cannot do.
+// =============================================================================
+TEST_F(NetIbMPITest, PostRecoveryPingPongHoldsSync) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    const char* failoverEnv = getenv("NCCL_IB_RESILIENCY_PORT_FAILOVER");
+    const char* recoveryEnv = getenv("NCCL_IB_RESILIENCY_PORT_RECOVERY");
+    if (!failoverEnv || strcmp(failoverEnv, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_RESILIENCY_PORT_FAILOVER=1";
+    }
+    if (!recoveryEnv || strcmp(recoveryEnv, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_RESILIENCY_PORT_RECOVERY=1";
+    }
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads < 2) {
+        GTEST_SKIP() << "Requires --net_ib_nthreads of at least 2: the drift needs a worker, "
+                        "which cannot use the MPI handshakes that hide it";
+    }
+
+    const int rank = MPIEnvironment::world_rank;
+    net_ = &netIbCast;
+    int totalDevs = 0;
+    AssertInitAndGetDevices(&totalDevs);
+
+    int mergedDev = CreateMergedDeviceForFailover(net_, totalDevs);
+    if (mergedDev < 0) {
+        GTEST_SKIP() << "Requires NIC Fusion (ndevs >= 2). Found " << totalDevs
+                     << " physical devices.";
+    }
+
+    static constexpr int    kPostRecoveryMsgs = 10;
+    static constexpr int    kRecoveryPollIterations = 6000;  // 6000 * 10ms = 60s
+    // The receiver cannot learn when the sender leaves its recovery poll, so the
+    // first post-recovery message has to wait out that whole budget as well.
+    static constexpr int    kFirstMsgTimeoutMs =
+        kRecoveryPollIterations * (kPollIntervalUs / 1000) + kLargeTransferTimeoutMs;
+    static constexpr size_t kMsgSize = 8192;
+
+    // Shared gate: non-overlapping recoveries are a different situation.
+    std::atomic<int> atFailure{0};
+
+    RunMultiThreadedIndependent(
+        mergedDev, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadResult result;
+            void* buffer = malloc(kMsgSize);
+            if (!buffer) {
+                result.ok = false;
+                result.msg = "malloc failed";
+                return result;
+            }
+            auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+            void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+            void* mhandle = nullptr;
+            result = WorkerRegister(workerComm, buffer, kMsgSize, NCCL_PTR_HOST, &mhandle);
+            if (!result.ok) return result;
+            NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                               NetMHandleWorkerDeleter(net_, workerComm));
+
+            result = WorkerSendRecvPattern(rank, pair, buffer, kMsgSize, 1400, mhandle,
+                                           WorkerSeed(threadIdx, 0));
+            if (!result.ok) return result;
+
+            // QP 0 broken while idle, then the transfer; both sides enter recovery.
+            if (!WorkerRendezvous(atFailure, nThreads, 3000)) {
+                result.ok = false;
+                result.msg = "workers did not all reach the link failure together";
+                return result;
+            }
+            result = WorkerTransferAcrossQpFailure(rank, pair, buffer, kMsgSize, 1401, mhandle,
+                                                   WorkerSeed(threadIdx, 1),
+                                                   kLargeTransferTimeoutMs);
+            if (!result.ok) {
+                result.msg = "failover transfer after the link failure: " + result.msg;
+                return result;
+            }
+
+            if (rank == 1) {
+                bool recovered = false;
+                int  lastState = -1;
+                int  recoveries = 0;
+                for (int poll = 0; poll < kRecoveryPollIterations; poll++) {
+                    struct ncclIbCastResiliencyState state = {};
+                    if (ncclIbCastGetResiliencyState(pair.sendComm, &state) != ncclSuccess) {
+                        result.ok = false;
+                        result.msg = "ncclIbCastGetResiliencyState failed while waiting for "
+                                     "recovery";
+                        return result;
+                    }
+                    lastState = state.devState[0];
+                    recoveries = state.recoveryCount[0];
+                    // Ok is also device 0's state before anything happened, so accepting
+                    // it on its own would call the communicator recovered on a run where
+                    // the injected failure was never observed -- and the traffic below
+                    // would then prove nothing. recoveryCount separates the two.
+                    if (lastState == kDevStateRecovered
+                        || (lastState == kDevStateOk && recoveries > 0)) {
+                        recovered = true;
+                        break;
+                    }
+                    if (lastState == kDevStateRecoveryFailed
+                        || lastState == kDevStateErrorPermanent) {
+                        break;
+                    }
+                    usleep(kPollIntervalUs);
+                }
+                if (!recovered) {
+                    result.ok = false;
+                    result.msg = "device 0 never reported a completed recovery; last "
+                                 "state was " + std::to_string(lastState)
+                                 + " with recoveryCount=" + std::to_string(recoveries);
+                    return result;
+                }
+            }
+
+            // The claim under test: a recovered connection carries a run of
+            // blocking messages without the two sides losing each other.
+            // Per-message patterns: a stale message must not verify as its successor.
+            for (int i = 0; i < kPostRecoveryMsgs; i++) {
+                result = WorkerSendRecvPattern(rank, pair, buffer, kMsgSize, 1410 + i, mhandle,
+                                               WorkerSeed(threadIdx, 10 + i),
+                                               (i == 0) ? kFirstMsgTimeoutMs
+                                                        : kLargeTransferTimeoutMs);
+                if (!result.ok) {
+                    result.msg = "post-recovery message " + std::to_string(i) + " of "
+                                 + std::to_string(kPostRecoveryMsgs) + ": " + result.msg;
+                    if (rank == 1) {
+                        struct ncclIbCastResiliencyState state = {};
+                        if (ncclIbCastGetResiliencyState(pair.sendComm, &state) == ncclSuccess) {
+                            result.msg += "; devState[0]=" + std::to_string(state.devState[0])
+                                          + " devState[1]=" + std::to_string(state.devState[1])
+                                          + " (both Ok here is the drift, not a link failure)";
+                        }
+                        result.msg += "; fatalCount="
+                                      + std::to_string(WorkerCastFatalCount(pair.sendComm));
+                    }
+                    // The drift leaves the receiver waiting on a request the wait cannot
+                    // cancel, so both guards are retained rather than unwound here.
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
+                }
+            }
+
+            if (rank == 1) {
+                const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+                if (fatalCount != 0) {
+                    result.ok = false;
+                    result.msg = "sustained post-recovery traffic left " + std::to_string(fatalCount)
+                                 + " fatal errors on the connection";
+                }
+            }
+            return result;
+        });
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 // =============================================================================
@@ -3265,6 +3944,23 @@ TEST_F(NetIbMPITest, FaultInjectionShimsAbsentUnlessRequested) {
     constexpr size_t kMsgSize = 1024;
     std::vector<char> buf(kMsgSize, 0);
     void* comm    = (rank == 0) ? recvComm : sendComm;
+    // Checked, because the assertions inside SetupCastConnection return from the
+    // helper rather than from this test: a cross-node accept that fails leaves this
+    // rank holding a null communicator, and registering against one crashes inside
+    // the plugin (IbCastRegMrDmaBufInternal dereferences it), which then takes the
+    // rest of the suite down with it -- every later test in the same run could not
+    // connect. Both ranks agree so neither is left waiting at the barrier below.
+    int localUp = comm != nullptr ? 1 : 0;
+    int bothUp = 0;
+    if (MPI_Allreduce(&localUp, &bothUp, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD) != MPI_SUCCESS)
+        bothUp = 0;
+    if (!bothUp) {
+        ADD_FAILURE() << "connection setup did not produce a usable communicator on both ranks, "
+                         "so the shim probe cannot run";
+        TeardownConnection(recvComm, listenComm, sendComm, nullptr);
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
     void* mhandle = nullptr;
     ASSERT_EQ(RegisterMemory(comm, buf.data(), kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
 
@@ -3295,6 +3991,180 @@ TEST_F(NetIbMPITest, FaultInjectionShimsAbsentUnlessRequested) {
 
     MPI_Barrier(MPI_COMM_WORLD);
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
+// =============================================================================
+// Test: FaultIsolationAcrossWorkers
+//
+// Multithread-only. One worker arms error injection on its own connection and
+// must observe the failure; every other worker keeps transferring on its own
+// connection and must stay clean, with a fatal count of zero.
+//
+// This is the assertion the serial tests cannot make: injected state lives in
+// ncclIbNetCommBase, so a broken connection must not disturb its siblings on the
+// same device. It also puts a failing connection and healthy traffic on one NIC
+// at the same time, which is how a real process behaves when one link dies.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultIsolationAcrossWorkers) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+    const int nThreads = MPIEnvironment::nThreads;
+    if (nThreads < 2) {
+        GTEST_SKIP() << "requires --net_ib_nthreads greater than one: the whole point is one "
+                        "failing connection alongside healthy ones";
+    }
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kHealthyTransfers = 10;
+        // The isolation claim holds only while the fault is live, and the start gate
+        // synchronizes nothing past entry: bystanders wait for the victim to arm, the victim
+        // waits for their traffic before clearing, and the fatal count is read in between.
+    std::atomic<bool> faultArmed{false};
+    std::atomic<bool> victimFinished{false};
+    std::atomic<int>  bystandersDone{0};
+    const int kBystanders = nThreads - 1;
+    // Bounded, so a victim that dies before arming cannot hang its siblings.
+    static constexpr int kFlagPollIterations = 3000;  // 3000 * 10ms = 30s
+    auto waitForFlag = [](std::atomic<bool>& flag, int pollIterations) {
+        for (int poll = 0; poll < pollIterations; poll++) {
+            if (flag.load(std::memory_order_acquire)) return true;
+            usleep(kPollIntervalUs);
+        }
+        return false;
+    };
+
+    RunMultiThreadedIndependent(
+        0, nThreads, [&](int threadIdx, ConnectionPair& pair) -> ThreadResult {
+            ThreadResult result;
+            const size_t size = 1024;
+            void* buffer = malloc(size);
+            if (!buffer) {
+                result.ok = false;
+                result.msg = "malloc failed";
+                return result;
+            }
+            auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+            void* workerComm = (rank == 0) ? pair.recvComm : pair.sendComm;
+            void* mhandle = nullptr;
+            result = WorkerRegister(workerComm, buffer, size, NCCL_PTR_HOST, &mhandle);
+            if (!result.ok) return result;
+            NetMHandleWorkerGuard mhandleGuard(mhandle,
+                                               NetMHandleWorkerDeleter(net_, workerComm));
+
+            // Every worker starts from a working connection.
+            result = WorkerSendRecvPattern(rank, pair, buffer, size, 800, mhandle,
+                                           WorkerSeed(threadIdx, 0));
+            if (!result.ok) return result;
+
+            const bool victim = (threadIdx == 0);
+            if (victim) {
+                // Releases the siblings on every exit, including the failure
+                // paths, so they never wait on a victim that already gave up.
+                struct FaultWindow {
+                    std::atomic<bool>& armed;
+                    std::atomic<bool>& finished;
+                    ~FaultWindow() {
+                        armed.store(true, std::memory_order_release);
+                        finished.store(true, std::memory_order_release);
+                    }
+                } window{faultArmed, victimFinished};
+
+                if (rank == 0) {
+                    // Posting this receive is what lets the peer reach the injected
+                    // error, so it is the local point where the fault window opens.
+                    // Nothing will complete it, so it is flushed before the worker
+                    // unwinds its registration.
+                    void* request = nullptr;
+                    result = WorkerPostRecv(pair.recvComm, buffer, size, 801, mhandle, &request);
+                    if (!result.ok) return result;
+                    faultArmed.store(true, std::memory_order_release);
+                    if (WorkerDrainRecv(request, 100)) return result;
+                    return WorkerCastFlushAbandonedRecv(pair.recvComm, request);
+                }
+
+                int liveNqps = 0;
+                result = WorkerCastLiveNqps(pair.sendComm, &liveNqps);
+                if (!result.ok) return result;
+
+                result = WorkerCastFaultArmError(pair.sendComm, liveNqps);
+                if (!result.ok) return result;
+                faultArmed.store(true, std::memory_order_release);
+
+                const WorkerFaultSendOutcome outcome =
+                    WorkerCastFaultSend(pair.sendComm, buffer, size, 801, mhandle, 200);
+                if (outcome.sendRet == ncclSuccess && outcome.fatalCount <= 0) {
+                    result.ok = false;
+                    result.msg = "the victim connection did not observe its injected fault";
+                    return result;
+                }
+
+                // Hold the fault until the bystanders have finished, so their
+                // traffic really did share the device with a broken connection.
+                for (int poll = 0; poll < kFlagPollIterations; poll++) {
+                    if (bystandersDone.load(std::memory_order_acquire) >= kBystanders) break;
+                    usleep(kPollIntervalUs);
+                }
+                if (bystandersDone.load(std::memory_order_acquire) < kBystanders) {
+                    result.ok = false;
+                    result.msg = "only " + std::to_string(bystandersDone.load())
+                                 + " of " + std::to_string(kBystanders)
+                                 + " bystander workers finished while the fault was armed";
+                    return result;
+                }
+
+                return WorkerCastFaultClear(pair.sendComm);
+            }
+
+            // Bystanders must be untouched by the victim's failure, and their
+            // traffic has to run while that fault is live.
+            if (!waitForFlag(faultArmed, kFlagPollIterations)) {
+                result.ok = false;
+                result.msg = "the victim worker never reported its fault as armed";
+                return result;
+            }
+            // Worker-constant: a bystander asserts whose data arrived.
+            const int bystanderSeed = WorkerSeed(threadIdx, 0);
+            for (int i = 0; i < kHealthyTransfers; i++) {
+                result = WorkerSendRecvPattern(rank, pair, buffer, size, 810 + i, mhandle,
+                                               bystanderSeed, kLargeTransferTimeoutMs);
+                if (!result.ok) {
+                    result.msg = "bystander worker disturbed by another worker's fault: "
+                                 + result.msg;
+                    // Counted even on failure: the victim is waiting for this, and
+                    // its own timeout would bury the real error under a second one.
+                    bystandersDone.fetch_add(1, std::memory_order_release);
+                    return result;
+                }
+            }
+            bystandersDone.fetch_add(1, std::memory_order_release);
+
+            if (rank == 1) {
+                // Read the count only once the victim is finished, so it covers
+                // the whole time the fault was live.
+                if (!waitForFlag(victimFinished, kFlagPollIterations)) {
+                    result.ok = false;
+                    result.msg = "the victim worker never finished";
+                    return result;
+                }
+                const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+                if (fatalCount != 0) {
+                    result.ok = false;
+                    result.msg = "bystander connection reports " + std::to_string(fatalCount)
+                                 + " fatal errors after a sibling connection failed";
+                }
+            }
+            return result;
+        });
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -112,7 +112,9 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorIsFatal) {
                 // Warm the scheduler up before arming, as the serial body does.
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 300, mhandle,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 if (rank == 0) {
                     // Posting this receive is what lets the peer reach the injected
@@ -451,7 +453,9 @@ TEST_F(NetIbMPITest, FaultInjCastDelayDataIntegrity) {
 
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 4999, mhandle,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 if (rank == 1) {
                     result = WorkerCastFaultSetDelay(pair.sendComm, /*qpIdx=*/0,
@@ -464,7 +468,9 @@ TEST_F(NetIbMPITest, FaultInjCastDelayDataIntegrity) {
                 for (int i = 0; i < kThreadedMsgs; i++) {
                     result = WorkerSendRecvPattern(rank, pair, buffer, size, 5000 + i, mhandle,
                                                    seed, kLargeTransferTimeoutMs);
-                    if (!result.ok) return result;
+                    if (!result.ok)
+                        return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                                 &bufferGuard);
                 }
 
                 if (rank == 1) return WorkerCastFaultClear(pair.sendComm);
@@ -716,7 +722,9 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
 
                 result = WorkerSendRecvPattern(rank, faulted, buffer, size, 500, faultedMh,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, faulted, rank, &faultedGuard,
+                                                             &bufferGuard);
 
                 if (rank == 0) {
                     // Flushed rather than left hanging: phase 2 reuses this buffer,
@@ -759,7 +767,9 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
 
                 result = WorkerSendRecvPattern(rank, fresh, buffer, size, 502, freshMh,
                                                WorkerSeed(threadIdx, 7));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, fresh, rank, &freshGuard,
+                                                             &bufferGuard);
 
                 if (rank == 1) {
                     const int fatalCount = WorkerCastFatalCount(fresh.sendComm);
@@ -1060,7 +1070,9 @@ TEST_F(NetIbMPITest, FailoverCqeErrorRecovered) {
 
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 600, mhandle,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 return WorkerCastFailoverTransfer(rank, pair, buffer, size, 601, mhandle,
                                                   WorkerSeed(threadIdx, 1), /*messages=*/1, &atFailure,
@@ -1503,7 +1515,9 @@ TEST_F(NetIbMPITest, FailoverLargeMessageDataIntegrity) {
 
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 900, mhandle,
                                                WorkerSeed(threadIdx, 0), kLargeTransferTimeoutMs);
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 return WorkerCastFailoverTransfer(rank, pair, buffer, size, 901, mhandle,
                                                   WorkerSeed(threadIdx, 1), /*messages=*/1, &atFailure,
@@ -1827,7 +1841,9 @@ TEST_F(NetIbMPITest, FailoverMultiRequestInFlight) {
 
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 1200, mhandle,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 // This test is about requests already in flight when the link
                 // dies, so the fault lands after every message is posted.
@@ -2128,7 +2144,9 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
 
                 result = WorkerSendRecvPattern(rank, pair, buffer, size, 1300, mhandle,
                                                WorkerSeed(threadIdx, 0));
-                if (!result.ok) return result;
+                if (!result.ok)
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
 
                 // QP 0 is broken while the connection is idle: the serial body's
                 // in-flight break needs an MPI handshake a worker cannot make. Gated so
@@ -2141,7 +2159,8 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
                 }
                 result = WorkerTransferAcrossQpFailure(rank, pair, buffer, size, 1301, mhandle,
                                                       WorkerSeed(threadIdx, 1),
-                                                      kLargeTransferTimeoutMs);
+                                                      kLargeTransferTimeoutMs, &mhandleGuard,
+                                                      &bufferGuard);
                 if (!result.ok) {
                     result.msg = "failover transfer after the link failure: " + result.msg;
                     return result;
@@ -2541,7 +2560,9 @@ TEST_F(NetIbMPITest, PostRecoveryPingPongHoldsSync) {
 
             result = WorkerSendRecvPattern(rank, pair, buffer, kMsgSize, 1400, mhandle,
                                            WorkerSeed(threadIdx, 0));
-            if (!result.ok) return result;
+            if (!result.ok)
+                return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                         &bufferGuard);
 
             // QP 0 broken while idle, then the transfer; both sides enter recovery.
             if (!WorkerRendezvous(atFailure, nThreads, 3000)) {
@@ -2551,7 +2572,8 @@ TEST_F(NetIbMPITest, PostRecoveryPingPongHoldsSync) {
             }
             result = WorkerTransferAcrossQpFailure(rank, pair, buffer, kMsgSize, 1401, mhandle,
                                                    WorkerSeed(threadIdx, 1),
-                                                   kLargeTransferTimeoutMs);
+                                                   kLargeTransferTimeoutMs, &mhandleGuard,
+                                                   &bufferGuard);
             if (!result.ok) {
                 result.msg = "failover transfer after the link failure: " + result.msg;
                 return result;
@@ -4097,7 +4119,9 @@ TEST_F(NetIbMPITest, FaultIsolationAcrossWorkers) {
             // Every worker starts from a working connection.
             result = WorkerSendRecvPattern(rank, pair, buffer, size, 800, mhandle,
                                            WorkerSeed(threadIdx, 0));
-            if (!result.ok) return result;
+            if (!result.ok)
+                return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                         &bufferGuard);
 
             const bool victim = (threadIdx == 0);
             if (victim) {
@@ -4176,7 +4200,8 @@ TEST_F(NetIbMPITest, FaultIsolationAcrossWorkers) {
                     // Counted even on failure: the victim is waiting for this, and
                     // its own timeout would bury the real error under a second one.
                     bystandersDone.fetch_add(1, std::memory_order_release);
-                    return result;
+                    return WorkerRetainAfterAbandonedRequest(result, pair, rank, &mhandleGuard,
+                                                             &bufferGuard);
                 }
             }
             bystandersDone.fetch_add(1, std::memory_order_release);

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1411,6 +1411,426 @@ protected:
         return result;
     }
 
+
+#if defined(ENABLE_FAULT_INJECTION)
+    // ── Worker-safe IB-CAST fault injection ──────────────────────────
+    // The pre-call intercept hooks store their state in the communicator
+    // (faultQpDelayUs / faultQpError in ncclIbNetCommBase), so a worker can
+    // break its own connection without touching anybody else's. The
+    // libibverbs-level ops registry is process-global and deliberately not
+    // used here.
+
+    ThreadResult WorkerCastFaultArmError(void* sendComm, int nqps) {
+        ThreadResult result;
+        for (int qp = 0; qp < nqps; qp++) {
+            if (ncclIbCastFaultSetQpError(sendComm, qp, /*inject=*/true) != ncclSuccess) {
+                result.ok = false;
+                result.msg = "ncclIbCastFaultSetQpError failed on QP " + std::to_string(qp);
+                return result;
+            }
+        }
+        return result;
+    }
+
+    ThreadResult WorkerCastFaultSetDelay(void* sendComm, int qpIdx, uint32_t delayUs) {
+        ThreadResult result;
+        if (ncclIbCastFaultSetQpDelay(sendComm, qpIdx, delayUs) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastFaultSetQpDelay failed";
+        }
+        return result;
+    }
+
+    ThreadResult WorkerCastFaultClear(void* sendComm) {
+        ThreadResult result;
+        if (ncclIbCastFaultClear(sendComm) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastFaultClear failed";
+        }
+        return result;
+    }
+
+    int WorkerCastFatalCount(void* sendComm) {
+        int count = 0;
+        if (ncclIbCastFaultGetFatalCount(sendComm, &count) != ncclSuccess) return -1;
+        return count;
+    }
+
+    ThreadResult WorkerCastDriveQpToError(void* sendComm, int qpIdx) {
+        ThreadResult result;
+        if (ncclIbCastFaultDriveQpToError(sendComm, qpIdx) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastFaultDriveQpToError failed";
+        }
+        return result;
+    }
+
+    // Post one send and poll it, treating both a failed isend and a fatal error
+    // count as an outcome rather than a test failure. Used by fault tests that
+    // accept either signal.
+    struct WorkerFaultSendOutcome {
+        ncclResult_t sendRet = ncclSuccess;
+        bool         completed = false;
+        int          fatalCount = 0;
+    };
+
+    WorkerFaultSendOutcome WorkerCastFaultSend(void* sendComm, void* buffer, size_t size, int tag,
+                                               void* mhandle, int pollIterations) {
+        WorkerFaultSendOutcome outcome;
+        void* request = nullptr;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            outcome.sendRet = PostSend(sendComm, buffer, size, tag, mhandle, &request);
+            if (outcome.sendRet != ncclSuccess || request != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+        outcome.fatalCount = WorkerCastFatalCount(sendComm);
+
+        if (outcome.sendRet == ncclSuccess && request != nullptr) {
+            for (int poll = 0; poll < pollIterations; poll++) {
+                int done = 0;
+                int sizes[1] = {0};
+                const ncclResult_t testRet = TestRequest(request, &done, sizes);
+                if (testRet != ncclSuccess) {
+                    outcome.sendRet = testRet;
+                    break;
+                }
+                outcome.fatalCount = WorkerCastFatalCount(sendComm);
+                if (done) {
+                    outcome.completed = true;
+                    break;
+                }
+                if (outcome.fatalCount > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+        return outcome;
+    }
+
+    // Shared worker body for the failover tests: drive the sender's QP 0 into
+    // the error state, then require the payload to still arrive over the
+    // surviving device of a fused NIC, with no fatal error and a device state
+    // that is no longer Ok.
+    //
+    // What the concurrency exercises here is overlapping failovers, not recovery:
+    // the suites that run this leave NCCL_IB_RESILIENCY_PORT_RECOVERY at its
+    // default of off, because these assertions require the device to stay
+    // not-Ok and recovery would undo that underneath them. Resiliency state is per
+    // communicator, so N workers drive their own links into error at the same
+    // moment on one fused device, and every one of them has to keep routing over
+    // the survivor. The process-global recovery thread is a different claim, and
+    // fault_recovery_multithread_2 is where it is made.
+    ThreadResult WorkerCastFailoverTransfer(int rank, ConnectionPair& pair, void* buffer,
+                                            size_t size, int tag, void* mhandle, int seed,
+                                            int messages = 1, std::atomic<int>* arrived = nullptr,
+                                            int expected = 0) {
+        ThreadResult result;
+        // Without a gate here the failures are merely started from several workers,
+        // not overlapping: each worker allocates, registers and warms up first, so a
+        // fast one can be through failover before a slow one reaches this line, and
+        // simultaneous errors on the one fused device -- the thing this body claims
+        // to cover -- go untested. Bounded, and a timeout is reported rather than
+        // asserted, since a worker cannot fail the test alone.
+        if (arrived && expected > 1
+            && !WorkerRendezvous(*arrived, expected, kFailureGatePolls)) {
+            result.ok = false;
+            result.msg = "workers did not all reach the link failure together";
+            return result;
+        }
+        if (rank == 1) {
+            result = WorkerCastDriveQpToError(pair.sendComm, 0);
+            if (!result.ok) return result;
+        }
+
+        for (int i = 0; i < messages; i++) {
+            result = WorkerSendRecvPattern(rank, pair, buffer, size, tag + i, mhandle, seed + i,
+                                           kLargeTransferTimeoutMs);
+            if (!result.ok) {
+                result.msg = "after driving QP 0 to error: " + result.msg;
+                return result;
+            }
+        }
+
+        if (rank != 1) return result;
+
+        const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+        if (fatalCount != 0) {
+            result.ok = false;
+            result.msg = "failover should have handled the QP error, but the fatal count is "
+                         + std::to_string(fatalCount);
+            return result;
+        }
+
+        struct ncclIbCastResiliencyState state = {};
+        if (ncclIbCastGetResiliencyState(pair.sendComm, &state) != ncclSuccess) {
+            result.ok = false;
+            result.msg = "ncclIbCastGetResiliencyState failed";
+            return result;
+        }
+        // 0 is ncclIbResiliencyDevStateOk; anything else means the failure was
+        // registered (Error, RecoveryInProgress or Recovered).
+        if (state.devState[0] == 0) {
+            result.ok = false;
+            result.msg = "device 0 still reports Ok after its QP was driven to error";
+        }
+        return result;
+    }
+
+    // The receiver cannot be asked how many queue pairs its connection uses, so a flush
+    // walks this many; extra indices are refused harmlessly.
+    static constexpr int kMaxQpsToFlush = 8;
+
+    // For a failure where a request may still be live and the test cannot reach it:
+    // WorkerSendRecvPattern owns its request and a timed-out wait does not cancel the
+    // work, so the buffer and its registration must not be released as the worker
+    // unwinds. This side's queue pairs are driven to error first, which retires
+    // outstanding work with a flush status, and both guards are then retained because
+    // nothing here can prove the request is gone. Leaking one buffer on a failing test
+    // is the cheaper mistake.
+    ThreadResult WorkerRetainAfterAbandonedRequest(ThreadResult failure, ConnectionPair& pair,
+                                                   int rank, NetMHandleWorkerGuard* registration,
+                                                   HostBufferAutoGuard* allocation) {
+        if (rank == 1) {
+            int nqps = 0;
+            if (!WorkerCastLiveNqps(pair.sendComm, &nqps).ok || nqps <= 0) nqps = 1;
+            for (int qp = 0; qp < nqps; qp++) WorkerCastDriveQpToError(pair.sendComm, qp);
+        } else {
+            for (int qp = 0; qp < kMaxQpsToFlush; qp++)
+                ncclIbCastFaultDriveRecvQpToError(pair.recvComm, qp);
+        }
+        failure.msg += "; the buffer and its registration are retained, since a request may "
+                       "still reference them";
+        if (registration) registration->release();
+        if (allocation) allocation->release();
+        return failure;
+    }
+
+    // Bounded gate for the failure point: 30 s is well past the setup a sibling
+    // still has to finish, and a worker that already failed must not hang the rest.
+    static constexpr int kFailureGatePolls = 3000;  // 3000 * 10ms
+
+    // Failover with requests already in flight. isend only gets a request once the
+    // receiver has published a FIFO slot, so "all sends posted" implies "all receives
+    // posted" -- the ordering the serial test buys with a barrier a worker cannot use.
+    // buffer must hold messages * size bytes, one slice each.
+    ThreadResult WorkerCastFailoverInFlight(int rank, ConnectionPair& pair, void* buffer,
+                                            size_t size, int tag, void* mhandle, int seed,
+                                            int messages, std::atomic<int>* arrived = nullptr,
+                                            int expected = 0,
+                                            NetMHandleWorkerGuard* registration = nullptr,
+                                            HostBufferAutoGuard* allocation = nullptr,
+                                            int* repostsOut = nullptr) {
+        ThreadResult result;
+        std::vector<void*> requests(messages, nullptr);
+
+        // Every exit from the first successful post onwards goes through this: a request
+        // still posted keeps the NIC writing into the buffer the caller's guards are
+        // about to release. Waiting is tried first; anything that will not complete is
+        // flushed by driving this side's queue pairs to error, which retires outstanding
+        // work with a flush status. If even that leaves a request live, both the
+        // registration and the allocation are retained -- keeping the MR while the memory
+        // is freed would not be safer -- and the message says so.
+        auto finish = [&](ThreadResult failure) -> ThreadResult {
+            auto waitAll = [&]() {
+                int live = 0;
+                for (int i = 0; i < messages; i++) {
+                    if (!requests[i]) continue;
+                    int sizes[1] = {0};
+                    if (WorkerWait(requests[i], sizes, kLargeTransferTimeoutMs).ok) {
+                        requests[i] = nullptr;
+                    } else {
+                        live++;
+                    }
+                }
+                return live;
+            };
+
+            if (waitAll() > 0) {
+                // Each rank flushes its own side. Only the sender can be asked for the
+                // live count, so the receiver walks the same span it was told to expect;
+                // driving a queue pair that does not exist is harmless here, and using
+                // the send-side call on a receive communicator would flush nothing.
+                int nqps = 0;
+                if (rank == 1) {
+                    if (!WorkerCastLiveNqps(pair.sendComm, &nqps).ok || nqps <= 0) nqps = 1;
+                    for (int qp = 0; qp < nqps; qp++) WorkerCastDriveQpToError(pair.sendComm, qp);
+                } else {
+                    for (int qp = 0; qp < kMaxQpsToFlush; qp++)
+                        ncclIbCastFaultDriveRecvQpToError(pair.recvComm, qp);
+                }
+                const int live = waitAll();
+                if (live > 0) {
+                    failure.msg += "; " + std::to_string(live)
+                                   + " request(s) never completed even after flushing, so the "
+                                     "buffer and its registration are retained rather than "
+                                     "released";
+                    if (registration) registration->release();
+                    if (allocation) allocation->release();
+                }
+            }
+            return failure;
+        };
+
+        // Gate before posting, not after. A gate between the posts and the transition
+        // would have an early worker wait for its siblings with its work already
+        // posted, and hardware needs no polling to retire it -- so the wait itself
+        // would empty the queue pair this test wants broken while it is busy. Here it
+        // only lines the workers up, and each one then posts and breaks its own link
+        // without pausing in between.
+        if (arrived && expected > 1
+            && !WorkerRendezvous(*arrived, expected, kFailureGatePolls)) {
+            result.ok = false;
+            result.msg = "workers did not all reach the link failure together";
+            return finish(result);
+        }
+
+        for (int i = 0; i < messages; i++) {
+            char* slice = static_cast<char*>(buffer) + static_cast<size_t>(i) * size;
+            if (rank == 0) {
+                memset(slice, 0, size);
+                result = WorkerPostRecv(pair.recvComm, slice, size, tag + i, mhandle,
+                                        &requests[i]);
+            } else {
+                fillHostBufferWithPattern<uint8_t>(slice, size, makeBytePattern(seed + i));
+                result = WorkerPostSend(pair.sendComm, slice, size, tag + i, mhandle,
+                                        &requests[i]);
+            }
+            if (!result.ok) return finish(result);
+        }
+
+        // Nothing is polled before the transition: polling would drain the
+        // communicator's shared completion queues and hurry the very requests this
+        // is about. The ordering is all that is arranged here -- posted, then broken,
+        // then waited on -- and the note above the count at the end of this function
+        // says why the stronger claim is not made.
+        if (rank == 1) {
+            result = WorkerCastDriveQpToError(pair.sendComm, 0);
+            if (!result.ok) return finish(result);
+        }
+
+        for (int i = 0; i < messages; i++) {
+            int sizes[1] = {0};
+            result = WorkerWait(requests[i], sizes, kLargeTransferTimeoutMs);
+            if (!result.ok) {
+                result.msg = "request " + std::to_string(i)
+                             + " never completed after QP 0 was driven to error";
+                return finish(result);
+            }
+            requests[i] = nullptr;
+            if (rank != 0) continue;
+
+            char* slice = static_cast<char*>(buffer) + static_cast<size_t>(i) * size;
+            if (sizes[0] != (int)size
+                || !verifyHostBufferData<uint8_t>(slice, size, makeBytePattern(seed + i))) {
+                result.ok = false;
+                result.msg = "message " + std::to_string(i)
+                             + " arrived corrupted or short after failover";
+                return finish(result);
+            }
+        }
+
+        if (rank != 1) return result;
+
+        // Reported, not asserted, and that is the end of a long thread. Four ways of
+        // establishing "the failure caught several requests in flight" were tried
+        // here and none of them holds with recovery off: the QP delay hook sleeps
+        // before post_send, so it only slows posting; outstandingRequests counts
+        // requests already registered as failed, which is zero before the failure;
+        // polling each request in turn is not a snapshot, because TestRequest drains
+        // the communicator's shared completion queues; and the repost counter stays
+        // at zero even in the serial body, which orders the break against a transfer
+        // with an MPI handshake and passes -- so it does not record this path at all
+        // without port recovery.
+        //
+        // What the threaded body does establish is the ordering: every message is
+        // posted, then this worker's QP 0 is driven to error, then every message must
+        // arrive intact with no fatal error, while the sibling workers do the same to
+        // their own connections. Whether a data work request was on the wire at the
+        // instant of the transition is not observable from here, and the serial body
+        // does not observe it either -- it arranges it with a handshake a worker
+        // cannot use. The count is handed back for the main thread to log: TEST_INFO
+        // reaches MPI_Comm_rank, which a worker must not call.
+        if (repostsOut) {
+            int reposts = -1;
+            if (ncclIbCastGetRepostCount(pair.sendComm, &reposts) != ncclSuccess) reposts = -1;
+            *repostsOut = reposts;
+        }
+
+        const int fatalCount = WorkerCastFatalCount(pair.sendComm);
+        if (fatalCount != 0) {
+            result.ok = false;
+            result.msg = "failover should have absorbed the QP error, but the fatal count is "
+                         + std::to_string(fatalCount);
+        }
+        return result;
+    }
+
+    // Poll a receive the peer may never satisfy, and report whether it finished.
+    bool WorkerDrainRecv(void* request, int pollIterations) {
+        if (!request) return true;
+        for (int poll = 0; poll < pollIterations; poll++) {
+            int done = 0;
+            int sizes[1] = {0};
+            if (TestRequest(request, &done, sizes) != ncclSuccess) return false;
+            if (done) return true;
+            usleep(kPollIntervalUs);
+        }
+        return false;
+    }
+
+    // Releases a receive the peer's injected send will never satisfy. It cannot be
+    // waited out -- the failed send consumed its FIFO slot -- and the work request holds
+    // the memory region until the queue pair dies, which is after the worker must
+    // deregister. Driving this side to error flushes it instead.
+    ThreadResult WorkerCastFlushAbandonedRecv(void* recvComm, void* request) {
+        ThreadResult result;
+        if (!request) return result;
+
+        // The API rejects an index past the connection's QP count, which is how
+        // the loop learns where to stop.
+        static constexpr int kQpProbeLimit = 64;
+        for (int qp = 0; qp < kQpProbeLimit; qp++) {
+            if (ncclIbCastFaultDriveRecvQpToError(recvComm, qp) != ncclSuccess) break;
+        }
+
+        // A flush completion surfaces as an error, and that is the expected
+        // outcome here: all that matters is that the request stops being
+        // outstanding before the memory region goes away.
+        static constexpr int kFlushPolls = 500;  // 500 * 10ms = 5s
+        for (int poll = 0; poll < kFlushPolls; poll++) {
+            int done = 0;
+            int sizes[1] = {0};
+            if (TestRequest(request, &done, sizes) != ncclSuccess) return result;
+            if (done) return result;
+            usleep(kPollIntervalUs);
+        }
+        result.ok = false;
+        result.msg = "the abandoned receive was still outstanding after its queue pairs were "
+                     "driven to error";
+        return result;
+    }
+
+    // Both sides lose QP 0 and the payload rides the surviving device. The serial test
+    // breaks the queue pairs mid-transfer, which needs an MPI handshake a worker cannot
+    // make; both in-flight orders left the two sides a message apart, so the break here
+    // happens while the connection is idle.
+    ThreadResult WorkerTransferAcrossQpFailure(int rank, ConnectionPair& pair, void* buffer,
+                                               size_t size, int tag, void* mhandle, int seed,
+                                               int timeoutMs) {
+        ThreadResult result;
+        if (rank == 0) {
+            if (ncclIbCastFaultDriveRecvQpToError(pair.recvComm, 0) != ncclSuccess) {
+                result.ok = false;
+                result.msg = "ncclIbCastFaultDriveRecvQpToError failed";
+                return result;
+            }
+        } else {
+            result = WorkerCastDriveQpToError(pair.sendComm, 0);
+            if (!result.ok) return result;
+        }
+        return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+    }
+#endif /* ENABLE_FAULT_INJECTION */
+
     ncclResult_t InitNetIbCtx(void** ctxOut) {
         ncclNetCommConfig_t commConfig = {};
         commConfig.trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -1813,9 +1813,19 @@ protected:
     // breaks the queue pairs mid-transfer, which needs an MPI handshake a worker cannot
     // make; both in-flight orders left the two sides a message apart, so the break here
     // happens while the connection is idle.
+    //
+    // The guards are taken rather than left to the caller because this helper is the one
+    // that knows a transfer was attempted. WorkerSendRecvPattern owns its request and a
+    // timed-out wait does not cancel it, so returning that failure straight up would let
+    // the caller's guards deregister and free memory the NIC may still be writing into --
+    // and a transfer that runs immediately after both queue pairs were driven to error is
+    // the likeliest one in the file to time out. Callers that pass no guards get the old
+    // behaviour, which is correct only when they hold no buffer of their own.
     ThreadResult WorkerTransferAcrossQpFailure(int rank, ConnectionPair& pair, void* buffer,
                                                size_t size, int tag, void* mhandle, int seed,
-                                               int timeoutMs) {
+                                               int timeoutMs,
+                                               NetMHandleWorkerGuard* registration = nullptr,
+                                               HostBufferAutoGuard* allocation = nullptr) {
         ThreadResult result;
         if (rank == 0) {
             if (ncclIbCastFaultDriveRecvQpToError(pair.recvComm, 0) != ncclSuccess) {
@@ -1827,7 +1837,11 @@ protected:
             result = WorkerCastDriveQpToError(pair.sendComm, 0);
             if (!result.ok) return result;
         }
-        return WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+        // Nothing has been posted yet on either exit above, so those return unchanged.
+        result = WorkerSendRecvPattern(rank, pair, buffer, size, tag, mhandle, seed, timeoutMs);
+        if (!result.ok && (registration || allocation))
+            return WorkerRetainAfterAbandonedRequest(result, pair, rank, registration, allocation);
+        return result;
     }
 #endif /* ENABLE_FAULT_INJECTION */
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -249,6 +249,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2820,6 +2846,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -505,6 +505,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_initialization": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -4013,6 +4039,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -214,7 +214,7 @@
         "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
         "NCCL_IB_RESILIENCY_PORT_RECOVERY": "1"
       },
-      "description": "A20: open finding, nightly only. Ten blocking messages on a connection the recovery thread has restored must not leave the two ranks a message apart. Named \"Nightly\" rather than \"Component\" so the label-gated PR subset, which selects \"A*. Component*\", does not run it: until the plugin side is fixed it is expected to fail some nights, and a PR author cannot act on that.",
+      "description": "A20: open finding, nightly only. Ten blocking messages on a connection the recovery thread has restored must not leave the two ranks a message apart. This suite is omitted from the smoke subset used by label-gated PR runs, so until the plugin side is fixed it is expected to fail only some nightly runs, where a reader can act on it.",
       "tests": [
         {
           "name": "A20_Cast_PostRecoveryPingPongHoldsSync",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -205,6 +205,45 @@
         }
       ]
     },
+    "a_fault_recovery_nightly": {
+      "extends": "cast_base",
+      "timeout": 900,
+      "command_args": "--net_ib_nthreads=2",
+      "env_variables": {
+        "RCCL_IB_FAULT_INJECTION": "0",
+        "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
+        "NCCL_IB_RESILIENCY_PORT_RECOVERY": "1"
+      },
+      "description": "A20: open finding, nightly only. Ten blocking messages on a connection the recovery thread has restored must not leave the two ranks a message apart. Named \"Nightly\" rather than \"Component\" so the label-gated PR subset, which selects \"A*. Component*\", does not run it: until the plugin side is fixed it is expected to fail some nights, and a PR author cannot act on that.",
+      "tests": [
+        {
+          "name": "A20_Cast_PostRecoveryPingPongHoldsSync",
+          "description": "After recovery reports device 0 healthy, ten ping-pong messages must all arrive; the sender exhausting its FIFO-slot retries on message n+1 while the receiver waits for n is the finding.",
+          "test_filter": "NetIbMPITest.PostRecoveryPingPongHoldsSync"
+        }
+      ]
+    },
+    "a_fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "description": "A19: fault isolation between workers. One worker breaks its own connection while the others must keep transferring cleanly. Fault injection stays off: the tests use the per-comm hooks, and the libibverbs shims add process-global mutex traffic to every poll_cq while their per-device registry lets one worker's clear disarm the others.",
+      "tests": [
+        {
+          "name": "A19_Cast_FaultIsolationAcrossWorkers",
+          "description": "Injected fault state stays inside its communicator; bystander connections stay clean.",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "A19_Cast_FaultShimsAbsentUnlessRequested",
+          "description": "The libibverbs ops shims must not be installed while RCCL_IB_FAULT_INJECTION is off: their poll_cq serializes the whole process on one mutex.",
+          "test_filter": "NetIbMPITest.FaultInjectionShimsAbsentUnlessRequested"
+        }
+      ]
+    },
 
     "gin_proxy": {
       "extends": "gtest_base",
@@ -496,6 +535,8 @@
     { "config": "bootstrap_socket_poll", "enabled": true, "smoke": true },
     { "config": "a_netib_multithread",   "enabled": true, "smoke": true },
     { "config": "a_cast_multithread",    "enabled": true, "smoke": true },
+    { "config": "a_fault_inject_multithread", "enabled": true, "smoke": true },
+    { "config": "a_fault_recovery_nightly",   "enabled": true },
 
     { "config": "ib_baseline",           "enabled": true, "smoke": true },
     { "config": "cast_alltoall_full",    "enabled": true, "smoke": true },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -268,6 +268,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -4341,6 +4367,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -255,6 +255,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2862,6 +2888,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -264,6 +264,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -3650,6 +3676,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -249,6 +249,32 @@
         }
       ]
     },
+    "fault_inject_multithread": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "command_args": "--net_ib_nthreads=4",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring cleanly",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data on a second one",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
     "net_ib_gdr_flush": {
       "extends": "net_ib_base",
       "timeout": 120,
@@ -2815,6 +2841,12 @@
       "name": "NET IB - CAST Multithread (4)",
       "description": "4 worker threads/rank driving independent IB-CAST connections and WRR schedulers",
       "config": "cast_multithread",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "Per-communicator fault injection across concurrent workers, including cross-worker isolation",
+      "config": "fault_inject_multithread",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1245,6 +1245,104 @@
           "test_filter": "NetIbMPITest.CastEnableDisableSplitData"
         }
       ]
+    },
+    "fault_multithread_base": {
+      "extends": "cast_base",
+      "timeout": 600,
+      "description": "IB-CAST fault environment for the threaded suites, carrying no tests of its own for the reason given in net_ib_multithread_base. Port failover is on and port recovery is left at its default of off: the failover tests here assert that failover absorbed the error and that the device is no longer Ok, which recovery would undo underneath them. Concurrent recovery is covered by fault_recovery_multithread_2 and the nightly drift suite, which enable it. RCCL_IB_FAULT_INJECTION stays off: these tests use the per-communicator pre-call hooks and have no use for the libibverbs ops shims, which add two acquisitions of one process-global mutex to every poll_cq and whose registry is per device, so one worker's clear disarms every other worker's faults.",
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
+        "RCCL_IB_FAULT_INJECTION": "0"
+      }
+    },
+    "fault_inject_multithread": {
+      "extends": "fault_multithread_base",
+      "tests": [
+        {
+          "name": "FaultInj_ShimsAbsentUnlessRequested",
+          "description": "With RCCL_IB_FAULT_INJECTION off, arming an ops-level fault must be refused: if it succeeds the libibverbs shims are installed, and their poll_cq takes one process-global mutex per call, serializing progress for the whole process",
+          "test_filter": "NetIbMPITest.FaultInjectionShimsAbsentUnlessRequested"
+        },
+        {
+          "name": "FaultInj_MultiThread_IsolationAcrossWorkers",
+          "description": "One worker breaks its own connection while the others keep transferring: proves injected fault state stays inside its communicator",
+          "test_filter": "NetIbMPITest.FaultIsolationAcrossWorkers"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorIsFatal",
+          "description": "Every worker arms error injection on its own QPs and must observe the failure itself",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorIsFatal"
+        },
+        {
+          "name": "FaultInj_MultiThread_DelayDataIntegrity",
+          "description": "Every worker slows its own QP 0 and still delivers intact data while the others load the device",
+          "test_filter": "NetIbMPITest.FaultInjCastDelayDataIntegrity"
+        },
+        {
+          "name": "FaultInj_MultiThread_QpErrorClearRecovers",
+          "description": "Each worker breaks one connection, clears the fault and must move data cleanly on a second connection",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        },
+        {
+          "name": "FaultInj_MultiThread_FailoverCqeErrorRecovered",
+          "description": "N links fail at once, so the process-global recovery thread serves several communicators",
+          "test_filter": "NetIbMPITest.FailoverCqeErrorRecovered"
+        },
+        {
+          "name": "FaultInj_MultiThread_FailoverLargeMessage",
+          "description": "Concurrent 64 KB messages survive their own link failure byte for byte",
+          "test_filter": "NetIbMPITest.FailoverLargeMessageDataIntegrity"
+        },
+        {
+          "name": "FaultInj_MultiThread_FailoverMultiRequest",
+          "description": "Every worker posts several messages, then breaks its own QP 0, then requires all of them to arrive intact with no fatal error, while the other workers do the same to their own connections. Whether a request was still on the wire at the transition is not observable from a worker, so it is not asserted; the repost count is logged as diagnostics",
+          "test_filter": "NetIbMPITest.FailoverMultiRequestInFlight"
+        }
+      ]
+    },
+    "fault_inject_multithread_2": {
+      "extends": "fault_inject_multithread",
+      "command_args": "--net_ib_nthreads=2"
+    },
+    "fault_inject_multithread_4": {
+      "extends": "fault_inject_multithread",
+      "command_args": "--net_ib_nthreads=4"
+    },
+    "fault_recovery_nightly_drift": {
+      "extends": "fault_multithread_base",
+      "timeout": 900,
+      "command_args": "--net_ib_nthreads=2",
+      "env_variables": {
+        "NCCL_IB_RESILIENCY_PORT_RECOVERY": "1"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_PostRecoveryPingPongHoldsSync",
+          "description": "Ten blocking messages on a recovered connection must not leave the two ranks a message apart (open finding, expected to fail some runs)",
+          "test_filter": "NetIbMPITest.PostRecoveryPingPongHoldsSync"
+        }
+      ]
+    },
+    "fault_recovery_multithread_2": {
+      "extends": "fault_multithread_base",
+      "timeout": 900,
+      "command_args": "--net_ib_nthreads=2",
+      "env_variables": {
+        "NCCL_IB_RESILIENCY_PORT_RECOVERY": "1"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_MultiThread_RecoverySuccessRestoresTraffic",
+          "description": "Concurrent recoveries share one global recovery thread, then every worker's traffic must resume",
+          "test_filter": "NetIbMPITest.RecoverySuccessRestoresTraffic"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -1570,6 +1668,30 @@
       "name": "NET IB - CAST WRR only, long update interval",
       "description": "Scheduler toggle tests that need RCCL_IB_QP_SCHED_UPDATE_INTERVAL >= 10 s; they skip in every other config",
       "config": "cast_wrr_no_split_long_interval",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (2)",
+      "description": "2 worker threads/rank injecting per-communicator faults, including cross-worker isolation",
+      "config": "fault_inject_multithread_2",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection Multithread (4)",
+      "description": "4 worker threads/rank injecting per-communicator faults, including cross-worker isolation",
+      "config": "fault_inject_multithread_4",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Recovery Multithread (2)",
+      "description": "Concurrent link recoveries through the single process-global recovery thread",
+      "config": "fault_recovery_multithread_2",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CAST Recovery Nightly Drift (2)",
+      "description": "Open finding: post-recovery ping-pong drifts a message apart",
+      "config": "fault_recovery_nightly_drift",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

Last of four stacked PRs. The per-communicator fault hooks are what make this worth doing: a worker can break its own connection without touching anybody else's, so isolation becomes assertable rather than assumed. The failover tests break N links at once, so N failovers overlap on one fused device; the recovery suites, which enable port recovery, are where the process-global recovery thread is seen serving several communicators. It also adds a test for an open finding on the recovery path, and the nightly-only slot in CI that such a test needs.

Base: `users/ilkosare/netib-threaded-cast-vnic`.

## Technical Details

`RCCL_IB_FAULT_INJECTION` stays off in the threaded fault suites: these tests use
the per-communicator hooks, not the libibverbs ops shims, and the shims would both
serialize every `poll_cq` on a process-global mutex and let one worker's clear
disarm another worker's faults, since their registry is keyed by device.

The nightly test runs nightly and not on pull requests, and that is arranged by
the plan entry, not by any suite name: `a_fault_recovery_nightly` is listed in the
AINIC plan without `"smoke": true`. The workflow passes `--scope smoke` on
`pull_request` and `nightly` on schedule
(`.github/workflows/rccl-ainic-tw-gfx950-runner.yml`), and `--scope smoke`
restricts the run to the flagged suites, skipping the rest
(`tools/scripts/test_runner/test_runner.py`). No workflow change is needed for
this. A PR author cannot act on a failure whose cause is an open plugin question;
a nightly reader can.

## Issue Tracking

JIRA ID: AICOMNET-323

## Test Plan

### Enabled tests

Two and four workers, per-communicator fault hooks:

- `FaultIsolationAcrossWorkers` — **new test.** One worker breaks its own
  connection and must observe the failure while every other worker keeps
  transferring with a fatal count of zero. No serial test can assert this.
- `FaultInjCastQpErrorIsFatal` — each worker arms error injection on its own QPs
  and must see the failure itself.
- `FaultInjCastDelayDataIntegrity` — each worker slows its own QP 0 and still
  delivers intact data while the others load the device.
- `FaultInjCastQpErrorClearRecovers` — each worker owns two connections: break the
  first, clear, then move data cleanly on the second.
- `FailoverCqeErrorRecovered` — N links fail at once, so N failovers overlap on one
  fused device, each rewriting its own per-communicator resiliency state. Port
  recovery stays at its default of off in this suite: these tests assert that
  failover absorbed the error and that device 0 is no longer Ok, and recovery exists
  to undo exactly that.
- `FailoverLargeMessageDataIntegrity` — 64 KB messages survive their own link
  failure byte for byte.
- `FailoverMultiRequestInFlight` — several messages are posted first, then QP 0 is
  driven to error under them.

Two workers:

- `RecoverySuccessRestoresTraffic` — the suite that does enable port recovery, at two
  workers: concurrent recoveries share one recovery thread, then traffic must resume
  on every worker. Two deliberate differences from
  the serial body, both forced: the queue pairs are broken while the connection is
  idle, because the serial in-flight break relies on an MPI handshake a worker
  cannot make, and one message is sent after recovery rather than a run of them.

Nightly only, suite `a_fault_recovery_nightly` (outside the smoke subset):

- `PostRecoveryPingPongHoldsSync` — **new test**, and the reason the nightly slot
  exists. It sends ten blocking messages on the recovered connection and asserts
  they all arrive. The finding it tracks: after recovery reports device 0 healthy on
  both sides, the two ranks get a message apart, the sender exhausting its
  FIFO-slot retries on message n+1 while the receiver still waits for n, both
  devices reported Ok. Seen at two workers, and on every run of a variant that
  breaks only the sender's queue pair with a request in flight. The serial body sends
  its own run of messages and does not drift, because its MPI handshakes
  resynchronize the two sides between phases — which is why this only appears on the
  threaded path.

  No rate is quoted, deliberately. The earlier figure was measured before this test's
  recovery wait required `recoveryCount > 0`, when a green run could accept device 0's
  initial `Ok` without recovery having been exercised at all, so it says nothing about
  the corrected test. Establishing the rate is what the nightly runs are for, and
  until the plugin side is understood the test is expected to fail some of them.

### Procedure

Hardware: mia1, AINIC/Pensando with RoCE on `rdma0..rdma3`, gfx950, host build,
two ranks.

- Rebuild `rccl-UnitTestsMPI` in a debug configuration with MPI tests enabled.
- Run this level's fault, failover and recovery suites at 2 and 4 workers, the
  nightly drift suite, and everything the three levels below ship.
- Run the nightly drift test repeatedly on its own: a test meant to fail sometimes
  proves nothing from one green run.
- Check scope selection through the runner's own config resolver: which suites
  `--scope smoke` keeps and which it skips.
- Load every runner config through the runner's own resolver and compile the test
  sources with fault injection off and with MPI tests off.

## Test Result

mia1, gfx950, two ranks, on `develop` at `60030ad2f2`:

- Everything the stack runs, all four levels together, two ranks on one node:
  **99 PASS / 0 FAIL / 0 HANG / 1 SKIP**. The skip is the serialization gate
  declining two workers.
- The nightly drift suite runs and passed, and 20 consecutive runs on a quiet node
  passed as well, with the `recoveryCount` guard in place so a green run means
  recovery actually happened. That is why the finding above is described as open
  rather than as a rate; figures taken before that guard are not carried over.
- With the ranks on **separate nodes** the same matrix gives **98 PASS / 1 FAIL /
  0 HANG / 1 SKIP**, and the failure is worth stating rather than hiding: one fault
  test per cross-node run stalls, and which one varies -- `FailoverCqeErrorRecovered`
  in one run, `RecoverySuccessRestoresTraffic` in the next. In the latter the
  receiver never completed the receive posted across the QP-0 error while the
  sender reported `devState[0]=4` (Recovered) and then starved 90 s for a FIFO slot
  the receiver never published. Neither reproduces in isolation: 6 of 6 and 4 of 4
  passes for the failing test on its own, and two consecutive clean passes of the
  whole fault suite cross-node. This looks like the same post-recovery
  desynchronisation the nightly test tracks, one step earlier, and it is recorded as
  a finding rather than worked around.
- Fault suites cross-node, two passes back to back including the first after a
  build: **16 PASS** each.
- Scope selection, through the runner's own `TestConfigProcessor`: of the 26 enabled
  AINIC suites, `--scope smoke` keeps 17 and skips 9, `a_fault_recovery_nightly`
  among them. A scheduled run passes `nightly` and takes all 26.
- Configs combine through `TestConfigProcessor`; all four levels' translation units
  compile in three configurations each -- normal, without fault injection, without
  MPI tests -- twelve combinations, all clean on the current branch heads.
- AINIC CI cannot report on this stack yet: its build of RCCL fails with
  `undefined symbol: rcclCanUseWarpSpeedAuto`, and the nightly run on `develop`
  itself fails the same way, so the breakage is upstream of this branch, which
  touches no production code.

## Submission Checklist

- [x] Look over the contributing guidelines at
  https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

