### PR TITLE
[rocjitsu] Fix CDNA5 async LDS and scaled WMMA execution for gluon units

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -211,8 +211,10 @@ void flat_calculate_addresses(const VglobalMachineInst &inst, amdgpu::Wavefront 
 
 uint32_t async_lds_lane_address(const VglobalMachineInst &inst, const amdgpu::Wavefront &wf,
                                 uint32_t lds_operand, uint32_t access_size_bytes) {
-  int64_t relative_addr = static_cast<int64_t>(lds_operand) + signed_ioffset(inst.ioffset);
-  if (relative_addr < 0 || static_cast<uint64_t>(relative_addr) + access_size_bytes > wf.lds_size())
+  // The VGPR operand is 32 bits, so adding IOFFSET wraps before the LDS bounds check. This
+  // matters when code materializes (address - IOFFSET) in the VGPR, for example -64 + 64.
+  uint32_t relative_addr = lds_operand + static_cast<uint32_t>(signed_ioffset(inst.ioffset));
+  if (static_cast<uint64_t>(relative_addr) + access_size_bytes > wf.lds_size())
     return amdgpu::kInvalidLdsAddress;
 
   uint64_t absolute_addr = static_cast<uint64_t>(wf.lds_base()) + relative_addr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -410,6 +410,34 @@ inline InputLoc wmma_b_input_loc(uint32_t N, uint32_t K, uint32_t col, uint32_t 
   return wmma_f8f6f4_input_loc(N, K, col, k, b_bits, b_bits < 8 && a_bits == 8);
 }
 
+/// Compute the CDNA5 block-scaled WMMA input layout. Unlike the ordinary
+/// F8F6F4 WMMA layout, each operand format stores contiguous K ranges in each
+/// lane group: 16 values for 8-bit inputs and 32 values for 4/6-bit inputs.
+inline InputLoc wmma_block_scaled_input_loc(uint32_t dim, uint32_t K, uint32_t index, uint32_t k,
+                                            uint32_t data_bits) {
+  if (dim != 16 || K != 128 || (data_bits != 4 && data_bits != 6 && data_bits != 8))
+    throw util::UnimplementedInst("unsupported CDNA5 block-scaled WMMA input shape");
+  const uint32_t block_elems = data_bits == 8 ? 16u : 32u;
+  const uint32_t lane = index + 16u * ((k / block_elems) & 1u);
+  const uint32_t local = (k / (2u * block_elems)) * block_elems + (k % block_elems);
+  return wmma_packed_input_loc(lane, local, data_bits);
+}
+
+inline InputLoc wmma_block_scaled_a_input_loc(uint32_t M, uint32_t K, uint32_t row, uint32_t k,
+                                              uint32_t a_bits) {
+  if (M == 32 && K == 128 && a_bits == 4) {
+    auto loc = wmma_block_scaled_input_loc(16, K, row % 16, k, a_bits);
+    loc.vgpr_offset += 8u * (row / 16u);
+    return loc;
+  }
+  return wmma_block_scaled_input_loc(M, K, row, k, a_bits);
+}
+
+inline InputLoc wmma_block_scaled_b_input_loc(uint32_t N, uint32_t K, uint32_t col, uint32_t k,
+                                              uint32_t b_bits) {
+  return wmma_block_scaled_input_loc(N, K, col, k, b_bits);
+}
+
 inline InputLoc gfx12_wmma_a_input_loc(uint32_t wave_size, uint32_t M, uint32_t K, uint32_t row,
                                        uint32_t k, uint32_t a_bits, uint32_t b_bits) {
   if (wave_size == WMMA_WAVE32)
@@ -899,6 +927,10 @@ inline uint32_t wmma_f8f6f4_scale_byte(uint32_t k, uint32_t data_bits, bool mixe
   if (mixed_pair || data_bits == 8)
     return k >> 5;
   return 2u * (k >> 6) + ((k >> 2) & 1u);
+}
+
+inline uint32_t wmma_block_scale_byte(uint32_t k, bool scale16) {
+  return k / (scale16 ? 16u : 32u);
 }
 
 template <typename Run> bool dispatch_matrix_fmt_pair(uint32_t a_fmt, uint32_t b_fmt, Run run) {
@@ -1894,9 +1926,6 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
   };
   std::vector<Result> results;
   results.reserve(M * N);
-  const bool mixed_subbyte_a = a_bits < 8 && b_bits == 8;
-  const bool mixed_subbyte_b = b_bits < 8 && a_bits == 8;
-  const bool mixed_pair = mixed_subbyte_a || mixed_subbyte_b;
   const uint32_t num_scale_blocks = scale16 ? 8u : 4u;
 
   auto scale_for = [](uint64_t scale_word, uint32_t scale_byte, uint32_t scale_fmt) -> float {
@@ -1919,10 +1948,10 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
         for (uint32_t block = 0; block < num_scale_blocks; ++block) {
           float block_sum = 0.0f;
           for (uint32_t k = 0; k < K; ++k) {
-            if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) != block)
+            if (wmma_block_scale_byte(k, scale16) != block)
               continue;
-            auto al = wmma_a_input_loc(M, K, row, k, a_bits, b_bits);
-            auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
+            auto al = wmma_block_scaled_a_input_loc(M, K, row, k, a_bits);
+            auto bl = wmma_block_scaled_b_input_loc(N, K, col, k, b_bits);
             block_sum = std::fma(ea(cu, s0, al), eb(cu, s1, bl), block_sum);
           }
           block_sum *= scale_for(a_scale_word, block, matrix_a_scale_fmt);
@@ -1960,13 +1989,13 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
         }
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t k = 0; k < K; ++k) {
-          auto al = wmma_a_input_loc(M, K, row, k, a_bits, b_bits);
+          auto al = wmma_block_scaled_a_input_loc(M, K, row, k, a_bits);
           Abuf[row * K + k] = ea(reads.a, s0, al);
         }
       }
       for (uint32_t col = 0; col < N; ++col) {
         for (uint32_t k = 0; k < K; ++k) {
-          auto bl = wmma_b_input_loc(N, K, col, k, a_bits, b_bits);
+          auto bl = wmma_block_scaled_b_input_loc(N, K, col, k, b_bits);
           Bbuf[k * stride + col] = eb(reads.b, s1, bl);
         }
       }
@@ -1979,7 +2008,7 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
           for (; col + W <= N; col += W) {
             util::native<float> block_sum(0.0f);
             for (uint32_t k = 0; k < K; ++k) {
-              if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) != block)
+              if (wmma_block_scale_byte(k, scale16) != block)
                 continue;
               util::native<float> a(Abuf[row * K + k]);
               util::native<float> bv;
@@ -1997,7 +2026,7 @@ void exec_wmma_f32_scaled_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, ui
           for (; col < N; ++col) {
             float block_sum = 0.0f;
             for (uint32_t k = 0; k < K; ++k) {
-              if (wmma_f8f6f4_scale_byte(k, a_bits, mixed_pair, scale16) == block)
+              if (wmma_block_scale_byte(k, scale16) == block)
                 block_sum = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], block_sum);
             }
             block_sum *= scale_for(a_scale_word, block, matrix_a_scale_fmt);

--- a/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_architecture_test.cpp
@@ -84,6 +84,82 @@ void write_wmma_packed(amdgpu::ComputeUnitCore &cu, uint32_t base, const amdgpu:
   }
 }
 
+uint8_t encode_wmma_value(uint32_t fmt, float value) {
+  switch (fmt) {
+  case 0:
+    return util::f32_to_fp8_e4m3_rne(value);
+  case 1:
+    return util::f32_to_bf8_e5m2_rne(value);
+  case 2:
+    return util::f32_to_fp6_e2m3_rne(value);
+  case 3:
+    return util::f32_to_bf6_e3m2_rne(value);
+  case 4:
+    return util::f32_to_fp4_e2m1_rne(value);
+  default:
+    return 0;
+  }
+}
+
+float decode_wmma_value(uint32_t fmt, uint8_t value) {
+  switch (fmt) {
+  case 0:
+    return util::fp8_e4m3_to_f32(value);
+  case 1:
+    return util::bf8_e5m2_to_f32(value);
+  case 2:
+    return util::fp6_e2m3_to_f32(value);
+  case 3:
+    return util::bf6_e3m2_to_f32(value);
+  case 4:
+    return util::fp4_e2m1_to_f32(value);
+  default:
+    return 0.0f;
+  }
+}
+
+// Independent transcription of the CDNA5 block-scaled WMMA tables. Keeping the
+// physical writer separate from the execution helper makes this an integration
+// check rather than seeding data through the implementation under test.
+amdgpu::InputLoc manual_block_scaled_wmma_loc(uint32_t dim, uint32_t index, uint32_t k,
+                                              uint32_t data_bits) {
+  const uint32_t slice = dim == 32 ? index / 16u : 0u;
+  const uint32_t index_in_slice = index % 16u;
+  const uint32_t block_elems = data_bits == 8 ? 16u : 32u;
+  const uint32_t lane = index_in_slice + 16u * ((k / block_elems) & 1u);
+  const uint32_t slot = (k / (2u * block_elems)) * block_elems + (k % block_elems);
+  const uint32_t bit = slot * data_bits;
+  const uint32_t bit_in_word = bit % 32u;
+  const uint32_t sub_element = (32u % data_bits == 0) ? bit_in_word / data_bits : 0u;
+  return {bit / 32u + 8u * slice, lane, sub_element, bit_in_word, data_bits};
+}
+
+std::array<uint32_t, 4> build_scaled_wmma_execution_words(
+    uint32_t M, bool scale16, uint32_t matrix_a_fmt, uint32_t matrix_b_fmt, uint16_t scale_src0,
+    uint16_t scale_src1, uint32_t scale_a_select, uint32_t scale_b_select, uint8_t vdst = 64) {
+  constexpr uint16_t kVgprEncoding = 256;
+  auto prefix =
+      cdna5::build_vop3p(scale16 ? 0x3a : 0x35, {.opsel = static_cast<uint8_t>(scale_a_select),
+                                                 .src0 = scale_src0,
+                                                 .src1 = scale_src1,
+                                                 .src2 = kVgprEncoding,
+                                                 .opsel_hi = static_cast<uint8_t>(scale_b_select)});
+  const uint16_t matrix_op =
+      M == 32 ? cdna5::kVWmmaF3232x16x128F4Vop3p : cdna5::kVWmmaF3216x16x128F8f6f4Vop3p;
+  auto matrix =
+      cdna5::build_vop3p(matrix_op, {.vdst = vdst,
+                                     .opsel = static_cast<uint8_t>(matrix_a_fmt),
+                                     .src0 = kVgprEncoding,
+                                     .src1 = kVgprEncoding + 32,
+                                     .src2 = 128,
+                                     .opsel_hi = static_cast<uint8_t>(matrix_b_fmt & 0x3u)});
+  if (M == 32)
+    matrix[0] |= 1u << 14u;
+  else
+    matrix[0] |= (matrix_b_fmt >> 2u) << 14u;
+  return {prefix[0], prefix[1], matrix[0], matrix[1]};
+}
+
 struct ForceScalarGuard {
   bool old = util::force_scalar();
   ~ForceScalarGuard() { util::set_force_scalar_for_testing(old); }
@@ -978,6 +1054,147 @@ TEST(Gfx1250ExecutionTest, WmmaNonE8ScalesApplyAfterEachBlockDot) {
         for (uint32_t reg = 0; reg < 8; ++reg)
           for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
             EXPECT_EQ(cu->read_vgpr(vgpr_base + 64 + reg, lane), std::bit_cast<uint32_t>(expected));
+      }
+    }
+  }
+}
+
+TEST(Gfx1250ExecutionTest, WmmaScaledExecutionMatchesManualLayoutAndDistinctBlockScales) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = sim.dispatch_scratch_wf();
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0xffffffffu);
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA5);
+  ASSERT_NE(decoder, nullptr);
+  ForceScalarGuard scalar_guard;
+
+  constexpr uint32_t kMatrixA = 0;
+  constexpr uint32_t kMatrixB = 32;
+  constexpr uint32_t kOutput = 64;
+  constexpr uint32_t kScaleA = 80;
+  constexpr uint32_t kScaleB = 82;
+  constexpr std::array<float, 4> matrix_values = {-1.0f, -0.5f, 0.5f, 1.5f};
+
+  struct TestCase {
+    uint32_t M;
+    uint32_t matrix_a_fmt;
+    uint32_t matrix_b_fmt;
+    bool scale16;
+    uint32_t scale_a_select;
+    uint32_t scale_b_select;
+  };
+  constexpr TestCase cases[] = {
+      {16, 0, 4, false, 1, 0}, // FP8 x FP4, 32 values per scale.
+      {16, 4, 0, true, 0, 1},  // FP4 x FP8, 16 values per scale.
+      {16, 2, 3, false, 1, 1}, // FP6 x BF6, including cross-VGPR packed values.
+      {32, 4, 4, true, 0, 1},  // Two-slice FP4 A matrix and 64-bit scale words.
+  };
+
+  const auto matrix_a_raw = [&](const TestCase &tc, uint32_t row, uint32_t k) {
+    const float value = matrix_values[(3u * row + 5u * k + k / 16u) % matrix_values.size()];
+    return encode_wmma_value(tc.matrix_a_fmt, value);
+  };
+  const auto matrix_b_raw = [&](const TestCase &tc, uint32_t col, uint32_t k) {
+    const float value = matrix_values[(5u * col + 3u * k + k / 32u + 1u) % matrix_values.size()];
+    return encode_wmma_value(tc.matrix_b_fmt, value);
+  };
+  const auto scale_a_raw = [](uint32_t row, uint32_t block) {
+    return static_cast<uint8_t>(0x7eu + ((row + 2u * block) % 3u));
+  };
+  const auto scale_b_raw = [](uint32_t col, uint32_t block) {
+    return static_cast<uint8_t>(0x7eu + ((2u * col + block + 1u) % 3u));
+  };
+
+  for (const auto &tc : cases) {
+    SCOPED_TRACE(::testing::Message() << "M=" << tc.M << " a_fmt=" << tc.matrix_a_fmt
+                                      << " b_fmt=" << tc.matrix_b_fmt << " scale16=" << tc.scale16);
+    const uint32_t N = 16;
+    const uint32_t K = 128;
+    const uint32_t a_bits = wmma_format_bits(tc.matrix_a_fmt);
+    const uint32_t b_bits = wmma_format_bits(tc.matrix_b_fmt);
+    const uint32_t scale_blocks = tc.scale16 ? 8u : 4u;
+
+    auto seed_inputs_and_scales = [&]() {
+      for (uint32_t reg = 0; reg < 84; ++reg)
+        for (uint32_t lane = 0; lane < wf->wf_size(); ++lane)
+          cu->write_vgpr(vgpr_base + reg, lane, 0);
+
+      for (uint32_t row = 0; row < tc.M; ++row)
+        for (uint32_t k = 0; k < K; ++k)
+          write_wmma_packed(*cu, vgpr_base + kMatrixA,
+                            manual_block_scaled_wmma_loc(tc.M, row, k, a_bits),
+                            matrix_a_raw(tc, row, k));
+      for (uint32_t col = 0; col < N; ++col)
+        for (uint32_t k = 0; k < K; ++k)
+          write_wmma_packed(*cu, vgpr_base + kMatrixB,
+                            manual_block_scaled_wmma_loc(N, col, k, b_bits),
+                            matrix_b_raw(tc, col, k));
+
+      for (uint32_t row = 0; row < tc.M; ++row) {
+        uint64_t word = 0;
+        for (uint32_t block = 0; block < scale_blocks; ++block)
+          word |= static_cast<uint64_t>(scale_a_raw(row, block)) << (8u * block);
+        const uint32_t lane = tc.M == 32 ? row : row + 16u * tc.scale_a_select;
+        cu->write_vgpr(vgpr_base + kScaleA, lane, static_cast<uint32_t>(word));
+        if (tc.scale16)
+          cu->write_vgpr(vgpr_base + kScaleA + 1, lane, static_cast<uint32_t>(word >> 32u));
+      }
+      for (uint32_t col = 0; col < N; ++col) {
+        uint64_t word = 0;
+        for (uint32_t block = 0; block < scale_blocks; ++block)
+          word |= static_cast<uint64_t>(scale_b_raw(col, block)) << (8u * block);
+        const uint32_t lane = col + 16u * tc.scale_b_select;
+        cu->write_vgpr(vgpr_base + kScaleB, lane, static_cast<uint32_t>(word));
+        if (tc.scale16)
+          cu->write_vgpr(vgpr_base + kScaleB + 1, lane, static_cast<uint32_t>(word >> 32u));
+      }
+    };
+
+    const auto words = build_scaled_wmma_execution_words(
+        tc.M, tc.scale16, tc.matrix_a_fmt, tc.matrix_b_fmt, 256 + kScaleA, 256 + kScaleB,
+        tc.scale_a_select, tc.scale_b_select, kOutput);
+    auto run = [&](bool force_scalar) {
+      util::set_force_scalar_for_testing(force_scalar);
+      seed_inputs_and_scales();
+      std::unique_ptr<Instruction> inst(decode_valid(*decoder, words.data()));
+      EXPECT_NE(inst, nullptr);
+      if (!inst)
+        return std::vector<uint32_t>{};
+      cu->execute_instruction(inst.get(), *wf);
+      std::vector<uint32_t> output;
+      output.reserve(tc.M * N);
+      for (uint32_t row = 0; row < tc.M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          const auto loc = amdgpu::wmma_output_loc_32(tc.M, N, row, col);
+          output.push_back(cu->read_vgpr(vgpr_base + kOutput + loc.reg, loc.lane));
+        }
+      return output;
+    };
+
+    const auto scalar = run(true);
+    const auto simd = run(false);
+    ASSERT_EQ(scalar.size(), tc.M * N);
+    ASSERT_EQ(simd, scalar);
+
+    const uint32_t block_size = tc.scale16 ? 16u : 32u;
+    for (uint32_t row = 0; row < tc.M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        float expected = 0.0f;
+        for (uint32_t block = 0; block < scale_blocks; ++block) {
+          float block_sum = 0.0f;
+          for (uint32_t k = block * block_size; k < (block + 1u) * block_size; ++k) {
+            const float a = decode_wmma_value(tc.matrix_a_fmt, matrix_a_raw(tc, row, k));
+            const float b = decode_wmma_value(tc.matrix_b_fmt, matrix_b_raw(tc, col, k));
+            block_sum = std::fma(a, b, block_sum);
+          }
+          block_sum *= util::e8m0_to_f32(scale_a_raw(row, block));
+          block_sum *= util::e8m0_to_f32(scale_b_raw(col, block));
+          expected += block_sum;
+        }
+        EXPECT_EQ(scalar[row * N + col], std::bit_cast<uint32_t>(expected))
+            << "row=" << row << " col=" << col;
       }
     }
   }

--- a/emulation/rocjitsu/tests/cdna5_cluster_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_cluster_test.cpp
@@ -337,6 +337,166 @@ TEST(Gfx1250ExecutionTest, AsyncLdsAddressRejectsAccessOutsideAllocation) {
   EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 256, 4), wf->lds_base() + 252);
   EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 256, 16), amdgpu::kInvalidLdsAddress);
   EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, 260, 4), amdgpu::kInvalidLdsAddress);
+
+  inst.ioffset = 64;
+  EXPECT_EQ(cdna5::async_lds_lane_address(inst, *wf, UINT32_MAX - 63, 4), wf->lds_base());
+}
+
+TEST(Gfx1250ExecutionTest, DecodedAsyncLdsLoadsHonorEveryAccessWidthAtAllocationEnd) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x1u);
+  wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_lds_size(256);
+
+  constexpr uint64_t kGlobalBase = 0x1a0000u;
+  write_wave_sgpr(*cu, *wf, 0, static_cast<uint32_t>(kGlobalBase));
+  write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base, 0, 0);
+
+  struct TestCase {
+    uint16_t opcode;
+    std::string_view mnemonic;
+    uint32_t access_size;
+  };
+  constexpr TestCase cases[] = {
+      {cdna5::kGlobalLoadAsyncToLdsB8Vglobal, "global_load_async_to_lds_b8", 1},
+      {cdna5::kGlobalLoadAsyncToLdsB32Vglobal, "global_load_async_to_lds_b32", 4},
+      {cdna5::kGlobalLoadAsyncToLdsB64Vglobal, "global_load_async_to_lds_b64", 8},
+      {cdna5::kGlobalLoadAsyncToLdsB128Vglobal, "global_load_async_to_lds_b128", 16},
+  };
+
+  for (const auto &tc : cases) {
+    SCOPED_TRACE(tc.mnemonic);
+    const auto words =
+        cdna5::build_vglobal(tc.opcode, {.saddr = 0, .vdst = 1, .vaddr = 0, .ioffset = 0});
+    auto execute_at = [&](uint32_t relative_addr) {
+      cu->write_vgpr(vgpr_base + 1, 0, relative_addr);
+      auto inst = decode_gfx1250(words, tc.mnemonic);
+      EXPECT_NE(inst, nullptr);
+      if (!inst)
+        return amdgpu::kInvalidLdsAddress;
+      inst->execute(*inst, wf);
+      auto *state = inst->data_as<amdgpu::VectorMemState>();
+      EXPECT_NE(state, nullptr);
+      if (!state)
+        return amdgpu::kInvalidLdsAddress;
+      EXPECT_EQ(state->elem_size * state->num_elems, tc.access_size);
+      return state->per_lane_lds_addr[0];
+    };
+
+    const uint32_t last_valid = wf->lds_size() - tc.access_size;
+    EXPECT_EQ(execute_at(last_valid), wf->lds_base() + last_valid);
+    EXPECT_EQ(execute_at(last_valid + 1), amdgpu::kInvalidLdsAddress);
+  }
+}
+
+TEST(Gfx1250SimulationTest, GlobalLoadAsyncToLdsWrapsBeforeAddingAllocationBase) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2a00;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t expected = 0x12345678u;
+  constexpr auto move_wrapping_lds =
+      cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 255, .vdst = 1});
+  constexpr auto async_load = cdna5::build_vglobal(
+      cdna5::kGlobalLoadAsyncToLdsB32Vglobal, {.saddr = 0, .vdst = 1, .vaddr = 0, .ioffset = 64});
+  const uint32_t code[] = {
+      0xBE8000FFu,
+      static_cast<uint32_t>(input_addr - 64), // s_mov_b32 s0, input_addr - 64
+      0xBE810080u,                            // s_mov_b32 s1, 0
+      0x7E000280u,                            // v_mov_b32_e32 v0, 0
+      move_wrapping_lds[0],
+      UINT32_MAX - 63, // v_mov_b32_e32 v1, 0xffffffc0
+      async_load[0],
+      async_load[1],
+      async_load[2],
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.memory->write32(input_addr, expected);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 32;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.group_segment_size = lds_bytes_per_wg;
+  pkt.kernel_object = kernel_object;
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(sim.cu()->allocate_lds(lds_bytes_per_wg));
+  ASSERT_NE(wf->lds_base(), 0u);
+  const uint32_t lds_base = wf->lds_base();
+  sim.cu()->lds().write32(lds_base, 0xa5a5a5a5u);
+  EXPECT_NO_THROW(sim.engine->run());
+  EXPECT_EQ(sim.cu()->lds().read32(lds_base), expected);
+}
+
+TEST(Gfx1250SimulationTest, GlobalStoreAsyncFromLdsWrapsBeforeAddingAllocationBase) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t output_addr = 0x2c00;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t expected = 0x89abcdefu;
+  constexpr auto move_wrapping_lds =
+      cdna5::build_vop1(cdna5::kVMovB32Vop1, {.src0 = 255, .vdst = 1});
+  constexpr auto async_store =
+      cdna5::build_vglobal(cdna5::kGlobalStoreAsyncFromLdsB32Vglobal,
+                           {.saddr = 0, .vsrc = 1, .vaddr = 0, .ioffset = 64});
+  const uint32_t code[] = {
+      0xBE8000FFu,
+      static_cast<uint32_t>(output_addr - 64), // s_mov_b32 s0, output_addr - 64
+      0xBE810080u,                             // s_mov_b32 s1, 0
+      0x7E000280u,                             // v_mov_b32_e32 v0, 0
+      move_wrapping_lds[0],
+      UINT32_MAX - 63, // v_mov_b32_e32 v1, 0xffffffc0
+      async_store[0],
+      async_store[1],
+      async_store[2],
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  sim.memory->write32(output_addr, 0u);
+
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 32;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.group_segment_size = lds_bytes_per_wg;
+  pkt.kernel_object = kernel_object;
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  wf->set_lds_base(sim.cu()->allocate_lds(lds_bytes_per_wg));
+  ASSERT_NE(wf->lds_base(), 0u);
+  const uint32_t lds_base = wf->lds_base();
+  sim.cu()->lds().write32(lds_base, expected);
+  EXPECT_NO_THROW(sim.engine->run());
+  EXPECT_EQ(sim.memory->read32(output_addr), expected);
 }
 
 TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -921,6 +921,30 @@ TEST(MfmaExecTest, WmmaF8f6f4K128InputLocMatchesManualLayoutsExhaustively) {
   }
 }
 
+TEST(MfmaExecTest, Cdna5BlockScaledWmmaUsesContiguousKBlocks) {
+  for (uint32_t data_bits : {4u, 6u, 8u}) {
+    const uint32_t block_elems = data_bits == 8 ? 16u : 32u;
+    for (uint32_t index = 0; index < 16; ++index) {
+      for (uint32_t k = 0; k < 128; ++k) {
+        SCOPED_TRACE(::testing::Message()
+                     << "data_bits=" << data_bits << " index=" << index << " k=" << k);
+        const uint32_t expected_lane = index + 16u * ((k / block_elems) & 1u);
+        const uint32_t expected_slot = (k / (2u * block_elems)) * block_elems + (k % block_elems);
+        const uint32_t expected_bit = expected_slot * data_bits;
+        const auto actual = amdgpu::wmma_block_scaled_input_loc(16, 128, index, k, data_bits);
+        EXPECT_EQ(actual.lane, expected_lane);
+        EXPECT_EQ(actual.vgpr_offset, expected_bit / 32u);
+        EXPECT_EQ(actual.bit_offset, expected_bit % 32u);
+      }
+    }
+  }
+
+  for (uint32_t k = 0; k < 128; ++k) {
+    EXPECT_EQ(amdgpu::wmma_block_scale_byte(k, /*scale16=*/false), k / 32u);
+    EXPECT_EQ(amdgpu::wmma_block_scale_byte(k, /*scale16=*/true), k / 16u);
+  }
+}
+
 TEST(MfmaExecTest, Cdna4ScaledMfmaInputLocMatchesSiliconQualifiedLayouts) {
   constexpr std::array<uint32_t, 3> widths = {8, 6, 4};
   for (const auto &[dim, k_size] :


### PR DESCRIPTION
Wrap async LDS IOFFSET arithmetic to 32 bits before applying the wave allocation bounds and physical base. This handles VGPR operands such as -64 + 64 with the instruction-defined wraparound.

Use the CDNA5 block-scaled WMMA input layout for contiguous K blocks of 4-, 6-, and 8-bit values, including the 32x16 FP4 form. Select scale bytes over 16- or 32-element blocks in both scalar and SIMD execution.

Add decoded allocation-boundary tests, end-to-end async load and store coverage, and independent scaled WMMA layout and result oracles.