### PR TITLE
fix(rocprofiler-systems): fix empty check list and silent timeouts

### DIFF
--- a/.github/workflows/rocprofiler-systems-clang-tidy.yml
+++ b/.github/workflows/rocprofiler-systems-clang-tidy.yml
@@ -67,4 +67,4 @@ jobs:
             --base "origin/${{ github.base_ref }}" \
             --build-path build/debug-mpi \
             -j $(nproc) \
-            --timeout 120
+            --timeout 600

--- a/projects/rocprofiler-systems/scripts/clang-tidy-check.py
+++ b/projects/rocprofiler-systems/scripts/clang-tidy-check.py
@@ -244,9 +244,9 @@ def run_clang_tidy(
     return proc.stdout + proc.stderr, True
 
 
-def get_enabled_checks(args: argparse.Namespace, sample_file: str) -> list[str]:
-    """Resolve the effective check list clang-tidy will apply to `sample_file`."""
-    result = _clang_tidy(args, "-list-checks", sample_file)
+def get_enabled_checks(args: argparse.Namespace) -> list[str]:
+    """Resolve the effective check list clang-tidy will apply."""
+    result = _clang_tidy(args, "-list-checks")
 
     if result.returncode != 0:
         detail = result.stderr.strip() or "clang-tidy -list-checks failed"
@@ -312,6 +312,7 @@ def print_rule_diagnostics(
     print(_color(title, "bold"))
     if not rule_diagnostics:
         print(f"  {_color('No issues found.', 'green')}")
+        print()
         return
     for check_name, diagnostics in sorted(
         rule_diagnostics.items(), key=lambda kv: len(kv[1]), reverse=True
@@ -321,6 +322,20 @@ def print_rule_diagnostics(
             location = f"{diagnostic.file}:{diagnostic.line}:{diagnostic.col}"
             color = "red" if diagnostic.severity == "error" else "yellow"
             print(f"        {_color(location, color)}: {diagnostic.message}")
+    print()
+
+
+def print_timed_out_files(paths: list[str], timeout: float | None) -> None:
+    """Report files clang-tidy could not finish, which make the run fail."""
+    if not paths:
+        return
+    print(_color(f"Timed out after {timeout}s ({len(paths)}):", "bold"))
+    for path in paths:
+        print(f"  {_color(path, 'red')}")
+    print(
+        "  These files were not fully checked, so the run is reported as "
+        "failed; raise --timeout to give them more time."
+    )
     print()
 
 
@@ -377,8 +392,7 @@ def main() -> int:
         print("No relevant changes found.")
         return 0
 
-    sample_file = os.path.join(repo_root, changed_files[0].path)
-    enabled_checks = get_enabled_checks(args, sample_file)
+    enabled_checks = get_enabled_checks(args)
 
     if not enabled_checks:
         print("No checks enabled.")
@@ -391,7 +405,7 @@ def main() -> int:
 
     rule_diagnostics: dict[str, list[Diagnostic]] = {}
     preexisting_rule_diagnostics: dict[str, list[Diagnostic]] = {}
-    any_timed_out = False
+    timed_out_files: list[str] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
         futures = {
             pool.submit(
@@ -405,7 +419,8 @@ def main() -> int:
         for future in concurrent.futures.as_completed(futures):
             changed_file = futures[future]
             output, succeeded = future.result()
-            any_timed_out = any_timed_out or not succeeded
+            if not succeeded:
+                timed_out_files.append(changed_file.path)
 
             for diagnostic in parse_diagnostics(output, repo_root):
                 classification = classify_diagnostic(diagnostic, changed_file)
@@ -423,8 +438,9 @@ def main() -> int:
     print_rule_diagnostics(
         "Pre-existing issues (outside this diff):", preexisting_rule_diagnostics
     )
+    print_timed_out_files(timed_out_files, args.timeout)
 
-    return 1 if rule_diagnostics or any_timed_out else 0
+    return 1 if rule_diagnostics or timed_out_files else 0
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
+++ b/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
@@ -145,8 +145,8 @@ def test_parse_diagnostics_ignores_fatal_error_line():
 def test_clang_tidy_command_without_checks(monkeypatch):
     run = _CaptureRun()
     monkeypatch.setattr(ctc.subprocess, "run", run)
-    ctc._clang_tidy(_args(checks=""), "-list-checks", "/f.cpp")
-    assert run.cmd == ["clang-tidy", "-p=/build", "-list-checks", "/f.cpp"]
+    ctc._clang_tidy(_args(checks=""), "-list-checks")
+    assert run.cmd == ["clang-tidy", "-p=/build", "-list-checks"]
     # check=False is behavioral: clang-tidy exits nonzero when it finds issues,
     # so check=True would raise on any file with diagnostics and break the tool.
     assert run.kwargs["check"] is False
@@ -210,7 +210,7 @@ def test_get_enabled_checks_parses_list(monkeypatch):
     monkeypatch.setattr(
         ctc, "_clang_tidy", lambda a, *e, timeout=None: _completed(list(e), 0, out, "")
     )
-    assert ctc.get_enabled_checks(_args(), "/f.cpp") == [
+    assert ctc.get_enabled_checks(_args()) == [
         "misc-const-correctness",
         "modernize-use-auto",
     ]
@@ -220,8 +220,26 @@ def test_get_enabled_checks_failure_warns_and_returns_empty(monkeypatch, capsys)
     monkeypatch.setattr(
         ctc, "_clang_tidy", lambda a, *e, timeout=None: _completed(list(e), 1, "", "boom")
     )
-    assert ctc.get_enabled_checks(_args(), "/f.cpp") == []
+    assert ctc.get_enabled_checks(_args()) == []
     assert "could not resolve check list" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# print_timed_out_files
+# --------------------------------------------------------------------------- #
+def test_print_timed_out_files_lists_each_file(capsys):
+    ctc.print_timed_out_files(["a.cpp", "b.cpp"], 600)
+    out = capsys.readouterr().out
+    # A timeout is otherwise a silent failure: it makes the run exit nonzero
+    # while the diff section still reports "No issues found."
+    assert "Timed out after 600s (2)" in out
+    assert "a.cpp" in out
+    assert "b.cpp" in out
+
+
+def test_print_timed_out_files_prints_nothing_when_empty(capsys):
+    ctc.print_timed_out_files([], 600)
+    assert capsys.readouterr().out == ""
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Motivation

The clang-tidy CI check has two reporting defects that make its result untrustworthy.

1. **Empty check list.** `get_enabled_checks` passed the first changed file to `clang-tidy -list-checks`. When that file has no entry in `compile_commands.json` (a header, a test fixture, a file excluded from the configured preset), clang-tidy emits an empty `Enabled checks:` listing. The script then printed `No checks enabled.` and exited 0 — a green check that verified nothing.

2. **Silent timeouts.** `run_clang_tidy` turned a per-file timeout into a message string, but that string was only ever passed to `parse_diagnostics`, which discards anything that isn't a diagnostic. The timeout still set the failure flag, so a run could print `No issues found.` for the diff and then exit 1 with nothing explaining why.

## Technical Details

### Key Changes

- `get_enabled_checks(args)` drops the `sample_file` parameter and calls `-list-checks` with no source file. The flag reports the checks enabled by the resolved configuration; it does not need a translation unit, and supplying one that isn't in the compilation database is what produced the empty listing.
- `main` collects `timed_out_files` instead of a boolean, and the new `print_timed_out_files` prints a dedicated section naming each file that was not fully checked and pointing at `--timeout`. Exit status is unchanged: a timeout still fails the run, it is just no longer invisible.
- Added the missing blank line after an empty diagnostics section, so the two report sections stay visually separated.
- Workflow: per-file budget `--timeout 120` -> `--timeout 600`. Large translation units such as `source/lib/core/config.cpp` do not finish in two minutes.

## JIRA

JIRA ID : AIPROFSYST-496

## Test Plan

### Automated Tests

- `test_clang_tidy_command_without_checks` — asserts the command is `[clang-tidy, -p=..., -list-checks]` with no trailing file.
- `test_get_enabled_checks_parses_list` / `test_get_enabled_checks_failure_warns_and_returns_empty` — updated to the one-argument signature.
- `test_print_timed_out_files_lists_each_file` — asserts the header count and every file name reach stdout.
- `test_print_timed_out_files_prints_nothing_when_empty` — no output when nothing timed out.

Full suite: 29 passed (`pytest projects/rocprofiler-systems/scripts/test_clang_tidy_check.py`).

### Verification

- Pre-commit hooks pass (black, trailing whitespace, YAML).
- No behavior change to diagnostic classification or exit codes beyond making the timeout cause visible.
