### PR TITLE
chore(hipfile): Bump version to 0.5.0

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Set the library version in a variable so we can use
 # it in *.in files and avoid version mismatch.
 set(AIS_LIBRARY_MAJOR 0)
-set(AIS_LIBRARY_MINOR 4)
+set(AIS_LIBRARY_MINOR 5)
 set(AIS_LIBRARY_PATCH 0)
 set(AIS_LIBRARY_VERSION "${AIS_LIBRARY_MAJOR}.${AIS_LIBRARY_MINOR}.${AIS_LIBRARY_PATCH}")
 

--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -84,7 +84,7 @@ extern "C" {
  * @brief hipFile minor version number
  * @ingroup core
  */
-#define HIPFILE_VERSION_MINOR 4
+#define HIPFILE_VERSION_MINOR 5
 /*!
  * @brief hipFile patch version number
  * @ingroup core

--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the hipFile Python bindings will be documented in this file.
 
+## [0.5.0.dev0]
+
 ## [0.4.0.dev0]
 
 ### Added

--- a/projects/hipfile/python/pyproject.toml
+++ b/projects/hipfile/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hipfile"
-version = "0.4.0.dev0"
+version = "0.5.0.dev0"
 classifiers = [
     "Development Status :: 3 - Alpha",
 ]


### PR DESCRIPTION
## Motivation

Bump hipFile version for next release

## Technical Details

* Bump version to 0.5.0 in CMakeLists.txt, hipfile.h, and pyproject.toml
* Add 0.5.0.dev0 to the Python wrapper CHANGELOG file
* The main CHANGELOG file already has a 0.5.0 section

## Issue Tracking

JIRA ID: AIHIPFILE-232

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
