### PR TITLE
fix(rocr): lock AsyncEventsPool::clear() against concurrent alloc

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2182,6 +2182,31 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
 }
 
 void Runtime::AsyncEventsPool::clear() {
+  // The same lock alloc() and free() take. Without it this walks and releases
+  // block_list_, and empties free_list_, while another thread is still handing
+  // items out of them: ConcurrentAsyncEvents::Clear() runs on the async-event
+  // monitor thread, and application threads can be inside
+  // hsa_amd_signal_async_handler() -> PushBack() -> alloc() at the same moment.
+  // Not recursive, so this cannot self-deadlock: neither caller (the destructor,
+  // and ConcurrentAsyncEvents::Clear()) holds the lock.
+  //
+  // What this lock does not cover is an item alloc() already returned. That
+  // caller releases the lock before it runs item->init() and enqueues, so a
+  // clear() landing in between frees the block out from under that write. No
+  // lock here can close that window: the item outlives the critical section it
+  // came from. What closes it is the API contract. Both callers run only from
+  // teardown, reached from Runtime::Unload() under bootstrap_lock(), and the
+  // HSA specification leaves it undefined to call into the runtime concurrently
+  // with the hsa_shut_down() releasing the last reference, so in a conforming
+  // program no PushBack() is in flight by the time either runs. The runtime
+  // does not enforce that, though: IS_OPEN() reads ref_count_ once and holds
+  // nothing for the rest of the call, so a thread can pass it and then be
+  // descheduled while another tears the runtime down. Holding the lock here is
+  // what keeps that program from corrupting the pool's vectors outright, a far
+  // likelier and less debuggable failure than the item-lifetime window it
+  // leaves; it is not a substitute for callers quiescing before shutdown.
+  std::lock_guard<HybridMutex> lock(lock_);
+
   ifdebug {
     size_t capacity = 0;
     for (auto& block : block_list_) capacity += block.second;


### PR DESCRIPTION
AsyncEventsPool guards its free list and block list with lock_, and both alloc() and free() take it, but clear() did not. It walks block_list_ releasing every block through free_(), then empties both vectors, with nothing held. ConcurrentAsyncEvents::Clear() reaches it from the async-event monitor thread as that loop exits, while application threads can still be inside hsa_amd_signal_async_handler() -> PushBack() -> alloc(), so one thread frees the pool's storage while another is handing items out of it -- a use-after-free whose window is exactly runtime teardown, and which a sanitizer sees as an unsynchronized malloc/free pair between those two threads.

Take lock_ for the whole of clear(), covering the leak-accounting debug walk as well since it reads the same two vectors. It cannot self-deadlock: HybridMutex is not recursive, and neither caller, the destructor, and ConcurrentAsyncEvents::Clear(), holds the lock.

Found while chasing a ThreadSanitizer report that named this async-event path but came from a build linking a release runtime, where the pool's HybridMutex and queue atomics are invisible to the tool and any cross-thread malloc/free looks unsynchronized, a signal too weak to act on. Getting a trustworthy one meant running an instrumented runtime, and that normally needs an AMD GPU. rocjitsu, the emulator in this repository, supplies an emulated KFD through library interposition, so an unmodified libhsa-runtime64 built here with ThreadSanitizer comes up, spawns its async-event monitor thread, and tears down on a host with no hardware at all. Auditing the pool against that running system is what exposed the missing lock, and re-running under it confirms the fix: neither AsyncEventsPool nor GetAllEvents appears in any report afterwards, and a harness that quiesces its callers before hsa_shut_down() is clean.

#10586