### PR TITLE
[rocjitsu] Batch L1 MTYPE lookups by page

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -475,6 +476,7 @@ public:
   /// @param mtype PTE MTYPE for these pages (derived from allocation flags).
   void map_pages(uint64_t gpu_va, void *host_ptr, size_t size,
                  amdgpu::Mtype mtype = amdgpu::Mtype::RW) {
+    std::unique_lock request_lock(*page_table_request_mutex_);
     std::unique_lock lock(page_table_mutex_);
     auto *base = static_cast<uint8_t *>(host_ptr);
     uint64_t mapped_va = gpu_va;
@@ -500,6 +502,7 @@ public:
 
   /// @brief Unmap pages from this process's GPU page table.
   void unmap_pages(uint64_t gpu_va, size_t size) {
+    std::unique_lock request_lock(*page_table_request_mutex_);
     std::unique_lock lock(page_table_mutex_);
     uint64_t mapped_va = gpu_va;
     size_t unmapped_bytes = 0;
@@ -525,6 +528,7 @@ public:
   /// page-table critical section. Only entries still pointing at the expected
   /// old page are changed.
   void remap_page_host_ptrs(uint64_t gpu_va, void *old_host_ptr, void *new_host_ptr, size_t size) {
+    std::unique_lock request_lock(*page_table_request_mutex_);
     std::unique_lock lock(page_table_mutex_);
     auto *old_base = static_cast<uint8_t *>(old_host_ptr);
     auto *new_base = static_cast<uint8_t *>(new_host_ptr);
@@ -558,6 +562,7 @@ public:
 
   /// @brief Update the MTYPE of mapped pages and invalidate cached PTE copies.
   void set_page_mtype(uint64_t gpu_va, size_t size, amdgpu::Mtype mtype) {
+    std::unique_lock request_lock(*page_table_request_mutex_);
     std::unique_lock lock(page_table_mutex_);
     bool changed = false;
     uint64_t mapped_va = gpu_va;
@@ -579,6 +584,11 @@ public:
 
   /// @brief Return the mutation counter used by GpuMemory translation caches.
   const uint64_t *page_table_generation() const { return &page_table_generation_; }
+
+  /// @brief Return the lease shared by page-table readers and mutations.
+  std::shared_ptr<std::shared_mutex> page_table_request_mutex() const {
+    return page_table_request_mutex_;
+  }
 
   mutable std::shared_mutex page_table_mutex_;
   PageTable page_table_;
@@ -721,8 +731,11 @@ private:
 
   /// @brief Page table version counter, bumped on every PTE mutation.
   /// @details GpuMemory keeps per-thread TLB-like translation caches keyed by
-  ///          this generation; all reads and writes occur while holding
-  ///          page_table_mutex_, so the counter itself does not need atomics.
+  ///          this generation. Mutations hold both page_table_request_mutex_
+  ///          and page_table_mutex_; readers hold at least one of those locks,
+  ///          so the counter itself does not need atomics.
+  std::shared_ptr<std::shared_mutex> page_table_request_mutex_ =
+      std::make_shared<std::shared_mutex>();
   uint64_t page_table_generation_{1};
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -739,7 +739,7 @@ int SimulatedKfd::open() {
   for (auto &g : gpus_) {
     if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
       mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
-                            proc->page_table_generation());
+                            proc->page_table_generation(), proc->page_table_request_mutex());
       if (!daemon_mode_)
         mem->set_passthrough(true);
     }
@@ -801,7 +801,7 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
     for (auto &g : gpus_) {
       if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_,
-                              proc->page_table_generation());
+                              proc->page_table_generation(), proc->page_table_request_mutex());
         if (client_pid > 0)
           mem->set_process_client_pid(pid, client_pid);
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -470,7 +470,9 @@ private:
   /// held simultaneously (allocate_scratch_backing and close() both release
   /// process_mutex_ before taking alloc_mutex_):
   ///   op_mutex_ < process_mutex_
-  ///   op_mutex_ < alloc_mutex_ < {ipc_mutex_, page_table_mutex_, owned_fds_mutex_}
+  ///   op_mutex_ < alloc_mutex_ < {ipc_mutex_, page_table_request_mutex_, owned_fds_mutex_}
+  ///   page_table_request_mutex_ < page_table_mutex_
+  ///   page_table_request_mutex_ < vmid_mutex_       (GpuMemory binding validation)
   ///   op_mutex_ < runtime_mutex_ < alloc_mutex_        (runtime_enable_ioctl)
   ///   op_mutex_ < debug_sessions_mutex_ < runtime_mutex_ (debug_trap_ioctl)
   ///   process_mutex_ < interrupt_mutex_                (open()/open_process())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -65,6 +65,52 @@ static_assert(KfdProcess::kPageSize == simdojo::SparseMemory::PAGE_SIZE,
 /// hierarchy.
 class GpuMemory : public simdojo::SparseMemory {
 public:
+  class PageTableRequestGuard {
+  public:
+    PageTableRequestGuard() = default;
+    PageTableRequestGuard(PageTableRequestGuard &&) noexcept = default;
+    PageTableRequestGuard &operator=(PageTableRequestGuard &&) noexcept = default;
+    PageTableRequestGuard(const PageTableRequestGuard &) = delete;
+    PageTableRequestGuard &operator=(const PageTableRequestGuard &) = delete;
+
+    bool owns_lock() const { return lock_.owns_lock(); }
+    bool cacheable() const { return owns_lock() && generation_ != nullptr; }
+    uint64_t registry_generation() const {
+      assert(owns_lock());
+      return registry_generation_;
+    }
+    uint64_t page_table_generation() const {
+      assert(cacheable());
+      return *generation_;
+    }
+    void unlock() {
+      if (owns_lock())
+        lock_.unlock();
+    }
+
+  private:
+    friend class GpuMemory;
+
+    explicit PageTableRequestGuard(std::shared_ptr<std::shared_mutex> mutex)
+        : mutex_(std::move(mutex)),
+          lock_(mutex_ ? std::shared_lock(*mutex_) : std::shared_lock<std::shared_mutex>{}) {}
+
+    void bind(KfdProcess::PageTable *page_table, std::shared_mutex *page_table_mutex,
+              const uint64_t *generation, uint64_t registry_generation) {
+      page_table_ = page_table;
+      page_table_mutex_ = page_table_mutex;
+      generation_ = generation;
+      registry_generation_ = registry_generation;
+    }
+
+    std::shared_ptr<std::shared_mutex> mutex_;
+    std::shared_lock<std::shared_mutex> lock_;
+    KfdProcess::PageTable *page_table_ = nullptr;
+    std::shared_mutex *page_table_mutex_ = nullptr;
+    const uint64_t *generation_ = nullptr;
+    uint64_t registry_generation_ = 0;
+  };
+
   explicit GpuMemory(std::string name)
       : simdojo::SparseMemory(std::move(name)),
         // Function-static TLS translation caches may outlive a GpuMemory on a
@@ -90,33 +136,88 @@ public:
   /// @brief Register a process's page table in the VMID table.
   /// @param generation Optional mutation counter used by translation caches.
   ///        Omitting it disables the per-thread fast path for this page table.
+  /// @param request_mutex Optional lease that stabilizes batched page-table
+  ///        lookups. Omitting it disables cross-chunk MTYPE reuse.
   void register_process(uint32_t pid, KfdProcess::PageTable *pt, std::shared_mutex *mu,
-                        const uint64_t *generation = nullptr) {
+                        const uint64_t *generation = nullptr,
+                        std::shared_ptr<std::shared_mutex> request_mutex = {}) {
     util::Logger::cp("VMID_REG pid=", pid, " mem=0x", std::hex, reinterpret_cast<uintptr_t>(this),
                      std::dec, " pt_size=", pt->size());
-    std::unique_lock lk(vmid_mutex_);
-    vmid_table_[pid] = {
-        .page_table = pt,
-        .mutex = mu,
-        .client_pid = 0,
-        .client_mem_fd = {},
-        .generation = generation,
-    };
-    // The VMID may now select a different page table even though neither page
-    // table changed. Invalidate TLS entries that cached the old registration.
-    ++vmid_registry_generation_;
+    update_vmid_registration(pid, [&](auto) {
+      vmid_table_[pid] = {
+          .page_table = pt,
+          .mutex = mu,
+          .client_pid = 0,
+          .client_mem_fd = {},
+          .generation = generation,
+          .request_mutex = std::move(request_mutex),
+      };
+      return true;
+    });
+  }
+
+  /// @brief Stabilize a registered process's page table for one MTYPE lookup.
+  /// @details Page-table mutations take the exclusive side of this lease before
+  /// the ordinary page-table lock. Callers must release the lease before a
+  /// backing-memory access, whose allocator metadata query may reenter KFD.
+  PageTableRequestGuard acquire_page_table_request(uint32_t vmid) const {
+    if (vmid == 0)
+      return {};
+    while (true) {
+      std::shared_ptr<std::shared_mutex> request_mutex;
+      {
+        std::shared_lock lock(vmid_mutex_);
+        auto it = vmid_table_.find(vmid);
+        if (it == vmid_table_.end() || !it->second.request_mutex)
+          return {};
+        request_mutex = it->second.request_mutex;
+      }
+
+      PageTableRequestGuard guard(request_mutex);
+      std::shared_lock lock(vmid_mutex_);
+      auto it = vmid_table_.find(vmid);
+      if (it != vmid_table_.end() && it->second.request_mutex == request_mutex) {
+        guard.bind(it->second.page_table, it->second.mutex, it->second.generation,
+                   vmid_registry_generation_);
+        return guard;
+      }
+    }
+  }
+
+  /// @brief Reacquire a previously discovered request lease and revalidate its
+  /// VMID binding.
+  /// @details The cached mutex avoids the initial VMID-table lookup on the hot
+  /// path. The binding is still checked after locking because replacement can
+  /// install a different page table while the lease is released.
+  bool reacquire_page_table_request(uint32_t vmid, PageTableRequestGuard &guard) const {
+    if (vmid == 0)
+      return false;
+    if (guard.mutex_) {
+      guard.lock_.lock();
+      std::shared_lock lock(vmid_mutex_);
+      auto it = vmid_table_.find(vmid);
+      if (it != vmid_table_.end() && it->second.request_mutex == guard.mutex_) {
+        guard.bind(it->second.page_table, it->second.mutex, it->second.generation,
+                   vmid_registry_generation_);
+        return true;
+      }
+      guard.lock_.unlock();
+      guard = {};
+    }
+    guard = acquire_page_table_request(vmid);
+    return guard.owns_lock();
   }
 
   /// @brief Unregister a process from the VMID table.
   void unregister_process(uint32_t pid) {
     util::Logger::cp("VMID_UNREG pid=", pid, " mem=0x", std::hex, reinterpret_cast<uintptr_t>(this),
                      std::dec);
-    std::unique_lock lk(vmid_mutex_);
-    auto it = vmid_table_.find(pid);
-    if (it == vmid_table_.end())
-      return;
-    vmid_table_.erase(it);
-    ++vmid_registry_generation_;
+    update_vmid_registration(pid, [&](auto it) {
+      if (it == vmid_table_.end())
+        return false;
+      vmid_table_.erase(it);
+      return true;
+    });
   }
 
   void set_process_client_pid(uint32_t pid, pid_t client_pid) {
@@ -218,13 +319,28 @@ public:
   }
 
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
+  /// @details This reads only the page-wide policy. It deliberately avoids the
+  /// host-extent copy, addressability checks, and external allocator queries
+  /// needed by accesses that expose backing storage.
   Mtype pte_mtype(uint64_t addr, uint32_t vmid = 0) const {
     if (vmid == 0)
       return Mtype::RW;
-    static thread_local PteCache cache;
-    return cached_walk(addr, vmid, cache, [](const KfdProcess::PageTableEntry *pte) {
-      return pte ? pte->mtype : Mtype::RW;
-    });
+    std::shared_lock vmid_lock(vmid_mutex_);
+    auto vmid_entry = vmid_table_.find(vmid);
+    if (vmid_entry == vmid_table_.end())
+      return Mtype::RW;
+    std::shared_lock page_table_lock(*vmid_entry->second.mutex);
+    auto pte = vmid_entry->second.page_table->find(addr >> PAGE_SHIFT);
+    return pte != vmid_entry->second.page_table->end() ? pte->second.mtype : Mtype::RW;
+  }
+
+  /// @brief Look up PTE MTYPE through an already validated request lease.
+  Mtype pte_mtype(uint64_t addr, const PageTableRequestGuard &guard) const {
+    assert(guard.owns_lock());
+    assert(guard.page_table_ != nullptr && guard.page_table_mutex_ != nullptr);
+    std::shared_lock page_table_lock(*guard.page_table_mutex_);
+    auto pte = guard.page_table_->find(addr >> PAGE_SHIFT);
+    return pte != guard.page_table_->end() ? pte->second.mtype : Mtype::RW;
   }
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
@@ -899,7 +1015,40 @@ private:
     /// Debugger-authorized /proc/<target>/mem fd, or empty.
     util::UniqueHandle client_mem_fd;
     const uint64_t *generation = nullptr;
+    std::shared_ptr<std::shared_mutex> request_mutex;
   };
+
+  /// @brief Update a VMID binding while excluding an in-progress MTYPE lookup.
+  /// @details The lease is acquired without holding vmid_mutex_, then the
+  /// binding is revalidated under the exclusive VMID lock. This prevents a
+  /// replacement or removal from overtaking an active lookup without
+  /// introducing a lock-order cycle.
+  template <typename F> void update_vmid_registration(uint32_t pid, F &&update) {
+    while (true) {
+      std::shared_ptr<std::shared_mutex> request_mutex;
+      {
+        std::shared_lock lock(vmid_mutex_);
+        auto it = vmid_table_.find(pid);
+        if (it != vmid_table_.end())
+          request_mutex = it->second.request_mutex;
+      }
+
+      std::unique_lock<std::shared_mutex> request_lock;
+      if (request_mutex)
+        request_lock = std::unique_lock(*request_mutex);
+
+      std::unique_lock lock(vmid_mutex_);
+      auto it = vmid_table_.find(pid);
+      const auto current_request_mutex =
+          it != vmid_table_.end() ? it->second.request_mutex : nullptr;
+      if (current_request_mutex != request_mutex)
+        continue;
+
+      if (update(it))
+        ++vmid_registry_generation_;
+      return;
+    }
+  }
 
   struct PteCache {
     const GpuMemory *memory = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/request_mtype_resolver.h"
 
 #include <algorithm>
 #include <cassert>
@@ -46,6 +47,7 @@ void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
 
 void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid) {
   synchronize_epoch();
+  RequestMtypeResolver mtypes(memory_, vmid);
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4];
@@ -57,9 +59,7 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
       const uint32_t chunk =
           std::min<uint32_t>(sizeof(buf) - copied, CacheStore::LINE_SIZE - line_offset);
 
-      Mtype mtype = Mtype::RW;
-      if (memory_)
-        mtype = memory_->pte_mtype(chunk_addr, vmid);
+      const Mtype mtype = mtypes.at(chunk_addr);
 
       if (mtype == Mtype::UC) {
         flush_line(chunk_addr, vmid);
@@ -120,6 +120,7 @@ void L1ScalarCache::flush_line(uint64_t addr, uint32_t vmid) {
 
 void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint32_t vmid) {
   synchronize_epoch();
+  RequestMtypeResolver mtypes(memory_, vmid);
   for (uint32_t i = 0; i < num_dwords; ++i) {
     uint64_t ea = addr + i * 4;
     uint8_t buf[4]{};
@@ -130,9 +131,7 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
       const uint32_t chunk =
           std::min<uint32_t>(sizeof(buf) - copied, CacheStore::LINE_SIZE - line_offset);
 
-      Mtype mtype = Mtype::RW;
-      if (memory_)
-        mtype = memory_->pte_mtype(chunk_addr, vmid);
+      const Mtype mtype = mtypes.at(chunk_addr);
 
       if (mtype == Mtype::UC) {
         flush_line(chunk_addr, vmid);
@@ -152,15 +151,14 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
 
 void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, uint32_t vmid) {
   synchronize_epoch();
+  RequestMtypeResolver mtypes(memory_, vmid);
   uint32_t copied = 0;
   while (copied < num_bytes) {
     uint64_t ea = addr + copied;
     uint32_t line_offset = CacheStore::line_offset(ea);
     uint32_t chunk = std::min(num_bytes - copied, CacheStore::LINE_SIZE - line_offset);
 
-    Mtype mtype = Mtype::RW;
-    if (memory_)
-      mtype = memory_->pte_mtype(ea, vmid);
+    const Mtype mtype = mtypes.at(ea);
 
     if (mtype == Mtype::UC) {
       flush_line(ea, vmid);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/vm/amdgpu/device_cache_coherence.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/request_mtype_resolver.h"
 #include "util/log.h"
 
 #include <algorithm>
@@ -96,12 +97,10 @@ void L1VectorCache::ensure_line(uint64_t addr, uint32_t vmid) {
 // Per-line CC invalidation is sufficient: the CP serializes dispatch N's cache
 // management before dispatch N+1 begins execution, so no blanket invalidation
 // at dispatch boundaries is needed.
-void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype,
-                               bool non_temporal, bool request_l1_bypass, uint32_t vmid) {
-  Mtype inst_mtype = mtype;
-  Mtype effective = mtype;
-  if (memory_)
-    effective = effective_mtype(mtype, memory_->pte_mtype(addr, vmid));
+void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, bool non_temporal,
+                               bool request_l1_bypass, uint32_t vmid,
+                               RequestMtypeResolver &mtypes) {
+  const Mtype effective = mtypes.at(addr);
 
   util::Logger::cp([&](auto &os) {
     static thread_local uint64_t mtype_counts[5] = {};
@@ -112,7 +111,7 @@ void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype
       os << std::format("L1V_READ_MTYPE_STATS total={} UC={} CC={} RW={} WB={} NT={} "
                         "last: addr={:#x} inst={} eff={} vmid={}",
                         total, mtype_counts[0], mtype_counts[1], mtype_counts[2], mtype_counts[3],
-                        mtype_counts[4], addr, static_cast<int>(inst_mtype),
+                        mtype_counts[4], addr, static_cast<int>(mtypes.fallback()),
                         static_cast<int>(effective), vmid);
     }
   });
@@ -122,9 +121,7 @@ void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
-    Mtype chunk_mtype = inst_mtype;
-    if (memory_)
-      chunk_mtype = effective_mtype(inst_mtype, memory_->pte_mtype(ea, vmid));
+    const Mtype chunk_mtype = mtypes.at(ea);
 
     if (chunk_mtype == Mtype::UC || non_temporal || request_l1_bypass) {
       cache_.invalidate(ea, vmid);
@@ -146,12 +143,9 @@ void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype
   }
 }
 
-void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype,
-                                bool non_temporal, uint32_t vmid) {
-  Mtype inst_mtype = mtype;
-  Mtype effective = mtype;
-  if (memory_)
-    effective = effective_mtype(mtype, memory_->pte_mtype(addr, vmid));
+void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, bool non_temporal,
+                                uint32_t vmid, RequestMtypeResolver &mtypes) {
+  const Mtype effective = mtypes.at(addr);
 
   util::Logger::vm([&](auto &os) {
     if (addr >= 0x4d00c00000ULL && addr < 0x4d00c00100ULL) {
@@ -174,9 +168,7 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
-    Mtype chunk_mtype = inst_mtype;
-    if (memory_)
-      chunk_mtype = effective_mtype(inst_mtype, memory_->pte_mtype(ea, vmid));
+    const Mtype chunk_mtype = mtypes.at(ea);
 
     if (chunk_mtype == Mtype::UC || non_temporal) {
       cache_.invalidate(ea, vmid);
@@ -211,6 +203,7 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
                          bool request_l1_bypass, uint32_t wf_size, uint32_t vmid,
                          uint32_t addr_stride, std::span<const uint64_t> element_lane_masks) {
   synchronize_epoch();
+  RequestMtypeResolver mtypes(memory_, vmid, mtype);
   uint32_t stride = num_elems * elem_size;
   // Scratch swizzle: consecutive dwords of one lane's private space sit
   // addr_stride bytes apart, the hardware dword-interleaved layout rocm-dbgapi
@@ -234,8 +227,8 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
           const uint32_t chunk = std::min(elem_end - copied, 4 - byte_in_dword);
           const uint64_t ea =
               (base & ~uint64_t{3}) + ((base & 3) + copied) / 4 * astride + byte_in_dword;
-          read_bytes(ea, dst + lane * stride + copied, chunk, mtype, non_temporal,
-                     request_l1_bypass, vmid);
+          read_bytes(ea, dst + lane * stride + copied, chunk, non_temporal, request_l1_bypass, vmid,
+                     mtypes);
           copied += chunk;
         }
       }
@@ -246,8 +239,8 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
     uint64_t full_lane_mask = fully_valid_lane_mask(element_lane_masks, lane_mask);
     for_each_coalesced_lane_run(
         addrs, full_lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
-          read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, mtype,
-                     non_temporal, request_l1_bypass, vmid);
+          read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, non_temporal,
+                     request_l1_bypass, vmid, mtypes);
         });
     for (uint32_t elem = 0; elem < num_elems; ++elem) {
       uint64_t mask = element_lane_masks[elem] & lane_mask & ~full_lane_mask;
@@ -255,16 +248,16 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
         const uint32_t lane = std::countr_zero(mask);
         mask &= ~(uint64_t{1} << lane);
         read_bytes(addrs[lane] + static_cast<uint64_t>(elem) * elem_size,
-                   dst + lane * stride + elem * elem_size, elem_size, mtype, non_temporal,
-                   request_l1_bypass, vmid);
+                   dst + lane * stride + elem * elem_size, elem_size, non_temporal,
+                   request_l1_bypass, vmid, mtypes);
       }
     }
     return;
   }
   for_each_coalesced_lane_run(
       addrs, lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
-        read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, mtype,
-                   non_temporal, request_l1_bypass, vmid);
+        read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, non_temporal,
+                   request_l1_bypass, vmid, mtypes);
       });
 }
 
@@ -273,6 +266,7 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
                           uint32_t wf_size, uint32_t vmid, uint32_t addr_stride,
                           std::span<const uint64_t> element_lane_masks) {
   synchronize_epoch();
+  RequestMtypeResolver mtypes(memory_, vmid, mtype);
   uint32_t stride = num_elems * elem_size;
   const uint32_t active_lanes = std::popcount(lane_mask);
   ++store_count_;
@@ -301,7 +295,7 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
           const uint32_t chunk = std::min(elem_end - copied, 4 - byte_in_dword);
           const uint64_t ea =
               (base & ~uint64_t{3}) + ((base & 3) + copied) / 4 * astride + byte_in_dword;
-          write_bytes(ea, src + lane * stride + copied, chunk, mtype, non_temporal, vmid);
+          write_bytes(ea, src + lane * stride + copied, chunk, non_temporal, vmid, mtypes);
           copied += chunk;
         }
       }
@@ -312,8 +306,8 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
     uint64_t full_lane_mask = fully_valid_lane_mask(element_lane_masks, lane_mask);
     store_l2_writes_ += for_each_coalesced_lane_run(
         addrs, full_lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
-          write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride, mtype,
-                      non_temporal, vmid);
+          write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride,
+                      non_temporal, vmid, mtypes);
         });
     for (uint32_t elem = 0; elem < num_elems; ++elem) {
       uint64_t mask = element_lane_masks[elem] & lane_mask & ~full_lane_mask;
@@ -322,15 +316,15 @@ void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t el
         const uint32_t lane = std::countr_zero(mask);
         mask &= ~(uint64_t{1} << lane);
         write_bytes(addrs[lane] + static_cast<uint64_t>(elem) * elem_size,
-                    src + lane * stride + elem * elem_size, elem_size, mtype, non_temporal, vmid);
+                    src + lane * stride + elem * elem_size, elem_size, non_temporal, vmid, mtypes);
       }
     }
     return;
   }
   store_l2_writes_ += for_each_coalesced_lane_run(
       addrs, lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
-        write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride, mtype,
-                    non_temporal, vmid);
+        write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride, non_temporal,
+                    vmid, mtypes);
       });
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -15,6 +15,7 @@ namespace amdgpu {
 
 class GpuMemory;
 class L2Cache;
+class RequestMtypeResolver;
 
 /// @brief L1 Vector Cache (V$) controller for FLAT/MUBUF/MTBUF instructions.
 ///
@@ -70,10 +71,10 @@ public:
 private:
   void invalidate_all_lines();
   void synchronize_epoch();
-  void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, bool non_temporal,
-                  bool request_l1_bypass, uint32_t vmid);
-  void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, bool non_temporal,
-                   uint32_t vmid);
+  void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, bool non_temporal,
+                  bool request_l1_bypass, uint32_t vmid, RequestMtypeResolver &mtypes);
+  void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, bool non_temporal,
+                   uint32_t vmid, RequestMtypeResolver &mtypes);
   void ensure_line(uint64_t addr, uint32_t vmid);
 
   CacheStore cache_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/request_mtype_resolver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/request_mtype_resolver.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_REQUEST_MTYPE_RESOLVER_H_
+#define ROCJITSU_VM_AMDGPU_REQUEST_MTYPE_RESOLVER_H_
+
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/mtype.h"
+
+#include <cstdint>
+#include <limits>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// Caches the effective MTYPE for the current page within one memory request.
+/// Each chunk briefly reacquires the page-table request lease and reuses the
+/// cached value only while the VMID binding and page-table generation match.
+class RequestMtypeResolver {
+public:
+  RequestMtypeResolver(GpuMemory *memory, uint32_t vmid)
+      : memory_(memory), vmid_(vmid), fallback_(Mtype::RW), combine_(false) {}
+
+  RequestMtypeResolver(GpuMemory *memory, uint32_t vmid, Mtype instruction_mtype)
+      : memory_(memory), vmid_(vmid), fallback_(instruction_mtype), combine_(true) {}
+
+  Mtype fallback() const { return fallback_; }
+
+  Mtype at(uint64_t addr) {
+    if (!memory_)
+      return fallback_;
+
+    const uint64_t page = addr >> GpuMemory::PAGE_SHIFT;
+    if (vmid_ == 0) {
+      if (page != page_) {
+        page_ = page;
+        page_mtype_ = fallback_;
+      }
+      return page_mtype_;
+    }
+
+    if (!memory_->reacquire_page_table_request(vmid_, request_guard_)) {
+      // Registrations without a request lease perform a full MTYPE-only walk
+      // under the page-table lock for every chunk.
+      const Mtype pte_mtype = memory_->pte_mtype(addr, vmid_);
+      return combine_ ? effective_mtype(fallback_, pte_mtype) : pte_mtype;
+    }
+
+    const bool cacheable = request_guard_.cacheable();
+    const uint64_t registry_generation = request_guard_.registry_generation();
+    const uint64_t page_table_generation = cacheable ? request_guard_.page_table_generation() : 0;
+    if (!cacheable || page != page_ || registry_generation != registry_generation_ ||
+        page_table_generation != page_table_generation_) {
+      page_ = page;
+      registry_generation_ = registry_generation;
+      page_table_generation_ = page_table_generation;
+      const Mtype pte_mtype = memory_->pte_mtype(addr, request_guard_);
+      page_mtype_ = combine_ ? effective_mtype(fallback_, pte_mtype) : pte_mtype;
+    }
+    // Backing-memory translation may query allocator metadata without the VMID
+    // and page-table locks. Release this lease first so that query can reenter
+    // KFD page-table mutation; the next chunk revalidates both generations.
+    request_guard_.unlock();
+    return page_mtype_;
+  }
+
+private:
+  GpuMemory *memory_;
+  uint32_t vmid_;
+  Mtype fallback_;
+  bool combine_;
+  GpuMemory::PageTableRequestGuard request_guard_;
+  uint64_t page_ = std::numeric_limits<uint64_t>::max();
+  uint64_t registry_generation_ = 0;
+  uint64_t page_table_generation_ = 0;
+  Mtype page_mtype_ = Mtype::RW;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_REQUEST_MTYPE_RESOLVER_H_

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -22,6 +22,7 @@
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/request_mtype_resolver.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
@@ -1114,6 +1115,75 @@ TEST(GpuMemoryTest, SanitizedMappedExtentTracksCurrentShadowState) {
   __asan_unpoison_memory_region(allocation.get() + kInteriorPoisonOffset, kInteriorPoisonBytes);
 }
 
+TEST(GpuMemoryTest, SanitizedMtypeLookupAvoidsAllocatorMetadataReentry) {
+  amdgpu::GpuMemory memory("memory");
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  allocation[0] = 0x5a;
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize, amdgpu::Mtype::UC);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation(), process.page_table_request_mutex());
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    ++hook_calls;
+    process.set_page_mtype(kBaseVa, KfdProcess::kPageSize, amdgpu::Mtype::RW);
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+  {
+    amdgpu::RequestMtypeResolver request(&memory, kPid);
+    EXPECT_EQ(request.at(kBaseVa), amdgpu::Mtype::UC);
+    EXPECT_EQ(hook_calls, 0u);
+  }
+
+  EXPECT_EQ(memory.read8(kBaseVa, kPid), 0x5a);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(memory.pte_mtype(kBaseVa, kPid), amdgpu::Mtype::RW);
+}
+
+TEST(GpuMemoryTest, SanitizedL1BackingLookupAllowsAllocatorMetadataReentry) {
+  amdgpu::GpuMemory memory("memory");
+  amdgpu::L2Cache l2("l2");
+  amdgpu::L1ScalarCache l1(&l2);
+  constexpr uint32_t kPid = 7;
+  constexpr uint64_t kBaseVa = 0x40000000;
+  constexpr uint32_t kInitial = 0x11112222;
+  constexpr uint32_t kReplacement = 0x33334444;
+  constexpr uint32_t kLatest = 0x55556666;
+
+  KfdProcess process(kPid);
+  auto allocation = std::make_unique<uint8_t[]>(KfdProcess::kPageSize);
+  std::memcpy(allocation.get(), &kInitial, sizeof(kInitial));
+  process.map_pages(kBaseVa, allocation.get(), KfdProcess::kPageSize, amdgpu::Mtype::RW);
+  memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
+                          process.page_table_generation(), process.page_table_request_mutex());
+  l2.set_backing_memory(&memory);
+  l1.set_memory(&memory);
+
+  size_t hook_calls = 0;
+  std::function<void()> query_hook = [&] {
+    amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
+    ++hook_calls;
+    process.set_page_mtype(kBaseVa, KfdProcess::kPageSize, amdgpu::Mtype::UC);
+    std::memcpy(allocation.get(), &kReplacement, sizeof(kReplacement));
+  };
+  amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
+
+  uint32_t result = 0;
+  l1.load(kBaseVa, 1, &result, kPid);
+  EXPECT_EQ(result, kReplacement);
+  EXPECT_EQ(hook_calls, 1u);
+  EXPECT_EQ(memory.pte_mtype(kBaseVa, kPid), amdgpu::Mtype::UC);
+
+  std::memcpy(allocation.get(), &kLatest, sizeof(kLatest));
+  l1.load(kBaseVa, 1, &result, kPid);
+  EXPECT_EQ(result, kLatest);
+}
+
 TEST(GpuMemoryTest, SanitizedUnlockedQueryPreservesOuterWalkAcrossReentry) {
   amdgpu::GpuMemory memory("memory");
   constexpr uint32_t kPid = 7;
@@ -1128,13 +1198,13 @@ TEST(GpuMemoryTest, SanitizedUnlockedQueryPreservesOuterWalkAcrossReentry) {
   process.map_pages(kOuterVa, outer_page.get(), KfdProcess::kPageSize);
   process.map_pages(kNestedVa, nested_page.get(), KfdProcess::kPageSize);
   memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                          process.page_table_generation());
+                          process.page_table_generation(), process.page_table_request_mutex());
 
   std::function<void()> query_hook = [&] {
     amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, nullptr);
     memory.unregister_process(kPid);
     memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                            process.page_table_generation());
+                            process.page_table_generation(), process.page_table_request_mutex());
     EXPECT_EQ(memory.read8(kNestedVa, kPid), 0x22);
   };
   amdgpu::GpuMemoryTestAccess::set_page_table_unlocked_hook(memory, &query_hook);
@@ -1155,7 +1225,8 @@ TEST(GpuMemoryTest, SanitizedUnlockedQueryRetriesAfterRemap) {
     new_page[0] = 0x22;
     process.map_pages(kBaseVa, old_page.get(), KfdProcess::kPageSize);
     memory.register_process(kPid, &process.page_table_, &process.page_table_mutex_,
-                            use_generation ? process.page_table_generation() : nullptr);
+                            use_generation ? process.page_table_generation() : nullptr,
+                            process.page_table_request_mutex());
 
     uint8_t *current_page = old_page.get();
     size_t hook_calls = 0;

--- a/emulation/rocjitsu/tests/l2_cache_test.cpp
+++ b/emulation/rocjitsu/tests/l2_cache_test.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/memory_side_cache.h"
+#include "rocjitsu/vm/amdgpu/request_mtype_resolver.h"
 #include "simdojo/sim/exec_mode.h"
 
 #include <gtest/gtest.h>
@@ -19,6 +20,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -42,6 +44,7 @@ using rocjitsu::amdgpu::L1VectorCache;
 using rocjitsu::amdgpu::L2Cache;
 using rocjitsu::amdgpu::MemorySideCache;
 using rocjitsu::amdgpu::Mtype;
+using rocjitsu::amdgpu::RequestMtypeResolver;
 
 void increment_u32(uint8_t *line, uint32_t offset) {
   uint32_t value = 0;
@@ -318,6 +321,198 @@ private:
   std::vector<uint8_t> bytes_;
   simdojo::Port *port_ = nullptr;
 };
+
+class L1CacheMtypeTest : public testing::Test {
+protected:
+  static constexpr uint32_t kVmid = 7;
+  static constexpr uint64_t kBase = 0x100000;
+  static constexpr uint64_t kAddr = kBase + GpuMemory::PAGE_SIZE - sizeof(uint32_t);
+  static constexpr uint32_t kFirst = 0x11112222;
+  static constexpr uint32_t kSecond = 0x33334444;
+  static constexpr uint32_t kFirstReplacement = 0x55556666;
+  static constexpr uint32_t kSecondReplacement = 0x77778888;
+  static constexpr std::array<uint32_t, 2> kValues = {kFirst, kSecond};
+
+  void map_pages(Mtype first_mtype, Mtype second_mtype) {
+    process_.map_pages(kBase, first_page_.data(), first_page_.size(), first_mtype);
+    process_.map_pages(kBase + GpuMemory::PAGE_SIZE, second_page_.data(), second_page_.size(),
+                       second_mtype);
+    memory_.register_process(kVmid, &process_.page_table_, &process_.page_table_mutex_,
+                             process_.page_table_generation(), process_.page_table_request_mutex());
+    l2_.set_backing_memory(&memory_);
+  }
+
+  void write_words(uint32_t first, uint32_t second) {
+    std::memcpy(first_page_.data() + GpuMemory::PAGE_SIZE - sizeof(first), &first, sizeof(first));
+    std::memcpy(second_page_.data(), &second, sizeof(second));
+  }
+
+  std::array<uint32_t, 2> read_words() const {
+    std::array<uint32_t, 2> result{};
+    std::memcpy(&result[0], first_page_.data() + GpuMemory::PAGE_SIZE - sizeof(result[0]),
+                sizeof(result[0]));
+    std::memcpy(&result[1], second_page_.data(), sizeof(result[1]));
+    return result;
+  }
+
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> first_page_{};
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> second_page_{};
+  rocjitsu::KfdProcess process_{kVmid};
+  GpuMemory memory_{"memory"};
+  L2Cache l2_{"l2"};
+};
+
+TEST_F(L1CacheMtypeTest, ScalarLoadKeepsPageSpecificMtypeAcrossBoundary) {
+  write_words(kFirst, kSecond);
+  map_pages(Mtype::RW, Mtype::UC);
+  L1ScalarCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  std::array<uint32_t, 2> result{};
+  l1.load(kAddr, result.size(), result.data(), kVmid);
+  ASSERT_EQ(result, kValues);
+
+  write_words(kFirstReplacement, kSecondReplacement);
+  l1.load(kAddr, result.size(), result.data(), kVmid);
+
+  EXPECT_EQ(result[0], kFirst);
+  EXPECT_EQ(result[1], kSecondReplacement);
+}
+
+TEST_F(L1CacheMtypeTest, ScalarLoadBytesKeepsPageSpecificMtypeAcrossBoundary) {
+  write_words(kFirst, kSecond);
+  map_pages(Mtype::RW, Mtype::UC);
+  L1ScalarCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  std::array<uint32_t, 2> result{};
+  l1.load_bytes(kAddr, sizeof(result), reinterpret_cast<uint8_t *>(result.data()), kVmid);
+  ASSERT_EQ(result, kValues);
+
+  write_words(kFirstReplacement, kSecondReplacement);
+  l1.load_bytes(kAddr, sizeof(result), reinterpret_cast<uint8_t *>(result.data()), kVmid);
+
+  EXPECT_EQ(result[0], kFirst);
+  EXPECT_EQ(result[1], kSecondReplacement);
+}
+
+TEST_F(L1CacheMtypeTest, PageMtypeMutationRefreshesLiveResolver) {
+  write_words(kFirst, kSecond);
+  map_pages(Mtype::RW, Mtype::UC);
+  L1ScalarCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  uint32_t result = 0;
+  l1.load(kAddr, 1, &result, kVmid);
+  ASSERT_EQ(result, kFirst);
+
+  RequestMtypeResolver request(&memory_, kVmid);
+  ASSERT_EQ(request.at(kAddr), Mtype::RW);
+  process_.set_page_mtype(kBase, GpuMemory::PAGE_SIZE, Mtype::CC);
+  write_words(kFirstReplacement, kSecond);
+  EXPECT_EQ(request.at(kAddr + 1), Mtype::CC);
+
+  l1.load(kAddr, 1, &result, kVmid);
+  EXPECT_EQ(result, kFirstReplacement);
+}
+
+TEST_F(L1CacheMtypeTest, VmidRebindingRefreshesLiveResolverAndUsesNewPolicy) {
+  write_words(kFirst, kSecond);
+  map_pages(Mtype::RW, Mtype::RW);
+  L1ScalarCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  uint32_t result = 0;
+  l1.load(kAddr, 1, &result, kVmid);
+  ASSERT_EQ(result, kFirst);
+
+  rocjitsu::KfdProcess replacement_process(kVmid);
+  std::array<uint8_t, GpuMemory::PAGE_SIZE> replacement_page{};
+  std::memcpy(replacement_page.data() + GpuMemory::PAGE_SIZE - sizeof(kFirstReplacement),
+              &kFirstReplacement, sizeof(kFirstReplacement));
+  replacement_process.map_pages(kBase, replacement_page.data(), replacement_page.size(), Mtype::UC);
+
+  RequestMtypeResolver request(&memory_, kVmid);
+  ASSERT_EQ(request.at(kAddr), Mtype::RW);
+  memory_.register_process(
+      kVmid, &replacement_process.page_table_, &replacement_process.page_table_mutex_,
+      replacement_process.page_table_generation(), replacement_process.page_table_request_mutex());
+  EXPECT_EQ(request.at(kAddr + 1), Mtype::UC);
+
+  l1.load(kAddr, 1, &result, kVmid);
+  EXPECT_EQ(result, kFirstReplacement);
+}
+
+TEST_F(L1CacheMtypeTest, VmidUnregistrationRefreshesLiveResolver) {
+  map_pages(Mtype::UC, Mtype::UC);
+
+  RequestMtypeResolver request(&memory_, kVmid);
+  ASSERT_EQ(request.at(kAddr), Mtype::UC);
+  memory_.unregister_process(kVmid);
+  EXPECT_EQ(request.at(kAddr + 1), Mtype::RW);
+  EXPECT_FALSE(memory_.is_mapped(kAddr, kVmid));
+}
+
+TEST_F(L1CacheMtypeTest, VectorLoadKeepsPageSpecificMtypeAcrossBoundary) {
+  write_words(kFirst, kSecond);
+  map_pages(Mtype::RW, Mtype::UC);
+  L1VectorCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  const uint64_t addrs[] = {kAddr};
+  std::array<uint32_t, 2> result{};
+  l1.load(addrs, /*lane_mask=*/1, sizeof(uint32_t), result.size(),
+          reinterpret_cast<uint8_t *>(result.data()), Mtype::RW, /*non_temporal=*/false,
+          /*request_l1_bypass=*/false, /*wf_size=*/1, kVmid);
+  ASSERT_EQ(result, kValues);
+
+  write_words(kFirstReplacement, kSecondReplacement);
+  l1.load(addrs, /*lane_mask=*/1, sizeof(uint32_t), result.size(),
+          reinterpret_cast<uint8_t *>(result.data()), Mtype::RW, /*non_temporal=*/false,
+          /*request_l1_bypass=*/false, /*wf_size=*/1, kVmid);
+
+  EXPECT_EQ(result[0], kFirst);
+  EXPECT_EQ(result[1], kSecondReplacement);
+}
+
+TEST_F(L1CacheMtypeTest, ScalarStoreKeepsPageSpecificMtypeAcrossBoundary) {
+  map_pages(Mtype::RW, Mtype::UC);
+  L1ScalarCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  l1.store(kAddr, kValues.size(), kValues.data(), kVmid);
+
+  EXPECT_EQ(read_words(), kValues);
+  EXPECT_EQ(l2_.backing_read_transactions(), 1u);
+}
+
+TEST_F(L1CacheMtypeTest, VectorStoreKeepsPageSpecificMtypeAcrossBoundary) {
+  map_pages(Mtype::RW, Mtype::UC);
+  L1VectorCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  const uint64_t addrs[] = {kAddr};
+  l1.store(addrs, /*lane_mask=*/1, sizeof(uint32_t), kValues.size(),
+           reinterpret_cast<const uint8_t *>(kValues.data()), Mtype::RW,
+           /*non_temporal=*/false, /*wf_size=*/1, kVmid);
+
+  EXPECT_EQ(read_words(), kValues);
+  EXPECT_EQ(l2_.backing_read_transactions(), 1u);
+}
+
+TEST_F(L1CacheMtypeTest, VectorStoreKeepsUcThenRwMtypeAcrossBoundary) {
+  map_pages(Mtype::UC, Mtype::RW);
+  L1VectorCache l1(&l2_);
+  l1.set_memory(&memory_);
+
+  const uint64_t addrs[] = {kAddr};
+  l1.store(addrs, /*lane_mask=*/1, sizeof(uint32_t), kValues.size(),
+           reinterpret_cast<const uint8_t *>(kValues.data()), Mtype::RW,
+           /*non_temporal=*/false, /*wf_size=*/1, kVmid);
+
+  EXPECT_EQ(read_words(), kValues);
+  EXPECT_EQ(l2_.backing_read_transactions(), 1u);
+}
 
 TEST(L2CacheThreadingTest, ConcurrentDifferentSetWritesArePreserved) {
   GpuMemory memory("memory");


### PR DESCRIPTION
Avoid reacquiring page-table shared locks for each cache-line chunk by caching effective MTYPE per page for the duration of an L1 request. Share the resolver across fragmented vector accesses and retain page-boundary handling for cache policy changes.

For simulated gfx1250 IREE kernels pinned to CPUs 0-95, this improves median active throughput by 1.89% versus origin/develop and 3.06% atop users/arosa/rj/per-cu. Gluon end-to-end time is unchanged. Add scalar, vector, byte-load, and reverse-boundary coverage.