### PR TITLE
ci(amdsmi): add concurrency groups and version-comment the pinned actions

### DIFF
--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -27,6 +27,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by PR number so a new push supersedes the previous run. Pushes to
+  # develop fall back to the commit sha, which is unique, so post-merge runs
+  # never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   DEBIAN_FRONTEND: noninteractive
   DEBCONF_NONINTERACTIVE_SEEN: true
@@ -49,7 +56,7 @@ jobs:
     steps:
       # rocm-systems is a large monorepo; the wheel gate only needs the amdsmi
       # project and this workflow, so sparse-checkout keeps the fetch cheap.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             projects/amdsmi
@@ -156,7 +163,7 @@ jobs:
     steps:
       # rocm-systems is a large monorepo; only the amdsmi project and this
       # workflow are needed, so sparse-checkout keeps the fetch cheap.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             projects/amdsmi
@@ -211,7 +218,7 @@ jobs:
         # Not consumed by any downstream job; kept so a reviewer can download
         # the built .deb/.rpm from a PR run for manual testing.
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: amd-smi-lib-${{ matrix.package_format }}-${{ matrix.os }}-${{ env.PR_NUMBER }}-${{ env.BUILD_DATE }}
           # 99999 is the local (non-release) package version CPack stamps when
@@ -259,7 +266,7 @@ jobs:
 
       - name: Upload AMDSMI Command Test Results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: amdsmi-command-tests-${{ matrix.os }}
           path: /tmp/test-results-${{ matrix.os }}

--- a/.github/workflows/amdsmi-manylinux-build.yml
+++ b/.github/workflows/amdsmi-manylinux-build.yml
@@ -32,6 +32,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by PR number so a new push supersedes the previous run. Pushes to
+  # develop fall back to the commit sha, which is unique, so post-merge runs
+  # never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-amdsmi-wheels:
     name: ${{matrix.target.name}}
@@ -70,7 +77,7 @@ jobs:
     steps:
       # rocm-systems is a large monorepo; the wheel build only needs the amdsmi
       # project, so sparse-checkout keeps the fetch cheap.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             projects/amdsmi
@@ -130,7 +137,7 @@ jobs:
       # Not consumed by any downstream job; kept so a reviewer can download the
       # built wheel from a run. Named by commit SHA for traceability.
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{matrix.target.artifact-prefix}}-${{github.sha}}
           path: ${{github.workspace}}/wheels/*.whl

--- a/.github/workflows/amdsmi-python-versions.yml
+++ b/.github/workflows/amdsmi-python-versions.yml
@@ -33,6 +33,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by PR number so a new push supersedes the previous run. Pushes to
+  # develop fall back to the commit sha, which is unique, so post-merge runs
+  # never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   python-version-tests:
     name: Python ${{matrix.python-version}}

--- a/.github/workflows/amdsmi-sles-packaging.yml
+++ b/.github/workflows/amdsmi-sles-packaging.yml
@@ -36,6 +36,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by PR number so a new push supersedes the previous run. Pushes to
+  # develop fall back to the commit sha, which is unique, so post-merge runs
+  # never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   sles-packaging:
     name: SLES RPM packaging (openSUSE Leap 15.6)

--- a/.github/workflows/amdsmi-upgrade-downgrade.yml
+++ b/.github/workflows/amdsmi-upgrade-downgrade.yml
@@ -42,6 +42,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by PR number so a new push supersedes the previous run. Pushes to
+  # develop fall back to the commit sha, which is unique, so post-merge runs
+  # never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   upgrade-downgrade:
     name: ${{matrix.name}}


### PR DESCRIPTION
## Motivation

Two CI hygiene gaps in the amd-smi workflows, found while reviewing an unrelated
stack. Neither is coupled to that work, so they are split out here.

**Superseded runs were not cancelled.** Five of the six `amdsmi-*` workflows had
no `concurrency` block, so pushing twice to a PR left the first run going. That
is worst for `amdsmi-build.yml`, which builds a distro matrix on self-hosted GPU
runners: a run that is already obsolete can hold a runner the newer commit is
queued for.

**Six SHA pins had no version comment.** The repo has 226 SHA-pinned actions and
215 of them carry a `# vX.Y.Z` comment. `amdsmi-build.yml` and
`amdsmi-manylinux-build.yml` held 6 of the 11 exceptions.

## Technical Details

**Concurrency.** Added to `amdsmi-build.yml`, `amdsmi-manylinux-build.yml`,
`amdsmi-python-versions.yml`, `amdsmi-sles-packaging.yml`, and
`amdsmi-upgrade-downgrade.yml`. `amdsmi-dme-ci.yml` already had one and is
untouched.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
  cancel-in-progress: true
```

Grouped by PR number, not by `github.ref`. All five of these workflows also run
on `push` to `develop`, and a ref-based group would put every develop push in
the group `<workflow>-refs/heads/develop`, so consecutive merges would cancel
each other's post-merge validation. `github.event.number` is empty outside a
`pull_request` event, so the fallback to `github.sha` gives each develop push its
own group. Same idiom as `hip-nvidia-ci.yml` and `media-libs-ci.yml`.

**Version comments.** The pins are unchanged; only a trailing comment is added.
The SHA stays the pin because tags are mutable and can be re-pointed. The comment
is there so a reviewer can see what version a SHA is without resolving it, and it
is the form Dependabot already maintains for the other 215 pins in this repo.
Both versions were confirmed against the upstream tag refs rather than copied
from elsewhere in the repo:

| Action | Pin | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | `v6.0.2` |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `v4.6.2` |

`cuid-workflow.yml` and `pre-formatting.yml` also have uncommented pins but are
owned by other components, so they are left alone.

## Issue Tracking

<!-- JIRA ID: ROCM-28065 -->

## Test Plan

No build or runtime code is touched, so there is nothing to unit test. Verified:

- All six `amdsmi-*` workflows parse with `yaml.safe_load` and `concurrency`
  resolves as a top-level key, not nested under `jobs` or `permissions`.
- Both SHA to tag claims resolved independently through the GitHub tags API.
- The SHA pins are byte-for-byte identical to `develop`, so the comment change
  cannot alter which action code runs.
- Scoped `pre-commit run --files` over the five changed files.
- Diff confined to `.github/workflows/amdsmi-*.yml`; no change under `projects/`.

## Test Result

All checks above pass. Key expression behaviour:

| Scenario | Group | Outcome |
|---|---|---|
| Two pushes to one PR | `<workflow>-<PR#>`, same | Older run cancelled |
| Two merges to develop | `<workflow>-<sha>`, differ | Neither cancelled |

Neither uploaded artifact is consumed by a downstream job, so cancelling a
superseded run cannot feed a partial artifact into a later step. Cancelled checks
on a superseded commit do not gate merge, which keys off the latest commit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
