### PR TITLE
[RCCL] Fix host micro-init test link error for WarpSpeed symbols

### DIFF
--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -113,3 +113,9 @@ ncclResult_t ncclMemFree(void* ptr) { ::abort(); }
 ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) { ::abort(); }
 int64_t rcclParamHierarchicalReduceScatter() { ::abort(); }
 size_t rcclHierarchicalTempBufferSize(int nNodes, bool allGather, bool reduceScatter) { ::abort(); }
+
+// WarpSpeed eligibility (rccl_wrap.cc), referenced by init.cc's willEnableWarpSpeed().
+// Same deep ncclCommInitRankFunc arm as the floor above -- never entered by the
+// current tests, so fail loudly if a future test reaches it.
+int64_t rcclParamWarpSpeedForceEnable() { ::abort(); }
+bool rcclCanUseWarpSpeedAuto(struct ncclComm* comm, int nNodes) { ::abort(); }


### PR DESCRIPTION
## Summary
- `rccl-UnitTestsMicroInit(+-uncached)` fail to link on `develop`: `init.cc`'s `willEnableWarpSpeed()` references `rcclParamWarpSpeedForceEnable()` and `rcclCanUseWarpSpeedAuto()`, which live in `rccl_wrap.cc` - a TU the host-only micro-init binary deliberately does not compile.
- Adds two fail-loud link stubs to `test/host/fakes/nccl_stubs.cc`, matching the existing deep-`ncclCommInitRankFunc`-arm stub floor (e.g. `ncclSymkInitOnce`, `rcclParamHierarchicalReduceScatter`).
- Unrelated to any specific feature branch; this is a `develop` regression that breaks the `precheckin(rccl)` Compile stage for every open PR.

## Test plan
- Built `rccl-UnitTestsMicroInit` and `rccl-UnitTestsMicroInit-uncached` (ROCm 7.2 container): both link cleanly.
- Ran both binaries: 79/79 tests pass; the new `::abort()` stubs are never reached (deep init arm is not exercised by current tests).

