### PR TITLE
fix(rccl): require bidirectional HIP peer access for P2P transport

### DIFF
--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -194,6 +194,21 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  if (p2p != 0 && cudaDev1 != cudaDev2) {
+    // Both endpoints must select the same transport. Require peer access in both directions before using P2P.
+    int reverseP2p;
+    if (!CUDASUCCESS(cudaDeviceCanAccessPeer(&reverseP2p, cudaDev2, cudaDev1))) {
+      INFO(NCCL_INIT | NCCL_P2P, "reverse peer query failed between dev %d(=%lx) and dev %d(=%lx)", cudaDev2,
+           info2->busId, cudaDev1, info1->busId);
+      *ret = 0;
+      return ncclSuccess;
+    }
+    if (reverseP2p == 0) {
+      TRACE(NCCL_P2P, "asymmetric peer access between dev %d(=%lx) and dev %d(=%lx): %d/%d", cudaDev1, info1->busId,
+            cudaDev2, info2->busId, p2p, reverseP2p);
+    }
+    p2p = p2p && reverseP2p;
+  }
 #else
   // This will always fail when using NCCL_CUMEM_ENABLE=1
   if (p2p != 0 && !ncclCuMemEnable()) {


### PR DESCRIPTION
## Motivation

`p2pCanConnect()` uses `cudaDeviceCanAccessPeer()` which is mapped to `hipDeviceCanAccessPeer()` on AMD to decide whether two local devices can use the P2P transport.

The peer-access query is directional. Each endpoint evaluates the same device pair with its own device first, so two endpoints can query the pair in opposite orders.

On an affected 8-GPU system, HIP reported 7 one-way peer pairs. One representative pair reported:

```text
hipDeviceCanAccessPeer(0, 1) = 0
hipDeviceCanAccessPeer(1, 0) = 1
```
For that pair, the two RCCL endpoints selected different transports:

```
rank 0: 0 -> 1 via SHM/direct/direct
rank 1: 1 -> 0 via P2P/IPC
```

The connection data was consequently interpreted using incompatible transport layouts. One endpoint failed with HIP invalid argument, while the other interpreted the exchanged bytes as invalid SHM metadata and reported an impossible multi-terabyte SHM segment size.

The platform condition that exposed the asymmetric capability was later resolved by a firmware correction to MMIO placement. However, RCCL should still avoid selecting incompatible transports if directional peer capability results disagree.

## Technical Details

In the AMD specific branch of `p2pCanConnect()`, query peer capability in the reverse direction when the forward query reports support.

P2P is retained only when both directional queries report support. Otherwise, the P2P transport is rejected so transport selection can fall back consistently.

If the forward query already reports no access, the reverse query is skipped because the result cannot change. A reverse-query failure follows the existing forward-query behavior and disables P2P.

The same-device special case and CUDA-specific legacy IPC path are unchanged. The additional query occurs only during transport initialization and only for AMD device pairs whose forward query reports P2P support; it adds no data-path overhead.

This change is intentionally AMD-specific because the observed failure and validation were performed with HIP/RCCL. It does not make a claim about whether CUDA platforms can expose an equivalent asymmetric state.

## Issue Tracking

Fixes #10586 

## Test Plan

1. Build control and patched RCCL libraries from the same upstream source revision.

2. With NCCL_P2P_DISABLE unset, run an exact-value AllGather on an affected two-GPU pair.

3. Run the same correctness test across all eight GPUs.
4. Verify both in-place and out-of-place rccl-tests results.
5. On the corrected symmetric platform, verify that mutual-access pairs still select P2P and pass the same tests.

## Test Result

### Historical affected-state A/B

Tested on one node with eight AMD Radeon Pro W7900 GPUs (gfx1100), ROCm 7.14, and `NCCL_P2P_DISABLE` unset.

The historical two-GPU A/B compared unmodified and patched builds from upstream commit `704600e2b8`. The retained 8-GPU validation used the equivalent change built from RCCL commit `96a25b5f`. This PR preserves the same bidirectional capability requirement after rebasing onto current develop.

The affected HIP topology contained:

- 7 one-way GPU pairs
- 21 no-access pairs
- 0 mutual-access pairs

A raw peer-memory kernel read 1,048,576 floats successfully in every direction that HIP advertised, with zero mismatches. This confirmed that the advertised one-way access was functional.

Unpatched two-GPU result:

- One endpoint selected SHM.
- The other endpoint selected P2P/IPC.
- Communicator setup failed with HIP invalid argument.
- The SHM endpoint reported an invalid multi-terabyte segment size.

Patched two-GPU result:
```
means=[0.0, 1.0]
minima=[0.0, 1.0]
maxima=[0.0, 1.0]
correct=True
```

Patched eight-GPU result:

```
means=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
minima=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
maxima=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
correct=True
```
The patched eight-GPU run used 30 SHM connections and zero P2P connections, and completed with the exact expected values (correct=True).

### Current symmetric-platform validation

The current PR revision is `b3c9ffeb81`, based on develop commit `5399559d46`.

After the platform firmware was corrected, all 28 GPU pairs reported mutual peer access.

The current branch:

- built successfully, including the final HIP fat-binary check;
- retained direct P2P on the symmetric topology;
- passed the two-GPU and eight-GPU AllGather correctness sweeps;
- reported zero incorrect and zero out-of-bounds values.

The original asymmetric hardware state is no longer reproducible after the firmware correction, so the historical control/patched logs are retained as the affected-state evidence.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
