### PR TITLE
test(rocprofiler-compute): Cover analyze txt and stdout output formats

### DIFF
--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -284,14 +284,15 @@ def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
     analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     analyzer.pre_processing()
 
-    report = tmp_path / "analysis_report.txt"
-    assert report.is_file()
-    assert not analyzer._output.closed
-    assert Path(analyzer._output.name).resolve() == report
-    assert analyzer._output.writable()
-    assert "analysis_report.txt" in mocks["warning"].call_args.args[1]
-
-    analyzer._output.close()
+    try:
+        report = tmp_path / "analysis_report.txt"
+        assert report.is_file()
+        assert not analyzer._output.closed
+        assert Path(analyzer._output.name).resolve() == report
+        assert analyzer._output.writable()
+        assert "analysis_report.txt" in mocks["warning"].call_args.args[1]
+    finally:
+        analyzer._output.close()
 
 
 def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
@@ -302,11 +303,12 @@ def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
     analyzer = make_analyzer(monkeypatch, "txt")
     analyzer.pre_processing()
 
-    created = list(tmp_path.iterdir())
-    assert len(created) == 1
-    assert created[0].match("rocprof_compute_*.txt")
-
-    analyzer._output.close()
+    try:
+        created = list(tmp_path.iterdir())
+        assert len(created) == 1
+        assert created[0].match("rocprof_compute_*.txt")
+    finally:
+        analyzer._output.close()
 
 
 def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
@@ -328,11 +330,13 @@ def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None
 
     txt_analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     txt_analyzer.pre_processing()
-    render_report(txt_analyzer, monkeypatch)
-    # The analyzer never closes _output, so flush before reading it back.
-    txt_analyzer._output.flush()
-    txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
-    txt_analyzer._output.close()
+    try:
+        render_report(txt_analyzer, monkeypatch)
+        # The analyzer never closes _output, so flush before reading it back.
+        txt_analyzer._output.flush()
+        txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
+    finally:
+        txt_analyzer._output.close()
 
     stdout_analyzer = make_analyzer(monkeypatch, "stdout")
     stdout_analyzer.pre_processing()

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -5,13 +5,18 @@
 
 import argparse
 import gzip
+import os
+import sys
+from collections import OrderedDict
 from pathlib import Path
+from types import SimpleNamespace
 
 import common
 import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
@@ -189,3 +194,170 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
         OmniAnalyze_Base(argparse.Namespace(tui=False, path=paths), {}).sanitize()
 
     assert "last two components" in mock_error.call_args.args[1]
+
+
+# -- pre_processing output_format dispatch ----------------------------------
+
+
+def _make_analyzer(
+    monkeypatch: pytest.MonkeyPatch,
+    output_format: str,
+    output_name: str = None,
+) -> OmniAnalyze_Base:
+    """Return an analyzer wired for pre_processing() with no workload on disk.
+
+    pre_processing() normally walks args.path to load sysinfo.csv and join
+    counter files. An empty path list plus a stubbed initalize_runs() reduces
+    it to the --output-format dispatch these tests are about.
+    """
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: OrderedDict())
+
+    args = argparse.Namespace(
+        output_format=output_format,
+        output_name=output_name,
+        path=[],
+        gpu_kernel=None,
+        gpu_id=None,
+        gpu_dispatch_id=None,
+    )
+    analyzer = OmniAnalyze_Base(args, {})
+    analyzer._profiling_config = {}
+    return analyzer
+
+
+def _render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write one rendered panel to analyzer._output via the real tty renderer."""
+    metric_dataframe = pd.DataFrame({
+        "Metric": ["EA read request fraction - HBM"],
+        "Avg": [50.0],
+        "Unit": ["Percent"],
+    })
+    table_config = {
+        "id": 3013,
+        "title": "EA Interface",
+        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
+    }
+    arch_configs = SimpleNamespace(
+        panel_configs={
+            3000: {
+                "id": 3000,
+                "title": "Memory Bandwidth Analysis",
+                "data source": [{"metric_table": table_config}],
+            }
+        }
+    )
+    runs = {
+        "fixture": SimpleNamespace(
+            dfs={3013: metric_dataframe},
+            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
+        )
+    }
+    monkeypatch.setattr(
+        "utils.tty.process_table_data", lambda *_args, **_kwargs: metric_dataframe
+    )
+
+    show_all(
+        argparse.Namespace(
+            decimal=2,
+            filter_metrics=None,
+            include_cols=None,
+            membw_analysis=True,
+            normal_unit="per_wave",
+            path=[["fixture"]],
+            time_unit="ns",
+            view=None,
+        ),
+        runs,
+        arch_configs,
+        analyzer._output,
+        profiling_config={"filter_blocks": []},
+    )
+
+
+def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
+    """--output-format txt with --output-name writes <name>.txt in the cwd."""
+    mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer.pre_processing()
+
+    report = tmp_path / "analysis_report.txt"
+    assert report.is_file()
+    assert not analyzer._output.closed
+    assert Path(analyzer._output.name).resolve() == report
+    assert analyzer._output.writable()
+    assert "analysis_report.txt" in mocks["warning"].call_args.args[1]
+
+    analyzer._output.close()
+
+
+def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
+    """Without --output-name the txt file falls back to rocprof_compute_<uuid>."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "txt")
+    analyzer.pre_processing()
+
+    created = list(tmp_path.iterdir())
+    assert len(created) == 1
+    assert created[0].match("rocprof_compute_*.txt")
+
+    analyzer._output.close()
+
+
+def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
+    """--output-format stdout routes to the terminal and touches no file."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "stdout")
+    analyzer.pre_processing()
+
+    assert analyzer._output is sys.stdout
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None:
+    """The txt file and the terminal receive byte-identical report content."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    txt_analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    txt_analyzer.pre_processing()
+    _render_report(txt_analyzer, monkeypatch)
+    # The analyzer never closes _output, so flush before reading it back.
+    txt_analyzer._output.flush()
+    txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
+    txt_analyzer._output.close()
+
+    stdout_analyzer = _make_analyzer(monkeypatch, "stdout")
+    stdout_analyzer.pre_processing()
+    capsys.readouterr()
+    _render_report(stdout_analyzer, monkeypatch)
+    stdout_report = capsys.readouterr().out
+
+    assert txt_report == stdout_report
+    assert "30. Memory Bandwidth Analysis" in txt_report
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits required")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses directory write permissions",
+)
+def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -> None:
+    """An unwritable cwd surfaces the raw OSError from the unguarded open()."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    read_only = tmp_path / "read_only"
+    read_only.mkdir()
+    read_only.chmod(0o555)
+    monkeypatch.chdir(read_only)
+
+    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    try:
+        with pytest.raises(PermissionError):
+            analyzer.pre_processing()
+    finally:
+        read_only.chmod(0o755)

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -196,10 +196,12 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
     assert "last two components" in mock_error.call_args.args[1]
 
 
-# -- pre_processing output_format dispatch ----------------------------------
+# ---------------------------------------------------------------------------
+# pre_processing output_format dispatch
+# ---------------------------------------------------------------------------
 
 
-def _make_analyzer(
+def make_analyzer(
     monkeypatch: pytest.MonkeyPatch,
     output_format: str,
     output_name: str = None,
@@ -225,7 +227,7 @@ def _make_analyzer(
     return analyzer
 
 
-def _render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
+def render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
     """Write one rendered panel to analyzer._output via the real tty renderer."""
     metric_dataframe = pd.DataFrame({
         "Metric": ["EA read request fraction - HBM"],
@@ -279,7 +281,7 @@ def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
     mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     analyzer.pre_processing()
 
     report = tmp_path / "analysis_report.txt"
@@ -297,7 +299,7 @@ def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "txt")
+    analyzer = make_analyzer(monkeypatch, "txt")
     analyzer.pre_processing()
 
     created = list(tmp_path.iterdir())
@@ -312,7 +314,7 @@ def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "stdout")
+    analyzer = make_analyzer(monkeypatch, "stdout")
     analyzer.pre_processing()
 
     assert analyzer._output is sys.stdout
@@ -324,25 +326,24 @@ def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    txt_analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    txt_analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     txt_analyzer.pre_processing()
-    _render_report(txt_analyzer, monkeypatch)
+    render_report(txt_analyzer, monkeypatch)
     # The analyzer never closes _output, so flush before reading it back.
     txt_analyzer._output.flush()
     txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
     txt_analyzer._output.close()
 
-    stdout_analyzer = _make_analyzer(monkeypatch, "stdout")
+    stdout_analyzer = make_analyzer(monkeypatch, "stdout")
     stdout_analyzer.pre_processing()
     capsys.readouterr()
-    _render_report(stdout_analyzer, monkeypatch)
+    render_report(stdout_analyzer, monkeypatch)
     stdout_report = capsys.readouterr().out
 
     assert txt_report == stdout_report
     assert "30. Memory Bandwidth Analysis" in txt_report
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits required")
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="root bypasses directory write permissions",
@@ -355,7 +356,7 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
     read_only.chmod(0o555)
     monkeypatch.chdir(read_only)
 
-    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     try:
         with pytest.raises(PermissionError):
             analyzer.pre_processing()

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -184,10 +184,12 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
     assert "last two components" in mock_error.call_args.args[1]
 
 
-# -- pre_processing output_format dispatch ----------------------------------
+# ---------------------------------------------------------------------------
+# pre_processing output_format dispatch
+# ---------------------------------------------------------------------------
 
 
-def _make_analyzer(
+def make_analyzer(
     monkeypatch: pytest.MonkeyPatch,
     output_format: str,
     output_name: str = None,
@@ -213,7 +215,7 @@ def _make_analyzer(
     return analyzer
 
 
-def _render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
+def render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
     """Write one rendered panel to analyzer._output via the real tty renderer."""
     metric_dataframe = pd.DataFrame({
         "Metric": ["EA read request fraction - HBM"],
@@ -267,7 +269,7 @@ def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
     mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     analyzer.pre_processing()
 
     report = tmp_path / "analysis_report.txt"
@@ -285,7 +287,7 @@ def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "txt")
+    analyzer = make_analyzer(monkeypatch, "txt")
     analyzer.pre_processing()
 
     created = list(tmp_path.iterdir())
@@ -300,7 +302,7 @@ def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = _make_analyzer(monkeypatch, "stdout")
+    analyzer = make_analyzer(monkeypatch, "stdout")
     analyzer.pre_processing()
 
     assert analyzer._output is sys.stdout
@@ -312,25 +314,24 @@ def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    txt_analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    txt_analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     txt_analyzer.pre_processing()
-    _render_report(txt_analyzer, monkeypatch)
+    render_report(txt_analyzer, monkeypatch)
     # The analyzer never closes _output, so flush before reading it back.
     txt_analyzer._output.flush()
     txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
     txt_analyzer._output.close()
 
-    stdout_analyzer = _make_analyzer(monkeypatch, "stdout")
+    stdout_analyzer = make_analyzer(monkeypatch, "stdout")
     stdout_analyzer.pre_processing()
     capsys.readouterr()
-    _render_report(stdout_analyzer, monkeypatch)
+    render_report(stdout_analyzer, monkeypatch)
     stdout_report = capsys.readouterr().out
 
     assert txt_report == stdout_report
     assert "30. Memory Bandwidth Analysis" in txt_report
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits required")
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="root bypasses directory write permissions",
@@ -343,7 +344,7 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
     read_only.chmod(0o555)
     monkeypatch.chdir(read_only)
 
-    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
     try:
         with pytest.raises(PermissionError):
             analyzer.pre_processing()

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -5,13 +5,18 @@
 
 import argparse
 import gzip
+import os
+import sys
+from collections import OrderedDict
 from pathlib import Path
+from types import SimpleNamespace
 
 import common
 import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
@@ -177,3 +182,170 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
         OmniAnalyze_Base(argparse.Namespace(tui=False, path=paths), {}).sanitize()
 
     assert "last two components" in mock_error.call_args.args[1]
+
+
+# -- pre_processing output_format dispatch ----------------------------------
+
+
+def _make_analyzer(
+    monkeypatch: pytest.MonkeyPatch,
+    output_format: str,
+    output_name: str = None,
+) -> OmniAnalyze_Base:
+    """Return an analyzer wired for pre_processing() with no workload on disk.
+
+    pre_processing() normally walks args.path to load sysinfo.csv and join
+    counter files. An empty path list plus a stubbed initalize_runs() reduces
+    it to the --output-format dispatch these tests are about.
+    """
+    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: OrderedDict())
+
+    args = argparse.Namespace(
+        output_format=output_format,
+        output_name=output_name,
+        path=[],
+        gpu_kernel=None,
+        gpu_id=None,
+        gpu_dispatch_id=None,
+    )
+    analyzer = OmniAnalyze_Base(args, {})
+    analyzer._profiling_config = {}
+    return analyzer
+
+
+def _render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write one rendered panel to analyzer._output via the real tty renderer."""
+    metric_dataframe = pd.DataFrame({
+        "Metric": ["EA read request fraction - HBM"],
+        "Avg": [50.0],
+        "Unit": ["Percent"],
+    })
+    table_config = {
+        "id": 3013,
+        "title": "EA Interface",
+        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
+    }
+    arch_configs = SimpleNamespace(
+        panel_configs={
+            3000: {
+                "id": 3000,
+                "title": "Memory Bandwidth Analysis",
+                "data source": [{"metric_table": table_config}],
+            }
+        }
+    )
+    runs = {
+        "fixture": SimpleNamespace(
+            dfs={3013: metric_dataframe},
+            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
+        )
+    }
+    monkeypatch.setattr(
+        "utils.tty.process_table_data", lambda *_args, **_kwargs: metric_dataframe
+    )
+
+    show_all(
+        argparse.Namespace(
+            decimal=2,
+            filter_metrics=None,
+            include_cols=None,
+            membw_analysis=True,
+            normal_unit="per_wave",
+            path=[["fixture"]],
+            time_unit="ns",
+            view=None,
+        ),
+        runs,
+        arch_configs,
+        analyzer._output,
+        profiling_config={"filter_blocks": []},
+    )
+
+
+def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
+    """--output-format txt with --output-name writes <name>.txt in the cwd."""
+    mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer.pre_processing()
+
+    report = tmp_path / "analysis_report.txt"
+    assert report.is_file()
+    assert not analyzer._output.closed
+    assert Path(analyzer._output.name).resolve() == report
+    assert analyzer._output.writable()
+    assert "analysis_report.txt" in mocks["warning"].call_args.args[1]
+
+    analyzer._output.close()
+
+
+def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
+    """Without --output-name the txt file falls back to rocprof_compute_<uuid>."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "txt")
+    analyzer.pre_processing()
+
+    created = list(tmp_path.iterdir())
+    assert len(created) == 1
+    assert created[0].match("rocprof_compute_*.txt")
+
+    analyzer._output.close()
+
+
+def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
+    """--output-format stdout routes to the terminal and touches no file."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    analyzer = _make_analyzer(monkeypatch, "stdout")
+    analyzer.pre_processing()
+
+    assert analyzer._output is sys.stdout
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None:
+    """The txt file and the terminal receive byte-identical report content."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    monkeypatch.chdir(tmp_path)
+
+    txt_analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    txt_analyzer.pre_processing()
+    _render_report(txt_analyzer, monkeypatch)
+    # The analyzer never closes _output, so flush before reading it back.
+    txt_analyzer._output.flush()
+    txt_report = (tmp_path / "analysis_report.txt").read_text(encoding="utf-8")
+    txt_analyzer._output.close()
+
+    stdout_analyzer = _make_analyzer(monkeypatch, "stdout")
+    stdout_analyzer.pre_processing()
+    capsys.readouterr()
+    _render_report(stdout_analyzer, monkeypatch)
+    stdout_report = capsys.readouterr().out
+
+    assert txt_report == stdout_report
+    assert "30. Memory Bandwidth Analysis" in txt_report
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits required")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses directory write permissions",
+)
+def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -> None:
+    """An unwritable cwd surfaces the raw OSError from the unguarded open()."""
+    common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
+    read_only = tmp_path / "read_only"
+    read_only.mkdir()
+    read_only.chmod(0o555)
+    monkeypatch.chdir(read_only)
+
+    analyzer = _make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    try:
+        with pytest.raises(PermissionError):
+            analyzer.pre_processing()
+    finally:
+        read_only.chmod(0o755)


### PR DESCRIPTION
## Motivation

The txt output format writes the analysis report through a plain file handle, a path distinct from the csv and db exporters that already have coverage. This adds unit coverage for that path along with the stdout default, so all four --output-format values are exercised.

## Technical Details

- Unit tests drive OmniAnalyze_Base.pre_processing() directly with a stubbed run initializer, keeping the format dispatch under test without a workload on disk.
- Coverage of --output-format txt asserts the report file is created both for an explicit --output-name and for the rocprof_compute_<uuid> fallback.
- One test renders the same panel through tty.show_all into both the txt handle and stdout, asserting byte-identical content.
- --output-format stdout is asserted to route to sys.stdout and leave the working directory untouched.
- A permission test pins current behavior when the output directory is not writable, and skips as root.

## JIRA ID

JIRA ID: AIROCVAL-125

## PR Stack

<!-- rocprof-compute-stack:start -->
<!-- stack-position: 1/2 -->
<!-- stack-current: WP1|users/abchoudh/test-coverage/test1-output-format -->
<!-- stack-previous: none -->
<!-- stack-next: WP2|users/abchoudh/test-coverage/test3-specs-correction|https://github.com/ROCm/rocm-systems/pull/10620 -->
<!-- stack-jira: AIROCVAL-125 -->
<!-- stack-entry: 1|WP1|users/abchoudh/test-coverage/test1-output-format|self -->
<!-- stack-entry: 2|WP2|users/abchoudh/test-coverage/test3-specs-correction|https://github.com/ROCm/rocm-systems/pull/10620 -->
1. **WP1** — `users/abchoudh/test-coverage/test1-output-format` (current)
2. [WP2](https://github.com/ROCm/rocm-systems/pull/10620) — `users/abchoudh/test-coverage/test3-specs-correction`
<!-- rocprof-compute-stack:end -->

## Test Plan

- [x] Run pytest tests/unit/rocprof_compute_analyze/test_analysis_base.py
- [x] Run pytest tests/unit/rocprof_compute_analyze

## Test Result

- [x] pytest tests/unit/rocprof_compute_analyze/test_analysis_base.py passes
- [x] pytest tests/unit/rocprof_compute_analyze passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.