### PR TITLE
fix(rocprofiler-sdk) fix hang on pc sampling teardown in some applications

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.cpp
@@ -31,6 +31,7 @@
 #include "lib/rocprofiler-sdk/hsa/pc_sampling.hpp"
 #include "lib/rocprofiler-sdk/hsa/scratch_memory.hpp"
 #include "lib/rocprofiler-sdk/hsa/utils.hpp"
+#include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
@@ -574,6 +575,13 @@ hsa_shut_down_refcnt_impl()
             // thread-trace producer/consumer threads *before* ROCR tears down
             // SDMA engines and signal pools in Runtime::Unload().
             thread_trace::flush_and_stop();
+
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+            // Similarly, this can't wait until finalize() since finalize() is
+            // an atexit handler which may not be run before HIP's exit
+            // handler and thus may not get the chance to stop PC sampling.
+            ::rocprofiler::pc_sampling::stop_all_services();
+#endif
         }
         return get_core_table()->hsa_shut_down_fn();
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -375,11 +375,6 @@ service_fini()
 void
 stop_all_services()
 {
-    // Stops the HSA-level PC sampling session for every context that currently has one
-    // enabled. `stop_service` is a no-op (via its enabled-flag CAS) for contexts whose
-    // service was never started or was already stopped, so calling it unconditionally
-    // here and letting the normal per-client stop path (context::stop_client_contexts)
-    // run again later is harmless.
     for(const auto* ctx :
         context::get_registered_contexts([](const auto* c) { return c->pc_sampler != nullptr; }))
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -372,6 +372,21 @@ service_fini()
     flush_all_agents_buffers();
 }
 
+void
+stop_all_services()
+{
+    // Stops the HSA-level PC sampling session for every context that currently has one
+    // enabled. `stop_service` is a no-op (via its enabled-flag CAS) for contexts whose
+    // service was never started or was already stopped, so calling it unconditionally
+    // here and letting the normal per-client stop path (context::stop_client_contexts)
+    // run again later is harmless.
+    for(const auto* ctx :
+        context::get_registered_contexts([](const auto* c) { return c->pc_sampler != nullptr; }))
+    {
+        stop_service(ctx);
+    }
+}
+
 }  // namespace pc_sampling
 }  // namespace rocprofiler
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.hpp
@@ -84,6 +84,15 @@ service_sync(rocprofiler_client_id_t client_id);
 
 void
 service_fini();
+
+/// \brief Stops the HSA-level PC sampling session (if enabled) on every registered
+/// context. Must be invoked before `hsa::queue_controller_fini()` tears down the queue
+/// interceptor infrastructure that the HSA PC sampling stop/flush path relies on
+/// (e.g. the intercept-marker callbacks registered in
+/// `pc_sampling_service_finish_configuration`). Safe to call unconditionally: contexts
+/// whose PC sampling service is not currently enabled are simply skipped.
+void
+stop_all_services();
 }  // namespace pc_sampling
 }  // namespace rocprofiler
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.hpp
@@ -86,11 +86,15 @@ void
 service_fini();
 
 /// \brief Stops the HSA-level PC sampling session (if enabled) on every registered
-/// context. Must be invoked before `hsa::queue_controller_fini()` tears down the queue
-/// interceptor infrastructure that the HSA PC sampling stop/flush path relies on
-/// (e.g. the intercept-marker callbacks registered in
-/// `pc_sampling_service_finish_configuration`). Safe to call unconditionally: contexts
-/// whose PC sampling service is not currently enabled are simply skipped.
+/// context, joining ROCr's per-XCC sampler threads and consumer thread and flushing
+/// their buffers.
+///
+/// Must run before both `hsa::queue_controller_fini()` (which tears down the
+/// intercept-marker infrastructure the stop/flush path uses) and ROCr's
+/// `hsa_shut_down()` (whose `~GpuAgent()` deadlocks if a session is still live).
+/// Whichever of those happens first is not fixed, so both call sites invoke this.
+/// Safe to call unconditionally and repeatedly: the enabled-flag CAS in `stop_service`
+/// makes every call after the first a no-op.
 void
 stop_all_services();
 }  // namespace pc_sampling

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1015,16 +1015,8 @@ finalize()
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
-        // WARNING: this must precede `queue_controller_fini()`. Stopping PC sampling at
-        // the HSA/ROCr level depends on the queue interceptor infrastructure (e.g. the
-        // intercept-marker callbacks registered in
-        // `pc_sampling_service_finish_configuration`) still being alive. Previously this
-        // stop only happened later, inside `invoke_client_finalizers()`, i.e. well after
-        // `queue_controller_fini()` had already torn that infrastructure down. On
-        // processes with many host threads/queues (e.g. JAX/PyTorch training workloads)
-        // this made the HSA-level stop fail ("HSA runtime failed to stop PC sampling on
-        // the agent") and left the subsequent queue/buffer drain waiting on state that
-        // would never settle, hanging at teardown.
+        // one of this or the HIP runtime's exit handler must run before
+        // hsa::queue_controller_fini() since they rely on the queue interceptor
         pc_sampling::stop_all_services();
 #endif
         hsa::queue_controller_fini();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1014,6 +1014,19 @@ finalize()
         set_fini_status(-1);
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+        // WARNING: this must precede `queue_controller_fini()`. Stopping PC sampling at
+        // the HSA/ROCr level depends on the queue interceptor infrastructure (e.g. the
+        // intercept-marker callbacks registered in
+        // `pc_sampling_service_finish_configuration`) still being alive. Previously this
+        // stop only happened later, inside `invoke_client_finalizers()`, i.e. well after
+        // `queue_controller_fini()` had already torn that infrastructure down. On
+        // processes with many host threads/queues (e.g. JAX/PyTorch training workloads)
+        // this made the HSA-level stop fail ("HSA runtime failed to stop PC sampling on
+        // the agent") and left the subsequent queue/buffer drain waiting on state that
+        // would never settle, hanging at teardown.
+        pc_sampling::stop_all_services();
+#endif
         hsa::queue_controller_fini();
         thread_trace::finalize();
         ompt::finalize_ompt();

--- a/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
@@ -93,14 +93,14 @@ class PcsRuntime {
     core::Agent* agent;
     void SetThunkId(HsaPcSamplingTraceId thunkId) { thunkId_ = thunkId; }
     HsaPcSamplingTraceId ThunkId() { return thunkId_; }
-    bool isActive() { return active_; }
-    void start() { active_ = true; }
-    void stop() { active_ = false; }
+    bool isActive() { return active_.load(std::memory_order_acquire); }
+    void start() { active_.store(true, std::memory_order_release); }
+    void stop() { active_.store(false, std::memory_order_release); }
 
    private:
     HsaPcSamplingTraceId thunkId_;
 
-    bool active_;  // Set to true when the session is started
+    std::atomic<bool> active_{false};  // Set to true when the session is started
     bool valid_;   // Whether configuration parameters are valid
     size_t sample_size_;
 


### PR DESCRIPTION
## Motivation

rocprof was observed hanging when trying to exit a pc sampling session.

## Technical Details

GpuAgent tears down a condition variable that may still be waited on by pc sampling threads, causing a deadlock. The fix is to ensure pc sampling has been shut down by adding a shutdown command to the hsa_shut_down interception function.

Also changed an interthread bool to be atomic to be safe.

## Issue Tracking

JIRA ID: AIPROFSDK-1047

## Test Plan

run test applications that produced hangs
run ctest suite

## Test Result

test applications no longer hang
no regressions in ctest suite

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
