### PR TITLE
test(rccl): BarrierSession validations for 2.30

### DIFF
--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -329,6 +329,14 @@ if(BUILD_TESTS)
     RCCL_STUBS_OMIT_ncclInitKernelsForDevice
     RCCL_STUBS_OMIT_ncclParamGraphStreamOrdering
     ENQUEUE_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/enqueue.cc")
+
+  # Mirrors the opt-out in test/CMakeLists.txt, whose loop does not reach this target.
+  # Inheriting ENABLE_ROCSHMEM_GIN defaults NCCL_GIN_ANVIL_SDMA_ENABLE to 1, which pulls
+  # in rocSHMEM's sdma device headers.
+  if(ENABLE_ROCSHMEM_GIN)
+    target_compile_definitions(rccl-UnitTestsMicroEnqueue PRIVATE NCCL_GIN_ANVIL_SDMA_ENABLE=0)
+  endif()
+
   # HIP compile requirements without linking the runtime (see rccl-UnitTestsMicro).
   foreach(_hip_tgt hip::host hip::device)
     if(TARGET ${_hip_tgt})

--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -64,6 +64,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclDevrFindWindow(struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin) { ::abort(); }
 bool ncclDevrIsOneLsaTeam(struct ncclComm* comm) { ::abort(); }
 ncclResult_t ncclGinA2AFinalize(struct ncclComm* comm) { return ncclSuccess; }
+ncclResult_t ncclGinAllReduceFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclGinFinalize(struct ncclComm* comm) { return ncclSuccess; }
 ncclResult_t ncclGinHostFinalize(struct ncclComm* comm) { return ncclSuccess; }
 // Omitted when RCCL_STUBS_OMIT_ncclInitKernelsForDevice is defined -- the unit

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1806,6 +1806,58 @@ TEST_F(GinMPIDeviceTests, Barrier_WorldTeamUsesWorldPool) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// Small because all CTAs must be resident at once, each waiting on its peers.
+constexpr int kWorldBarrierCtas = 4;
+
+// One barrier index per CTA, so the world pool's cell striding is exercised.
+__global__ void barrierWorldMultiIndexKernel(int iters, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/blockIdx.x};
+  for (int i = 0; i < iters; i++) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+// World-team GIN barrier driven on several barrier indices at the same time.
+TEST_F(GinMPIDeviceTests, Barrier_WorldMultiIndex) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int nRanks = -1;
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // Enough rounds that broken bookkeeping deadlocks instead of passing round 0.
+  constexpr int kIters = 16;
+
+  // One barrier per CTA, with no ncclGinBarrierCreateRequirement call needed.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.worldGinBarrierCount = kWorldBarrierCtas;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // All ranks finished setup before any kernel launches.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // CTA k barriers with CTA k on every peer, and returning is the assertion.
+  barrierWorldMultiIndexKernel<<<kWorldBarrierCtas, kGinKernelThreads, 0, stream>>>(kIters, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // Direct tests for ncclBarrierSession (barrier.h), separate from the alltoall
 // kernels that use it incidentally: BarrierSession_LsaOnly (LSA-only subset,
 // ncclTeamTagLsa, no GIN) and BarrierSession_Hybrid (world-team: inner LSA +
@@ -2140,6 +2192,104 @@ TEST_F(GinMPIDeviceTests, BarrierPools_AreIsolated) {
   ASSERT_MPI_EQ(lsa.nRanks, observation.dedicatedLsaNRanks);
   ASSERT_MPI_EQ(rail.nRanks, observation.directRailNRanks);
   ASSERT_MPI_EQ(world.nRanks, observation.directWorldNRanks);
+}
+
+// Arrival totals per GIN barrier pool. Shared cells make one pool count both
+// sessions, so every pool holding exactly one session's rounds is the proof.
+struct BarrierPoolSignalSums {
+  uint64_t rail;
+  uint64_t world;
+  uint64_t hybridRail;
+  uint64_t hybridWorld;
+};
+
+__device__ uint64_t sumBarrierSignals(const ncclGin& gin, uint32_t signal0, int nRanks) {
+  uint64_t sum = 0;
+  for (int i = 0; i < nRanks; i++) sum += gin.readSignal(signal0 + i);
+  return sum;
+}
+
+// Direct and generic sessions run on barrier index 0 together. The default fence
+// keeps the generic one on its world arm, so each round feeds two distinct pools.
+__global__ void barrierPoolCrossTalkKernel(
+    int iters, BarrierPoolSignalSums* sums, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclGinBarrierSession<ncclCoopCta> direct{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/0};
+  ncclBarrierSession<ncclCoopCta> generic{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, /*index=*/0};
+  for (int i = 0; i < iters; i++) {
+    direct.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+    generic.sync(ncclCoopCta(), cuda::memory_order_relaxed);
+  }
+
+  // Leaving the loop means every peer's last round landed in both pools.
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  int railRanks = ncclTeamRail(devComm).nRanks;
+  int worldRanks = ncclTeamWorld(devComm).nRanks;
+  sums->rail = sumBarrierSignals(gin, devComm.railGinBarrier.signal0, railRanks);
+  sums->world = sumBarrierSignals(gin, devComm.worldGinBarrier.signal0, worldRanks);
+  sums->hybridRail = sumBarrierSignals(gin, devComm.hybridRailGinBarrier.signal0, railRanks);
+  sums->hybridWorld = sumBarrierSignals(gin, devComm.hybridWorldGinBarrier.signal0, worldRanks);
+}
+
+// Generic and specialized sessions sharing one index must not share cells.
+TEST_F(GinMPIDeviceTests, BarrierPools_NoCrossTalk) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+  int worldRanks = ncclTeamWorld(comm).nRanks;
+
+  // Enough rounds that a shared cell doubles into an obvious mismatch.
+  constexpr int kIters = 8;
+
+  // Every pool is requested at once so an overlapping allocation cannot hide.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.barrierCount = 1;
+  reqs.railGinBarrierCount = 1;
+  reqs.worldGinBarrierCount = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Railed contexts leave the generic session's world arm unreachable.
+  if (devComm.ginContextsRailed)
+    GTEST_SKIP() << "Requires fully connected GIN contexts";
+
+  BarrierPoolSignalSums* dSums = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dSums, sizeof(BarrierPoolSignalSums)));
+  auto sumsCleanup = makeScopeGuard([&]() {
+    if (dSums) (void)hipFree(dSums);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dSums, 0, sizeof(BarrierPoolSignalSums)));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  barrierPoolCrossTalkKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(
+      kIters, dSums, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  BarrierPoolSignalSums sums{};
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&sums, dSums, sizeof(sums), hipMemcpyDeviceToHost));
+
+  // A relaxed round is signalled by the peers only, a Put round adds our own slot.
+  const uint64_t relaxedRounds = static_cast<uint64_t>(kIters) * (worldRanks - 1);
+  const uint64_t putRounds = static_cast<uint64_t>(kIters) * worldRanks;
+  ASSERT_MPI_EQ(relaxedRounds, sums.world);
+  ASSERT_MPI_EQ(putRounds, sums.hybridWorld);
+  ASSERT_MPI_EQ(uint64_t{0}, sums.rail);
+  ASSERT_MPI_EQ(uint64_t{0}, sums.hybridRail);
+
+  MPI_Barrier(MPI_COMM_WORLD);
 }
 
 // ---------------------------------------------------------------------------
@@ -3051,7 +3201,7 @@ TEST_F(GinMPIDeviceTests, DevComm_LegacyGinSignalRequestRejected) {
 }
 
 // A compatible 2.30 request carries its requested ABI version into the returned
-// device communicator; it is not silently stamped with the runtime's version.
+// device communicator, rather than the runtime stamping its own version on it.
 TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
   if (auto reason = cuMemReason(); !reason.empty())
     GTEST_SKIP() << reason;
@@ -3061,8 +3211,10 @@ TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t comm = getActiveCommunicator();
 
+  // 2.30.3 is the oldest version the GIN proxy backend has a GPU context layout
+  // for, and GIN is already enabled on the comm whenever NCCL_GIN_ENABLE is set.
   ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.version = NCCL_VERSION(2, 30, 0);
+  reqs.version = NCCL_VERSION(2, 30, 3);
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1465,6 +1465,58 @@ TEST_F(GinMPIDeviceTests, Barrier_WorldTeamUsesWorldPool) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// Small because all CTAs must be resident at once, each waiting on its peers.
+constexpr int kWorldBarrierCtas = 4;
+
+// One barrier index per CTA, so the world pool's cell striding is exercised.
+__global__ void barrierWorldMultiIndexKernel(int iters, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/blockIdx.x};
+  for (int i = 0; i < iters; i++) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+// World-team GIN barrier driven on several barrier indices at the same time.
+TEST_F(GinMPIDeviceTests, Barrier_WorldMultiIndex) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int nRanks = -1;
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // Enough rounds that broken bookkeeping deadlocks instead of passing round 0.
+  constexpr int kIters = 16;
+
+  // One barrier per CTA, with no ncclGinBarrierCreateRequirement call needed.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.worldGinBarrierCount = kWorldBarrierCtas;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // All ranks finished setup before any kernel launches.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // CTA k barriers with CTA k on every peer, and returning is the assertion.
+  barrierWorldMultiIndexKernel<<<kWorldBarrierCtas, kGinKernelThreads, 0, stream>>>(kIters, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // Direct tests for ncclBarrierSession (barrier.h), separate from the alltoall
 // kernels that use it incidentally: BarrierSession_LsaOnly (LSA-only subset,
 // ncclTeamTagLsa, no GIN) and BarrierSession_Hybrid (world-team: inner LSA +
@@ -1624,7 +1676,7 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
 
   constexpr int kIters = 16;
 
-  // Only barrierCount provisions the two pools consumed by the generic
+  // Only barrierCount provisions the three pools consumed by the generic
   // world-team session. Keeping every specialized count at zero ensures an
   // accidental constructor or requirement-routing regression cannot be masked.
   ncclDevCommRequirements reqs = defaultGinReqs();
@@ -1637,7 +1689,8 @@ TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
 
   ASSERT_MPI_EQ(1, devComm.hybridLsaBarrier.nBarriers);
   ASSERT_MPI_EQ(0, devComm.lsaBarrier.nBarriers);
-  ASSERT_MPI_EQ(ncclTeamRail(comm).nRanks, devComm.ginSignalCount);
+  // barrierCount sizes both outer GIN arms: one cell per source rank of the rail team and of the world team.
+  ASSERT_MPI_EQ(ncclTeamRail(comm).nRanks + ncclTeamWorld(comm).nRanks, devComm.ginSignalCount);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1798,6 +1851,104 @@ TEST_F(GinMPIDeviceTests, BarrierPools_AreIsolated) {
   ASSERT_MPI_EQ(lsa.nRanks, observation.dedicatedLsaNRanks);
   ASSERT_MPI_EQ(rail.nRanks, observation.directRailNRanks);
   ASSERT_MPI_EQ(world.nRanks, observation.directWorldNRanks);
+}
+
+// Arrival totals per GIN barrier pool. Shared cells make one pool count both
+// sessions, so every pool holding exactly one session's rounds is the proof.
+struct BarrierPoolSignalSums {
+  uint64_t rail;
+  uint64_t world;
+  uint64_t hybridRail;
+  uint64_t hybridWorld;
+};
+
+__device__ uint64_t sumBarrierSignals(const ncclGin& gin, uint32_t signal0, int nRanks) {
+  uint64_t sum = 0;
+  for (int i = 0; i < nRanks; i++) sum += gin.readSignal(signal0 + i);
+  return sum;
+}
+
+// Direct and generic sessions run on barrier index 0 together. The default fence
+// keeps the generic one on its world arm, so each round feeds two distinct pools.
+__global__ void barrierPoolCrossTalkKernel(
+    int iters, BarrierPoolSignalSums* sums, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclGinBarrierSession<ncclCoopCta> direct{
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/0};
+  ncclBarrierSession<ncclCoopCta> generic{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, /*index=*/0};
+  for (int i = 0; i < iters; i++) {
+    direct.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+    generic.sync(ncclCoopCta(), cuda::memory_order_relaxed);
+  }
+
+  // Leaving the loop means every peer's last round landed in both pools.
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  int railRanks = ncclTeamRail(devComm).nRanks;
+  int worldRanks = ncclTeamWorld(devComm).nRanks;
+  sums->rail = sumBarrierSignals(gin, devComm.railGinBarrier.signal0, railRanks);
+  sums->world = sumBarrierSignals(gin, devComm.worldGinBarrier.signal0, worldRanks);
+  sums->hybridRail = sumBarrierSignals(gin, devComm.hybridRailGinBarrier.signal0, railRanks);
+  sums->hybridWorld = sumBarrierSignals(gin, devComm.hybridWorldGinBarrier.signal0, worldRanks);
+}
+
+// Generic and specialized sessions sharing one index must not share cells.
+TEST_F(GinMPIDeviceTests, BarrierPools_NoCrossTalk) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+  int worldRanks = ncclTeamWorld(comm).nRanks;
+
+  // Enough rounds that a shared cell doubles into an obvious mismatch.
+  constexpr int kIters = 8;
+
+  // Every pool is requested at once so an overlapping allocation cannot hide.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.barrierCount = 1;
+  reqs.railGinBarrierCount = 1;
+  reqs.worldGinBarrierCount = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Railed contexts leave the generic session's world arm unreachable.
+  if (devComm.ginContextsRailed)
+    GTEST_SKIP() << "Requires fully connected GIN contexts";
+
+  BarrierPoolSignalSums* dSums = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dSums, sizeof(BarrierPoolSignalSums)));
+  auto sumsCleanup = makeScopeGuard([&]() {
+    if (dSums) (void)hipFree(dSums);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dSums, 0, sizeof(BarrierPoolSignalSums)));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  barrierPoolCrossTalkKernel<<<kGinKernelBlocks, kGinKernelThreads, 0, stream>>>(
+      kIters, dSums, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  BarrierPoolSignalSums sums{};
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&sums, dSums, sizeof(sums), hipMemcpyDeviceToHost));
+
+  // A relaxed round is signalled by the peers only, a Put round adds our own slot.
+  const uint64_t relaxedRounds = static_cast<uint64_t>(kIters) * (worldRanks - 1);
+  const uint64_t putRounds = static_cast<uint64_t>(kIters) * worldRanks;
+  ASSERT_MPI_EQ(relaxedRounds, sums.world);
+  ASSERT_MPI_EQ(putRounds, sums.hybridWorld);
+  ASSERT_MPI_EQ(uint64_t{0}, sums.rail);
+  ASSERT_MPI_EQ(uint64_t{0}, sums.hybridRail);
+
+  MPI_Barrier(MPI_COMM_WORLD);
 }
 
 // ---------------------------------------------------------------------------
@@ -2290,8 +2441,7 @@ __global__ void alltoallPureKernel(
   // Cross-rank sync ensures every rank's sendbuf is registered before any
   // peer reads from it via gin.put below.
   ncclGinBarrierSession<ncclCoopCta> bar{
-      ncclCoopCta(), gin, ncclTeamWorld(devComm),
-      devComm.railGinBarrier, blockIdx.x};
+      ncclCoopCta(), gin, ncclTeamTagWorld{}, blockIdx.x};
   bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -2336,11 +2486,11 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
   ASSERT_GE(nRanks, 2);
   ASSERT_LE(nRanks, 8);
 
-  // ginSignalCount=1 covers signalIndex=0; railGinBarrierCount=1 matches
-  // our single-CTA launch.
+  // ginSignalCount=1 covers signalIndex=0, and the world barrier count matches
+  // the single-CTA launch below.
   ncclDevCommRequirements reqs = defaultGinReqs();
-  reqs.railGinBarrierCount = 1;
-  reqs.ginSignalCount      = 1;
+  reqs.worldGinBarrierCount = 1;
+  reqs.ginSignalCount       = 1;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {
@@ -2349,7 +2499,7 @@ TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
 
   // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
   const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
-  constexpr int kCTAs          = 1;   // == railGinBarrierCount
+  constexpr int kCTAs          = 1;   // == worldGinBarrierCount
   constexpr int kThreadsPerCTA = 512; // matches the production example launch
 
   for (size_t count : counts) {
@@ -2614,7 +2764,7 @@ TEST_F(GinMPIDeviceTests, DevComm_LegacyGinSignalRequestRejected) {
 }
 
 // A compatible 2.30 request carries its requested ABI version into the returned
-// device communicator; it is not silently stamped with the runtime's version.
+// device communicator, rather than the runtime stamping its own version on it.
 TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
   if (auto reason = cuMemReason(); !reason.empty())
     GTEST_SKIP() << reason;
@@ -2624,8 +2774,10 @@ TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t comm = getActiveCommunicator();
 
+  // 2.30.3 is the oldest version the GIN proxy backend has a GPU context layout
+  // for, and GIN is already enabled on the comm whenever NCCL_GIN_ENABLE is set.
   ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.version = NCCL_VERSION(2, 30, 0);
+  reqs.version = NCCL_VERSION(2, 30, 3);
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
   auto devCommCleanup = makeScopeGuard([&]() {

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1809,13 +1809,39 @@ TEST_F(GinMPIDeviceTests, Barrier_WorldTeamUsesWorldPool) {
 // Small because all CTAs must be resident at once, each waiting on its peers.
 constexpr int kWorldBarrierCtas = 4;
 
+// Per-CTA view of the slice its barrier index resolved to, and of the arrivals
+// that landed there.
+struct MultiIndexBarrierObservation {
+  uint32_t activeSignal;
+  int      completedIters;
+  int      signalMismatches;
+};
+
 // One barrier index per CTA, so the world pool's cell striding is exercised.
-__global__ void barrierWorldMultiIndexKernel(int iters, struct ncclDevComm devComm) {
+__global__ void barrierWorldMultiIndexKernel(
+    int iters, MultiIndexBarrierObservation* observations,
+    struct ncclDevComm devComm) {
   ncclGin gin{devComm, /*ginContext=*/0};
   ncclGinBarrierSession<ncclCoopCta> bar{
       ncclCoopCta(), gin, ncclTeamTagWorld{}, /*barrierIndex=*/blockIdx.x};
+  ncclTeam world = ncclTeamWorld(devComm);
+
+  if (threadIdx.x == 0) observations[blockIdx.x].activeSignal = bar.signal;
+
   for (int i = 0; i < iters; i++) {
     bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+
+  // Only peer CTA k signals this CTA's slice, once per round, so every peer
+  // cell holds exactly iters. CTAs sharing one slice inflates these instead.
+  if (threadIdx.x == 0) {
+    int mismatches = 0;
+    for (int peer = 0; peer < world.nRanks; ++peer) {
+      uint64_t expected = peer == world.rank ? 0 : static_cast<uint64_t>(iters);
+      if (gin.readSignal(bar.signal + peer) != expected) ++mismatches;
+    }
+    observations[blockIdx.x].completedIters = iters;
+    observations[blockIdx.x].signalMismatches = mismatches;
   }
 }
 
@@ -1848,12 +1874,36 @@ TEST_F(GinMPIDeviceTests, Barrier_WorldMultiIndex) {
     (void)ncclDevCommDestroy(comm, &devComm);
   });
 
+  constexpr size_t kObservationBytes =
+      kWorldBarrierCtas * sizeof(MultiIndexBarrierObservation);
+  MultiIndexBarrierObservation* dObservations = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dObservations, kObservationBytes));
+  auto observationsCleanup = makeScopeGuard([&]() {
+    if (dObservations) (void)hipFree(dObservations);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dObservations, 0, kObservationBytes));
+
   // All ranks finished setup before any kernel launches.
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // CTA k barriers with CTA k on every peer, and returning is the assertion.
-  barrierWorldMultiIndexKernel<<<kWorldBarrierCtas, kGinKernelThreads, 0, stream>>>(kIters, devComm);
+  // CTA k barriers with CTA k on every peer.
+  barrierWorldMultiIndexKernel<<<kWorldBarrierCtas, kGinKernelThreads, 0, stream>>>(
+      kIters, dObservations, devComm);
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MultiIndexBarrierObservation observations[kWorldBarrierCtas]{};
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(observations, dObservations, kObservationBytes,
+                                      hipMemcpyDeviceToHost));
+
+  // Completing the barrier is not enough: collapsing the pool's cell striding
+  // scales arrivals and wait targets together, so every CTA still returns.
+  for (int cta = 0; cta < kWorldBarrierCtas; ++cta) {
+    SCOPED_TRACE("barrier index " + std::to_string(cta));
+    ASSERT_MPI_EQ(devComm.worldGinBarrier.signal0 + cta * nRanks,
+                  observations[cta].activeSignal);
+    ASSERT_MPI_EQ(kIters, observations[cta].completedIters);
+    ASSERT_MPI_EQ(0, observations[cta].signalMismatches);
+  }
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -3211,8 +3261,9 @@ TEST_F(GinMPIDeviceTests, DevComm_ReturnsRequestedVersion) {
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t comm = getActiveCommunicator();
 
-  // 2.30.3 is the oldest version the GIN proxy backend has a GPU context layout
-  // for, and GIN is already enabled on the comm whenever NCCL_GIN_ENABLE is set.
+  // Anything below 2.30.3 maps to GIN proxy backend version 0
+  // (proxyBackendMinVersions), which ncclGinProxyGpuCtx_init does not
+  // implement, so ncclDevCommCreate fails.
   ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
   reqs.version = NCCL_VERSION(2, 30, 3);
   ncclDevComm devComm{};

--- a/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/gin_rocshmem_backends_mellanox.json
@@ -133,6 +133,11 @@
           "name": "BarrierSession_Hybrid", "description": "ncclBarrierSession hybrid inner-LSA + outer rail-GIN (2 ranks/node)", "test_filter": "GinMPIDeviceTests.BarrierSession_Hybrid",
           "num_ranks": 4, "num_gpus": 2
         },
+        { "name": "Barrier_WorldMultiIndex", "description": "World-team GIN barrier, 4 concurrent barrier indices", "test_filter": "GinMPIDeviceTests.Barrier_WorldMultiIndex" },
+        {
+          "name": "BarrierPools_NoCrossTalk", "description": "Generic and specialized GIN barrier sessions keep separate signal pools (2 ranks/node, self-skips on a single node)", "test_filter": "GinMPIDeviceTests.BarrierPools_NoCrossTalk",
+          "num_ranks": 4, "num_gpus": 2
+        },
         { "name": "SignalAdd_AndShadow",      "description": "GIN device signal-add and shadow counter",              "test_filter": "GinMPIDeviceTests.SignalAdd_AndShadow" },
         { "name": "SymPtr_PutAndPutValue",    "description": "GIN symmetric-pointer put and put-value",               "test_filter": "GinMPIDeviceTests.SymPtr_PutAndPutValue" },
         { "name": "Alltoall_PureReference",   "description": "GIN pure-reference alltoall kernel",                    "test_filter": "GinMPIDeviceTests.Alltoall_PureReference" },
@@ -143,7 +148,7 @@
         },
         {
           "name": "Alltoall_SdmaInternal", "description": "GIN-SDMA alltoall via ncclAlltoAll (SDMA only, 8 ranks)", "test_filter": "GinMPIDeviceTests.Alltoall_SdmaInternal",
-          "num_ranks": 8, "num_gpus": 8
+          "num_ranks": 8, "num_nodes": 1, "num_gpus": 8
         },
         { "name": "MultiContext_AllFourRoute","description": "GIN multi-context, all four routes",                    "test_filter": "GinMPIDeviceTests.MultiContext_AllFourRoute" },
         {
@@ -193,9 +198,18 @@
       "extends": "gin_devmpi_common",
       "description": "SDMA is a single-node backend: every GinMPIDeviceTests case runs on a single node (num_nodes=1). Cross-node cases (Put_CrossNode/Alltoall_CrossNode/ReduceScatter_Symmetric*) self-skip.",
       "num_nodes": 1,
+      "num_gpus": 2,
       "env_variables": {
         "NCCL_GIN_TYPE": "6"
-      }
+      },
+      "tests": [
+        { "name": "BarrierSession_LsaOnly",      "num_gpus": 4 },
+        { "name": "BarrierSession_Hybrid",       "num_gpus": 4 },
+        { "name": "BarrierPools_NoCrossTalk",    "num_gpus": 4 },
+        { "name": "AlltoallHybrid_Reference",    "num_gpus": 4 },
+        { "name": "ReduceScatter_Symmetric",     "num_gpus": 4 },
+        { "name": "ReduceScatter_Symmetric_Avg", "num_gpus": 4 }
+      ]
     },
 
     "gin_a2a_eligibility": {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3751,6 +3751,24 @@
             "NCCL_GIN_TYPE": "2",
             "NCCL_GIN_ENABLE": "1"
           }
+        },
+        {
+          "name": "GIN_Barrier_WorldMultiIndex",
+          "description": "ncclGinBarrierSession world team with 4 concurrent barrier indices, one per CTA, exercising the cell striding of the pool auto-allocated from worldGinBarrierCount",
+          "test_filter": "GinMPIDeviceTests.Barrier_WorldMultiIndex",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GIN_BarrierPools_NoCrossTalk",
+          "description": "Generic ncclBarrierSession and the specialized GIN sessions run on the same barrier index and must advance only their own signal pools, covering the hybrid world arm the default fence selects under fully connected GIN",
+          "test_filter": "GinMPIDeviceTests.BarrierPools_NoCrossTalk",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3756,6 +3756,7 @@
           "name": "GIN_Barrier_WorldMultiIndex",
           "description": "ncclGinBarrierSession world team with 4 concurrent barrier indices, one per CTA, exercising the cell striding of the pool auto-allocated from worldGinBarrierCount",
           "test_filter": "GinMPIDeviceTests.Barrier_WorldMultiIndex",
+          "num_ranks": 2, "num_nodes": 2, "num_gpus": 1,
           "env_variables": {
             "NCCL_GIN_TYPE": "2",
             "NCCL_GIN_ENABLE": "1"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3705,6 +3705,24 @@
             "NCCL_GIN_TYPE": "2",
             "NCCL_GIN_ENABLE": "1"
           }
+        },
+        {
+          "name": "GIN_Barrier_WorldMultiIndex",
+          "description": "ncclGinBarrierSession world team with 4 concurrent barrier indices, one per CTA, exercising the cell striding of the pool auto-allocated from worldGinBarrierCount",
+          "test_filter": "GinMPIDeviceTests.Barrier_WorldMultiIndex",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
+        },
+        {
+          "name": "GIN_BarrierPools_NoCrossTalk",
+          "description": "Generic ncclBarrierSession and the specialized GIN sessions run on the same barrier index and must advance only their own signal pools, covering the hybrid world arm the default fence selects under fully connected GIN",
+          "test_filter": "GinMPIDeviceTests.BarrierPools_NoCrossTalk",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Motivation

BarrierSession updates:

- `ncclGinBarrierSession` can now be created directly for the world team, without manually allocating the barrier resource.
- `ncclBarrierSession` no longer shares resources with `ncclLsaBarrierSession` or `ncclGinBarrierSession`.

Both reached RCCL with the sync to NCCL v2.30.4-1 (b40d918f58, #6837), and the generic session's world arm followed in the drop_2026-07 sync (131884a2ba, #9924).

## Technical Details

- `ncclGinBarrierSession` : worldGinBarrierCount allocates the world barrier pool at devcomm create and the ncclTeamTagWorld constructor binds a session to it, so no manual barrier requirement is needed, and each session takes its own slice at signal0 + barrierIndex * nRanks.

- `ncclBarrierSession` : barrierCount now allocates hybridLsaBarrier, hybridRailGinBarrier and hybridWorldGinBarrier for it instead of reusing lsaBarrier and railGinBarrier, and its world arm is picked when the fence asks for Put and GIN is not railed.

## Issue Tracking

JIRA ID: AICOMRCCL-1868, AICOMRCCL-1871

## Test Plan

- `Barrier_WorldMultiIndex`: 4 CTAs each sync on their own barrier index for 16 rounds, so overlapping slices deadlock instead of passing. Runs at 2 to 8 ranks.

- `BarrierPools_NoCrossTalk`: a direct GIN world session and a generic session run on index 0 together, then all four pools are summed.

- `Alltoall_PureReference` moved to the tag constructor and `worldGinBarrierCount`.

## Test Result

`Barrier_WorldMultiIndex` and `BarrierPools_NoCrossTalk` added and pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
