### PR TITLE
fix(rccl): don't record doneEvent on a possibly-destroyed stream

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1985,6 +1985,10 @@ static void persistentDestructor(void* plans_) {
 NCCL_PARAM(LaunchOrderImplicit, "LAUNCH_ORDER_IMPLICIT", 0);
 NCCL_PARAM(GraphStreamOrdering, "GRAPH_STREAM_ORDERING", NCCL_CONFIG_UNDEF_INT);
 
+// Biased so the default stream (nullptr) tags as 1, leaving 0 free as the "no launch yet"
+// sentinel. See ncclComm::lastStreamTag.
+static inline uintptr_t ncclStreamTag(hipStream_t s) { return (uintptr_t)s + 1; }
+
 namespace {
 enum ncclImplicitOrder {
   ncclImplicitOrderNone,
@@ -2131,15 +2135,11 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       }
       // userStream[0] waits on deviceStream
       NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
-    } else if (comm->lastStreamValid && comm->lastStream != launchStream) {
-      // Stream changed from last call. The new launchStream has no implicit edge to the
-      // previous kernel's completion; install a direct event-based dependency on doneEvent.
-      // Record lazily here on lastStream — HIP's per-stream FIFO guarantees the record
-      // sequences after the prior cuLaunchKernel — then wait on it from launchStream.
-      // Recording only on detected stream change (instead of after every ncclLaunchKernel)
-      // avoids a per-launch HIP runtime cost. Bypasses deviceStream, which the fast path
-      // leaves stale by skipping Finish-side advance.
-      CUDACHECKGOTO(hipEventRecord(comm->doneEvent, comm->lastStream), result, failure);
+    } else if (comm->lastStreamTag != 0 &&
+               comm->lastStreamTag != ncclStreamTag(launchStream)) {
+      // Stream changed. Wait on doneEvent, recorded by ncclLaunchKernel on the previous launch
+      // stream; deviceStream is stale here because the fast path skips the Finish-side advance.
+      // Don't record it here — that stream may already be destroyed (ROCM-29677).
       CUDACHECKGOTO(hipStreamWaitEvent(launchStream, comm->doneEvent, 0), result, failure);
     }
 
@@ -2253,11 +2253,10 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr,
                                extra),
                 ret, do_return);
-    // doneEvent is recorded lazily by ncclLaunchPrepare on a detected stream change; no
-    // per-launch hipEventRecord is needed here. lastStream/lastStreamValid bookkeeping is
-    // still required so the next call's ncclLaunchPrepare can detect that change.
-    comm->lastStream = launchStream;
-    comm->lastStreamValid = true;
+    // Record while launchStream is guaranteed live; bookkeeping after, so a failed record
+    // leaves no false claim of a recorded event.
+    CUDACHECKGOTO(hipEventRecord(comm->doneEvent, launchStream), ret, do_return);
+    comm->lastStreamTag = ncclStreamTag(launchStream);
     latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
     return ncclSuccess;
   }
@@ -2347,10 +2346,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra),
               ret, do_return);
   latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
-  // Mirror fast-path bookkeeping so the next ncclLaunchPrepare can detect stream-change.
-  // doneEvent is recorded lazily by ncclLaunchPrepare in the stream-change branch.
-  comm->lastStream = launchStream;
-  comm->lastStreamValid = true;
+  // Mirror the fast path.
+  CUDACHECKGOTO(hipEventRecord(comm->doneEvent, launchStream), ret, do_return);
+  comm->lastStreamTag = ncclStreamTag(launchStream);
 
 do_return:
   NCCLCHECK(ncclProfilerStopKernelLaunchEvent(plan));

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -867,11 +867,11 @@ struct ncclComm {
   struct ncclIntruQueueMpsc<struct ncclCommCallback, &ncclCommCallback::next> callbackQueue;
 
   hipEvent_t doneEvent;
-  hipStream_t lastStream;
-  // False until the first kernel launch on this comm. Distinguishes "no prior launch"
-  // from "prior launch on the default stream (lastStream==nullptr)" so ncclLaunchPrepare
-  // can correctly detect a stream change in either case.
-  bool lastStreamValid;
+  // Opaque tag identifying the last launch stream, for stream-change detection only; 0 means
+  // no launch yet, which keeps "launched on the default stream" distinguishable. Not a
+  // hipStream_t: the app may destroy that stream while the comm lives on and HIP gives no
+  // notification, so this is compared, never passed to a HIP API.
+  uintptr_t lastStreamTag;
   latency_profiler::CollTrace* ctrace;
 
 #ifdef ENABLE_WARP_SPEED

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -754,8 +754,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   CUDACHECK(hipEventCreateWithFlags(&doneEvent, hipEventDisableTiming));
 
   comm->doneEvent = doneEvent;
-  comm->lastStream = nullptr;
-  comm->lastStreamValid = false;
+  comm->lastStreamTag = 0;
 
   // RCCL: acquire a scoped side stream for init-time allocations. It is
   // released once init completes (see ncclCommInitRankFunc) so it does not hold

--- a/projects/rccl/test/DoneEventOrderingTests.cpp
+++ b/projects/rccl/test/DoneEventOrderingTests.cpp
@@ -39,6 +39,10 @@ static constexpr int kIterations = 20;
 // Cap on communicators/GPUs used by single-node tests.
 static constexpr int kMaxGpus = 8;
 
+// Streams created between destroying one stream and creating its replacement, so the
+// replacement is unlikely to draw the freed handle and the stream-change branch is reached.
+static constexpr int kDecoyStreams = 8;
+
 class DoneEventOrdering : public ::testing::Test
 {
     // All work runs under process isolation; no fixture setup/teardown.
@@ -685,9 +689,7 @@ TEST_F(DoneEventOrdering, SameStreamThenSwitch)
                 const float expected = static_cast<float>(nGpus * (nGpus + 1) / 2);
 
                 // Phase 1: kIterations AllReduces all on streamA with NO synchronize.
-                // No hipEventRecord is emitted during this phase under the lazy scheme;
-                // only lastStream=streamA and lastStreamValid=true are recorded.
-                // This mirrors the real training-loop pattern (many collectives on one stream).
+                // Mirrors the real training-loop pattern (many collectives on one stream).
                 for(int iter = 0; iter < kIterations; ++iter)
                 {
                     for(int i = 0; i < nGpus; ++i)
@@ -702,11 +704,9 @@ TEST_F(DoneEventOrdering, SameStreamThenSwitch)
                 }
 
                 // Phase 2: single AllReduce on streamB per communicator — the stream switch.
-                // ncclLaunchPrepare detects lastStream(=streamA) != streamB, fires
-                // hipEventRecord(doneEvent, streamA) then hipStreamWaitEvent(streamB, doneEvent).
-                // ncclLaunchPrepare detects the stream change, lazily records doneEvent on
-                // streamA, then waits on it from streamB. Without this, streamB starts while
-                // streamA's kernels are still in flight, producing a wrong sum or a hang.
+                // ncclLaunchPrepare detects the change and waits on doneEvent from streamB.
+                // Without that edge, streamB starts while streamA's kernels are still in
+                // flight, producing a wrong sum or a hang.
                 for(int i = 0; i < nGpus; ++i)
                 {
                     ncclResult_t res = ncclAllReduce(
@@ -734,6 +734,137 @@ TEST_F(DoneEventOrdering, SameStreamThenSwitch)
                         kElemCount, 0.0, &errIdx, &expVal, &actVal);
                     EXPECT_TRUE(ok)
                         << "SameStreamThenSwitch rank " << i << ": wrong at index " << errIdx
+                        << " expected " << expVal << " got " << actVal;
+                }
+            })
+            .withNumGpus(kMaxGpus)
+            .withEnvironment({{"NCCL_DEBUG", "WARN"}})
+            .withTimeout(std::chrono::seconds(kDoneEventTimeoutSeconds)));
+}
+
+// Communicator outlives the stream it last launched on. Destroying that stream and then
+// issuing a collective on a fresh one must not touch the dead handle (ROCM-29677).
+TEST_F(DoneEventOrdering, StreamDestroyedThenSwitch)
+{
+    ProcessIsolatedTestRunner::ExecutionOptions options;
+    options.stopOnFirstFailure = false;
+    options.verboseLogging     = true;
+
+    RUN_ISOLATED_TESTS_WITH_OPTIONS(
+        options,
+        ProcessIsolatedTestRunner::TestConfig(
+            "StreamDestroyedThenSwitch",
+            []()
+            {
+                int devCount = 0;
+                HIP_CHECK(hipGetDeviceCount(&devCount));
+                const int nGpus = std::min(devCount, kMaxGpus);
+                if(nGpus < 2)
+                    GTEST_SKIP() << "Requires >= 2 GPUs; found " << devCount;
+
+                std::vector<int> devices(nGpus);
+                std::iota(devices.begin(), devices.end(), 0);
+
+                std::vector<ncclComm_t> comms(nGpus, nullptr);
+                {
+                    ncclResult_t res = ncclCommInitAll(comms.data(), nGpus, devices.data());
+                    ASSERT_EQ(res, ncclSuccess) << ncclGetErrorString(res);
+                }
+                std::vector<RCCLTestGuards::NcclCommAutoGuard> commGuards;
+                commGuards.reserve(nGpus);
+                for(int i = 0; i < nGpus; ++i)
+                    commGuards.push_back(RCCLTestGuards::makeCommAutoGuard(comms[i]));
+
+                std::vector<RCCLTestGuards::HipStreamAutoGuard>    decoyGuards, streamBGuards;
+                std::vector<RCCLTestGuards::DeviceBufferAutoGuard> sendbufGuards, recvbufGuards;
+                decoyGuards.reserve(static_cast<size_t>(nGpus) * kDecoyStreams);
+                streamBGuards.reserve(nGpus);
+                sendbufGuards.reserve(nGpus);
+                recvbufGuards.reserve(nGpus);
+
+                // streamA is destroyed mid-test on purpose, so it is not RAII-guarded.
+                std::vector<hipStream_t> streamA(nGpus, nullptr);
+                std::vector<hipStream_t> streamB(nGpus, nullptr);
+                std::vector<float*>      sendbuf(nGpus, nullptr);
+                std::vector<float*>      recvbuf(nGpus, nullptr);
+
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    HIP_CHECK(hipSetDevice(devices[i]));
+                    HIP_CHECK(hipStreamCreate(&streamA[i]));
+
+                    HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&sendbuf[i]), kBufferBytes));
+                    sendbufGuards.push_back(RCCLTestGuards::makeDeviceBufferAutoGuard(sendbuf[i]));
+                    HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&recvbuf[i]), kBufferBytes));
+                    recvbufGuards.push_back(RCCLTestGuards::makeDeviceBufferAutoGuard(recvbuf[i]));
+
+                    HIP_CHECK(RCCLTestHelpers::initializeBufferWithPattern<float>(
+                        sendbuf[i], kElemCount,
+                        [i](size_t) { return static_cast<float>(i + 1); }));
+                    HIP_CHECK(RCCLTestHelpers::zeroInitializeBuffer<float>(recvbuf[i], kElemCount));
+                }
+
+                const float expected = static_cast<float>(nGpus * (nGpus + 1) / 2);
+
+                // Phase 1: collectives on streamA, then drain so the destroy below is clean.
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    ncclResult_t res = ncclAllReduce(sendbuf[i], recvbuf[i], kElemCount,
+                                                     ncclFloat, ncclSum, comms[i], streamA[i]);
+                    ASSERT_EQ(res, ncclSuccess)
+                        << "phase1 rank=" << i << ": " << ncclGetErrorString(res);
+                }
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    HIP_CHECK(hipSetDevice(devices[i]));
+                    HIP_CHECK(hipStreamSynchronize(streamA[i]));
+                }
+
+                // Each communicator now holds streamA's identity. Destroy it; the comm lives on.
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    HIP_CHECK(hipSetDevice(devices[i]));
+                    HIP_CHECK(hipStreamDestroy(streamA[i]));
+                }
+
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    HIP_CHECK(hipSetDevice(devices[i]));
+                    for(int k = 0; k < kDecoyStreams; ++k)
+                    {
+                        hipStream_t decoy = nullptr;
+                        HIP_CHECK(hipStreamCreate(&decoy));
+                        decoyGuards.push_back(RCCLTestGuards::makeStreamAutoGuard(decoy));
+                    }
+                    HIP_CHECK(hipStreamCreate(&streamB[i]));
+                    streamBGuards.push_back(RCCLTestGuards::makeStreamAutoGuard(streamB[i]));
+                }
+
+                // Phase 2: the stream change. Before the fix this recorded doneEvent on the
+                // destroyed streamA and returned ncclUnhandledCudaError, or segfaulted.
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    ncclResult_t res = ncclAllReduce(sendbuf[i], recvbuf[i], kElemCount,
+                                                     ncclFloat, ncclSum, comms[i], streamB[i]);
+                    ASSERT_EQ(res, ncclSuccess)
+                        << "phase2 rank=" << i << ": " << ncclGetErrorString(res);
+                }
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    HIP_CHECK(hipSetDevice(devices[i]));
+                    HIP_CHECK(hipStreamSynchronize(streamB[i]));
+                }
+
+                for(int i = 0; i < nGpus; ++i)
+                {
+                    size_t errIdx = 0;
+                    float  expVal = 0.0f, actVal = 0.0f;
+                    bool   ok = RCCLTestHelpers::verifyBufferData<float>(
+                        recvbuf[i], kElemCount,
+                        [expected](size_t) { return expected; },
+                        kElemCount, 0.0, &errIdx, &expVal, &actVal);
+                    EXPECT_TRUE(ok)
+                        << "StreamDestroyedThenSwitch rank " << i << ": wrong at index " << errIdx
                         << " expected " << expVal << " got " << actVal;
                 }
             })


### PR DESCRIPTION
## Motivation

PR #6130 moved the `hipEventRecord(comm->doneEvent, ...)` out of `ncclLaunchKernel` and
into `ncclLaunchPrepare`'s stream-change branch, recording it on `comm->lastStream`
rather than on the stream being launched.

That turned `lastStream` from a compare-only value into a **dereferenced handle**. RCCL
never learns when the application destroys a stream — HIP has no destruction notification
and no safe validity probe — and `lastStreamValid` was only ever set `true`, never
cleared. So an application that destroys the stream a communicator last launched on, and
then issues a collective on a different stream, hits a use-after-destroy.

It surfaces two ways:
- `ncclUnhandledCudaError` from `HIP failure: 'invalid resource handle'`
- a **segfault**, when the freed handle has been recycled onto an unrelated live stream,
  producing a bogus ordering edge

This is not theoretical — it reproduces on a real QA workload (see Test Result).

## Technical Details

Record `doneEvent` at launch time again, on `launchStream`, which is live by construction:
the application has just handed it to us. `ncclLaunchPrepare` now only waits on the event,
never records it.

`lastStream` + `lastStreamValid` collapse into a single `uintptr_t lastStreamTag`, produced
by `ncclStreamTag(s) = (uintptr_t)s + 1` so `0` stays free as the "no launch yet" sentinel
and a prior launch on the default stream remains distinguishable (the case #5800 fixed).
One word also removes any torn-read question between a handle and a separate flag.

Comparing a stale tag is safe in both directions:
- **handle recycled** -> compares equal -> no edge installed. Safe: `hipStreamDestroy`
  defers handle reuse until the stream's work completes, so a recycled handle proves the
  prior kernel already finished.
- **handle not recycled** -> compares unequal -> wait on `doneEvent`, recorded on that
  stream while it was alive. The event is comm-owned and outlives the stream.

Typing it as `uintptr_t` makes the unsafe use unrepresentable rather than relying on a
comment to prevent recurrence.

## JIRA ID

ROCM-29677

## Test Plan

- Targeted repro: allreduce on stream A -> `hipStreamDestroy(A)` -> create decoy streams to
  force handle divergence -> allreduce on a new stream B, same comm.
- New unit test `DoneEventOrdering.StreamDestroyedThenSwitch`, run against both a patched
  and an unpatched RCCL to confirm it actually catches the defect.
- Real workload: AIGQA `concurrent_collectives weekly` (8x MI350X, 1000 iterations, 256 MB),
  which creates 6 streams per datatype phase and destroys them while the 6 communicators
  span all three phases.
- Version sweep across every ROCm install on the test node, HIP held constant and only
  `librccl` swapped via `LD_PRELOAD`.
- `rccl-tests all_reduce_perf` A/B for the performance impact.

## Test Result

**Targeted repro** — same binary, same HIP (`/opt/rocm/lib/libamdhip64.so.7`), only librccl swapped:

| RCCL | Result |
| --- | --- |
| stock 2.30.4 (has #6130) | `invalid resource handle`, exit 3 |
| this branch | `phase2 OK -- NO CRASH`, exit 0 |

**New unit test** — validated in both directions:

| library | `StreamDestroyedThenSwitch` |
| --- | --- |
| this branch | PASSED (23.1 s) |
| stock 2.30.4 | FAILED — `HIP failure: 'invalid resource handle'` |

**Real workload**, 4 runs per arm, alternating:

| arm | result |
| --- | --- |
| this branch | **0 failures / 4 runs** — all 3 phases, ~675 s |
| stock 2.30.4 | **3 failures / 4 runs** — rc 139/139/134, dying after 1 of 3 phases at ~250 s |

Note the defect is intermittent at the workload level (it only fires when the replacement
stream draws a different handle than the destroyed one), which is why the deterministic
repro above uses decoy streams to force the condition.

**Affected versions** — the bug is present in every RCCL from 2.28.9 onward:

| ROCm tree | RCCL | Verdict |
| --- | --- | --- |
| therock-dist 10.0.0rc3 | 2.30.4 | FAIL |
| rocm-7.14.0a20260612 | 2.29.7 | FAIL |
| rocm-7.14.0-1417 | 2.28.9 | FAIL |
| rocm-from-therock | 2.28.9 | FAIL |
| rocm-7.12.0 | 2.28.3 | PASS |
| rocm-7.12.0-pass | 2.28.3 | PASS |

Consistent with the dates: #6130 merged 2026-05-15; the 2.28.9 bump (`46931872a0`) landed
2026-05-18. **ROCm 10.0.0rc3 ships this defect.**

## Performance Impact

This restores the per-launch `hipEventRecord` that #6130 removed, and that cost is real.
`all_reduce_perf -b 8 -e 8K -f 8 -n 1000 -w 200`, idle node, median of 5 alternating reps
per arm. All 20 runs exited 0 with `#wrong = 0` on every size row; none discarded.

| gpus | size | stock us | this branch us | delta us | delta/G us | change |
| --- | --- | --- | --- | --- | --- | --- |
| 8 | 8    | 38.36 | 57.07 | 18.71 | 2.34 | +49% |
| 8 | 64   | 37.87 | 62.62 | 24.75 | 3.09 | +65% |
| 8 | 512  | 38.91 | 63.09 | 24.18 | 3.02 | +62% |
| 8 | 4096 | 38.77 | 61.71 | 22.94 | 2.87 | +59% |
| 2 | 8    | 8.94  | 14.43 | 5.49  | 2.75 | +61% |
| 2 | 64   | 8.40  | 13.68 | 5.28  | 2.64 | +63% |
| 2 | 512  | 8.30  | 13.41 | 5.11  | 2.56 | +62% |
| 2 | 4096 | 8.17  | 13.78 | 5.61  | 2.81 | +69% |

rccl-tests reports one time per op while issuing `-g N` `ncclAllReduce` calls, so the per-op
delta scales with N; `delta/G` is the implied per-launch cost. It lands in the same
2.5-3.1 us band at both GPU counts, averaging **2.76 us per launch** — matching the figure
#6130 cited.

**This is a knowing tradeoff: a crash is being exchanged for a latency regression that
#6130 was created to remove.** Recovering it is tracked as an immediate follow-up — fusing
the record into the launch via `hipExtModuleLaunchKernel`, which accepts both the packed
`extra` buffer this code needs and a `stopEvent`, exactly as RCCL did via
`hipExtLaunchKernel`'s 8th argument before #3741. That restores the ordering edge at zero
extra host calls. Reviewers who care about the #6130 workloads (ROCM-21756, ROCM-24157)
should track that follow-up.

## Submission Checklist

- [ ] Look over the contributing guidelines at
      https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
