### PR TITLE
[rocjitsu] Materialize LDS backing on demand

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds.h
@@ -6,7 +6,9 @@
 
 #include "simdojo/components/memory_interface.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -23,25 +25,37 @@ constexpr uint32_t kInvalidLdsAddress = UINT32_MAX;
 /// RDNA WGP-mode workgroups use a backing owned by the sibling-CU pair. The
 /// latter has the combined capacity of both physical CUs. Addresses are
 /// byte-granularity and local to the selected placement (not globally visible).
+/// Logical capacity is independent of host storage: unmaterialized bytes read
+/// as zero, while writes and workgroup reservations grow a contiguous,
+/// prefix in fixed 4 KiB backing granules. Clearing LDS retains the materialized
+/// prefix for reuse.
 class Lds : public simdojo::MemoryInterface {
 public:
   /// @brief Construct LDS with the given size in kilobytes.
-  explicit Lds(uint32_t size_kb) : data_(static_cast<size_t>(size_kb) * 1024, 0) {}
+  explicit Lds(uint32_t size_kb) : capacity_bytes_(static_cast<size_t>(size_kb) * 1024) {}
 
   /// @brief Return the total size in bytes.
-  size_t size_bytes() const { return data_.size(); }
+  size_t size_bytes() const { return capacity_bytes_; }
+
+  /// @brief Return the bytes currently backed by host storage.
+  ///
+  /// @details The remaining logical capacity reads as zero and is materialized
+  /// on the first write or workgroup allocation that reaches it. This accessor
+  /// is intended for diagnostics and allocation tests.
+  size_t materialized_size_bytes() const { return data_.size(); }
 
   /// @brief Read a single byte from LDS. OOB returns 0.
   uint8_t read8(uint32_t addr) const {
-    if (addr >= data_.size())
+    if (addr >= capacity_bytes_ || addr >= data_.size())
       return 0;
     return data_[addr];
   }
 
   /// @brief Write a single byte to LDS. OOB writes are dropped.
   void write8(uint32_t addr, uint8_t val) {
-    if (addr >= data_.size())
+    if (addr >= capacity_bytes_)
       return;
+    ensure_materialized(static_cast<size_t>(addr) + 1);
     data_[addr] = val;
   }
 
@@ -49,8 +63,8 @@ public:
   uint16_t read16(uint32_t addr) const {
     if (!contains(addr, 2))
       return 0;
-    uint16_t val;
-    std::memcpy(&val, &data_[addr], 2);
+    uint16_t val = 0;
+    read_backing(addr, reinterpret_cast<uint8_t *>(&val), sizeof(val));
     return val;
   }
 
@@ -58,6 +72,7 @@ public:
   void write16(uint32_t addr, uint16_t val) {
     if (!contains(addr, 2))
       return;
+    ensure_materialized(static_cast<size_t>(addr) + sizeof(val));
     std::memcpy(&data_[addr], &val, 2);
   }
 
@@ -65,8 +80,8 @@ public:
   uint32_t read32(uint32_t addr) const {
     if (!contains(addr, 4))
       return 0;
-    uint32_t val;
-    std::memcpy(&val, &data_[addr], 4);
+    uint32_t val = 0;
+    read_backing(addr, reinterpret_cast<uint8_t *>(&val), sizeof(val));
     return val;
   }
 
@@ -74,6 +89,7 @@ public:
   void write32(uint32_t addr, uint32_t val) {
     if (!contains(addr, 4))
       return;
+    ensure_materialized(static_cast<size_t>(addr) + sizeof(val));
     std::memcpy(&data_[addr], &val, 4);
   }
 
@@ -81,8 +97,8 @@ public:
   uint64_t read64(uint32_t addr) const {
     if (!contains(addr, 8))
       return 0;
-    uint64_t val;
-    std::memcpy(&val, &data_[addr], 8);
+    uint64_t val = 0;
+    read_backing(addr, reinterpret_cast<uint8_t *>(&val), sizeof(val));
     return val;
   }
 
@@ -90,36 +106,45 @@ public:
   void write64(uint32_t addr, uint64_t val) {
     if (!contains(addr, 8))
       return;
+    ensure_materialized(static_cast<size_t>(addr) + sizeof(val));
     std::memcpy(&data_[addr], &val, 8);
   }
 
   /// @brief Bulk read of arbitrary size from LDS. OOB returns 0.
   void read(uint32_t addr, uint8_t *dst, uint32_t size) const {
+    if (size == 0)
+      return;
     if (!contains(addr, size)) {
       std::memset(dst, 0, size);
       return;
     }
-    std::memcpy(dst, &data_[addr], size);
+    read_backing(addr, dst, size);
   }
 
   /// @brief Bulk write of arbitrary size to LDS. OOB writes are dropped.
   void write(uint32_t addr, const uint8_t *src, uint32_t size) {
-    if (!contains(addr, size))
+    if (size == 0 || !contains(addr, size))
       return;
+    ensure_materialized(static_cast<size_t>(addr) + size);
     std::memcpy(&data_[addr], src, size);
   }
 
   /// @brief MemoryInterface read (truncates addr to 32-bit local address).
   void read(uint64_t addr, uint8_t *dst, uint32_t size) override {
+    if (size == 0)
+      return;
     auto a = static_cast<uint32_t>(addr);
     assert(contains(a, size));
-    std::memcpy(dst, &data_[a], size);
+    read_backing(a, dst, size);
   }
 
   /// @brief MemoryInterface write (truncates addr to 32-bit local address).
   void write(uint64_t addr, const uint8_t *src, uint32_t size) override {
+    if (size == 0)
+      return;
     auto a = static_cast<uint32_t>(addr);
     assert(contains(a, size));
+    ensure_materialized(static_cast<size_t>(a) + size);
     std::memcpy(&data_[a], src, size);
   }
 
@@ -145,11 +170,11 @@ public:
       uint64_t base = static_cast<uint64_t>(static_cast<uint32_t>(addrs[lane])) + base_offset;
       for (uint32_t e = 0; e < num_elems; ++e) {
         uint64_t ea = base + static_cast<uint64_t>(e) * elem_size;
-        if (ea + elem_size > data_.size()) {
+        if (ea + elem_size > capacity_bytes_) {
           std::memset(dst + lane * stride + e * elem_size, 0, elem_size);
           continue;
         }
-        std::memcpy(dst + lane * stride + e * elem_size, &data_[ea], elem_size);
+        read_backing(static_cast<uint32_t>(ea), dst + lane * stride + e * elem_size, elem_size);
       }
     }
   }
@@ -164,31 +189,61 @@ public:
       uint64_t base = static_cast<uint64_t>(static_cast<uint32_t>(addrs[lane])) + base_offset;
       for (uint32_t e = 0; e < num_elems; ++e) {
         uint64_t ea = base + static_cast<uint64_t>(e) * elem_size;
-        if (ea + elem_size > data_.size())
+        if (ea + elem_size > capacity_bytes_)
           continue;
+        ensure_materialized(static_cast<size_t>(ea) + elem_size);
         std::memcpy(&data_[ea], src + lane * stride + e * elem_size, elem_size);
       }
     }
   }
 
   /// @brief Zero all LDS contents.
-  void clear() { std::memset(data_.data(), 0, data_.size()); }
-
-  void zero_range(uint32_t offset, uint32_t len) {
-    uint32_t end = std::min(static_cast<uint32_t>(data_.size()), offset + len);
-    if (offset < end)
-      std::memset(&data_[offset], 0, end - offset);
+  void clear() {
+    if (!data_.empty())
+      std::memset(data_.data(), 0, data_.size());
   }
 
-  /// @brief Direct pointer access (for DMA or debugging).
-  const uint8_t *data() const { return data_.data(); }
-  uint8_t *data() { return data_.data(); }
+  void zero_range(uint32_t offset, uint32_t len) {
+    const size_t begin = offset;
+    const size_t end = std::min(capacity_bytes_, begin + static_cast<size_t>(len));
+    if (begin >= end)
+      return;
+    ensure_materialized(end);
+    std::memset(&data_[begin], 0, end - begin);
+  }
 
 private:
   bool contains(uint32_t addr, uint32_t size) const {
-    return static_cast<uint64_t>(addr) + size <= data_.size();
+    return static_cast<uint64_t>(addr) + size <= capacity_bytes_;
   }
 
+  void read_backing(uint32_t addr, uint8_t *dst, uint32_t size) const {
+    const size_t begin = addr;
+    const size_t backed = begin < data_.size() ? std::min<size_t>(size, data_.size() - begin) : 0;
+    if (backed != 0)
+      std::memcpy(dst, &data_[begin], backed);
+    if (backed != size)
+      std::memset(dst + backed, 0, size - backed);
+  }
+
+  void ensure_materialized(size_t required) {
+    if (required <= data_.size())
+      return;
+    assert(required <= capacity_bytes_);
+
+    // Grow in fixed 4 KiB backing granules so storage tracks the allocated LDS
+    // prefix without exposing vector growth heuristics as part of the model.
+    constexpr size_t kBackingGranuleBytes = 4096;
+    size_t rounded = required;
+    const size_t remainder = rounded % kBackingGranuleBytes;
+    if (remainder != 0) {
+      const size_t increment = kBackingGranuleBytes - remainder;
+      rounded = increment <= capacity_bytes_ - rounded ? rounded + increment : capacity_bytes_;
+    }
+    data_.resize(rounded, 0);
+  }
+
+  size_t capacity_bytes_ = 0;
   std::vector<uint8_t> data_;
 };
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -412,6 +412,7 @@ add_executable(
     cdna5_instruction_test.cpp
     cdna5_sdma_test.cpp
     cdna5_tensor_dma_test.cpp
+    lds_test.cpp
     l2_cache_test.cpp
     sparse_memory_test.cpp
     simdojo_sim_test.cpp

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -234,6 +234,65 @@ void step_until_halted(simdojo::SimulationEngine &engine,
   }
 }
 
+TEST(LdsAllocationTest, ZeroLdsDispatchKeepsCuBackingUnmaterialized) {
+  VmFixture f("cdna5", 1, 8, /*lds_size_kb=*/64);
+  constexpr uint32_t kCdna5Endpgm = 0xBFB00000u;
+  const uint64_t kernel_object = f.write_kernel(0x1000, &kCdna5Endpgm, sizeof(kCdna5Endpgm));
+  test::AqlQueue queue(f.mem(), f.cp());
+
+  ASSERT_EQ(f.cu()->lds().materialized_size_bytes(), 0u);
+  queue.dispatch(kernel_object, /*grid_size_x=*/32, /*workgroup_size_x=*/32);
+  ASSERT_NO_THROW(f.engine->run());
+  EXPECT_EQ(f.cu()->lds().materialized_size_bytes(), 0u);
+}
+
+TEST(LdsAllocationTest, DescriptorFixedSizeMaterializesWorkgroupBacking) {
+  VmFixture f("cdna5", 1, 8, /*lds_size_kb=*/64);
+  constexpr uint32_t kStaticLdsBytes = 1537;
+  constexpr uint32_t kCdna5Endpgm = 0xBFB00000u;
+  const uint32_t code[] = {kCdna5Endpgm};
+  const uint64_t kernel_object =
+      f.write_kernel(0x1000, code, sizeof(code), /*sgprs=*/104, /*vgprs=*/256,
+                     /*user_sgprs=*/2, kStaticLdsBytes);
+  test::AqlQueue queue(f.mem(), f.cp());
+
+  ASSERT_EQ(f.cu()->lds().materialized_size_bytes(), 0u);
+  queue.dispatch(kernel_object, /*grid_size_x=*/32, /*workgroup_size_x=*/32);
+  ASSERT_NO_THROW(f.engine->run());
+
+  constexpr uint32_t kAlignedStaticLdsBytes = 1792;
+  EXPECT_GE(f.cu()->lds().materialized_size_bytes(), kAlignedStaticLdsBytes);
+  EXPECT_LT(f.cu()->lds().materialized_size_bytes(), f.cu()->lds().size_bytes());
+}
+
+TEST(LdsAllocationTest, PacketGroupSizeMaterializesDynamicWorkgroupBacking) {
+  VmFixture f("cdna5", 1, 8, /*lds_size_kb=*/64);
+  constexpr uint32_t kCdna5Endpgm = 0xBFB00000u;
+  const uint32_t code[] = {kCdna5Endpgm};
+  const uint64_t kernel_object = f.write_kernel(0x1000, code, sizeof(code));
+  constexpr uint32_t kDynamicLdsBytes = 6145;
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  packet.setup = 1;
+  packet.workgroup_size_x = 32;
+  packet.workgroup_size_y = 1;
+  packet.workgroup_size_z = 1;
+  packet.grid_size_x = 32;
+  packet.grid_size_y = 1;
+  packet.grid_size_z = 1;
+  packet.group_segment_size = kDynamicLdsBytes;
+  packet.kernel_object = kernel_object;
+  test::AqlQueue queue(f.mem(), f.cp());
+
+  ASSERT_EQ(f.cu()->lds().materialized_size_bytes(), 0u);
+  queue.submit(packet);
+  ASSERT_NO_THROW(f.engine->run());
+
+  constexpr uint32_t kAlignedDynamicLdsBytes = 6400;
+  EXPECT_GE(f.cu()->lds().materialized_size_bytes(), kAlignedDynamicLdsBytes);
+  EXPECT_LT(f.cu()->lds().materialized_size_bytes(), f.cu()->lds().size_bytes());
+}
+
 TEST(RdnaDispatchTest, DescriptorSelectsCoherentWaveWidthAndVgprGranule) {
   constexpr uint32_t kRdnaEndpgm = 0xBFB00000u;
 
@@ -431,6 +490,21 @@ TEST(RdnaDispatchTest, WgpModeCombinesSiblingCuLdsCapacity) {
     for (const auto &wf : snap->snapshots())
       EXPECT_EQ(wf.lds_size_bytes, kWgpLdsBytes);
   }
+}
+
+TEST(RdnaDispatchTest, ZeroLdsReservationKeepsWgpBackingUnmaterialized) {
+  VmFixture f("rdna4", 2, 10, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+  amdgpu::DispatchEntry entry{};
+  entry.dispatch_id = 1;
+  entry.wgp_mode = true;
+  entry.group_segment_fixed_size = 0;
+
+  auto placement = f.se()->spi().allocate_workgroup(entry, /*global_wg_id=*/0);
+  ASSERT_TRUE(placement.has_value());
+  ASSERT_NE(placement->lds, nullptr);
+  EXPECT_NE(placement->lds, &placement->cu->lds());
+  EXPECT_EQ(placement->lds->materialized_size_bytes(), 0u);
+  EXPECT_TRUE(f.se()->spi().release_wgp_workgroup(entry.dispatch_id, /*global_wg_id=*/0));
 }
 
 TEST(AqlDispatchTest, InitializesModeFromComputePgmRsrc1) {

--- a/emulation/rocjitsu/tests/lds_test.cpp
+++ b/emulation/rocjitsu/tests/lds_test.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/lds.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+using rocjitsu::amdgpu::Lds;
+
+TEST(LdsTest, ConstructionKeepsLogicalCapacityUnmaterialized) {
+  Lds lds(320);
+
+  EXPECT_EQ(lds.size_bytes(), 320u * 1024u);
+  EXPECT_EQ(lds.materialized_size_bytes(), 0u);
+  EXPECT_EQ(lds.read32(0), 0u);
+  EXPECT_EQ(lds.read32(320u * 1024u - sizeof(uint32_t)), 0u);
+  EXPECT_EQ(lds.materialized_size_bytes(), 0u);
+}
+
+TEST(LdsTest, ZeroRangeMaterializesOnlyAWorkingPrefix) {
+  Lds lds(320);
+
+  lds.zero_range(512, 256);
+  EXPECT_GE(lds.materialized_size_bytes(), 768u);
+  EXPECT_LT(lds.materialized_size_bytes(), lds.size_bytes());
+
+  lds.write32(700, 0xA5A5A5A5u);
+  lds.zero_range(512, 256);
+  EXPECT_EQ(lds.read32(700), 0u);
+  EXPECT_LT(lds.materialized_size_bytes(), lds.size_bytes());
+}
+
+TEST(LdsTest, ReadsAcrossBackingBoundaryPreserveImplicitZeros) {
+  Lds lds(64);
+  lds.zero_range(0, 256);
+  const auto boundary = lds.materialized_size_bytes();
+  ASSERT_GE(boundary, 256u);
+  ASSERT_LT(boundary, lds.size_bytes());
+  lds.write8(static_cast<uint32_t>(boundary - 1), 0xAB);
+
+  EXPECT_EQ(lds.read16(static_cast<uint32_t>(boundary - 1)), 0x00ABu);
+  std::array<uint8_t, 4> bytes{0xFF, 0xFF, 0xFF, 0xFF};
+  static_cast<const Lds &>(lds).read(static_cast<uint32_t>(boundary - 1), bytes.data(),
+                                     static_cast<uint32_t>(bytes.size()));
+  EXPECT_EQ(bytes, (std::array<uint8_t, 4>{0xAB, 0, 0, 0}));
+  EXPECT_EQ(lds.materialized_size_bytes(), boundary);
+}
+
+TEST(LdsTest, VectorAccessesCrossBackingBoundaryLazily) {
+  Lds lds(64);
+  lds.zero_range(0, 256);
+  const auto boundary = lds.materialized_size_bytes();
+  ASSERT_LT(boundary, lds.size_bytes());
+  lds.write8(static_cast<uint32_t>(boundary - 1), 0xAB);
+
+  std::array<uint64_t, 64> addrs{};
+  addrs[0] = boundary - 1;
+  std::array<uint8_t, 4> bytes{0xFF, 0xFF, 0xFF, 0xFF};
+  lds.vector_load(addrs.data(), 1, bytes.size(), 1, bytes.data());
+  EXPECT_EQ(bytes, (std::array<uint8_t, 4>{0xAB, 0, 0, 0}));
+  EXPECT_EQ(lds.materialized_size_bytes(), boundary);
+
+  bytes = {0x11, 0x22, 0x33, 0x44};
+  lds.vector_store(addrs.data(), 1, bytes.size(), 1, bytes.data());
+  EXPECT_GT(lds.materialized_size_bytes(), boundary);
+  std::array<uint8_t, 4> stored{};
+  static_cast<const Lds &>(lds).read(static_cast<uint32_t>(boundary - 1), stored.data(),
+                                     static_cast<uint32_t>(stored.size()));
+  EXPECT_EQ(stored, bytes);
+}
+
+TEST(LdsTest, WritesGrowBackingAndOutOfBoundsWritesDoNot) {
+  Lds lds(64);
+  const uint32_t last_word = static_cast<uint32_t>(lds.size_bytes() - sizeof(uint32_t));
+
+  lds.write32(last_word, 0x12345678u);
+  EXPECT_EQ(lds.read32(last_word), 0x12345678u);
+  EXPECT_EQ(lds.materialized_size_bytes(), lds.size_bytes());
+
+  Lds untouched(64);
+  untouched.write32(static_cast<uint32_t>(untouched.size_bytes() - 2), 0xFFFFFFFFu);
+  EXPECT_EQ(untouched.materialized_size_bytes(), 0u);
+}
+
+} // namespace


### PR DESCRIPTION
Separate the architectural LDS capacity from its host backing. Keep new CU and WGP pools unmaterialized, return zero for reads from untouched storage, and grow a contiguous prefix in fixed 4 KiB granules when workgroup reservations or writes reach it. Retain materialized storage across clears so repeated dispatches avoid allocation churn.

Static descriptor LDS and dynamic AQL group-segment requests continue through the same aligned reservation path. Add coverage for implicit-zero reads, boundary accesses, zero-sized CU and WGP reservations, dynamic and static allocations, vector accesses, and out-of-bounds behavior.

On simulated gfx1250, a three-sample matrix of the full 26-case IREE suite and 10 representative Gluon cases reduces median peak RSS by 162 MiB, summed wall time for the 28 short cases by 5.2%, and overall wall time by 3.2% versus 1e5754f. All 108 candidate case executions pass with identical wave-instruction counts.