### PR TITLE
fix(rocprof-sys): Fix clang-tidy diff only to show diff files

### DIFF
--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -306,3 +306,7 @@ CheckOptions:
     value: "3"
   - key: readability-identifier-length.MinimumLoopCounterNameLength
     value: "3"
+
+  # include igrone
+  - key: misc-include-cleaner.IgnoreHeaders
+    value: "<compare>,<string_view>"

--- a/projects/rocprofiler-systems/scripts/clang-tidy-check.py
+++ b/projects/rocprofiler-systems/scripts/clang-tidy-check.py
@@ -73,6 +73,27 @@ def in_line_ranges(line: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= line <= end for start, end in ranges)
 
 
+def classify_diagnostic(diagnostic: Diagnostic, changed_file: ChangedFile) -> str | None:
+    """Classify `diagnostic` as belonging to `changed_file`, or not at all.
+
+    clang-tidy analyzes the whole translation unit, so scanning one file can
+    also emit diagnostics located in headers it includes (per
+    HeaderFilterRegex in .clang-tidy). Those are a different file's concern
+    and are picked up when that file is scanned instead, so only diagnostics
+    actually located in `changed_file.path` are classified here.
+
+    Returns "in_diff", "preexisting", or None if the diagnostic is in a
+    different file.
+    """
+    if os.path.normpath(diagnostic.file) != os.path.normpath(changed_file.path):
+        return None
+    return (
+        "in_diff"
+        if in_line_ranges(diagnostic.line, changed_file.line_ranges)
+        else "preexisting"
+    )
+
+
 def _git(git_args: list[str], cwd: str | None = None) -> str:
     """Run a git command, returning stdout; exit with git's own error on failure.
 
@@ -387,9 +408,12 @@ def main() -> int:
             any_timed_out = any_timed_out or not succeeded
 
             for diagnostic in parse_diagnostics(output, repo_root):
+                classification = classify_diagnostic(diagnostic, changed_file)
+                if classification is None:
+                    continue
                 target = (
                     rule_diagnostics
-                    if in_line_ranges(diagnostic.line, changed_file.line_ranges)
+                    if classification == "in_diff"
                     else preexisting_rule_diagnostics
                 )
                 for check_name in diagnostic.checks:

--- a/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
+++ b/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
@@ -79,6 +79,36 @@ def test_in_line_ranges(line, ranges, expected):
 
 
 # --------------------------------------------------------------------------- #
+# classify_diagnostic
+# --------------------------------------------------------------------------- #
+def _diagnostic(file: str, line: int) -> "ctc.Diagnostic":
+    return ctc.Diagnostic(
+        file=file, line=line, col=1, severity="warning", message="msg", checks=["c"]
+    )
+
+
+def test_classify_diagnostic_in_diff():
+    changed_file = ctc.ChangedFile("src/foo.cpp", [(10, 20)])
+    diagnostic = _diagnostic("src/foo.cpp", 15)
+    assert ctc.classify_diagnostic(diagnostic, changed_file) == "in_diff"
+
+
+def test_classify_diagnostic_preexisting_same_file_outside_diff():
+    changed_file = ctc.ChangedFile("src/foo.cpp", [(10, 20)])
+    diagnostic = _diagnostic("src/foo.cpp", 999)
+    assert ctc.classify_diagnostic(diagnostic, changed_file) == "preexisting"
+
+
+def test_classify_diagnostic_ignores_included_header():
+    # clang-tidy analyzes the whole translation unit; a diagnostic located in
+    # a header the changed file includes must not be attributed to it, even
+    # when the header's line number happens to fall inside the diff range.
+    changed_file = ctc.ChangedFile("src/foo.cpp", [(10, 20)])
+    diagnostic = _diagnostic("include/foo.hpp", 15)
+    assert ctc.classify_diagnostic(diagnostic, changed_file) is None
+
+
+# --------------------------------------------------------------------------- #
 # parse_diagnostics
 # --------------------------------------------------------------------------- #
 def test_parse_diagnostics_single():


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Current script include files that are not changed by user. So it includes files which are included in that file, which causes for us to fix issues which are out of scope. This PR have intention to fix it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Compare which files are in diff and for which files we found diagnostics, just show files that are actually changed.
Add exclude filter for include cleaner, because it report false-positives for some headers.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->
JIRA ID: AIPROFSYST-496
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Write test for script.
## Test Result

<!-- Briefly summarize test outcomes. -->
Test and CI pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
