### PR TITLE
docs(rocprofiler-compute): let the code review skill take a PR URL

### DIFF
--- a/projects/rocprofiler-compute/.ai/skills/rocprof-compute-code-review.md
+++ b/projects/rocprofiler-compute/.ai/skills/rocprof-compute-code-review.md
@@ -2,6 +2,11 @@
 
 Follow **[`AGENTS.md`](../../AGENTS.md)** and the full redirect chain it references.
 
+If given a PR URL or number, first check out its exact `headRefName` in the
+current worktree: stop if `git status --porcelain` is non-empty or another
+worktree holds that branch, else fetch the head ref and fast-forward onto it
+(never `-B`/`reset --hard`). Leave it checked out. No argument: review HEAD.
+
 Understand the changes made in this PR branch. Use the `gh` command to obtain
 the PR metadata and base branch, and to fetch the context of all review
 comments on the PR.


### PR DESCRIPTION
## Motivation

The code review skill assumes the PR branch is already checked out. Accepting a
PR URL or number lets it put the worktree on the right branch itself.

## Technical Details

- Given a PR URL or number, check out its exact `headRefName`; no argument still
  reviews HEAD.
- Guard the switch: stop on a non-empty `git status --porcelain` or a branch held
  by another worktree, and fast-forward only (no `-B`/`reset --hard`) so local
  commits are never rewritten.
- Leave the worktree on the PR branch rather than restoring the previous one.

## JIRA ID

N/A

## Test Plan

Invoke the skill with a PR URL from a clean worktree and confirm it lands on the
PR's head branch under its real name; repeat with a dirty tree and with the
branch checked out in a second worktree, and confirm it stops both times.

## Test Result

Pending.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)