### PR TITLE
[rocjitsu] Compact register ownership by allocation block

### DIFF
--- a/emulation/rocjitsu/docs/plugins.md
+++ b/emulation/rocjitsu/docs/plugins.md
@@ -285,6 +285,12 @@ every high-frequency callback, serializing it with the infrequent callbacks
 without a per-instruction scan of the plugin list. Plugins that protect their
 own shared state should retain the parallel default.
 
+SGPR owner resolution is skipped when no contained plugin observes SGPR reads.
+Plugins that do not consume `onAmdgpuReadSgpr` should override
+`observes_sgpr_reads()` to return `false`. The group samples this policy when
+each plugin is added. Its conservative default is `true`, so existing plugins
+continue receiving SGPR read callbacks unless they explicitly opt out.
+
 Pass the complete sink configuration to the group constructor and add plugins
 before publishing the group to simulation components. `add()` is not
 thread-safe, and the group must remain immutable while callbacks may dispatch
@@ -304,5 +310,7 @@ concurrently.
    high-frequency and infrequent callbacks. Override
    `requires_serial_hot_hooks()` when that state cannot be protected within the
    plugin.
-6. Enable it by adding `"myname": { ... }` to the `plugins` section of
+6. Override `observes_sgpr_reads()` to return `false` when the plugin does not
+   consume `onAmdgpuReadSgpr`.
+7. Enable it by adding `"myname": { ... }` to the `plugins` section of
    the config file.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -102,7 +102,9 @@ ComputeUnitCore::ComputeUnitCore(std::string name, const Config &config, GpuMemo
 
   wfs_.resize(config.num_wf_slots);
   sgpr_file_.init(config.num_wf_slots * config.sgprs_per_wf, config.sgprs_per_wf);
-  sgpr_to_wave_.resize(config.num_wf_slots * config.sgprs_per_wf, nullptr);
+  sgpr_block_owners_.resize(config.num_wf_slots);
+  if (std::has_single_bit(config.sgprs_per_wf))
+    sgpr_block_shift_ = std::countr_zero(config.sgprs_per_wf);
 
   // Completer port: CP sends dispatch activation messages here.
   cpl_ = add_port(std::make_unique<simdojo::Port>("cpl", 0, this, simdojo::PortDirection::IN,
@@ -220,8 +222,9 @@ Wavefront *ComputeUnitCore::dispatch_wf_at(uint32_t wf_id, uint32_t wg_id, uint6
   wf->set_ready_cycle(cycle_counter_);
   wf->trace_inst_count_ = 0;
 
-  std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + num_sgprs, wf);
-  fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgpr_allocation_block_size(), wf);
+  sgpr_block_owners_[static_cast<uint32_t>(sgpr_base) / config_.sgprs_per_wf] = {
+      wf, static_cast<uint32_t>(sgpr_base) + num_sgprs};
+  set_vgpr_block_owner(static_cast<uint32_t>(vgpr_base), wf);
 
   util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", wf_id,
                    " pc=0x", std::hex, pc, std::dec, " wg=", wg_id, " pid=", wf->process_id());
@@ -242,6 +245,7 @@ size_t ComputeUnitCore::num_wfs() const {
 void ComputeUnitCore::free_wavefront_resources(Wavefront &wf) {
   std::lock_guard<std::recursive_mutex> wave_state_lock(wave_state_mutex_);
   if (wf.sgpr_alloc().count > 0) {
+    sgpr_block_owners_[wf.sgpr_alloc().base / config_.sgprs_per_wf] = {};
     sgpr_file_.free(wf.sgpr_alloc().base);
     free_vgprs(wf.vgpr_alloc().base);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -35,10 +35,12 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -51,6 +53,9 @@
 #include <vector>
 
 namespace rocjitsu {
+namespace test {
+class ComputeUnitTestAccess;
+}
 namespace amdgpu {
 
 class CommandProcessor;
@@ -306,6 +311,7 @@ public:
   /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
+    observes_sgpr_reads_ = plugin_group_->observes_sgpr_reads();
   }
 
   /// @brief Return the execution plugin group.
@@ -519,9 +525,9 @@ public:
   // TODO(newling) consider cmake flag to build without plugins, this call
   // overhead might be non-negligible.
   uint32_t read_sgpr(uint32_t reg_idx) const {
-    if (auto *wf = sgpr_to_wave_[reg_idx]) {
-      plugin_group_->onAmdgpuReadSgpr(wf, reg_idx);
-    }
+    if (observes_sgpr_reads_)
+      if (auto *wf = sgpr_owner(reg_idx))
+        plugin_group_->onAmdgpuReadSgpr(wf, reg_idx);
     return sgpr_file_[reg_idx];
   }
 
@@ -857,18 +863,40 @@ protected:
   uint64_t private_aperture_limit_ = 0;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
+  bool observes_sgpr_reads_ = false;
 
-  /// Reverse lookup: physical SGPR index -> owning wavefront (for race detection).
-  /// Populated at dispatch_wf time. Null entries mean "not allocated".
-  std::vector<Wavefront *> sgpr_to_wave_;
-  /// Populated by the ISA-specific subclass (which owns the VGPR file).
-  virtual void fill_vgpr_to_wave(uint32_t /*base*/, uint32_t /*count*/, Wavefront * /*wf*/) {}
+  /// @brief Resolve the owner of a physical SGPR from its allocation block.
+  /// @details Power-of-two block sizes use a shift on the instruction read path;
+  /// other target configurations retain exact division semantics.
+  Wavefront *sgpr_owner(uint32_t reg_idx) const {
+    const uint32_t block = sgpr_block_shift_ != kVariableSgprBlockShift
+                               ? reg_idx >> sgpr_block_shift_
+                               : reg_idx / config_.sgprs_per_wf;
+    const auto &allocation = sgpr_block_owners_[block];
+    return reg_idx < allocation.end ? allocation.owner : nullptr;
+  }
+
+  static constexpr uint32_t kVariableSgprBlockShift = std::numeric_limits<uint32_t>::max();
+  struct SgprBlockOwner {
+    Wavefront *owner = nullptr;
+    uint32_t end = 0;
+  };
+  /// Reverse lookup: SGPR allocation block -> owning wavefront (for race detection).
+  /// One entry per hardware wave slot replaces one pointer per physical SGPR,
+  /// while end preserves the requested-register boundary for plugin observation.
+  std::vector<SgprBlockOwner> sgpr_block_owners_;
+  uint32_t sgpr_block_shift_ = kVariableSgprBlockShift;
+  /// Record or clear the owner of one VGPR allocation block.
+  /// @param base Allocation-block-aligned physical VGPR base.
+  /// @param wf Owning wavefront, or nullptr when the block is freed.
+  virtual void set_vgpr_block_owner(uint32_t base, Wavefront *wf) = 0;
   simdojo::Port *cpl_ = nullptr; ///< Completer port: dispatch activation from CP.
   simdojo::Port *req_ = nullptr; ///< Requester port: L2 cache request (structural).
   uint64_t step_count_ = 0;
   bool functional_yield_requested_ = false;
 
   friend class CommandProcessor;
+  friend class ::rocjitsu::test::ComputeUnitTestAccess;
 };
 
 inline L1ScalarCache &InstructionComputeUnitView::l1_scalar() { return raw_cu().l1_scalar(); }
@@ -1035,7 +1063,6 @@ public:
         Isa::MAX_ACC_VGPRS_PER_WF == 0 ? 0 : accvgpr_physical_base + Isa::MAX_ACC_VGPRS_PER_WF;
     vgprs_per_block_ = std::max(config.vgprs_per_wf, accvgpr_physical_limit);
     vgpr_file_.init(config.num_wf_slots * vgprs_per_block_, vgprs_per_block_);
-    vgpr_to_wave_.resize(config.num_wf_slots * vgprs_per_block_, nullptr);
     for (uint32_t i = 0; i < config.num_wf_slots; ++i)
       this->wfs_[i] = std::make_unique<IsaWavefront<Isa>>(*this, i);
     this->sram_ecc_ = Isa::SRAM_ECC;
@@ -1050,23 +1077,29 @@ public:
   void notify_vgpr_read_by_reg(
       uint32_t reg_idx, uint64_t lane_mask,
       uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const override {
-    if (auto *wf = vgpr_to_wave_[reg_idx])
+    if (auto *wf = vgpr_owner(reg_idx))
       this->notify_vgpr_read(wf, reg_idx, lane_mask, byte_mask);
   }
 
   void notify_vgpr_write_by_reg(
       uint32_t reg_idx, uint64_t lane_mask,
       uint8_t byte_mask = rocjitsu::ExecutionPlugin::kFullByteMask) const override {
-    if (auto *wf = vgpr_to_wave_[reg_idx])
+    if (auto *wf = vgpr_owner(reg_idx))
       this->notify_vgpr_write(wf, reg_idx, lane_mask, byte_mask);
   }
 
   const Wavefront *vgpr_owner(uint32_t reg_idx) const override {
-    return reg_idx < vgpr_to_wave_.size() ? vgpr_to_wave_[reg_idx] : nullptr;
+    if (vgprs_per_block_ == 0)
+      return nullptr;
+    const size_t block = reg_idx / vgprs_per_block_;
+    return block < this->config_.num_wf_slots ? vgpr_block_owners_[block] : nullptr;
   }
 
-  void fill_vgpr_to_wave(uint32_t base, uint32_t count, Wavefront *wf) override {
-    std::fill(vgpr_to_wave_.begin() + base, vgpr_to_wave_.begin() + base + count, wf);
+  void set_vgpr_block_owner(uint32_t base, Wavefront *wf) override {
+    assert(vgprs_per_block_ != 0 && base % vgprs_per_block_ == 0);
+    const size_t block = base / vgprs_per_block_;
+    assert(block < this->config_.num_wf_slots);
+    vgpr_block_owners_[block] = wf;
   }
 
   /// @brief Write a value to the VGPR file.
@@ -1109,7 +1142,7 @@ protected:
   /// @brief Return allocated VGPRs to the free pool.
   void free_vgprs(uint32_t base) override {
     vgpr_file_.free(base);
-    fill_vgpr_to_wave(base, vgprs_per_block_, nullptr);
+    set_vgpr_block_owner(base, nullptr);
   }
 
   uint32_t free_vgpr_blocks() const override { return vgpr_file_.free_block_count(); }
@@ -1139,7 +1172,11 @@ protected:
 
 private:
   VgprFile vgpr_file_{"vgpr"};
-  std::vector<Wavefront *> vgpr_to_wave_; ///< Physical VGPR → owning wavefront.
+  /// One owner per register-file allocation block. Every VGPR in a block has
+  /// the same owner, so a per-register reverse map would duplicate each pointer
+  /// @c vgprs_per_block_ times. The array is sized by wave slots because the
+  /// register file currently contains exactly one allocation block per slot.
+  std::array<Wavefront *, Isa::MAX_WF_SLOTS> vgpr_block_owners_{};
   uint32_t vgprs_per_block_ = 0;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -175,6 +175,12 @@ public:
   /// Infrequent hook; see the concurrency contract on requires_serial_hot_hooks().
   virtual void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 
+  /// Whether this plugin needs SGPR read callbacks. The group samples this
+  /// policy once when the plugin is added. The conservative default preserves
+  /// existing plugin behavior: callbacks continue unless a plugin explicitly
+  /// opts out.
+  virtual bool observes_sgpr_reads() const { return true; }
+
 private:
   friend class ExecutionPluginGroup;
   std::string name_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -102,6 +102,7 @@ public:
         return false;
     p->slot_index_ = static_cast<uint32_t>(plugins_.size());
     serialize_hot_hooks_ |= p->requires_serial_hot_hooks();
+    observes_sgpr_reads_ |= p->observes_sgpr_reads();
     SinkBundle sink = build_sink_bundle(p->name() + ".log");
     if (auto *configured_sink = sink.get())
       p->sink_ = configured_sink;
@@ -120,6 +121,10 @@ public:
   /// Whether high-frequency callbacks are serialized for this group. Plugin
   /// policy is sampled when each plugin is added so hot dispatch stays O(1).
   bool requires_serial_hot_hooks() const { return serialize_hot_hooks_; }
+
+  /// Whether any contained plugin observes SGPR reads. Plugin policy is
+  /// sampled when each plugin is added so SGPR access stays O(1).
+  bool observes_sgpr_reads() const { return observes_sgpr_reads_; }
 
   // -- Lifecycle (non-virtual) --
   // The host calls these outside the simulation-callback interval: onInit()
@@ -293,6 +298,7 @@ private:
   // empty groups return before touching either the mutex or this counter.
   uint64_t callback_lock_acquisitions_ = 0;
   bool serialize_hot_hooks_ = false;
+  bool observes_sgpr_reads_ = false;
 
   /// Internal fanout over sinks whose lifetime is guaranteed by the owning
   /// group or SinkBundle. It is deliberately not part of the public sink API.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/logging/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/logging/plugin.h
@@ -20,6 +20,8 @@ public:
   explicit KernelLoggingPlugin(const char *config_json = nullptr);
   ~KernelLoggingPlugin() override;
 
+  bool observes_sgpr_reads() const override { return false; }
+
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
   void onAmdgpuAfterExecuteInstruction(uint64_t pc, const Instruction &inst,
                                        Wavefront &wf) override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -94,6 +94,8 @@ public:
   explicit RaceDetectorPlugin(const char *config_json = nullptr);
   ~RaceDetectorPlugin() override;
 
+  bool observes_sgpr_reads() const override { return true; }
+
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
 
   void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/throughput/plugin.h
@@ -50,6 +50,8 @@ public:
   explicit ThroughputPlugin(const char *config_json = nullptr);
   ~ThroughputPlugin() override;
 
+  bool observes_sgpr_reads() const override { return false; }
+
   void onShutdown() override;
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
   void onAmdgpuDispatchExecutionBegin(uint32_t dispatch_id) override;

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -98,6 +98,13 @@ public:
   }
 };
 
+class ComputeUnitTestAccess {
+public:
+  static amdgpu::Wavefront *sgpr_owner(const amdgpu::ComputeUnitCore &cu, uint32_t reg_idx) {
+    return cu.sgpr_owner(reg_idx);
+  }
+};
+
 } // namespace rocjitsu::test
 
 namespace {
@@ -393,6 +400,15 @@ class SerialHotHookPlugin final : public ExecutionPlugin {
 public:
   SerialHotHookPlugin() : ExecutionPlugin("serial_hot_hook") {}
   bool requires_serial_hot_hooks() const override { return true; }
+};
+
+class NoSgprReadPlugin final : public ExecutionPlugin {
+public:
+  NoSgprReadPlugin() : ExecutionPlugin("no_sgpr_read") {}
+  bool observes_sgpr_reads() const override { return false; }
+  void onAmdgpuReadSgpr(const amdgpu::Wavefront *, uint32_t) override { ++callbacks; }
+
+  uint32_t callbacks = 0;
 };
 
 class OverlapProbe {
@@ -783,7 +799,7 @@ struct PluginFixture {
   amdgpu::GpuMemory *mem = nullptr;
 
   explicit PluginFixture(uint32_t num_wf_slots = 10, std::string_view arch = "cdna4",
-                         uint32_t wavefront_size = 64) {
+                         uint32_t wavefront_size = 64, uint32_t sgprs_per_wf = 104) {
     std::string json = std::format(R"({{
       "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
       "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{}}}}}}},
@@ -795,7 +811,7 @@ struct PluginFixture {
           {{"name":"se0","type":"shader_engine","children":[
             {{"name":"cu[0:1]","type":"compute_unit","config":[
               {{"key":"num_wf_slots","value":"{}"}},
-              {{"key":"sgprs_per_wf","value":"104"}},
+              {{"key":"sgprs_per_wf","value":"{}"}},
               {{"key":"vgprs_per_wf","value":"256"}},
               {{"key":"lds_size_kb","value":"64"}}
             ]}}
@@ -806,7 +822,7 @@ struct PluginFixture {
         {{"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}}
       ]}}}}
     )",
-                                   arch, wavefront_size, num_wf_slots);
+                                   arch, wavefront_size, num_wf_slots, sgprs_per_wf);
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
     soc = loaded.soc();
     mem = loaded.memory();
@@ -863,6 +879,57 @@ struct PluginFixture {
     run_until_idle();
   }
 };
+
+TEST(ExecutionPluginTest, SgprBlockOwnersTrackDispatchAndSlotReuseAcrossTargets) {
+  struct TargetCase {
+    std::string_view arch;
+    uint32_t wave_size;
+    uint32_t sgprs_per_wf;
+  };
+
+  for (const TargetCase target : {TargetCase{"cdna4", 64, 104}, TargetCase{"cdna5", 32, 128}}) {
+    SCOPED_TRACE(target.arch);
+    PluginFixture f(/*num_wf_slots=*/3, target.arch, target.wave_size, target.sgprs_per_wf);
+    auto *plugin = f.attach_ordering_plugin();
+    const uint32_t first_sgpr_count = target.sgprs_per_wf / 2;
+    auto *first = f.cu()->dispatch_wf(/*wg_id=*/10, /*pc=*/0, first_sgpr_count,
+                                      /*vgprs=*/32);
+    auto *second = f.cu()->dispatch_wf(/*wg_id=*/20, /*pc=*/0, target.sgprs_per_wf,
+                                       /*vgprs=*/32);
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    ASSERT_EQ(first->sgpr_alloc().base, 0u);
+    ASSERT_EQ(second->sgpr_alloc().base, target.sgprs_per_wf);
+
+    auto expect_owner = [&](const Wavefront &owner, uint32_t physical_reg) {
+      plugin->events.clear();
+      EXPECT_EQ(f.cu()->read_sgpr(physical_reg), 0u);
+      ASSERT_EQ(plugin->events.size(), 1u);
+      EXPECT_EQ(plugin->events[0].kind, HookEvent::READ_SGPR);
+      EXPECT_EQ(plugin->events[0].wf_id, owner.wf_id());
+      EXPECT_EQ(plugin->events[0].wg_id, owner.wg_id());
+      EXPECT_EQ(plugin->events[0].physical_reg, physical_reg);
+    };
+
+    expect_owner(*first, first->sgpr_alloc().base + first_sgpr_count - 1);
+    expect_owner(*second, second->sgpr_alloc().base);
+    plugin->events.clear();
+    EXPECT_EQ(f.cu()->read_sgpr(first->sgpr_alloc().base + first_sgpr_count), 0u);
+    EXPECT_TRUE(plugin->events.empty());
+
+    const uint32_t reused_base = first->sgpr_alloc().base;
+    const uint32_t reused_slot = first->wf_id();
+    first->halt(Wavefront::CpCompletionNotice::Suppress);
+    EXPECT_EQ(test::ComputeUnitTestAccess::sgpr_owner(*f.cu(), reused_base), nullptr);
+    auto *reused = f.cu()->dispatch_wf(/*wg_id=*/30, /*pc=*/0, target.sgprs_per_wf,
+                                       /*vgprs=*/32);
+    ASSERT_NE(reused, nullptr);
+    EXPECT_EQ(reused->wf_id(), reused_slot);
+    EXPECT_EQ(reused->sgpr_alloc().base, reused_base);
+    expect_owner(*reused, reused_base + target.sgprs_per_wf - 1);
+    expect_owner(*second, second->sgpr_alloc().base + target.sgprs_per_wf - 1);
+  }
+}
 
 struct Wave32PluginFixture {
   std::unique_ptr<amdgpu::GpuMemory> gpu_mem;
@@ -1323,6 +1390,32 @@ TEST(ExecutionPluginTest, HotHookPolicyComesFromContainedPlugins) {
 
   ASSERT_TRUE(group.add(std::make_unique<SerialHotHookPlugin>()));
   EXPECT_TRUE(group.requires_serial_hot_hooks());
+}
+
+TEST(ExecutionPluginTest, SgprReadPolicyComesFromContainedPlugins) {
+  ExecutionPluginGroup group(PluginSinkConfig{});
+  EXPECT_FALSE(group.observes_sgpr_reads());
+
+  ASSERT_TRUE(group.add(std::make_unique<NoSgprReadPlugin>()));
+  EXPECT_FALSE(group.observes_sgpr_reads());
+
+  ASSERT_TRUE(group.add(std::make_unique<ParallelSafePlugin>()));
+  EXPECT_TRUE(group.observes_sgpr_reads());
+}
+
+TEST(ExecutionPluginTest, SgprReadOptOutSkipsComputeUnitCallback) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto plugin = std::make_unique<NoSgprReadPlugin>();
+  auto *plugin_ptr = plugin.get();
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  f.soc->set_plugin_group(group);
+
+  auto *wf = f.cu()->dispatch_wf(/*wg_id=*/1, /*pc=*/0, /*sgprs=*/32, /*vgprs=*/32);
+  ASSERT_NE(wf, nullptr);
+  f.cu()->write_sgpr(wf->sgpr_alloc().base, 0x12345678u);
+  EXPECT_EQ(f.cu()->read_sgpr(wf->sgpr_alloc().base), 0x12345678u);
+  EXPECT_EQ(plugin_ptr->callbacks, 0u);
 }
 
 TEST(ExecutionPluginTest, InfrequentHooksSerializeAtGroupBoundary) {

--- a/emulation/rocjitsu/tests/vgpr_redispatch_test.cpp
+++ b/emulation/rocjitsu/tests/vgpr_redispatch_test.cpp
@@ -77,9 +77,56 @@ TEST_P(VgprRedispatchTest, RecycledAllocationStartsZero) {
   second->halt();
 }
 
+TEST_P(VgprRedispatchTest, BlockOwnershipTracksDispatchAndRetirement) {
+  const RedispatchCase test_case = GetParam();
+  GpuMemory gpu_memory{"vgpr_owner_memory"};
+  L2Cache l2{"vgpr_owner_l2"};
+
+  ComputeUnitCore::Config config{};
+  config.arch = test_case.arch;
+  config.num_wf_slots = 2;
+  config.sgprs_per_wf = 106;
+  config.vgprs_per_wf = test_case.vgprs_per_wf;
+  config.lds_size_kb = 64;
+
+  auto compute_unit = ComputeUnitCore::create("vgpr_owner_cu", config, &gpu_memory, &l2);
+  const uint32_t block_size = compute_unit->vgpr_allocation_block_size();
+  ASSERT_GT(block_size, 0u);
+
+  Wavefront *first = compute_unit->dispatch_wf(/*wg_id=*/0, /*pc=*/0, /*num_sgprs=*/32,
+                                               /*num_vgprs=*/test_case.vgprs_per_wf);
+  Wavefront *second = compute_unit->dispatch_wf(/*wg_id=*/1, /*pc=*/0, /*num_sgprs=*/32,
+                                                /*num_vgprs=*/test_case.vgprs_per_wf);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  ASSERT_NE(first->vgpr_alloc().base, second->vgpr_alloc().base);
+
+  EXPECT_EQ(compute_unit->vgpr_owner(first->vgpr_alloc().base), first);
+  EXPECT_EQ(compute_unit->vgpr_owner(first->vgpr_alloc().base + block_size - 1), first);
+  EXPECT_EQ(compute_unit->vgpr_owner(second->vgpr_alloc().base), second);
+  EXPECT_EQ(compute_unit->vgpr_owner(second->vgpr_alloc().base + block_size - 1), second);
+
+  const uint32_t first_base = first->vgpr_alloc().base;
+  first->halt();
+  EXPECT_EQ(compute_unit->vgpr_owner(first_base), nullptr);
+  EXPECT_EQ(compute_unit->vgpr_owner(first_base + block_size - 1), nullptr);
+  EXPECT_EQ(compute_unit->vgpr_owner(second->vgpr_alloc().base), second);
+
+  Wavefront *third = compute_unit->dispatch_wf(/*wg_id=*/2, /*pc=*/0, /*num_sgprs=*/32,
+                                               /*num_vgprs=*/test_case.vgprs_per_wf);
+  ASSERT_NE(third, nullptr);
+  ASSERT_EQ(third->vgpr_alloc().base, first_base);
+  EXPECT_EQ(compute_unit->vgpr_owner(first_base), third);
+  EXPECT_EQ(compute_unit->vgpr_owner(first_base + block_size - 1), third);
+  EXPECT_EQ(compute_unit->vgpr_owner(second->vgpr_alloc().base), second);
+  third->halt();
+  second->halt();
+}
+
 INSTANTIATE_TEST_SUITE_P(
-    WaveSizes, VgprRedispatchTest,
+    Configurations, VgprRedispatchTest,
     ::testing::Values(RedispatchCase{ROCJITSU_CODE_ARCH_RDNA4, 32, 256, "Wave32"},
+                      RedispatchCase{ROCJITSU_CODE_ARCH_RDNA4, 32, 17, "OddBlock"},
                       RedispatchCase{ROCJITSU_CODE_ARCH_CDNA4, 64, 256, "Wave64"},
                       RedispatchCase{ROCJITSU_CODE_ARCH_CDNA5, 32, 1024, "Gfx1250"}),
     [](const ::testing::TestParamInfo<RedispatchCase> &info) { return info.param.name; });


### PR DESCRIPTION
Replace the physical-register-sized SGPR and VGPR reverse maps with one owner record per allocation block. Preserve partial SGPR allocation boundaries and plugin observation, while using shift-based lookups for power-of-two gfx1250 layouts and exact fallbacks for other configurations.

Let plugins that do not observe SGPR reads bypass owner resolution and cache that policy in each compute unit. Cover allocation, retirement, redispatch, slot reuse, partial SGPR ranges, plugin callbacks, and non-power-of-two target layouts.

On gfx1250 this removes 143.625 MiB of fixed owner-map storage across 256 CUs: 127.875 MiB from VGPR ownership and 15.75 MiB from SGPR ownership.

Measured separately versus 1e5754f before squashing, VGPR compaction reduces median peak RSS by 129 MiB, short-case wall time by 3.7%, and overall wall time by 1.7% across the 26-case IREE and 10-case Gluon matrix. The refined SGPR path is CPU-neutral in its six-run real-workload gate: median wall time, cycles, and instructions improve by 0.28%, 0.21%, and 0.66%; IREE wall time changes by +0.10% and the representative Gluon subset improves by 2.84%.