### PR TITLE
[rocjitsu] qualify apply_vop3_b32_src_mod with amdgpu namespace

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -5186,8 +5186,8 @@ class CodeGenerator:
                             '  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {\n'
                             '    if (!(exec & (1ULL << lane)))\n'
                             '      continue;\n'
-                            f'    const uint32_t src0_value = apply_vop3_b32_src_mod(amdgpu::RegisterAccess(wf).read_lane({src_ops[0]}, lane), inst_.abs, inst_.neg, 0);\n'
-                            f'    const uint32_t src1_value = apply_vop3_b32_src_mod(amdgpu::RegisterAccess(wf).read_lane({src_ops[1]}, lane), inst_.abs, inst_.neg, 1);\n'
+                            f'    const uint32_t src0_value = amdgpu::apply_vop3_b32_src_mod(amdgpu::RegisterAccess(wf).read_lane({src_ops[0]}, lane), inst_.abs, inst_.neg, 0);\n'
+                            f'    const uint32_t src1_value = amdgpu::apply_vop3_b32_src_mod(amdgpu::RegisterAccess(wf).read_lane({src_ops[1]}, lane), inst_.abs, inst_.neg, 1);\n'
                             f'    amdgpu::RegisterAccess(wf).write_lane({dst_ops[0]}, lane, (({selector_read} >> lane) & 1) ? src1_value : src0_value);\n'
                             '  }\n'
                         )

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2713,20 +2713,17 @@ def test_single_isa_cdna1_sources_include_simd_glue_once(tmp_path):
         assert source.count(simd_glue_include) == 1
 
 
-def test_single_isa_cndmask_qualifies_amdgpu_src_modifier(tmp_path):
-    args = SimpleNamespace(
-        multi=[f'rdna4:{_mrisa_dir() / "amdgpu_isa_rdna4.xml"}'],
-        gen_isas=True,
-        gen_dbt=False,
-        isa_output=str(tmp_path),
-        dbt_output=None,
+def test_single_isa_cndmask_qualifies_amdgpu_src_modifier():
+    spec = Parser(str(_mrisa_dir() / 'amdgpu_isa_rdna4.xml'), Rdna4Profile()).parse()
+    semantics = derive_all_semantics(spec)
+    generator = CodeGenerator(spec, '', semantics)
+    vop3 = next(
+        encoding for encoding in spec.inst_encodings if encoding.enc_name == 'ENC_VOP3'
     )
+    cndmask = next(inst for inst in vop3.insts if inst.name == 'V_CNDMASK_B32')
 
-    _run_multi(args)
-
-    execute_shared = (tmp_path / 'shared' / 'execute_shared.h').read_text()
-    body = _shared_execute_body(
-        execute_shared, 'v_cndmask_b32_vop3', 'v_ctz_i32_b32_vop1'
+    body = generator._gen_execute_body(
+        cndmask, semantics.instructions[cndmask.name], vop3.enc_name
     )
 
     assert body.count('amdgpu::apply_vop3_b32_src_mod(') == 2

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -2713,6 +2713,26 @@ def test_single_isa_cdna1_sources_include_simd_glue_once(tmp_path):
         assert source.count(simd_glue_include) == 1
 
 
+def test_single_isa_cndmask_qualifies_amdgpu_src_modifier(tmp_path):
+    args = SimpleNamespace(
+        multi=[f'rdna4:{_mrisa_dir() / "amdgpu_isa_rdna4.xml"}'],
+        gen_isas=True,
+        gen_dbt=False,
+        isa_output=str(tmp_path),
+        dbt_output=None,
+    )
+
+    _run_multi(args)
+
+    execute_shared = (tmp_path / 'shared' / 'execute_shared.h').read_text()
+    body = _shared_execute_body(
+        execute_shared, 'v_cndmask_b32_vop3', 'v_ctz_i32_b32_vop1'
+    )
+
+    assert body.count('amdgpu::apply_vop3_b32_src_mod(') == 2
+    assert re.search(r'(?<!amdgpu::)apply_vop3_b32_src_mod\(', body) is None
+
+
 def test_rdna4_64bit_literal_widening_is_format_specific(tmp_path):
     args = SimpleNamespace(
         multi=[f'rdna4:{_mrisa_dir() / "amdgpu_isa_rdna4.xml"}'],

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -8192,9 +8192,9 @@ inline void execute_v_cndmask_b32_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    const uint32_t src0_value = apply_vop3_b32_src_mod(
+    const uint32_t src0_value = amdgpu::apply_vop3_b32_src_mod(
         amdgpu::RegisterAccess(wf).read_lane(inst.src0, lane), inst.inst_.abs, inst.inst_.neg, 0);
-    const uint32_t src1_value = apply_vop3_b32_src_mod(
+    const uint32_t src1_value = amdgpu::apply_vop3_b32_src_mod(
         amdgpu::RegisterAccess(wf).read_lane(inst.src1, lane), inst.inst_.abs, inst.inst_.neg, 1);
     sdwa::write_lane<false>(
         inst, wf, inst.vdst, lane,


### PR DESCRIPTION
## Motivation

When building single ISA, calls to apply_vop3_b32_src_mod need to be qualified with the amdgpu namespace since the function call happens in the ISA namespace instead of the amdgpu namespace used by the shared code.

## Technical Details

Same as motivation

## Issue Tracking

N/A

## Test Plan

Write amdisa test

## Test Result

* Run tests, regenerate

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
