### PR TITLE
fix(clr): clamp cast_to_f8 mantissa shifts so far-underflowing inputs give zero

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -327,8 +327,18 @@ So for fp32/fp16, exponent -8 is the cut point to convert to fp8 nanoo */
     mantissa += (1ull << mfmt);  // Add the implicit 1 into mantissa
   }
 
-  bool midpoint = (mantissa & ((1ull << (mfmt - wm + exponent_diff)) - 1)) ==
-                  (1ull << (mfmt - wm + exponent_diff - 1));
+  /* exponent_diff is unbounded below: an input far under the f8 denormal range gives a diff of up
+to 120 for float and 1016 for double. Shifting the 64-bit mantissa by that much is undefined
+behavior, and in practice the shift count is taken mod 64, which turns a full underflow into a
+non-zero code. Both shifts are guarded, not just the mantissa shift: the tie detection shifts by
+mfmt - wm + exponent_diff, so it leaves the valid range much earlier (from exponent_diff == 15 for
+a double converted to e4m3). Once a shift reaches the operand width the whole mantissa is gone,
+which is the underflow-to-zero case the f8_exponent == 0 && mantissa == 0 check at the end already
+turns into a signed zero. */
+  const int mantissa_bits = 8 * static_cast<int>(sizeof(mantissa));
+  const int midpoint_shift = mfmt - wm + exponent_diff;
+  bool midpoint = midpoint_shift < mantissa_bits &&
+                  (mantissa & ((1ull << midpoint_shift) - 1)) == (1ull << (midpoint_shift - 1));
   /* This part is a bit tricky. The judgment of whether it is a tie needs to be done before we shift
 right as shift right could rip off some residual part and make something not midpoint look like
 midpoint. For example, the fp16 number 0x1002 (0 00100 0000000010), it is larger than midpoint, but
@@ -336,7 +346,7 @@ after shift right by 4 bits, it would look like midpoint.
 */
 
   if (exponent_diff > 0)
-    mantissa >>= exponent_diff;
+    mantissa = (exponent_diff >= mantissa_bits) ? 0ull : (mantissa >> exponent_diff);
   else if (exponent_diff == -1)
     mantissa <<= -exponent_diff;
   bool implicit_one = mantissa & (1ull << mfmt);

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -317,6 +317,9 @@ deviceLib:
   Unit_fp8_ocp_vector_basic_conversions:
     <<: *level_2
     tags: [types]
+  Unit_fp8_ocp_underflow_host:
+    <<: *level_2
+    tags: [types]
   Unit_fp8_fnuz_bool_host:
     <<: *level_2
     tags: [types]
@@ -327,6 +330,12 @@ deviceLib:
     <<: *level_2
     tags: [types]
   Unit_fp8_fnuz_vector_basic_conversions:
+    <<: *level_2
+    tags: [types]
+  Unit_fp8_fnuz_underflow_host:
+    <<: *level_2
+    tags: [types]
+  Unit_all_fp8_underflow_known_bad_inputs_host:
     <<: *level_2
     tags: [types]
   Unit__hip_cvt_bfloat16raw_to_e8m0:

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
@@ -10,6 +10,8 @@
 #include <type_traits>
 #include <vector>
 #include <bitset>
+#include <cmath>
+#include <cstring>
 
 /*
  * Tests for fp8 conversions on host
@@ -1193,5 +1195,110 @@ HIP_TEST_CASE(Unit_fp8_fnuz_vector_basic_conversions) {
 
     REQUIRE(f2 == bf2_1);
     REQUIRE(f2 == h2_1);
+  }
+}
+
+/*
+ * Underflow: a magnitude below half the smallest f8 subnormal has to convert to a signed zero.
+ *
+ * cast_to_f8() shifted the mantissa right by exponent_diff without bounding the shift count, and
+ * exponent_diff is unbounded below - it reaches 120 for float inputs and 1016 for double inputs.
+ * A shift of 64 or more on the 64-bit mantissa is undefined behavior and in practice wraps mod
+ * 64, so a value that underflows completely came back as a non-zero code instead of zero.
+ */
+namespace {
+// Smallest positive subnormal of each format is 2^(1 - bias - wm).
+constexpr int kMinSubnormalExpE4M3Ocp = 1 - 7 - 3;    // 2^-9
+constexpr int kMinSubnormalExpE5M2Ocp = 1 - 15 - 2;   // 2^-16
+constexpr int kMinSubnormalExpE4M3Fnuz = 1 - 8 - 3;   // 2^-10
+constexpr int kMinSubnormalExpE5M2Fnuz = 1 - 16 - 2;  // 2^-17
+
+template <typename fp8_t, typename T>
+void CheckUnderflowsToZero(int min_subnormal_exp, bool is_fnuz) {
+  // Lowest exponent that is still a subnormal of the input type.
+  constexpr int lowest_exp = std::is_same<T, float>::value ? -149 : -1074;
+  const T mantissas[] = {T(1.0), T(1.25), T(1.5), T(1.75), T(1.99)};
+
+  // m * 2^e with m in [1, 2) and e <= min_subnormal_exp - 2 is strictly below half the smallest
+  // subnormal, so it rounds to zero whichever way a tie would go.
+  for (int e = min_subnormal_exp - 2; e >= lowest_exp; --e) {
+    for (const T m : mantissas) {
+      const T magnitude = std::ldexp(m, e);
+      for (int negative = 0; negative < 2; ++negative) {
+        const T value = negative ? -magnitude : magnitude;
+        const unsigned char expected = (is_fnuz || !negative) ? 0x00 : 0x80;
+        const fp8_t converted(value);
+        INFO("input " << static_cast<double>(value) << " = " << static_cast<double>(m) << " * 2^"
+                      << e << ", got 0x" << std::hex << static_cast<int>(converted.__x)
+                      << ", expected 0x" << static_cast<int>(expected));
+        REQUIRE(converted.__x == expected);
+      }
+    }
+  }
+}
+}  // namespace
+
+HIP_TEMPLATE_TEST_CASE(Unit_fp8_ocp_underflow_host, float, double) {
+  SECTION("e4m3_ocp") {
+    CheckUnderflowsToZero<__hip_fp8_e4m3, TestType>(kMinSubnormalExpE4M3Ocp, false);
+  }
+  SECTION("e5m2_ocp") {
+    CheckUnderflowsToZero<__hip_fp8_e5m2, TestType>(kMinSubnormalExpE5M2Ocp, false);
+  }
+}
+
+HIP_TEMPLATE_TEST_CASE(Unit_fp8_fnuz_underflow_host, float, double) {
+  SECTION("e4m3_fnuz") {
+    CheckUnderflowsToZero<__hip_fp8_e4m3_fnuz, TestType>(kMinSubnormalExpE4M3Fnuz, true);
+  }
+  SECTION("e5m2_fnuz") {
+    CheckUnderflowsToZero<__hip_fp8_e5m2_fnuz, TestType>(kMinSubnormalExpE5M2Fnuz, true);
+  }
+}
+
+// Spot checks on the exact inputs the unbounded shift used to get wrong. The comment on each line
+// is the code that was returned before the shifts were guarded.
+HIP_TEST_CASE(Unit_all_fp8_underflow_known_bad_inputs_host) {
+  auto as_float = [](unsigned int bits) {
+    float f;
+    std::memcpy(&f, &bits, sizeof(f));
+    return f;
+  };
+  auto as_double = [](unsigned long long bits) {
+    double d;
+    std::memcpy(&d, &bits, sizeof(d));
+    return d;
+  };
+
+  SECTION("e5m2_ocp") {
+    REQUIRE(__hip_fp8_e5m2(as_float(0x17800000)).__x == 0x00);           // was 0x01 (2^-16)
+    REQUIRE(__hip_fp8_e5m2(as_float(0x18000000)).__x == 0x00);           // was 0x02 (2^-15)
+    REQUIRE(__hip_fp8_e5m2(as_float(0x18800000)).__x == 0x00);           // was 0x04 (2^-14)
+    REQUIRE(__hip_fp8_e5m2(as_float(0x98800000)).__x == 0x80);           // was 0x84
+    REQUIRE(__hip_fp8_e5m2(as_double(0x0319000000000000)).__x == 0x00);  // was 0x06
+  }
+
+  SECTION("e4m3_ocp") {
+    REQUIRE(__hip_fp8_e4m3(as_float(0x1b000000)).__x == 0x00);           // was 0x01 (2^-9)
+    REQUIRE(__hip_fp8_e4m3(as_float(0x1b800000)).__x == 0x00);           // was 0x02 (2^-8)
+    REQUIRE(__hip_fp8_e4m3(as_float(0x1c000000)).__x == 0x00);           // was 0x04 (2^-7)
+    REQUIRE(__hip_fp8_e4m3(as_float(0x1c800000)).__x == 0x00);           // was 0x08 (2^-6)
+    REQUIRE(__hip_fp8_e4m3(as_float(0x9c800000)).__x == 0x80);           // was 0x88
+    REQUIRE(__hip_fp8_e4m3(as_double(0x0399000000000000)).__x == 0x00);  // was 0x0c
+  }
+
+  SECTION("e5m2_fnuz") {
+    REQUIRE(__hip_fp8_e5m2_fnuz(as_float(0x17000000)).__x == 0x00);           // was 0x01
+    REQUIRE(__hip_fp8_e5m2_fnuz(as_float(0x17800000)).__x == 0x00);           // was 0x02
+    REQUIRE(__hip_fp8_e5m2_fnuz(as_float(0x18000000)).__x == 0x00);           // was 0x04
+    REQUIRE(__hip_fp8_e5m2_fnuz(as_double(0x0309000000000000)).__x == 0x00);  // was 0x06
+  }
+
+  SECTION("e4m3_fnuz") {
+    REQUIRE(__hip_fp8_e4m3_fnuz(as_float(0x1a800000)).__x == 0x00);           // was 0x01
+    REQUIRE(__hip_fp8_e4m3_fnuz(as_float(0x1b000000)).__x == 0x00);           // was 0x02
+    REQUIRE(__hip_fp8_e4m3_fnuz(as_float(0x1b800000)).__x == 0x00);           // was 0x04
+    REQUIRE(__hip_fp8_e4m3_fnuz(as_float(0x1c000000)).__x == 0x00);           // was 0x08
+    REQUIRE(__hip_fp8_e4m3_fnuz(as_double(0x0389000000000000)).__x == 0x00);  // was 0x0c
   }
 }


### PR DESCRIPTION
Fixes #10591.

`internal::cast_to_f8` shifts the mantissa right by `exponent_diff`, but nothing bounds that value. It is the gap between the input exponent and the target format's denormal exponent, so for an input well below the smallest f8 subnormal it grows to 120 for a float and 1016 for a double. Shifting the 64-bit mantissa by 64 or more is UB, and the count ends up taken mod 64, so a value that should underflow to a signed zero comes back as a *larger* code instead. `3.3e-24f` converts to e5m2 as `0x04` (2^-14) rather than `0x00`, with nothing to indicate it happened.

The tie detection just above has the same problem, and it leaves the valid range much earlier since it shifts by `mfmt - wm + exponent_diff` — for a double converted to e4m3 that is already out of range at `exponent_diff == 15`, i.e. for any magnitude below about 2^-21. It has been harmless in practice on hardware that wraps the shift count, but it is UB either way, so I guarded both shifts rather than adding a single early return.

Once a shift reaches the operand width the mantissa is entirely gone, which is the case the trailing `f8_exponent == 0 && mantissa == 0` check already turns into a signed zero, so the guard just lets the existing underflow path run.

This is the software conversion path, so it applies to host conversions and to device conversions on anything without `HIP_FP8_CVT_FAST_PATH` (everything outside gfx942/gfx950/gfx1200/gfx1201/gfx1250).

### Scope

The issue reports e5m2. All four formats are affected, and the e4m3 window is both wider and worse — it returns codes up to `0x08` for float inputs and `0x0c` for double inputs:

| target | affected f32 exponent fields | worst code returned |
| --- | --- | --- |
| e5m2 OCP | 46-49 | `0x04` (2^-14) |
| e4m3 OCP | 53-57 | `0x08` (2^-6) |
| e5m2 fnuz | 45-48 | `0x04` |
| e4m3 fnuz | 52-56 | `0x08` |

### Verification

I extracted `cast_to_f8` into a host harness and compared it against an independently written encoder (round-to-nearest-even, subnormals rounded rather than flushed, signed zero preserved, saturating overflow), which I first checked against a brute-force nearest-code search over the format's 256 codes.

Sweeping all 2^32 float bit patterns per format, excluding inf/NaN:

| target | mismatches before | mismatches after |
| --- | --- | --- |
| e5m2 OCP | 65011710 | 0 |
| e4m3 OCP | 82837502 | 0 |
| e5m2 fnuz | 66060286 | 0 |
| e4m3 fnuz | 83361790 | 0 |

Same result for the `double` overload over all 2^32 f32-exact doubles, and over all 2048 double exponent fields crossed with a structured mantissa set. Outside the underflow window the patched code is bit-identical to the current code — the guards can only fire where the old shift count was already out of range, and `_Float16` inputs never get there at all (`exponent_diff` maxes out at 8), so that path is unchanged.

### Tests

Added to `unit/deviceLib/fp8_host.cc`:

- `Unit_fp8_ocp_underflow_host` / `Unit_fp8_fnuz_underflow_host` — for each format and for both float and double, every magnitude strictly below half the smallest subnormal has to convert to a signed zero.
- `Unit_all_fp8_underflow_known_bad_inputs_host` — the specific bit patterns that were wrong, with the old result in a comment on each line.

Against the current header these fail on 2676 assertions; with the fix they pass.

### One thing for maintainers

The header notes that this function came from rocBLAS, and the same unguarded shift is still there. It has also been copied into a number of other components — MIOpen, Tensile, composable_kernel, MIGraphX, rocMLIR, rocRoller, hipBLASLt, aiter, and `rccl_float8.h` in this repo. I kept this PR to the HIP header since that is what the issue is about, but the copies will need the same treatment if you want them consistent.
