### PR TITLE
fix(rocr): [ROCM-27751]  Make hsa_amd_memory_lock actually pin under t…

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -601,7 +601,13 @@ typedef struct _HsaMemFlags
             unsigned int Contiguous:    1; // Allocate contiguous VRAM
             unsigned int ExecuteBlit:   1; // default = 0; If 1: The caller indicates that the memory is for blit kernel object.
             unsigned int QueueObject:   1; // AQL queue object, used in windows for CPU access to get the read pointer from amd_queue_t
-            unsigned int Reserved:      7;
+            unsigned int AlwaysMapped:  1; // default = 0; If 1: the caller is pinning this memory (hsaKmtRegisterMemory* on
+                                           // behalf of hsa_amd_memory_lock) and requires the GPU mapping to stay valid for
+                                           // the lifetime of the registration. Under the SVM API this sets
+                                           // HSA_SVM_FLAG_GPU_ALWAYS_MAPPED so KFD does not unmap the range from the GPU on
+                                           // MMU invalidation while a transfer is in flight. Ignored on the userptr BO path,
+                                           // which is already durable. Requires KFD interface minor version >= 11.
+            unsigned int Reserved:      6;
 
         } ui32;
         HSAuint32 Value;

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -250,6 +250,30 @@ typedef struct {
 	uint32_t alignment_order;
 } svm_t;
 
+/* An SVM registration made on behalf of a pin (HsaMemFlags.AlwaysMapped).
+ *
+ * The SVM registration path does not create a vm_object, so there is nothing
+ * for hsakmt_fmm_deregister_memory() to look up.  Clearing
+ * HSA_SVM_FLAG_GPU_ALWAYS_MAPPED needs an explicit start and size, and the
+ * deregister API only supplies an address, so record the range here at
+ * registration time and consume it at deregistration.
+ *
+ * @regs holds the aligned start address of every pin the record covers, rather
+ * than a plain count.  hsakmt_fmm_deregister_memory() cannot tell a pinning
+ * registration from a plain one -- it takes only an address -- so a count would
+ * be decremented by plain registrations that merely fall inside a pinned union,
+ * clearing the flag while the pin is still live.  Matching the address against
+ * @regs makes a deregistration a no-op unless it really is releasing a pin.
+ */
+typedef struct svm_always_mapped_range {
+	rbtree_node_t node;
+	HSAuint64 start;	/* page-aligned */
+	HSAuint64 size;		/* page-aligned, widest ever registered */
+	HSAuint64 *regs;	/* aligned start address of each live pin */
+	HSAuint32 nregs;	/* entries used in @regs */
+	HSAuint32 nalloc;	/* entries allocated in @regs */
+} svm_always_mapped_range_t;
+
 struct hsa_kfd_fmm_context
 {
 	/* The other apertures are specific to each GPU. gpu_mem_t manages GPU
@@ -267,6 +291,12 @@ struct hsa_kfd_fmm_context
 	void *dgpu_shared_aperture_limit;
 
 	svm_t svm;
+
+	/* Ranges registered with AlwaysMapped, keyed by aligned start address.
+	 * See svm_always_mapped_range_t.
+	 */
+	rbtree_t always_mapped_tree;
+	pthread_mutex_t always_mapped_mutex;
 
 	/* On APU, for memory allocated on the system memory that GPU doesn't
 	 * access via GPU driver, they are not managed by GPUVM. cpuvm_aperture
@@ -323,6 +353,10 @@ int hsakmt_kfdcontext_init_fmm_context(HsaKFDContext *ctx)
 	ctx->fmm_context->svm.reserve_svm = false;
 	ctx->fmm_context->svm.disable_cache = false;
 	ctx->fmm_context->svm.alignment_order = 0;
+
+	/* Initialize the AlwaysMapped registration tracker */
+	rbtree_init(&ctx->fmm_context->always_mapped_tree);
+	pthread_mutex_init(&ctx->fmm_context->always_mapped_mutex, NULL);
 
 	/* Initialize cpuvm_aperture */
 	ctx->fmm_context->cpuvm_aperture = init_aperture;
@@ -1102,6 +1136,281 @@ static HsaMemFlags fmm_translate_ioc_to_hsa_flags(uint32_t ioc_flags)
 	return mflags;
 }
 
+/* Find the record covering @addr, or NULL.  Records in the tree are kept
+ * pairwise disjoint by svm_always_mapped_record_locked(), so at most one can
+ * match and no record earlier than the one returned here can reach @addr.
+ *
+ * Caller must hold fmm_ctx->always_mapped_mutex.
+ */
+static svm_always_mapped_range_t *
+svm_always_mapped_find(struct hsa_kfd_fmm_context *fmm_ctx, HSAuint64 addr)
+{
+	rbtree_key_t key = rbtree_key(addr, 0);
+	svm_always_mapped_range_t *r;
+	rbtree_node_t *n;
+
+	/* Greatest record starting at or before @addr. */
+	n = rbtree_lookup_nearest(&fmm_ctx->always_mapped_tree, &key, LKP_ADDR,
+				  LEFT);
+	if (!n)
+		return NULL;
+
+	r = rb_entry(n, svm_always_mapped_range_t, node);
+
+	return addr < r->start + r->size ? r : NULL;
+}
+
+/* Caller must hold fmm_ctx->always_mapped_mutex. */
+static svm_always_mapped_range_t *
+svm_always_mapped_first_at_or_after(struct hsa_kfd_fmm_context *fmm_ctx,
+				    HSAuint64 addr)
+{
+	rbtree_key_t key = rbtree_key(addr, 0);
+	rbtree_node_t *n;
+
+	n = rbtree_lookup_nearest(&fmm_ctx->always_mapped_tree, &key, LKP_ADDR,
+				  RIGHT);
+
+	return n ? rb_entry(n, svm_always_mapped_range_t, node) : NULL;
+}
+
+static void svm_always_mapped_free(svm_always_mapped_range_t *r)
+{
+	free(r->regs);
+	free(r);
+}
+
+/* Append @addr to @r's pin list.  False on allocation failure, with @r
+ * unmodified.
+ */
+static bool svm_always_mapped_add_reg(svm_always_mapped_range_t *r,
+				      HSAuint64 addr)
+{
+	if (r->nregs == r->nalloc) {
+		HSAuint32 n = r->nalloc ? r->nalloc * 2 : 4;
+		HSAuint64 *regs = realloc(r->regs, n * sizeof(*regs));
+
+		if (!regs)
+			return false;
+		r->regs = regs;
+		r->nalloc = n;
+	}
+
+	r->regs[r->nregs++] = addr;
+	return true;
+}
+
+/* Remove one occurrence of @addr from @r's pin list.  False if @addr is not a
+ * pin this record is holding the flag for.  Order does not matter, so the hole
+ * is filled from the end.
+ */
+static bool svm_always_mapped_del_reg(svm_always_mapped_range_t *r,
+				      HSAuint64 addr)
+{
+	HSAuint32 i;
+
+	for (i = 0; i < r->nregs; i++) {
+		if (r->regs[i] == addr) {
+			r->regs[i] = r->regs[--r->nregs];
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Track [@start, @start + @size) as flagged, merging it with every record it
+ * overlaps into a single union record holding all of their pins.
+ *
+ * Overlapping pins have to share one record.  Tracking them separately would
+ * let the first deregistration clear GPU_ALWAYS_MAPPED across pages that
+ * another live pin still covers, silently unpinning them.  Merging keeps the
+ * flag set until the last overlapping pin is released, at the cost of holding
+ * it on the whole union until then -- the conservative direction.
+ *
+ * False on allocation failure, with the tree unchanged.
+ *
+ * Caller must hold fmm_ctx->always_mapped_mutex.
+ */
+static bool svm_always_mapped_record_locked(struct hsa_kfd_fmm_context *fmm_ctx,
+					    HSAuint64 start, HSAuint64 size)
+{
+	HSAuint64 end = start + size;
+	HSAuint64 reg = start;
+	svm_always_mapped_range_t *r, *merged, *p;
+	HSAuint32 nabsorbed = 0, i;
+
+	r = svm_always_mapped_find(fmm_ctx, start);
+	if (r && end <= r->start + r->size)
+		/* Already covered -- the same range pinned again, or a
+		 * subrange of one that is. Nothing to merge.
+		 */
+		return svm_always_mapped_add_reg(r, reg);
+
+	/* Pass one: find the bounds of the union and how many pins it absorbs.
+	 * @r is the record covering @start if there is one, otherwise the first
+	 * starting after it.  Widening @end can bring further records into
+	 * range, which the loop condition picks up on the next pass.  Nothing
+	 * is mutated here, so an allocation failure below leaves the tree
+	 * intact.
+	 */
+	if (!r)
+		r = svm_always_mapped_first_at_or_after(fmm_ctx, start);
+
+	for (p = r; p && p->start < end; ) {
+		rbtree_node_t *n = hsakmt_rbtree_next(
+				&fmm_ctx->always_mapped_tree, &p->node);
+
+		if (p->start + p->size > start) {
+			if (p->start < start)
+				start = p->start;
+			if (p->start + p->size > end)
+				end = p->start + p->size;
+			nabsorbed += p->nregs;
+		}
+		p = n ? rb_entry(n, svm_always_mapped_range_t, node) : NULL;
+	}
+
+	merged = calloc(1, sizeof(*merged));
+	if (!merged)
+		goto no_mem;
+
+	/* Size the pin list up front: growing it while absorbing would leave
+	 * records already deleted on failure.
+	 */
+	merged->regs = calloc(nabsorbed + 1, sizeof(*merged->regs));
+	if (!merged->regs) {
+		free(merged);
+		goto no_mem;
+	}
+	merged->nalloc = nabsorbed + 1;
+	merged->regs[merged->nregs++] = reg;
+
+	/* Pass two: absorb.  @start may have moved down, so re-find the
+	 * leftmost overlapping record.
+	 */
+	r = svm_always_mapped_find(fmm_ctx, start);
+	if (!r)
+		r = svm_always_mapped_first_at_or_after(fmm_ctx, start);
+
+	while (r && r->start < end) {
+		rbtree_node_t *n = hsakmt_rbtree_next(
+				&fmm_ctx->always_mapped_tree, &r->node);
+		svm_always_mapped_range_t *next =
+			n ? rb_entry(n, svm_always_mapped_range_t, node) : NULL;
+
+		if (r->start + r->size > start) {
+			for (i = 0; i < r->nregs; i++)
+				merged->regs[merged->nregs++] = r->regs[i];
+			hsakmt_rbtree_delete(&fmm_ctx->always_mapped_tree,
+					     &r->node);
+			svm_always_mapped_free(r);
+		}
+		r = next;
+	}
+
+	merged->start = start;
+	merged->size = end - start;
+	merged->node.key = rbtree_key(start, end - start);
+	hsakmt_rbtree_insert(&fmm_ctx->always_mapped_tree, &merged->node);
+	return true;
+
+no_mem:
+	/* @start may already have been widened by pass one; report what the
+	 * caller actually asked for.
+	 */
+	pr_warn("Failed to track AlwaysMapped range %p size %lu\n",
+		(void *)reg, size);
+	return false;
+}
+
+/* Release the pin registered at @addr.  Returns the size to clear when the last
+ * pin the record covers goes away, and 0 otherwise -- including when @addr is
+ * not a recorded pin at all, which is the ordinary case for the plain
+ * registrations that share this deregistration path.  On a non-zero return
+ * @start_out receives the start of the record, which merging may have pushed
+ * below @addr, and @r_out the record itself, which stays in the tree until the
+ * caller has confirmed the flag is actually gone.
+ *
+ * Caller must hold fmm_ctx->always_mapped_mutex.
+ */
+static HSAuint64 svm_always_mapped_take_locked(
+					struct hsa_kfd_fmm_context *fmm_ctx,
+					HSAuint64 addr, HSAuint64 *start_out,
+					svm_always_mapped_range_t **r_out)
+{
+	svm_always_mapped_range_t *r = svm_always_mapped_find(fmm_ctx, addr);
+
+	if (!r || !svm_always_mapped_del_reg(r, addr) || r->nregs)
+		return 0;
+
+	*start_out = r->start;
+	*r_out = r;
+	return r->size;
+}
+
+/* Drop GPU_ALWAYS_MAPPED from a range that is no longer pinned, so it can
+ * migrate under XNACK again.
+ */
+static HSAKMT_STATUS svm_always_mapped_clear(HsaKFDContext *ctx,
+					     HSAuint64 start, HSAuint64 size)
+{
+	struct kfd_ioctl_svm_args *args;
+	size_t s_attr = sizeof(struct kfd_ioctl_svm_attribute);
+	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
+
+	args = malloc(sizeof(*args) + s_attr);
+	if (!args)
+		return HSAKMT_STATUS_NO_MEMORY;
+
+	args->start_addr = start;
+	args->size = size;
+	args->op = KFD_IOCTL_SVM_OP_SET_ATTR;
+	args->nattr = 1;
+	args->attrs[0].type = HSA_SVM_ATTR_CLR_FLAGS;
+	args->attrs[0].value = HSA_SVM_FLAG_GPU_ALWAYS_MAPPED;
+
+	pr_debug("Clearing GPU_ALWAYS_MAPPED on %p size: %lu\n",
+		 (void *)start, size);
+	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT),
+			 args)) {
+		pr_debug("op clear always-mapped failed %s\n", strerror(errno));
+		ret = HSAKMT_STATUS_ERROR;
+	}
+
+	free(args);
+	return ret;
+}
+
+/* Free the AlwaysMapped tracker at context teardown.  The address space is
+ * going away with the context, so there is no flag left to clear in the kernel
+ * -- this only reclaims the records themselves.
+ */
+void hsakmt_fmm_destroy_always_mapped_tracker(HsaKFDContext *ctx)
+{
+	struct hsa_kfd_fmm_context *fmm_ctx;
+	rbtree_t *tree;
+
+	if (!ctx || !ctx->fmm_context)
+		return;
+
+	fmm_ctx = ctx->fmm_context;
+	tree = &fmm_ctx->always_mapped_tree;
+
+	pthread_mutex_lock(&fmm_ctx->always_mapped_mutex);
+	while (tree->root != &tree->sentinel) {
+		rbtree_node_t *n = rbtree_min(tree->root, &tree->sentinel);
+		svm_always_mapped_range_t *r =
+			rb_entry(n, svm_always_mapped_range_t, node);
+
+		hsakmt_rbtree_delete(tree, n);
+		svm_always_mapped_free(r);
+	}
+	pthread_mutex_unlock(&fmm_ctx->always_mapped_mutex);
+
+	pthread_mutex_destroy(&fmm_ctx->always_mapped_mutex);
+}
+
 static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 						  void *address,
 					      uint64_t size, HsaMemFlags flags)
@@ -1113,12 +1422,26 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	HSAuint64 aligned_size = PAGE_ALIGN_UP(page_offset + size);
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	HSAKMT_STATUS ret;
+	HSAuint32 nattr = 2;
 
 	if (!fmm_ctx->first_gpu_mem)
 		return HSAKMT_STATUS_ERROR;
 
-	/* s_attr is a compile-time constant (16 bytes); no overflow possible */
-	s_attr = 2 * sizeof(struct kfd_ioctl_svm_attribute);
+	/* A caller that is pinning this range (hsa_amd_memory_lock) needs the
+	 * GPU mapping to survive MMU invalidations.  Without
+	 * GPU_ALWAYS_MAPPED, svm_range_evict() takes its xnack_enabled branch
+	 * and unmaps the range from the GPU while a transfer may still be
+	 * reading it; if the resulting retry fault then fails to restore, the
+	 * PTE is poisoned with AMDGPU_VM_NORETRY_FLAGS and the fault becomes
+	 * fatal.  The userptr BO path below is durable already, so this only
+	 * matters here.
+	 */
+	if (flags.ui32.AlwaysMapped &&
+	    hsakmt_kfd_version_info.KernelInterfaceMinorVersion >= 11)
+		nattr = 3;
+
+	/* s_attr is at most 24 bytes; no overflow possible */
+	s_attr = nattr * sizeof(struct kfd_ioctl_svm_attribute);
 	args = malloc(sizeof(*args) + s_attr);
 	if (!args)
 		return HSAKMT_STATUS_NO_MEMORY;
@@ -1126,25 +1449,53 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	args->start_addr = aligned_addr;
 	args->size = aligned_size;
 	args->op = KFD_IOCTL_SVM_OP_SET_ATTR;
-	args->nattr = 2;
+	args->nattr = nattr;
 	args->attrs[0].type = flags.ui32.CoarseGrain ?
 			      HSA_SVM_ATTR_CLR_FLAGS : HSA_SVM_ATTR_SET_FLAGS;
 	args->attrs[0].value = HSA_SVM_FLAG_COHERENT;
 	args->attrs[1].type = flags.ui32.ExtendedCoherent ?
 							HSA_SVM_ATTR_SET_FLAGS : HSA_SVM_ATTR_CLR_FLAGS;
 	args->attrs[1].value = HSA_SVM_FLAG_EXT_COHERENT;
-	pr_debug("Registering to SVM %p size: %ld\n", (void*)aligned_addr,
-		 aligned_size);
+	if (nattr == 3) {
+		args->attrs[2].type = HSA_SVM_ATTR_SET_FLAGS;
+		args->attrs[2].value = HSA_SVM_FLAG_GPU_ALWAYS_MAPPED;
+	}
+	pr_debug("Registering to SVM %p size: %ld nattr %u\n", (void*)aligned_addr,
+		 aligned_size, nattr);
+
+	/* Setting the flag and recording the range have to look atomic to a
+	 * concurrent deregistration, or one slipping between them would find
+	 * nothing to take, return success, and leave this pin flagged but
+	 * untracked -- or worse, take an overlapping record and clear the flag
+	 * back off the range we just set it on.
+	 */
+	if (nattr == 3)
+		pthread_mutex_lock(&fmm_ctx->always_mapped_mutex);
+
 	/* Driver does one copy_from_user, with extra attrs size */
 	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT), args)) {
 		pr_debug("op set range attrs failed %s\n", strerror(errno));
 		ret = HSAKMT_STATUS_ERROR;
-		goto out;
+		goto unlock;
+	}
+
+	/* Remember the range so deregister can clear the flag again */
+	if (nattr == 3 &&
+	    !svm_always_mapped_record_locked(fmm_ctx, aligned_addr, aligned_size)) {
+		/* Undo the flag rather than report success: an untracked
+		 * flagged range would stay resident for the life of the
+		 * mapping, with nothing left that could clear it.
+		 */
+		svm_always_mapped_clear(ctx, aligned_addr, aligned_size);
+		ret = HSAKMT_STATUS_NO_MEMORY;
+		goto unlock;
 	}
 
 	ret = HSAKMT_STATUS_SUCCESS;
 
-out:
+unlock:
+	if (nattr == 3)
+		pthread_mutex_unlock(&fmm_ctx->always_mapped_mutex);
 	free(args);
 	return ret;
 }
@@ -4419,6 +4770,44 @@ HSAKMT_STATUS hsakmt_fmm_deregister_memory(HsaKFDContext *ctx, void *address)
 	manageable_aperture_t *aperture;
 	vm_object_t *object;
 	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
+	svm_always_mapped_range_t *always_mapped_rec = NULL;
+	HSAuint64 always_mapped_start;
+	HSAuint64 always_mapped_size;
+
+	/* SVM-API registrations leave no vm_object behind, so undo the
+	 * GPU_ALWAYS_MAPPED we may have set in fmm_register_mem_svm_api()
+	 * before falling into the no-op return below.  The record is looked up
+	 * by the page-aligned address that was registered, but it may span more
+	 * than that if overlapping pins were merged, so clear what it reports.
+	 * A plain registration that merely falls inside a pinned range is not
+	 * one of the record's pins and takes nothing.
+	 *
+	 * The lock is dropped before vm_find_object(), which takes an
+	 * aperture's fmm_mutex, so the two are never held nested.
+	 */
+	pthread_mutex_lock(&fmm_ctx->always_mapped_mutex);
+	always_mapped_size = svm_always_mapped_take_locked(fmm_ctx,
+					(HSAuint64)address & ~(HSAuint64)(PAGE_SIZE - 1),
+					&always_mapped_start, &always_mapped_rec);
+	if (always_mapped_size) {
+		/* Drop the record only once the kernel has really cleared the
+		 * flag.  Discarding it on a failed ioctl would lose the only
+		 * handle on a still-flagged range; keeping it lets a later pin
+		 * of the same range merge in and retry the clear on release.
+		 */
+		if (svm_always_mapped_clear(ctx, always_mapped_start,
+					    always_mapped_size) ==
+		    HSAKMT_STATUS_SUCCESS) {
+			hsakmt_rbtree_delete(&fmm_ctx->always_mapped_tree,
+					     &always_mapped_rec->node);
+			svm_always_mapped_free(always_mapped_rec);
+		} else {
+			pr_warn("Failed to clear AlwaysMapped on %p size %lu\n",
+				(void *)always_mapped_start,
+				always_mapped_size);
+		}
+	}
+	pthread_mutex_unlock(&fmm_ctx->always_mapped_mutex);
 
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
 	if (!object)

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -24,6 +24,7 @@
  */
 
 #include "kfdcontext.h"
+#include "libhsakmt.h"
 #include <stdlib.h>
 #include <stddef.h>
 #include <assert.h>
@@ -65,6 +66,10 @@ void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx)
         ctx->queue_context = NULL;
     }
     if (ctx->fmm_context) {
+        /* The AlwaysMapped tracker owns heap records and a mutex, neither of
+         * which the free() below reclaims.
+         */
+        hsakmt_fmm_destroy_always_mapped_tracker(ctx);
         free(ctx->fmm_context);
         ctx->fmm_context = NULL;
     }

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -274,6 +274,7 @@ extern int hsakmt_ioctl(int fd, unsigned long request, void *arg);
 void hsakmt_clear_events_page(HsaKFDContext *ctx);
 void hsakmt_fmm_clear_all_mem(HsaKFDContext *ctx);
 void hsakmt_fmm_clear_all_aperture(HsaKFDContext *ctx);
+void hsakmt_fmm_destroy_always_mapped_tracker(HsaKFDContext *ctx);
 void hsakmt_clear_process_doorbells(HsaKFDContext *ctx);
 uint32_t hsakmt_get_num_sysfs_nodes(HsaKFDContext *ctx);
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -277,6 +277,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterMemoryCtx(HsaKFDContext *ctx,
 		return HSAKMT_STATUS_SUCCESS;
 
 	HsaMemFlags flags;
+
+	flags.Value = 0;
 	flags.ui32.CoarseGrain = 1;
 	flags.ui32.ExtendedCoherent = 0;
 	return hsakmt_fmm_register_memory(ctx,
@@ -306,6 +308,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterMemoryToNodesCtx(HsaKFDContext *ctx,
 
 	if (ret == HSAKMT_STATUS_SUCCESS) {
 		HsaMemFlags flags;
+
+		flags.Value = 0;
 		flags.ui32.CoarseGrain = 1;
 		flags.ui32.ExtendedCoherent = 0;
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -2331,4 +2331,163 @@ TEST_P(KFDSVMRangeTest, IntegerOverflowProtection) {
     TEST_END
 }
 
+/*
+ * A caller that registers with HsaMemFlags.ui32.AlwaysMapped is pinning the
+ * range (hsa_amd_memory_lock), and needs the GPU mapping to stay valid until
+ * the matching deregistration.  Under the SVM API that requires
+ * KFD_IOCTL_SVM_FLAG_GPU_ALWAYS_MAPPED; without it svm_range_evict() takes its
+ * xnack_enabled branch and unmaps the range from the GPU on any MMU
+ * invalidation, even while a transfer is still reading it.
+ *
+ * The SVM registration path creates no vm_object, so libhsakmt refcounts the
+ * flagged ranges itself in order to clear the flag again on deregistration.
+ * Overlapping pins share one record, because releasing one of them must not
+ * clear the flag on pages that another live pin still covers -- section 4
+ * below is the regression test for that.
+ */
+TEST_P(KFDSVMRangeTest, RegisterMemoryAlwaysMapped) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+
+    if (!SVMAPISupported())
+        return;
+
+    int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
+    ASSERT_GE(defaultGPUNode, 0) << "failed to get default GPU Node";
+
+    if (!SVMAPISupported_GPU(defaultGPUNode)) {
+        LOG() << "Skipping test: SVM not supported on gpuNode." << defaultGPUNode << std::endl;
+        return;
+    }
+
+    /* GPU_ALWAYS_MAPPED arrived in KFD interface minor version 11 */
+    if (Get_Version()->KernelInterfaceMinorVersion < 11) {
+        LOG() << "Skipping test: GPU_ALWAYS_MAPPED needs KFD interface 1.11" << std::endl;
+        return;
+    }
+
+    if (Get_NodeInfo()->GetNodeProperties(defaultGPUNode)->Integrated) {
+        LOG() << "Skipping test on APU: system memory registration is a no-op" << std::endl;
+        return;
+    }
+
+    const HSAuint64 nPages = 8;
+    const HSAuint64 BufferSize = nPages * PAGE_SIZE;
+
+    /* Plain anonymous host memory: the registration has to be what creates
+     * the SVM range, so HsaSVMRange is deliberately not used here.
+     */
+    void *pBuf = mmap(NULL, BufferSize, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void *pCtrl = mmap(NULL, BufferSize, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, pBuf) << "failed to mmap test buffer";
+    ASSERT_NE(MAP_FAILED, pCtrl) << "failed to mmap control buffer";
+
+    /* GetAttr reports SET_FLAGS as the AND over every range in the interval
+     * and CLR_FLAGS as the complement of the OR, so "set on all pages" and
+     * "set on no page" are both directly observable, and a range that is only
+     * partly flagged answers false to both.
+     */
+    auto MappedOnAllPages = [&](void *addr, HSAuint64 size) -> bool {
+        HSA_SVM_ATTRIBUTE attr;
+
+        attr.type = HSA_SVM_ATTR_SET_FLAGS;
+        attr.value = 0;
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx,
+                                   addr, size, 1, &attr));
+        return !!(attr.value & HSA_SVM_FLAG_GPU_ALWAYS_MAPPED);
+    };
+    auto MappedOnNoPage = [&](void *addr, HSAuint64 size) -> bool {
+        HSA_SVM_ATTRIBUTE attr;
+
+        attr.type = HSA_SVM_ATTR_CLR_FLAGS;
+        attr.value = 0;
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx,
+                                   addr, size, 1, &attr));
+        return !!(attr.value & HSA_SVM_FLAG_GPU_ALWAYS_MAPPED);
+    };
+
+    HsaMemFlags pinFlags;
+    HsaMemFlags plainFlags;
+
+    pinFlags.Value = 0;
+    pinFlags.ui32.HostAccess = 1;
+    pinFlags.ui32.AlwaysMapped = 1;
+
+    plainFlags.Value = 0;
+    plainFlags.ui32.HostAccess = 1;
+
+    /* 1. A registration that is not a pin must be left alone */
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pCtrl, BufferSize, plainFlags));
+    EXPECT_TRUE(MappedOnNoPage(pCtrl, BufferSize))
+        << "GPU_ALWAYS_MAPPED set on a registration that is not a pin";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pCtrl));
+
+    /* 2. A pin sets the flag on the whole range, unpinning clears it */
+    EXPECT_TRUE(MappedOnNoPage(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED already set before registration";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pBuf, BufferSize, pinFlags));
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED not set by a pinning registration";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pBuf));
+    EXPECT_TRUE(MappedOnNoPage(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED still set after deregistration";
+
+    /* 3. The same range pinned twice takes two deregistrations to release */
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pBuf, BufferSize, pinFlags));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pBuf, BufferSize, pinFlags));
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pBuf));
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED dropped while a second pin of the same range is live";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pBuf));
+    EXPECT_TRUE(MappedOnNoPage(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED still set after the last deregistration";
+
+    /* 4. Overlapping pins at different start addresses.  Releasing the inner
+     * one must not unpin the pages the outer one still covers.
+     */
+    void *pInner = reinterpret_cast<char *>(pBuf) + 4 * PAGE_SIZE;
+    const HSAuint64 InnerSize = 4 * PAGE_SIZE;
+
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pBuf, BufferSize, pinFlags));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pInner, InnerSize, pinFlags));
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pInner));
+    EXPECT_TRUE(MappedOnAllPages(pInner, InnerSize))
+        << "inner deregistration cleared GPU_ALWAYS_MAPPED under a live outer pin";
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize))
+        << "inner deregistration partly unpinned the outer range";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pBuf));
+    EXPECT_TRUE(MappedOnNoPage(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED still set after the last deregistration";
+
+    /* 5. A plain registration inside a pinned range is not a pin.  Its
+     * deregistration goes through the same path but must not release the pin,
+     * which it cannot be distinguished from by anything except its address.
+     */
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pBuf, BufferSize, pinFlags));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryWithFlags, m_hsakmt_current_ctx,
+                               pInner, InnerSize, plainFlags));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pInner));
+    EXPECT_TRUE(MappedOnAllPages(pBuf, BufferSize))
+        << "a plain deregistration released the pin covering it";
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, pBuf));
+    EXPECT_TRUE(MappedOnNoPage(pBuf, BufferSize))
+        << "GPU_ALWAYS_MAPPED still set after the pin was released";
+
+    munmap(pBuf, BufferSize);
+    munmap(pCtrl, BufferSize);
+
+    TEST_END
+}
+
 INSTANTIATE_TEST_CASE_P(, KFDSVMRangeTest,::testing::Values(0, 1));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -595,6 +595,12 @@ hsa_status_t MemoryRegion::Lock(uint32_t num_agents, const hsa_agent_t* agents,
     local_mem_flag.ui32.ExtendedCoherent = 0;
   }
 
+  // This is a pin: the mapping must stay valid until Unlock. Under the KFD SVM
+  // API the registration is otherwise advisory, and KFD will unmap the range
+  // from the GPU on any MMU invalidation while XNACK is on -- including while a
+  // transfer is reading it.
+  local_mem_flag.ui32.AlwaysMapped = 1;
+
   // Call kernel driver to register and pin the memory.
   if (owner()->driver().RegisterMemory(host_ptr, size, local_mem_flag) ==
       HSA_STATUS_SUCCESS) {


### PR DESCRIPTION
Make hsa_amd_memory_lock actually pin under the SVM API

## Motivation

Problem:
A pageable hipMemcpy makes ROCr pin the host source with hsa_amd_memory_lock(), whose contract is that the GPU mapping stays valid until the matching unlock. On a kernel exposing the KFD SVM API, libhsakmt implements the registration half of that contract in fmm_register_mem_svm_api() as a single SET_ATTR ioctl carrying two coherency attributes. It never sets HSA_SVM_FLAG_GPU_ALWAYS_MAPPED (0x40, the thunk spelling of the kernel's KFD_IOCTL_SVM_FLAG_GPU_ALWAYS_MAPPED; "GPU_ALWAYS_MAPPED" below means that one bit), so the "pin" is advisory only.

svm_range_evict() keeps a range mapped only when "!p->xnack_enabled || (prange->flags & KFD_IOCTL_SVM_FLAG_GPU_ALWAYS_MAPPED)", and otherwise calls svm_range_unmap_from_gpus(). So with XNACK on, any MMU invalidation overlapping the range -- migration, compaction, khugepaged, reclaim -- unmaps it from the GPU while SDMA may still be reading it. GPU_ALWAYS_MAPPED and !xnack_enabled being the same branch condition is why HSA_XNACK=0 is immune. Normally the resulting retry fault is repaired transparently, but if one restore attempt returns a non-EAGAIN error, amdgpu_vm_handle_fault() poisons the PTE with AMDGPU_VM_NORETRY_FLAGS and the next fault on that page is fatal:
VM_L2_PROTECTION_FAULT_STATUS:0x00320031, PERMISSION_FAULTS: 0x3.

Exposure scales with page count, not bytes, so disabling THP raises the failure rate roughly 500x on a 1920 MB transfer (~490,000 4 KB pages vs ~960 huge pages). THP is the catalyst, not the cause.

libhsakmt already sets GPU_ALWAYS_MAPPED for its own CWSR memory; it was simply never applied to caller pins.


## Technical Details

Solution:
Add an AlwaysMapped bit to HsaMemFlags that a caller sets when it is pinning, and have fmm_register_mem_svm_api() translate it into a third SET_FLAGS(GPU_ALWAYS_MAPPED) attribute. MemoryRegion::Lock() sets the bit; nothing else does, so unrelated registrations are unaffected. The userptr BO path ignores it, being durable already. Gated on KFD interface minor version >= 11, when GPU_ALWAYS_MAPPED became available.

GPU_ALWAYS_MAPPED must be dropped again on unlock, or a range stays permanently resident after it stops being pinned. The SVM path creates no vm_object, so hsakmt_fmm_deregister_memory() has nothing to look up and cannot recover the size CLR_FLAGS needs; ranges carrying GPU_ALWAYS_MAPPED are tracked in an rbtree instead.

Overlapping pins have to share one refcount, so a registration is merged with every record it overlaps into a union record whose refcount is the sum. Tracking them separately would let the first deregistration clear GPU_ALWAYS_MAPPED across pages another live pin still covers -- the exact failure this change exists to prevent. Merging over-flags for a while but never under-flags, and keeps records pairwise disjoint, so the lookup a deregistration needs has at most one answer.

Also zeroes HsaMemFlags before use in hsaKmtRegisterMemoryCtx() and hsaKmtRegisterMemoryToNodesCtx(). Pre-existing bug: both left the bitfield uninitialized and set only two members, so every other flag took a stack-garbage value. Latent because the SVM path read only CoarseGrain and ExtendedCoherent; a third consumer makes it live.

## Issue Tracking

JIRA ID: ROCM-27751

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Testing:
Reproducer is a pageable H2D hipMemcpy loop with THP disabled, on MI210 / gfx90a with HSA_XNACK=1.

- New KFDSVMRangeTest.RegisterMemoryAlwaysMapped, run for both values of the fixture's XNACK parameter. It registers anonymous host memory through hsaKmtRegisterMemoryWithFlags() and reads the flags back with hsaKmtSVMGetAttr(), which reports SET_FLAGS as the AND over the interval and CLR_FLAGS as the complement of the OR, so "set on every page" and "set on no page" are both observable. It checks that a non-pinning registration is left alone, that a pin sets GPU_ALWAYS_MAPPED and deregistration clears it, that two pins need two deregistrations, and that releasing an inner pin does not clear GPU_ALWAYS_MAPPED under a live overlapping outer pin. It fails against the unfixed libhsakmt, and against a version of this change without the union merge it fails only the two overlap assertions. The rest of the kfdtest suite is unaffected by this change.

- 16 paired rounds, 2 x 512 MB, arms interleaved, under deliberate compaction pressure, counting kfd_svm dynamic_debug branches:

      arm      rounds  mid-transfer unmaps  retry faults  safe evicts
      stock    16      4143 (15 rounds)     730 (6)       0
      patched  16       413 (5 rounds)        0 (0)      16

  Retry faults -- the step that can poison a PTE -- are zero in every patched round. The residual patched unmaps are invalidations landing outside a lock window or on the runtime's own SVM ranges; the kernel tests GPU_ALWAYS_MAPPED per prange, so those correctly still unmap.


- Confirmed on customer hardware, which reproduces the crash at ~50% per run. The development box  above does not reproduce it despite being the same part and effectively the same driver -- MI210 (Aldebaran, gfx90a, 1002:740f) on RHEL 8.10, in-tree amdgpu from kernel 4.18.0-553.el8_10 against the customer's 4.18.0-553.129.1.el8_10, whose SVM fault path is byte-identical across that z-stream gap. The mechanism is armed here -- the mid-transfer unmaps and retry faults in the table above are real -- but the box is idle enough that every restore succeeds on retry, so no PTE is ever poisoned. On the customer's system, interleaved 20-round A/B: 10 of 20 stock runs failed, 0 of 20 fixed runs failed. A 200-iteration 1920 MB soak (~375 GB pageable H2D, 12,000 pinned registrations) completed clean.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
