### PR TITLE
test(rocprofiler-compute): Cover analyze --specs-correction overrides

### DIFF
--- a/projects/rocprofiler-compute/PYTHON_CODING_STYLE.md
+++ b/projects/rocprofiler-compute/PYTHON_CODING_STYLE.md
@@ -837,6 +837,7 @@ Before adding or modifying tests, read the existing test modules to understand t
 - Integration test modules are named after the user-facing feature or workflow they exercise end-to-end (e.g. `test_roofline_workflow.py`, `test_profile_export.py`), not after a single source file. The name should tell a reader what scenario is being validated without opening the file.
 - Prefer `monkeypatch` (pytest fixture) over `unittest.mock.Mock` / `MagicMock` — `monkeypatch` integrates with pytest's fixture lifecycle and is the dominant pattern in this project. Reserve `Mock` / `MagicMock` for cases that genuinely need call tracking or attribute auto-creation.
 - Use `types.SimpleNamespace` or `argparse.Namespace` for plain attribute bags instead of mock objects.
+- Define module-level helpers, constants, and fixtures at the top of a test module, above the first test. Do not interleave them between test functions, even when a helper serves only one section.
 
 ## Key Principles Summary
 

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -16,9 +16,25 @@ import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from utils import schema
+from utils.specs import MachineSpecsCDNA
 from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
+
+# Trimmed MI350 sysinfo.
+MI350_SYSINFO = {
+    "ip_blocks": "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
+    "version": "3",
+    "compute_partition": "SPX",
+    "memory_partition": "NPS1",
+    "gpu_series": "MI350",
+    "gpu_model": "MI350",
+    "gpu_arch": "gfx950",
+    "cu_per_gpu": "256",
+    "total_l2_chan": "128",
+    "num_xcd": "8",
+}
 
 
 def test_concat_result_csvs_concatenates_rocpd_results(tmp_path, monkeypatch) -> None:
@@ -366,3 +382,71 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
             analyzer.pre_processing()
     finally:
         read_only.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# initalize_runs --specs-correction handling
+# ---------------------------------------------------------------------------
+
+
+def make_specs_correction_analyzer(tmp_path, monkeypatch, specs_correction):
+    """Analyzer wired to a minimal MI350 workload, ready for initalize_runs().
+
+    Panel config generation is stubbed out so the run loop can be exercised
+    without loading the real arch YAML.
+    """
+    # MI350_SYSINFO is trimmed, so silence the "missing specs" warnings the
+    # spec-to-frame conversion emits for the fields it leaves unset.
+    common.patch_console(monkeypatch, "utils.specs", "warning")
+    pd.DataFrame([MI350_SYSINFO]).to_csv(tmp_path / "sysinfo.csv", index=False)
+
+    args = argparse.Namespace(
+        path=[[str(tmp_path)]],
+        specs_correction=specs_correction,
+        no_roof=True,
+        normal_unit="per_kernel",
+        gpu_kernel=None,
+        list_stats=False,
+        filter_metrics=None,
+        tui=False,
+        config_dir=str(tmp_path),
+    )
+    inst = OmniAnalyze_Base(args, {})
+    monkeypatch.setattr(inst, "generate_configs", lambda *a, **kw: {})
+    inst._arch_configs = {MI350_SYSINFO["gpu_arch"]: schema.ArchConfig()}
+    inst.set_soc({
+        MI350_SYSINFO["gpu_arch"]: SimpleNamespace(
+            _mspec=MachineSpecsCDNA(**MI350_SYSINFO)
+        )
+    })
+    return inst
+
+
+def test_initalize_runs_applies_specs_correction(tmp_path, monkeypatch) -> None:
+    """--specs-correction overrides the specs analysis runs on."""
+    inst = make_specs_correction_analyzer(
+        tmp_path, monkeypatch, "num_xcd:4,cu_per_gpu:64"
+    )
+
+    workload = inst.initalize_runs()[str(tmp_path)]
+
+    assert workload.sys_info["num_xcd"].item() == "4"
+    assert workload.sys_info["cu_per_gpu"].item() == "64"
+    # Uncorrected specs come through untouched, including the ip_blocks entry
+    # initalize_runs() reads right after applying the correction.
+    assert workload.sys_info["gpu_arch"].item() == "gfx950"
+    assert workload.sys_info["total_l2_chan"].item() == "128"
+    assert "SQ" in workload.avail_ips
+    assert "roofline" in workload.avail_ips
+
+
+def test_initalize_runs_without_specs_correction_keeps_sysinfo(
+    tmp_path, monkeypatch
+) -> None:
+    """Without the option the workload keeps the recorded sysinfo values."""
+    inst = make_specs_correction_analyzer(tmp_path, monkeypatch, None)
+
+    workload = inst.initalize_runs()[str(tmp_path)]
+
+    assert workload.sys_info["num_xcd"].item() == 8
+    assert workload.sys_info["cu_per_gpu"].item() == 256

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -22,19 +22,93 @@ from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
 
-# Trimmed MI350 sysinfo.
-MI350_SYSINFO = {
-    "ip_blocks": "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
-    "version": "3",
-    "compute_partition": "SPX",
-    "memory_partition": "NPS1",
-    "gpu_series": "MI350",
-    "gpu_model": "MI350",
-    "gpu_arch": "gfx950",
-    "cu_per_gpu": "256",
-    "total_l2_chan": "128",
-    "num_xcd": "8",
+# The args every analyzer needs; make_analyzer() overrides per test.
+ANALYZER_ARG_DEFAULTS = {
+    "output_format": "stdout",
+    "output_name": None,
+    "path": [],
+    "gpu_kernel": None,
+    "gpu_id": None,
+    "gpu_dispatch_id": None,
 }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_analyzer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stub_initalize_runs: bool = True,
+    **arg_overrides,
+) -> OmniAnalyze_Base:
+    """Return an analyzer built from ANALYZER_ARG_DEFAULTS plus arg_overrides.
+
+    pre_processing() normally walks args.path to load sysinfo.csv and join
+    counter files. The default empty path list plus a stubbed initalize_runs()
+    reduces it to the --output-format dispatch. Pass stub_initalize_runs=False
+    with a path to exercise the real run loop.
+    """
+    if stub_initalize_runs:
+        monkeypatch.setattr(
+            OmniAnalyze_Base, "initalize_runs", lambda self: OrderedDict()
+        )
+
+    args = argparse.Namespace(**{**ANALYZER_ARG_DEFAULTS, **arg_overrides})
+    analyzer = OmniAnalyze_Base(args, {})
+    analyzer._profiling_config = {}
+    return analyzer
+
+
+def render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write one rendered panel to analyzer._output via the real tty renderer."""
+    metric_dataframe = pd.DataFrame({
+        "Metric": ["EA read request fraction - HBM"],
+        "Avg": [50.0],
+        "Unit": ["Percent"],
+    })
+    table_config = {
+        "id": 3013,
+        "title": "EA Interface",
+        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
+    }
+    arch_configs = SimpleNamespace(
+        panel_configs={
+            3000: {
+                "id": 3000,
+                "title": "Memory Bandwidth Analysis",
+                "data source": [{"metric_table": table_config}],
+            }
+        }
+    )
+    runs = {
+        "fixture": SimpleNamespace(
+            dfs={3013: metric_dataframe},
+            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
+        )
+    }
+    monkeypatch.setattr(
+        "utils.tty.process_table_data", lambda *_args, **_kwargs: metric_dataframe
+    )
+
+    show_all(
+        argparse.Namespace(
+            decimal=2,
+            filter_metrics=None,
+            include_cols=None,
+            membw_analysis=True,
+            normal_unit="per_wave",
+            path=[["fixture"]],
+            time_unit="ns",
+            view=None,
+        ),
+        runs,
+        arch_configs,
+        analyzer._output,
+        profiling_config={"filter_blocks": []},
+    )
 
 
 def test_concat_result_csvs_concatenates_rocpd_results(tmp_path, monkeypatch) -> None:
@@ -217,87 +291,14 @@ def test_sanitize_rejects_paths_sharing_a_workload_name(tmp_path, monkeypatch) -
 # ---------------------------------------------------------------------------
 
 
-def make_analyzer(
-    monkeypatch: pytest.MonkeyPatch,
-    output_format: str,
-    output_name: str = None,
-) -> OmniAnalyze_Base:
-    """Return an analyzer wired for pre_processing() with no workload on disk.
-
-    pre_processing() normally walks args.path to load sysinfo.csv and join
-    counter files. An empty path list plus a stubbed initalize_runs() reduces
-    it to the --output-format dispatch these tests are about.
-    """
-    monkeypatch.setattr(OmniAnalyze_Base, "initalize_runs", lambda self: OrderedDict())
-
-    args = argparse.Namespace(
-        output_format=output_format,
-        output_name=output_name,
-        path=[],
-        gpu_kernel=None,
-        gpu_id=None,
-        gpu_dispatch_id=None,
-    )
-    analyzer = OmniAnalyze_Base(args, {})
-    analyzer._profiling_config = {}
-    return analyzer
-
-
-def render_report(analyzer: OmniAnalyze_Base, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Write one rendered panel to analyzer._output via the real tty renderer."""
-    metric_dataframe = pd.DataFrame({
-        "Metric": ["EA read request fraction - HBM"],
-        "Avg": [50.0],
-        "Unit": ["Percent"],
-    })
-    table_config = {
-        "id": 3013,
-        "title": "EA Interface",
-        "header": {"metric": "Metric", "value": "Avg", "unit": "Unit"},
-    }
-    arch_configs = SimpleNamespace(
-        panel_configs={
-            3000: {
-                "id": 3000,
-                "title": "Memory Bandwidth Analysis",
-                "data source": [{"metric_table": table_config}],
-            }
-        }
-    )
-    runs = {
-        "fixture": SimpleNamespace(
-            dfs={3013: metric_dataframe},
-            sys_info=pd.DataFrame([{"gpu_arch": "gfx950"}]),
-        )
-    }
-    monkeypatch.setattr(
-        "utils.tty.process_table_data", lambda *_args, **_kwargs: metric_dataframe
-    )
-
-    show_all(
-        argparse.Namespace(
-            decimal=2,
-            filter_metrics=None,
-            include_cols=None,
-            membw_analysis=True,
-            normal_unit="per_wave",
-            path=[["fixture"]],
-            time_unit="ns",
-            view=None,
-        ),
-        runs,
-        arch_configs,
-        analyzer._output,
-        profiling_config={"filter_blocks": []},
-    )
-
-
 def test_pre_processing_txt_creates_named_file(tmp_path, monkeypatch) -> None:
     """--output-format txt with --output-name writes <name>.txt in the cwd."""
     mocks = common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(
+        monkeypatch, output_format="txt", output_name="analysis_report"
+    )
     analyzer.pre_processing()
 
     try:
@@ -316,7 +317,7 @@ def test_pre_processing_txt_default_name_is_uuid(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(monkeypatch, "txt")
+    analyzer = make_analyzer(monkeypatch, output_format="txt")
     analyzer.pre_processing()
 
     try:
@@ -332,7 +333,7 @@ def test_pre_processing_stdout_creates_no_file(tmp_path, monkeypatch) -> None:
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    analyzer = make_analyzer(monkeypatch, "stdout")
+    analyzer = make_analyzer(monkeypatch, output_format="stdout")
     analyzer.pre_processing()
 
     assert analyzer._output is sys.stdout
@@ -344,7 +345,9 @@ def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None
     common.patch_console(monkeypatch, MODULE, "debug", "log", "warning")
     monkeypatch.chdir(tmp_path)
 
-    txt_analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    txt_analyzer = make_analyzer(
+        monkeypatch, output_format="txt", output_name="analysis_report"
+    )
     txt_analyzer.pre_processing()
     try:
         render_report(txt_analyzer, monkeypatch)
@@ -354,7 +357,7 @@ def test_txt_output_matches_stdout_output(tmp_path, monkeypatch, capsys) -> None
     finally:
         txt_analyzer._output.close()
 
-    stdout_analyzer = make_analyzer(monkeypatch, "stdout")
+    stdout_analyzer = make_analyzer(monkeypatch, output_format="stdout")
     stdout_analyzer.pre_processing()
     capsys.readouterr()
     render_report(stdout_analyzer, monkeypatch)
@@ -376,7 +379,9 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
     read_only.chmod(0o555)
     monkeypatch.chdir(read_only)
 
-    analyzer = make_analyzer(monkeypatch, "txt", output_name="analysis_report")
+    analyzer = make_analyzer(
+        monkeypatch, output_format="txt", output_name="analysis_report"
+    )
     try:
         with pytest.raises(PermissionError):
             analyzer.pre_processing()
@@ -389,64 +394,60 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
 # ---------------------------------------------------------------------------
 
 
-def make_specs_correction_analyzer(tmp_path, monkeypatch, specs_correction):
-    """Analyzer wired to a minimal MI350 workload, ready for initalize_runs().
+@pytest.mark.parametrize(
+    "specs_correction, expected",
+    [
+        (None, {"num_xcd": 8, "cu_per_gpu": 256}),
+        ("num_xcd:4,cu_per_gpu:64", {"num_xcd": "4", "cu_per_gpu": "64"}),
+    ],
+    ids=["recorded_sysinfo", "corrected_specs"],
+)
+def test_initalize_runs_specs_correction(
+    tmp_path, monkeypatch, specs_correction, expected
+) -> None:
+    """--specs-correction replaces the specs analysis runs on.
 
-    Panel config generation is stubbed out so the run loop can be exercised
-    without loading the real arch YAML.
+    Corrected values stay strings because the correction assigns them onto the
+    spec object, while uncorrected ones keep the dtype read_csv inferred.
     """
-    # MI350_SYSINFO is trimmed, so silence the "missing specs" warnings the
+    sysinfo = {
+        "ip_blocks": "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
+        "version": "3",
+        "gpu_model": "MI350",
+        "gpu_arch": "gfx950",
+        "cu_per_gpu": "256",
+        "num_xcd": "8",
+    }
+    # The spec is trimmed, so silence the "missing specs" warnings the
     # spec-to-frame conversion emits for the fields it leaves unset.
     common.patch_console(monkeypatch, "utils.specs", "warning")
-    pd.DataFrame([MI350_SYSINFO]).to_csv(tmp_path / "sysinfo.csv", index=False)
+    pd.DataFrame([sysinfo]).to_csv(tmp_path / "sysinfo.csv", index=False)
 
-    args = argparse.Namespace(
+    analyzer = make_analyzer(
+        monkeypatch,
+        stub_initalize_runs=False,
         path=[[str(tmp_path)]],
         specs_correction=specs_correction,
         no_roof=True,
         normal_unit="per_kernel",
-        gpu_kernel=None,
         list_stats=False,
         filter_metrics=None,
         tui=False,
         config_dir=str(tmp_path),
     )
-    inst = OmniAnalyze_Base(args, {})
-    monkeypatch.setattr(inst, "generate_configs", lambda *a, **kw: {})
-    inst._arch_configs = {MI350_SYSINFO["gpu_arch"]: schema.ArchConfig()}
-    inst.set_soc({
-        MI350_SYSINFO["gpu_arch"]: SimpleNamespace(
-            _mspec=MachineSpecsCDNA(**MI350_SYSINFO)
-        )
+    # Panel config generation would load the real arch YAML, which these tests
+    # are not about.
+    monkeypatch.setattr(analyzer, "generate_configs", lambda *a, **kw: {})
+    analyzer._arch_configs = {sysinfo["gpu_arch"]: schema.ArchConfig()}
+    analyzer.set_soc({
+        sysinfo["gpu_arch"]: SimpleNamespace(_mspec=MachineSpecsCDNA(**sysinfo))
     })
-    return inst
 
+    workload = analyzer.initalize_runs()[str(tmp_path)]
 
-def test_initalize_runs_applies_specs_correction(tmp_path, monkeypatch) -> None:
-    """--specs-correction overrides the specs analysis runs on."""
-    inst = make_specs_correction_analyzer(
-        tmp_path, monkeypatch, "num_xcd:4,cu_per_gpu:64"
-    )
-
-    workload = inst.initalize_runs()[str(tmp_path)]
-
-    assert workload.sys_info["num_xcd"].item() == "4"
-    assert workload.sys_info["cu_per_gpu"].item() == "64"
+    assert workload.sys_info["num_xcd"].item() == expected["num_xcd"]
+    assert workload.sys_info["cu_per_gpu"].item() == expected["cu_per_gpu"]
     # Uncorrected specs come through untouched, including the ip_blocks entry
     # initalize_runs() reads right after applying the correction.
     assert workload.sys_info["gpu_arch"].item() == "gfx950"
-    assert workload.sys_info["total_l2_chan"].item() == "128"
-    assert "SQ" in workload.avail_ips
-    assert "roofline" in workload.avail_ips
-
-
-def test_initalize_runs_without_specs_correction_keeps_sysinfo(
-    tmp_path, monkeypatch
-) -> None:
-    """Without the option the workload keeps the recorded sysinfo values."""
-    inst = make_specs_correction_analyzer(tmp_path, monkeypatch, None)
-
-    workload = inst.initalize_runs()[str(tmp_path)]
-
-    assert workload.sys_info["num_xcd"].item() == 8
-    assert workload.sys_info["cu_per_gpu"].item() == 256
+    assert workload.avail_ips == sysinfo["ip_blocks"].split("|")

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_analyze/test_analysis_base.py
@@ -16,9 +16,25 @@ import pandas as pd
 import pytest
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from utils import schema
+from utils.specs import MachineSpecsCDNA
 from utils.tty import show_all
 
 MODULE = "rocprof_compute_analyze.analysis_base"
+
+# Trimmed MI350 sysinfo.
+MI350_SYSINFO = {
+    "ip_blocks": "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
+    "version": "3",
+    "compute_partition": "SPX",
+    "memory_partition": "NPS1",
+    "gpu_series": "MI350",
+    "gpu_model": "MI350",
+    "gpu_arch": "gfx950",
+    "cu_per_gpu": "256",
+    "total_l2_chan": "128",
+    "num_xcd": "8",
+}
 
 
 def _write_results_gz(path: Path, content: str) -> None:
@@ -350,3 +366,71 @@ def test_pre_processing_txt_unwritable_directory_raises(tmp_path, monkeypatch) -
             analyzer.pre_processing()
     finally:
         read_only.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# initalize_runs --specs-correction handling
+# ---------------------------------------------------------------------------
+
+
+def make_specs_correction_analyzer(tmp_path, monkeypatch, specs_correction):
+    """Analyzer wired to a minimal MI350 workload, ready for initalize_runs().
+
+    Panel config generation is stubbed out so the run loop can be exercised
+    without loading the real arch YAML.
+    """
+    # MI350_SYSINFO is trimmed, so silence the "missing specs" warnings the
+    # spec-to-frame conversion emits for the fields it leaves unset.
+    common.patch_console(monkeypatch, "utils.specs", "warning")
+    pd.DataFrame([MI350_SYSINFO]).to_csv(tmp_path / "sysinfo.csv", index=False)
+
+    args = argparse.Namespace(
+        path=[[str(tmp_path)]],
+        specs_correction=specs_correction,
+        no_roof=True,
+        normal_unit="per_kernel",
+        gpu_kernel=None,
+        list_stats=False,
+        filter_metrics=None,
+        tui=False,
+        config_dir=str(tmp_path),
+    )
+    inst = OmniAnalyze_Base(args, {})
+    monkeypatch.setattr(inst, "generate_configs", lambda *a, **kw: {})
+    inst._arch_configs = {MI350_SYSINFO["gpu_arch"]: schema.ArchConfig()}
+    inst.set_soc({
+        MI350_SYSINFO["gpu_arch"]: SimpleNamespace(
+            _mspec=MachineSpecsCDNA(**MI350_SYSINFO)
+        )
+    })
+    return inst
+
+
+def test_initalize_runs_applies_specs_correction(tmp_path, monkeypatch) -> None:
+    """--specs-correction overrides the specs analysis runs on."""
+    inst = make_specs_correction_analyzer(
+        tmp_path, monkeypatch, "num_xcd:4,cu_per_gpu:64"
+    )
+
+    workload = inst.initalize_runs()[str(tmp_path)]
+
+    assert workload.sys_info["num_xcd"].item() == "4"
+    assert workload.sys_info["cu_per_gpu"].item() == "64"
+    # Uncorrected specs come through untouched, including the ip_blocks entry
+    # initalize_runs() reads right after applying the correction.
+    assert workload.sys_info["gpu_arch"].item() == "gfx950"
+    assert workload.sys_info["total_l2_chan"].item() == "128"
+    assert "SQ" in workload.avail_ips
+    assert "roofline" in workload.avail_ips
+
+
+def test_initalize_runs_without_specs_correction_keeps_sysinfo(
+    tmp_path, monkeypatch
+) -> None:
+    """Without the option the workload keeps the recorded sysinfo values."""
+    inst = make_specs_correction_analyzer(tmp_path, monkeypatch, None)
+
+    workload = inst.initalize_runs()[str(tmp_path)]
+
+    assert workload.sys_info["num_xcd"].item() == 8
+    assert workload.sys_info["cu_per_gpu"].item() == 256

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 """Unit tests for utils.parser.build_dfs, apply_filters, apply_kernel_filter,
-load_pc_sampling_data, utils_analysis filter resolution, and
+load_pc_sampling_data, correct_sys_info, utils_analysis filter resolution, and
 utils_common.expand_placeholder_ranges."""
 
 from collections import OrderedDict
@@ -15,12 +15,15 @@ import pytest
 
 from pc_sampling.pc_sampling_analysis import load_pc_sample_records
 from utils import schema
+from utils.metrics.evaluation_pipeline import create_sys_vars
 from utils.parser import (
     apply_filters,
     apply_kernel_filter,
     build_dfs,
+    correct_sys_info,
     load_pc_sampling_data,
 )
+from utils.specs import MachineSpecsCDNA
 from utils.utils_common import (
     convert_filter_blocks_to_panel_ids,
     expand_placeholder_ranges,
@@ -941,3 +944,149 @@ def test_display_dedup_across_dataframes():
     matched = get_matched_torch_operators_for_display(torch_operators, ["all"])
     op_names = [name for name, _ in matched]
     assert op_names.count(H3) == 1
+
+
+# =============================================================================
+# Tests for correct_sys_info (analyze --specs-correction)
+# =============================================================================
+
+MI350_IP_BLOCKS = "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline"
+
+
+def _mi350_mspec() -> MachineSpecsCDNA:
+    """Fully populated MI350 (gfx950) specs, mirroring the vcopy fixture.
+
+    Values match tests/workloads/vcopy/MI350/sysinfo.csv so that
+    get_class_members() reports no missing required fields.
+    """
+    return MachineSpecsCDNA(
+        workload_path="/workloads/vcopy/MI350",
+        command="./tests/vcopy -n 1048576 -b 256 -i 3",
+        ip_blocks=MI350_IP_BLOCKS,
+        timestamp="Fri Jun 26 20:32:27 2026 (UTC)",
+        version="3",
+        hostname="test-host",
+        cpu_model="AMD EPYC 9575F 64-Core Processor",
+        sbios="American Megatrends International, LLC.1.8",
+        linux_distro="Ubuntu 22.04.5 LTS",
+        linux_kernel_version="6.17.0-35-generic",
+        amd_gpu_kernel_version="6.19.9.31400000",
+        cpu_memory="3170244916",
+        gpu_memory="264224768",
+        rocm_version="7.14.0",
+        vbios="113-M350-01-1K1-040A",
+        compute_partition="SPX",
+        memory_partition="NPS1",
+        gpu_series="MI350",
+        gpu_model="MI350",
+        gpu_arch="gfx950",
+        gpu_chip_id="30112",
+        gpu_l1="32",
+        gpu_l2="4096",
+        cu_per_gpu="256",
+        simd_per_cu="4",
+        se_per_gpu="32",
+        sa_per_se="1",
+        wave_size="64",
+        workgroup_max_size="1024",
+        max_waves_per_cu="32",
+        max_sclk="2200",
+        max_mclk="1900",
+        cur_sclk="2200",
+        cur_mclk="1900",
+        l2_banks="16",
+        total_l2_chan="128",
+        lds_banks_per_cu="32",
+        sqc_per_gpu="128",
+        pipes_per_gpu="4",
+        num_xcd="8",
+        num_memory_channels="128",
+    )
+
+
+class TestCorrectSysInfo:
+    """--specs-correction parsing, spec overrides, and error handling."""
+
+    def test_single_pair_overrides_spec(self) -> None:
+        """One name:value pair updates the spec object and the returned frame."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4")
+
+        assert mspec.num_xcd == "4"
+        assert len(sys_info) == 1
+        assert sys_info["num_xcd"].item() == "4"
+
+    def test_multiple_pairs_override_every_spec(self) -> None:
+        """Comma-separated pairs are all applied."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4,cu_per_gpu:64")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "64"
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        """Spaces around names and values do not break the override."""
+        sys_info = correct_sys_info(_mi350_mspec(), " num_xcd : 4 , cu_per_gpu:64 ")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "64"
+
+    def test_untouched_specs_are_preserved(self) -> None:
+        """Specs that were not corrected survive the rebuild of sys_info.
+
+        analysis_base.initalize_runs() reads sys_info["ip_blocks"] straight
+        after the correction, so dropping columns here would break analysis.
+        """
+        sys_info = correct_sys_info(_mi350_mspec(), "num_xcd:4")
+
+        assert sys_info["ip_blocks"].item() == MI350_IP_BLOCKS
+        assert sys_info["gpu_arch"].item() == "gfx950"
+        assert sys_info["gpu_model"].item() == "MI350"
+        assert sys_info["total_l2_chan"].item() == "128"
+
+    def test_fragment_without_separator_is_ignored(self) -> None:
+        """A fragment with no ':' is skipped; valid pairs still apply."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4,garbage")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "256"
+
+    def test_value_keeps_everything_after_the_first_colon(self) -> None:
+        """Only the first ':' separates name from value."""
+        sys_info = correct_sys_info(_mi350_mspec(), "command:./vcopy -n 1:2")
+
+        assert sys_info["command"].item() == "./vcopy -n 1:2"
+
+    def test_unknown_spec_name_errors_and_exits(self, monkeypatch) -> None:
+        """An unknown spec name reports the name and aborts."""
+        error_calls = []
+
+        def record_and_exit(*args, **_kwargs):
+            error_calls.append(args)
+            raise SystemExit(1)
+
+        common.patch_console(
+            monkeypatch, "utils.parser", "error", error=record_and_exit
+        )
+
+        with pytest.raises(SystemExit):
+            correct_sys_info(_mi350_mspec(), "not_a_spec:1")
+
+        assert "not_a_spec" in str(error_calls[0])
+        assert "--specs" in str(error_calls[0])
+
+    def test_corrected_specs_reach_metric_evaluation(self) -> None:
+        """Overrides land in the ammolite__* variables metric formulas use.
+
+        create_sys_vars() consumes the corrected sys_info row, so this is what
+        makes $num_xcd and $cu_per_gpu in the panel configs pick up the
+        --specs-correction values.
+        """
+        corrected = correct_sys_info(_mi350_mspec(), "num_xcd:4,cu_per_gpu:64")
+        sys_vars = create_sys_vars(corrected.iloc[0])
+
+        assert sys_vars["ammolite__num_xcd"] == 4
+        assert sys_vars["ammolite__cu_per_gpu"] == 64
+        # An uncorrected spec keeps its fixture value.
+        assert sys_vars["ammolite__total_l2_chan"] == 128

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -15,7 +15,6 @@ import pytest
 
 from pc_sampling.pc_sampling_analysis import load_pc_sample_records
 from utils import schema
-from utils.metrics.evaluation_pipeline import create_sys_vars
 from utils.parser import (
     apply_filters,
     apply_kernel_filter,
@@ -73,6 +72,24 @@ def _make_arch_config(panels: list[tuple[int, dict[str, Any]]]) -> schema.ArchCo
 
 def _sys_info() -> dict[str, Any]:
     return {"total_l2_chan": 4}
+
+
+def make_mi350_machine_specs(monkeypatch: pytest.MonkeyPatch) -> MachineSpecsCDNA:
+    """MI350 (gfx950) specs, trimmed to the fields the correction tests assert.
+
+    get_class_members() warns once per spec left unset, so the warning is
+    silenced here instead of populating every field to keep the output quiet.
+    """
+    common.patch_console(monkeypatch, "utils.specs", "warning")
+    return MachineSpecsCDNA(
+        command="./tests/vcopy -n 1048576 -b 256 -i 3",
+        ip_blocks="SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline",
+        gpu_model="MI350",
+        gpu_arch="gfx950",
+        cu_per_gpu="256",
+        total_l2_chan="128",
+        num_xcd="8",
+    )
 
 
 # =============================================================================
@@ -950,116 +967,62 @@ def test_display_dedup_across_dataframes():
 # Tests for correct_sys_info (analyze --specs-correction)
 # =============================================================================
 
-MI350_IP_BLOCKS = "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline"
-
-
-def make_mi350_machine_specs() -> MachineSpecsCDNA:
-    """
-    Fully populated MI350 (gfx950) specs.
-
-    Values match sysinfo.csv so that get_class_members() reports
-    no missing required fields.
-    """
-    return MachineSpecsCDNA(
-        workload_path="/workloads/vcopy/MI350",
-        command="./tests/vcopy -n 1048576 -b 256 -i 3",
-        ip_blocks=MI350_IP_BLOCKS,
-        timestamp="Fri Jun 26 20:32:27 2026 (UTC)",
-        version="3",
-        hostname="test-host",
-        cpu_model="AMD EPYC 9575F 64-Core Processor",
-        sbios="American Megatrends International, LLC.1.8",
-        linux_distro="Ubuntu 22.04.5 LTS",
-        linux_kernel_version="6.17.0-35-generic",
-        amd_gpu_kernel_version="6.19.9.31400000",
-        cpu_memory="3170244916",
-        gpu_memory="264224768",
-        rocm_version="7.14.0",
-        vbios="113-M350-01-1K1-040A",
-        compute_partition="SPX",
-        memory_partition="NPS1",
-        gpu_series="MI350",
-        gpu_model="MI350",
-        gpu_arch="gfx950",
-        gpu_chip_id="30112",
-        gpu_l1="32",
-        gpu_l2="4096",
-        cu_per_gpu="256",
-        simd_per_cu="4",
-        se_per_gpu="32",
-        sa_per_se="1",
-        wave_size="64",
-        workgroup_max_size="1024",
-        max_waves_per_cu="32",
-        max_sclk="2200",
-        max_mclk="1900",
-        cur_sclk="2200",
-        cur_mclk="1900",
-        l2_banks="16",
-        total_l2_chan="128",
-        lds_banks_per_cu="32",
-        sqc_per_gpu="128",
-        pipes_per_gpu="4",
-        num_xcd="8",
-        num_memory_channels="128",
-    )
-
 
 class TestCorrectSysInfo:
     """--specs-correction parsing, spec overrides, and error handling."""
 
-    def test_single_pair_overrides_spec(self) -> None:
+    def test_single_pair_overrides_spec(self, monkeypatch) -> None:
         """One name:value pair updates the spec object and the returned frame."""
-        mspec = make_mi350_machine_specs()
+        mspec = make_mi350_machine_specs(monkeypatch)
         sys_info = correct_sys_info(mspec, "num_xcd:4")
 
         assert mspec.num_xcd == "4"
         assert len(sys_info) == 1
         assert sys_info["num_xcd"].item() == "4"
 
-    def test_multiple_pairs_override_every_spec(self) -> None:
+    def test_multiple_pairs_override_every_spec(self, monkeypatch) -> None:
         """Comma-separated pairs are all applied."""
-        mspec = make_mi350_machine_specs()
+        mspec = make_mi350_machine_specs(monkeypatch)
         sys_info = correct_sys_info(mspec, "num_xcd:4,cu_per_gpu:64")
 
         assert sys_info["num_xcd"].item() == "4"
         assert sys_info["cu_per_gpu"].item() == "64"
 
-    def test_surrounding_whitespace_is_stripped(self) -> None:
+    def test_surrounding_whitespace_is_stripped(self, monkeypatch) -> None:
         """Spaces around names and values do not break the override."""
         sys_info = correct_sys_info(
-            make_mi350_machine_specs(), " num_xcd : 4 , cu_per_gpu:64 "
+            make_mi350_machine_specs(monkeypatch), " num_xcd : 4 , cu_per_gpu:64 "
         )
 
         assert sys_info["num_xcd"].item() == "4"
         assert sys_info["cu_per_gpu"].item() == "64"
 
-    def test_untouched_specs_are_preserved(self) -> None:
+    def test_untouched_specs_are_preserved(self, monkeypatch) -> None:
         """
         Specs that were not corrected survive the rebuild of sys_info.
 
         analysis_base.initalize_runs() reads sys_info["ip_blocks"] straight
         after the correction, so dropping columns here would break analysis.
         """
-        sys_info = correct_sys_info(make_mi350_machine_specs(), "num_xcd:4")
+        sys_info = correct_sys_info(make_mi350_machine_specs(monkeypatch), "num_xcd:4")
 
-        assert sys_info["ip_blocks"].item() == MI350_IP_BLOCKS
+        assert sys_info["ip_blocks"].item().startswith("SQ|LDS|")
         assert sys_info["gpu_arch"].item() == "gfx950"
         assert sys_info["gpu_model"].item() == "MI350"
         assert sys_info["total_l2_chan"].item() == "128"
 
-    def test_fragment_without_separator_is_ignored(self) -> None:
+    def test_fragment_without_separator_is_ignored(self, monkeypatch) -> None:
         """A fragment with no ':' is skipped; valid pairs still apply."""
-        mspec = make_mi350_machine_specs()
+        mspec = make_mi350_machine_specs(monkeypatch)
         sys_info = correct_sys_info(mspec, "num_xcd:4,garbage")
 
         assert sys_info["num_xcd"].item() == "4"
         assert sys_info["cu_per_gpu"].item() == "256"
 
-    def test_value_keeps_everything_after_the_first_colon(self) -> None:
+    def test_value_keeps_everything_after_the_first_colon(self, monkeypatch) -> None:
         """Only the first ':' separates name from value."""
         sys_info = correct_sys_info(
-            make_mi350_machine_specs(), "command:./vcopy -n 1:2"
+            make_mi350_machine_specs(monkeypatch), "command:./vcopy -n 1:2"
         )
 
         assert sys_info["command"].item() == "./vcopy -n 1:2"
@@ -1077,25 +1040,7 @@ class TestCorrectSysInfo:
         )
 
         with pytest.raises(SystemExit):
-            correct_sys_info(make_mi350_machine_specs(), "not_a_spec:1")
+            correct_sys_info(make_mi350_machine_specs(monkeypatch), "not_a_spec:1")
 
         assert "not_a_spec" in str(error_calls[0])
         assert "--specs" in str(error_calls[0])
-
-    def test_corrected_specs_reach_metric_evaluation(self) -> None:
-        """
-        Overrides land in the ammolite__* variables metric formulas use.
-
-        create_sys_vars() consumes the corrected sys_info row, so this is what
-        makes $num_xcd and $cu_per_gpu in the panel configs pick up the
-        --specs-correction values.
-        """
-        corrected = correct_sys_info(
-            make_mi350_machine_specs(), "num_xcd:4,cu_per_gpu:64"
-        )
-        sys_vars = create_sys_vars(corrected.iloc[0])
-
-        assert sys_vars["ammolite__num_xcd"] == 4
-        assert sys_vars["ammolite__cu_per_gpu"] == 64
-        # An uncorrected spec keeps its fixture value.
-        assert sys_vars["ammolite__total_l2_chan"] == 128

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -953,11 +953,12 @@ def test_display_dedup_across_dataframes():
 MI350_IP_BLOCKS = "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline"
 
 
-def _mi350_mspec() -> MachineSpecsCDNA:
-    """Fully populated MI350 (gfx950) specs, mirroring the vcopy fixture.
+def make_mi350_machine_specs() -> MachineSpecsCDNA:
+    """
+    Fully populated MI350 (gfx950) specs.
 
-    Values match tests/workloads/vcopy/MI350/sysinfo.csv so that
-    get_class_members() reports no missing required fields.
+    Values match sysinfo.csv so that get_class_members() reports
+    no missing required fields.
     """
     return MachineSpecsCDNA(
         workload_path="/workloads/vcopy/MI350",
@@ -1009,7 +1010,7 @@ class TestCorrectSysInfo:
 
     def test_single_pair_overrides_spec(self) -> None:
         """One name:value pair updates the spec object and the returned frame."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4")
 
         assert mspec.num_xcd == "4"
@@ -1018,7 +1019,7 @@ class TestCorrectSysInfo:
 
     def test_multiple_pairs_override_every_spec(self) -> None:
         """Comma-separated pairs are all applied."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4,cu_per_gpu:64")
 
         assert sys_info["num_xcd"].item() == "4"
@@ -1026,18 +1027,21 @@ class TestCorrectSysInfo:
 
     def test_surrounding_whitespace_is_stripped(self) -> None:
         """Spaces around names and values do not break the override."""
-        sys_info = correct_sys_info(_mi350_mspec(), " num_xcd : 4 , cu_per_gpu:64 ")
+        sys_info = correct_sys_info(
+            make_mi350_machine_specs(), " num_xcd : 4 , cu_per_gpu:64 "
+        )
 
         assert sys_info["num_xcd"].item() == "4"
         assert sys_info["cu_per_gpu"].item() == "64"
 
     def test_untouched_specs_are_preserved(self) -> None:
-        """Specs that were not corrected survive the rebuild of sys_info.
+        """
+        Specs that were not corrected survive the rebuild of sys_info.
 
         analysis_base.initalize_runs() reads sys_info["ip_blocks"] straight
         after the correction, so dropping columns here would break analysis.
         """
-        sys_info = correct_sys_info(_mi350_mspec(), "num_xcd:4")
+        sys_info = correct_sys_info(make_mi350_machine_specs(), "num_xcd:4")
 
         assert sys_info["ip_blocks"].item() == MI350_IP_BLOCKS
         assert sys_info["gpu_arch"].item() == "gfx950"
@@ -1046,7 +1050,7 @@ class TestCorrectSysInfo:
 
     def test_fragment_without_separator_is_ignored(self) -> None:
         """A fragment with no ':' is skipped; valid pairs still apply."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4,garbage")
 
         assert sys_info["num_xcd"].item() == "4"
@@ -1054,7 +1058,9 @@ class TestCorrectSysInfo:
 
     def test_value_keeps_everything_after_the_first_colon(self) -> None:
         """Only the first ':' separates name from value."""
-        sys_info = correct_sys_info(_mi350_mspec(), "command:./vcopy -n 1:2")
+        sys_info = correct_sys_info(
+            make_mi350_machine_specs(), "command:./vcopy -n 1:2"
+        )
 
         assert sys_info["command"].item() == "./vcopy -n 1:2"
 
@@ -1071,19 +1077,22 @@ class TestCorrectSysInfo:
         )
 
         with pytest.raises(SystemExit):
-            correct_sys_info(_mi350_mspec(), "not_a_spec:1")
+            correct_sys_info(make_mi350_machine_specs(), "not_a_spec:1")
 
         assert "not_a_spec" in str(error_calls[0])
         assert "--specs" in str(error_calls[0])
 
     def test_corrected_specs_reach_metric_evaluation(self) -> None:
-        """Overrides land in the ammolite__* variables metric formulas use.
+        """
+        Overrides land in the ammolite__* variables metric formulas use.
 
         create_sys_vars() consumes the corrected sys_info row, so this is what
         makes $num_xcd and $cu_per_gpu in the panel configs pick up the
         --specs-correction values.
         """
-        corrected = correct_sys_info(_mi350_mspec(), "num_xcd:4,cu_per_gpu:64")
+        corrected = correct_sys_info(
+            make_mi350_machine_specs(), "num_xcd:4,cu_per_gpu:64"
+        )
         sys_vars = create_sys_vars(corrected.iloc[0])
 
         assert sys_vars["ammolite__num_xcd"] == 4

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 """Unit tests for utils.parser.build_dfs, apply_filters, apply_kernel_filter,
-load_pc_sampling_data, utils_analysis filter resolution, and
+load_pc_sampling_data, correct_sys_info, utils_analysis filter resolution, and
 utils_common.expand_placeholder_ranges."""
 
 from collections import OrderedDict
@@ -15,12 +15,15 @@ import pytest
 
 from pc_sampling.pc_sampling_analysis import load_pc_sample_records
 from utils import schema
+from utils.metrics.evaluation_pipeline import create_sys_vars
 from utils.parser import (
     apply_filters,
     apply_kernel_filter,
     build_dfs,
+    correct_sys_info,
     load_pc_sampling_data,
 )
+from utils.specs import MachineSpecsCDNA
 from utils.utils_common import (
     convert_filter_blocks_to_panel_ids,
     expand_placeholder_ranges,
@@ -924,3 +927,149 @@ def test_display_dedup_across_dataframes():
     matched = get_matched_torch_operators_for_display(torch_operators, ["all"])
     op_names = [name for name, _ in matched]
     assert op_names.count(H3) == 1
+
+
+# =============================================================================
+# Tests for correct_sys_info (analyze --specs-correction)
+# =============================================================================
+
+MI350_IP_BLOCKS = "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline"
+
+
+def _mi350_mspec() -> MachineSpecsCDNA:
+    """Fully populated MI350 (gfx950) specs, mirroring the vcopy fixture.
+
+    Values match tests/workloads/vcopy/MI350/sysinfo.csv so that
+    get_class_members() reports no missing required fields.
+    """
+    return MachineSpecsCDNA(
+        workload_path="/workloads/vcopy/MI350",
+        command="./tests/vcopy -n 1048576 -b 256 -i 3",
+        ip_blocks=MI350_IP_BLOCKS,
+        timestamp="Fri Jun 26 20:32:27 2026 (UTC)",
+        version="3",
+        hostname="test-host",
+        cpu_model="AMD EPYC 9575F 64-Core Processor",
+        sbios="American Megatrends International, LLC.1.8",
+        linux_distro="Ubuntu 22.04.5 LTS",
+        linux_kernel_version="6.17.0-35-generic",
+        amd_gpu_kernel_version="6.19.9.31400000",
+        cpu_memory="3170244916",
+        gpu_memory="264224768",
+        rocm_version="7.14.0",
+        vbios="113-M350-01-1K1-040A",
+        compute_partition="SPX",
+        memory_partition="NPS1",
+        gpu_series="MI350",
+        gpu_model="MI350",
+        gpu_arch="gfx950",
+        gpu_chip_id="30112",
+        gpu_l1="32",
+        gpu_l2="4096",
+        cu_per_gpu="256",
+        simd_per_cu="4",
+        se_per_gpu="32",
+        sa_per_se="1",
+        wave_size="64",
+        workgroup_max_size="1024",
+        max_waves_per_cu="32",
+        max_sclk="2200",
+        max_mclk="1900",
+        cur_sclk="2200",
+        cur_mclk="1900",
+        l2_banks="16",
+        total_l2_chan="128",
+        lds_banks_per_cu="32",
+        sqc_per_gpu="128",
+        pipes_per_gpu="4",
+        num_xcd="8",
+        num_memory_channels="128",
+    )
+
+
+class TestCorrectSysInfo:
+    """--specs-correction parsing, spec overrides, and error handling."""
+
+    def test_single_pair_overrides_spec(self) -> None:
+        """One name:value pair updates the spec object and the returned frame."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4")
+
+        assert mspec.num_xcd == "4"
+        assert len(sys_info) == 1
+        assert sys_info["num_xcd"].item() == "4"
+
+    def test_multiple_pairs_override_every_spec(self) -> None:
+        """Comma-separated pairs are all applied."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4,cu_per_gpu:64")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "64"
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        """Spaces around names and values do not break the override."""
+        sys_info = correct_sys_info(_mi350_mspec(), " num_xcd : 4 , cu_per_gpu:64 ")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "64"
+
+    def test_untouched_specs_are_preserved(self) -> None:
+        """Specs that were not corrected survive the rebuild of sys_info.
+
+        analysis_base.initalize_runs() reads sys_info["ip_blocks"] straight
+        after the correction, so dropping columns here would break analysis.
+        """
+        sys_info = correct_sys_info(_mi350_mspec(), "num_xcd:4")
+
+        assert sys_info["ip_blocks"].item() == MI350_IP_BLOCKS
+        assert sys_info["gpu_arch"].item() == "gfx950"
+        assert sys_info["gpu_model"].item() == "MI350"
+        assert sys_info["total_l2_chan"].item() == "128"
+
+    def test_fragment_without_separator_is_ignored(self) -> None:
+        """A fragment with no ':' is skipped; valid pairs still apply."""
+        mspec = _mi350_mspec()
+        sys_info = correct_sys_info(mspec, "num_xcd:4,garbage")
+
+        assert sys_info["num_xcd"].item() == "4"
+        assert sys_info["cu_per_gpu"].item() == "256"
+
+    def test_value_keeps_everything_after_the_first_colon(self) -> None:
+        """Only the first ':' separates name from value."""
+        sys_info = correct_sys_info(_mi350_mspec(), "command:./vcopy -n 1:2")
+
+        assert sys_info["command"].item() == "./vcopy -n 1:2"
+
+    def test_unknown_spec_name_errors_and_exits(self, monkeypatch) -> None:
+        """An unknown spec name reports the name and aborts."""
+        error_calls = []
+
+        def record_and_exit(*args, **_kwargs):
+            error_calls.append(args)
+            raise SystemExit(1)
+
+        common.patch_console(
+            monkeypatch, "utils.parser", "error", error=record_and_exit
+        )
+
+        with pytest.raises(SystemExit):
+            correct_sys_info(_mi350_mspec(), "not_a_spec:1")
+
+        assert "not_a_spec" in str(error_calls[0])
+        assert "--specs" in str(error_calls[0])
+
+    def test_corrected_specs_reach_metric_evaluation(self) -> None:
+        """Overrides land in the ammolite__* variables metric formulas use.
+
+        create_sys_vars() consumes the corrected sys_info row, so this is what
+        makes $num_xcd and $cu_per_gpu in the panel configs pick up the
+        --specs-correction values.
+        """
+        corrected = correct_sys_info(_mi350_mspec(), "num_xcd:4,cu_per_gpu:64")
+        sys_vars = create_sys_vars(corrected.iloc[0])
+
+        assert sys_vars["ammolite__num_xcd"] == 4
+        assert sys_vars["ammolite__cu_per_gpu"] == 64
+        # An uncorrected spec keeps its fixture value.
+        assert sys_vars["ammolite__total_l2_chan"] == 128

--- a/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_parser.py
@@ -936,11 +936,12 @@ def test_display_dedup_across_dataframes():
 MI350_IP_BLOCKS = "SQ|LDS|SQC|TA|TD|TCP|TCC|SPI|CPC|CPF|roofline"
 
 
-def _mi350_mspec() -> MachineSpecsCDNA:
-    """Fully populated MI350 (gfx950) specs, mirroring the vcopy fixture.
+def make_mi350_machine_specs() -> MachineSpecsCDNA:
+    """
+    Fully populated MI350 (gfx950) specs.
 
-    Values match tests/workloads/vcopy/MI350/sysinfo.csv so that
-    get_class_members() reports no missing required fields.
+    Values match sysinfo.csv so that get_class_members() reports
+    no missing required fields.
     """
     return MachineSpecsCDNA(
         workload_path="/workloads/vcopy/MI350",
@@ -992,7 +993,7 @@ class TestCorrectSysInfo:
 
     def test_single_pair_overrides_spec(self) -> None:
         """One name:value pair updates the spec object and the returned frame."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4")
 
         assert mspec.num_xcd == "4"
@@ -1001,7 +1002,7 @@ class TestCorrectSysInfo:
 
     def test_multiple_pairs_override_every_spec(self) -> None:
         """Comma-separated pairs are all applied."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4,cu_per_gpu:64")
 
         assert sys_info["num_xcd"].item() == "4"
@@ -1009,18 +1010,21 @@ class TestCorrectSysInfo:
 
     def test_surrounding_whitespace_is_stripped(self) -> None:
         """Spaces around names and values do not break the override."""
-        sys_info = correct_sys_info(_mi350_mspec(), " num_xcd : 4 , cu_per_gpu:64 ")
+        sys_info = correct_sys_info(
+            make_mi350_machine_specs(), " num_xcd : 4 , cu_per_gpu:64 "
+        )
 
         assert sys_info["num_xcd"].item() == "4"
         assert sys_info["cu_per_gpu"].item() == "64"
 
     def test_untouched_specs_are_preserved(self) -> None:
-        """Specs that were not corrected survive the rebuild of sys_info.
+        """
+        Specs that were not corrected survive the rebuild of sys_info.
 
         analysis_base.initalize_runs() reads sys_info["ip_blocks"] straight
         after the correction, so dropping columns here would break analysis.
         """
-        sys_info = correct_sys_info(_mi350_mspec(), "num_xcd:4")
+        sys_info = correct_sys_info(make_mi350_machine_specs(), "num_xcd:4")
 
         assert sys_info["ip_blocks"].item() == MI350_IP_BLOCKS
         assert sys_info["gpu_arch"].item() == "gfx950"
@@ -1029,7 +1033,7 @@ class TestCorrectSysInfo:
 
     def test_fragment_without_separator_is_ignored(self) -> None:
         """A fragment with no ':' is skipped; valid pairs still apply."""
-        mspec = _mi350_mspec()
+        mspec = make_mi350_machine_specs()
         sys_info = correct_sys_info(mspec, "num_xcd:4,garbage")
 
         assert sys_info["num_xcd"].item() == "4"
@@ -1037,7 +1041,9 @@ class TestCorrectSysInfo:
 
     def test_value_keeps_everything_after_the_first_colon(self) -> None:
         """Only the first ':' separates name from value."""
-        sys_info = correct_sys_info(_mi350_mspec(), "command:./vcopy -n 1:2")
+        sys_info = correct_sys_info(
+            make_mi350_machine_specs(), "command:./vcopy -n 1:2"
+        )
 
         assert sys_info["command"].item() == "./vcopy -n 1:2"
 
@@ -1054,19 +1060,22 @@ class TestCorrectSysInfo:
         )
 
         with pytest.raises(SystemExit):
-            correct_sys_info(_mi350_mspec(), "not_a_spec:1")
+            correct_sys_info(make_mi350_machine_specs(), "not_a_spec:1")
 
         assert "not_a_spec" in str(error_calls[0])
         assert "--specs" in str(error_calls[0])
 
     def test_corrected_specs_reach_metric_evaluation(self) -> None:
-        """Overrides land in the ammolite__* variables metric formulas use.
+        """
+        Overrides land in the ammolite__* variables metric formulas use.
 
         create_sys_vars() consumes the corrected sys_info row, so this is what
         makes $num_xcd and $cu_per_gpu in the panel configs pick up the
         --specs-correction values.
         """
-        corrected = correct_sys_info(_mi350_mspec(), "num_xcd:4,cu_per_gpu:64")
+        corrected = correct_sys_info(
+            make_mi350_machine_specs(), "num_xcd:4,cu_per_gpu:64"
+        )
         sys_vars = create_sys_vars(corrected.iloc[0])
 
         assert sys_vars["ammolite__num_xcd"] == 4


### PR DESCRIPTION
## Motivation

Analyze mode accepts --specs-correction to override the hardware specs recorded in sysinfo.csv, but the option had no automated coverage. A regression in how the correction string is parsed, or in the path that hands corrected specs to metric evaluation, would silently produce analysis results computed from the wrong machine specs.

## Technical Details

- Unit tests pin the parsing contract for the correction string, covering multiple comma-separated pairs, surrounding whitespace, values that themselves contain a colon, fragments without a separator, and an unknown spec name aborting the run.
- One test asserts that correcting a spec preserves every untouched spec, which guards the ip_blocks lookup that analysis performs immediately after applying the correction.
- Another test feeds the corrected specs through the evaluation pipeline and asserts the resulting ammolite variables carry the overrides, proving the values reach the metric expressions that reference them.
- Tests around run initialization confirm the option changes the specs analysis actually runs on, and that omitting it leaves the recorded sysinfo values untouched.
- No production code changes accompany these tests.

## JIRA ID

JIRA ID: AIROCVAL-131

## PR Stack

<!-- rocprof-compute-stack:start -->
<!-- stack-position: 2/2 -->
<!-- stack-current: WP2|users/abchoudh/test-coverage/test3-specs-correction -->
<!-- stack-previous: WP1|users/abchoudh/test-coverage/test1-output-format|https://github.com/ROCm/rocm-systems/pull/10619 -->
<!-- stack-next: none -->
<!-- stack-jira: AIROCVAL-131 -->
<!-- stack-dependency: WP1|users/abchoudh/test-coverage/test1-output-format|https://github.com/ROCm/rocm-systems/pull/10619 -->
<!-- stack-entry: 1|WP1|users/abchoudh/test-coverage/test1-output-format|https://github.com/ROCm/rocm-systems/pull/10619 -->
<!-- stack-entry: 2|WP2|users/abchoudh/test-coverage/test3-specs-correction|self -->
1. [WP1](https://github.com/ROCm/rocm-systems/pull/10619) — `users/abchoudh/test-coverage/test1-output-format`
2. **WP2** — `users/abchoudh/test-coverage/test3-specs-correction` (current)
<!-- rocprof-compute-stack:end -->

## Test Plan

- [x] Run pytest tests/unit/utils/test_parser.py tests/unit/rocprof_compute_analyze/test_analysis_base.py
- [x] Run pytest tests/unit

## Test Result

- [x] pytest tests/unit/utils/test_parser.py tests/unit/rocprof_compute_analyze/test_analysis_base.py passes
- [x] pytest tests/unit passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.