### PR TITLE
fix(ci): Pass rocm_deb_package_version, rocm_rpm_package_version in multi-arch-ci-asan workflows

### DIFF
--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -65,6 +65,8 @@ jobs:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
+      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -77,6 +77,8 @@ jobs:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
+      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock


### PR DESCRIPTION
## Motivation

Extend the two missing deb/rpm version inputs to linux_build_and_test of therock-multi-arch-ci-asan workflows
This fix is to prevent wheel package version getting passed to deb/rpm.
This PR is extending the fix to ASAN workflows.

ISSUE ID : https://github.com/ROCm/TheROCK/issues/7161
ISSUE ID : https://github.com/ROCm/rocm-libraries/issues/11106


## Technical Details

Pass deb/rpm package version
rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}

Dependent PRs : https://github.com/ROCm/rocm-systems/pull/10530


## Test Plan

 [] Verify ASAN CI run completes the Build RPM Packages and Build DEB Packages steps without error after this change
 [] Confirm produced RPM/DEB version strings match the expected <rocm-version>~<YYYYMMDD>g<sha> format for ci release type

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
