### PR TITLE
[RCCL] QP sharing functional fixes

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -116,6 +116,7 @@ struct alignas(64) ncclIbDev {
   char* pciPath;
   int realPort;
   int maxQp;
+  int maxCqe;
   float latency;
   struct ncclIbMrCache mrCache;
   int ar; // ADAPTIVE_ROUTING

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1062,6 +1062,17 @@ ib_recv_dev_list:
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
         comm->devs[i].base.cq = existingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = comm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       existingSlot->cqRefcount++;
 
@@ -1864,6 +1875,17 @@ ib_recv:
       for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
         rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = rComm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       recvExistingSlot->cqRefcount++;
 

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1102,7 +1102,7 @@ qp_sharing_skip_sender:
       int devIdx = q % comm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -1926,7 +1926,7 @@ qp_sharing_skip_recv:
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
       if (entry) {
         entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
         if (q == 0) {
@@ -1948,7 +1948,7 @@ qp_sharing_skip_recv:
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
         IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -91,7 +91,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int64_t cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -103,12 +103,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
   }
 
   if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
-    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+    WARN("NET/IB: %s: requested CQ size %ld exceeds device %s max_cqe %d, clamping",
          __func__, cqSize, ibDev->devName, ibDev->maxCqe);
     cqSize = ibDev->maxCqe;
   }
 
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, (int)cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -961,7 +961,7 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, ((int64_t)cqSize * depthMult)), ret, fail);
     if (depthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what depthMult asked for, shrink depthMult to match so QP WR depth
@@ -1762,7 +1762,7 @@ ib_recv:
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, ((int64_t)cqSize * recvDepthMult)), ret, fail);
     if (recvDepthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
@@ -2003,8 +2003,14 @@ qp_sharing_skip_recv:
         flushKey.groupIdx = rComm->base.sharedGroupIdx;
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
-        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
             rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+        if (flushEntry == NULL) {
+          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+          continue;
+        }
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2121,12 +2121,6 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           }
         }
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
 
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
@@ -2144,6 +2138,15 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them, or ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown
@@ -2203,12 +2206,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // GPU flush cleanup — flush QP is shared, memory resources are per-comm
@@ -2250,6 +2247,16 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           IbCastResiliencyDevDestroy(comm->base.resiliency, i);
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them (data QPs above, this comm's own flush QP just above), or
+      // ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1114,12 +1114,16 @@ qp_sharing_skip_sender:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
           comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry && q == 0) {
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      if (q == 0) {
         entry->cqRefcount = 1;
       }
-      if (entry) {
-        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
-      }
+      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
     }
   }
 
@@ -1949,11 +1953,15 @@ qp_sharing_skip_recv:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
           rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry) {
-        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-        if (q == 0) {
-          entry->cqRefcount = 1;
-        }
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+      if (q == 0) {
+        entry->cqRefcount = 1;
       }
     }
 
@@ -2253,10 +2261,12 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                flushSlot->used = false;
+                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
               }
             } else {
-              // Not in pool (shouldn't happen), destroy directly
+              // Not in pool -- e.g. registration hit the pool-exhaustion
+              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
+              // flush QP was never pool-tracked, so just destroy it directly.
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
             commDev->gpuFlush.qp.qp = NULL;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -102,6 +102,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
+  if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
+    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+         __func__, cqSize, ibDev->devName, ibDev->maxCqe);
+    cqSize = ibDev->maxCqe;
+  }
+
   NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
@@ -637,9 +643,13 @@ fail:
 // is updated accordingly. The meta data structure is then expected to be
 // delivered to the remote side (receiver) as part of the connection
 // establishment process.
-static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
+static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId,
+                                          int depthMult) {
   uint nqps = comm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -648,7 +658,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -953,6 +962,13 @@ ib_recv_dev_list:
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    if (depthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what depthMult asked for, shrink depthMult to match so QP WR depth
+      // and this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = comm->devs[i].base.cq->cqe / cqSize;
+      if (achievedMult < depthMult) depthMult = std::max(1, achievedMult);
+    }
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1090,7 +1106,7 @@ ib_recv_dev_list:
 
 qp_sharing_skip_sender:
   // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
 
   // If primary, register QPs in shared pool
   if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
@@ -1361,10 +1377,14 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
-                                                 struct ncclIbConnectionMetadata* meta, int channelId) {
+                                                 struct ncclIbConnectionMetadata* meta, int channelId,
+                                                 int depthMult) {
   uint nqps = rComm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1378,7 +1398,6 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
 
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1744,6 +1763,13 @@ ib_recv:
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    if (recvDepthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
+      // this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = rCommDev->base.cq->cqe / cqSize;
+      if (achievedMult < recvDepthMult) recvDepthMult = std::max(1, achievedMult);
+    }
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1929,7 +1955,7 @@ ib_recv:
   }
 
 qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
 
   // If primary receiver, register QPs in shared pool
   if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -472,6 +472,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             }
 
             IbCastDevs[IbCastNDevs].maxQp = devAttr.max_qp;
+            IbCastDevs[IbCastNDevs].maxCqe = devAttr.max_cqe;
             IbCastDevs[IbCastNDevs].oooRqSize = oooRqSize;
             IbCastDevs[IbCastNDevs].mrCache.capacity = 0;
             IbCastDevs[IbCastNDevs].mrCache.population = 0;

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -60,7 +60,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
 
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+    int primaryIbDevN, int devIndex, int initialRefcount) {
 
     if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
@@ -70,7 +70,7 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
-    entry->primaryDevBase = primaryDevBase;
+    entry->primaryIbDevN = primaryIbDevN;
     entry->devIndex = devIndex;
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
@@ -197,8 +197,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
                      g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
             }
             destroyedCqs[nDestroyed++] = cq;
-            if (g_IbCastSharedQpPool[i].primaryDevBase) {
-                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+            {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryIbDevN;
                 std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
                 INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
                      ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -14,6 +14,8 @@ RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
+int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpFreeTop = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
 uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -62,11 +64,18 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount) {
 
-    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int idx;
+    if (g_IbCastSharedQpFreeTop > 0) {
+        // Reuse a slot freed by IbCastCleanupGroupCqs -- O(1)
+        idx = g_IbCastSharedQpFreeStack[--g_IbCastSharedQpFreeTop];
+    } else if (g_IbCastSharedQpPoolCount < IBCAST_MAX_SHARED_QPS) {
+        idx = g_IbCastSharedQpPoolCount++;
+    } else {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
         return NULL;
     }
-    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[idx];
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
@@ -77,6 +86,13 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->used = true;
     entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
+}
+
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry) {
+    if (entry == NULL) return;
+    int idx = (int)(entry - g_IbCastSharedQpPool);
+    entry->used = false;
+    g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = idx;
 }
 
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
@@ -209,5 +225,6 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
             }
         }
         g_IbCastSharedQpPool[i].used = false;
+        g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -42,7 +42,10 @@ struct IbCastSharedQp {
     IbCastSharedQpKey key;
     struct ibv_qp*    qp;                  // the physical QP
     struct ibv_cq*    primaryCq;           // CQ for this device in this group
-    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      primaryIbDevN;                // local IB device index of the primary comm's device,
+                                            // captured by value: the primary comm (and its inline
+                                            // devs[]) may be freed while secondaries or this pool
+                                            // entry still reference the group
     int      devIndex;                     // local device index within comm->devs[]
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
@@ -81,7 +84,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 // Register a new shared QP in the pool
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+    int primaryIbDevN, int devIndex, int initialRefcount);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -63,6 +63,8 @@ struct IbCastCommTableEntry {
 // Pool and comm table globals (defined in qp_sharing.cc)
 extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
+extern int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpFreeTop;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
 extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -85,6 +87,10 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount);
+
+// Undo a registration for a slot whose last user is closing outside of
+// IbCastCleanupGroupCqs (the flush-QP path).
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,


### PR DESCRIPTION
## Motivation

This PR adds multiple fixes to QP sharing functionality. These issues were found by Unit tests from https://github.com/ROCm/rocm-systems/pull/10612
And multithreaded rccl-tests executions.

## Technical Details

This pull request makes several important improvements to the InfiniBand (IB) collective broadcast (IBCast) transport layer, primarily focusing on resource management, robustness, and correctness in shared Queue Pair (QP) and Completion Queue (CQ) handling. The key changes ensure that QP and CQ resources are correctly sized, clamped to device limits, and properly reference-counted and cleaned up, especially in shared scenarios. Additionally, the changes improve error handling for resource exhaustion and clarify the relationship between QP depth multipliers and device capabilities.

The most important changes are:

**Resource Management and Correctness:**

* Added tracking of each device's `maxCqe` (maximum CQ entries) in `ncclIbDev`, and now clamp requested CQ sizes to this device limit to prevent oversubscription and potential failures. (`common_cast.h`, `init.cc`, `connect.cc`) [[1]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R119) [[2]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R475) [[3]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L105-R111)
* Adjusted QP depth multipliers (`depthMult`) to match the actual CQ capacity achieved after clamping, ensuring QP work request (WR) depth and shared-QP capacity never exceed what the CQ can record. (`connect.cc`) [[1]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L955-R971) [[2]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1731-R1772)

**Shared QP/CQ Pool Robustness:**

* Improved error handling when registering shared QPs or flush QPs: now checks for pool exhaustion and issues warnings, failing gracefully instead of proceeding with invalid state. (`connect.cc`) [[1]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1105-L1113) [[2]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1929-L1936) [[3]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1950-R2013)
* Ensured proper reference counting and cleanup for shared CQs and protection domains (PDs), including releasing unused PD refs for secondary comms and guaranteeing CQs are destroyed only after all QPs are unbound, preventing resource leaks and EBUSY errors. (`connect.cc`) [[1]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2R1081-R1091) [[2]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2R1908-R1918) [[3]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2R2204-R2212) [[4]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2R2315-R2324)

**API and Parameter Consistency:**

* Updated function signatures and usage to consistently pass and apply `depthMult` (the QP depth multiplier), reflecting the actual CQ sizing and device limits throughout the connection and QP creation process. (`connect.cc`) [[1]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L640-L642) [[2]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2R1380-L1352) [[3]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1366) [[4]](diffhunk://#diff-f4cba3e97da7cfa270890b95d85f7211b1fcff38231d238cc706218e52e50fb2L1906-R1958)

**Shared QP Pool Infrastructure:**

* Introduced a free stack for managing available shared QP pool slots, improving pool management and future extensibility. (`qp_sharing.cc`)

These changes collectively make the IB collective broadcast transport more robust, reliable, and maintainable, especially in environments with shared resources and high concurrency.

## Issue Tracking

AICOMNET-384

## Test Plan

MpiUnitTests https://github.com/ROCm/rocm-systems/pull/10612/changes
rccl-test with different configurations of NGROUPS and DEPTH

## Test Result

Tests from https://github.com/ROCm/rocm-systems/pull/10612/changes
```
RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile MPI_PATH=~/openmpi-5.0.9/install python3 tools/scripts/test_runner/test_runner.py     -c tools/scripts/test_runner/configs/net_ib_transport.json     --suite-name "NET IB - QP Sharing*"     --system ainic --no-build --build-dir ~/rccl_qp-sharing-tests-and-fixes/rccl/build/debug     --verbose
------------------------------------------------------------------------------------------------------------------------
Test Suite                               Test Name                                Result     Duration
------------------------------------------------------------------------------------------------------------------------
NET IB - QP Sharing (NGROUPS=1)          QpShare_AlgoLayoutSweep                  PASSED     1.918 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_AlgoChurnLayout                  PASSED     1.767 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataAllConnsTransfer             PASSED     2.268 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataUnsharedGroups               PASSED     1.567 seconds
NET IB - QP Sharing (NGROUPS=1)          QpShare_DataFlushRouting                 PASSED     1.667 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_AlgoLayoutSweep                  PASSED     1.667 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_AlgoChurnLayout                  PASSED     2.218 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataAllConnsTransfer             PASSED     2.318 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataUnsharedGroups               PASSED     1.517 seconds
NET IB - QP Sharing (NGROUPS=2)          QpShare_DataFlushRouting                 PASSED     1.918 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_AlgoLayoutSweep                  PASSED     4.072 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_AlgoChurnLayout                  PASSED     6.776 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataAllConnsTransfer             PASSED     6.526 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataUnsharedGroups               PASSED     2.368 seconds
NET IB - QP Sharing (NGROUPS=16)         QpShare_DataFlushRouting                 PASSED     3.571 seconds
NET IB - QP Sharing (depth multiplier ceiling) QpShare_DataAllConnsTransfer_DepthCeiling PASSED     1.717 seconds
NET IB - QP Sharing Stress               QpShare_StressManyConns                  PASSED     9.381 seconds
NET IB - QP Sharing Stress               QpShare_StressSharedRqSaturation         PASSED     4.623 seconds
NET IB - QP Sharing Stress               QpShare_StressBatchCreateDestroy         PASSED     102.447 seconds
NET IB - QP Sharing Stress (connection churn) QpShare_StressConnectionChurn            PASSED     201.576 seconds
NET IB - QP Sharing (use-after-free teardown) QpShare_AlgoChurnLayout_UafTeardown      PASSED     6.726 seconds
------------------------------------------------------------------------------------------------------------------------
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
