### PR TITLE
ci(rccl): fold host unit tests into TheRock CI so failures block merges

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -376,7 +376,12 @@ class ConfigureCITest(unittest.TestCase):
     @patch("therock_configure_ci.get_modified_paths")
     def test_rccl_host_tests_triggered_by_own_workflow(self, mock_get_modified):
         """Editing the host-test workflow runs the host tests, so it stays
-        self-testing -- but must NOT pull in the multi-hour GPU job."""
+        self-testing -- but must NOT pull in the multi-hour GPU job.
+
+        The second assertion also pins check_rccl_changes()'s
+        include_host_test_workflow default to False: that predicate gates the
+        GPU job and the push-event subtree fallback, so a CI-only edit must
+        not reach either."""
         args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
 
         mock_get_modified.return_value = [therock_configure_ci.RCCL_HOST_TESTS_WORKFLOW]

--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -351,6 +351,42 @@ class ConfigureCITest(unittest.TestCase):
         projects = json.loads(outputs["projects"])
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
+        self.assertEqual(outputs["run_rccl_host_tests"], "false")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_host_tests_triggered_by_own_workflow(self, mock_get_modified):
+        """Editing the host-test workflow runs the host tests, so it stays
+        self-testing -- but must NOT pull in the multi-hour GPU job."""
+        args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            ".github/workflows/rccl-host-unit-tests.yml"
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        self.assertEqual(outputs["run_rccl_host_tests"], "true")
+        self.assertEqual(outputs["run_linux_rccl_ci"], "false")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_host_tests_triggered_by_rccl_paths(self, mock_get_modified):
+        """An RCCL source change runs the host tests as well as the GPU job."""
+        args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = ["projects/rccl/rccl.cpp"]
+
+        outputs = therock_configure_ci.run(args)
+        self.assertEqual(outputs["run_rccl_host_tests"], "true")
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_host_tests_not_triggered_by_other_workflow(self, mock_get_modified):
+        """A different workflow file must not trigger the host tests."""
+        args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [".github/workflows/therock-ci.yml"]
+
+        outputs = therock_configure_ci.run(args)
+        self.assertEqual(outputs["run_rccl_host_tests"], "false")
 
     def test_rccl_ci_triggered_nightly(self):
         """A nightly event should run both regular and RCCL CI."""

--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -353,15 +353,33 @@ class ConfigureCITest(unittest.TestCase):
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
         self.assertEqual(outputs["run_rccl_host_tests"], "false")
 
+    def test_rccl_host_tests_workflow_constant_is_wired_up(self):
+        """RCCL_HOST_TESTS_WORKFLOW is matched by exact string compare, so a
+        rename would silently disable the self-test property while every other
+        test here still passed (the rename PR has no reason to touch this
+        script). Pin the constant to the real file and to therock-ci.yml's
+        uses: target so such a rename fails loudly right here."""
+        repo_root = Path(__file__).parent.parent.parent.parent
+        workflow = repo_root / therock_configure_ci.RCCL_HOST_TESTS_WORKFLOW
+        self.assertTrue(
+            workflow.is_file(),
+            f"RCCL_HOST_TESTS_WORKFLOW points at a missing file: {workflow}",
+        )
+
+        caller = (repo_root / ".github/workflows/therock-ci.yml").read_text()
+        self.assertIn(
+            f"uses: ./{therock_configure_ci.RCCL_HOST_TESTS_WORKFLOW}",
+            caller,
+            "therock-ci.yml does not invoke RCCL_HOST_TESTS_WORKFLOW",
+        )
+
     @patch("therock_configure_ci.get_modified_paths")
     def test_rccl_host_tests_triggered_by_own_workflow(self, mock_get_modified):
         """Editing the host-test workflow runs the host tests, so it stays
         self-testing -- but must NOT pull in the multi-hour GPU job."""
         args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
 
-        mock_get_modified.return_value = [
-            ".github/workflows/rccl-host-unit-tests.yml"
-        ]
+        mock_get_modified.return_value = [therock_configure_ci.RCCL_HOST_TESTS_WORKFLOW]
 
         outputs = therock_configure_ci.run(args)
         self.assertEqual(outputs["run_rccl_host_tests"], "true")

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -183,13 +183,6 @@ def get_pr_labels(args) -> List[str]:
     return labels
 
 
-def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
-    """Returns true if any files under projects/rccl/ were modified."""
-    if modified_paths is None:
-        return False
-    return any(path.startswith("projects/rccl/") for path in modified_paths)
-
-
 # The workflow that runs the RCCL host unit tests. It is invoked via workflow_call
 # from therock-ci.yml, so it has no paths: trigger of its own and would otherwise
 # never be exercised by a PR that edits it -- a breakage would first surface on an
@@ -197,19 +190,24 @@ def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
 RCCL_HOST_TESTS_WORKFLOW = ".github/workflows/rccl-host-unit-tests.yml"
 
 
-def check_rccl_host_test_changes(modified_paths: Optional[Iterable[str]]) -> bool:
-    """Returns true if the RCCL host unit tests need to run.
+def check_rccl_changes(
+    modified_paths: Optional[Iterable[str]],
+    include_host_test_workflow: bool = False,
+) -> bool:
+    """Returns true if any files under projects/rccl/ were modified.
 
-    This is check_rccl_changes() plus the host-test workflow itself, so that
-    workflow stays self-testing. Kept separate from check_rccl_changes() on
-    purpose: widening that predicate would also pull in the multi-hour GPU
-    job (therock-rccl-ci-linux) on a CI-only edit.
+    include_host_test_workflow also matches the host-test workflow's own path, so
+    that workflow stays self-testing. It defaults to False because only the
+    CPU-only host tests want it: the GPU job (therock-rccl-ci-linux) starts with a
+    ~60 min package build per family, and a CI-only edit must not pull that in.
     """
     if modified_paths is None:
         return False
-    if check_rccl_changes(modified_paths):
+    if any(path.startswith("projects/rccl/") for path in modified_paths):
         return True
-    return any(path == RCCL_HOST_TESTS_WORKFLOW for path in modified_paths)
+    return include_host_test_workflow and any(
+        path == RCCL_HOST_TESTS_WORKFLOW for path in modified_paths
+    )
 
 
 def check_hip_rocr_changes(modified_paths: Optional[Iterable[str]]) -> bool:
@@ -522,7 +520,7 @@ def run(args):
                 outputs["run_linux_rccl_ci"] = "true"
             else:
                 outputs["run_linux_rccl_ci"] = "false"
-            if check_rccl_host_test_changes(modified_paths):
+            if check_rccl_changes(modified_paths, include_host_test_workflow=True):
                 outputs["run_rccl_host_tests"] = "true"
             else:
                 outputs["run_rccl_host_tests"] = "false"

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -190,6 +190,28 @@ def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
     return any(path.startswith("projects/rccl/") for path in modified_paths)
 
 
+# The workflow that runs the RCCL host unit tests. It is invoked via workflow_call
+# from therock-ci.yml, so it has no paths: trigger of its own and would otherwise
+# never be exercised by a PR that edits it -- a breakage would first surface on an
+# unrelated RCCL PR, which cannot merge because the job gates the summary check.
+RCCL_HOST_TESTS_WORKFLOW = ".github/workflows/rccl-host-unit-tests.yml"
+
+
+def check_rccl_host_test_changes(modified_paths: Optional[Iterable[str]]) -> bool:
+    """Returns true if the RCCL host unit tests need to run.
+
+    This is check_rccl_changes() plus the host-test workflow itself, so that
+    workflow stays self-testing. Kept separate from check_rccl_changes() on
+    purpose: widening that predicate would also pull in the multi-hour GPU
+    job (therock-rccl-ci-linux) on a CI-only edit.
+    """
+    if modified_paths is None:
+        return False
+    if check_rccl_changes(modified_paths):
+        return True
+    return any(path == RCCL_HOST_TESTS_WORKFLOW for path in modified_paths)
+
+
 def check_hip_rocr_changes(modified_paths: Optional[Iterable[str]]) -> bool:
     """Returns true if any HIP or ROCR files were modified (excluding docs).
 
@@ -475,18 +497,23 @@ def run(args):
         "test_type": test_type,
     }
 
-    # Determine if RCCL CI should run (only relevant for Linux platform)
+    # Determine if RCCL CI should run (only relevant for Linux platform).
+    # run_linux_rccl_ci gates the GPU job; run_rccl_host_tests gates the CPU-only
+    # host unit tests, which additionally run when their own workflow is edited.
     if args.get("platform") == "linux":
         if args.get("is_nightly"):
             # Nightly runs always run RCCL CI
             outputs["run_linux_rccl_ci"] = "true"
+            outputs["run_rccl_host_tests"] = "true"
         elif args.get("is_workflow_dispatch"):
             # For workflow_dispatch, check if projects/rccl was explicitly selected
             input_projects = args.get("input_projects", "")
             if "projects/rccl" in input_projects:
                 outputs["run_linux_rccl_ci"] = "true"
+                outputs["run_rccl_host_tests"] = "true"
             else:
                 outputs["run_linux_rccl_ci"] = "false"
+                outputs["run_rccl_host_tests"] = "false"
         else:
             # For push/PR events, check if any files under projects/rccl/ changed
             base_ref = args.get("base_ref")
@@ -495,6 +522,10 @@ def run(args):
                 outputs["run_linux_rccl_ci"] = "true"
             else:
                 outputs["run_linux_rccl_ci"] = "false"
+            if check_rccl_host_test_changes(modified_paths):
+                outputs["run_rccl_host_tests"] = "true"
+            else:
+                outputs["run_rccl_host_tests"] = "false"
 
     # Determine if MI455 CI should run (only for PRs on Linux when HIP/ROCR or CI changes)
     if args.get("platform") == "linux":

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -22,8 +22,13 @@ permissions:
 
 jobs:
   rccl-host-unit-tests:
-    name: Host unit tests (CPU-only)
+    # Caller supplies the "RCCL Host Unit Tests" half of the published check name.
+    name: CPU-only
     runs-on: ubuntu-24.04
+    # Median run is ~3.5 min. Without a cap the job would inherit GitHub's
+    # 6-hour default, and it now feeds a required check -- a hung run would
+    # hold up every RCCL merge.
+    timeout-minutes: 30
     container:
       image: rocm/dev-ubuntu-22.04:7.2
     env:
@@ -69,6 +74,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: host-unit-test-results
+          # Glob: run_host_tests.sh writes one JUnit XML per binary
+          # (host_tests.xml plus host_tests_micro*.xml), not just the first.
           path: |
             projects/rccl/test/host/host_tests.log
-            projects/rccl/test/host/host_tests.xml
+            projects/rccl/test/host/host_tests*.xml

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -7,7 +7,8 @@ name: RCCL host unit tests
 #
 # Invoked by TheRock CI (.github/workflows/therock-ci.yml), which gates this on
 # `run_rccl_host_tests` -- projects/rccl/ changes PLUS this file's own path, so
-# editing this workflow still exercises it (check_rccl_host_test_changes() in
+# editing this workflow still exercises it
+# (check_rccl_changes(include_host_test_workflow=True) in
 # .github/scripts/therock_configure_ci.py). That workflow has no `paths:` filter
 # of its own, so its required `TheRock CI Summary` check always reports; folding
 # in here is what makes a host-test failure block a merge without stalling PRs

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -6,10 +6,12 @@ name: RCCL host unit tests
 # JIRA ID: AICOMRCCL-1711
 #
 # Invoked by TheRock CI (.github/workflows/therock-ci.yml), which gates this on
-# `run_linux_rccl_ci` -- i.e. only when projects/rccl/ changed. That workflow has
-# no `paths:` filter of its own, so its required `TheRock CI Summary` check always
-# reports; folding in here is what makes a host-test failure block a merge without
-# stalling PRs that never touch RCCL.
+# `run_rccl_host_tests` -- projects/rccl/ changes PLUS this file's own path, so
+# editing this workflow still exercises it (check_rccl_host_test_changes() in
+# .github/scripts/therock_configure_ci.py). That workflow has no `paths:` filter
+# of its own, so its required `TheRock CI Summary` check always reports; folding
+# in here is what makes a host-test failure block a merge without stalling PRs
+# that never touch RCCL.
 #
 # Not triggered directly on `pull_request`: doing so alongside the TheRock CI call
 # would run the whole pipeline twice on every RCCL PR.

--- a/.github/workflows/rccl-host-unit-tests.yml
+++ b/.github/workflows/rccl-host-unit-tests.yml
@@ -1,28 +1,24 @@
 name: RCCL host unit tests
 
-# Builds and runs RCCL's CPU-only host unit-test binary (rccl-HostUnitTests, added
-# in PR #9320) on every PR to develop touching projects/rccl/**. No GPU or network
-# hardware is required: the binary is compiled with `hipcc --offload-host-only` and
-# links no HIP/ROCm runtime. The workflow's own path is in the trigger so it
-# self-runs on the PR that introduces it. JIRA ID: AICOMRCCL-1711
+# Builds and runs RCCL's CPU-only host unit-test binaries (rccl-HostUnitTests plus
+# the host-only microtests). No GPU or network hardware is required: they are
+# compiled with `hipcc --offload-host-only` and link no HIP/ROCm runtime.
+# JIRA ID: AICOMRCCL-1711
 #
-# TODO(AICOMRCCL-1711): fold this into TheRock's packaged CI once the host-test
-# gate stabilizes
+# Invoked by TheRock CI (.github/workflows/therock-ci.yml), which gates this on
+# `run_linux_rccl_ci` -- i.e. only when projects/rccl/ changed. That workflow has
+# no `paths:` filter of its own, so its required `TheRock CI Summary` check always
+# reports; folding in here is what makes a host-test failure block a merge without
+# stalling PRs that never touch RCCL.
+#
+# Not triggered directly on `pull_request`: doing so alongside the TheRock CI call
+# would run the whole pipeline twice on every RCCL PR.
 
 on:
-  pull_request:
-    branches:
-      - develop
-    paths:
-      - 'projects/rccl/**'
-      - '.github/workflows/rccl-host-unit-tests.yml'
+  workflow_call:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
 
 jobs:
   rccl-host-unit-tests:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -237,7 +237,8 @@ jobs:
   # runs in parallel with the GPU jobs rather than waiting on a package build.
   # Gated on run_rccl_host_tests, which is run_linux_rccl_ci plus the host-test
   # workflow's own path so that workflow stays self-testing -- see
-  # check_rccl_host_test_changes() in .github/scripts/therock_configure_ci.py.
+  # check_rccl_changes(include_host_test_workflow=True) in
+  # .github/scripts/therock_configure_ci.py.
   rccl-host-unit-tests:
     name: RCCL Host Unit Tests
     needs: setup

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -232,6 +232,19 @@ jobs:
         -DTHEROCK_ENABLE_ROCPROFV3=ON
         -DTHEROCK_ENABLE_MPI=ON
 
+  # CPU-only RCCL host unit tests (no GPU, no TheRock build artifacts), so this
+  # runs in parallel with the GPU jobs rather than waiting on a package build.
+  # Gated on the same run_linux_rccl_ci signal as therock-rccl-ci-linux above,
+  # which is true exactly when projects/rccl/ changed -- see check_rccl_changes()
+  # in .github/scripts/therock_configure_ci.py.
+  rccl-host-unit-tests:
+    name: RCCL Host Unit Tests
+    needs: setup
+    if: ${{ needs.setup.outputs.run_linux_rccl_ci == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/rccl-host-unit-tests.yml
+
   therock-ci-windows:
     name: Windows (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
@@ -262,6 +275,7 @@ jobs:
       - therock-ci-linux
       - therock-build-linux-mi455
       - therock-rccl-ci-linux
+      - rccl-host-unit-tests
       - therock-ci-windows
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -48,6 +48,7 @@ jobs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
+      run_rccl_host_tests: ${{ steps.linux_projects.outputs.run_rccl_host_tests }}
       run_mi455_test: ${{ steps.linux_projects.outputs.run_mi455_test }}
       test_type: ${{ steps.linux_projects.outputs.test_type }}
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
@@ -234,13 +235,13 @@ jobs:
 
   # CPU-only RCCL host unit tests (no GPU, no TheRock build artifacts), so this
   # runs in parallel with the GPU jobs rather than waiting on a package build.
-  # Gated on the same run_linux_rccl_ci signal as therock-rccl-ci-linux above,
-  # which is true exactly when projects/rccl/ changed -- see check_rccl_changes()
-  # in .github/scripts/therock_configure_ci.py.
+  # Gated on run_rccl_host_tests, which is run_linux_rccl_ci plus the host-test
+  # workflow's own path so that workflow stays self-testing -- see
+  # check_rccl_host_test_changes() in .github/scripts/therock_configure_ci.py.
   rccl-host-unit-tests:
     name: RCCL Host Unit Tests
     needs: setup
-    if: ${{ needs.setup.outputs.run_linux_rccl_ci == 'true' }}
+    if: ${{ needs.setup.outputs.run_rccl_host_tests == 'true' }}
     permissions:
       contents: read
     uses: ./.github/workflows/rccl-host-unit-tests.yml


### PR DESCRIPTION
## Summary

Makes RCCL's CPU-only host unit tests block merges, by running them under `TheRock CI` instead of as a standalone workflow.

They can't be made a required check on their own: the workflow is path-filtered on `projects/rccl/**`, and a required check that never reports leaves every PR that doesn't touch RCCL stuck on *"Expected — waiting for status to be reported."* `TheRock CI` has no `paths:` filter and already owns a required summary check, so folding in there gives a real gate with no ruleset change.

## Changes

**`rccl-host-unit-tests.yml`** — `on:` `pull_request` + `paths:` → `workflow_call` (direct trigger removed so it doesn't run twice); dropped the local `concurrency:` block since the caller sets one; added `timeout-minutes: 30` (it feeds a required check, so it must not inherit the 6-hour default); upload `host_tests*.xml` so all four JUnit files are kept, not just the first.

**`therock-ci.yml`** — new `rccl-host-unit-tests` job, plus one line adding it to `therock_ci_summary.needs` — that's what makes the gate bite.

**`therock_configure_ci.py`** — new `run_rccl_host_tests` output = `check_rccl_changes()` **plus this workflow's own path**, so the workflow stays self-testing. Deliberately a separate predicate rather than widening `check_rccl_changes()`, which `therock-rccl-ci-linux` also reads — widening it would fire the multi-hour GPU job on a CI-only edit. 4 unit tests added, including one that fails loudly if the workflow is renamed out from under the constant.

Gating, verified by executing the real predicate:

| changed paths | host tests | GPU RCCL CI |
|---|---|---|
| `projects/rccl/...` | run | run |
| this workflow only | run | **skip** |
| `therock-ci.yml` only | skip | skip |
| unrelated project | skip | skip |

Safe because the summary already treats `skipped` as passing:
```bash
map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")
```
Host tests fail → summary red → merge blocked. Not an RCCL PR → skipped → unaffected. (`cancelled` and `timed_out` also block, so the new timeout is enforceable.)

The check is renamed `Host unit tests (CPU-only)` → `RCCL Host Unit Tests / CPU-only`.

## Verification

This PR edits the host-test workflow, so it triggers its own gate — the run path is demonstrated here.

- [x] **Run path** — [`RCCL Host Unit Tests / CPU-only` passed in 3m8s](https://github.com/ROCm/rocm-systems/actions/runs/32608538786/job/97117756562): 282 + 30 + 80 + 79 gtests, matching the baseline below.
- [x] **Correct gating** — `TheRock RCCL CI Linux` [skipped](https://github.com/ROCm/rocm-systems/actions/runs/32608538786/job/97117756983) on the same run, confirming a CI-only edit doesn't pull in the multi-hour GPU job.
- [x] **No double-run** — `workflow_call`-only with exactly one caller; no standalone run exists for this branch.
- [ ] **Failure path** — needs a deliberately broken assertion to show `TheRock CI Summary` going red.
- [ ] **Skip path** — no longer exercised by this PR (the job now runs here by design); needs a non-RCCL PR.

Baseline: `rccl-HostUnitTests` 282/282, `rccl-UnitTestsMicro` 30/30, `rccl-UnitTestsMicroInit` 80/80, `rccl-UnitTestsMicroInit-uncached` 79/79.

## Notes for reviewers

- `branches: [develop]` is gone because `therock-ci.yml` has no `branches:` filter; the workflow only exists on `develop`, so there is no other base where the job can run.
- Known limitation, pre-existing and not introduced here: on `workflow_dispatch`, `run()` tests `"projects/rccl" in input_projects` as a substring, so `projects: all` skips both RCCL lanes and `projects/rccl-tests` triggers them. This PR adds a second consumer of that predicate but does not change it.

JIRA ID: AICOMRCCL-1711
