### PR TITLE
fix(rocjitsu): Populate KFD CPU node name

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -191,6 +191,8 @@ void Sysfs::write_cpu_node(const std::string &nodes_dir, uint32_t num_gpu_links)
     make_dir(node_dir + "/io_links/" + std::to_string(i));
 
   write_file(node_dir + "/gpu_id", "0\n");
+  // KFD publishes a name file for every topology node.
+  write_file(node_dir + "/name", "");
 
   long nproc = sysconf(_SC_NPROCESSORS_ONLN);
   if (nproc < 1)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -192,7 +192,7 @@ void Sysfs::write_cpu_node(const std::string &nodes_dir, uint32_t num_gpu_links)
 
   write_file(node_dir + "/gpu_id", "0\n");
   // KFD publishes a name file for every topology node.
-  write_file(node_dir + "/name", "");
+  write_file(node_dir + "/name", "\n");
 
   long nproc = sysconf(_SC_NPROCESSORS_ONLN);
   if (nproc < 1)

--- a/emulation/rocjitsu/tests/sysfs_test.cpp
+++ b/emulation/rocjitsu/tests/sysfs_test.cpp
@@ -50,6 +50,13 @@ std::unordered_map<std::string, uint64_t> read_properties(const std::string &pat
   return props;
 }
 
+std::string read_sysfs_file(const std::string &path) {
+  std::ifstream f(path);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
 Sysfs::GpuInfo make_gpu_info(uint32_t gfx_target_version) {
   Sysfs::GpuInfo gpu{};
   gpu.gpu_id = 1;
@@ -126,6 +133,23 @@ Sysfs::GpuInfo debug_gpu_info(const config::KfdDeviceConfig &dev) {
   gpu.capability2 = dev.capability2;
   gpu.debug_prop = dev.debug_prop;
   return gpu;
+}
+
+// KFD's node_show() publishes a "name" sysfs file for every topology node.
+// GPU nodes carry the marketing name; the CPU node is present but empty. Clients
+// that walk the topology tree expect the file to exist on node 0 as well.
+TEST(SysfsTopologyTest, CpuNodePublishesNameFile) {
+  Sysfs sysfs;
+  std::string topology_dir = sysfs.generate(make_gpu_info(90402u /* gfx942 */));
+  ASSERT_FALSE(topology_dir.empty());
+
+  const std::string cpu_name_path = topology_dir + "/nodes/0/name";
+  ASSERT_TRUE(std::filesystem::exists(cpu_name_path));
+  EXPECT_EQ(read_sysfs_file(cpu_name_path), "\n");
+
+  const std::string gpu_name_path = topology_dir + "/nodes/1/name";
+  ASSERT_TRUE(std::filesystem::exists(gpu_name_path));
+  EXPECT_EQ(read_sysfs_file(gpu_name_path), "Test GPU\n");
 }
 
 TEST(SysfsTopologyDebugCapabilityTest, PerGfxipDebugBitsMatchDriver) {


### PR DESCRIPTION
rocprofiler-sdk unconditionally checks every KFD topology node’s name file. Add the missing name file to rocjitsu's simulated CPU node to resolve this compatibility issue.

Close issue: https://github.com/ROCm/rocm-systems/issues/10566