### PR TITLE
[RCCL]: Add parametric QP-sharing MPI test suite

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -464,6 +464,7 @@ set(SRC_FILES
   transport/net_ib/p2p_resiliency_recovery.h
   transport/net_ib/reg.cc
   transport/net_ib_cast/net_ib_cast_inspect.h
+  transport/net_ib_cast/net_ib_qp_sharing_inspect.h
   transport/net_ib_cast/net_ib_fault_inject.h
   transport/net_ib/gdaki/gin_host_gdaki.h
   transport/net_socket.cc

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+    src/transport/net_ib_cast/qp_sharing.h
     src/transport/net_ib_cast/common.cc
     src/transport/net_ib_cast/connect.cc
     src/transport/net_ib_cast/gdr.cc
@@ -23,6 +24,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/reg.cc
     src/transport/net_ib_cast/scheduler.cc
     src/transport/net_ib_cast/gin.cc
+    src/transport/net_ib_cast/qp_sharing.cc
 )
 
 # The cast headers (common_cast.h, p2p_cast.h, etc.) live in this directory.

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(NET_IB_CAST_SOURCES
     src/transport/net_ib_limits.h
     src/transport/net_ib_cast/net_ib_cast_inspect.h
+    src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
     src/transport/net_ib_cast/net_ib_ops_fault.h
     src/transport/net_ib_cast/common_cast.h
     src/transport/net_ib_cast/connect_cast.h

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,6 +23,9 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
+extern int ncclParamIbCastResiliencyPortFailover();
+extern int64_t rcclParamIbCastCommNGroups();
+
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -84,6 +87,17 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
+#if 0
+  if (rcclParamIbCastCommNGroups() > 0) {
+    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
+    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
+    // which is correct for a shared RQ.
+    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
+    }
+    recvComm->prepostReceiveWorkRequests = true;
+  }
+#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -116,6 +116,7 @@ struct alignas(64) ncclIbDev {
   char* pciPath;
   int realPort;
   int maxQp;
+  int maxCqe;
   float latency;
   struct ncclIbMrCache mrCache;
   int ar; // ADAPTIVE_ROUTING

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -138,10 +138,17 @@ extern struct ncclIbDev IbCastDevs[MAX_IB_DEVS];
 extern int IbCastRelaxedOrderingEnabled;
 extern bool IbCastUseInline;
 
+#define WR_ID_RX_COMM_ID_MASK  0xffff
+#define WR_ID_RX_COMM_ID_SHIFT 48
 #define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000
 #define WR_IMM_SIZE_MASK 0x007fffff
+// QP sharing BY_ID imm_data layout: reqId in bits[7:0], receiver commId in bits[23:8].
+// reqId fits in 8 bits (NET_IB_MAX_REQUESTS <= 256); commId fits in 16 bits.
+#define WR_IMM_BYID_REQ_ID_MASK   0xff
+#define WR_IMM_BYID_COMM_ID_SHIFT 8
+#define WR_IMM_BYID_COMM_ID_MASK  0xffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool IbCastAinicCtsInlineData;
@@ -505,6 +512,13 @@ struct alignas(32) ncclIbNetCommBase {
   bool faultQpError[NCCL_IB_MAX_QPS];
 #endif
   struct ncclIbResiliency* resiliency;
+
+  // QP Sharing fields
+  uint16_t commId;              // 0 = not shared
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;      // -1 = not shared
+  int      remIbDevIdx;
+  int      sharedPrimaryNqps;
 };
 
 struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -601,6 +615,7 @@ struct ncclIbSendComm {
   int ar; // Use adaptive routing when all merged devices have it enabled
   uint64_t putSignalScratchpad;
   bool useCtsOffload;
+  uint16_t remCommId;           // receiver's commId for imm_data encoding (QP sharing)
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1867,6 +1867,31 @@ ib_recv:
       }
       recvExistingSlot->cqRefcount++;
 
+      // Share flush QPs from primary
+      if (rComm->flushEnabled) {
+        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+          IbCastSharedQpKey flushKey;
+          memset(&flushKey, 0, sizeof(flushKey));
+          flushKey.ibDevN = rComm->base.vProps.devs[i];
+          flushKey.peerAddr = recvPeerAddr;
+          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+          flushKey.isSend = false;
+          flushKey.groupIdx = recvGroupIdx;
+          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+          if (flushSlot) {
+            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+            flushSlot->refcount++;
+            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+          } else {
+            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+                 __func__, i, recvGroupIdx, rComm->base.commId);
+          }
+        }
+      }
+
       goto qp_sharing_done_recv;
     } else {
       // PRIMARY receiver: create QPs with scaled depth, register in pool
@@ -1907,6 +1932,26 @@ qp_sharing_skip_recv:
         if (q == 0) {
           entry->cqRefcount = 1;
         }
+      }
+    }
+
+    // Register flush QPs in shared pool (primary only)
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = rComm->base.sharedGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+             rComm->base.sharedGroupIdx, rComm->base.commId);
       }
     }
   }
@@ -2166,10 +2211,11 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
-      // GPU flush cleanup remains per-comm
+      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
+          // Per-comm flush memory cleanup (always done)
           if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
             CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
             commDev->gpuFlush.gpuFlushGpuMem = nullptr;
@@ -2177,7 +2223,25 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             commDev->gpuFlush.gpuMr = nullptr;
             if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
           }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          // Shared flush QP teardown (refcount-based)
+          if (commDev->gpuFlush.qp.qp != NULL) {
+            struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
+                commDev->gpuFlush.qp.qp->qp_num, false);
+            if (flushSlot) {
+              flushSlot->refcount--;
+              if (flushSlot->refcount <= 0 && flushSlot->qp) {
+                INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared flush QP qpn=%u group=%d",
+                     flushSlot->qp->qp_num, flushSlot->key.groupIdx);
+                wrap_ibv_destroy_qp(flushSlot->qp);
+                flushSlot->qp = NULL;
+                flushSlot->used = false;
+              }
+            } else {
+              // Not in pool (shouldn't happen), destroy directly
+              NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+            }
+            commDev->gpuFlush.qp.qp = NULL;
+          }
           if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
         }
         if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -8,6 +8,7 @@
 #include "connect_cast.h"
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbCastRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
@@ -73,6 +74,10 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
 
   if (useCtsOffload) {
     return BY_ORDER;
+  }
+
+  if (rcclParamIbCastCommNGroups() > 0) {
+    return BY_ID;
   }
 
   if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
@@ -401,6 +406,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   return ncclSuccess;
 }
 
+
 static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs, struct ncclIbQp* qp) {
   struct ibv_qp_init_attr qpInitAttr;
   enum ncclIbChannelType channel_type = (createQpAttrs->isDataQp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
@@ -409,8 +415,14 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
   qpInitAttr.qp_type = createQpAttrs->type;
-  qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
-  qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  // Scale WR depths for QP sharing
+  if (createQpAttrs->isQpSharingEnabled) {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest * createQpAttrs->cqDepthMultiplier;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest * createQpAttrs->cqDepthMultiplier;
+  } else {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  }
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
   if (createQpAttrs->isCtsEnabled) {
@@ -435,17 +447,23 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
 
-  if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
-    bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
-    nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
-      !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
-  }
-  if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+  if (createQpAttrs->isQpSharingEnabled && (createQpAttrs->qpSharingGroupIdx >= 0)) {
+    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
+    uint8_t mask = (createQpAttrs->qpSharingGroupIdx % 2 == 0) ? IONIC_UDMA_MASK_LOW : IONIC_UDMA_MASK_HIGH;
+    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, mask);
   } else {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
+      bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
+      nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
+        !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
+    }
+    if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+    } else {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    }
   }
 
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, createQpAttrs->pd, &qpInitAttr));
@@ -621,12 +639,17 @@ fail:
 // establishment process.
 static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = comm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -718,6 +741,25 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    comm->remCommId = remMeta->commId;
+
+    // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
+    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+      // Just assign remDevIdx from remote metadata
+      uint nqps = comm->base.nqps;
+      for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+        ncclIbQp* localQp = &comm->base.qps[qpIndex];
+        ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
+        localQp->remDevIdx = remQpInfo->devIndex;
+      }
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
+      }
+      return ncclSuccess;
+    }
+  }
+
   uint nqps = comm->base.nqps;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
@@ -746,6 +788,7 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
 
     struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    remDevInfo->mtu = rtrAttr->mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
     rtrAttr->sl = remMeta->sl;
@@ -882,9 +925,21 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
+  // Initialize QP sharing fields
+  comm->base.commId = 0;
+  comm->base.isSharedQpPrimary = false;
+  comm->base.sharedGroupIdx = -1;
+  comm->base.remIbDevIdx = -1;
+  comm->base.sharedPrimaryNqps = 0;
+  comm->remCommId = 0;
+
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
+
+  // Compute depth multiplier for QP sharing
+  int depthMult;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -897,7 +952,7 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -908,9 +963,162 @@ ib_recv_dev_list:
   meta.ndevs = comm->base.vProps.ndevs;
   meta.isP2p = isP2p;
   meta.isRMA = handle->isRMA;
+  meta.sharedGroupIdx = -1;
+  meta.commId = 0;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
+  // QP Sharing: sender-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
+    int ngroups = rcclParamIbCastCommNGroups();
+
+    // Allocate commId for this comm
+    comm->base.commId = IbCastAllocCommId(comm, true);
+    if (comm->base.commId == 0) {
+      // Fallback to non-sharing if pool exhausted
+      goto qp_sharing_skip_sender;
+    }
+
+    // Check if primary exists for this group
+    IbCastSharedQpKey probeKey;
+    memset(&probeKey, 0, sizeof(probeKey));
+    // Build probe key from peer address
+    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+    IbCastStripPort(&probeKey.peerAddr);
+
+    // Use first device's ibDevN for the probe
+    int probeIbDevN;
+    int probeRemIbDevIdx;
+    // TODO - QP sharing
+    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
+    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+    probeRemIbDevIdx = remoteVProps.devs[0];
+
+    // Count existing refs to determine groupIdx
+    int totalRefs;
+    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+    int groupIdx;
+    groupIdx = totalRefs % ngroups;
+    comm->base.sharedGroupIdx = groupIdx;
+    comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+    probeKey.ibDevN = probeIbDevN;
+    probeKey.remIbDevIdx = probeRemIbDevIdx;
+    probeKey.isSend = true;
+    probeKey.groupIdx = groupIdx;
+    probeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* existingSlot;
+    existingSlot = IbCastFindSharedQp(&probeKey);
+
+    if (existingSlot != NULL) {
+      // SECONDARY: reuse existing QPs from pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+           __func__, comm->base.commId, groupIdx, totalRefs);
+
+      comm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+      comm->base.sharedPrimaryNqps = primaryNqps;
+
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+      key.isSend = true;
+      key.groupIdx = groupIdx;
+
+      int nqps = comm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+        int mappedQP = q % primaryNqps;
+        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
+        key.qpIdx = mappedQP;
+
+        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+        if (slot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+          // Fallback: free commId and go non-sharing
+          IbCastFreeCommId(comm->base.commId);
+          comm->base.commId = 0;
+          comm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_sender;
+        }
+
+        // Copy QP info from shared pool to this comm
+        comm->base.qps[q].qp = slot->qp;
+        comm->base.qps[q].devIndex = slot->devIndex;
+        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+        comm->base.activeQps[q] = &comm->base.qps[q];
+
+        // Populate metadata with shared QP info
+        meta.qpInfo[q].qpn = slot->qp->qp_num;
+        meta.qpInfo[q].devIndex = slot->devIndex;
+
+        slot->refcount++;
+      }
+
+      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+        comm->devs[i].base.cq = existingSlot->primaryCq;
+      }
+      existingSlot->cqRefcount++;
+
+      // Skip QP creation; metadata is already populated
+      goto qp_sharing_done_sender;
+    } else {
+      // PRIMARY: create QPs with scaled depth, then register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+           __func__, comm->base.commId, groupIdx, depthMult);
+
+      comm->base.isSharedQpPrimary = true;
+    }
+  }
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+
+qp_sharing_skip_sender:
   // Create QPs on the sender side
   NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+
+  // If primary, register QPs in shared pool
+  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
+    union ncclSocketAddress peerAddr;
+    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
+    IbCastStripPort(&peerAddr);
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+      IbCastStripPort(&key.peerAddr);
+      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
+      key.groupIdx = comm->base.sharedGroupIdx;
+      key.isSend = true;
+      key.qpIdx = q;
+
+      int devIdx = q % comm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+      if (entry && q == 0) {
+        entry->cqRefcount = 1;
+      }
+      if (entry) {
+        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+      }
+    }
+  }
+
+qp_sharing_done_sender:
+  // Populate QP sharing metadata
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  meta.commId = comm->base.commId;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
@@ -1141,6 +1349,7 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
                                                  struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = rComm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1151,6 +1360,11 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // When resiliency is enabled, the number of send work requests is as the
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
+
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1205,6 +1419,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
         return ncclInternalError;
       }
     }
+
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
@@ -1291,6 +1506,10 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
+      // QP sharing is disabled for flush QP
+      qpCreateAttrs.isQpSharingEnabled = false;
+      qpCreateAttrs.qpSharingGroupIdx = -1;
+      qpCreateAttrs.cqDepthMultiplier = 1;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1470,6 +1689,13 @@ ib_recv:
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);
 
+  // Initialize QP sharing fields on receiver
+  rComm->base.commId = 0;
+  rComm->base.isSharedQpPrimary = false;
+  rComm->base.sharedGroupIdx = -1;
+  rComm->base.remIbDevIdx = -1;
+  rComm->base.sharedPrimaryNqps = 0;
+
   // IB setup
   // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
@@ -1486,6 +1712,11 @@ ib_recv:
   // Metadata to send back to requestor (sender)
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
+
+  // Compute depth multiplier for receiver QP sharing
+  int recvDepthMult;
+  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
@@ -1497,7 +1728,7 @@ ib_recv:
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1551,7 +1782,140 @@ ib_recv:
                           1 :
                           0;
 
+  // QP Sharing: receiver-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
+    int recvGroupIdx = remMeta.sharedGroupIdx;
+    int recvProbeIbDevN;
+
+    rComm->base.commId = IbCastAllocCommId(rComm, false);
+    if (rComm->base.commId == 0) {
+      goto qp_sharing_skip_recv;
+    }
+    // Build probe key from peer address
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    rComm->base.sharedGroupIdx = recvGroupIdx;
+	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+    IbCastSharedQpKey recvProbeKey;
+    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+    recvProbeKey.ibDevN = recvProbeIbDevN;
+    recvProbeKey.peerAddr = recvPeerAddr;
+    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeKey.isSend = false;
+    recvProbeKey.groupIdx = recvGroupIdx;
+    recvProbeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* recvExistingSlot;
+    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+    if (recvExistingSlot != NULL) {
+      // SECONDARY receiver: reuse existing QPs
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+           __func__, rComm->base.commId, recvGroupIdx);
+
+      rComm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
+
+      rComm->base.sharedPrimaryNqps = primaryNqps;
+      rComm->useCtsOffload = false;
+
+      IbCastSharedQpKey recvKey;
+      memset(&recvKey, 0, sizeof(recvKey));
+      recvKey.peerAddr = recvPeerAddr;
+      recvKey.isSend = false;
+      recvKey.groupIdx = recvGroupIdx;
+
+      int nqps = rComm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+		int mappedQ = q % primaryNqps;
+		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        recvKey.qpIdx = mappedQ;
+
+        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+        if (recvSlot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+          IbCastFreeCommId(rComm->base.commId);
+          rComm->base.commId = 0;
+          rComm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_recv;
+        }
+
+        rComm->base.qps[q].qp = recvSlot->qp;
+        rComm->base.qps[q].devIndex = recvSlot->devIndex;
+        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
+        rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
+        meta.qpInfo[q].devIndex = recvSlot->devIndex;
+
+        recvSlot->refcount++;
+      }
+
+      // Redirect CQs
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+      }
+      recvExistingSlot->cqRefcount++;
+
+      goto qp_sharing_done_recv;
+    } else {
+      // PRIMARY receiver: create QPs with scaled depth, register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
+           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
+      rComm->base.isSharedQpPrimary = true;
+      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    }
+  }
+
+qp_sharing_skip_recv:
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+
+  // If primary receiver, register QPs in shared pool
+  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvKey.isSend = false;
+    recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+      recvKey.qpIdx = q;
+
+      int devIdx = q % rComm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+      if (entry) {
+        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+        if (q == 0) {
+          entry->cqRefcount = 1;
+        }
+      }
+    }
+  }
+
+qp_sharing_done_recv:
+  // Populate QP sharing metadata in response
+  meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
+  meta.commId = rComm->base.commId;
+
   if (rComm->prepostReceiveWorkRequests) {
     NCCLCHECKGOTO(IbCastReceiverPrePostReceiveWorkRequests(rComm), ret, fail);
   }
@@ -1694,23 +2058,70 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbSendCommDev* commDev = comm->devs + i;
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared send QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
+          }
+        }
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // Deregister per-comm MRs (not shared)
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }
@@ -1725,34 +2136,86 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbRecvCommDev* commDev = comm->devs + i;
-      if (comm->flushEnabled) {
-        if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-          commDev->gpuFlush.gpuMr = nullptr;
-          if (commDev->gpuFlush.dmabufFd > 0) {
-            close(commDev->gpuFlush.dmabufFd);
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared recv QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
           }
         }
-        if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+
       if (comm->base.resiliency) {
-        IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // GPU flush cleanup remains per-comm
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1062,6 +1062,17 @@ ib_recv_dev_list:
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
         comm->devs[i].base.cq = existingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = comm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       existingSlot->cqRefcount++;
 
@@ -1864,6 +1875,17 @@ ib_recv:
       for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
         rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = rComm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       recvExistingSlot->cqRefcount++;
 

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1102,7 +1102,7 @@ qp_sharing_skip_sender:
       int devIdx = q % comm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -1926,7 +1926,7 @@ qp_sharing_skip_recv:
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
       if (entry) {
         entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
         if (q == 0) {
@@ -1948,7 +1948,7 @@ qp_sharing_skip_recv:
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
         IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -91,7 +91,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int64_t cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -103,12 +103,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
   }
 
   if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
-    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+    WARN("NET/IB: %s: requested CQ size %ld exceeds device %s max_cqe %d, clamping",
          __func__, cqSize, ibDev->devName, ibDev->maxCqe);
     cqSize = ibDev->maxCqe;
   }
 
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, (int)cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -961,7 +961,7 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, ((int64_t)cqSize * depthMult)), ret, fail);
     if (depthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what depthMult asked for, shrink depthMult to match so QP WR depth
@@ -1762,7 +1762,7 @@ ib_recv:
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, ((int64_t)cqSize * recvDepthMult)), ret, fail);
     if (recvDepthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
@@ -2003,8 +2003,14 @@ qp_sharing_skip_recv:
         flushKey.groupIdx = rComm->base.sharedGroupIdx;
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
-        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
             rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+        if (flushEntry == NULL) {
+          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+          continue;
+        }
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2121,12 +2121,6 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           }
         }
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
 
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
@@ -2144,6 +2138,15 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them, or ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown
@@ -2203,12 +2206,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // GPU flush cleanup — flush QP is shared, memory resources are per-comm
@@ -2250,6 +2247,16 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           IbCastResiliencyDevDestroy(comm->base.resiliency, i);
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them (data QPs above, this comm's own flush QP just above), or
+      // ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1114,12 +1114,16 @@ qp_sharing_skip_sender:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
           comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry && q == 0) {
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      if (q == 0) {
         entry->cqRefcount = 1;
       }
-      if (entry) {
-        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
-      }
+      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
     }
   }
 
@@ -1949,11 +1953,15 @@ qp_sharing_skip_recv:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
           rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry) {
-        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-        if (q == 0) {
-          entry->cqRefcount = 1;
-        }
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+      if (q == 0) {
+        entry->cqRefcount = 1;
       }
     }
 
@@ -2253,10 +2261,12 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                flushSlot->used = false;
+                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
               }
             } else {
-              // Not in pool (shouldn't happen), destroy directly
+              // Not in pool -- e.g. registration hit the pool-exhaustion
+              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
+              // flush QP was never pool-tracked, so just destroy it directly.
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
             commDev->gpuFlush.qp.qp = NULL;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -102,6 +102,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
+  if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
+    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+         __func__, cqSize, ibDev->devName, ibDev->maxCqe);
+    cqSize = ibDev->maxCqe;
+  }
+
   NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
@@ -637,9 +643,13 @@ fail:
 // is updated accordingly. The meta data structure is then expected to be
 // delivered to the remote side (receiver) as part of the connection
 // establishment process.
-static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
+static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId,
+                                          int depthMult) {
   uint nqps = comm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -648,7 +658,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -953,6 +962,13 @@ ib_recv_dev_list:
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    if (depthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what depthMult asked for, shrink depthMult to match so QP WR depth
+      // and this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = comm->devs[i].base.cq->cqe / cqSize;
+      if (achievedMult < depthMult) depthMult = std::max(1, achievedMult);
+    }
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1090,7 +1106,7 @@ ib_recv_dev_list:
 
 qp_sharing_skip_sender:
   // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
 
   // If primary, register QPs in shared pool
   if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
@@ -1361,10 +1377,14 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
-                                                 struct ncclIbConnectionMetadata* meta, int channelId) {
+                                                 struct ncclIbConnectionMetadata* meta, int channelId,
+                                                 int depthMult) {
   uint nqps = rComm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1378,7 +1398,6 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
 
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1744,6 +1763,13 @@ ib_recv:
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    if (recvDepthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
+      // this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = rCommDev->base.cq->cqe / cqSize;
+      if (achievedMult < recvDepthMult) recvDepthMult = std::max(1, achievedMult);
+    }
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1929,7 +1955,7 @@ ib_recv:
   }
 
 qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
 
   // If primary receiver, register QPs in shared pool
   if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -53,6 +53,9 @@ struct ncclIbQpCreateAttr {
   int channelId;
   int ibDevN;
   bool useIonic;
+  bool isQpSharingEnabled;
+  int  cqDepthMultiplier;
+  int  qpSharingGroupIdx;
 };
 
 // Per-QP connection metatdata
@@ -101,6 +104,11 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
+
+  // QP Sharing metadata
+  int      sharedGroupIdx;      // QP sharing group index (-1 = not shared)
+  uint16_t commId;              // QP sharing comm ID (0 = not shared)
+  int      senderIbDevIdx;      // sender's IB device index
 };
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -7,6 +7,7 @@
 
 #include "common_cast.h"
 #include "p2p_resiliency_recovery_cast.h"
+#include "qp_sharing.h"
 
 extern int64_t ncclParamIbCastQpsPerConn();
 RCCL_PARAM(IbCastQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -564,6 +565,12 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // flag IbCastAinicCtsInlineData is used specifically to identify UseInline for Ainic
       IbCastAinicCtsInlineData = IbCastUseInline;
 
+      // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
+      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+        INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
+        IbCastOffloadEnabled = false;
+      }
+
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: %s; GDR Flush: %s",
@@ -579,6 +586,10 @@ exit:
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
                                "(load balancer integration with resiliency is pending)");
+    castGlobalQpSchedParms.enable = false;
+  }
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -472,6 +472,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             }
 
             IbCastDevs[IbCastNDevs].maxQp = devAttr.max_qp;
+            IbCastDevs[IbCastNDevs].maxCqe = devAttr.max_cqe;
             IbCastDevs[IbCastNDevs].oooRqSize = oooRqSize;
             IbCastDevs[IbCastNDevs].mrCache.capacity = 0;
             IbCastDevs[IbCastNDevs].mrCache.population = 0;

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_QP_SHARING_INSPECT_H_
+#define RCCL_NET_IB_QP_SHARING_INSPECT_H_
+
+#include <stdint.h>
+#include "net_ib_limits.h"
+
+#ifdef __cplusplus
+#include "nccl.h"  /* ncclResult_t */
+extern "C" {
+#else
+#include "nccl.h"
+#endif
+
+/*
+ * Test-only introspection API for QP sharing (RCCL_IB_COMM_NGROUPS).
+ * Shared between librccl.so and the unit tests so the struct layout
+ * and signatures cannot diverge.
+ */
+
+struct ncclIbQpSharingState {
+  uint16_t commId;             /* 0 = not shared */
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;     /* -1 = not shared */
+  int      refcount;           /* comms sharing this physical QP (0 if not shared) */
+  int      cqRefcount;         /* comms sharing this group's CQ (0 if not shared) */
+  int      nqps;
+  uint32_t qpn[NCCL_IB_MAX_QPS];
+};
+
+/* Copy QP-sharing state out of a connected sendComm or recvComm.
+ * Returns ncclInvalidArgument on null pointers. */
+ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* RCCL_NET_IB_QP_SHARING_INSPECT_H_ */

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -12,6 +12,7 @@
 #ifdef ENABLE_FAULT_INJECTION
 #include "net_ib_ops_fault.h"
 #endif
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
@@ -66,14 +67,14 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   switch (wr->opcode) {
   case IBV_WR_RDMA_WRITE:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
     break;
   case IBV_WR_RDMA_WRITE_WITH_IMM:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
@@ -113,7 +114,12 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : ctsFifoAddr(slots, r);
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    wr->wr_id = wr_id;
+    // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    } else {
+      wr->wr_id = wr_id;
+    }
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif
@@ -130,6 +136,9 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   }
 
   // For ID-based matching scheme, immData carries the request ID.
+  //   If QP sharing is enabled, immData also carries the receiver's commId:
+  //       reqId in bits[7:0],
+  //       remCommId in bits[23:8].
   // For index-based matching scheme, immData layout (BY_INDEX):
   //   bits [31:24] - rxReqIndex: receiver's request slot index (from CTS fifo)
   //   bit  [23]    - WR_IMM_SPLIT_DATA_FLAG: set when sending across >1 QPs
@@ -141,6 +150,10 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
+      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
+                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
       immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
@@ -164,7 +177,14 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     lastWr->imm_data = htobe32(immData);
   }
-  lastWr->wr_id = wr_id;
+  // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
+  // route the send completion to the right comm on a shared QP. The scheduler
+  // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
+  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  } else {
+    lastWr->wr_id = wr_id;
+  }
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
@@ -176,7 +196,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
     TRACE(NCCL_NET,
-          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx) on QP (qp_num=%u, "
           "devIndex=%d, qpIndex=%d)",
           __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
@@ -321,8 +341,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       reqs[r]->send.sentData[qpIndex] = true;
 
       TRACE(NCCL_VERBS,
-            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
-            "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            "Posted send wr_id=0x%lx, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
+            "imm_data=0x%x, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
             comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
             comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid, comm->wrs[r].opcode,
             comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
@@ -331,7 +351,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx)", __func__,
         reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
   if (nowNs) {
     if (comm->base.nextQpTxSchedUpdateNs == 0)
@@ -557,11 +577,15 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
+    // QP Sharing: encode commId in upper bits of CTS wr_id
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -569,7 +593,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -726,6 +750,9 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
     wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
@@ -734,7 +761,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
@@ -743,7 +770,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
   }
 
@@ -763,6 +790,7 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
+// QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id
 static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
                                                                ncclIbRequest** req) {
   assert(req != NULL);
@@ -772,24 +800,38 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=0x%lx, opcode=%s, imm_data=0x%x, byte_len=%d)",
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+      *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
+    } else {
+      *req = recvComm->recvReqs[immDataHost % NET_IB_MAX_REQUESTS];
+    }
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
-    *req = &base->reqs[((be32toh(wc->imm_data) >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK)];
+    // BY_INDEX (non-sharing CAST default): rxReqIndex is echoed in imm_data[31:24].
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
+    *req = &base->reqs[reqIdx];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
-    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
+    // wr_id[63:48] may carry a commId for completion routing (zero if sharing is
+    // disabled). Strip it to recover the original request index.
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (IbCastStripCommId(wc->wr_id) - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
+    // Non-wr-imm recv (e.g. signalled CTS completion). base is the polling comm.
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[wc->wr_id];
+    *req = recvComm->recvReqs[wc->wr_id & 0xFFFF];
   } else {
+    // Sender completion. targetBase was routed by IbCastTest via commId in wr_id[63:48];
+    // the low byte is the request slot. (BY_ID / BY_ORDER: no scheduler remap.)
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
-      // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
+      // BY_INDEX: wr_id was remapped by the CAST scheduler for RTT timing.
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
@@ -797,13 +839,12 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
-      // BY_ID / other: wr_id is raw slot-encoded value (no remap)
       *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
   TRACE(NCCL_NET,
-        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
-        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, wc.opcode=%s, "
+        "wc.imm_data=0x%x, wc.byte_len=%d, wc.qp_num=%u)",
         __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type],
         wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
@@ -889,21 +930,23 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
     WARN("NET/IB: %s: recvMatchingScheme not supported", __func__);
     return ncclInternalError;
   }
+
   if (commBase->isSend) {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    req = &(commBase->reqs[wc->wr_id & 0xff]);
   }
 
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -914,7 +957,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -922,7 +965,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
@@ -951,7 +994,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -977,8 +1020,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
       req->events[devIndex]--;
       return ncclSuccess;
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1003,7 +1046,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(IbCastRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -1012,7 +1055,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 #ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN + 1];
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -1020,18 +1063,19 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
-    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
+    // QP Sharing: use the target comm from the routed request, not the polling comm
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)req->base;
     struct ncclIbRequest* sendReq = NULL;
     int slot = req->id % NET_IB_MAX_REQUESTS;
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
-      if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
+      if (!req->base->resiliency && (sendReq->events[devIndex] <= 0)) {
         WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
@@ -1051,13 +1095,13 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
-             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=0x%lx, wc.imm_data=0x%x, wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
              ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1082,9 +1126,15 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
+#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
+        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
+        uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
+        commBase->rxPosts[rawWrId]--;
+#else
         commBase->rxPosts[wc->wr_id]--;
+#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
@@ -1116,14 +1166,14 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
-             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             "id=%ld, wc.wr_id=0x%lx, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
              __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
              be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1186,7 +1236,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
         struct ibv_wc* wc = wcs + w;
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=0x%lx, qp_num=%d)", __func__,
                  i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             IbCastLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
@@ -1194,13 +1244,24 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          TRACE(NCCL_NET,
-                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
-                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
-          if (r->base->recvMatchingScheme != BY_ORDER) {
-            NCCLCHECK(IbCastCompletionEventProcess(r->base, wc, i));
+          struct ncclIbNetCommBase* targetBase = (struct ncclIbNetCommBase*)r->base;
+          // RECV_RDMA_WITH_IMM (data receive) carries commId in imm_data and is
+          // routed in IbCastRequestRetrieveFromCompletion. All other completions
+          // (send, CTS/RDMA_WRITE, flush/RDMA_READ) carry commId in wr_id[63:48]
+          // and are routed here.
+          if (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromWrId(wc->wr_id);
+            if (routed) targetBase = routed;
           } else {
-            NCCLCHECK(IbCastCompletionEventByOrder(r->base, wc, i));
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromImmData((struct ncclIbNetCommBase*)r->base, be32toh(wc->imm_data));
+            if (routed && !routed->isSend && (routed->recvMatchingScheme == BY_ID)) targetBase = routed;
+          }
+
+          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)", __func__, i, targetBase, targetBase->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          if (targetBase->recvMatchingScheme != BY_ORDER) {
+            NCCLCHECK(IbCastCompletionEventProcess(targetBase, wc, i));
+          } else {
+            NCCLCHECK(IbCastCompletionEventByOrder(targetBase, wc, i));
           }
         }
       }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -745,6 +745,10 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
   req->sock = &comm->base.sock;
   struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[last];
 
+  INFO(NCCL_NET, "NET/IB: %s: flush commId=%u group=%d isPrimary=%d ndevs=%d",
+       __func__, comm->base.commId, comm->base.sharedGroupIdx,
+       comm->base.isSharedQpPrimary, comm->base.vProps.ndevs);
+
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     struct ibv_send_wr wr;
@@ -765,6 +769,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
+    INFO(NCCL_NET, "NET/IB: %s: posting flush dev=%d qpn=%u wr_id=0x%lx",
+         __func__, i, comm->devs[i].gpuFlush.qp.qp->qp_num, wr.wr_id);
     NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
     TIME_STOP(4);
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -17,6 +17,7 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
+extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -275,7 +276,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   bool inFlushRange =
     (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+    WARN("NET/IB: %s: Invalid wr_id (0x%lx). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
          wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
@@ -286,7 +287,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=0x%lx, wc.status=%s(%d)).", __func__,
          resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
@@ -352,7 +353,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
 
   if (request == NULL) {
     WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
-         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         "wc.wr_id=0x%lx, wc.status=%s(%d), wc.opcode=%s(%d)).",
          __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
          ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
@@ -361,7 +362,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = IbCastResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, "
          "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
          __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id,
          ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
@@ -540,7 +541,7 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
 static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
                                                                struct ibv_wc* probeWc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=0x%lx, wc->qp_num=%u)",
        __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
@@ -598,9 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
-         baseComm->isSend ? "send" : "recv", baseComm);
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+    // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
+    // when QP sharing is enabled.
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm,
+         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -810,6 +814,9 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -898,6 +905,9 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"
@@ -1047,7 +1057,7 @@ ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bo
 
 ncclResult_t IbCastResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=0x%lx, "
        "wc->qp_num=%u, wc->byte_len=%d)",
        __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
        wc->qp_num, wc->byte_len);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,6 +313,9 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -384,6 +387,9 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -42,6 +42,13 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     createAttr.isDataQp = localQp->isDataQp;
     // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
     // CTS offload is disabled when resiliency features are enabled (init.cc).
+    // TODO - QP sharing:
+    //        as of now QP sharing disabled during recovery restore.
+    //        to analyze and set sharing accordingly for this QP during recovery restore.
+    //        identify if it is primary or secondary comm and set sharing attributes accordingly.
+    createAttr.isQpSharingEnabled = false;
+    createAttr.qpSharingGroupIdx = -1;
+    createAttr.cqDepthMultiplier = 1;
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
 
     INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)", __func__,
@@ -73,6 +80,11 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
+        // TODO - QP sharing:
+        //        disabled for flush QP
+        flushCreateAttr.isQpSharingEnabled = false;
+        flushCreateAttr.qpSharingGroupIdx = -1;
+        flushCreateAttr.cqDepthMultiplier = 1;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -16,6 +16,8 @@ struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+int                         g_IbCastCommIdFreeTop = 0;
 std::mutex                  g_IbCastSharedQpMutex;
 
 void IbCastStripPort(union ncclSocketAddress* addr) {
@@ -109,11 +111,17 @@ int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peer
 
 uint16_t IbCastAllocCommId(void* comm, bool isSend) {
     std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+    uint16_t id;
+    if (g_IbCastCommIdFreeTop > 0) {
+        // Reuse a previously freed commId — O(1)
+        id = g_IbCastCommIdFreeStack[--g_IbCastCommIdFreeTop];
+    } else if (g_IbCastNextCommId < IBCAST_MAX_COMMS) {
+        // Allocate a fresh commId — O(1)
+        id = g_IbCastNextCommId++;
+    } else {
         WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
         return 0;
     }
-    uint16_t id = g_IbCastNextCommId++;
     g_IbCastCommTable[id].comm = comm;
     g_IbCastCommTable[id].isSend = isSend;
     g_IbCastCommTable[id].used = true;
@@ -126,6 +134,7 @@ void IbCastFreeCommIdLocked(uint16_t commId) {
     if (commId > 0 && commId < IBCAST_MAX_COMMS) {
         g_IbCastCommTable[commId].used = false;
         g_IbCastCommTable[commId].comm = NULL;
+        g_IbCastCommIdFreeStack[g_IbCastCommIdFreeTop++] = commId;
     }
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -60,7 +60,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
 
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+    int primaryIbDevN, int devIndex, int initialRefcount) {
 
     if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
@@ -70,7 +70,7 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
-    entry->primaryDevBase = primaryDevBase;
+    entry->primaryIbDevN = primaryIbDevN;
     entry->devIndex = devIndex;
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
@@ -197,8 +197,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
                      g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
             }
             destroyedCqs[nDestroyed++] = cq;
-            if (g_IbCastSharedQpPool[i].primaryDevBase) {
-                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+            {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryIbDevN;
                 std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
                 INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
                      ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -14,6 +14,8 @@ RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
+int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpFreeTop = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
 uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -62,11 +64,18 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount) {
 
-    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int idx;
+    if (g_IbCastSharedQpFreeTop > 0) {
+        // Reuse a slot freed by IbCastCleanupGroupCqs -- O(1)
+        idx = g_IbCastSharedQpFreeStack[--g_IbCastSharedQpFreeTop];
+    } else if (g_IbCastSharedQpPoolCount < IBCAST_MAX_SHARED_QPS) {
+        idx = g_IbCastSharedQpPoolCount++;
+    } else {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
         return NULL;
     }
-    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[idx];
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
@@ -77,6 +86,13 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->used = true;
     entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
+}
+
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry) {
+    if (entry == NULL) return;
+    int idx = (int)(entry - g_IbCastSharedQpPool);
+    entry->used = false;
+    g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = idx;
 }
 
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
@@ -209,5 +225,6 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
             }
         }
         g_IbCastSharedQpPool[i].used = false;
+        g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -1,0 +1,204 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing pool management implementation for IB CAST transport layer.
+ ************************************************************************/
+
+#include "qp_sharing.h"
+
+// QP sharing configuration parameters
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+
+// Pool and comm table globals
+struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpPoolCount = 0;
+struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+std::mutex                  g_IbCastSharedQpMutex;
+
+void IbCastStripPort(union ncclSocketAddress* addr) {
+    if (addr->sa.sa_family == AF_INET) {
+        addr->sin.sin_port = 0;
+    } else if (addr->sa.sa_family == AF_INET6) {
+        addr->sin6.sin6_port = 0;
+    }
+}
+
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b) {
+    if (a->ibDevN != b->ibDevN) return false;
+    if (a->isSend != b->isSend) return false;
+    if (a->groupIdx != b->groupIdx) return false;
+    if (a->qpIdx != b->qpIdx) return false;
+    if (a->remIbDevIdx != b->remIbDevIdx) return false;
+    if (memcmp(&a->peerAddr, &b->peerAddr, sizeof(union ncclSocketAddress)) != 0) return false;
+    return true;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && IbCastSharedQpKeyMatch(&g_IbCastSharedQpPool[i].key, key)) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && g_IbCastSharedQpPool[i].qp &&
+            g_IbCastSharedQpPool[i].key.isSend == isSend &&
+            g_IbCastSharedQpPool[i].qp->qp_num == qpn) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+
+    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+        WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
+        return NULL;
+    }
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    entry->key = *key;
+    entry->qp = qp;
+    entry->primaryCq = primaryCq;
+    entry->primaryDevBase = primaryDevBase;
+    entry->devIndex = devIndex;
+    entry->refcount = initialRefcount;
+    entry->cqRefcount = 0;
+    entry->used = true;
+    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
+    return entry;
+}
+
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx) {
+    int count = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend) {
+    int total = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.qpIdx != 0) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            total += g_IbCastSharedQpPool[i].refcount;
+        }
+    }
+    return total;
+}
+
+uint16_t IbCastAllocCommId(void* comm, bool isSend) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+        WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
+        return 0;
+    }
+    uint16_t id = g_IbCastNextCommId++;
+    g_IbCastCommTable[id].comm = comm;
+    g_IbCastCommTable[id].isSend = isSend;
+    g_IbCastCommTable[id].used = true;
+    return id;
+}
+
+// Caller MUST hold g_IbCastSharedQpMutex. Used by the teardown paths, which take
+// the mutex across the whole shared-QP cleanup block.
+void IbCastFreeCommIdLocked(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        g_IbCastCommTable[commId].used = false;
+        g_IbCastCommTable[commId].comm = NULL;
+    }
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
+  uint16_t commId = (wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
+  if (commId == 0 || commId >= IBCAST_MAX_COMMS || !g_IbCastCommTable[commId].used) return NULL;
+  return g_IbCastCommTable[commId].isSend
+    ? &((struct ncclIbSendComm*)g_IbCastCommTable[commId].comm)->base
+    : &((struct ncclIbRecvComm*)g_IbCastCommTable[commId].comm)->base;
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
+    //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+    if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+      return g_IbCastCommTable[immCommId].isSend
+        ? &((struct ncclIbSendComm*)g_IbCastCommTable[immCommId].comm)->base
+        : &((struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm)->base;
+    }
+  }
+  return NULL;
+}
+
+// Self-locking variant for callers that do NOT already hold the mutex
+// (e.g. the connect/accept non-sharing fallback paths).
+void IbCastFreeCommId(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        IbCastFreeCommIdLocked(commId);
+    }
+}
+
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
+    struct ibv_cq* destroyedCqs[NCCL_IB_MAX_DEVS_PER_NIC];
+    int nDestroyed = 0;
+
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, &slot0Entry->key.peerAddr,
+                   sizeof(union ncclSocketAddress)) != 0) continue;
+
+        struct ibv_cq* cq = g_IbCastSharedQpPool[i].primaryCq;
+        bool alreadyDestroyed = false;
+        for (int j = 0; j < nDestroyed; j++) {
+            if (destroyedCqs[j] == cq) { alreadyDestroyed = true; break; }
+        }
+        if (!alreadyDestroyed && cq != NULL) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying CQ %p group=%d ibDevN=%d isSend=%d remIbDev=%d qpIdx=%d refcount=%d",
+                 (void*)cq, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                 g_IbCastSharedQpPool[i].key.isSend, g_IbCastSharedQpPool[i].key.remIbDevIdx,
+                 g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            ncclResult_t cqRet = wrap_ibv_destroy_cq(cq);
+            if (cqRet != ncclSuccess) {
+                WARN("IB CAST TEARDOWN: ibv_destroy_cq FAILED cq=%p errno=%d group=%d ibDevN=%d qpIdx=%d refcount=%d",
+                     (void*)cq, errno, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                     g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            }
+            destroyedCqs[nDestroyed++] = cq;
+            if (g_IbCastSharedQpPool[i].primaryDevBase) {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+                std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
+                INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
+                     ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,
+                     (IbCastDevs[ibDevN2].pdRefs == 1) ? "DEALLOC" : "");
+                if (0 == --IbCastDevs[ibDevN2].pdRefs) {
+                    wrap_ibv_dealloc_pd(IbCastDevs[ibDevN2].pd);
+                }
+            }
+        }
+        g_IbCastSharedQpPool[i].used = false;
+    }
+}

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "qp_sharing.h"
+#include "net_ib_qp_sharing_inspect.h"
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -227,4 +228,40 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
         g_IbCastSharedQpPool[i].used = false;
         g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
     }
+}
+
+// =============================================================================
+// Test introspection API — exposes internal QP-sharing pool state from a
+// sendComm/recvComm handle. Only intended for unit tests; not part of the
+// public net plugin ABI.
+// =============================================================================
+
+// ncclIbCastGetQpSharingState — copy QP-sharing pool state out of a comm.
+extern "C" ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out) {
+    if (!comm || !out) return ncclInvalidArgument;
+    struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+
+    out->commId = base->commId;
+    out->isSharedQpPrimary = base->isSharedQpPrimary;
+    out->sharedGroupIdx = base->sharedGroupIdx;
+    out->nqps = base->nqps;
+    out->refcount = 0;
+    out->cqRefcount = 0;
+
+    int n = (base->nqps < NCCL_IB_MAX_QPS) ? base->nqps : NCCL_IB_MAX_QPS;
+    for (int i = 0; i < n; i++) {
+        struct ncclIbQp* qp = base->activeQps[i];
+        out->qpn[i] = (qp && qp->qp) ? qp->qp->qp_num : 0;
+    }
+
+    if (base->sharedGroupIdx >= 0 && n > 0 && base->activeQps[0] && base->activeQps[0]->qp) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(base->activeQps[0]->qp->qp_num, base->isSend);
+        if (slot) {
+            out->refcount = slot->refcount;
+            out->cqRefcount = slot->cqRefcount;
+        }
+    }
+
+    return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -42,7 +42,10 @@ struct IbCastSharedQp {
     IbCastSharedQpKey key;
     struct ibv_qp*    qp;                  // the physical QP
     struct ibv_cq*    primaryCq;           // CQ for this device in this group
-    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      primaryIbDevN;                // local IB device index of the primary comm's device,
+                                            // captured by value: the primary comm (and its inline
+                                            // devs[]) may be freed while secondaries or this pool
+                                            // entry still reference the group
     int      devIndex;                     // local device index within comm->devs[]
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
@@ -81,7 +84,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 // Register a new shared QP in the pool
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+    int primaryIbDevN, int devIndex, int initialRefcount);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -62,6 +62,8 @@ extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
+extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+extern int                         g_IbCastCommIdFreeTop;
 extern std::mutex                  g_IbCastSharedQpMutex;
 
 // Strip port from socket address for peer matching

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -63,6 +63,8 @@ struct IbCastCommTableEntry {
 // Pool and comm table globals (defined in qp_sharing.cc)
 extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
+extern int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpFreeTop;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
 extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -85,6 +87,10 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount);
+
+// Undo a registration for a slot whose last user is closing outside of
+// IbCastCleanupGroupCqs (the flush-QP path).
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -25,6 +25,7 @@ extern int64_t rcclParamIbCastQpDepthMultiplier();
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+#define IBCAST_FLUSH_QP_IDX  -1   // sentinel qpIdx for flush QPs in the shared pool
 
 // Pool key -- uniquely identifies a shared QP
 struct IbCastSharedQpKey {

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -1,0 +1,119 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing infrastructure for IB CAST transport layer.
+ * Allows multiple RCCL communicator channels to share physical IB QPs,
+ * reducing QP count and improving scalability.
+ * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ ************************************************************************/
+
+#ifndef NET_IB_CAST_QP_SHARING_H_
+#define NET_IB_CAST_QP_SHARING_H_
+
+#include "common_cast.h"
+#include "param.h"
+#include <mutex>
+
+// QP sharing configuration parameters
+// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
+// 0 = disabled, >0 = enable QP sharing with N groups
+extern int64_t rcclParamIbCastCommNGroups();
+// CQ/WR depth scaling for primary QPs
+extern int64_t rcclParamIbCastQpDepthMultiplier();
+
+#define IBCAST_MAX_SHARED_QPS 1024
+#define IBCAST_MAX_COMMS      4096
+#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+
+// Pool key -- uniquely identifies a shared QP
+struct IbCastSharedQpKey {
+    int             ibDevN;              // local IB device index
+    union ncclSocketAddress peerAddr;    // remote peer address (port stripped)
+    int             remIbDevIdx;         // remote IB device index for disambiguation
+    bool            isSend;              // send vs recv direction
+    int             groupIdx;            // sharing group (0..m-1)
+    int             qpIdx;              // QP slot within the group (0..nqps-1)
+};
+
+// Pool entry -- one per physical shared QP
+struct IbCastSharedQp {
+    IbCastSharedQpKey key;
+    struct ibv_qp*    qp;                  // the physical QP
+    struct ibv_cq*    primaryCq;           // CQ for this device in this group
+    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      devIndex;                     // local device index within comm->devs[]
+    int      refcount;                     // number of comms using this QP
+    int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
+    bool     used;                         // slot in use
+    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+};
+
+// Global comm table for completion routing (commId -> comm pointer)
+struct IbCastCommTableEntry {
+    void*    comm;          // ncclIbSendComm* or ncclIbRecvComm*
+    bool     isSend;
+    bool     used;
+};
+
+// Pool and comm table globals (defined in qp_sharing.cc)
+extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpPoolCount;
+extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+extern uint16_t                    g_IbCastNextCommId;
+extern std::mutex                  g_IbCastSharedQpMutex;
+
+// Strip port from socket address for peer matching
+void IbCastStripPort(union ncclSocketAddress* addr);
+
+// Compare two pool keys
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b);
+
+// Find a shared QP by key
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key);
+
+// Find a shared QP by QP number and direction (for teardown)
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
+
+// Register a new shared QP in the pool
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+
+// Count QP slots registered by the primary for a given group
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx);
+
+// Count total comms connected to a peer (for channelSeq computation)
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend);
+
+// Allocate a commId and register in the global comm table (mutex-protected)
+uint16_t IbCastAllocCommId(void* comm, bool isSend);
+
+// Free a commId (self-locking; for callers NOT holding g_IbCastSharedQpMutex)
+void IbCastFreeCommId(uint16_t commId);
+
+// Free a commId; caller MUST already hold g_IbCastSharedQpMutex (teardown paths)
+void IbCastFreeCommIdLocked(uint16_t commId);
+
+// Destroy all CQs for a group when cqRefcount reaches 0
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Strip the commId from wr_id[63:48], recovering the original index. Safe when
+// sharing is disabled (commId==0, so the mask is a no-op).
+static inline uint64_t IbCastStripCommId(uint64_t wr_id) {
+  return wr_id & ~((uint64_t)WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Look up the target comm from the commId encoded in wr_id[63:48]. Returns NULL
+// if sharing is disabled or the commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id);
+
+// Look up the target comm from the commId encoded in immData.
+// Returns target base based on commId in immData if sharing is enabled or
+// returns NULL if sharing is disabled or commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(
+    struct ncclIbNetCommBase* base, uint32_t immDataHost);
+
+#endif // NET_IB_CAST_QP_SHARING_H_

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -118,7 +118,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/gensrc # for rccl_bfloat16.h
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h, net_ib_qp_sharing_inspect.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
@@ -562,6 +562,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/OpsFaultUnitTests.cpp
       transport/GinMPI/GinMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
+      transport/NetIbMPI/QpSharingTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -161,6 +161,67 @@ test_categories:
       - "NCCL_LAUNCH_MODE=GROUP"
       - "NCCL_DMABUF_ENABLE=1"
       - "RCCL_MPI_LOG_ALL_RANKS=1"
+  # The QP-sharing functional gate. The same five tests run at three values of
+  # RCCL_IB_COMM_NGROUPS: expectations are derived from ngroups by the reference
+  # model (test/transport/NetIbMPI/QpShareRefModel.hpp), so no test is pinned to
+  # a value and none skips outside one. RCCL_PARAM caches both tunables per
+  # process, which is why ngroups varies across categories rather than within a
+  # test.
+  quick_env_qpshare_ngroups1:
+    description: "QP sharing gate, maximum concentration: NGROUPS=1 puts every connection in group 0, so the whole functional set runs on one shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling; measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement."
+    test_patterns: &qpshare_functional_tests
+      - "NetIbMPITest.QpShareAlgoLayoutSweep:NetIbMPITest.QpShareAlgoChurnLayout:NetIbMPITest.QpShareDataAllConnsTransfer:NetIbMPITest.QpShareDataUnsharedGroups:NetIbMPITest.QpShareDataFlushRouting"
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups2:
+    description: "QP sharing gate, smallest mixed configuration: NGROUPS=2 places a PRIMARY-only group beside a PRIMARY+SECONDARY group — the first point at which group-index arithmetic can be wrong without being invisible. Same five functional tests."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups16:
+    description: "QP sharing gate, wide configuration: at NGROUPS=16 the connection counts straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. Same five functional tests. Expected green, but INTERMITTENTLY CRASHES — measured 2 runs in 18 on AINIC (2026-08-17) — on a use-after-free in the group teardown path, so a signal-kill here is that known defect rather than a new regression. The qpshare_uaf_teardown category below reproduces the same bug deterministically and is the acceptance criterion for it; do not add a retry here to make this category look stable."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_depth_ceiling:
+    description: "QP sharing depth-multiplier ceiling — the same missing capacity check from the opposite side. The multiplier is applied to the QP work-queue sizing as given, so a value the device cannot allocate kills the FIRST connection instead of being clamped to the device limit; nothing is shared yet at that point, so a saturation fallback would not help either. EXPECTED RED, acceptance criterion for clamping the multiplier. Root cause measured 2026-08-17 on AINIC: the shared CQ is sized 768 × NCCL_IB_QPS_PER_CONNECTION × RCCL_IB_QP_DEPTH_MULTIPLIER entries (connect.cc:949, :1730) and passed to ibv_create_cq unchecked against device_attr.max_cqe. Bisected against that device's max_cqe of 65435: qps × depth = 85 passes, 86 fails, on both the qps=1 and qps=2 paths, so the usable depth is floor(max_cqe / (768 × qps)) — 85 at QPS=1, 42 at the default QPS of 2. Both knobs are pinned here because they multiply into the same limit. The ceiling is hardware-dependent — on a NIC with a larger max_cqe this category passes until the multiplier is raised past floor(max_cqe / 768)."
+    test_patterns:
+      - "NetIbMPITest.QpShareDataAllConnsTransfer"
+    exclude_windows: *mpi_exclude_windows
+    # Deliberately NOT *mpi_quick_labels: this category is expected red, and a
+    # permanently-red entry in the smoke/precheck gate gets muted, which is how
+    # an acceptance criterion quietly stops being one. Selectable and
+    # excludable via the qpshare_known_red label instead.
+    labels: &qpshare_known_red_labels
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=96"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+      - "QPSHARE_TEST_NCONNS=2"
   standard:
     description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
@@ -347,6 +408,63 @@ test_categories:
       - "RCCL_LL128_FORCE_ENABLE=1"
       - "NCCL_PROTO=LL128"
       - "NCCL_ALGO=Tree"
+  # The stress tests are split across two categories on purpose. The ctest
+  # generator joins a category's test_patterns with ':' into ONE --gtest_filter,
+  # i.e. one process (shared/ctest/parse_test_categories.py, positive_string),
+  # and gtest runs registration order, not filter order. QpShareStressConnectionChurn
+  # leaves the process unusable, so any test registered after it in the same
+  # process never reports. Keeping churn in its own category is what makes the
+  # batch result observable at all -- do not merge these back together.
+  qpshare_stress:
+    description: "QP sharing stress, everything except connection churn: many-connection load, shared-RQ saturation, and batch create/destroy under sharing. Scale with QPSHARE_TEST_NCONNS and QPSHARE_TEST_ITERS; the defaults are what this category gates on. One EXPECTED RED. StressBatchCreateDestroy: one PD leaked in total (rank 0, before=1 after=2) at the default batch of 10. The leak rate is a function of live comms per group at teardown, not of RCCL_IB_COMM_NGROUPS directly: a protection-domain reference is taken per comm but released once per group, so the release only reaches zero -- and only then attempts the ibv_dealloc_pd that fails -- when a group held exactly one comm. QPSHARE_TEST_NCONNS=1 or 2 therefore leaks one PD per batch rather than one in total. Same underlying bug as qpshare_stress_churn, at its mildest rate."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressManyConns:NetIbMPITest.QpShareStressSharedRqSaturation:NetIbMPITest.QpShareStressBatchCreateDestroy"
+    exclude_windows: *mpi_exclude_windows
+    labels:
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  qpshare_stress_churn:
+    description: "QP sharing connection churn, isolated in its own category because it crashes the process. EXPECTED RED, kept as the acceptance criterion for the sharing-specific protection-domain leak. One comm is live at a time, so every earlier cycle was fully closed, yet one PD is leaked per cycle with a matching ibv_dealloc_pd() failure. On this device (max_pd=1024) connect then fails at iteration 1022 of 2048 with no diagnostic from the transport, and the following connect segfaults rather than failing cleanly. The iteration number is device-specific: it is max_pd, not a fixed constant. Not shared-QP pool exhaustion despite IBCAST_MAX_SHARED_QPS also being 1024 -- no 'pool full' WARN is ever emitted, and a full pool cannot fail a connect in the first place, since the NULL return from IbCastRegisterSharedQp is ignored at connect.cc:1109."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressConnectionChurn"
+    exclude_windows: *mpi_exclude_windows
+    labels:
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+      - "qpshare_known_red"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  # Deterministic form of the crash that hits quick_env_qpshare_ngroups16 about
+  # once in nine runs. Same test, same tunables; the only difference is
+  # MALLOC_PERTURB_=165, which tells glibc to overwrite freed heap with 0xa5 so
+  # the stale read faults instead of usually finding intact memory. Measured
+  # 2026-08-17 on AINIC: 6/6 crashes with the poison, 0/6 without it.
+  qpshare_uaf_teardown:
+    description: "QP sharing use-after-free in group teardown. EXPECTED RED, and it dies by signal rather than by a failed assertion — the process is gone before gtest can report. IbCastRegisterSharedQp stores &comm->devs[devIdx].base in the shared-QP pool slot (connect.cc:1105); IbCastCloseSend/IbCastCloseRecv free(comm) (connect.cc:2140/:2235); IbCastCleanupGroupCqs then reads primaryDevBase->ibDevN through that freed pointer (qp_sharing.cc:193) and locks IbCastDevs[ibDevN].mutex with the resulting index (:194). Backtrace: pthread_mutex_lock ← IbCastCleanupGroupCqs+0x248 ← IbCastCloseRecv+0x373. Acceptance criterion for storing ibDevN by value in the pool slot. When testing a fix, re-run two controls beside it: the same filter without MALLOC_PERTURB_ (must still pass) and non-sharing NetIb tests with the poison on (must be unaffected — they are today). MALLOC_PERTURB_ is a glibc feature and is inert elsewhere, so on a non-glibc platform this category degrades into a duplicate of quick_env_qpshare_ngroups16 and stops being a reliable gate."
+    test_patterns:
+      - "NetIbMPITest.QpShareAlgoChurnLayout"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_known_red_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+      - "MALLOC_PERTURB_=165"
 
 execution_settings:
   mpi_launch:
@@ -363,6 +481,10 @@ execution_settings:
     quick_env_net_graph_register: 1200
     quick_env_netib_xfer_trace: 1200
     quick_env_netib_xfer_log_ranks: 1200
+    quick_env_qpshare_ngroups1: 1200
+    quick_env_qpshare_ngroups2: 1200
+    quick_env_qpshare_ngroups16: 1200
+    quick_env_qpshare_depth_ceiling: 1200
     standard: 1200
     comprehensive: 1200
     comprehensive_disable_env: 1200
@@ -374,3 +496,6 @@ execution_settings:
     full_pow2_tree_ll: 1200
     full_pow2_ring_ll128: 1200
     full_pow2_tree_ll128: 1200
+    qpshare_stress: 3600
+    qpshare_stress_churn: 3600
+    qpshare_uaf_teardown: 1200

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -11,6 +11,8 @@
 #include <hip/hip_runtime.h>
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "DeviceBufferHelpers.hpp"
@@ -82,6 +84,33 @@ using namespace RCCLTestHelpers;
             GTEST_SKIP() << "Requires RCCL_IB_QP_SCHED_UPDATE_INTERVAL >= "             \
                          << (long long)(min_us) << " us (current: " << _v << ")";        \
         }                                                                                \
+    } while (0)
+
+// Skip a QP-sharing test when RCCL_IB_COMM_NGROUPS is absent/disabled, or when
+// a feature known to be mutually exclusive with sharing (resiliency, CAST
+// scheduler) is enabled alongside it. Must be called from the test body (not
+// a helper), because GTEST_SKIP() only interrupts execution when expanded
+// inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
+// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
+// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+#define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
+    do {                                                                                   \
+        const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
+        if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
+            GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
+                            "Use qpshare_* configs in net_ib_transport.json.";              \
+        }                                                                                   \
+        auto _qpshareIsSetTo1 = [](const char* name) {                                     \
+            const char* v = getenv(name);                                                  \
+            return v && v[0] && strcmp(v, "1") == 0;                                       \
+        };                                                                                  \
+        if (_qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_FAILOVER") ||                        \
+            _qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_RECOVERY")) {                         \
+            GTEST_SKIP() << "QP sharing tests do not support resiliency combos yet.";      \
+        }                                                                                   \
+        if (_qpshareIsSetTo1("RCCL_IB_QP_SCHED_ENABLE")) {                                 \
+            GTEST_SKIP() << "QP sharing tests do not support CAST scheduler combos yet.";  \
+        }                                                                                   \
     } while (0)
 
 // External NET IB plugin
@@ -202,6 +231,13 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
+
+    // ExpectQpShareLayout re-checks every live comm after every create and
+    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
+    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
+    // each TEST_F.
+    static constexpr int kMaxLayoutFailures = 40;
+    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -702,6 +738,196 @@ protected:
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
+    // Non-fatal, rank-agreed variant of SetupCastConnection.
+    //
+    // Returns true only when BOTH ranks established their side (agreed via
+    // MPI_LAND, so the two ranks never disagree about whether the connection
+    // exists). On false, each rank has closed whatever it managed to open and
+    // all three out-params are left null, so the caller can stop cleanly.
+    // It prevents a timeout in the case of a failed connection.
+    bool TryCastConnection(int dev,
+                           void** listenComm, void** sendComm, void** recvComm) {
+        const int rank = MPIEnvironment::world_rank;
+        const int peer = 1 - rank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+        int ok = 1;
+
+        if (rank == 0) {
+            if (CreateListenComm(dev, &handle, listenComm) != ncclSuccess || *listenComm == nullptr)
+                ok = 0;
+            // Sent unconditionally: rank 1 is already blocked in MPI_Recv, and
+            // a zeroed handle makes its connect fail rather than hang.
+            MPI_Send(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *recvComm == nullptr; i++) {
+                if (AcceptConnection(*listenComm, recvComm) != ncclSuccess) ok = 0;
+                else if (*recvComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*recvComm == nullptr) ok = 0;
+        } else {
+            MPI_Recv(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *sendComm == nullptr; i++) {
+                if (ConnectToRemote(dev, &handle, sendComm) != ncclSuccess) ok = 0;
+                else if (*sendComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*sendComm == nullptr) ok = 0;
+        }
+
+        int bothOk = 0;
+        MPI_Allreduce(&ok, &bothOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        if (!bothOk) {
+            if (*recvComm)   { CloseRecvComm(*recvComm);     *recvComm   = nullptr; }
+            if (*listenComm) { CloseListenComm(*listenComm); *listenComm = nullptr; }
+            if (*sendComm)   { CloseSendComm(*sendComm);     *sendComm   = nullptr; }
+        }
+        return bothOk != 0;
+    }
+
+    // Close one cast connection with no memory handle and no barrier. Each rank
+    // holds only its own comms (rank 0: listen+recv, rank 1: send), so the null
+    // checks make this rank-conditional without a rank test. Non-fatal: a close
+    // failure must not strand the peer at the next barrier.
+    void CloseCastConnection(void* listenComm, void* sendComm, void* recvComm) {
+        if (recvComm)   EXPECT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        if (listenComm) EXPECT_EQ(CloseListenComm(listenComm), ncclSuccess);
+        if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+
+    // Same MPI_LAND agreement TryCastConnection uses, for any other loop of
+    // per-connection setup calls (RegisterMemory, PostRecv, ...) that can fail
+    // on one rank but not the other.
+    bool RankAgree(bool localOk) {
+        int ok = localOk ? 1 : 0;
+        int allOk = 0;
+        MPI_Allreduce(&ok, &allOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        return allOk != 0;
+    }
+
+    // Highest refcount across the given comms: the sharing depth this run
+    // actually achieved. 1 means no QP ended up shared.
+    int MaxObservedSharingDepth(const std::vector<void*>& comms) {
+        int m = 0;
+        for (void* c : comms) {
+            if (c == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(c);
+            m = std::max(m, st.refcount);
+        }
+        return m;
+    }
+
+    // Report what a QP-sharing run actually exercised.
+    //
+    // Goes to stdout on rank 0 (visible in mpirun logs) and into the gtest XML.
+    void ReportQpShareCoverage(const char* what, int nconns, int maxCommsPerGroup,
+                               int spread = -1) {
+        const int ng = QpShareEnvNGroups();
+        const int dm = QpShareEnvDepthMultiplier();
+        RecordProperty("qpshare_ngroups", ng);
+        RecordProperty("qpshare_depth_multiplier", dm);
+        RecordProperty("qpshare_nconns", nconns);
+        RecordProperty("qpshare_max_comms_per_group", maxCommsPerGroup);
+        if (spread >= 0) RecordProperty("qpshare_group_spread", spread);
+        if (MPIEnvironment::world_rank != 0) return;
+        printf("[QPSHARE-COV] %s ngroups=%d depth=%d nconns=%d max_comms_per_group=%d",
+               what, ng, dm, nconns, maxCommsPerGroup);
+        if (spread >= 0) printf(" group_spread=%d", spread);
+        if (maxCommsPerGroup <= 1)
+            printf("  (NO QP WAS SHARED -- unshared data path only)");
+        printf("\n");
+        fflush(stdout);
+    }
+
+    // Compare every live comm's actual sharing state against the reference
+    // model, including cross-comm QP identity: comms in the same group must sit
+    // on one physical QP, comms in different groups must not.
+    //
+    // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
+    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
+    // Non-fatal throughout, so a layout divergence is reported for every comm
+    // rather than only the first, and both ranks always reach the next barrier.
+    void ExpectQpShareLayout(const std::vector<void*>& comms,
+                             const std::vector<QpShareRefModel::Placement>& places,
+                             const QpShareRefModel& model,
+                             const char* stage) {
+        EXPECT_EQ(comms.size(), places.size()) << stage;
+        if (comms.size() != places.size()) return;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
+        const int partsOnEntry = CurrentTestFailureParts();
+        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
+            const int g = places[i].group;
+
+            EXPECT_EQ(st.sharedGroupIdx, g)
+                << stage << ": conn " << i << " group mismatch";
+            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
+                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
+                << " (group " << g << ")";
+            EXPECT_EQ(st.refcount, model.Load(g))
+                << stage << ": conn " << i << " refcount does not match the "
+                << "number of live comms in group " << g;
+            // cqRefcount is a second, independent counter over the same set of
+            // comms: connect.cc increments refcount and cqRefcount together on
+            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
+            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
+            // They must therefore always agree. It is worth asserting
+            // separately because cqRefcount alone gates IbCastCleanupGroupCqs
+            // -- the release path that leaks a protection domain today (see
+            // QpShareStressConnectionChurn / QpShareStressBatchCreateDestroy,
+            // which reproduce it directly). A drift between the two would say
+            // which counter is wrong, which the PD leak by itself does not.
+            EXPECT_EQ(st.cqRefcount, st.refcount)
+                << stage << ": conn " << i << " in group " << g
+                << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                << st.refcount << ". These count the same comms and are"
+                << " maintained in lockstep; cqRefcount alone decides when the"
+                << " group's CQ and PD are released, so a drift here either"
+                << " frees a CQ that is still in use or never frees it.";
+            EXPECT_NE(st.commId, 0)
+                << stage << ": conn " << i << " has no commId -- it silently fell "
+                << "back off the sharing path";
+
+            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
+            auto it = groupQpn.find(g);
+            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
+            else EXPECT_EQ(st.qpn[0], it->second)
+                << stage << ": conn " << i << " is in group " << g
+                << " but not on that group's physical QP";
+        }
+        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
+            auto b = a;
+            for (++b; b != groupQpn.end(); ++b) {
+                EXPECT_NE(a->second, b->second)
+                    << stage << ": groups " << a->first << " and " << b->first
+                    << " unexpectedly share one physical QP";
+            }
+        }
+        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
+            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
+                   " further per-comm layout checks suppressed for this test."
+                   " The test still fails -- read the FIRST divergence above,"
+                   " not the last: every later one is downstream of it.\n",
+                   kMaxLayoutFailures, stage);
+            fflush(stdout);
+        }
+    }
+
+    // Failure records logged so far by the currently running test. Used as a
+    // cheap delta counter; gtest exposes no "did that block just fail" query.
+    static int CurrentTestFailureParts() {
+        const ::testing::TestInfo* info =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        if (info == nullptr || info->result() == nullptr) return 0;
+        const ::testing::TestResult* res = info->result();
+        int n = 0;
+        for (int i = 0; i < res->total_part_count(); i++)
+            if (res->GetTestPartResult(i).failed()) n++;
+        return n;
+    }
+
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.
     // Both ranks call this together. actualNqps is broadcast so rank 0 can coordinate.
     // buf/mhandle must already be registered against the caller's comm.
@@ -718,6 +944,16 @@ protected:
         MPI_Bcast(&nqps, 1, MPI_INT, 1, MPI_COMM_WORLD);
         EXPECT_GT(nqps, 0);
         return nqps;
+    }
+
+    // Read QP-sharing pool state directly from a connected sendComm/recvComm.
+    // Unlike GetActualNqps(), no warmup send/recv is required: PRIMARY/SECONDARY
+    // role, groupIdx, refcount, and QP handles are all fixed at connect()/accept()
+    // time (see connect.cc groupIdx assignment), not populated lazily by traffic.
+    struct ncclIbQpSharingState GetActualQpSharingState(void* comm) {
+        struct ncclIbQpSharingState state = {};
+        EXPECT_EQ(ncclIbCastGetQpSharingState(comm, &state), ncclSuccess);
+        return state;
     }
 
     // Read RCCL_IB_QP_SCHED_SPLIT_DATA_MIN from the environment.

--- a/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+#define RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+
+#ifdef MPI_TESTS_ENABLED
+
+/*
+ * Re-export the shared struct and function declarations from the library's
+ * internal header.  Using the same header in both the library (qp_sharing.cc)
+ * and the tests guarantees that the ABI can never silently diverge.
+ */
+#include "net_ib_qp_sharing_inspect.h"
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
@@ -1,0 +1,140 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+#define RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+
+#include <cstdlib>
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+
+#ifdef MPI_TESTS_ENABLED
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Environment readers
+//
+// RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER are plain RCCL_PARAMs
+// (qp_sharing.cc) -- only the RCCL_ prefix is honoured, there is no NCCL_ alias
+// for either despite what the feature commit message says. RCCL_PARAM caches
+// both for the process lifetime, so a test may read them once and assume they
+// hold for its whole run. That also means a sweep over either value needs one
+// process (one mpirun) per point.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static inline int QpShareEnvInt(const char* name, int fallback) {
+    const char* v = getenv(name);
+    if (!v || v[0] == '\0') return fallback;
+    return static_cast<int>(std::atoll(v));
+}
+
+static inline int QpShareEnvNGroups() {
+    return QpShareEnvInt("RCCL_IB_COMM_NGROUPS", 0);
+}
+
+// connect.cc clamps the multiplier to >= 1 before scaling CQ/WR depth, so 0 or
+// a negative value behaves exactly like the default of 1.
+static inline int QpShareEnvDepthMultiplier() {
+    return std::max(1, QpShareEnvInt("RCCL_IB_QP_DEPTH_MULTIPLIER", 1));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// QpShareRefModel -- expected group layout, derived from RCCL_IB_COMM_NGROUPS
+//
+// Encodes the assignment rule the transport implements today (connect.cc):
+//
+//     groupIdx = IbCastCountPeerTotalRefcount(...) % ngroups
+//
+// i.e. occupancy-modulo -- the next comm joins the group selected by the total
+// number of *live* refcounts to that peer, not by a monotonic counter and not
+// by picking the least-loaded group. 
+// ─────────────────────────────────────────────────────────────────────────────
+class QpShareRefModel {
+public:
+    // Where one comm landed. Both fields are fixed at connect()/accept() time,
+    // exactly like ncclIbQpSharingState::sharedGroupIdx / isSharedQpPrimary:
+    // releasing the PRIMARY of a group does not promote a SECONDARY.
+    struct Placement {
+        int  group   = -1;
+        bool primary = false;
+    };
+
+    explicit QpShareRefModel(int ngroups)
+        : ngroups_(ngroups > 0 ? ngroups : 1), loads_(ngroups_, 0) {}
+
+    // Model the next successful connect(). Call this immediately before the
+    // real connection is established, in the same order the test issues them.
+    Placement AssignOnCreate() {
+        Placement p;
+        p.group   = TotalRefs() % ngroups_;
+        p.primary = (loads_[p.group] == 0);
+        loads_[p.group]++;
+        peakLoad_ = std::max(peakLoad_, loads_[p.group]);
+        return p;
+    }
+
+    // Model a comm teardown. Pass the Placement returned by AssignOnCreate().
+    void Release(const Placement& p) {
+        if (p.group < 0 || p.group >= ngroups_) return;
+        if (loads_[p.group] > 0) loads_[p.group]--;
+    }
+
+    int NGroups() const { return ngroups_; }
+
+    // Live comms in `group` -- the expected ncclIbQpSharingState::refcount for
+    // every comm currently in it.
+    int Load(int group) const {
+        if (group < 0 || group >= ngroups_) return -1;
+        return loads_[group];
+    }
+
+    int TotalRefs() const {
+        int sum = 0;
+        for (int l : loads_) sum += l;
+        return sum;
+    }
+
+    // Busiest group -- the achieved sharing depth, and the value
+    // RCCL_IB_QP_DEPTH_MULTIPLIER must currently cover. Simulated rather than
+    // computed as ceil(nconns/ngroups), because occupancy-modulo does not
+    // balance once teardowns are interleaved with creates.
+    int MaxLoad() const {
+        int m = 0;
+        for (int l : loads_) m = std::max(m, l);
+        return m;
+    }
+
+    // Busiest any group ever got, over the whole create/destroy sequence.
+    //
+    // This, not MaxLoad(), is the sharing depth a run achieved. MaxLoad() is
+    // instantaneous: a churn test that stacked three comms on one group and
+    // then released two reports MaxLoad()==1, and the coverage line then prints
+    // "NO QP WAS SHARED" for a run that plainly did share. Measured: churn at
+    // ngroups=2 reported max_comms_per_group=1 beside group_spread=3, which
+    // cannot both be true of the same instant.
+    int PeakLoad() const { return peakLoad_; }
+
+    int MinLoad() const {
+        int m = loads_.empty() ? 0 : loads_[0];
+        for (int l : loads_) m = std::min(m, l);
+        return m;
+    }
+
+    // Imbalance across groups. Reported by the tests, never asserted: how
+    // evenly occupancy-modulo spreads comms is a property worth measuring (it
+    // drives the depth multiplier a given ngroups demands) but not one this
+    // suite is entitled to dictate.
+    int Spread() const { return MaxLoad() - MinLoad(); }
+
+private:
+    int              ngroups_;
+    std::vector<int> loads_;
+    int              peakLoad_ = 0;
+};
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_QP_SHARE_REF_MODEL_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
@@ -1,0 +1,1034 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// MPI test suite for QP sharing (RCCL_IB_COMM_NGROUPS /
+// RCCL_IB_QP_DEPTH_MULTIPLIER).  2-rank, single-IB-device (dev=0).
+//
+// Three categories:
+//
+//   QpShareAlgo*    group-assignment and PRIMARY/SECONDARY bookkeeping,
+//                   validated against QpShareRefModel. No data phase.
+//   QpShareData*    the data path must be correct at every parameter point.
+//   QpShareStress*  scale and churn, with the scale under env control.
+//
+// Every test derives its expectations from RCCL_IB_COMM_NGROUPS rather than
+// pinning one hand-picked value, so all three categories are valid at any
+// (ngroups, depth, nconns). 
+//
+// Both tunables are RCCL_PARAM-backed and therefore cached for the process
+// lifetime (src/include/param.h): a sweep over either needs one mpirun per
+// point. The connection count is *not* cached and can be varied in-process,
+// which is why it is an ordinary env knob (QPSHARE_TEST_NCONNS /
+// QPSHARE_TEST_ITERS).
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
+
+#ifdef MPI_TESTS_ENABLED
+
+namespace {
+
+// Connections opened by the algo sweep: enough for every group to hold two
+// comms plus one, so PRIMARY-only, PRIMARY+SECONDARY and (at ngroups=1)
+// deep-stacking layouts all occur in one run. Capped so a large ngroups does
+// not turn a state-only test into a connection-setup benchmark.
+constexpr int kAlgoMaxConns = 64;
+
+// Live connections held by the churn test. Kept at two per group so the test
+// stays about pool bookkeeping rather than about RQ depth.
+constexpr int kChurnMaxLive = 32;
+
+// Connections the flush test may open. It needs ngroups+1 to guarantee one
+// shared pair; past this cap it reports that no pair was formed rather than
+// opening an unbounded number of GDR-registered connections.
+constexpr int kFlushMaxConns = 128;
+
+int Clamp(int v, int lo, int hi) { return std::max(lo, std::min(hi, v)); }
+
+std::string Stage(const char* what, int i) {
+    return std::string(what) + " " + std::to_string(i);
+}
+
+// One rank's view of a set of cast connections, paired with the reference
+// model's prediction for each.
+struct QpShareConns {
+    std::vector<void*> listen;
+    std::vector<void*> send;
+    std::vector<void*> recv;
+    std::vector<void*> mine;   // recvComm on rank 0, sendComm on rank 1
+    std::vector<QpShareRefModel::Placement> place;
+
+    size_t size() const { return mine.size(); }
+
+    void Add(int rank, void* l, void* s, void* r, QpShareRefModel::Placement p) {
+        listen.push_back(l);
+        send.push_back(s);
+        recv.push_back(r);
+        mine.push_back(rank == 0 ? r : s);
+        place.push_back(p);
+    }
+
+    void Erase(size_t i) {
+        listen.erase(listen.begin() + i);
+        send.erase(send.begin() + i);
+        recv.erase(recv.begin() + i);
+        mine.erase(mine.begin() + i);
+        place.erase(place.begin() + i);
+    }
+};
+
+}  // namespace
+
+// =============================================================================
+// Test: QpShareAlgoLayoutSweep  (category: algo)
+//
+// The group-assignment contract, validated at whatever RCCL_IB_COMM_NGROUPS is
+// configured. Opens connections one at a time up to min(2*ngroups+1, 64), and
+// after every single create re-checks *every* live comm against
+// QpShareRefModel: group index, PRIMARY/SECONDARY role, refcount, commId, and
+// the physical-QP identity relation (same group => same QP, different groups
+// => different QPs). Then tears down in creation order -- which releases each
+// group's PRIMARY while its SECONDARYs are still live -- re-checking after
+// every destroy.
+//
+// Subsumes the old QpShareNGroupsOne (ngroups=1), QpSharePrimarySecondaryMix
+// (ngroups=2) and QpShareNGroupsExceedsConns (ngroups > nconns) as three
+// points of the same sweep rather than three hand-computed layouts.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoLayoutSweep) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int target  = std::min(2 * ngroups + 1, kAlgoMaxConns);
+    if (2 * ngroups + 1 > kAlgoMaxConns && rank == 0) {
+        printf("[QPSHARE-COV] algo sweep capped at %d conns (ngroups=%d would need %d "
+               "for two per group)\n", kAlgoMaxConns, ngroups, 2 * ngroups + 1);
+    }
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < target; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << target << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << ". It would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ". This test never approaches the shared-QP pool's capacity (target <= "
+                << kAlgoMaxConns << " connections), so a connect() failure here means either "
+                   "a pool slot leaked by an earlier test in this process (slots are reclaimed "
+                   "on close, so this should not occur under normal operation) or a genuine "
+                   "hard-fail on pool exhaustion -- check NCCL_DEBUG=WARN for \"shared-QP pool "
+                   "exhausted\".";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after create", c).c_str());
+    }
+
+    ReportQpShareCoverage("algo_layout_sweep", static_cast<int>(cs.size()),
+                          model.PeakLoad(), model.Spread());
+
+    // Teardown from the front: releases group PRIMARYs ahead of their
+    // SECONDARYs, which is where refcount and pool bookkeeping are most likely
+    // to diverge from the model.
+    for (int c = 0; cs.size() > 0; c++) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after destroy", c).c_str());
+    }
+}
+
+// =============================================================================
+// Test: QpShareAlgoChurnLayout  (category: algo)
+//
+// Group assignment under interleaved create/destroy, including releases from
+// the middle of the live set rather than only the tail. This is where
+// occupancy-modulo (groupIdx = live totalRefs % ngroups) stops looking like
+// round-robin: after a non-tail release the next comm can land back in a group
+// that already has members while another sits empty. That behaviour is
+// reproduced by QpShareRefModel and asserted; the resulting imbalance is
+// measured and reported (group_spread) but deliberately not asserted -- how
+// evenly the rule spreads comms is a design question, not this suite's call.
+//
+// Also the sharpest check on pool bookkeeping: a slot freed on close but still
+// counted by IbCastCountPeerTotalRefcount shifts every subsequent assignment
+// and shows up here as a group mismatch.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoChurnLayout) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int maxLive = Clamp(2 * ngroups, 2, kChurnMaxLive);
+    const int steps   = 3 * maxLive + 6;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    int  observedSpread = 0;
+    bool broke          = false;
+
+    // Deterministic and rank-identical: the decision depends only on `step` and
+    // the live count, both of which evolve the same way on both ranks.
+    for (int step = 0; step < steps && !broke; step++) {
+        const bool create = cs.size() == 0 ||
+                            (static_cast<int>(cs.size()) < maxLive && (step % 3) != 2);
+        if (create) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "step " << step << ": connect failed with " << cs.size()
+                    << " live comms at RCCL_IB_COMM_NGROUPS=" << ngroups
+                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                    << " (would have been comm #" << (model.Load(p.group) + 1)
+                    << " in group " << p.group << ")";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+        } else {
+            // Rotating, non-tail victim: exercises releasing a comm that still
+            // has live neighbours in its group.
+            const size_t victim = static_cast<size_t>(step / 2) % cs.size();
+            model.Release(cs.place[victim]);
+            CloseCastConnection(cs.listen[victim], cs.send[victim], cs.recv[victim]);
+            cs.Erase(victim);
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+        observedSpread = std::max(observedSpread, model.Spread());
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("churn step", step).c_str());
+    }
+
+    ReportQpShareCoverage("algo_churn_layout", static_cast<int>(cs.size()),
+                          model.PeakLoad(), observedSpread);
+
+    while (cs.size() > 0) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataAllConnsTransfer  (category: data path)
+//
+// The core data-path gate: at the configured (ngroups, depth), open nconns
+// connections and require every one of them to connect and to move data
+// correctly across a size sweep covering zero-length, single-byte and
+// powers-of-two +/-1 up to 1 MB.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS",
+                                                  Clamp(ngroups + 2, 4, 32)));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << nconns << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << " -- it would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ", and the shared QP is sized for " << QpShareEnvDepthMultiplier() << "."
+                << (c == 0
+                        ? " This is the FIRST connection, so nothing is shared yet:"
+                          " the depth multiplier itself exceeds what the device can"
+                          " allocate (a known depth-sizing limit, not pool exhaustion)."
+                        : " Pool exhaustion is now a hard connect() failure by design"
+                          " (net_ib_cast no longer falls back to unshared silently), so"
+                          " this is expected only if the shared-QP pool is genuinely"
+                          " full at this scale -- otherwise it indicates a leaked slot.");
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "all conns established");
+    ReportQpShareCoverage("data_all_conns_transfer", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        const std::vector<size_t> kSizes = {0, 1, 127, 128, 4095, 4096, 65535, 65536, 1 << 20};
+        const size_t kMaxSz = kSizes.back();
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMaxSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMaxSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMaxSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 5300;
+        for (size_t i = 0; i < kSizes.size(); i++) {
+            for (int c = 0; c < established; c++) {
+                if (rank == 0) memset(recvBufs[c].data(), 0, kSizes[i]);
+                DoSendRecv(cs.send[c], cs.recv[c],
+                           sendBufs[c].data(), recvBufs[c].data(),
+                           kSizes[i], kTagBase + static_cast<int>(i) * established + c,
+                           mhandles[c], mhandles[c],
+                           /*patternSeed=*/static_cast<int>(i) * 31 + c);
+            }
+        }
+
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataUnsharedGroups  (category: data path)
+//
+// The nconns <= ngroups regime, where occupancy-modulo gives every connection
+// a group of its own and no QP is shared at all.
+//
+// nconns is derived as min(ngroups, 8) so the test is in the unshared regime
+// whatever ngroups is set to -- there is nothing to skip.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = Clamp(ngroups, 1, 8);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " -- nothing is even shared at this connection count";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "unshared groups established");
+    for (int c = 0; c < established; c++) {
+        EXPECT_EQ(model.Load(cs.place[c].group), 1)
+            << "test bug: conn " << c << " was expected to be alone in its group";
+        EXPECT_TRUE(cs.place[c].primary);
+    }
+    ReportQpShareCoverage("data_unshared_groups", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 64 * 1024;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+        constexpr int kTagBase = 5100;
+        for (int c = 0; c < established; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], sendBufs[c].data(), recvBufs[c].data(),
+                       kMsgSz, kTagBase + c, mhandles[c], mhandles[c],
+                       /*patternSeed=*/c + 11);
+        }
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataFlushRouting  (category: data path)
+//
+// GDR flush completion routing across a shared CQ. A flush QP is per-comm and
+// is not itself shared, but its completion still lands on the group's shared CQ.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::min(ngroups + 1, kFlushMaxConns);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    ncclNetProperties_t props;
+    ASSERT_EQ(GetDeviceProperties(0, &props), ncclSuccess);
+    if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+        // Hardware capability, not a tunable: without GDR there is no flush to
+        // route. This is the one thing in the suite a parameter cannot fix.
+        GTEST_SKIP() << "GDR not supported on this device, skipping flush routing test";
+    }
+
+    const size_t kSz = (nconns <= 8) ? (1024 * 1024) : (64 * 1024);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "flush conns established");
+
+    // Locate a PRIMARY/SECONDARY pair and an unshared baseline from the model.
+    int primaryIdx = -1, secondaryIdx = -1, baselineIdx = -1;
+    for (int c = 0; c < established && secondaryIdx < 0; c++) {
+        if (cs.place[c].primary) continue;
+        secondaryIdx = c;
+        for (int q = 0; q < c; q++)
+            if (cs.place[q].group == cs.place[c].group && cs.place[q].primary) primaryIdx = q;
+    }
+    if (primaryIdx >= 0)
+        for (int c = 0; c < established; c++)
+            if (cs.place[c].group != cs.place[primaryIdx].group) { baselineIdx = c; break; }
+
+    const bool havePair = (primaryIdx >= 0 && secondaryIdx >= 0);
+    ReportQpShareCoverage("data_flush_routing", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+    if (!havePair && rank == 0) {
+        printf("[QPSHARE-COV] data_flush_routing: no PRIMARY/SECONDARY pair formed at "
+               "ngroups=%d with %d conns (cap %d) -- shared-CQ flush routing was NOT "
+               "exercised; only the unshared flush path was\n",
+               ngroups, established, kFlushMaxConns);
+        fflush(stdout);
+    }
+
+    if (established > 0) {
+        std::vector<void*> devBufs(established, nullptr);
+        std::vector<DeviceBufferAutoGuard> bufGuards;
+        bufGuards.reserve(established);
+        std::vector<void*> mhandles(established, nullptr);
+        bool setupOk = true;
+        for (int c = 0; c < established && setupOk; c++) {
+            if (hipMalloc(&devBufs[c], kSz) != hipSuccess) {
+                ADD_FAILURE() << "hipMalloc failed for conn " << c;
+                setupOk = false;
+                break;
+            }
+            bufGuards.push_back(makeDeviceBufferAutoGuard(devBufs[c]));
+            if (RegisterMemory(cs.mine[c], devBufs[c], kSz, NCCL_PTR_CUDA, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                setupOk = false;
+                break;
+            }
+            if (rank == 1) {
+                if (initializeBufferWithPattern<uint8_t>(devBufs[c], kSz,
+                                                          makeBytePattern(c + 700)) != hipSuccess) {
+                    ADD_FAILURE() << "initializeBufferWithPattern failed for conn " << c;
+                    setupOk = false;
+                    break;
+                }
+            }
+        }
+        ASSERT_TRUE(RankAgree(setupOk)) << "buffer/registration setup failed on one rank only";
+
+        // Transfer every connection concurrently (post-all, wait-all).
+        std::vector<void*> reqs(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            if (rank == 0) PostSingleRecv(cs.recv[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+            else           PostSendWithRetry(cs.send[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++) {
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kLargeTransferTimeoutMs), ncclSuccess)
+                << "conn " << c << " transfer completion";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0 && havePair) {
+            void* fReqP = nullptr; void* fReqS = nullptr;
+            int fszP = static_cast<int>(kSz), fszS = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[primaryIdx], 1, &devBufs[primaryIdx], &fszP,
+                                &mhandles[primaryIdx], &fReqP), ncclSuccess);
+            EXPECT_EQ(FlushRecv(cs.recv[secondaryIdx], 1, &devBufs[secondaryIdx], &fszS,
+                                &mhandles[secondaryIdx], &fReqS), ncclSuccess);
+            EXPECT_NE(fReqP, nullptr);
+            EXPECT_NE(fReqS, nullptr);
+
+            // Wait SECONDARY first: completions must be routed by commId, not by
+            // the order the requests were posted or polled.
+            int wS = 0, wP = 0;
+            EXPECT_EQ(WaitForCompletion(fReqS, &wS, kLargeTransferTimeoutMs), ncclSuccess)
+                << "SECONDARY (conn " << secondaryIdx << ") flush completion misrouted or lost";
+            EXPECT_EQ(WaitForCompletion(fReqP, &wP, kLargeTransferTimeoutMs), ncclSuccess)
+                << "PRIMARY (conn " << primaryIdx << ") flush completion misrouted or lost";
+
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[primaryIdx], kSz,
+                                                  makeBytePattern(primaryIdx + 700)))
+                << "PRIMARY conn " << primaryIdx << " data wrong after flush -- cross-comm misroute";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[secondaryIdx], kSz,
+                                                  makeBytePattern(secondaryIdx + 700)))
+                << "SECONDARY conn " << secondaryIdx << " data wrong after flush -- cross-comm misroute";
+        }
+
+        // Unshared baseline: flush on a solo group must behave exactly like the
+        // non-sharing path. Falls back to conn 0 when every comm shares a group.
+        const int soloIdx = (baselineIdx >= 0) ? baselineIdx : (havePair ? -1 : 0);
+        if (rank == 0 && soloIdx >= 0) {
+            void* fReq = nullptr;
+            int fsz = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[soloIdx], 1, &devBufs[soloIdx], &fsz,
+                                &mhandles[soloIdx], &fReq), ncclSuccess);
+            int w = 0;
+            EXPECT_EQ(WaitForCompletion(fReq, &w, kLargeTransferTimeoutMs), ncclSuccess)
+                << "unshared baseline conn " << soloIdx << " flush completion";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[soloIdx], kSz,
+                                                  makeBytePattern(soloIdx + 700)));
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressManyConns  (category: stress)
+//
+// Flagship regression guard: many connections to one peer under sustained
+// batched concurrent traffic on all of them. At ngroups=2 the default 100
+// connections put ~50 comms on each shared QP.
+//
+// Scale with QPSHARE_TEST_NCONNS.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressManyConns) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 100));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                          << " (comm #" << (model.Load(p.group) + 1) << " in group "
+                          << p.group << ")";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "stress conns established");
+    ReportQpShareCoverage("stress_many_conns", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr int    kNMsgs = 20;
+        constexpr size_t kMsgSz = 4096;
+        constexpr size_t kBufSz = kNMsgs * kMsgSz;
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kBufSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kBufSz));
+        for (int c = 0; c < established; c++) {
+            for (size_t i = 0; i < kBufSz; i++)
+                sendBufs[c][i] = static_cast<char>(((i + c) * 5 + 11) & 0xFF);
+            memset(recvBufs[c].data(), 0, kBufSz);
+        }
+
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kBufSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 6000;
+        for (int c = 0; c < established; c++) {
+            CastDoBatchSendRecv(rank, cs.send[c], cs.recv[c],
+                                sendBufs[c].data(), recvBufs[c].data(),
+                                kMsgSz, kNMsgs, kTagBase + c * kNMsgs, mhandles[c]);
+        }
+
+        if (rank == 0) {
+            for (int c = 0; c < established; c++)
+                EXPECT_EQ(memcmp(recvBufs[c].data(), sendBufs[c].data(), kBufSz), 0)
+                    << "data corruption on conn " << c;
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressSharedRqSaturation  (category: stress)
+//
+// Deliberately tries to starve the shared receive queue: one message posted
+// from every connection simultaneously (post-all before any wait), repeated
+// over several rounds.
+//
+// Scale with QPSHARE_TEST_NCONNS (connections) and QPSHARE_TEST_ITERS (rounds).
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 50));
+    const int rounds  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ReportQpShareCoverage("stress_rq_saturation", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 512;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 7000;
+        for (int round = 0; round < rounds; round++) {
+            std::vector<void*> reqs(established, nullptr);
+            const int tagRoundBase = kTagBase + round * established;
+            bool postOk = true;
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    void*  bufs[1]    = {recvBufs[c].data()};
+                    size_t sizes[1]   = {kMsgSz};
+                    int    tags[1]    = {tagRoundBase + c};
+                    void*  handles[1] = {mhandles[c]};
+                    if (PostRecv(cs.recv[c], 1, bufs, sizes, tags, handles, &reqs[c]) != ncclSuccess
+                        || reqs[c] == nullptr) {
+                        ADD_FAILURE() << "PostRecv failed for round " << round << " conn " << c;
+                        postOk = false;
+                        break;
+                    }
+                }
+            } else {
+                for (int c = 0; c < established; c++) {
+                    fillHostBufferWithPattern<uint8_t>(sendBufs[c].data(), kMsgSz,
+                                                       makeBytePattern(round * established + c));
+                    PostSendWithRetry(cs.send[c], sendBufs[c].data(), kMsgSz,
+                                      tagRoundBase + c, mhandles[c], &reqs[c]);
+                }
+            }
+            ASSERT_TRUE(RankAgree(postOk)) << "PostRecv failed on one rank only (round " << round << ")";
+            for (int c = 0; c < established; c++) {
+                int sz = 0;
+                EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kStressTimeoutMs), ncclSuccess)
+                    << "round " << round << " conn " << c;
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    size_t errIdx; uint8_t errExp, errGot;
+                    EXPECT_TRUE(verifyHostBufferData<uint8_t>(
+                        recvBufs[c].data(), kMsgSz, makeBytePattern(round * established + c),
+                        0, 0.0, &errIdx, &errExp, &errGot))
+                        << "round " << round << " conn " << c << " data mismatch at byte " << errIdx;
+                }
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressConnectionChurn  (category: stress)
+//
+// Sequential connect -> transfer -> close cycles, by default 2048 of them.
+// Only one connection is live at a time, so nothing accumulates that the
+// transport is entitled to keep, so every cycle is fully torn down before the
+// next begins. What the checkpoints measure is whether that teardown returns
+// the device resources it took.
+//
+// Iterations are set by QPSHARE_TEST_ITERS;
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank  = MPIEnvironment::world_rank;
+    const int iters = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 2048));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 1024;
+    std::vector<char> buf(sz);
+
+    // Warmup connect+transfer+close so driver-internal CQs settle before baselining.
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            // The shared-QP pool reclaims slots on close (free-stack), so this
+            // should not happen from cross-test accumulation anymore. A failure
+            // here now points at a slot leaked by an earlier test's teardown.
+            ADD_FAILURE() << "warmup connection failed before churn even started "
+                             "(shared-QP pool slot leak from an earlier test in this "
+                             "process? slots are reclaimed on close, so this should "
+                             "not occur under normal operation)";
+            return;
+        }
+        void* mh = nullptr;
+        bool regOk = (RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed during warmup";
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only during warmup";
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/599, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Checkpoint every quarter, so a failure localises without depending on the
+    // iteration count being the default.
+    const int stride = std::max(1, iters / 4);
+
+    for (int iter = 0; iter < iters; iter++) {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            ADD_FAILURE()
+                << "connect failed at churn iteration " << iter << " of " << iters
+                << ". Only one connection is live at a time, so every earlier"
+                   " cycle was fully closed: a resource acquired per cycle was"
+                   " not returned. Check the RDMA-resource checkpoints above and"
+                   " run with NCCL_DEBUG=WARN -- pass -x"
+                   " NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log and read the per-rank"
+                   " files, since a merged mpirun log usually carries rank 0"
+                   " only and the absence of a WARN there is not evidence that"
+                   " none was emitted";
+            break;
+        }
+        void* comm = (rank == 0) ? r : s;
+        void* mh   = nullptr;
+        bool regOk = (RegisterMemory(comm, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed at churn iteration " << iter;
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only at iteration " << iter;
+
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/iter % 1000, mh, mh, iter);
+
+        const bool checkpoint = ((iter + 1) % stride == 0) || (iter == iters - 1);
+        if (checkpoint) {
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comm);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at iter " << iter
+                << " -- the comm is live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0)
+                << "commId cleared at iter " << iter
+                << " -- the comm silently fell off the sharing path";
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+
+        if (checkpoint) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("churn@" + std::to_string(iter + 1)).c_str());
+        }
+    }
+
+    // Exactly one comm is live at any instant, so this test never stacks two
+    // comms on one QP -- achieved sharing depth is 1 by construction, not by
+    // accident, and the "NO QP WAS SHARED" banner is the correct label. Report
+    // it rather than leaving the driver's max/grp column blank: a blank column
+    // invites the reading that churn says something about sharing depth. It
+    // does not. It exercises the create/destroy lifecycle of a shared group
+    // whose membership never exceeds one, which is the occupancy that reaches
+    // the group-release path on every single cycle (the same path
+    // QpShareStressBatchCreateDestroy shows leaking a PD).
+    ReportQpShareCoverage("stress_connection_churn", iters, /*maxCommsPerGroup=*/1);
+}
+
+// =============================================================================
+// Test: QpShareStressBatchCreateDestroy  (category: stress)
+//
+// Resource lifetime under a bursty cadence: batches of connections created
+// together, used, and destroyed together. Defaults to 110 batches of 10.
+// RDMA-resource and refcount checkpoints every 25 batches.
+//
+// What this test is positioned to catch is anything that survives a completed
+// batch, which is why the checkpoints compare RDMA object counts against a
+// pre-batch baseline.
+//
+// Batch count from QPSHARE_TEST_ITERS, batch size from QPSHARE_TEST_NCONNS.
+// Unlike the sequential churn test this one holds several comms live at once,
+// so the batch size also has to fit the configured depth multiplier.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank     = MPIEnvironment::world_rank;
+    const int ngroups  = QpShareEnvNGroups();
+    const int batches  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 110));
+    const int perBatch = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 512;
+    std::vector<char> buf(sz);
+
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            // The shared-QP pool reclaims slots on close (free-stack), so this
+            // should not happen from cross-test accumulation anymore. A failure
+            // here now points at a slot leaked by an earlier test's teardown.
+            ADD_FAILURE() << "warmup connection failed before batching even started "
+                             "(shared-QP pool slot leak from an earlier test in this "
+                             "process? slots are reclaimed on close, so this should "
+                             "not occur under normal operation)";
+            return;
+        }
+        void* mh = nullptr;
+        bool regOk = (RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed during warmup";
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only during warmup";
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/699, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool broke = false;
+    int  peakDepth = 0;   // deepest any group got in any batch
+    int  peakSpread = 0;
+    for (int batch = 0; batch < batches && !broke; batch++) {
+        QpShareRefModel model(ngroups);
+        QpShareConns    cs;
+        std::vector<void*> mhandles;
+
+        for (int c = 0; c < perBatch; c++) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "connect failed at batch " << batch << " of " << batches
+                    << ", connection " << c << " of " << perBatch
+                    << " (cumulative connection #" << (batch * perBatch + c)
+                    << "). ngroups=" << ngroups << " depth="
+                    << QpShareEnvDepthMultiplier()
+                    << ". Every previous batch was fully torn down, so a failure "
+                       "here means a per-batch resource was not returned -- check "
+                       "the RDMA-count checkpoints above for which one.";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+            void* mh = nullptr;
+            bool regOk = (RegisterMemory(cs.mine.back(), buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+            if (!regOk) {
+                ADD_FAILURE() << "RegisterMemory failed at batch " << batch
+                              << ", connection " << c;
+            }
+            if (!RankAgree(regOk)) {
+                broke = true;
+                break;
+            }
+            mhandles.push_back(mh);
+        }
+
+        const int live = static_cast<int>(cs.size());
+        peakDepth  = std::max(peakDepth, model.PeakLoad());
+        peakSpread = std::max(peakSpread, model.Spread());
+        for (int c = 0; c < live; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], buf.data(), buf.data(), sz,
+                       /*tag=*/c, mhandles[c], mhandles[c], batch * perBatch + c);
+        }
+
+        const bool checkpoint = ((batch + 1) % 25 == 0) || (batch == batches - 1);
+        if (checkpoint && live > 0) {
+            // Every batch starts from an empty live set, so the layout must be
+            // identical to batch 0's. Drift here means teardown left refcounts
+            // behind that IbCastCountPeerTotalRefcount still sees.
+            ExpectQpShareLayout(cs.mine, cs.place, model,
+                                Stage("batch checkpoint", batch).c_str());
+            struct ncclIbQpSharingState st = GetActualQpSharingState(cs.mine[0]);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at batch " << batch
+                << " -- comms are live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0) << "commId cleared at batch " << batch;
+        }
+
+        for (int c = 0; c < live; c++) {
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            CloseCastConnection(cs.listen[c], cs.send[c], cs.recv[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (checkpoint && !broke) {
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("batch@" + std::to_string(batch + 1)).c_str());
+        }
+    }
+
+    // Depth reached inside a batch, which is what sets how often the
+    // group-release path runs: perBatch/ngroups comms per group means only
+    // 1-in-that-many teardowns reaches it. At the default 10 conns / ngroups=2
+    // that is the mild leak rate; at ngroups=10 every group holds one comm and
+    // the rate is the churn test's. Reported so the two are comparable.
+    ReportQpShareCoverage("stress_batch_create_destroy", perBatch, peakDepth, peakSpread);
+}
+
+#endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -498,6 +498,213 @@
       ]
     },
 
+    "qpshare_ngroups1": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "description": "At NGROUPS=1 every connection lands in group 0, so this is the maximum-concentration point -- the whole functional set runs on a single shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling: measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups2": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "description": "NGROUPS=2 is the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, and the first point at which group-index arithmetic can be wrong without being invisible. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling: measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups16": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "description": "NGROUPS=16 is the wide point: connection counts here straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so the preset does not sit near the saturation ceiling: measured on AINIC that ceiling is between 112 and 128 comms per group even at depth 1, far above anything these tests reach, so 8 is headroom and not a requirement.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Creates connections one at a time up to min(2*NGROUPS+1, 64) and checks every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create -- sharedGroupIdx, isSharedQpPrimary, refcount, commId and cross-comm QP identity -- then tears down from the front, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS, so the test runs and asserts at every value instead of skipping outside a pinned one.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims, layout re-validated against the reference model after every operation. This is the pool-bookkeeping check: a refcount that survives teardown, or a freed pool slot still counted, makes model and implementation disagree. Reports observed group spread; balance is measured, never asserted.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "QpShare_DataAllConnsTransfer",
+          "description": "Universal invariant at this (NGROUPS, DEPTH_MULTIPLIER) point: every connection must be established and must transfer correctly. Sweeps payload sizes from 0 to 1 MiB across the protocol boundaries on every comm, pattern-verified. Connection count from QPSHARE_TEST_NCONNS, defaulting to a value that forces sharing at the configured NGROUPS.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as a first-class case rather than a skip: connection count is derived as min(NGROUPS, 8) so every comm is a solo PRIMARY on its own physical QP. Asserts the distinct-QP layout and a correct data path on each.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing on a shared CQ: a PRIMARY/SECONDARY pair (located from the reference model, not from hardcoded indices) posts iflush() concurrently, verifying each completion routes back to the correct comm by commId rather than being cross-attributed. An unshared comm provides the baseline. Requires GDR-capable hardware and skips otherwise -- a hardware capability, not a tunable.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_depth_ceiling": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "96",
+        "NCCL_IB_QPS_PER_CONNECTION": "1",
+        "QPSHARE_TEST_NCONNS": "2"
+      },
+      "tests": [
+        {
+          "name": "QpShare_DataAllConnsTransfer_DepthCeiling",
+          "description": "The same missing capacity check seen from the opposite side: a depth multiplier larger than the device can allocate. The multiplier is applied to the QP's work-queue sizing as given, so an unhonourable value kills the FIRST connection outright instead of clamping to the device limit or falling back to an unshared QP -- and it fails before anything is shared, so no saturation fallback would help. Root cause measured 2026-08-17 on AINIC: the shared CQ is sized 3 x NET_IB_MAX_REQUESTS(256) x NCCL_IB_QPS_PER_CONNECTION x RCCL_IB_QP_DEPTH_MULTIPLIER = 768 x qps x depth entries (connect.cc:949 sender, :1730 receiver) and passed to ibv_create_cq with no comparison against device_attr.max_cqe. Bisected against that device's max_cqe of 65435: qps x depth = 85 passes at 65280 entries and 86 fails at 66048, identically on the qps=1 and qps=2 paths, so the usable depth is floor(max_cqe / (768 x qps)) -- 85 at QPS=1 and only 42 at the default QPS of 2. Both knobs are pinned in this preset because they multiply into the same limit. EXPECTED RED; acceptance criterion for clamping the multiplier to the queried device limit. The ceiling is device-specific: on a NIC with a larger max_cqe this preset passes, so raise the multiplier past floor(max_cqe / 768) rather than assuming 96 is universally over the line.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        }
+      ]
+    },
+
+    "qpshare_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "QpShare_StressManyConns",
+          "description": "Sustained batched traffic over QPSHARE_TEST_NCONNS connections (default 100, so ~50 comms per group at NGROUPS=2). DEPTH_MULTIPLIER=64 carries headroom above the 50 required.",
+          "test_filter": "NetIbMPITest.QpShareStressManyConns"
+        },
+        {
+          "name": "QpShare_StressSharedRqSaturation",
+          "description": "Post-all-then-wait-all across every connection in a shared group, QPSHARE_TEST_ITERS rounds (default 10) over QPSHARE_TEST_NCONNS connections (default 50) -- deliberately tries to starve the shared RQ.",
+          "test_filter": "NetIbMPITest.QpShareStressSharedRqSaturation"
+        },
+        {
+          "name": "QpShare_StressBatchCreateDestroy",
+          "description": "QPSHARE_TEST_ITERS batches (default 110) of QPSHARE_TEST_NCONNS connections (default 10), with the layout revalidated against a fresh reference model at batch checkpoints -- every batch starts from an empty live set, so drift means teardown left refcounts behind -- and RDMA object counts compared against a pre-batch baseline. What it reports is a protection-domain leak. This is the same PD-lifetime bug as QpShare_StressConnectionChurn, at a rate set by group OCCUPANCY (comms per group), i.e. by batch size AND NGROUPS together -- not by either alone. A PD reference is taken once per comm (connect.cc:99) but released once per GROUP (qp_sharing.cc:198), so a group holding k comms returns k-1 fewer references than it took and only a group that held exactly one comm reaches the dealloc at all. Measured 2026-08-17 on AINIC, same 10 connections x 20 batches: NGROUPS=10 (1 comm/group) gives before=1 after=21 with 21 dealloc WARNs per rank, while NGROUPS=2 (5 comms/group) gives before=1 after=2 with 1 WARN. Leaking less at low NGROUPS is the release path being reached less often, not health. When the dealloc IS reached it fails EBUSY, because IbCastCleanupGroupCqs runs at connect.cc:2094/:2176 before the per-comm MR deregistration loop at :2104/:2182, and the failure is only WARNed -- IbCastCleanupGroupCqs itself returns void (qp_sharing.h:101) and the wrap_ibv_dealloc_pd result at qp_sharing.cc:199 is dropped outright, so pdRefs is left at 0 with a stale non-NULL IbCastDevs[].pd. Attribution does not depend on this suite: the sharing-unaware NetIbMPITest.ConnectionBatchCreateDestroy is clean on generic IB and on IB-CAST with sharing off, and shows the same leak with sharing on. EXPECTED RED; acceptance criterion for the PD-lifetime fix. Runs in its own mpirun, separate from QpShare_StressConnectionChurn, so the churn crash cannot mask it.",
+          "test_filter": "NetIbMPITest.QpShareStressBatchCreateDestroy"
+        }
+      ]
+    },
+    "qpshare_stress_churn": {
+      "extends": "net_ib_base",
+      "timeout": 1800,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "QpShare_StressConnectionChurn",
+          "description": "QPSHARE_TEST_ITERS connect/transfer/close cycles (default 2048). Only one connection is live at a time, so every cycle is fully torn down before the next begins and nothing is entitled to accumulate. Measured 2026-08-17 on AINIC: each cycle leaks exactly one protection domain (one comm per group, so the group teardown reaches the dealloc every time), each announced by 'ibv_dealloc_pd failed with error Device or resource busy errno 16' -- 1023 of them per rank -- and connect stops working at iteration 1022 of 2048, this device reporting max_pd=1024. This is the same PD-lifetime bug as QpShare_StressBatchCreateDestroy, at the occupancy that hits it hardest. It is NOT shared-QP pool exhaustion even though IBCAST_MAX_SHARED_QPS is also 1024: per-rank logs of that run contain zero 'pool full' WARNs, and a full pool could not fail a connect anyway since IbCastRegisterSharedQp's NULL return is ignored at connect.cc:1109. The failing connect DOES report itself, once, on the connect-side rank: 'Call to ibv_alloc_pd failed with error No space left on device'. It is invisible in a merged mpirun log, which carries rank 0 only -- pass -x NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log to see it. The process is not usable afterwards: the next connect attempt segfaults rather than failing cleanly, which is why this test has its own configuration and its own mpirun instead of sharing one with qpshare_stress. EXPECTED RED against that pre-existing transport bug, kept gating as its acceptance criterion. Set QPSHARE_TEST_ITERS well below 1024 to exercise the pre-exhaustion path; the leak is already visible in the checkpoints there.",
+          "test_filter": "NetIbMPITest.QpShareStressConnectionChurn"
+        }
+      ]
+    },
+
+    "qpshare_uaf_teardown": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "NCCL_NET_FORCE_MERGE": "",
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0",
+        "MALLOC_PERTURB_": "165"
+      },
+      "tests": [
+        {
+          "name": "QpShare_AlgoChurnLayout_UafTeardown",
+          "description": "The deterministic form of a use-after-free that otherwise crashes qpshare_ngroups16 intermittently (measured 2 runs in 18 on AINIC, 2026-08-17). Same test and same tunables as that configuration; the only addition is MALLOC_PERTURB_=165, which makes glibc overwrite freed heap with 0xa5 so the stale read faults instead of usually reading intact memory. With it the crash is 6/6; without it 0/6 in the same session. Cause: IbCastRegisterSharedQp stores a pointer to the per-comm device block, &comm->devs[devIdx].base, in the shared-QP pool slot as primaryDevBase (connect.cc:1105). IbCastCloseSend/IbCastCloseRecv free(comm) at connect.cc:2140/:2235, and IbCastCleanupGroupCqs then dereferences that freed pointer to read primaryDevBase->ibDevN (qp_sharing.cc:193) and locks IbCastDevs[ibDevN].mutex (:194) with whatever garbage index came back. Backtrace lands in pthread_mutex_lock via IbCastCleanupGroupCqs+0x248 from IbCastCloseRecv+0x373. EXPECTED RED, and it does not fail an assertion -- the process dies, so the configuration reports a signal rather than a test failure. Acceptance criterion for storing ibDevN by value in the pool slot instead of a pointer into the comm. Controls to re-run alongside any fix attempt: the same filter without MALLOC_PERTURB_ (passes), and non-sharing NetIb tests with the poison on (unaffected). MALLOC_PERTURB_ is glibc-only and is inert on other allocators, so on a non-glibc platform this configuration silently degrades to being the same as qpshare_ngroups16.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        }
+      ]
+    },
+
     "cast_single_qp": {
       "extends": "cast_base",
       "timeout": 60,
@@ -1022,6 +1229,48 @@
       "name": "NET IB - CAST WRR only (QPS=2, splitData=0)",
       "description": "White-box WRR scheduler tests without split-data: weights distribution, doWrr toggle, splitData toggle, sched parms reflection",
       "config": "cast_wrr_no_split",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=1)",
+      "description": "QP-sharing gate at maximum concentration -- every connection on one shared QP. Layout sweep, churn layout, all-connection data path, unshared-regime data path and GDR flush routing, all with expectations derived from NGROUPS rather than pinned to it.",
+      "config": "qpshare_ngroups1",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=2)",
+      "description": "QP-sharing gate at the smallest mixed configuration: PRIMARY-only and PRIMARY+SECONDARY groups side by side. Same five functional tests.",
+      "config": "qpshare_ngroups2",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (NGROUPS=16)",
+      "description": "QP-sharing gate at the wide configuration, straddling the shared and unshared regimes within one run. Same five functional tests. Expected green, but INTERMITTENTLY CRASHES -- measured 2 runs in 18 on AINIC (2026-08-17) -- on a use-after-free in the group teardown path. A signal-kill here is that known defect, not a new regression; the qpshare_uaf_teardown configuration reproduces it deterministically. Do not paper over it with a retry.",
+      "config": "qpshare_ngroups16",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (depth multiplier ceiling)",
+      "description": "The same missing capacity check from the other side: a depth multiplier the device cannot allocate. EXPECTED RED -- the first connection fails outright instead of the multiplier being clamped to the device limit. Ceiling is on depth x NCCL_IB_QPS_PER_CONNECTION and is hardware-dependent, so on a NIC with more work-queue room this preset passes until the multiplier is raised further.",
+      "config": "qpshare_depth_ceiling",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing Stress",
+      "description": "Many-connection load, shared-RQ saturation and batch create/destroy under sharing. One EXPECTED RED: StressBatchCreateDestroy, against a sharing-specific protection-domain leak whose rate is set by group occupancy (comms per group). Kept gating as an acceptance criterion for the PD-lifetime fix, not disabled. Connection churn is deliberately NOT in this configuration -- see the separate qpshare_stress_churn entry below.",
+      "config": "qpshare_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing Stress (connection churn)",
+      "description": "Connection churn under sharing, in its own configuration and therefore its own process. EXPECTED RED against the same PD-lifetime bug as qpshare_stress, at the occupancy that hits it hardest: one comm per group, so every cycle reaches the group teardown and leaks one PD, exhausting the device max_pd (1024) at iteration 1022. Separated from qpshare_stress because churn leaves the process unable to connect and the next attempt segfaults -- anything sharing a process with it would never report. Longer timeout (1800s) than the rest: 2048 connect/transfer/close cycles is minutes of wall time, not seconds.",
+      "config": "qpshare_stress_churn",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - QP Sharing (use-after-free teardown)",
+      "description": "The deterministic form of the intermittent ngroups=16 crash: same test and tunables, plus MALLOC_PERTURB_=165 so the stale read into a freed comm faults every time (6/6 with the poison, 0/6 without). EXPECTED RED, reported as a signal rather than a test failure because the process dies. Acceptance criterion for storing ibDevN by value in the shared-QP pool slot instead of a pointer into the comm. glibc-only: on another allocator this degrades to a duplicate of qpshare_ngroups16.",
+      "config": "qpshare_uaf_teardown",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

This PR adds Unit tests for QP sharing feature.

## Technical Details

This pull request adds a comprehensive test and introspection framework for the QP-sharing feature in the Net IB-CAST transport, along with new test categories and expected failure cases for stress and edge conditions. The main changes include the introduction of a test-only introspection API for QP-sharing, new and updated test infrastructure, and the addition of several new test categories and configuration presets to ensure robust validation and gating of QP-sharing functionality.

**Key changes:**

### QP-sharing Introspection API

* Added `net_ib_qp_sharing_inspect.h` and its implementation, which define a test-only introspection API (`ncclIbCastGetQpSharingState`) for extracting the internal QP-sharing state from a communication handle. This API is shared between the library and unit tests to ensure consistency and facilitate white-box testing. [[1]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44) [[2]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R215-R256) [[3]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R9)
* Updated CMake build files to include the new header and source in both the library and test builds. [[1]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR467) [[2]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR5) [[3]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517L121-R121) [[4]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517R565)

### Test Infrastructure and Utilities

* Added `NetIbQpSharingInspect.hpp` and `QpShareRefModel.hpp` to the test suite, providing helpers and a reference model for validating QP-sharing state and expected layouts.
* Introduced the `QPSHARE_ENV_CHECK_OR_SKIP()` macro to conditionally skip QP-sharing tests when required environment variables are missing or incompatible features are enabled. This ensures tests only run in valid configurations.
* Enhanced the test fixture (`NetIbMPITest`) with layout failure tracking to better report and cap layout validation errors during test runs.

### Test Categories and Presets

* Added several new test categories to `test_categories_mpi.yaml` for QP-sharing, covering functional gates at different group counts, stress tests (including expected red/failure cases), and deterministic bug reproduction for teardown issues and resource leaks. Each category is carefully described with expected outcomes and hardware caveats. [[1]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R164-R224) [[2]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R411-R467)
* Updated test execution timeouts to accommodate new and longer-running QP-sharing tests. [[1]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R484-R488) [[2]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R500-R502)

These changes provide robust, white-box validation for the QP-sharing feature, ensure that known defects are explicitly gated, and improve test maintainability and clarity.

**References:**  
[[1]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44) [[2]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R215-R256) [[3]](diffhunk://#diff-70b0869b17d4af5fda1739b7d072dd860df724d3cc420200db6dc79493bd28c8R9) [[4]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR467) [[5]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR5) [[6]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517L121-R121) [[7]](diffhunk://#diff-b1d600d115875effbf7733d071b657787e4aaae5c2bcf27dae6e2cfa96cf5517R565) [[8]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR14-R15) [[9]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR89-R129) [[10]](diffhunk://#diff-47a79903364d01496c2b52036be9cbe35ee7ab66b68d819ab1aedfb3917a1accR249-R255) [[11]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R164-R224) [[12]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R411-R467) [[13]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R484-R488) [[14]](diffhunk://#diff-15028c666a858bb85ef7bc784a5884ae7c26eeb425d049a1e706216ab5f93933R500-R502)

## Issue Tracking

AICOMNET-352

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

```
RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile MPI_PATH=~/openmpi-5.0.9/install python3 tools/scripts/test_runner/test_runner.py     -c tools/scripts/test_runner/configs/net_ib_transport.json     --suite-name "NET IB - QP Sharing*"     --system ainic --no-build --build-dir ~/rccl_qp-sharing-tests-and-fixes/rccl/build/debug     --verbose
------------------------------------------------------------------------------------------------------------------------
Test Suite                               Test Name                                Result     Duration
------------------------------------------------------------------------------------------------------------------------
NET IB - QP Sharing (NGROUPS=1)          QpShare_AlgoLayoutSweep                  PASSED     1.918 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_AlgoChurnLayout                  PASSED     1.767 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataAllConnsTransfer             PASSED     2.268 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataUnsharedGroups               PASSED     1.567 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataFlushRouting                 PASSED     1.667 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_AlgoLayoutSweep                  PASSED     1.667 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_AlgoChurnLayout                  PASSED     2.218 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataAllConnsTransfer             PASSED     2.318 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataUnsharedGroups               PASSED     1.517 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataFlushRouting                 PASSED     1.918 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_AlgoLayoutSweep                  PASSED     4.072 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_AlgoChurnLayout                  PASSED     6.776 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataAllConnsTransfer             PASSED     6.526 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataUnsharedGroups               PASSED     2.368 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataFlushRouting                 PASSED     3.571 seconds
NET IB - QP Sharing (depth multiplier ceiling) QpShare_DataAllConnsTransfer_DepthCeiling PASSED     1.717 seconds
NET IB - QP Sharing Stress               QpShare_StressManyConns                  PASSED     9.381 seconds
NET IB - QP Sharing Stress               QpShare_StressSharedRqSaturation         PASSED     4.623 seconds
NET IB - QP Sharing Stress               QpShare_StressBatchCreateDestroy         PASSED     102.447 seconds
NET IB - QP Sharing Stress (connection churn) QpShare_StressConnectionChurn            PASSED     201.576 seconds
NET IB - QP Sharing (use-after-free teardown) QpShare_AlgoChurnLayout_UafTeardown      PASSED     6.726 seconds
------------------------------------------------------------------------------------------------------------------------
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
