### PR TITLE
chore(rocprofiler-systems): remove unnecessary umbrella Timemory include from address_range.hpp

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/binary/address_range.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/binary/address_range.hpp
@@ -5,7 +5,6 @@
 
 #include "core/binary/fwd.hpp"
 #include "core/common.hpp"
-#include "core/timemory.hpp"
 
 #include <timemory/hash/types.hpp>
 #include <timemory/utility/macros.hpp>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`address_range.hpp` included `core/timemory.hpp` header. This include is not necessary for successful build, but slows down duration of clang-tidy `bugprone-exception-escape` check to more than an hour. With this include removed, `bugprone-exception-escape` check time for `address_range.hpp` goes down to 3 seconds.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-496

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Build should complete without errors
- Existing ctest suite should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

- Build completes successfully
- Existing ctest suite passes

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
