### PR TITLE
fix(rocprofiler-sdk): detect and filter out keywords from ENV VARs before writing into DB

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1309,7 +1309,7 @@ write_rocpd(
                 {
                     auto evar = std::string{itr}.substr(0, pos);
                     auto eval = std::string{itr}.substr(pos + 1);
-                    ROCP_TRACE << "ENV: " << evar << " = " << eval;
+
                     if(contains_sensitive_keyword(evar))
                     {
                         ROCP_INFO << fmt::format(

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1273,7 +1273,33 @@ write_rocpd(
     auto insert_process_data = [&db, &tool_metadata, &cfg, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_process");
         auto json_cfg          = get_json_string([&cfg](auto& ar) { cfg.save(ar); });
-        auto json_env          = get_json_string([](auto& ar) {
+
+        static constexpr auto sensitive_env_keywords =
+            std::array<std::string_view, 10>{"api_key",
+                                             "auth",
+                                             "cert",
+                                             "credential",
+                                             "key",
+                                             "password",
+                                             "private",
+                                             "pwd",
+                                             "secret",
+                                             "token"};
+
+        auto contains_sensitive_keyword = [](std::string_view name) {
+            auto lower_name = std::string{name};
+            std::transform(
+                lower_name.begin(), lower_name.end(), lower_name.begin(), [](unsigned char c) {
+                    return std::tolower(c);
+                });
+            return std::any_of(sensitive_env_keywords.begin(),
+                               sensitive_env_keywords.end(),
+                               [&lower_name](std::string_view keyword) {
+                                   return lower_name.find(keyword) != std::string::npos;
+                               });
+        };
+
+        auto json_env = get_json_string([&contains_sensitive_keyword](auto& ar) {
             size_t i = 0;
             while(true)
             {
@@ -1284,7 +1310,13 @@ write_rocpd(
                     auto evar = std::string{itr}.substr(0, pos);
                     auto eval = std::string{itr}.substr(pos + 1);
                     ROCP_TRACE << "ENV: " << evar << " = " << eval;
-                    if(eval.find(';') != std::string::npos)
+                    if(contains_sensitive_keyword(evar))
+                    {
+                        ROCP_INFO << fmt::format(
+                            "Env variable {} was excluded due to potentially sensitive content",
+                            evar);
+                    }
+                    else if(eval.find(';') != std::string::npos)
                     {
                         ROCP_INFO << fmt::format(
                             "Env variable {} was sanitized due to semi-colon in the value", evar);


### PR DESCRIPTION

## Motivation

We don't want to save all env vars, in case there are sensitive keys set

## Technical Details

Identify if env var contains a sensitive keyword.  Exclude from saving it into the DB if included in the list.
This is not an exhaustive list.  We can add more keywords to the list over time.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSDK-1050

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
