### PR TITLE
[rocjitsu] Materialize CU paths only for tracing

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -7001,7 +7001,6 @@ class CodeGenerator:
         L.append('    d->lane_mask = exec; d->exec_mask = exec;')
         L.append('    d->wf_size = wf.wf_size();')
         L.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
-        L.append('    d->cu_path = wf.cu().full_path();')
         L.append('    uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);')
         offset_expr = (
             'signed_ioffset(inst_.ioffset)'
@@ -7388,7 +7387,6 @@ class CodeGenerator:
         L.append('  d->lane_mask = exec;')
         L.append('  d->wg_id = wf.wg_id();')
         L.append('  d->wf_id = wf.wf_id();')
-        L.append('  d->cu_path = wf.cu().full_path();')
         L.append('  uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);')
         L.append('  uint32_t addr = wf.lds_base() + wf.m0() + offset;')
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
@@ -7598,7 +7596,6 @@ class CodeGenerator:
         lines.append('    uint64_t exec = wf.exec();')
         lines.append('    d->lane_mask = exec; d->exec_mask = exec;')
         lines.append('    d->wg_id = wf.wg_id(); d->wf_id = wf.wf_id();')
-        lines.append('    d->cu_path = wf.cu().full_path();')
         lines.append(
             '    uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;'
         )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -75,7 +75,6 @@ void init_vector_mem_state(amdgpu::Wavefront &wf, amdgpu::VectorMemState &d) {
   d.wf_size = wf.wf_size();
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
-  d.cu_path = wf.cu().full_path();
 }
 
 int64_t logical_buffer_offset(uint32_t index, uint32_t stride, uint32_t voffset, int32_t ioffset) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/ds_exec.cpp
@@ -2628,7 +2628,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
@@ -2656,7 +2655,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2681,7 +2679,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/ds_exec.cpp
@@ -2680,7 +2680,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
@@ -2708,7 +2707,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2733,7 +2731,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/ds_exec.cpp
@@ -2729,7 +2729,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
@@ -2805,7 +2804,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2830,7 +2828,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/ds_exec.cpp
@@ -2699,7 +2699,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;
@@ -2775,7 +2774,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2800,7 +2798,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
@@ -1304,7 +1304,6 @@ void DsConsumeVds::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1329,7 +1328,6 @@ void DsAppendVds::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -3073,7 +3071,6 @@ void DsStoreAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -3113,7 +3110,6 @@ void DsLoadAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vglobal_exec.cpp
@@ -468,7 +468,6 @@ void GlobalLoadAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_size = wf.wf_size();
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
     int64_t offset = static_cast<int64_t>(signed_ioffset(inst_.ioffset));
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -496,7 +495,6 @@ void GlobalStoreAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_size = wf.wf_size();
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
     int64_t offset = static_cast<int64_t>(signed_ioffset(inst_.ioffset));
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/ds_exec.cpp
@@ -1259,7 +1259,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1284,7 +1283,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2675,7 +2673,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/ds_exec.cpp
@@ -1259,7 +1259,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1284,7 +1283,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2675,7 +2673,6 @@ void DsReadAddtidB32Ds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/ds_exec.cpp
@@ -1259,7 +1259,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1284,7 +1283,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/ds_exec.cpp
@@ -1259,7 +1259,6 @@ void DsConsumeDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1284,7 +1283,6 @@ void DsAppendDs::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vds_exec.cpp
@@ -1072,7 +1072,6 @@ void DsConsumeVds::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -1095,7 +1094,6 @@ void DsAppendVds::execute_impl(amdgpu::Wavefront &wf) {
   d->lane_mask = exec;
   d->wg_id = wf.wg_id();
   d->wf_id = wf.wf_id();
-  d->cu_path = wf.cu().full_path();
   uint32_t offset = inst_.offset0 | (inst_.offset1 << 8);
   uint32_t addr = wf.lds_base() + wf.m0() + offset;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -2489,7 +2487,6 @@ void DsLoadAddtidB32Vds::execute_impl(amdgpu::Wavefront &wf) {
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst_.offset1) << 8) | inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vglobal_exec.cpp
@@ -422,7 +422,6 @@ void GlobalLoadAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_size = wf.wf_size();
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
     int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -450,7 +449,6 @@ void GlobalStoreAddtidB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     d->wf_size = wf.wf_size();
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint64_t base = amdgpu::RegisterAccess(wf).read_scalar64(saddr);
     int64_t offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/shared/execute_shared.h
@@ -162,7 +162,6 @@ inline void execute_ds_load_addtid_b32_ds([[maybe_unused]] Inst &inst,
     d->exec_mask = exec;
     d->wg_id = wf.wg_id();
     d->wf_id = wf.wf_id();
-    d->cu_path = wf.cu().full_path();
     uint32_t offset = (static_cast<uint32_t>(inst.inst_.offset1) << 8) | inst.inst_.offset0;
     uint32_t m0 = wf.m0();
     uint32_t ds_stride_bytes = ((m0 >> 16) & 0x1FF) * 4;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/addr_calc.cpp
@@ -49,7 +49,6 @@ void init_vector_mem_state(amdgpu::Wavefront &wf, amdgpu::VectorMemState &d) {
   d.wf_size = wf.wf_size();
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
-  d.cu_path = wf.cu().full_path();
 }
 
 } // namespace

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_buffer.h
@@ -54,7 +54,6 @@ void mubuf_calculate_addresses(const MubufInst &inst, amdgpu::Wavefront &wf, Vec
   d.wf_size = wf.wf_size();
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
-  d.cu_path = wf.cu().full_path();
   const uint32_t sb_sel = inst.srsrc * 4;
   uint32_t srd0 = amdgpu::read_scalar_selector(wf, sb_sel);
   uint32_t srd1 = amdgpu::read_scalar_selector(wf, sb_sel + 1);
@@ -164,7 +163,6 @@ void mtbuf_calculate_addresses(const MtbufInst &inst, amdgpu::Wavefront &wf, Vec
   d.wf_size = wf.wf_size();
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
-  d.cu_path = wf.cu().full_path();
   const uint32_t sb_sel = inst.srsrc * 4;
   uint32_t srd0 = amdgpu::read_scalar_selector(wf, sb_sel);
   uint32_t srd1 = amdgpu::read_scalar_selector(wf, sb_sel + 1);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_scalar.h
@@ -64,7 +64,6 @@ void ds_calculate_addresses(const DsInst &inst, amdgpu::Wavefront &wf, VectorMem
   d.wf_size = wf.wf_size();
   d.wg_id = wf.wg_id();
   d.wf_id = wf.wf_id();
-  d.cu_path = wf.cu().full_path();
   uint32_t offset = (static_cast<uint32_t>(inst.offset1) << 8) | inst.offset0;
   RegisterAccess regs(cu);
   auto addr_region = regs.read_vgpr_region(wf.vgpr_alloc().base + inst.addr, 1, exec);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -223,8 +223,10 @@ Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint6
   std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + num_sgprs, wf);
   fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgpr_allocation_block_size(), wf);
 
-  util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", wf_id,
-                   " pc=0x", std::hex, pc, std::dec, " wg=", wg_id, " pid=", wf->process_id());
+  util::Logger::cp([&](auto &os) {
+    os << "DISPATCH_WF cu=" << full_path() << " wf=" << wf->wf_id() << " slot=" << wf_id << " pc=0x"
+       << std::hex << pc << std::dec << " wg=" << wg_id << " pid=" << wf->process_id();
+  });
 
   schedule_work();
   return wf;
@@ -708,7 +710,7 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
     if (active->num_vgprs_ > 0) {
       util::Logger::vm([&](auto &os) {
         uint32_t vb = active->vgpr_alloc().base;
-        os << std::format("{} wg[{}] wf[{}] EXECUTE #{} pc={:#x} {} sz={}", this->full_path(),
+        os << std::format("{} wg[{}] wf[{}] EXECUTE #{} pc={:#x} {} sz={}", full_path(),
                           active->wg_id(), active->wf_id(), active->trace_inst_count_, active->pc,
                           inst->mnemonic(), inst_size);
         os << " enc=";
@@ -1016,7 +1018,7 @@ bool ComputeUnitCore::step() {
   if constexpr (util::Logger::group_enabled(util::Logger::GROUP_CP)) {
     if ((step_count_ & 0xFFFFF) == 0) {
       util::Logger::cp([&](auto &os) {
-        os << std::format("CU[{}] steps={}M", this->full_path(), step_count_ >> 20);
+        os << std::format("CU[{}] steps={}M", full_path(), step_count_ >> 20);
         for (auto &wf : wfs_) {
           auto st = wf->state();
           if (st == WfState::RUNNING || st == WfState::WAITCNT || st == WfState::BARRIER)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -20,7 +20,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
-#include <string>
 #include <vector>
 
 namespace rocjitsu {
@@ -206,9 +205,10 @@ struct VectorMemState : DynamicInstState {
   bool cluster_multicast = false;  ///< Cluster async-to-LDS load: multicast LDS writes by M0 mask.
   uint32_t cluster_mcast_mask = 0; ///< Cluster workgroup destination mask captured at issue time.
   uint64_t issue_pc = 0;           ///< PC at which the instruction was issued (debug).
-  uint32_t wg_id = 0;              ///< Workgroup ID (for trace output).
-  uint32_t wf_id = 0;              ///< Wavefront ID within WG (for trace output).
-  std::string cu_path;             ///< CU full path (for trace output).
+  // Snapshot dispatch identity at issue time for deferred trace output. The CU
+  // is stable for the slot, so its path is materialized only inside log lambdas.
+  uint32_t wg_id = 0; ///< Workgroup ID (for trace output).
+  uint32_t wf_id = 0; ///< Wavefront ID within WG (for trace output).
   std::vector<uint8_t> response_data;
   std::vector<uint8_t> store_data;
   uint8_t transpose = 0; ///< Transpose-load kind (0=none, see ds_transpose.h).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -93,8 +93,8 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
     if (++lds_dst_trace > 80)
       return;
     os << std::format("{} wg[{}] wf[{}] BUF->LDS: lds_base={:#x} plb={} mcast={:#x} targets={}",
-                      d.cu_path, d.wg_id, d.wf_id, d.lds_base, per_lane_bytes, d.cluster_mcast_mask,
-                      target_count);
+                      cu.full_path(), d.wg_id, d.wf_id, d.lds_base, per_lane_bytes,
+                      d.cluster_mcast_mask, target_count);
     for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
       if (!(d.lane_mask & (1ULL << ln)))
         continue;
@@ -155,7 +155,7 @@ MemoryAccessCompletion vector_complete(VectorMemState &d, Wavefront &wf, Compute
       static uint64_t oob_count = 0;
       if (++oob_count > 10)
         return;
-      os << d.cu_path << " wg[" << d.wg_id << "] wf[" << d.wf_id
+      os << cu.full_path() << " wg[" << d.wg_id << "] wf[" << d.wf_id
          << "] OOB zeroing: exec=" << std::hex << d.exec_mask << " lane=" << d.lane_mask
          << " oob=" << oob_mask << std::dec << " dst=" << d.dst_reg_base << " vgprs=" << vgpr_count;
     });
@@ -485,11 +485,8 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds,
 
 void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   auto &d = *inst.data_as<VectorMemState>();
-  if (d.cu_path.empty()) {
-    d.cu_path = wf.cu().full_path();
-    d.wg_id = wf.wg_id();
-    d.wf_id = wf.wf_id();
-  }
+  d.wg_id = wf.wg_id();
+  d.wf_id = wf.wf_id();
   if (d.atomic_op != AtomicOp::NONE) {
     execute_atomic_rmw(d, l2_, wf.process_id());
     return;
@@ -542,11 +539,8 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   auto &d = *inst.data_as<VectorMemState>();
   auto &lds = wf.lds();
   d.wf_size = wf.wf_size();
-  if (d.cu_path.empty()) {
-    d.cu_path = wf.cu().full_path();
-    d.wg_id = wf.wg_id();
-    d.wf_id = wf.wf_id();
-  }
+  d.wg_id = wf.wg_id();
+  d.wf_id = wf.wf_id();
   if (d.atomic_op != AtomicOp::NONE) {
     execute_lds_atomic_rmw(d, &lds, d.per_lane_addr, d.store_data, d.response_data);
     if (d.ds2_active) {
@@ -569,8 +563,8 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
       static thread_local uint64_t ds_ld_trace = 0;
       if (++ds_ld_trace > 80)
         return;
-      os << std::format("{} wg[{}] wf[{}] DS load: esz={} nelm={} ds2={}", d.cu_path, d.wg_id,
-                        d.wf_id, d.elem_size, d.num_elems, d.ds2_active);
+      os << std::format("{} wg[{}] wf[{}] DS load: esz={} nelm={} ds2={}", wf.cu().full_path(),
+                        d.wg_id, d.wf_id, d.elem_size, d.num_elems, d.ds2_active);
       uint32_t stride = d.num_elems * d.elem_size;
       for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
         if (!(d.lane_mask & (1ULL << ln)))
@@ -601,8 +595,8 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
           in_region = true;
       if (!in_region && ++ds_st_trace > 80)
         return;
-      os << std::format("{} wg[{}] wf[{}] DS store: esz={} nelm={} ds2={}", d.cu_path, d.wg_id,
-                        d.wf_id, d.elem_size, d.num_elems, d.ds2_active);
+      os << std::format("{} wg[{}] wf[{}] DS store: esz={} nelm={} ds2={}", wf.cu().full_path(),
+                        d.wg_id, d.wf_id, d.elem_size, d.num_elems, d.ds2_active);
       uint32_t stride = d.num_elems * d.elem_size;
       for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
         if (!(d.lane_mask & (1ULL << ln)))

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -162,6 +162,17 @@ public:
   }
 };
 
+class TestGlobalMemPipeline : public GlobalMemPipeline {
+public:
+  using GlobalMemPipeline::GlobalMemPipeline;
+  using GlobalMemPipeline::initiate_access;
+};
+
+class TestLocalMemPipeline : public LocalMemPipeline {
+public:
+  using LocalMemPipeline::initiate_access;
+};
+
 class TestWaitcntInstruction : public Instruction {
 public:
   TestWaitcntInstruction() : Instruction("s_waitcnt", nullptr) {}
@@ -2512,6 +2523,32 @@ TEST(ExecutionPluginTest, MemoryPipelineCompletionDoesNotObserveInstructionWrite
 
   EXPECT_TRUE(vgpr_write_events(*plugin).empty());
   EXPECT_EQ(cu->read_vgpr_storage(wf->vgpr_alloc().base + kDst, 0), kLoadedValue);
+}
+
+TEST(ExecutionPluginTest, MemoryPipelinesSnapshotDispatchIdentityAtIssue) {
+  PluginFixture f(/*num_wf_slots=*/4);
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf_at(/*wf_id=*/3, /*wg_id=*/17, /*pc=*/0, /*num_sgprs=*/104,
+                                /*num_vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+
+  auto global_state = std::make_unique<VectorMemState>(GLOBAL_MEM);
+  global_state->wg_id = 101;
+  global_state->wf_id = 202;
+  TestMemoryInstruction global_inst(std::move(global_state));
+  TestGlobalMemPipeline global_pipeline(&cu->l1_vector(), cu->l2());
+  global_pipeline.initiate_access(global_inst, *wf);
+  EXPECT_EQ(global_inst.data_as<VectorMemState>()->wg_id, 17u);
+  EXPECT_EQ(global_inst.data_as<VectorMemState>()->wf_id, 3u);
+
+  auto local_state = std::make_unique<VectorMemState>(LOCAL_MEM);
+  local_state->wg_id = 101;
+  local_state->wf_id = 202;
+  TestMemoryInstruction local_inst(std::move(local_state));
+  TestLocalMemPipeline local_pipeline;
+  local_pipeline.initiate_access(local_inst, *wf);
+  EXPECT_EQ(local_inst.data_as<VectorMemState>()->wg_id, 17u);
+  EXPECT_EQ(local_inst.data_as<VectorMemState>()->wf_id, 3u);
 }
 
 TEST(ExecutionPluginTest, D16MemoryCompletionPreservesHalfWithoutObservation) {


### PR DESCRIPTION
Materialize compute-unit paths only inside enabled tracing callbacks instead of caching them on each CU or storing them in per-instruction memory state. Keep workgroup and wave IDs captured at issue so deferred memory traces retain the correct dispatch identity.

This removes disabled-tracing string construction and path storage without introducing a borrowed-path lifetime contract. Convert dispatch and memory trace sites to lazy logger form, regenerate the affected instruction sources, and cover nonzero pipeline trace identity.

On simulated gfx1250, medians from three CPU-pinned samples per revision improve active throughput by 3.91% overall and 4.10% across the full 26-case IREE suite versus `1e5754f`. Overall and IREE end-to-end time fall by 1.28% and 2.58%; Gluon wall time changes by +0.12% across 10 representative cases. User cycles and instructions fall by 0.45% and 0.44%. All 36 benchmark cases pass with identical wave-instruction counts, and 31 focused memory, LDS, and address-calculation tests pass.