### PR TITLE
fix(clr): charge trap handler SGPR reserve in occupancy calculation

### DIFF
--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -77,6 +77,12 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
       ? std::min(VgprWaves, device.info().sgprsPerSimd_ / sgprsPerWave)
       : VgprWaves;
 
+  if (GprWaves == 0) {
+    // As above: a bad SGPR count would zero alu_limited_threads, and hence
+    // bestBlockSize, giving a divide by zero when bestBlocksPerCU is computed.
+    return hipErrorUnknown;
+  }
+
   // The table contains SIMD per CU, not per WGP, so when WGP mode is set
   // on kernel metadata, multiply the number of SIMDs by 2, to account for
   // 2CUs in 1 WGP.

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -63,9 +63,18 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
     return hipErrorUnknown;
   }
 
+  // A wave costs its granule-rounded SGPRs plus the trap handler's reserve;
+  // omitting the reserve over-reports SGPR-bound kernels by a wave per SIMD.
+  // Mirrors LLVM AMDGPUUtils::getOccupancyWithNumSGPRs().
+  constexpr size_t DefaultSgprAllocGranule = 16;
+  const size_t sgprAllocGranule = device.info().sgprAllocGranularity_ != 0
+      ? device.info().sgprAllocGranularity_
+      : DefaultSgprAllocGranule;
+  const size_t sgprsPerWave =
+      amd::alignUp(wrkGrpInfo->usedSGPRs_, sgprAllocGranule) +
+      device.info().sgprTrapHandlerReserve_;
   const size_t GprWaves = wrkGrpInfo->usedSGPRs_ > 0
-      ? std::min(VgprWaves, device.info().sgprsPerSimd_ /
-                            amd::alignUp(wrkGrpInfo->usedSGPRs_, 16))
+      ? std::min(VgprWaves, device.info().sgprsPerSimd_ / sgprsPerWave)
       : VgprWaves;
 
   // The table contains SIMD per CU, not per WGP, so when WGP mode is set

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -676,6 +676,10 @@ struct Info : public amd::EmbeddedObject {
   uint32_t driverNodeId_;
   //! Number of Physical SGPRs per SIMD
   uint32_t sgprsPerSimd_;
+  //! SGPR allocation granularity. Zero if the backend does not report it.
+  uint32_t sgprAllocGranularity_;
+  //! Per-wave SGPRs reserved by the trap handler. Zero if absent or unreported.
+  uint32_t sgprTrapHandlerReserve_;
 
   uint32_t numSDMAengines_;  //!< Number of available SDMA engines
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1732,6 +1732,22 @@ bool Device::populateOCLDeviceConstants() {
       (amd::device::getValueFromIsaMeta(isaName, "AddressableNumSGPRs", sgprValue))
       ? (atoi(sgprValue.c_str()))
       : 0;
+
+  std::string sgprAllocGranule, trapHandlerEnabled;
+  info_.sgprAllocGranularity_ =
+      amd::device::getValueFromIsaMeta(isaName, "SGPRAllocGranule", sgprAllocGranule)
+      ? atoi(sgprAllocGranule.c_str())
+      : 0;
+  // Comgr reports whether a trap handler is present, but not the size of the
+  // SGPR block it reserves per wave, which is arch-independent.
+  constexpr uint32_t kTrapNumSgprs = 16;  // LLVM IsaInfo::TRAP_NUM_SGPRS
+  info_.sgprTrapHandlerReserve_ =
+      (amd::device::getValueFromIsaMeta(isaName, "TrapHandlerEnabled", trapHandlerEnabled) &&
+       atoi(trapHandlerEnabled.c_str()) != 0)
+      ? kTrapNumSgprs
+      : 0;
+  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "sgprAllocGranule=%u, sgprTrapHandlerReserve=%u",
+          info_.sgprAllocGranularity_, info_.sgprTrapHandlerReserve_);
   std::string imageSupport;
   if (amd::device::getValueFromIsaMeta(isaName, "ImageSupport", imageSupport)) {
     info_.imageSupport_ =


### PR DESCRIPTION
## Motivation

hipOccupancyMaxActiveBlocksPerMultiprocessor computes the per-wave SGPR cost as alignUp(usedSGPRs, 16), omitting the SGPRs the trap handler reserves in every wave. For SGPR-bound kernels this over-reports occupancy by one wave per SIMD.

ihipLaunchCooperativeKernel validates the requested grid against that same number, so an oversized cooperative grid is accepted instead of being rejected with hipErrorCooperativeLaunchTooLarge. The workgroups that do become resident then spin forever in grid.sync() waiting for peers that can never be dispatched, and the launch hangs with no timeout.

Observed on gfx942 with an ASAN build: device instrumentation raises coop_kernel from 29 to 92 SGPRs, which moves it out of the VGPR-bound regime where the formula happens to be correct. The runtime reported 32 blocks/CU, the hardware fit 28, and Unit_hipCGGridGroupType_DataSharing hung indefinitely. The defect is not sanitizer specific; an uninstrumented kernel at 106 SGPRs reproduces the same one-wave-per-SIMD over-report.

## Technical Details

Charge a wave alignUp(usedSGPRs, granule) + trapHandlerReserve, mirroring LLVM IsaInfo::getOccupancyWithNumSGPRs(). SGPRAllocGranule and TrapHandlerEnabled are read from the comgr ISA metadata into two new device::Info fields, alongside the VGPR parameters already sourced there. The reserve size is LLVM's architecture-independent IsaInfo::TRAP_NUM_SGPRS.

Only kernels above 80 SGPRs change. Below that the SGPR term stays above the 8-wave ceiling, so min() picks the VGPR term exactly as before. From gfx10 SGPRs never limit occupancy, which sgprsPerSimd_ already encodes as UINT32_MAX. Backends that do not report these values keep current behaviour through zero defaults and a granule fallback.

## Issue Tracking

JIRA ID: ROCM-29763

## Test Plan

- gfx942 (MI300X, 304 CUs), ASAN build, HSA_XNACK=1.
- Run Unit_hipCGGridGroupType_{Basic,DataSharing,Barrier}.
- Measure real hardware co-residency for kernels spanning the VGPR-bound and SGPR-bound regimes and compare against reported occupancy.
- Confirm uninstrumented and low-SGPR kernels are unaffected.

## Test Result

Unit_hipCGGridGroupType_DataSharing hung indefinitely before the change and passes in 14.19s after. Basic, DataSharing and Barrier are 3/3.

Reported occupancy now matches measured co-residency on every kernel tested. The ASAN coop_kernel goes from 32 to 28 blocks/CU against a measured 28: 8512 of 9728 workgroups became resident, exactly 28 on each of the 304 CUs. Low-SGPR kernels are unchanged at 32 blocks/CU, and none of the 229 rocBLAS gfx942 kernels exceed 80 SGPRs, so they are unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.