### PR TITLE
[rocjitsu] Fix gfx1150 decoder discrepancies

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3201,13 +3201,124 @@ class CodeGenerator:
                         )
                     )
                 )
+
+            absolute_source_modifier_opcodes = [
+                inst.opcode
+                for inst in inst_enc.insts
+                if inst.name in profile.vop3p_absolute_source_instructions
+            ]
+            if absolute_source_modifier_opcodes:
+                public_members.append(
+                    cgen.Line('bool uses_vop3p_absolute_source_syntax() const;')
+                )
+                class_func_impls.append(
+                    cgen.Line(
+                        self._opcode_predicate_helper_impl(
+                            inst_enc,
+                            'uses_vop3p_absolute_source_syntax',
+                            sorted(set(absolute_source_modifier_opcodes)),
+                        )
+                    )
+                )
+
+            gfx11_mimg_no_dim_dmask_opcodes = []
+            if profile.renders_gfx11_image_syntax and enc_upper == 'ENC_MIMG':
+                gfx11_mimg_no_dim_dmask_opcodes = [
+                    inst.opcode
+                    for inst in inst_enc.insts
+                    if inst.name in profile.gfx11_mimg_fixed_vaddr_words
+                ]
+                if gfx11_mimg_no_dim_dmask_opcodes:
+                    public_members.append(
+                        cgen.Line('bool omits_gfx11_mimg_dim_dmask() const;')
+                    )
+                    class_func_impls.append(
+                        cgen.Line(
+                            self._opcode_predicate_helper_impl(
+                                inst_enc,
+                                'omits_gfx11_mimg_dim_dmask',
+                                sorted(set(gfx11_mimg_no_dim_dmask_opcodes)),
+                            )
+                        )
+                    )
+
+                nsa_group_rules = []
+                for inst in inst_enc.insts:
+                    groups = profile.gfx11_mimg_nsa_group_words.get(inst.name)
+                    if groups is not None:
+                        nsa_group_rules.append((inst.opcode, *groups))
+                if nsa_group_rules:
+                    public_members.append(
+                        cgen.Line(
+                            'uint32_t gfx11_mimg_nsa_group_width('
+                            'uint32_t index, uint32_t vaddr_words) const;'
+                        )
+                    )
+                    nsa_group_lines = [
+                        f'uint32_t {inst_enc.fmt_enc_name}::gfx11_mimg_nsa_group_width('
+                        'uint32_t index, uint32_t vaddr_words) const {',
+                        '  switch (inst_.op) {',
+                    ]
+                    for opcode, default_groups, a16_groups in nsa_group_rules:
+                        nsa_group_lines.extend(
+                            (
+                                f'  case {opcode}:',
+                                '    if (inst_.a16) {',
+                                '      static constexpr uint8_t widths[] = {'
+                                + ', '.join(str(width) for width in a16_groups)
+                                + '};',
+                                f'      return index < {len(a16_groups)} ? widths[index] : 0;',
+                                '    }',
+                                '    {',
+                                '      static constexpr uint8_t widths[] = {'
+                                + ', '.join(str(width) for width in default_groups)
+                                + '};',
+                                f'      return index < {len(default_groups)} ? widths[index] : 0;',
+                                '    }',
+                            )
+                        )
+                    nsa_group_lines.extend(
+                        (
+                            '  default:',
+                            '    if (index < 4) return 1;',
+                            '    return index == 4 && vaddr_words > 4 ? vaddr_words - 4 : 0;',
+                            '  }',
+                            '}',
+                        )
+                    )
+                    class_func_impls.append(cgen.Line('\n'.join(nsa_group_lines)))
+
             # TH/SCOPE rendering follows the encoding data itself. Keeping it
             # outside the profile modifier lists prevents a new memory format
             # with the same fields from silently losing its cache attributes.
             gfx12_cache_modifier = self._gfx12_cache_policy_modifier_impl(
                 inst_enc, enc_field_names
             )
+
             modifier_lines = ''
+            if profile.renders_gfx11_image_syntax and enc_upper == 'ENC_MIMG':
+                modifier_lines += (
+                    'if (!omits_gfx11_mimg_dim_dmask()) {'
+                    'modifiers_ += " dmask:0x"; '
+                    'modifiers_ += "0123456789abcdef"[inst->dmask & 0xfu]; }'
+                    'if (!omits_gfx11_mimg_dim_dmask()) {'
+                    'static constexpr std::string_view dims[] = {'
+                    '"1D", "2D", "3D", "CUBE", "1D_ARRAY", '
+                    '"2D_ARRAY", "2D_MSAA", "2D_MSAA_ARRAY"};'
+                    'modifiers_ += " dim:SQ_RSRC_IMG_";'
+                    'modifiers_ += dims[inst->dim & 7u];}'
+                    'if (!omits_gfx11_mimg_dim_dmask()) {'
+                    'if (inst->unorm) modifiers_ += " unorm";'
+                    'if (inst->glc) modifiers_ += " glc";'
+                    'if (inst->slc) modifiers_ += " slc";'
+                    'if (inst->dlc) modifiers_ += " dlc";'
+                    'if (inst->r128) modifiers_ += " r128";}'
+                    'if (inst->a16) modifiers_ += " a16";'
+                    'if (!omits_gfx11_mimg_dim_dmask()) {'
+                    'if (inst->tfe) modifiers_ += " tfe";'
+                    'if (inst->lwe) modifiers_ += " lwe";'
+                    'if (inst->d16) modifiers_ += " d16";}'
+                )
             for mod in profile.encoding_modifiers(inst_enc.enc_name):
                 if not mod.preamble and mod.field not in enc_field_names:
                     continue
@@ -3239,10 +3350,15 @@ class CodeGenerator:
                         if self.semantics
                         else None
                     )
-                    if sem is not None and sem.semantic_class in (
-                        'ds_read2',
-                        'ds_write2',
-                        'ds_atomic2',
+                    if (
+                        sem is not None
+                        and sem.semantic_class
+                        in (
+                            'ds_read2',
+                            'ds_write2',
+                            'ds_atomic2',
+                        )
+                        or (profile.split_ds_2addr_offsets and '_2ADDR_' in inst.name)
                     ):
                         split_offset_opcodes.append(inst.opcode)
                 if split_offset_opcodes:
@@ -3361,7 +3477,9 @@ class CodeGenerator:
                             if self.semantics
                             else None
                         )
-                        if sem is not None and sem.semantic_class.startswith('pk_'):
+                        if sem is not None and sem.semantic_class.startswith(
+                            ('pk_', 'dot2_')
+                        ):
                             packed_default_opcodes.append(inst.opcode)
                         if inst.name in profile.vop3p_source_modifier_omissions:
                             omitted_source_modifier_opcodes.append(inst.opcode)
@@ -3386,13 +3504,28 @@ class CodeGenerator:
                         if packed_default_opcodes
                         else 'false'
                     )
+                    source_count = 'vop3p_encoded_source_count()'
+                    if omitted_source_modifier_opcodes:
+                        source_count = (
+                            f'omits_vop3p_source_modifiers() ? 0 : {source_count}'
+                        )
+                    absolute_syntax = (
+                        'uses_vop3p_absolute_source_syntax()'
+                        if absolute_source_modifier_opcodes
+                        else 'false'
+                    )
+                    if absolute_source_modifier_opcodes:
+                        source_count = f'{absolute_syntax} ? 3 : ({source_count})'
+                        packed_defaults = (
+                            f'{absolute_syntax} ? false : ({packed_defaults})'
+                        )
                     modifier_lines += (
                         'amdgpu::vop::append_vop3p_disassembly('
                         f'modifiers_, inst->{op_sel}, '
                         f'inst->{op_sel_hi} | (inst->{op_sel_hi_high} << 2), '
-                        'inst->neg, inst->neg_hi, inst->clamp, '
-                        f'{"omits_vop3p_source_modifiers() ? 0 : " if omitted_source_modifier_opcodes else ""}'
-                        'vop3p_encoded_source_count(), '
+                        f'{absolute_syntax} ? 0 : inst->neg, '
+                        f'{absolute_syntax} ? 0 : inst->neg_hi, inst->clamp, '
+                        f'{source_count}, '
                         f'{packed_defaults});'
                     )
             dpp_modifier_line = ''
@@ -3660,6 +3793,82 @@ class CodeGenerator:
                     f'{{{size_line}}}'
                 )
             class_func_impls.append(cgen.Line(class_ctor_impl))
+            if profile.renders_gfx11_image_syntax and enc_upper == 'ENC_MIMG':
+                public_members.append(
+                    cgen.Line(
+                        'void capture_nsa_words(const MachineInst *inst, '
+                        'const Operand *vaddr);'
+                    )
+                )
+                public_members.append(
+                    cgen.Line(
+                        'void append_src_operand(std::string &out, '
+                        'uint8_t operand_index) const override {\n'
+                        '  const Operand *operand = src_operands_[operand_index];\n'
+                        '  if (!inst_.nsa || operand != nsa_vaddr_operand_) {\n'
+                        '    Instruction::append_src_operand(out, operand_index);\n'
+                        '    return;\n'
+                        '  }\n'
+                        '  const uint32_t vaddr_words = (operand->size_bits() + 31) / 32;\n'
+                        '  out += "[";\n'
+                        '  uint32_t consumed_words = 0;\n'
+                        '  for (uint32_t index = 0; index < 5 && consumed_words < vaddr_words; ++index) {\n'
+                        '    const uint32_t group_words = gfx11_mimg_nsa_group_width(index, vaddr_words);\n'
+                        '    if (group_words == 0) break;\n'
+                        '    if (index != 0) out += ", ";\n'
+                        '    const uint32_t selector = index == 0\n'
+                        '        ? inst_.vaddr\n'
+                        '        : (raw_words_[2] >> ((index - 1) * 8)) & 0xffu;\n'
+                        '    if (group_words > 1) {\n'
+                        '      out += "v[" + std::to_string(selector) + ":";\n'
+                        '      out += std::to_string(selector + group_words - 1) + "]";\n'
+                        '    } else {\n'
+                        '      out += "v" + std::to_string(selector);\n'
+                        '    }\n'
+                        '    consumed_words += group_words;\n'
+                        '  }\n'
+                        '  out += "]";\n'
+                        '}'
+                    )
+                )
+                class_func_impls.append(
+                    cgen.Line(
+                        f'void {inst_enc.fmt_enc_name}::capture_nsa_words('
+                        'const MachineInst *inst, const Operand *vaddr) {\n'
+                        '  if (!inst_.nsa) return;\n'
+                        '  nsa_vaddr_operand_ = vaddr;\n'
+                        '  size_ = sizeof(OpEncoding) + sizeof(MachineInst);\n'
+                        '  std::memcpy(raw_words_.data(), inst, size_);\n'
+                        '  raw_encoding_ = raw_words_.data();\n'
+                        '}'
+                    )
+                )
+            if absolute_source_modifier_opcodes:
+                public_members.append(
+                    cgen.Line(
+                        'void append_src_operand(std::string &out, '
+                        'uint8_t operand_index) const override {\n'
+                        '  const Operand *operand = src_operands_[operand_index];\n'
+                        '  if (!uses_vop3p_absolute_source_syntax() || operand_index >= 3) {\n'
+                        '    Instruction::append_src_operand(out, operand_index);\n'
+                        '    return;\n'
+                        '  }\n'
+                        '  if ((inst_.neg >> operand_index) & 1u) out += \'-\';\n'
+                        '  const bool absolute = ((inst_.neg_hi >> operand_index) & 1u) != 0;\n'
+                        '  if (absolute) out += \'|\';\n'
+                        '  const uint32_t selector = operand_index == 0 ? inst_.src0\n'
+                        '      : (operand_index == 1 ? inst_.src1 : inst_.src2);\n'
+                        '  if (selector == 255) {\n'
+                        '    out += "lit(";\n'
+                        '    out += operand->name();\n'
+                        '    out += \')\';\n'
+                        '  } else {\n'
+                        '    out += operand->name();\n'
+                        '  }\n'
+                        '  if (absolute) out += \'|\';\n'
+                        '}'
+                    )
+                )
             # Generate build_modifiers() overrides for encoding bases that
             # display memory flags, DPP controls, or other attributes. This is
             # called lazily by disassemble() instead of eagerly in the
@@ -3914,6 +4123,13 @@ class CodeGenerator:
                     cgen.Statement(
                         f'std::array<uint32_t, {raw_word_count}> raw_words_{{}}'
                     )
+                )
+            elif profile.renders_gfx11_image_syntax and enc_upper == 'ENC_MIMG':
+                class_members.append(
+                    cgen.Statement('std::array<uint32_t, 5> raw_words_{}')
+                )
+                class_members.append(
+                    cgen.Statement('const Operand *nsa_vaddr_operand_ = nullptr')
                 )
             if inst_enc.has_implied_literal_ops:
                 class_members.append(cgen.Statement('uint32_t literal_ = 0'))
@@ -4826,6 +5042,45 @@ class CodeGenerator:
             return None
         return 'vflat_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst))'
 
+    def _mimg_operand_size_expr(
+        self, enc_name: str, inst_name: str, opnd_name: str
+    ) -> str | None:
+        if (
+            not self.isa_spec.profile.renders_gfx11_image_syntax
+            or enc_name.upper() != 'ENC_MIMG'
+        ):
+            return None
+        if opnd_name == 'vdata':
+            fixed_words = self.isa_spec.profile.gfx11_mimg_fixed_vdata_words.get(
+                inst_name
+            )
+            if fixed_words is not None:
+                return str(fixed_words * 32)
+            gather = str(
+                inst_name.upper().startswith('IMAGE_GATHER')
+                or inst_name
+                in self.isa_spec.profile.gfx11_mimg_gather_style_instructions
+            ).lower()
+            return (
+                'mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), '
+                f'{gather})'
+            )
+        if opnd_name == 'vaddr':
+            fixed_words = self.isa_spec.profile.gfx11_mimg_fixed_vaddr_words.get(
+                inst_name
+            )
+            if fixed_words is not None:
+                default_words, a16_words = fixed_words
+                return (
+                    '(reinterpret_cast<const OpEncoding *>(inst)->a16 ? '
+                    f'{a16_words * 32} : {default_words * 32})'
+                )
+            return (
+                'mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), '
+                f'"{inst_name.lower()}")'
+            )
+        return None
+
     @staticmethod
     def _emit_buffer_vaddr_helpers(
         helper_name: str, machine_inst_type: str, *, templated: bool
@@ -4852,6 +5107,68 @@ class CodeGenerator:
             uint32_t vflat_vaddr_bits(const VmemMachineInst *inst) {
               // SADDR == NULL selects a 64-bit vector address; otherwise VADDR is a 32-bit offset.
               return inst->saddr == OPR_SREG_NULL ? 64 : 32;
+            }
+            } // namespace''')
+
+    @staticmethod
+    def _emit_gfx11_mimg_helpers() -> str:
+        return textwrap.dedent('''\
+            namespace {
+            template <typename MimgMachineInst>
+            uint32_t mimg_vdata_bits(const MimgMachineInst *inst, bool gather4) {
+              uint32_t words = gather4 ? 4u : 0u;
+              if (!gather4) {
+                uint32_t mask = inst->dmask & 0xfu;
+                while (mask) {
+                  words += mask & 1u;
+                  mask >>= 1;
+                }
+                if (words == 0)
+                  words = 1;
+              }
+              if (inst->d16)
+                words = (words + 1) / 2;
+              if (inst->tfe)
+                ++words;
+              return words * 32;
+            }
+
+            bool mimg_name_has_token(std::string_view name, std::string_view token) {
+              size_t pos = 0;
+              while (pos < name.size()) {
+                const size_t end = name.find('_', pos);
+                const size_t count = end == std::string_view::npos ? name.size() - pos : end - pos;
+                if (name.substr(pos, count) == token)
+                  return true;
+                if (end == std::string_view::npos)
+                  break;
+                pos = end + 1;
+              }
+              return false;
+            }
+
+            template <typename MimgMachineInst>
+            uint32_t mimg_vaddr_bits(const MimgMachineInst *inst, std::string_view name) {
+              static constexpr uint8_t coords[] = {1, 2, 3, 3, 2, 3, 3, 4};
+              static constexpr uint8_t gradients[] = {2, 4, 6, 4, 2, 4, 4, 4};
+              const uint32_t dim = inst->dim & 7u;
+              const bool resinfo = name == "image_get_resinfo";
+              const bool gradient = mimg_name_has_token(name, "d") ||
+                                    mimg_name_has_token(name, "cd");
+              const bool g16 = mimg_name_has_token(name, "g16");
+              const bool lod = resinfo || mimg_name_has_token(name, "mip") ||
+                               mimg_name_has_token(name, "l") ||
+                               mimg_name_has_token(name, "cl");
+              uint32_t words = mimg_name_has_token(name, "c") ? 1u : 0u;
+              words += mimg_name_has_token(name, "o") ? 1u : 0u;
+              words += mimg_name_has_token(name, "b") ? 1u : 0u;
+              const uint32_t coord_words = (resinfo ? 0u : coords[dim]) + (lod ? 1u : 0u);
+              words += inst->a16 ? (coord_words + 1) / 2 : coord_words;
+              if (gradient) {
+                const uint32_t gradient_words = gradients[dim];
+                words += g16 ? ((gradient_words / 2 + 1) & ~1u) : gradient_words;
+              }
+              return (words == 0 ? 1u : words) * 32;
             }
             } // namespace''')
 
@@ -9279,6 +9596,10 @@ class CodeGenerator:
                                 enc.enc_name, opnd.name
                             )
                         if opnd_size_expr is None:
+                            opnd_size_expr = self._mimg_operand_size_expr(
+                                enc.enc_name, inst.name, opnd.name
+                            )
+                        if opnd_size_expr is None:
                             opnd_size_expr = str(opnd.size)
                         # The gfx1250 MRISA describes VOP3 compare masks with
                         # the legacy 64-bit width. gfx1250 is wave32-only: V_CMP
@@ -9474,6 +9795,12 @@ class CodeGenerator:
                                     has_acc_cd_field='acc_cd' in inst_field_names,
                                 )
                             )
+                            if (
+                                profile.renders_gfx11_image_syntax
+                                and enc.enc_name.upper() == 'ENC_MIMG'
+                                and opnd.name in ('srsrc', 'ssamp')
+                            ):
+                                operand_value = f'({operand_value} * 4)'
                             opnd_ctor_init.append(
                                 f'{opnd.name}({opnd_size_expr}, '
                                 f'OperandType::{opr_type}, '
@@ -9655,7 +9982,27 @@ class CodeGenerator:
                     # so the encoding base gets a string_view to static storage.
                     rule = self.isa_spec.profile.mnemonic_rule(enc.enc_name)
                     full_mnemonic = inst.mnemonic + (rule.suffix or '')
-                    mnemonic_expr = f'"{full_mnemonic}"'
+                    rendered_mnemonic = (
+                        inst.mnemonic
+                        if (
+                            inst.name == 'V_SWAP_B16'
+                            and profile.uses_packed_16bit_e32_source_selectors
+                        )
+                        else full_mnemonic
+                    )
+                    mnemonic_expr = f'"{rendered_mnemonic}"'
+                    if inst.name == 'V_SWAP_B16':
+                        _, dpp8_struct = self._vop_dpp_struct_names(enc.enc_name)
+                        if dpp8_struct is not None:
+                            dpp_predicate = (
+                                'amdgpu::dpp::is_src_dpp8('
+                                'reinterpret_cast<const OpEncoding*>(inst)->src0)'
+                            )
+                            dpp_mnemonic = inst.mnemonic + '_dpp'
+                            mnemonic_expr = (
+                                f'{dpp_predicate} ? "{dpp_mnemonic}" : '
+                                f'"{rendered_mnemonic}"'
+                            )
                     if supports_sdwa_extension and self._instruction_supports_sdwa(
                         inst, enc.enc_name
                     ):
@@ -9749,6 +10096,20 @@ class CodeGenerator:
                         }
                     )
                     ctor_body_parts = list(opnd_body)
+                    if (
+                        inst.name == 'V_SWAP_B16'
+                        and self.isa_spec.profile.uses_packed_16bit_e32_source_selectors
+                    ) or (
+                        self.isa_spec.profile.renders_gfx11_image_syntax
+                        and (
+                            enc.enc_name.upper() == 'ENC_MIMG'
+                            or inst.name
+                            in self.isa_spec.profile.vop3p_absolute_source_instructions
+                        )
+                    ):
+                        ctor_body_parts.append(
+                            'omit_repeated_destination_sources_ = true;'
+                        )
                     fieldless_caps_guards: dict[str, str] = {}
                     factory_validation_parts: list[str] = []
                     factory_op_encoding = f'{inst.fmt_true_enc_name}::OpEncoding'
@@ -10432,6 +10793,25 @@ class CodeGenerator:
                                         'amdgpu::SRC_SDWA) '
                                         f'[[unlikely]] return emit_error.emit() << "{inst.name} does not support SDWA";'
                                     )
+
+                    if (
+                        inst.name == 'V_SWAP_B16'
+                        and profile.uses_packed_16bit_e32_source_selectors
+                    ):
+                        for opnd in inst.operands:
+                            if opnd.name == 'src0':
+                                ctor_body_parts.append(
+                                    ' src0 = Operand(16, OperandType::OPR_VGPR, '
+                                    'static_cast<unsigned short>('
+                                    'reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu), '
+                                    'true, true);'
+                                )
+
+                    if (
+                        profile.renders_gfx11_image_syntax
+                        and enc.enc_name.upper() == 'ENC_MIMG'
+                    ):
+                        ctor_body_parts.append('capture_nsa_words(inst, &vaddr);')
 
                     # Apply the fieldless-operand capability policy once, after
                     # every ctor-body reassignment. Fieldless operands are built
@@ -11910,6 +12290,13 @@ class CodeGenerator:
                     class_func_impls.model.insert(
                         0, cgen.Line(self._emit_vflat_helpers())
                     )
+                elif (
+                    enc.enc_name.upper() == 'ENC_MIMG'
+                    and self.isa_spec.profile.renders_gfx11_image_syntax
+                ):
+                    class_func_impls.model.insert(
+                        0, cgen.Line(self._emit_gfx11_mimg_helpers())
+                    )
 
                 if (
                     self.isa_spec.arch_name.lower() in {'cdna2', 'cdna3', 'cdna4'}
@@ -13237,6 +13624,26 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     f'  {wc}'
                     f'  return std::format("vmcnt({{}}) expcnt({{}}) lgkmcnt({{}})", '
                     f'vmcnt, expcnt, lgkmcnt);\n'
+                    f'}}'
+                )
+            elif (
+                t == 'OPR_SENDMSG_RTN' and self.isa_spec.profile.sendmsg_return_symbolic
+            ):
+                switch_cases.append(
+                    f'case OperandType::{t}: {{\n'
+                    f'  switch (static_cast<uint32_t>(encoding_value_) & 0xFFFF) {{\n'
+                    f'  case 128: return "sendmsg(MSG_RTN_GET_DOORBELL)";\n'
+                    f'  case 129: return "sendmsg(MSG_RTN_GET_DDID)";\n'
+                    f'  case 130: return "sendmsg(MSG_RTN_GET_TMA)";\n'
+                    f'  case 131: return "sendmsg(MSG_RTN_GET_REALTIME)";\n'
+                    f'  case 132: return "sendmsg(MSG_RTN_SAVE_WAVE)";\n'
+                    f'  case 133: return "sendmsg(MSG_RTN_GET_TBA)";\n'
+                    f'  case 134: return "sendmsg(MSG_RTN_GET_TBA_TO_PC)";\n'
+                    f'  default: break;\n'
+                    f'  }}\n'
+                    f'  const uint32_t value = static_cast<uint32_t>(encoding_value_) & 0xFFFF;\n'
+                    f'  if (value <= 0xFF) return std::format("sendmsg({{}}, 0, 0)", value);\n'
+                    f'  return std::to_string(encoding_value_);\n'
                     f'}}'
                 )
             else:

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -509,6 +509,48 @@ class IsaProfile(ABC):
         return False
 
     @property
+    def renders_gfx11_image_syntax(self) -> bool:
+        """Whether GFX11 image operands and modifiers use canonical syntax."""
+        return False
+
+    @property
+    def split_ds_2addr_offsets(self) -> bool:
+        """Whether DS 2ADDR instructions render two independent offsets."""
+        return False
+
+    @property
+    def vop3p_absolute_source_instructions(self) -> frozenset[str]:
+        """VOP3P instructions whose NEG fields encode source abs and negate."""
+        return frozenset()
+
+    @property
+    def gfx11_mimg_gather_style_instructions(self) -> frozenset[str]:
+        """GFX11 MIMG instructions with gather-style VDATA sizing."""
+        return frozenset()
+
+    @property
+    def gfx11_mimg_fixed_vdata_words(self) -> dict[str, int]:
+        """GFX11 MIMG instructions with a fixed VDATA width in DWORDs."""
+        return {}
+
+    @property
+    def gfx11_mimg_fixed_vaddr_words(self) -> dict[str, tuple[int, int]]:
+        """GFX11 MIMG VADDR widths as ``(default, a16)`` DWORD counts."""
+        return {}
+
+    @property
+    def gfx11_mimg_nsa_group_words(
+        self,
+    ) -> dict[str, tuple[tuple[int, ...], tuple[int, ...]]]:
+        """GFX11 partial-NSA group widths as ``(default, a16)`` tuples."""
+        return {}
+
+    @property
+    def sendmsg_return_symbolic(self) -> bool:
+        """Whether return-message selectors use symbolic assembly syntax."""
+        return False
+
+    @property
     def split_execution_sources(self) -> bool:
         """True when execution bodies are emitted to separate source files."""
         return False
@@ -2140,6 +2182,49 @@ class Rdna3_5Profile(Rdna3Profile):
     class so the codegen pipeline can auto-detect RDNA3.5 XML files
     separately from RDNA3.
     """
+
+    @property
+    def renders_gfx11_image_syntax(self) -> bool:
+        return True
+
+    @property
+    def split_ds_2addr_offsets(self) -> bool:
+        return True
+
+    @property
+    def vop3p_absolute_source_instructions(self) -> frozenset[str]:
+        return frozenset({'V_FMA_MIX_F32', 'V_FMA_MIXLO_F16', 'V_FMA_MIXHI_F16'})
+
+    @property
+    def gfx11_mimg_gather_style_instructions(self) -> frozenset[str]:
+        return frozenset({'IMAGE_MSAA_LOAD'})
+
+    @property
+    def gfx11_mimg_fixed_vdata_words(self) -> dict[str, int]:
+        return {
+            'IMAGE_BVH_INTERSECT_RAY': 4,
+            'IMAGE_BVH64_INTERSECT_RAY': 4,
+        }
+
+    @property
+    def gfx11_mimg_fixed_vaddr_words(self) -> dict[str, tuple[int, int]]:
+        return {
+            'IMAGE_BVH_INTERSECT_RAY': (11, 8),
+            'IMAGE_BVH64_INTERSECT_RAY': (12, 9),
+        }
+
+    @property
+    def gfx11_mimg_nsa_group_words(
+        self,
+    ) -> dict[str, tuple[tuple[int, ...], tuple[int, ...]]]:
+        return {
+            'IMAGE_BVH_INTERSECT_RAY': ((1, 1, 3, 3, 3), (1, 1, 3, 3)),
+            'IMAGE_BVH64_INTERSECT_RAY': ((2, 1, 3, 3, 3), (2, 1, 3, 3)),
+        }
+
+    @property
+    def sendmsg_return_symbolic(self) -> bool:
+        return True
 
 
 class Rdna4Profile(_AmdgpuProfileBase):

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -4167,6 +4167,107 @@ def test_generated_sendmsg_return_selectors_are_not_literals(
             assert 'LiteralSupport::None, 0' in sendmsg_decode
 
 
+def test_generated_rdna3_5_sendmsg_return_uses_symbolic_disassembly(
+    amdgpu_generated_root: Path,
+):
+    operand = (
+        amdgpu_generated_root / _generated_dir_name('rdna3_5') / 'operand.cpp'
+    ).read_text()
+    start = operand.index('case OperandType::OPR_SENDMSG_RTN:')
+    end = operand.index('case OperandType::OPR_SIMM16:', start)
+    sendmsg_return = operand[start:end]
+
+    assert 'return "sendmsg(MSG_RTN_GET_DOORBELL)";' in sendmsg_return
+    assert 'return std::format("sendmsg({}, 0, 0)", value);' in sendmsg_return
+
+
+def test_rdna3_5_disassembly_overrides_do_not_change_rdna3():
+    rdna3 = Rdna3Profile()
+    rdna3_5 = Rdna3_5Profile()
+
+    assert not rdna3.renders_gfx11_image_syntax
+    assert not rdna3.split_ds_2addr_offsets
+    assert not rdna3.vop3p_absolute_source_instructions
+    assert not rdna3.sendmsg_return_symbolic
+    assert rdna3_5.renders_gfx11_image_syntax
+    assert rdna3_5.split_ds_2addr_offsets
+    assert rdna3_5.vop3p_absolute_source_instructions == frozenset(
+        {'V_FMA_MIX_F32', 'V_FMA_MIXLO_F16', 'V_FMA_MIXHI_F16'}
+    )
+    assert rdna3_5.gfx11_mimg_gather_style_instructions == frozenset(
+        {'IMAGE_MSAA_LOAD'}
+    )
+    assert rdna3_5.gfx11_mimg_fixed_vdata_words == {
+        'IMAGE_BVH_INTERSECT_RAY': 4,
+        'IMAGE_BVH64_INTERSECT_RAY': 4,
+    }
+    assert rdna3_5.gfx11_mimg_fixed_vaddr_words == {
+        'IMAGE_BVH_INTERSECT_RAY': (11, 8),
+        'IMAGE_BVH64_INTERSECT_RAY': (12, 9),
+    }
+    assert rdna3_5.gfx11_mimg_nsa_group_words == {
+        'IMAGE_BVH_INTERSECT_RAY': ((1, 1, 3, 3, 3), (1, 1, 3, 3)),
+        'IMAGE_BVH64_INTERSECT_RAY': ((2, 1, 3, 3, 3), (2, 1, 3, 3)),
+    }
+    assert rdna3_5.sendmsg_return_symbolic
+
+
+def test_generated_rdna3_5_fuzz_disassembly_rules(amdgpu_generated_root: Path):
+    generated_root = amdgpu_generated_root / _generated_dir_name('rdna3_5')
+    encodings = (generated_root / 'encodings.cpp').read_text()
+    encodings_h = (generated_root / 'encodings.h').read_text()
+    encoding_model = encodings_h + '\n' + encodings
+    mimg = (generated_root / 'mimg.cpp').read_text()
+    vop1 = (generated_root / 'vop1.cpp').read_text()
+
+    assert 'if (!omits_gfx11_mimg_dim_dmask())' in encoding_model
+    assert 'out += "0123456789abcdef"[inst->dmask & 0xfu];' in encoding_model
+    assert 'nsa_vaddr_operand_ = vaddr;' in encoding_model
+    assert 'operand != nsa_vaddr_operand_' in encoding_model
+    assert 'gfx11_mimg_nsa_group_width' in encoding_model
+    assert 'const Operand *nsa_vaddr_operand_ = nullptr;' in encodings_h
+    assert '(reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)' in mimg
+    assert '(reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)' in mimg
+    assert 'mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst)' in mimg
+    assert 'mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst)' in mimg
+    assert 'mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true)' in mimg
+    assert 'vdata(128, OperandType::OPR_VGPR' in _generated_constructor_body(
+        mimg, 'ImageBvhIntersectRayMimg'
+    )
+    assert '(reinterpret_cast<const OpEncoding *>(inst)->a16 ? 256 : 352)' in (
+        _generated_constructor_body(mimg, 'ImageBvhIntersectRayMimg')
+    )
+    assert '(reinterpret_cast<const OpEncoding *>(inst)->a16 ? 288 : 384)' in (
+        _generated_constructor_body(mimg, 'ImageBvh64IntersectRayMimg')
+    )
+    assert 'capture_nsa_words(inst, &vaddr);' in mimg
+    assert 'omit_repeated_destination_sources_ = true;' in _generated_constructor_body(
+        mimg, 'ImageAtomicSubMimg'
+    )
+    assert 'inst_.op >= 46 && inst_.op <= 47' in _generated_bool_method_body(
+        encodings, 'Ds', 'uses_split_ds_offsets'
+    )
+    assert 'out += \'-\';' in _generated_inline_method_body(
+        encodings_h, 'Vop3p', 'void append_src_operand'
+    )
+    assert 'out += "lit(";' in _generated_inline_method_body(
+        encodings_h, 'Vop3p', 'void append_src_operand'
+    )
+    assert 'inst_.op == 26' in _generated_inline_method_body(
+        encodings_h, 'Vop3p', 'void build_modifiers'
+    )
+    v_swap_ctor = _generated_constructor_body(vop1, 'VSwapB16Vop1')
+    assert (
+        '"v_swap_b16_dpp"' in v_swap_ctor
+        and ': "v_swap_b16"' in v_swap_ctor
+        and 'omit_repeated_destination_sources_ = true;' in v_swap_ctor
+        and 'OperandType::OPR_VGPR' in v_swap_ctor
+        and 'reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu)' in v_swap_ctor
+        and 'true, true);' in v_swap_ctor
+        and '& 0x7fu' not in v_swap_ctor
+    )
+
+
 def test_gfx1250_compact_literal_policy_precedes_extension_sizing(
     gfx1250_generated_root: Path,
 ):

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna1/encodings.h
@@ -687,9 +687,10 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
-        inst_.op <= 18);
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp,
+        omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
+        inst_.op <= 18 || inst_.op == 35 || (inst_.op >= 38 && inst_.op <= 39));
   }
   using OpEncoding = Vop3pMachineInst;
   const OpEncoding inst_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna2/encodings.h
@@ -662,9 +662,11 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
-        inst_.op <= 18 || (inst_.op >= 48 && inst_.op <= 51));
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp,
+        omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
+        inst_.op <= 18 || inst_.op == 35 || (inst_.op >= 38 && inst_.op <= 39) ||
+            (inst_.op >= 48 && inst_.op <= 51));
   }
   using OpEncoding = Vop3pMachineInst;
   const OpEncoding inst_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna3/encodings.h
@@ -650,9 +650,11 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
-        inst_.op <= 18 || (inst_.op >= 48 && inst_.op <= 51));
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp,
+        omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
+        inst_.op <= 18 || inst_.op == 35 || (inst_.op >= 38 && inst_.op <= 39) ||
+            (inst_.op >= 48 && inst_.op <= 51));
   }
   using OpEncoding = Vop3pMachineInst;
   const OpEncoding inst_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna4/encodings.h
@@ -654,9 +654,11 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
-        inst_.op <= 18 || (inst_.op >= 27 && inst_.op <= 28) || (inst_.op >= 48 && inst_.op <= 51));
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp,
+        omits_vop3p_source_modifiers() ? 0 : vop3p_encoded_source_count(),
+        inst_.op <= 18 || (inst_.op >= 26 && inst_.op <= 28) || inst_.op == 35 ||
+            (inst_.op >= 38 && inst_.op <= 39) || (inst_.op >= 48 && inst_.op <= 51));
   }
   using OpEncoding = Vop3pMachineInst;
   const OpEncoding inst_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/encodings.h
@@ -815,8 +815,8 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->opsel, inst->opsel_hi | (inst->opsel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, vop3p_encoded_source_count(),
+        out, inst->opsel, inst->opsel_hi | (inst->opsel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp, vop3p_encoded_source_count(),
         inst_.op <= 17 || (inst_.op >= 20 && inst_.op <= 21) ||
             (inst_.op >= 27 && inst_.op <= 31) || inst_.op == 35 ||
             (inst_.op >= 40 && inst_.op <= 50) || (inst_.op >= 54 && inst_.op <= 57));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vop1.cpp
@@ -5105,7 +5105,10 @@ DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmit
 } // namespace detail
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16",
+           reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::VSwapB16Vop1)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
@@ -5115,17 +5118,25 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   src_operands_[0] = &vdst;
   src_operands_[1] = &src0;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 2;
+  src0 =
+      Operand(16, OperandType::OPR_VGPR,
+              static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu),
+              true, true);
   vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
 namespace detail {
 DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
-  Result validation =
-      Vop1::validate_encoding("v_swap_b16_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode),
-                              emit_error, LiteralSupport::None, 0);
+  const auto *inst = opcode;
+  Result validation = Vop1::validate_encoding(
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error, LiteralSupport::None, 0);
   if (validation.failed()) [[unlikely]]
     return Result::failure();
   return std::make_unique<VSwapB16Vop1>(opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna1/encodings.h
@@ -684,8 +684,8 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, vop3p_encoded_source_count(), inst_.op <= 18);
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp, vop3p_encoded_source_count(), inst_.op <= 18);
   }
   bool has_lit_0();
   bool has_lit_1();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna2/encodings.h
@@ -688,8 +688,8 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, vop3p_encoded_source_count(), inst_.op <= 18);
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp, vop3p_encoded_source_count(), inst_.op <= 21);
   }
   bool has_lit_0();
   bool has_lit_1();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/encodings.h
@@ -637,8 +637,9 @@ public:
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, vop3p_encoded_source_count(), inst_.op <= 18);
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp, vop3p_encoded_source_count(),
+        inst_.op <= 19 || inst_.op == 26);
     if (has_encoded_dpp())
       amdgpu::dpp::append_dpp16_disassembly(out, dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
                                             dpp_bound_ctrl_, dpp_fi_, true,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3/vop1.cpp
@@ -3702,7 +3702,10 @@ DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmit
 } // namespace detail
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16",
+           reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::VSwapB16Vop1)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
@@ -3712,14 +3715,23 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   src_operands_[0] = &vdst;
   src_operands_[1] = &src0;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 2;
+  src0 =
+      Operand(16, OperandType::OPR_VGPR,
+              static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu),
+              true, true);
 }
 
 namespace detail {
 DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
   Result validation = Vop1::validate_encoding(
-      "v_swap_b16_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
   if (validation.failed()) [[unlikely]]
     return Result::failure();
   return std::make_unique<VSwapB16Vop1>(opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.cpp
@@ -1457,6 +1457,8 @@ void Vop3p::append_mnemonic(std::string &out) const {
     out += "_e64_dpp";
 }
 
+bool Vop3p::uses_vop3p_absolute_source_syntax() const { return (inst_.op >= 32 && inst_.op <= 34); }
+
 uint32_t Vop3p::vop3p_encoded_source_count() const {
   uint32_t count = 0;
   for (uint8_t src = 0; src < num_src_; ++src) {
@@ -1600,8 +1602,9 @@ Ldsdir::Ldsdir(std::string_view mnemonic, const LdsdirMachineInst *inst, Execute
 bool Ldsdir::default_encoding() { return 1; }
 
 bool Ds::uses_split_ds_offsets() const {
-  return (inst_.op >= 14 && inst_.op <= 15) || (inst_.op >= 55 && inst_.op <= 56) ||
-         (inst_.op >= 78 && inst_.op <= 79) || (inst_.op >= 119 && inst_.op <= 120);
+  return (inst_.op >= 14 && inst_.op <= 15) || (inst_.op >= 46 && inst_.op <= 47) ||
+         (inst_.op >= 55 && inst_.op <= 56) || (inst_.op >= 78 && inst_.op <= 79) ||
+         (inst_.op >= 110 && inst_.op <= 111) || (inst_.op >= 119 && inst_.op <= 120);
 }
 
 Ds::Ds(std::string_view mnemonic, const DsMachineInst *inst, ExecuteFn exec_fn)
@@ -1628,12 +1631,50 @@ Mtbuf::Mtbuf(std::string_view mnemonic, const MtbufMachineInst *inst, ExecuteFn 
   opcode_ = inst_.op;
 }
 
+bool Mimg::omits_gfx11_mimg_dim_dmask() const { return (inst_.op >= 25 && inst_.op <= 26); }
+
+uint32_t Mimg::gfx11_mimg_nsa_group_width(uint32_t index, uint32_t vaddr_words) const {
+  switch (inst_.op) {
+  case 25:
+    if (inst_.a16) {
+      static constexpr uint8_t widths[] = {1, 1, 3, 3};
+      return index < 4 ? widths[index] : 0;
+    }
+    {
+      static constexpr uint8_t widths[] = {1, 1, 3, 3, 3};
+      return index < 5 ? widths[index] : 0;
+    }
+  case 26:
+    if (inst_.a16) {
+      static constexpr uint8_t widths[] = {2, 1, 3, 3};
+      return index < 4 ? widths[index] : 0;
+    }
+    {
+      static constexpr uint8_t widths[] = {2, 1, 3, 3, 3};
+      return index < 5 ? widths[index] : 0;
+    }
+  default:
+    if (index < 4)
+      return 1;
+    return index == 4 && vaddr_words > 4 ? vaddr_words - 4 : 0;
+  }
+}
+
 Mimg::Mimg(std::string_view mnemonic, const MimgMachineInst *inst, ExecuteFn exec_fn)
     : IsaInstruction<Isa>(mnemonic, exec_fn), inst_(*inst) {
   size_ = sizeof(OpEncoding);
   raw_encoding_ = reinterpret_cast<const uint32_t *>(&inst_);
   encoding_id_ = raw_encoding_[0] >> 23;
   opcode_ = inst_.op;
+}
+
+void Mimg::capture_nsa_words(const MachineInst *inst, const Operand *vaddr) {
+  if (!inst_.nsa)
+    return;
+  nsa_vaddr_operand_ = vaddr;
+  size_ = sizeof(OpEncoding) + sizeof(MachineInst);
+  std::memcpy(raw_words_.data(), inst, size_);
+  raw_encoding_ = raw_words_.data();
 }
 
 bool Mimg::has_nsa() { return (inst_.nsa == 1); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/encodings.h
@@ -637,6 +637,7 @@ public:
   bool has_encoded_dpp() const;
   bool has_encoded_dpp8() const;
   void append_mnemonic(std::string &out) const override;
+  bool uses_vop3p_absolute_source_syntax() const;
   uint32_t vop3p_encoded_source_count() const;
   bool has_encoded_literal32() const;
   static Result validate_encoding([[maybe_unused]] std::string_view mnemonic,
@@ -648,12 +649,38 @@ public:
       return emit_error.emit() << "DPP and literal operands cannot be combined";
     return Result::success();
   }
+  void append_src_operand(std::string &out, uint8_t operand_index) const override {
+    const Operand *operand = src_operands_[operand_index];
+    if (!uses_vop3p_absolute_source_syntax() || operand_index >= 3) {
+      Instruction::append_src_operand(out, operand_index);
+      return;
+    }
+    if ((inst_.neg >> operand_index) & 1u)
+      out += '-';
+    const bool absolute = ((inst_.neg_hi >> operand_index) & 1u) != 0;
+    if (absolute)
+      out += '|';
+    const uint32_t selector =
+        operand_index == 0 ? inst_.src0 : (operand_index == 1 ? inst_.src1 : inst_.src2);
+    if (selector == 255) {
+      out += "lit(";
+      out += operand->name();
+      out += ')';
+    } else {
+      out += operand->name();
+    }
+    if (absolute)
+      out += '|';
+  }
   void build_modifiers(std::string &out) const override {
     auto *inst = &inst_;
     (void)inst;
     amdgpu::vop::append_vop3p_disassembly(
-        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2), inst->neg, inst->neg_hi,
-        inst->clamp, vop3p_encoded_source_count(), inst_.op <= 18);
+        out, inst->op_sel, inst->op_sel_hi | (inst->op_sel_hi_2 << 2),
+        uses_vop3p_absolute_source_syntax() ? 0 : inst->neg,
+        uses_vop3p_absolute_source_syntax() ? 0 : inst->neg_hi, inst->clamp,
+        uses_vop3p_absolute_source_syntax() ? 3 : (vop3p_encoded_source_count()),
+        uses_vop3p_absolute_source_syntax() ? false : (inst_.op <= 19 || inst_.op == 26));
     if (has_encoded_dpp())
       amdgpu::dpp::append_dpp16_disassembly(out, dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
                                             dpp_bound_ctrl_, dpp_fi_, true,
@@ -769,9 +796,77 @@ public:
 class Mimg : public IsaInstruction<Isa> {
 public:
   Mimg(std::string_view mnemonic, const MimgMachineInst *inst, ExecuteFn exec_fn);
+  bool omits_gfx11_mimg_dim_dmask() const;
+  uint32_t gfx11_mimg_nsa_group_width(uint32_t index, uint32_t vaddr_words) const;
+  void capture_nsa_words(const MachineInst *inst, const Operand *vaddr);
+  void append_src_operand(std::string &out, uint8_t operand_index) const override {
+    const Operand *operand = src_operands_[operand_index];
+    if (!inst_.nsa || operand != nsa_vaddr_operand_) {
+      Instruction::append_src_operand(out, operand_index);
+      return;
+    }
+    const uint32_t vaddr_words = (operand->size_bits() + 31) / 32;
+    out += "[";
+    uint32_t consumed_words = 0;
+    for (uint32_t index = 0; index < 5 && consumed_words < vaddr_words; ++index) {
+      const uint32_t group_words = gfx11_mimg_nsa_group_width(index, vaddr_words);
+      if (group_words == 0)
+        break;
+      if (index != 0)
+        out += ", ";
+      const uint32_t selector =
+          index == 0 ? inst_.vaddr : (raw_words_[2] >> ((index - 1) * 8)) & 0xffu;
+      if (group_words > 1) {
+        out += "v[" + std::to_string(selector) + ":";
+        out += std::to_string(selector + group_words - 1) + "]";
+      } else {
+        out += "v" + std::to_string(selector);
+      }
+      consumed_words += group_words;
+    }
+    out += "]";
+  }
+  void build_modifiers(std::string &out) const override {
+    auto *inst = &inst_;
+    (void)inst;
+    if (!omits_gfx11_mimg_dim_dmask()) {
+      out += " dmask:0x";
+      out += "0123456789abcdef"[inst->dmask & 0xfu];
+    }
+    if (!omits_gfx11_mimg_dim_dmask()) {
+      static constexpr std::string_view dims[] = {
+          "1D", "2D", "3D", "CUBE", "1D_ARRAY", "2D_ARRAY", "2D_MSAA", "2D_MSAA_ARRAY"};
+      out += " dim:SQ_RSRC_IMG_";
+      out += dims[inst->dim & 7u];
+    }
+    if (!omits_gfx11_mimg_dim_dmask()) {
+      if (inst->unorm)
+        out += " unorm";
+      if (inst->glc)
+        out += " glc";
+      if (inst->slc)
+        out += " slc";
+      if (inst->dlc)
+        out += " dlc";
+      if (inst->r128)
+        out += " r128";
+    }
+    if (inst->a16)
+      out += " a16";
+    if (!omits_gfx11_mimg_dim_dmask()) {
+      if (inst->tfe)
+        out += " tfe";
+      if (inst->lwe)
+        out += " lwe";
+      if (inst->d16)
+        out += " d16";
+    }
+  }
   bool has_nsa();
   using OpEncoding = MimgMachineInst;
   const OpEncoding inst_;
+  std::array<uint32_t, 5> raw_words_{};
+  const Operand *nsa_vaddr_operand_ = nullptr;
 };
 
 class Exp : public IsaInstruction<Isa> {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mimg.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/mimg.cpp
@@ -11,17 +11,78 @@
 namespace rocjitsu {
 namespace rdna3_5 {
 
+namespace {
+template <typename MimgMachineInst>
+uint32_t mimg_vdata_bits(const MimgMachineInst *inst, bool gather4) {
+  uint32_t words = gather4 ? 4u : 0u;
+  if (!gather4) {
+    uint32_t mask = inst->dmask & 0xfu;
+    while (mask) {
+      words += mask & 1u;
+      mask >>= 1;
+    }
+    if (words == 0)
+      words = 1;
+  }
+  if (inst->d16)
+    words = (words + 1) / 2;
+  if (inst->tfe)
+    ++words;
+  return words * 32;
+}
+
+bool mimg_name_has_token(std::string_view name, std::string_view token) {
+  size_t pos = 0;
+  while (pos < name.size()) {
+    const size_t end = name.find('_', pos);
+    const size_t count = end == std::string_view::npos ? name.size() - pos : end - pos;
+    if (name.substr(pos, count) == token)
+      return true;
+    if (end == std::string_view::npos)
+      break;
+    pos = end + 1;
+  }
+  return false;
+}
+
+template <typename MimgMachineInst>
+uint32_t mimg_vaddr_bits(const MimgMachineInst *inst, std::string_view name) {
+  static constexpr uint8_t coords[] = {1, 2, 3, 3, 2, 3, 3, 4};
+  static constexpr uint8_t gradients[] = {2, 4, 6, 4, 2, 4, 4, 4};
+  const uint32_t dim = inst->dim & 7u;
+  const bool resinfo = name == "image_get_resinfo";
+  const bool gradient = mimg_name_has_token(name, "d") || mimg_name_has_token(name, "cd");
+  const bool g16 = mimg_name_has_token(name, "g16");
+  const bool lod = resinfo || mimg_name_has_token(name, "mip") || mimg_name_has_token(name, "l") ||
+                   mimg_name_has_token(name, "cl");
+  uint32_t words = mimg_name_has_token(name, "c") ? 1u : 0u;
+  words += mimg_name_has_token(name, "o") ? 1u : 0u;
+  words += mimg_name_has_token(name, "b") ? 1u : 0u;
+  const uint32_t coord_words = (resinfo ? 0u : coords[dim]) + (lod ? 1u : 0u);
+  words += inst->a16 ? (coord_words + 1) / 2 : coord_words;
+  if (gradient) {
+    const uint32_t gradient_words = gradients[dim];
+    words += g16 ? ((gradient_words / 2 + 1) & ~1u) : gradient_words;
+  }
+  return (words == 0 ? 1u : words) * 32;
+}
+} // namespace
+
 ImageLoadMimg::ImageLoadMimg(const MachineInst *inst)
     : Mimg("image_load", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -37,14 +98,18 @@ DecodeResult decodeImageLoadMimg(const MachineInst *opcode, const DecodeErrorEmi
 ImageLoadMipMimg::ImageLoadMipMimg(const MachineInst *inst)
     : Mimg("image_load_mip", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadMipMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load_mip"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -61,14 +126,18 @@ DecodeResult decodeImageLoadMipMimg(const MachineInst *opcode,
 ImageLoadPckMimg::ImageLoadPckMimg(const MachineInst *inst)
     : Mimg("image_load_pck", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadPckMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load_pck"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -85,14 +154,18 @@ DecodeResult decodeImageLoadPckMimg(const MachineInst *opcode,
 ImageLoadPckSgnMimg::ImageLoadPckSgnMimg(const MachineInst *inst)
     : Mimg("image_load_pck_sgn", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadPckSgnMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load_pck_sgn"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -109,14 +182,18 @@ DecodeResult decodeImageLoadPckSgnMimg(const MachineInst *opcode,
 ImageLoadMipPckMimg::ImageLoadMipPckMimg(const MachineInst *inst)
     : Mimg("image_load_mip_pck", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadMipPckMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load_mip_pck"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -133,14 +210,18 @@ DecodeResult decodeImageLoadMipPckMimg(const MachineInst *opcode,
 ImageLoadMipPckSgnMimg::ImageLoadMipPckSgnMimg(const MachineInst *inst)
     : Mimg("image_load_mip_pck_sgn", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageLoadMipPckSgnMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_load_mip_pck_sgn"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -157,14 +238,18 @@ DecodeResult decodeImageLoadMipPckSgnMimg(const MachineInst *opcode,
 ImageStoreMimg::ImageStoreMimg(const MachineInst *inst)
     : Mimg("image_store", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageStoreMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_store"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   src_operands_[0] = &vdata;
   src_operands_[1] = &vaddr;
   src_operands_[2] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 0;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -180,14 +265,18 @@ DecodeResult decodeImageStoreMimg(const MachineInst *opcode, const DecodeErrorEm
 ImageStoreMipMimg::ImageStoreMipMimg(const MachineInst *inst)
     : Mimg("image_store_mip", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageStoreMipMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_store_mip"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   src_operands_[0] = &vdata;
   src_operands_[1] = &vaddr;
   src_operands_[2] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 0;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -204,14 +293,18 @@ DecodeResult decodeImageStoreMipMimg(const MachineInst *opcode,
 ImageStorePckMimg::ImageStorePckMimg(const MachineInst *inst)
     : Mimg("image_store_pck", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageStorePckMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_store_pck"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   src_operands_[0] = &vdata;
   src_operands_[1] = &vaddr;
   src_operands_[2] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 0;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -228,14 +321,18 @@ DecodeResult decodeImageStorePckMimg(const MachineInst *opcode,
 ImageStoreMipPckMimg::ImageStoreMipPckMimg(const MachineInst *inst)
     : Mimg("image_store_mip_pck", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageStoreMipPckMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_store_mip_pck"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   src_operands_[0] = &vdata;
   src_operands_[1] = &vaddr;
   src_operands_[2] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 0;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -252,17 +349,21 @@ DecodeResult decodeImageStoreMipPckMimg(const MachineInst *opcode,
 ImageAtomicSwapMimg::ImageAtomicSwapMimg(const MachineInst *inst)
     : Mimg("image_atomic_swap", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicSwapMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_swap"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -281,17 +382,21 @@ DecodeResult decodeImageAtomicSwapMimg(const MachineInst *opcode,
 ImageAtomicCmpswapMimg::ImageAtomicCmpswapMimg(const MachineInst *inst)
     : Mimg("image_atomic_cmpswap", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicCmpswapMimg)),
-      vdata(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_cmpswap"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -310,17 +415,21 @@ DecodeResult decodeImageAtomicCmpswapMimg(const MachineInst *opcode,
 ImageAtomicAddMimg::ImageAtomicAddMimg(const MachineInst *inst)
     : Mimg("image_atomic_add", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicAddMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_add"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -339,17 +448,21 @@ DecodeResult decodeImageAtomicAddMimg(const MachineInst *opcode,
 ImageAtomicSubMimg::ImageAtomicSubMimg(const MachineInst *inst)
     : Mimg("image_atomic_sub", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicSubMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_sub"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -368,17 +481,21 @@ DecodeResult decodeImageAtomicSubMimg(const MachineInst *opcode,
 ImageAtomicSminMimg::ImageAtomicSminMimg(const MachineInst *inst)
     : Mimg("image_atomic_smin", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicSminMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_smin"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -397,17 +514,21 @@ DecodeResult decodeImageAtomicSminMimg(const MachineInst *opcode,
 ImageAtomicUminMimg::ImageAtomicUminMimg(const MachineInst *inst)
     : Mimg("image_atomic_umin", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicUminMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_umin"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -426,17 +547,21 @@ DecodeResult decodeImageAtomicUminMimg(const MachineInst *opcode,
 ImageAtomicSmaxMimg::ImageAtomicSmaxMimg(const MachineInst *inst)
     : Mimg("image_atomic_smax", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicSmaxMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_smax"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -455,17 +580,21 @@ DecodeResult decodeImageAtomicSmaxMimg(const MachineInst *opcode,
 ImageAtomicUmaxMimg::ImageAtomicUmaxMimg(const MachineInst *inst)
     : Mimg("image_atomic_umax", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicUmaxMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_umax"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -484,17 +613,21 @@ DecodeResult decodeImageAtomicUmaxMimg(const MachineInst *opcode,
 ImageAtomicAndMimg::ImageAtomicAndMimg(const MachineInst *inst)
     : Mimg("image_atomic_and", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicAndMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_and"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -513,17 +646,21 @@ DecodeResult decodeImageAtomicAndMimg(const MachineInst *opcode,
 ImageAtomicOrMimg::ImageAtomicOrMimg(const MachineInst *inst)
     : Mimg("image_atomic_or", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicOrMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_or"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -542,17 +679,21 @@ DecodeResult decodeImageAtomicOrMimg(const MachineInst *opcode,
 ImageAtomicXorMimg::ImageAtomicXorMimg(const MachineInst *inst)
     : Mimg("image_atomic_xor", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicXorMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_xor"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -571,17 +712,21 @@ DecodeResult decodeImageAtomicXorMimg(const MachineInst *opcode,
 ImageAtomicIncMimg::ImageAtomicIncMimg(const MachineInst *inst)
     : Mimg("image_atomic_inc", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicIncMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_inc"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -600,17 +745,21 @@ DecodeResult decodeImageAtomicIncMimg(const MachineInst *opcode,
 ImageAtomicDecMimg::ImageAtomicDecMimg(const MachineInst *inst)
     : Mimg("image_atomic_dec", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageAtomicDecMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_atomic_dec"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
       gpumem(32, OperandType::OPR_GPUMEM, 0), gpumem_in(32, OperandType::OPR_GPUMEM, 0) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   dst_operands_[1] = &gpumem;
   src_operands_[2] = &gpumem_in;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 2;
+  capture_nsa_words(inst, &vaddr);
   gpumem.apply_fieldless_caps(false, false, false);
   gpumem_in.apply_fieldless_caps(false, false, false);
 }
@@ -629,14 +778,18 @@ DecodeResult decodeImageAtomicDecMimg(const MachineInst *opcode,
 ImageGetResinfoMimg::ImageGetResinfoMimg(const MachineInst *inst)
     : Mimg("image_get_resinfo", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGetResinfoMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_get_resinfo"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -653,14 +806,18 @@ DecodeResult decodeImageGetResinfoMimg(const MachineInst *opcode,
 ImageMsaaLoadMimg::ImageMsaaLoadMimg(const MachineInst *inst)
     : Mimg("image_msaa_load", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageMsaaLoadMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_msaa_load"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -678,13 +835,16 @@ ImageBvhIntersectRayMimg::ImageBvhIntersectRayMimg(const MachineInst *inst)
     : Mimg("image_bvh_intersect_ray", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageBvhIntersectRayMimg)),
       vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(352, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vaddr((reinterpret_cast<const OpEncoding *>(inst)->a16 ? 256 : 352), OperandType::OPR_VGPR,
+            reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -702,13 +862,16 @@ ImageBvh64IntersectRayMimg::ImageBvh64IntersectRayMimg(const MachineInst *inst)
     : Mimg("image_bvh64_intersect_ray", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageBvh64IntersectRayMimg)),
       vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(384, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc) {
+      vaddr((reinterpret_cast<const OpEncoding *>(inst)->a16 ? 288 : 384), OperandType::OPR_VGPR,
+            reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -725,16 +888,20 @@ DecodeResult decodeImageBvh64IntersectRayMimg(const MachineInst *opcode,
 ImageSampleMimg::ImageSampleMimg(const MachineInst *inst)
     : Mimg("image_sample", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -751,16 +918,20 @@ DecodeResult decodeImageSampleMimg(const MachineInst *opcode,
 ImageSampleDMimg::ImageSampleDMimg(const MachineInst *inst)
     : Mimg("image_sample_d", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(288, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -777,16 +948,20 @@ DecodeResult decodeImageSampleDMimg(const MachineInst *opcode,
 ImageSampleLMimg::ImageSampleLMimg(const MachineInst *inst)
     : Mimg("image_sample_l", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleLMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_l"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -803,16 +978,20 @@ DecodeResult decodeImageSampleLMimg(const MachineInst *opcode,
 ImageSampleBMimg::ImageSampleBMimg(const MachineInst *inst)
     : Mimg("image_sample_b", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleBMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_b"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -829,16 +1008,20 @@ DecodeResult decodeImageSampleBMimg(const MachineInst *opcode,
 ImageSampleLzMimg::ImageSampleLzMimg(const MachineInst *inst)
     : Mimg("image_sample_lz", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleLzMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_lz"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -855,16 +1038,20 @@ DecodeResult decodeImageSampleLzMimg(const MachineInst *opcode,
 ImageSampleCMimg::ImageSampleCMimg(const MachineInst *inst)
     : Mimg("image_sample_c", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -881,16 +1068,20 @@ DecodeResult decodeImageSampleCMimg(const MachineInst *opcode,
 ImageSampleCDMimg::ImageSampleCDMimg(const MachineInst *inst)
     : Mimg("image_sample_c_d", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(320, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -907,16 +1098,20 @@ DecodeResult decodeImageSampleCDMimg(const MachineInst *opcode,
 ImageSampleCLMimg::ImageSampleCLMimg(const MachineInst *inst)
     : Mimg("image_sample_c_l", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCLMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_l"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -933,16 +1128,20 @@ DecodeResult decodeImageSampleCLMimg(const MachineInst *opcode,
 ImageSampleCBMimg::ImageSampleCBMimg(const MachineInst *inst)
     : Mimg("image_sample_c_b", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCBMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_b"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -959,16 +1158,20 @@ DecodeResult decodeImageSampleCBMimg(const MachineInst *opcode,
 ImageSampleCLzMimg::ImageSampleCLzMimg(const MachineInst *inst)
     : Mimg("image_sample_c_lz", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCLzMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_lz"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -985,16 +1188,20 @@ DecodeResult decodeImageSampleCLzMimg(const MachineInst *opcode,
 ImageSampleOMimg::ImageSampleOMimg(const MachineInst *inst)
     : Mimg("image_sample_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1011,16 +1218,20 @@ DecodeResult decodeImageSampleOMimg(const MachineInst *opcode,
 ImageSampleDOMimg::ImageSampleDOMimg(const MachineInst *inst)
     : Mimg("image_sample_d_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(320, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1037,16 +1248,20 @@ DecodeResult decodeImageSampleDOMimg(const MachineInst *opcode,
 ImageSampleLOMimg::ImageSampleLOMimg(const MachineInst *inst)
     : Mimg("image_sample_l_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleLOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_l_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1063,16 +1278,20 @@ DecodeResult decodeImageSampleLOMimg(const MachineInst *opcode,
 ImageSampleBOMimg::ImageSampleBOMimg(const MachineInst *inst)
     : Mimg("image_sample_b_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleBOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_b_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1089,16 +1308,20 @@ DecodeResult decodeImageSampleBOMimg(const MachineInst *opcode,
 ImageSampleLzOMimg::ImageSampleLzOMimg(const MachineInst *inst)
     : Mimg("image_sample_lz_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleLzOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_lz_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1115,16 +1338,20 @@ DecodeResult decodeImageSampleLzOMimg(const MachineInst *opcode,
 ImageSampleCOMimg::ImageSampleCOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1141,16 +1368,20 @@ DecodeResult decodeImageSampleCOMimg(const MachineInst *opcode,
 ImageSampleCDOMimg::ImageSampleCDOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(352, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1167,16 +1398,20 @@ DecodeResult decodeImageSampleCDOMimg(const MachineInst *opcode,
 ImageSampleCLOMimg::ImageSampleCLOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_l_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCLOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_l_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1193,16 +1428,20 @@ DecodeResult decodeImageSampleCLOMimg(const MachineInst *opcode,
 ImageSampleCBOMimg::ImageSampleCBOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_b_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCBOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_b_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1219,16 +1458,20 @@ DecodeResult decodeImageSampleCBOMimg(const MachineInst *opcode,
 ImageSampleCLzOMimg::ImageSampleCLzOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_lz_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCLzOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_lz_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1245,16 +1488,20 @@ DecodeResult decodeImageSampleCLzOMimg(const MachineInst *opcode,
 ImageGather4Mimg::ImageGather4Mimg(const MachineInst *inst)
     : Mimg("image_gather4", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1271,16 +1518,20 @@ DecodeResult decodeImageGather4Mimg(const MachineInst *opcode,
 ImageGather4LMimg::ImageGather4LMimg(const MachineInst *inst)
     : Mimg("image_gather4_l", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4LMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_l"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1297,16 +1548,20 @@ DecodeResult decodeImageGather4LMimg(const MachineInst *opcode,
 ImageGather4BMimg::ImageGather4BMimg(const MachineInst *inst)
     : Mimg("image_gather4_b", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4BMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_b"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1323,16 +1578,20 @@ DecodeResult decodeImageGather4BMimg(const MachineInst *opcode,
 ImageGather4LzMimg::ImageGather4LzMimg(const MachineInst *inst)
     : Mimg("image_gather4_lz", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4LzMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_lz"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1349,16 +1608,20 @@ DecodeResult decodeImageGather4LzMimg(const MachineInst *opcode,
 ImageGather4CMimg::ImageGather4CMimg(const MachineInst *inst)
     : Mimg("image_gather4_c", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1375,16 +1638,20 @@ DecodeResult decodeImageGather4CMimg(const MachineInst *opcode,
 ImageGather4CLzMimg::ImageGather4CLzMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_lz", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CLzMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_lz"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1401,16 +1668,20 @@ DecodeResult decodeImageGather4CLzMimg(const MachineInst *opcode,
 ImageGather4OMimg::ImageGather4OMimg(const MachineInst *inst)
     : Mimg("image_gather4_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4OMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1427,16 +1698,20 @@ DecodeResult decodeImageGather4OMimg(const MachineInst *opcode,
 ImageGather4LzOMimg::ImageGather4LzOMimg(const MachineInst *inst)
     : Mimg("image_gather4_lz_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4LzOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_lz_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1453,16 +1728,20 @@ DecodeResult decodeImageGather4LzOMimg(const MachineInst *opcode,
 ImageGather4CLzOMimg::ImageGather4CLzOMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_lz_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CLzOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_lz_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1479,16 +1758,20 @@ DecodeResult decodeImageGather4CLzOMimg(const MachineInst *opcode,
 ImageGetLodMimg::ImageGetLodMimg(const MachineInst *inst)
     : Mimg("image_get_lod", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGetLodMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_get_lod"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1505,16 +1788,20 @@ DecodeResult decodeImageGetLodMimg(const MachineInst *opcode,
 ImageSampleDG16Mimg::ImageSampleDG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_d_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(224, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1531,16 +1818,20 @@ DecodeResult decodeImageSampleDG16Mimg(const MachineInst *opcode,
 ImageSampleCDG16Mimg::ImageSampleCDG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1557,16 +1848,20 @@ DecodeResult decodeImageSampleCDG16Mimg(const MachineInst *opcode,
 ImageSampleDOG16Mimg::ImageSampleDOG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_d_o_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDOG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_o_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1583,16 +1878,20 @@ DecodeResult decodeImageSampleDOG16Mimg(const MachineInst *opcode,
 ImageSampleCDOG16Mimg::ImageSampleCDOG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_o_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDOG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(288, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_o_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1609,16 +1908,20 @@ DecodeResult decodeImageSampleCDOG16Mimg(const MachineInst *opcode,
 ImageSampleClMimg::ImageSampleClMimg(const MachineInst *inst)
     : Mimg("image_sample_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1635,16 +1938,20 @@ DecodeResult decodeImageSampleClMimg(const MachineInst *opcode,
 ImageSampleDClMimg::ImageSampleDClMimg(const MachineInst *inst)
     : Mimg("image_sample_d_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(320, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1661,16 +1968,20 @@ DecodeResult decodeImageSampleDClMimg(const MachineInst *opcode,
 ImageSampleBClMimg::ImageSampleBClMimg(const MachineInst *inst)
     : Mimg("image_sample_b_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleBClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_b_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1687,16 +1998,20 @@ DecodeResult decodeImageSampleBClMimg(const MachineInst *opcode,
 ImageSampleCClMimg::ImageSampleCClMimg(const MachineInst *inst)
     : Mimg("image_sample_c_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1713,16 +2028,20 @@ DecodeResult decodeImageSampleCClMimg(const MachineInst *opcode,
 ImageSampleCDClMimg::ImageSampleCDClMimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(352, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1739,16 +2058,20 @@ DecodeResult decodeImageSampleCDClMimg(const MachineInst *opcode,
 ImageSampleCBClMimg::ImageSampleCBClMimg(const MachineInst *inst)
     : Mimg("image_sample_c_b_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCBClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_b_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1765,16 +2088,20 @@ DecodeResult decodeImageSampleCBClMimg(const MachineInst *opcode,
 ImageSampleClOMimg::ImageSampleClOMimg(const MachineInst *inst)
     : Mimg("image_sample_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1791,16 +2118,20 @@ DecodeResult decodeImageSampleClOMimg(const MachineInst *opcode,
 ImageSampleDClOMimg::ImageSampleDClOMimg(const MachineInst *inst)
     : Mimg("image_sample_d_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(352, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1817,16 +2148,20 @@ DecodeResult decodeImageSampleDClOMimg(const MachineInst *opcode,
 ImageSampleBClOMimg::ImageSampleBClOMimg(const MachineInst *inst)
     : Mimg("image_sample_b_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleBClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_b_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1843,16 +2178,20 @@ DecodeResult decodeImageSampleBClOMimg(const MachineInst *opcode,
 ImageSampleCClOMimg::ImageSampleCClOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1869,16 +2208,20 @@ DecodeResult decodeImageSampleCClOMimg(const MachineInst *opcode,
 ImageSampleCDClOMimg::ImageSampleCDClOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(384, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1895,16 +2238,20 @@ DecodeResult decodeImageSampleCDClOMimg(const MachineInst *opcode,
 ImageSampleCBClOMimg::ImageSampleCBClOMimg(const MachineInst *inst)
     : Mimg("image_sample_c_b_cl_o", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCBClOMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(224, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_b_cl_o"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1921,16 +2268,20 @@ DecodeResult decodeImageSampleCBClOMimg(const MachineInst *opcode,
 ImageSampleCDClG16Mimg::ImageSampleCDClG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_cl_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDClG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(288, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_cl_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1947,16 +2298,20 @@ DecodeResult decodeImageSampleCDClG16Mimg(const MachineInst *opcode,
 ImageSampleDClOG16Mimg::ImageSampleDClOG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_d_cl_o_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDClOG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(288, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_cl_o_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1973,16 +2328,21 @@ DecodeResult decodeImageSampleDClOG16Mimg(const MachineInst *opcode,
 ImageSampleCDClOG16Mimg::ImageSampleCDClOG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_c_d_cl_o_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleCDClOG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(320, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(
+          mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_c_d_cl_o_g16"),
+          OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -1999,16 +2359,20 @@ DecodeResult decodeImageSampleCDClOG16Mimg(const MachineInst *opcode,
 ImageSampleDClG16Mimg::ImageSampleDClG16Mimg(const MachineInst *inst)
     : Mimg("image_sample_d_cl_g16", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageSampleDClG16Mimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(256, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), false),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_sample_d_cl_g16"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2025,16 +2389,20 @@ DecodeResult decodeImageSampleDClG16Mimg(const MachineInst *opcode,
 ImageGather4ClMimg::ImageGather4ClMimg(const MachineInst *inst)
     : Mimg("image_gather4_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4ClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2051,16 +2419,20 @@ DecodeResult decodeImageGather4ClMimg(const MachineInst *opcode,
 ImageGather4BClMimg::ImageGather4BClMimg(const MachineInst *inst)
     : Mimg("image_gather4_b_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4BClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_b_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2077,16 +2449,20 @@ DecodeResult decodeImageGather4BClMimg(const MachineInst *opcode,
 ImageGather4CClMimg::ImageGather4CClMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2103,16 +2479,20 @@ DecodeResult decodeImageGather4CClMimg(const MachineInst *opcode,
 ImageGather4CLMimg::ImageGather4CLMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_l", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CLMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_l"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2129,16 +2509,20 @@ DecodeResult decodeImageGather4CLMimg(const MachineInst *opcode,
 ImageGather4CBMimg::ImageGather4CBMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_b", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CBMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(160, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_b"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2155,16 +2539,20 @@ DecodeResult decodeImageGather4CBMimg(const MachineInst *opcode,
 ImageGather4CBClMimg::ImageGather4CBClMimg(const MachineInst *inst)
     : Mimg("image_gather4_c_b_cl", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4CBClMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(192, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4_c_b_cl"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {
@@ -2181,16 +2569,20 @@ DecodeResult decodeImageGather4CBClMimg(const MachineInst *opcode,
 ImageGather4hMimg::ImageGather4hMimg(const MachineInst *inst)
     : Mimg("image_gather4h", reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::ImageGather4hMimg)),
-      vdata(128, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
-      vaddr(96, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
-      srsrc(256, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->srsrc),
-      ssamp(128, OperandType::OPR_SREG, reinterpret_cast<const OpEncoding *>(inst)->ssamp) {
+      vdata(mimg_vdata_bits(reinterpret_cast<const OpEncoding *>(inst), true),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdata),
+      vaddr(mimg_vaddr_bits(reinterpret_cast<const OpEncoding *>(inst), "image_gather4h"),
+            OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vaddr),
+      srsrc(256, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->srsrc * 4)),
+      ssamp(128, OperandType::OPR_SREG, (reinterpret_cast<const OpEncoding *>(inst)->ssamp * 4)) {
   dst_operands_[0] = &vdata;
   src_operands_[0] = &vaddr;
   src_operands_[1] = &srsrc;
   src_operands_[2] = &ssamp;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
+  capture_nsa_words(inst, &vaddr);
 }
 
 namespace detail {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/operand.cpp
@@ -690,8 +690,30 @@ std::string Operand::name() const {
     return std::to_string(encoding_value_);
   case OperandType::OPR_SENDMSG:
     return std::to_string(encoding_value_);
-  case OperandType::OPR_SENDMSG_RTN:
+  case OperandType::OPR_SENDMSG_RTN: {
+    switch (static_cast<uint32_t>(encoding_value_) & 0xFFFF) {
+    case 128:
+      return "sendmsg(MSG_RTN_GET_DOORBELL)";
+    case 129:
+      return "sendmsg(MSG_RTN_GET_DDID)";
+    case 130:
+      return "sendmsg(MSG_RTN_GET_TMA)";
+    case 131:
+      return "sendmsg(MSG_RTN_GET_REALTIME)";
+    case 132:
+      return "sendmsg(MSG_RTN_SAVE_WAVE)";
+    case 133:
+      return "sendmsg(MSG_RTN_GET_TBA)";
+    case 134:
+      return "sendmsg(MSG_RTN_GET_TBA_TO_PC)";
+    default:
+      break;
+    }
+    const uint32_t value = static_cast<uint32_t>(encoding_value_) & 0xFFFF;
+    if (value <= 0xFF)
+      return std::format("sendmsg({}, 0, 0)", value);
     return std::to_string(encoding_value_);
+  }
   case OperandType::OPR_SIMM16:
     return std::to_string(encoding_value_);
   case OperandType::OPR_SIMM32:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop1.cpp
@@ -3702,7 +3702,10 @@ DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmit
 } // namespace detail
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16",
+           reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::VSwapB16Vop1)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
@@ -3712,14 +3715,23 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   src_operands_[0] = &vdst;
   src_operands_[1] = &src0;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 2;
+  src0 =
+      Operand(16, OperandType::OPR_VGPR,
+              static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu),
+              true, true);
 }
 
 namespace detail {
 DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
   Result validation = Vop1::validate_encoding(
-      "v_swap_b16_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
   if (validation.failed()) [[unlikely]]
     return Result::failure();
   return std::make_unique<VSwapB16Vop1>(opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna3_5/vop3p.cpp
@@ -1023,6 +1023,7 @@ VFmaMixF32Vop3p::VFmaMixF32Vop3p(const MachineInst *inst)
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;
   src_operands_[2] = &src2;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 3;
   num_dst_ = 1;
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
@@ -1085,6 +1086,7 @@ VFmaMixloF16Vop3p::VFmaMixloF16Vop3p(const MachineInst *inst)
   src_operands_[1] = &src1;
   src_operands_[2] = &src2;
   src_operands_[3] = &vdst;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 4;
   num_dst_ = 1;
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
@@ -1153,6 +1155,7 @@ VFmaMixhiF16Vop3p::VFmaMixhiF16Vop3p(const MachineInst *inst)
   src_operands_[1] = &src1;
   src_operands_[2] = &src2;
   src_operands_[3] = &vdst;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 4;
   num_dst_ = 1;
   if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/encodings.h
@@ -669,10 +669,10 @@ public:
   void build_modifiers(std::string &out) const override {
     auto *inst = &inst_;
     (void)inst;
-    amdgpu::vop::append_vop3p_disassembly(out, inst->opsel,
-                                          inst->opsel_hi | (inst->opsel_hi_2 << 2), inst->neg,
-                                          inst->neg_hi, inst->clamp, vop3p_encoded_source_count(),
-                                          inst_.op <= 16 || (inst_.op >= 27 && inst_.op <= 30));
+    amdgpu::vop::append_vop3p_disassembly(
+        out, inst->opsel, inst->opsel_hi | (inst->opsel_hi_2 << 2), false ? 0 : inst->neg,
+        false ? 0 : inst->neg_hi, inst->clamp, vop3p_encoded_source_count(),
+        inst_.op <= 16 || inst_.op == 19 || (inst_.op >= 26 && inst_.op <= 30));
     if (has_encoded_dpp())
       amdgpu::dpp::append_dpp16_disassembly(out, dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
                                             dpp_bound_ctrl_, dpp_fi_, true,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/rdna4/vop1.cpp
@@ -3702,7 +3702,10 @@ DecodeResult decodeVSwapB32Vop1(const MachineInst *opcode, const DecodeErrorEmit
 } // namespace detail
 
 VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
-    : Vop1("v_swap_b16_e32", reinterpret_cast<const OpEncoding *>(inst),
+    : Vop1(amdgpu::dpp::is_src_dpp8(reinterpret_cast<const OpEncoding *>(inst)->src0)
+               ? "v_swap_b16_dpp"
+               : "v_swap_b16",
+           reinterpret_cast<const OpEncoding *>(inst),
            selected_exec_fn(InstructionExecutionId::VSwapB16Vop1)),
       vdst(16, OperandType::OPR_VGPR,
            static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->vdst), true,
@@ -3712,14 +3715,23 @@ VSwapB16Vop1::VSwapB16Vop1(const MachineInst *inst)
   dst_operands_[1] = &src0;
   src_operands_[0] = &vdst;
   src_operands_[1] = &src0;
+  omit_repeated_destination_sources_ = true;
   num_src_ = 2;
   num_dst_ = 2;
+  src0 =
+      Operand(16, OperandType::OPR_VGPR,
+              static_cast<unsigned short>(reinterpret_cast<const OpEncoding *>(inst)->src0 & 0xffu),
+              true, true);
 }
 
 namespace detail {
 DecodeResult decodeVSwapB16Vop1(const MachineInst *opcode, const DecodeErrorEmitter &emit_error) {
+  const auto *inst = opcode;
   Result validation = Vop1::validate_encoding(
-      "v_swap_b16_e32", reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
+      amdgpu::dpp::is_src_dpp8(reinterpret_cast<const Vop1::OpEncoding *>(inst)->src0)
+          ? "v_swap_b16_dpp"
+          : "v_swap_b16",
+      reinterpret_cast<const Vop1::OpEncoding *>(opcode), emit_error);
   if (validation.failed()) [[unlikely]]
     return Result::failure();
   return std::make_unique<VSwapB16Vop1>(opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
@@ -354,6 +354,13 @@ public:
         if (src_operands_[operand_index]->size_bits() == 0 ||
             src_operands_[operand_index]->is_fieldless())
           continue;
+        if (omit_repeated_destination_sources_) {
+          bool repeats_dst = false;
+          for (uint8_t dst_index = 0; dst_index < num_dst_; ++dst_index)
+            repeats_dst |= src_operands_[operand_index] == dst_operands_[dst_index];
+          if (repeats_dst)
+            continue;
+        }
         disassembly_ += (first ? " " : ", ");
         append_src_operand(disassembly_, operand_index);
         first = false;
@@ -377,6 +384,8 @@ protected:
   /// CodeGenerator._DST_OPERANDS_CAPACITY; resize both together.
   std::array<Operand *, 3> dst_operands_{};
   uint8_t num_dst_ = 0;
+  /// @brief Whether read/write operands are rendered only in destination position.
+  bool omit_repeated_destination_sources_ = false;
   /// @brief Append the encoding-specific mnemonic spelling used by disassembly.
   /// The default matches mnemonic(); encoding decorations may override it.
   virtual void append_mnemonic(std::string &out) const { out += mnemonic_; }

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -533,6 +533,25 @@ TEST(DecoderSmokeTest, Gfx1201Vop3SdstRendersOutputModifiers) {
   }
 }
 
+TEST(PackedTrue16DisassemblyTest, SwapOmitsTiedSourceOperands) {
+  constexpr std::array architectures{
+      ROCJITSU_CODE_ARCH_RDNA3,
+      ROCJITSU_CODE_ARCH_RDNA3_5,
+      ROCJITSU_CODE_ARCH_RDNA4,
+      ROCJITSU_CODE_ARCH_CDNA5,
+  };
+  constexpr uint32_t words[] = {0x7E0ACD81u, 0u};
+
+  for (auto arch : architectures) {
+    SCOPED_TRACE(static_cast<int>(arch));
+    auto decoder = Decoder::create(arch);
+    ASSERT_NE(decoder, nullptr);
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->disassemble(), "v_swap_b16 v5.l, v1.h");
+  }
+}
+
 // AMDGPU ISAs × 2 instructions.
 // CDNA1/2/3/4 and RDNA1/2 share the GFX9/GFX10 s_endpgm encoding (op=1).
 // RDNA3/3.5/4 use the GFX11/GFX12 encoding where s_endpgm moved to op=48.
@@ -799,6 +818,222 @@ TEST(SendmsgReturnDecodeTest, Rdna3Selector255DoesNotConsumeLiteral) {
   EXPECT_EQ(inst->mnemonic(), "s_sendmsg_rtn_b32");
   EXPECT_EQ(inst->size(), sizeof(word));
   EXPECT_EQ(inst->src_operand(0)->name(), "255");
+}
+
+TEST(SendmsgReturnDecodeTest, Rdna35FormatsReturnMessageSelector) {
+  constexpr uint32_t words[] = {
+      0xBE804C00u, // s_sendmsg_rtn_b32 s0, sendmsg(0, 0, 0)
+      0xBE804D80u, // s_sendmsg_rtn_b64 s[0:1], sendmsg(MSG_RTN_GET_DOORBELL)
+  };
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+
+  std::unique_ptr<Instruction> b32(decode_valid(*decoder, &words[0]));
+  ASSERT_NE(b32, nullptr);
+  EXPECT_EQ(b32->disassemble(), "s_sendmsg_rtn_b32 s0, sendmsg(0, 0, 0)");
+
+  std::unique_ptr<Instruction> b64(decode_valid(*decoder, &words[1]));
+  ASSERT_NE(b64, nullptr);
+  EXPECT_EQ(b64->disassemble(), "s_sendmsg_rtn_b64 s[0:1], sendmsg(MSG_RTN_GET_DOORBELL)");
+}
+
+TEST(Rdna35FuzzDecodeTest, PreservesRoundTripSignificantSyntax) {
+  struct TestCase {
+    std::array<uint32_t, 3> words;
+    int size;
+    const char *disassembly;
+  };
+  constexpr TestCase cases[] = {
+      {{0x7FE0CD74u, 0u, 0u}, 4, "v_swap_b16 v112.h, v116.l"},
+      {{0xCC217FEEu, 0xBBBB00ECu, 0u},
+       8,
+       "v_fma_mixlo_f16 v238, -|src_shared_limit|, |v128|, -|src_private_limit| "
+       "op_sel:[1,1,1] op_sel_hi:[1,1,1]"},
+      {{0xCC200000u, 0x00E1FF00u, 0u}, 12, "v_fma_mix_f32 v0, v0, lit(0x0), s56"},
+      {{0xCC200000u, 0x040E04FAu, 0xFF010101u},
+       12,
+       "v_fma_mix_f32_e64_dpp v0, v1, v2, v3 row_shl:1 row_mask:0xf bank_mask:0xf"},
+      {{0xD9BE8102u, 0x03BFA100u, 0u},
+       8,
+       "ds_storexchg_2addr_stride64_rtn_b64 v[3:6], v0, v[161:162], v[191:192] "
+       "offset0:2 offset1:129 gds"},
+      {{0xF0701200u, 0x00010000u, 0u},
+       8,
+       "image_sample_d v0, v[0:2], s[4:11], s[0:3] dmask:0x2 "
+       "dim:SQ_RSRC_IMG_1D slc"},
+      {{0xF0000100u, 0x00000000u, 0u}, 8, "image_load v0, v0, s[0:7] dmask:0x1 dim:SQ_RSRC_IMG_1D"},
+      {{0xF003F380u, 0x00600000u, 0u},
+       8,
+       "image_load v[0:1], v0, s[0:7] dmask:0x3 dim:SQ_RSRC_IMG_1D unorm glc slc dlc "
+       "r128 a16 tfe lwe d16"},
+      {{0xF0340100u, 0u, 0u}, 8, "image_atomic_sub v0, v0, s[0:7] dmask:0x1 dim:SQ_RSRC_IMG_1D"},
+      {{0xF1107F01u, 0u, 0u},
+       12,
+       "image_sample_c_d_cl v[0:3], [v0, v0, v0, v0, v0], s[0:7], s[0:3] "
+       "dmask:0xf dim:SQ_RSRC_IMG_1D glc slc dlc"},
+      {{0xCC0F4205u, 0x5A00FAF0u, 0u}, 8, "v_pk_add_f16 v5, 0.5, m0 neg_lo:[0,1] neg_hi:[0,1]"},
+      {{0xCC0E0005u, 0x11A8F87Fu, 0u},
+       8,
+       "v_pk_fma_f16 v5, exec_hi, null, vcc_lo op_sel_hi:[0,1,0]"},
+      {{0xCC1A4105u, 0x3BF4D4FDu, 0u},
+       8,
+       "v_dot2_f32_bf16 v5, src_scc, vcc_lo, src_scc neg_lo:[1,0,0] "
+       "neg_hi:[1,0,0]"},
+  };
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+
+  for (const auto &test : cases) {
+    SCOPED_TRACE(test.disassembly);
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, test.words.data()));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->size(), test.size) << test.disassembly;
+    EXPECT_EQ(inst->disassemble(), test.disassembly);
+    for (int word = 0; word < test.size / 4; ++word)
+      EXPECT_EQ(inst->raw_encoding()[word], test.words[word]) << test.disassembly;
+  }
+}
+
+TEST(Rdna35MimgDecodeTest, PartialNsaUsesOneExtensionDword) {
+  struct TestCase {
+    std::array<uint32_t, 6> words;
+    const char *disassembly;
+  };
+  constexpr TestCase cases[] = {
+      {{{0xF0700F05u, 0x00000020u, 0x24232221u, S_NOP, 0u, 0u}},
+       "image_sample_d v[0:3], [v32, v33, v34, v35, v[36:37]], s[0:7], s[0:3] "
+       "dmask:0xf dim:SQ_RSRC_IMG_2D"},
+      {{{0xF0700F09u, 0x00000020u, 0x24232221u, S_NOP, 0u, 0u}},
+       "image_sample_d v[0:3], [v32, v33, v34, v35, v[36:40]], s[0:7], s[0:3] "
+       "dmask:0xf dim:SQ_RSRC_IMG_3D"},
+      {{{0xF1280F09u, 0x00000020u, 0x24232221u, S_NOP, 0u, 0u}},
+       "image_sample_c_d_cl_o v[0:3], [v32, v33, v34, v35, v[36:43]], s[0:7], "
+       "s[0:3] dmask:0xf dim:SQ_RSRC_IMG_3D"},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &test : cases) {
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, test.words.data()));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_EQ(inst->size(), 12);
+    EXPECT_EQ(inst->disassemble(), test.disassembly);
+    for (int word = 0; word < 3; ++word)
+      EXPECT_EQ(inst->raw_encoding()[word], test.words[word]);
+
+    std::unique_ptr<Instruction> next(decode_valid(*decoder, test.words.data() + 3));
+    ASSERT_NE(next, nullptr);
+    EXPECT_EQ(next->size(), 4);
+    EXPECT_EQ(next->mnemonic(), "s_nop");
+    EXPECT_EQ(next->raw_encoding()[0], S_NOP);
+  }
+}
+
+TEST(Rdna35MimgDecodeTest, FixedFormWidthsDriveDefUse) {
+  struct TestCase {
+    std::array<uint32_t, 2> words;
+    const char *disassembly;
+    uint16_t vdata_base;
+    uint16_t vaddr_base;
+    uint8_t vaddr_words;
+    uint16_t srsrc_base;
+    uint8_t srsrc_words;
+  };
+  constexpr TestCase cases[] = {
+      {{{0xF0600118u, 0x00020105u}},
+       "image_msaa_load v[1:4], v[5:7], s[8:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_MSAA",
+       1,
+       5,
+       3,
+       8,
+       8},
+      {{{0xF0648F80u, 0x00010409u}},
+       "image_bvh_intersect_ray v[4:7], v[9:19], s[4:7]",
+       4,
+       9,
+       11,
+       4,
+       4},
+      {{{0xF0658F80u, 0x00010409u}},
+       "image_bvh_intersect_ray v[4:7], v[9:16], s[4:7] a16",
+       4,
+       9,
+       8,
+       4,
+       4},
+      {{{0xF0688F80u, 0x00010409u}},
+       "image_bvh64_intersect_ray v[4:7], v[9:20], s[4:7]",
+       4,
+       9,
+       12,
+       4,
+       4},
+      {{{0xF0698F80u, 0x00010409u}},
+       "image_bvh64_intersect_ray v[4:7], v[9:17], s[4:7] a16",
+       4,
+       9,
+       9,
+       4,
+       4},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &test : cases) {
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, test.words.data()));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->disassemble(), test.disassembly);
+    ASSERT_EQ(inst->num_dst_operands(), 1);
+    ASSERT_EQ(inst->num_src_operands(), 2);
+    EXPECT_EQ(inst->dst_operand(0)->size_bits(), 128);
+    EXPECT_EQ(inst->src_operand(0)->size_bits(), test.vaddr_words * 32);
+
+    InstDefUse def_use(*inst);
+    EXPECT_TRUE(def_use.defs.contains({RegClass::VGPR, test.vdata_base, 4}));
+    EXPECT_TRUE(def_use.uses.contains({RegClass::VGPR, test.vaddr_base, test.vaddr_words}));
+    EXPECT_TRUE(def_use.uses.contains({RegClass::SGPR, test.srsrc_base, test.srsrc_words}));
+  }
+}
+
+TEST(Rdna35MimgDecodeTest, FixedFormNsaUsesCanonicalGroups) {
+  struct TestCase {
+    std::array<uint32_t, 3> words;
+    int vaddr_words;
+    const char *disassembly;
+  };
+  constexpr TestCase cases[] = {
+      {{{0xF060011Du, 0x000A0ACCu, 0x00130E0Bu}},
+       4,
+       "image_msaa_load v[10:13], [v204, v11, v14, v19], s[40:47] dmask:0x1 "
+       "dim:SQ_RSRC_IMG_2D_MSAA_ARRAY"},
+      {{{0xF0648F81u, 0x00032732u, 0x2F28142Eu}},
+       11,
+       "image_bvh_intersect_ray v[39:42], [v50, v46, v[20:22], v[40:42], "
+       "v[47:49]], s[12:15]"},
+      {{{0xF0658F81u, 0x00032732u, 0x0028142Eu}},
+       8,
+       "image_bvh_intersect_ray v[39:42], [v50, v46, v[20:22], v[40:42]], "
+       "s[12:15] a16"},
+      {{{0xF0688F81u, 0x00032732u, 0x2F28142Eu}},
+       12,
+       "image_bvh64_intersect_ray v[39:42], [v[50:51], v46, v[20:22], v[40:42], "
+       "v[47:49]], s[12:15]"},
+      {{{0xF0698F81u, 0x00032732u, 0x0028142Eu}},
+       9,
+       "image_bvh64_intersect_ray v[39:42], [v[50:51], v46, v[20:22], v[40:42]], "
+       "s[12:15] a16"},
+  };
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+  for (const auto &test : cases) {
+    std::unique_ptr<Instruction> inst(decode_valid(*decoder, test.words.data()));
+    ASSERT_NE(inst, nullptr);
+    EXPECT_EQ(inst->size(), 12);
+    EXPECT_EQ(inst->dst_operand(0)->size_bits(), 128);
+    EXPECT_EQ(inst->src_operand(0)->size_bits(), test.vaddr_words * 32);
+    EXPECT_EQ(inst->disassemble(), test.disassembly);
+  }
 }
 
 TEST(FieldlessOperandDecodeTest, SaveexecExposesInertExecAndSccOperands) {

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -5188,6 +5188,44 @@ TEST(Rdna3True16Vop1Test, MovB16HighDestinationPreservesLowHalf) {
     wf->halt();
 }
 
+TEST(Rdna35True16Vop1Test, SwapHighSourcePreservesBothUnselectedHalves) {
+  amdgpu::GpuMemory gpu_mem("rdna35_true16_vop1_mem");
+  amdgpu::L2Cache l2("rdna35_true16_vop1_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA3_5;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("rdna3_5", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3_5);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  cu->write_vgpr(vb + 5, 0, 0xAAAA1111u);
+  cu->write_vgpr(vb + 1, 0, 0x2222BBBBu);
+
+  // v_swap_b16 v5.l, v1.h
+  const uint32_t words[] = {0x7E0ACD81u, 0u};
+  std::unique_ptr<Instruction> inst(decode_valid(*decoder, words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(inst->disassemble(), "v_swap_b16 v5.l, v1.h");
+  cu->execute_instruction(inst.get(), *wf);
+
+  EXPECT_EQ(cu->read_vgpr(vb + 5, 0), 0xAAAA2222u);
+  EXPECT_EQ(cu->read_vgpr(vb + 1, 0), 0x1111BBBBu);
+
+  if (!wf->is_halted())
+    wf->halt();
+}
+
 TEST(Rdna3DppTest, VAddF32RowShrMatchesWaveReduceSequence) {
   const float input[] = {-5.0f, 5.0f,  7.0f,  -2.0f, -3.0f, -6.0f, 7.0f,  -2.0f, -4.0f, 6.0f, 3.0f,
                          -2.0f, -7.0f, -1.0f, 7.0f,  -7.0f, 2.0f,  -3.0f, 0.0f,  -6.0f, 7.0f, -3.0f,


### PR DESCRIPTION
Format return messages and render gfx11 image modifiers, descriptor groups, NSA address lists, source halves, negation, and paired DS offsets with LLVM-compatible syntax. Regenerate the affected decoders and cover each discovered family with generator and decode tests.