### PR TITLE
refactor(clr): improve AQL dispatch logging, add KDQ disable flag

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3573,8 +3573,12 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     QueueExtras extras;
     extras.deviceMemRingBuf = (desc.flags & HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF) != 0;
     extras.largestAqlBarrierBitSlot = std::make_shared<std::atomic<uint64_t>>(kInvalidAqlSlot);
-    hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                           &extras.metadataRingBuffer);
+    // Leaving the ring base null makes MetaDataPreloader::HasMetadataQueue() false,
+    // which is the single gate every metadata path already checks.
+    if (DEBUG_CLR_ENABLE_KDQ) {
+      hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
+                             &extras.metadataRingBuffer);
+    }
     if (DEBUG_CLR_DIRECT_DOORBELL) {
       uint64_t db_id = 0;
       if (hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &db_id) ==
@@ -3917,8 +3921,7 @@ hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, v
             std::string kernelName = vgpu->AnalyzeAqlQueue();
             const char* kname = kernelName.c_str();
             ClPrint(amd::LOG_NONE, amd::LOG_ALWAYS,
-                    "Memory Fault Error [%sGPU index: %u, "
-                    "faulting addr: 0x%" PRIx64 ", kernel: %s]",
+                    "[%sGPU index: %u, faulting addr: 0x%" PRIx64 ", kernel: %s]",
                     host_tag.c_str(), roc_dev->index(),
                     event->memory_fault.virtual_address, kname);
           }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -200,6 +200,21 @@ static inline void logAqlDispatchPacket(const Device& dev, const hsa_queue_t* qu
           rptr, wptr));
 }
 
+// The preloaded kernargs are split across three arrays separated by the interleaved
+// header dwords, so map a logical dword index onto the right section.
+static inline uint32_t metadataPreloadDword(
+    const hsa_amd_metadata_kernel_dispatch_packet_t* meta, uint16_t dword_idx) {
+  constexpr uint16_t kSection0Dwords = sizeof(meta->kernarg_preload_0_14) / sizeof(uint32_t);
+  constexpr uint16_t kSection1Dwords = sizeof(meta->kernarg_preload_15_29) / sizeof(uint32_t);
+  if (dword_idx < kSection0Dwords) {
+    return meta->kernarg_preload_0_14[dword_idx];
+  }
+  if (dword_idx < kSection0Dwords + kSection1Dwords) {
+    return meta->kernarg_preload_15_29[dword_idx - kSection0Dwords];
+  }
+  return meta->kernarg_preload_30_31[dword_idx - kSection0Dwords - kSection1Dwords];
+}
+
 static inline void logAqlMetadataPacket(const Device& dev, const hsa_queue_t* queue,
                                         const hsa_amd_metadata_kernel_dispatch_packet_t* meta,
                                         uint64_t wptr, AqlLogSink sink = AqlLogSink::kLog) {
@@ -207,6 +222,22 @@ static inline void logAqlMetadataPacket(const Device& dev, const hsa_queue_t* qu
     return;
   }
   const auto& desc = meta->kernel_descriptor;
+
+  // Dump the kernargs the preloader actually embedded in the packet. Hang analysis
+  // can reach here with a corrupted descriptor, so clamp the length before indexing.
+  constexpr uint16_t kMaxPreloadDwords =
+      (sizeof(meta->kernarg_preload_0_14) + sizeof(meta->kernarg_preload_15_29) +
+       sizeof(meta->kernarg_preload_30_31)) / sizeof(uint32_t);
+  const uint16_t preloadDwords =
+      std::min<uint16_t>(desc.kernarg_preload.length, kMaxPreloadDwords);
+  char preloadBlob[kMaxPreloadDwords * 11 + 1];
+  size_t preloadOffset = 0;
+  for (uint16_t dword_idx = 0; dword_idx < preloadDwords; ++dword_idx) {
+    preloadOffset += snprintf(preloadBlob + preloadOffset, sizeof(preloadBlob) - preloadOffset,
+                              "%s0x%08x", (dword_idx == 0) ? "" : " ",
+                              metadataPreloadDword(meta, dword_idx));
+  }
+  preloadBlob[preloadOffset] = '\0';
 
   // Dump the launch descriptor as a raw dword blob (13 dwords / 52 bytes).
   constexpr size_t kNumLaunchDescriptorDwords =
@@ -224,13 +255,13 @@ static inline void logAqlMetadataPacket(const Device& dev, const hsa_queue_t* qu
           "header=[0x%x, 0x%x, 0x%x, 0x%x], event_id=0x%x, "
           "kernel_code_entry_byte_offset=0x%llx, compute_pgm_rsrc1=0x%x, compute_pgm_rsrc2=0x%x, "
           "compute_pgm_rsrc3=0x%x, kernel_code_properties=0x%x, "
-          "kernarg_preload=[length=%u, offset=%u], launch_descriptor=[%s]",
+          "kernarg_preload=[length=%u, offset=%u, dwords=[%s]], launch_descriptor=[%s]",
           queue, queue->base_address, queue->id, wptr,
           meta->header0, meta->header1, meta->header2, meta->header3, meta->event_id,
           static_cast<unsigned long long>(desc.kernel_code_entry_byte_offset),
           desc.compute_pgm_rsrc1, desc.compute_pgm_rsrc2, desc.compute_pgm_rsrc3,
           desc.kernel_code_properties, desc.kernarg_preload.length, desc.kernarg_preload.offset,
-          launchDescriptorBlob));
+          preloadBlob, launchDescriptorBlob));
 }
 
 static inline void logAqlDispatchPacketExtended(
@@ -1315,6 +1346,23 @@ static inline void packet_store_release(uint32_t* packet, uint16_t header, uint1
 
 // ================================================================================================
 std::string VirtualGPU::AnalyzeAqlQueue() const {
+  static constexpr char kBannerRule[] =
+      "****************************************************************************";
+
+  fprintf(stderr, "\n%s\n", kBannerRule);
+  fprintf(stderr, "*** GPU HANG ANALYSIS - VGPU(%p) Queue(%p)\n", this, gpu_queue_);
+  fprintf(stderr, "%s\n", kBannerRule);
+
+  // The body has several early exits; running it as a separate call keeps them from
+  // skipping the closing rule.
+  const std::string kernelName = AnalyzeAqlQueueBody();
+
+  fprintf(stderr, "%s\n\n", kBannerRule);
+  return kernelName;
+}
+
+// ================================================================================================
+std::string VirtualGPU::AnalyzeAqlQueueBody() const {
   std::string kernelName = "<not identified>";
   const uint32_t queueMask = gpu_queue_->size - 1;
   const uint64_t index = Hsa::queue_load_write_index_relaxed(gpu_queue_);
@@ -1362,7 +1410,6 @@ std::string VirtualGPU::AnalyzeAqlQueue() const {
 
   // Reuse the shared AQL packet formatters with the stderr sink so hang analysis
   // and the debug log print identical packet detail, including the metadata blob.
-  fprintf(stderr, "VGPU(%p) hang analysis:\n", this);
   if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
     auto* vendor_hdr = reinterpret_cast<const hsa_amd_vendor_packet_header_t*>(aql_loc);
     if (vendor_hdr->AmdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
@@ -4651,7 +4698,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
 
   ClPrint(amd::LOG_INFO, amd::LOG_KERN2, "ShaderName : %s", gpuKernel.getDemangledName().c_str());
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
-          "argSize = %zu, KernargSegmentByteSize = %zu, KernargSegmentAlignment = %zu",
+          "argSize = %u, KernargSegmentByteSize = %u, KernargSegmentAlignment = %u",
           std::min(gpuKernel.KernargSegmentByteSize(), signature.paramsSize()),
           gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment());
 
@@ -5616,9 +5663,6 @@ uint32_t VirtualGPU::MetaDataPreloader::FillKernelDispatchMetadata(
       m->kernel_descriptor.kernarg_preload.length = kPreload_limit;
       preload_length = kPreload_limit;
     }
-    ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
-            "metadata prefetch: preload_length=%u, preload_offset=%u, preload_limit=%u",
-            preload_length, pending_preload_offset_, kPreload_limit);
 
     if (preload_length > 0) {
       const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -692,6 +692,10 @@ class VirtualGPU : public device::VirtualDevice {
   //! Analyzes a crashed AQL queue to find a broken AQL packet.
   //! Returns the faulting kernel name ("<not identified>" if not found).
   std::string AnalyzeAqlQueue() const;
+
+  //! Emits the hang report itself. Called by AnalyzeAqlQueue, which brackets it
+  //! with the banner.
+  std::string AnalyzeAqlQueueBody() const;
   bool ForceIrq() const { return force_irq_; }
 
   //! SDMA engine affinity management

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -139,8 +139,8 @@ release(uint, GPU_MAX_COMMAND_BUFFERS, 8,                                     \
          "The maximum number of command buffers allocated per queue")         \
 release(uint, GPU_MAX_HW_QUEUES, 4,                                           \
          "The maximum number of HW queues allocated per device")              \
-release(bool, DEBUG_CLR_AQL_BARRIER_OPT, true,                                 \
-        "Enable per-stream AQL barrier-bit optimization on shared HW queues")   \
+release(bool, DEBUG_CLR_AQL_BARRIER_OPT, true,                                \
+        "Enable per-stream AQL barrier-bit optimization on shared HW queues") \
 release(bool, GPU_IMAGE_BUFFER_WAR, true,                                     \
         "Enables image buffer workaround")                                    \
 release(cstring, HIP_VISIBLE_DEVICES, "",                                     \
@@ -292,6 +292,8 @@ release(uint, DEBUG_CLR_AQL_DEV_QUEUE, 0,                                     \
 release(uint, DEBUG_CLR_USE_MOVDIR64B, 1,                                     \
         "Use MOVDIR64B full-packet writes for AQL + metadata rings"           \
         "(1=enabled (default), 0=non-temporal store path)")                   \
+release(bool, DEBUG_CLR_ENABLE_KDQ, true,                                     \
+        "Kernel dispatch metadata (prefetch) queue, 0 = disable")             \
 
 namespace amd {
 


### PR DESCRIPTION
Fix incorrect and excessive logging on the AQL dispatch path, and add a flag to
disable the kernel dispatch metadata queue.

## Motivation

While triaging a memory fault the dispatch-path logs were actively misleading:

- The kernarg trace printed `KernargSegmentAlignment = 140728898420992` instead of `8`.
- The metadata packet dump showed `kernarg_preload=[length=N, offset=M]` but never the
  argument values that were preloaded, which is exactly what you need when the fault
  looks like a bad pointer argument.
- The hang report was a single unlabelled line buried in a large log.
- A per-dispatch "metadata prefetch" line duplicated information the metadata packet
  dump already carries.

There was also no way to take the metadata (prefetch) queue out of the picture to see
whether it was implicated in a failure.

## Technical Details

**Format specifier fix.** `submitKernelInternal` used `%zu` for three `uint32_t` values.
On x86-64 varargs each `%zu` consumes 64 bits while only 32 were pushed, so the printed
values were composed partly from adjacent stack garbage. Changed to `%u`.

**Preloaded kernarg dump.** `logAqlMetadataPacket` now prints the dwords the preloader
embedded in the packet. They are not contiguous — they live in `kernarg_preload_0_14`,
`kernarg_preload_15_29` and `kernarg_preload_30_31`, separated by interleaved header
dwords — so `metadataPreloadDword()` maps a logical dword index onto the correct section.
Hang analysis can reach this formatter with a corrupted descriptor, so
`kernarg_preload.length` is clamped to the array capacity before indexing.

**Hang report banner.** `AnalyzeAqlQueue` now emits a rule, a header line carrying the
`VirtualGPU` and `hsa_queue_t` pointers, and a closing rule. The existing body moved to
`AnalyzeAqlQueueBody`; it has several early returns, and calling it as a separate
function keeps those from skipping the closing rule.

**`DEBUG_CLR_ENABLE_KDQ`.** New release flag, default on, so no behavior change at the
default. With `DEBUG_CLR_ENABLE_KDQ=0`, `populateExtras()` skips the
`HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER` query. The ring base then stays null,
which makes `MetaDataPreloader::HasMetadataQueue()` return false — the single gate every
metadata path already checks — so CLR ignores the metadata ring entirely without
touching any of those paths.

Also prints the global memory cacheline size at init, and drops the "Memory Fault Error"
prefix that the surrounding output already conveys.

## Issue Tracking

JIRA ID: AIRUNTIME-N

## Test Plan

- Run a HIP workload with AQL and kernel logging enabled; confirm the kernarg sizes and
  alignment print sane values and that the metadata packet dump shows the preload dwords.
- Confirm default behavior is unchanged (new flag defaults on).
- Run with `DEBUG_CLR_ENABLE_KDQ=0` and confirm dispatches complete with the metadata
  ring unused.

## Test Result

Observed before the fix, from a memory-fault triage log:

```
argSize = 48, KernargSegmentByteSize = 48, KernargSegmentAlignment = 140728898420992
```

Runtime verification of the reworked output pending.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md

No unit test accompanies this change: it is diagnostic output plus a default-on flag,
with no functional change at default settings.
