### PR TITLE
[RCCL] Fix host micro-init test link error for WarpSpeed symbols

### DIFF
--- a/projects/rccl/test/host/fakes/nccl_stubs.cc
+++ b/projects/rccl/test/host/fakes/nccl_stubs.cc
@@ -113,3 +113,7 @@ ncclResult_t ncclMemFree(void* ptr) { ::abort(); }
 ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) { ::abort(); }
 int64_t rcclParamHierarchicalReduceScatter() { ::abort(); }
 size_t rcclHierarchicalTempBufferSize(int nNodes, bool allGather, bool reduceScatter) { ::abort(); }
+
+// WarpSpeed eligibility (rccl_wrap.cc), referenced by init.cc's willEnableWarpSpeed().
+int64_t rcclParamWarpSpeedForceEnable() { ::abort(); }
+bool rcclCanUseWarpSpeedAuto(struct ncclComm* comm, int nNodes) { ::abort(); }


### PR DESCRIPTION
## Motivation

The host-only `rccl-UnitTestsMicroInit` and `rccl-UnitTestsMicroInit-uncached` binaries fail to link on `develop`, which fails the `precheckin(rccl)` Compile stage for every open PR.

## Technical Details

`init.cc`'s `willEnableWarpSpeed()` calls `rcclParamWarpSpeedForceEnable()` and `rcclCanUseWarpSpeedAuto()`, which are defined in `rccl_wrap.cc`. The host micro-init binary compiles `init.cc` directly and deliberately does not link `rccl_wrap.cc`, so both symbols are undefined at link time. This adds two fail-loud link stubs to `test/host/fakes/nccl_stubs.cc`, matching the existing deep init-arm stub floor (`ncclSymkInitOnce`, `rcclParamHierarchicalReduceScatter`). Regression introduced by #10182, which added the micro-init binary without stubbing these symbols.

## Issue Tracking

JIRA ID : 

## Test Plan

Built both micro-init targets in a ROCm 7.2 container and ran them.

## Test Result

Both binaries link cleanly. 79/79 tests pass and the new `abort()` stubs are never reached (the deep init arm is not exercised by current tests).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
