### PR TITLE
feat(amdsmi): add amdsmi_get_fabric_cper_entries API declaration

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added IFoE fabric RAS CPER API**.
+  - `amdsmi_get_fabric_cper_entries()` — retrieve IFoE RAS CPER records from UALoE library
+  - CLI: `amd-smi ras --cper` now reports fabric link events alongside GPU errors (fabric-linkdown, fabric-linkup, fabric-fatal)
+
 ### Changed
 
 ### Optimized

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,14 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 10.2.0
+
+### Added
+
+- **Added IFoE fabric RAS CPER API**.
+  - `amdsmi_get_fabric_cper_entries()` — retrieve IFoE RAS CPER records from UALoE library
+  - CLI: `amd-smi ras --cper` now reports fabric link events alongside GPU errors (fabric-linkdown, fabric-linkup, fabric-fatal)
+
 ## amd_smi_lib for ROCm 10.1.0
 
 ### Added

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2251,44 +2251,43 @@ class AMDSMIHelpers:
 
     def _severity_as_string(self, error_severity, notify_type, for_filename, source=None):
         if source == "fabric":
-            # IFoE fabric event naming
+            # IFoE reports a link going down as non-fatal uncorrected and a link
+            # coming back up as non-fatal corrected; there is no other carrier.
             if error_severity == "non_fatal_uncorrected":
                 if for_filename:
                     return "fabric-linkdown"
                 return "FABRIC-LINKDOWN"
-            elif error_severity == "fatal":
-                if for_filename:
-                    return "fabric-fatal"
-                return "FABRIC-FATAL"
-            elif error_severity == "non_fatal_corrected":
+            if error_severity == "non_fatal_corrected":
                 if for_filename:
                     return "fabric-linkup"
                 return "FABRIC-LINKUP"
-            else:
+            if error_severity == "fatal":
                 if for_filename:
-                    return "fabric-unknown"
-                return "FABRIC-UNKNOWN"
-        else:
-            # Existing GPU CPER naming
-            if error_severity == "non_fatal_uncorrected":
-                if for_filename:
-                    return "uncorrected"
-                return "NONFATAL-UNCORRECTED"
-            elif error_severity == "non_fatal_corrected":
-                if for_filename:
-                    return "corrected"
-                return "NONFATAL-CORRECTED"
-            elif error_severity == "fatal":
-                if notify_type == "BOOT":
-                    if for_filename:
-                        return "boot"
-                    return "BOOT"
-                if for_filename:
-                    return "fatal"
-                return "FATAL"
+                    return "fabric-fatal"
+                return "FABRIC-FATAL"
             if for_filename:
-                return "unknown"
-            return "UNKNOWN"
+                return "fabric-unknown"
+            return "FABRIC-UNKNOWN"
+
+        if error_severity == "non_fatal_uncorrected":
+            if for_filename:
+                return "uncorrected"
+            return "NONFATAL-UNCORRECTED"
+        elif error_severity == "non_fatal_corrected":
+            if for_filename:
+                return "corrected"
+            return "NONFATAL-CORRECTED"
+        elif error_severity == "fatal":
+            if notify_type == "BOOT":
+                if for_filename:
+                    return "boot"
+                return "BOOT"
+            if for_filename:
+                return "fatal"
+            return "FATAL"
+        if for_filename:
+            return "unknown"
+        return "UNKNOWN"
 
     def display_cper_files_generated(
         self, entries, device_handle, logger: Optional["AMDSMILogger"] = None
@@ -2797,8 +2796,6 @@ class AMDSMIHelpers:
         while len(fabric_cursors) <= gpu_idx:
             fabric_cursors.append(0)
 
-        fabric_entries = {}
-        fabric_cper_data = []
         while True:
             try:
                 fabric_entries, new_fabric_cursor, fabric_cper_data, _fabric_status_code = (
@@ -2815,12 +2812,8 @@ class AMDSMIHelpers:
                 ):
                     logging.debug("Fabric CPER not supported on this device")
                     break
-                elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
-                    logging.debug(f"Invalid arguments to fabric CPER: {e}")
-                    break
-                else:
-                    logging.debug(f"Cannot retrieve fabric CPER entries: {e}")
-                    break
+                logging.debug(f"Cannot retrieve fabric CPER entries: {e}")
+                break
 
             fabric_cursors[gpu_idx] = new_fabric_cursor
             if len(fabric_entries) == 0:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2249,18 +2249,8 @@ class AMDSMIHelpers:
 
         return True
 
-    def _severity_as_string(self, error_severity, notify_type, for_filename):
-        # Check if this is an IFoE CPER (all-zeros GUID placeholder)
-        is_ifoe = False
-        if isinstance(notify_type, str):
-            # notify_type is formatted as hex string, check if all zeros
-            try:
-                notify_hex = notify_type.replace(":", "").replace(" ", "")
-                is_ifoe = all(c == "0" for c in notify_hex)
-            except Exception:
-                pass
-
-        if is_ifoe:
+    def _severity_as_string(self, error_severity, notify_type, for_filename, source=None):
+        if source == "fabric":
             # IFoE fabric event naming
             if error_severity == "non_fatal_uncorrected":
                 if for_filename:
@@ -2326,6 +2316,7 @@ class AMDSMIHelpers:
                     entry.get("error_severity", "Unknown"),
                     entry.get("notify_type", "Unknown"),
                     False,
+                    entry.get("source"),
                 )
                 output = f"{timestamp:<20} {gpu_id:<7} {prefix:<20}"
 
@@ -2387,7 +2378,8 @@ class AMDSMIHelpers:
             # Determine prefix/severity
             error_severity = entry.get("error_severity", "").lower()
             notify_type = entry.get("notify_type", "")
-            prefix = self._severity_as_string(error_severity, notify_type, True)
+            source = entry.get("source")
+            prefix = self._severity_as_string(error_severity, notify_type, True, source)
 
             # Generate filenames
             count = cper_counter[0] + 1
@@ -2426,7 +2418,7 @@ class AMDSMIHelpers:
             gpu_id = "-"
             if not isinstance(device_handle, Path):
                 gpu_id = self.get_gpu_id_from_device_handle(device_handle)
-            severity = self._severity_as_string(error_severity, notify_type, False)
+            severity = self._severity_as_string(error_severity, notify_type, False, source)
             output_rows[cper_path] = [
                 timestamp,
                 gpu_id,
@@ -2555,6 +2547,7 @@ class AMDSMIHelpers:
                             entry.get("error_severity", "Unknown"),
                             entry.get("notify_type", "Unknown"),
                             False,
+                            entry.get("source"),
                         )
                         json_rows.append(
                             {
@@ -2795,10 +2788,14 @@ class AMDSMIHelpers:
                 cper_counter,
             )
 
-        # Fetch fabric CPER entries (IFoE RAS events)
-        fabric_cursor_idx = gpu_idx  # Reuse same cursor index
-        if len(args.cursor) <= fabric_cursor_idx:
-            args.cursor.append(0)
+        # Fetch fabric CPER entries (IFoE RAS events). Fabric cursors live in a
+        # separate list so --follow does not interleave them with the GPU cursors.
+        fabric_cursors = getattr(args, "fabric_cursor", None)
+        if fabric_cursors is None:
+            fabric_cursors = []
+            args.fabric_cursor = fabric_cursors
+        while len(fabric_cursors) <= gpu_idx:
+            fabric_cursors.append(0)
 
         fabric_entries = {}
         fabric_cper_data = []
@@ -2806,7 +2803,7 @@ class AMDSMIHelpers:
             try:
                 fabric_entries, new_fabric_cursor, fabric_cper_data, _fabric_status_code = (
                     amdsmi_interface.amdsmi_get_fabric_cper_entries(
-                        device_handle, severity_mask, buffer_size, args.cursor[fabric_cursor_idx]
+                        device_handle, severity_mask, buffer_size, fabric_cursors[gpu_idx]
                     )
                 )
                 logging.debug(f"fabric_cper_entries | entries: {fabric_entries}")
@@ -2825,7 +2822,7 @@ class AMDSMIHelpers:
                     logging.debug(f"Cannot retrieve fabric CPER entries: {e}")
                     break
 
-            args.cursor[fabric_cursor_idx] = new_fabric_cursor
+            fabric_cursors[gpu_idx] = new_fabric_cursor
             if len(fabric_entries) == 0:
                 break
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2250,25 +2250,55 @@ class AMDSMIHelpers:
         return True
 
     def _severity_as_string(self, error_severity, notify_type, for_filename):
-        if error_severity == "non_fatal_uncorrected":
-            if for_filename:
-                return "uncorrected"
-            return "NONFATAL-UNCORRECTED"
-        elif error_severity == "non_fatal_corrected":
-            if for_filename:
-                return "corrected"
-            return "NONFATAL-CORRECTED"
-        elif error_severity == "fatal":
-            if notify_type == "BOOT":
+        # Check if this is an IFoE CPER (all-zeros GUID placeholder)
+        is_ifoe = False
+        if isinstance(notify_type, str):
+            # notify_type is formatted as hex string, check if all zeros
+            try:
+                notify_hex = notify_type.replace(":", "").replace(" ", "")
+                is_ifoe = all(c == "0" for c in notify_hex)
+            except Exception:
+                pass
+
+        if is_ifoe:
+            # IFoE fabric event naming
+            if error_severity == "non_fatal_uncorrected":
                 if for_filename:
-                    return "boot"
-                return "BOOT"
+                    return "fabric-linkdown"
+                return "FABRIC-LINKDOWN"
+            elif error_severity == "fatal":
+                if for_filename:
+                    return "fabric-fatal"
+                return "FABRIC-FATAL"
+            elif error_severity == "non_fatal_corrected":
+                if for_filename:
+                    return "fabric-linkup"
+                return "FABRIC-LINKUP"
+            else:
+                if for_filename:
+                    return "fabric-unknown"
+                return "FABRIC-UNKNOWN"
+        else:
+            # Existing GPU CPER naming
+            if error_severity == "non_fatal_uncorrected":
+                if for_filename:
+                    return "uncorrected"
+                return "NONFATAL-UNCORRECTED"
+            elif error_severity == "non_fatal_corrected":
+                if for_filename:
+                    return "corrected"
+                return "NONFATAL-CORRECTED"
+            elif error_severity == "fatal":
+                if notify_type == "BOOT":
+                    if for_filename:
+                        return "boot"
+                    return "BOOT"
+                if for_filename:
+                    return "fatal"
+                return "FATAL"
             if for_filename:
-                return "fatal"
-            return "FATAL"
-        if for_filename:
-            return "unknown"
-        return "UNKNOWN"
+                return "unknown"
+            return "UNKNOWN"
 
     def display_cper_files_generated(
         self, entries, device_handle, logger: Optional["AMDSMILogger"] = None
@@ -2757,6 +2787,51 @@ class AMDSMIHelpers:
             self._emit_cper_output(
                 entries,
                 cper_data,
+                device_handle,
+                args,
+                logger,
+                collected_json_rows,
+                emit_inline,
+                cper_counter,
+            )
+
+        # Fetch fabric CPER entries (IFoE RAS events)
+        fabric_cursor_idx = gpu_idx  # Reuse same cursor index
+        if len(args.cursor) <= fabric_cursor_idx:
+            args.cursor.append(0)
+
+        fabric_entries = {}
+        fabric_cper_data = []
+        while True:
+            try:
+                fabric_entries, new_fabric_cursor, fabric_cper_data, _fabric_status_code = (
+                    amdsmi_interface.amdsmi_get_fabric_cper_entries(
+                        device_handle, severity_mask, buffer_size, args.cursor[fabric_cursor_idx]
+                    )
+                )
+                logging.debug(f"fabric_cper_entries | entries: {fabric_entries}")
+                num_entries = num_entries + len(fabric_entries)
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                if (
+                    e.get_error_code()
+                    == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+                ):
+                    logging.debug("Fabric CPER not supported on this device")
+                    break
+                elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                    logging.debug(f"Invalid arguments to fabric CPER: {e}")
+                    break
+                else:
+                    logging.debug(f"Cannot retrieve fabric CPER entries: {e}")
+                    break
+
+            args.cursor[fabric_cursor_idx] = new_fabric_cursor
+            if len(fabric_entries) == 0:
+                break
+
+            self._emit_cper_output(
+                fabric_entries,
+                fabric_cper_data,
                 device_handle,
                 args,
                 logger,

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1822,6 +1822,17 @@ typedef enum {
 } amdsmi_cper_notify_type_t;
 
 /**
+ * @brief IFoE CPER notify type GUID
+ *
+ * Placeholder GUID for IFoE fabric error records. Will be replaced with
+ * official GUID once provided by UALoE team.
+ *
+ * @cond @tag{host} @endcond
+ */
+#define AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID \
+  {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+/**
  * @brief Ras policy v4.0
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
@@ -6154,6 +6165,54 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
                                             uint32_t severity_mask, char* cper_data,
                                             uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
                                             uint64_t* entry_count, uint64_t* cursor);
+
+/**
+ *  @brief Retrieve CPER entries for IFoE fabric RAS events
+ *
+ *  @ingroup tagRasInfo
+ *
+ *  @platform{host}
+ *
+ *  @details Returns CPER-formatted error records for IFoE network port link events
+ *  (link down, link up, fatal errors). Uses the same CPER format and calling
+ *  conventions as amdsmi_get_gpu_cper_entries() so callers can handle both GPU and
+ *  fabric CPERs with identical code paths.
+ *
+ *  Records are fetched from the UALoE library and transformed into full UEFI CPER
+ *  format. The notify_type field is set to AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID to
+ *  distinguish fabric events from GPU events.
+ *
+ *  @param[in] processor_handle GPU processor handle with UALoE fabric support.
+ *  @param[in] severity_mask Bitmask of severity levels to retrieve.
+ *                           Use (1U << AMDSMI_CPER_SEV_*) to construct the mask.
+ *                           Use (1U << AMDSMI_CPER_SEV_NUM) to retrieve all severities.
+ *
+ *  @param[in,out] cper_data Caller-allocated buffer for raw CPER data.
+ *                 Records are packed back-to-back.
+ *
+ *  @param[in,out] buf_size [in] size of cper_data buffer in bytes.
+ *                 [out] actual bytes written.
+ *
+ *  @param[in,out] cper_hdrs Array of pointers into cper_data, one per
+ *                 returned entry. Caller allocates the array.
+ *
+ *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold.
+ *              [out] number of CPER entries returned.
+ *
+ *  @param[in,out] cursor [in] cursor from previous call (0 = start).
+ *                 [out] cursor for next call (0 = no more data).
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success with no more data,
+ *          ::AMDSMI_STATUS_MORE_DATA if entries returned but more remain,
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if UALoE not available,
+ *          ::AMDSMI_STATUS_INVAL if null pointer arguments,
+ *          ::AMDSMI_STATUS_OUT_OF_RESOURCES if buffer too small for one entry,
+ *          non-zero on other failures
+ */
+amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor_handle,
+                                               uint32_t severity_mask, char* cper_data,
+                                               uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
+                                               uint64_t* entry_count, uint64_t* cursor);
 
 /** @} End tagRasInfo */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6196,7 +6196,8 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
  *  @param[in,out] cper_hdrs Array of pointers into cper_data, one per
  *                 returned entry. Caller allocates the array.
  *
- *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold.
+ *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold,
+ *              must be in [1, 4096].
  *              [out] number of CPER entries returned.
  *
  *  @param[in,out] cursor [in] cursor from previous call (0 = start).
@@ -6205,7 +6206,7 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success with no more data,
  *          ::AMDSMI_STATUS_MORE_DATA if entries returned but more remain,
  *          ::AMDSMI_STATUS_NOT_SUPPORTED if UALoE not available,
- *          ::AMDSMI_STATUS_INVAL if null pointer arguments,
+ *          ::AMDSMI_STATUS_INVAL if null pointer or out-of-range entry_count arguments,
  *          ::AMDSMI_STATUS_OUT_OF_RESOURCES if buffer too small for one entry,
  *          non-zero on other failures
  */

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6261,7 +6261,8 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
  *  @param[in,out] cper_hdrs Array of pointers into cper_data, one per
  *                 returned entry. Caller allocates the array.
  *
- *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold.
+ *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold,
+ *              must be in [1, 4096].
  *              [out] number of CPER entries returned.
  *
  *  @param[in,out] cursor [in] cursor from previous call (0 = start).
@@ -6270,7 +6271,7 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success with no more data,
  *          ::AMDSMI_STATUS_MORE_DATA if entries returned but more remain,
  *          ::AMDSMI_STATUS_NOT_SUPPORTED if UALoE not available,
- *          ::AMDSMI_STATUS_INVAL if null pointer arguments,
+ *          ::AMDSMI_STATUS_INVAL if null pointer or out-of-range entry_count arguments,
  *          ::AMDSMI_STATUS_OUT_OF_RESOURCES if buffer too small for one entry,
  *          non-zero on other failures
  */

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1851,6 +1851,17 @@ typedef enum {
 } amdsmi_cper_notify_type_t;
 
 /**
+ * @brief IFoE CPER notify type GUID
+ *
+ * Placeholder GUID for IFoE fabric error records. Will be replaced with
+ * official GUID once provided by UALoE team.
+ *
+ * @cond @tag{host} @endcond
+ */
+#define AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID \
+  {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+/**
  * @brief Ras policy v4.0
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
@@ -6219,6 +6230,54 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
                                             uint32_t severity_mask, char* cper_data,
                                             uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
                                             uint64_t* entry_count, uint64_t* cursor);
+
+/**
+ *  @brief Retrieve CPER entries for IFoE fabric RAS events
+ *
+ *  @ingroup tagRasInfo
+ *
+ *  @platform{host}
+ *
+ *  @details Returns CPER-formatted error records for IFoE network port link events
+ *  (link down, link up, fatal errors). Uses the same CPER format and calling
+ *  conventions as amdsmi_get_gpu_cper_entries() so callers can handle both GPU and
+ *  fabric CPERs with identical code paths.
+ *
+ *  Records are fetched from the UALoE library and transformed into full UEFI CPER
+ *  format. The notify_type field is set to AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID to
+ *  distinguish fabric events from GPU events.
+ *
+ *  @param[in] processor_handle GPU processor handle with UALoE fabric support.
+ *  @param[in] severity_mask Bitmask of severity levels to retrieve.
+ *                           Use (1U << AMDSMI_CPER_SEV_*) to construct the mask.
+ *                           Use (1U << AMDSMI_CPER_SEV_NUM) to retrieve all severities.
+ *
+ *  @param[in,out] cper_data Caller-allocated buffer for raw CPER data.
+ *                 Records are packed back-to-back.
+ *
+ *  @param[in,out] buf_size [in] size of cper_data buffer in bytes.
+ *                 [out] actual bytes written.
+ *
+ *  @param[in,out] cper_hdrs Array of pointers into cper_data, one per
+ *                 returned entry. Caller allocates the array.
+ *
+ *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold.
+ *              [out] number of CPER entries returned.
+ *
+ *  @param[in,out] cursor [in] cursor from previous call (0 = start).
+ *                 [out] cursor for next call (0 = no more data).
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success with no more data,
+ *          ::AMDSMI_STATUS_MORE_DATA if entries returned but more remain,
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if UALoE not available,
+ *          ::AMDSMI_STATUS_INVAL if null pointer arguments,
+ *          ::AMDSMI_STATUS_OUT_OF_RESOURCES if buffer too small for one entry,
+ *          non-zero on other failures
+ */
+amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor_handle,
+                                               uint32_t severity_mask, char* cper_data,
+                                               uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
+                                               uint64_t* entry_count, uint64_t* cursor);
 
 /** @} End tagRasInfo */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6261,9 +6261,9 @@ amdsmi_status_t amdsmi_get_gpu_cper_entries(amdsmi_processor_handle processor_ha
  *  @param[in,out] cper_hdrs Array of pointers into cper_data, one per
  *                 returned entry. Caller allocates the array.
  *
- *  @param[out] entry_count [in] maximum number of entries the cper_hdrs array can hold,
- *              must be in [1, 4096].
- *              [out] number of CPER entries returned.
+ *  @param[in,out] entry_count [in] maximum number of entries the cper_hdrs array can hold,
+ *                 must be in [1, 4096].
+ *                 [out] number of CPER entries returned.
  *
  *  @param[in,out] cursor [in] cursor from previous call (0 = start).
  *                 [out] cursor for next call (0 = no more data).

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -159,6 +159,7 @@ from .amdsmi_interface import amdsmi_get_gpu_board_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_feature_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_block_features_enabled
 from .amdsmi_interface import amdsmi_get_gpu_cper_entries
+from .amdsmi_interface import amdsmi_get_fabric_cper_entries
 from .amdsmi_interface import amdsmi_get_afids_from_cper
 from .amdsmi_interface import amdsmi_gpu_validate_ras_eeprom
 

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -158,6 +158,7 @@ from .amdsmi_interface import amdsmi_get_gpu_board_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_feature_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_block_features_enabled
 from .amdsmi_interface import amdsmi_get_gpu_cper_entries
+from .amdsmi_interface import amdsmi_get_fabric_cper_entries
 from .amdsmi_interface import amdsmi_get_afids_from_cper
 from .amdsmi_interface import amdsmi_gpu_validate_ras_eeprom
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3545,6 +3545,114 @@ def amdsmi_get_gpu_cper_entries(
     return entries, cur.value, cper_data, status_code
 
 
+def amdsmi_get_fabric_cper_entries(
+    processor_handle: amdsmi_wrapper.amdsmi_processor_handle,
+    severity_mask: int,
+    buffer_size: int = 4 * 1048576,
+    cursor: int = 0,
+) -> Tuple[Dict[int, Dict[str, Any]], int, List[Dict[str, Any]], int]:
+    """
+    Retrieve IFoE fabric CPER entries for a GPU with UALoE support.
+
+    Args:
+        processor_handle: GPU processor handle with fabric support
+        severity_mask: Bitmask of severity levels (1 << AMDSMI_CPER_SEV_*)
+        buffer_size: Size of buffer for CPER data (default 4 MB)
+        cursor: Cursor from previous call (0 for first call)
+
+    Returns:
+        Tuple of (entries_dict, new_cursor, cper_data_list, status_code)
+        - entries_dict: Dict mapping entry index to parsed CPER header fields
+        - new_cursor: Cursor for next call (0 means no more data)
+        - cper_data_list: List of dicts with 'bytes' and 'size' for each entry
+        - status_code: amdsmi_status_t (SUCCESS or MORE_DATA on success)
+
+    Raises:
+        AmdSmiParameterException: Invalid processor_handle type
+        AmdSmiLibraryException: API call failed (not supported, invalid args, etc.)
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    buf = ctypes.create_string_buffer(buffer_size)
+    buf_size = ctypes.c_uint64(buffer_size)
+    entry_count = ctypes.c_uint64(20)
+    cur = ctypes.c_uint64(cursor)
+    cper_hdrs_array = (ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t) * 20)()
+    cper_hdrs = ctypes.cast(
+        cper_hdrs_array, ctypes.POINTER(ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+    )
+
+    ret = amdsmi_wrapper.amdsmi_get_fabric_cper_entries(
+        processor_handle,
+        ctypes.c_uint32(severity_mask),
+        buf,
+        ctypes.byref(buf_size),
+        cper_hdrs,
+        ctypes.byref(entry_count),
+        ctypes.byref(cur),
+    )
+
+    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA):
+        raise AmdSmiLibraryException(ret)
+
+    entries = {}
+    cper_data = []
+    offset = 0
+
+    for i in range(entry_count.value):
+        entry_address = ctypes.addressof(buf) + offset
+        entry_ptr = ctypes.cast(entry_address, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+        cper_data.append(
+            {
+                "bytes": list(
+                    (entry_ptr.contents.record_length * ctypes.c_byte).from_address(entry_address)
+                ),
+                "size": entry_ptr.contents.record_length,
+            }
+        )
+
+        year = entry_ptr.contents.timestamp.year
+        if year < 100:
+            year += 2000
+
+        formatted_timestamp = (
+            f"{year:04d}/"
+            f"{entry_ptr.contents.timestamp.month:02d}/"
+            f"{entry_ptr.contents.timestamp.day:02d} "
+            f"{entry_ptr.contents.timestamp.hours:02d}:"
+            f"{entry_ptr.contents.timestamp.minutes:02d}:"
+            f"{entry_ptr.contents.timestamp.seconds:02d}"
+        )
+
+        cper_entry = {
+            "error_severity": amdsmi_wrapper.amdsmi_cper_sev_t__enumvalues.get(
+                entry_ptr.contents.error_severity, "AMDSMI_CPER_SEV_UNUSED"
+            )
+            .replace("AMDSMI_CPER_SEV_", "")
+            .lower(),
+            "notify_type": _notifyTypeToString(entry_ptr.contents.notify_type.b),
+            "timestamp": formatted_timestamp,
+            "signature": entry_ptr.contents.signature,
+            "revision": entry_ptr.contents.revision,
+            "signature_end": hex(entry_ptr.contents.signature_end),
+            "sec_cnt": entry_ptr.contents.sec_cnt,
+            "record_length": entry_ptr.contents.record_length,
+            "platform_id": entry_ptr.contents.platform_id,
+            "creator_id": entry_ptr.contents.creator_id,
+            "record_id": entry_ptr.contents.record_id,
+            "flags": entry_ptr.contents.flags,
+            "persistence_info": entry_ptr.contents.persistence_info,
+            "partition_id": entry_ptr.contents.partition_id,
+        }
+
+        entries[i] = cper_entry.copy()
+        offset += entry_ptr.contents.record_length
+
+    return entries, cur.value, cper_data, ret
+
+
 def amdsmi_get_afids_from_cper(cper_afid_data: bytes) -> Tuple[List[int], int]:
     """
     Extract AFIDs from a CPER blob.

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3532,6 +3532,7 @@ def amdsmi_get_gpu_cper_entries(
             "record_id": entry_ptr.contents.record_id,
             "flags": entry_ptr.contents.flags,
             "persistence_info": entry_ptr.contents.persistence_info,
+            "source": "gpu",
             # "reserved" : entry_ptr.contents.reserved
             # "cper_valid_bit" : entry_ptr.contents.cper_valid_bits,
             # "partition_id" : entry_ptr.contents.partition_id,
@@ -3645,6 +3646,7 @@ def amdsmi_get_fabric_cper_entries(
             "flags": entry_ptr.contents.flags,
             "persistence_info": entry_ptr.contents.persistence_info,
             "partition_id": entry_ptr.contents.partition_id,
+            "source": "fabric",
         }
 
         entries[i] = cper_entry.copy()

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3576,6 +3576,7 @@ def amdsmi_get_gpu_cper_entries(
             "record_id": entry_ptr.contents.record_id,
             "flags": entry_ptr.contents.flags,
             "persistence_info": entry_ptr.contents.persistence_info,
+            "source": "gpu",
             # "reserved" : entry_ptr.contents.reserved
             # "cper_valid_bit" : entry_ptr.contents.cper_valid_bits,
             # "partition_id" : entry_ptr.contents.partition_id,
@@ -3689,6 +3690,7 @@ def amdsmi_get_fabric_cper_entries(
             "flags": entry_ptr.contents.flags,
             "persistence_info": entry_ptr.contents.persistence_info,
             "partition_id": entry_ptr.contents.partition_id,
+            "source": "fabric",
         }
 
         entries[i] = cper_entry.copy()

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3589,6 +3589,114 @@ def amdsmi_get_gpu_cper_entries(
     return entries, cur.value, cper_data, status_code
 
 
+def amdsmi_get_fabric_cper_entries(
+    processor_handle: amdsmi_wrapper.amdsmi_processor_handle,
+    severity_mask: int,
+    buffer_size: int = 4 * 1048576,
+    cursor: int = 0,
+) -> Tuple[Dict[int, Dict[str, Any]], int, List[Dict[str, Any]], int]:
+    """
+    Retrieve IFoE fabric CPER entries for a GPU with UALoE support.
+
+    Args:
+        processor_handle: GPU processor handle with fabric support
+        severity_mask: Bitmask of severity levels (1 << AMDSMI_CPER_SEV_*)
+        buffer_size: Size of buffer for CPER data (default 4 MB)
+        cursor: Cursor from previous call (0 for first call)
+
+    Returns:
+        Tuple of (entries_dict, new_cursor, cper_data_list, status_code)
+        - entries_dict: Dict mapping entry index to parsed CPER header fields
+        - new_cursor: Cursor for next call (0 means no more data)
+        - cper_data_list: List of dicts with 'bytes' and 'size' for each entry
+        - status_code: amdsmi_status_t (SUCCESS or MORE_DATA on success)
+
+    Raises:
+        AmdSmiParameterException: Invalid processor_handle type
+        AmdSmiLibraryException: API call failed (not supported, invalid args, etc.)
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    buf = ctypes.create_string_buffer(buffer_size)
+    buf_size = ctypes.c_uint64(buffer_size)
+    entry_count = ctypes.c_uint64(20)
+    cur = ctypes.c_uint64(cursor)
+    cper_hdrs_array = (ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t) * 20)()
+    cper_hdrs = ctypes.cast(
+        cper_hdrs_array, ctypes.POINTER(ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+    )
+
+    ret = amdsmi_wrapper.amdsmi_get_fabric_cper_entries(
+        processor_handle,
+        ctypes.c_uint32(severity_mask),
+        buf,
+        ctypes.byref(buf_size),
+        cper_hdrs,
+        ctypes.byref(entry_count),
+        ctypes.byref(cur),
+    )
+
+    if ret not in (amdsmi_wrapper.AMDSMI_STATUS_SUCCESS, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA):
+        raise AmdSmiLibraryException(ret)
+
+    entries = {}
+    cper_data = []
+    offset = 0
+
+    for i in range(entry_count.value):
+        entry_address = ctypes.addressof(buf) + offset
+        entry_ptr = ctypes.cast(entry_address, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+        cper_data.append(
+            {
+                "bytes": list(
+                    (entry_ptr.contents.record_length * ctypes.c_byte).from_address(entry_address)
+                ),
+                "size": entry_ptr.contents.record_length,
+            }
+        )
+
+        year = entry_ptr.contents.timestamp.year
+        if year < 100:
+            year += 2000
+
+        formatted_timestamp = (
+            f"{year:04d}/"
+            f"{entry_ptr.contents.timestamp.month:02d}/"
+            f"{entry_ptr.contents.timestamp.day:02d} "
+            f"{entry_ptr.contents.timestamp.hours:02d}:"
+            f"{entry_ptr.contents.timestamp.minutes:02d}:"
+            f"{entry_ptr.contents.timestamp.seconds:02d}"
+        )
+
+        cper_entry = {
+            "error_severity": amdsmi_wrapper.amdsmi_cper_sev_t__enumvalues.get(
+                entry_ptr.contents.error_severity, "AMDSMI_CPER_SEV_UNUSED"
+            )
+            .replace("AMDSMI_CPER_SEV_", "")
+            .lower(),
+            "notify_type": _notifyTypeToString(entry_ptr.contents.notify_type.b),
+            "timestamp": formatted_timestamp,
+            "signature": entry_ptr.contents.signature,
+            "revision": entry_ptr.contents.revision,
+            "signature_end": hex(entry_ptr.contents.signature_end),
+            "sec_cnt": entry_ptr.contents.sec_cnt,
+            "record_length": entry_ptr.contents.record_length,
+            "platform_id": entry_ptr.contents.platform_id,
+            "creator_id": entry_ptr.contents.creator_id,
+            "record_id": entry_ptr.contents.record_id,
+            "flags": entry_ptr.contents.flags,
+            "persistence_info": entry_ptr.contents.persistence_info,
+            "partition_id": entry_ptr.contents.partition_id,
+        }
+
+        entries[i] = cper_entry.copy()
+        offset += entry_ptr.contents.record_length
+
+    return entries, cur.value, cper_data, ret
+
+
 def amdsmi_get_afids_from_cper(cper_afid_data: bytes) -> Tuple[List[int], int]:
     """
     Extract AFIDs from a CPER blob.

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3993,6 +3993,12 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_fabric_cper_entries = _libraries['libamd_smi.so'].amdsmi_get_fabric_cper_entries
+    amdsmi_get_fabric_cper_entries.restype = amdsmi_status_t
+    amdsmi_get_fabric_cper_entries.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.POINTER(struct_amdsmi_cper_hdr_t)), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
     amdsmi_get_gpu_ecc_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_status
     amdsmi_get_gpu_ecc_status.restype = amdsmi_status_t
     amdsmi_get_gpu_ecc_status.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
@@ -5331,6 +5337,7 @@ __all__ = \
     'amdsmi_get_cpu_svi3_vr_controller_temp', 'amdsmi_get_cpu_tdelta',
     'amdsmi_get_cpu_xgmi_pstate_range', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
+    'amdsmi_get_fabric_cper_entries',
     'amdsmi_get_fabric_telemetry_data', 'amdsmi_get_fw_info',
     'amdsmi_get_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_get_gpu_accelerator_partition_profile',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -4046,6 +4046,12 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_fabric_cper_entries = _libraries['libamd_smi.so'].amdsmi_get_fabric_cper_entries
+    amdsmi_get_fabric_cper_entries.restype = amdsmi_status_t
+    amdsmi_get_fabric_cper_entries.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.POINTER(struct_amdsmi_cper_hdr_t)), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
     amdsmi_get_gpu_ecc_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_status
     amdsmi_get_gpu_ecc_status.restype = amdsmi_status_t
     amdsmi_get_gpu_ecc_status.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
@@ -5404,6 +5410,7 @@ __all__ = \
     'amdsmi_get_cpu_svi3_vr_controller_temp', 'amdsmi_get_cpu_tdelta',
     'amdsmi_get_cpu_xgmi_pstate_range', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
+    'amdsmi_get_fabric_cper_entries',
     'amdsmi_get_fabric_telemetry_data', 'amdsmi_get_fw_info',
     'amdsmi_get_gpu_accelerator_partition_mem_alloc_mode',
     'amdsmi_get_gpu_accelerator_partition_profile',

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -137,7 +137,7 @@ pub const AMDSMI_MAX_NUM_CLKS_PER_MID: u32 = 2;
 pub const AMDSMI_TIME_FORMAT: &[u8; 20] = b"%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_DATE_FORMAT: &[u8; 35] = b"%04d-%02d-%02d:%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_LIB_VERSION_MAJOR: u32 = 27;
-pub const AMDSMI_LIB_VERSION_MINOR: u32 = 0;
+pub const AMDSMI_LIB_VERSION_MINOR: u32 = 1;
 pub const AMDSMI_LIB_VERSION_RELEASE: u32 = 0;
 pub const AMDSMI_MAX_DRIVER_INFO_RSVD: u32 = 64;
 pub const AMDSMI_MAX_UUID_ELEMENTS: u32 = 16;
@@ -4783,6 +4783,17 @@ extern "C" {
 }
 extern "C" {
     pub fn amdsmi_get_gpu_cper_entries(
+        processor_handle: AmdsmiProcessorHandle,
+        severity_mask: u32,
+        cper_data: *mut ::std::os::raw::c_char,
+        buf_size: *mut u64,
+        cper_hdrs: *mut *mut AmdsmiCperHdrT,
+        entry_count: *mut u64,
+        cursor: *mut u64,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_fabric_cper_entries(
         processor_handle: AmdsmiProcessorHandle,
         severity_mask: u32,
         cper_data: *mut ::std::os::raw::c_char,

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4835,6 +4835,17 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
+    pub fn amdsmi_get_fabric_cper_entries(
+        processor_handle: AmdsmiProcessorHandle,
+        severity_mask: u32,
+        cper_data: *mut ::std::os::raw::c_char,
+        buf_size: *mut u64,
+        cper_hdrs: *mut *mut AmdsmiCperHdrT,
+        entry_count: *mut u64,
+        cursor: *mut u64,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
     pub fn amdsmi_get_gpu_ecc_status(
         processor_handle: AmdsmiProcessorHandle,
         block: AmdsmiGpuBlockT,

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -949,6 +949,8 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return status;
   }
 
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
   if (ualoe_handle == -1) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -961,8 +963,14 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return AMDSMI_STATUS_OUT_OF_RESOURCES;
   }
 
-  // Allocate array for UALoE header pointers
-  const size_t max_ualoe_entries = *entry_count;
+  // Allocate array for UALoE header pointers. *entry_count is caller-supplied,
+  // so clamp it before sizing the allocation.
+  constexpr uint64_t kMaxUaloeEntries = 4096;
+  if (*entry_count == 0 || *entry_count > kMaxUaloeEntries) {
+    free(ualoe_buf);
+    return AMDSMI_STATUS_INVAL;
+  }
+  const size_t max_ualoe_entries = static_cast<size_t>(*entry_count);
   ualoe_cper_hdr_t** ualoe_hdrs =
       static_cast<ualoe_cper_hdr_t**>(malloc(max_ualoe_entries * sizeof(ualoe_cper_hdr_t*)));
   if (ualoe_hdrs == nullptr) {
@@ -982,7 +990,7 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     if (ret == ENOSPC) {
       return AMDSMI_STATUS_OUT_OF_RESOURCES;
     }
-    return AMDSMI_STATUS_UNEXPECTED_DATA;
+    return convert_errno_to_amdsmi_status(ret);
   }
 
   // Transform UALoE records into amdsmi CPER format
@@ -991,6 +999,9 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
 
   for (uint64_t i = 0; i < ualoe_entry_count; i++) {
     const ualoe_cper_hdr_t* ualoe_hdr = ualoe_hdrs[i];
+    if (ualoe_hdr == nullptr || ualoe_hdr->record_length < sizeof(ualoe_cper_hdr_t)) {
+      break;
+    }
     const uint32_t ualoe_payload_size =
         static_cast<uint32_t>(ualoe_hdr->record_length - sizeof(ualoe_cper_hdr_t));
     const uint32_t amdsmi_record_length = sizeof(amdsmi_cper_hdr_t) + ualoe_payload_size;

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -876,14 +876,11 @@ amdsmi_status_t amdsmi_get_tray_info(amdsmi_node_handle node_handle, amdsmi_tray
   return AMDSMI_STATUS_NOT_SUPPORTED;
 }
 
-namespace {
-
-// Convert POSIX timespec to BCD-encoded CPER timestamp
+// Convert POSIX timespec to the BCD-encoded timestamp UEFI CPER records use.
 static void timespec_to_cper_timestamp(const struct timespec* ts, amdsmi_cper_timestamp_t* out) {
   struct tm utc;
   gmtime_r(&ts->tv_sec, &utc);
 
-  // Encode each field as BCD (Binary-Coded Decimal)
   out->seconds = static_cast<uint8_t>((utc.tm_sec % 10) | ((utc.tm_sec / 10) << 4));
   out->minutes = static_cast<uint8_t>((utc.tm_min % 10) | ((utc.tm_min / 10) << 4));
   out->hours = static_cast<uint8_t>((utc.tm_hour % 10) | ((utc.tm_hour / 10) << 4));
@@ -901,38 +898,25 @@ static void synthesize_amdsmi_cper_header(const ualoe_cper_hdr_t* ualoe_hdr, uin
                                           amdsmi_cper_hdr_t* amdsmi_hdr) {
   memset(amdsmi_hdr, 0, sizeof(*amdsmi_hdr));
 
-  // Fixed CPER header fields
   memcpy(amdsmi_hdr->signature, "CPER", 4);
   amdsmi_hdr->revision = 0x0100;  // CPER v1.0
   amdsmi_hdr->signature_end = 0xFFFFFFFF;
   amdsmi_hdr->sec_cnt = 1;
 
-  // Severity: direct copy (enums match)
+  // The UALoE and amdsmi severity enumerators share their values.
   amdsmi_hdr->error_severity = static_cast<amdsmi_cper_sev_t>(ualoe_hdr->severity);
 
-  // Valid bits: only timestamp is valid
+  // No platform_id or partition_id is synthesized, so only the timestamp is valid.
   amdsmi_hdr->cper_valid_bits.valid_bits.timestamp = 1;
-  amdsmi_hdr->cper_valid_bits.valid_bits.platform_id = 0;
-  amdsmi_hdr->cper_valid_bits.valid_bits.partition_id = 0;
 
-  // Record length: full amdsmi header + payload
   amdsmi_hdr->record_length = sizeof(amdsmi_cper_hdr_t) + payload_size;
-
-  // Timestamp: convert timespec → BCD
   timespec_to_cper_timestamp(&ualoe_hdr->timestamp, &amdsmi_hdr->timestamp);
 
-  // Creator ID: "IFoE" (4 bytes, zero-padded to 16)
+  // creator_id and notify_type are 16-byte fields; the memset above zero-pads them.
   memcpy(amdsmi_hdr->creator_id, "IFoE", 4);
-
-  // Notify type: IFoE GUID (placeholder all-zeros)
   static const unsigned char ifoe_guid[16] = AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID;
   memcpy(amdsmi_hdr->notify_type.b, ifoe_guid, 16);
-
-  // Remaining fields: zero (platform_id, partition_id, record_id, flags,
-  // persistence_info, reserved already zeroed by memset)
 }
-
-}  // namespace
 
 amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor_handle,
                                                uint32_t severity_mask, char* cper_data,
@@ -956,7 +940,6 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
-  // Allocate temporary buffer for UALoE records
   const size_t ualoe_buf_size = 1048576;  // 1 MB
   char* ualoe_buf = static_cast<char*>(malloc(ualoe_buf_size));
   if (ualoe_buf == nullptr) {
@@ -978,7 +961,6 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return AMDSMI_STATUS_OUT_OF_RESOURCES;
   }
 
-  // Call UALoE library
   uint64_t ualoe_buf_size_var = ualoe_buf_size;
   uint64_t ualoe_entry_count = max_ualoe_entries;
   int ret = ualoe_get_ifoe_cper_entries(ualoe_handle, severity_mask, ualoe_buf, &ualoe_buf_size_var,
@@ -993,7 +975,6 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return convert_errno_to_amdsmi_status(ret);
   }
 
-  // Transform UALoE records into amdsmi CPER format
   uint64_t amdsmi_offset = 0;
   uint64_t transformed_entries = 0;
 
@@ -1006,32 +987,27 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
         static_cast<uint32_t>(ualoe_hdr->record_length - sizeof(ualoe_cper_hdr_t));
     const uint32_t amdsmi_record_length = sizeof(amdsmi_cper_hdr_t) + ualoe_payload_size;
 
-    // Validate UALoE record doesn't extend past input buffer
+    // The record must not claim to extend past the end of what UALoE filled in.
     const size_t ualoe_offset = reinterpret_cast<const char*>(ualoe_hdr) - ualoe_buf;
     if (ualoe_offset + ualoe_hdr->record_length > ualoe_buf_size_var) {
-      break;  // UALoE record claims to extend past buffer end
-    }
-
-    // Check if we have space in the output buffer
-    if (amdsmi_offset + amdsmi_record_length > *buf_size) {
-      break;  // Buffer full
-    }
-
-    // Check if we have space in the cper_hdrs array
-    if (transformed_entries >= max_ualoe_entries) {
       break;
     }
 
-    // Write synthesized amdsmi header
+    if (amdsmi_offset + amdsmi_record_length > *buf_size) {
+      break;  // Caller's buffer is full.
+    }
+
+    if (transformed_entries >= max_ualoe_entries) {
+      break;  // Caller's cper_hdrs array is full.
+    }
+
     amdsmi_cper_hdr_t* amdsmi_hdr = reinterpret_cast<amdsmi_cper_hdr_t*>(cper_data + amdsmi_offset);
     synthesize_amdsmi_cper_header(ualoe_hdr, ualoe_payload_size, amdsmi_hdr);
 
-    // Copy payload (data after UALoE header)
     const char* ualoe_payload = reinterpret_cast<const char*>(ualoe_hdr) + sizeof(ualoe_cper_hdr_t);
     memcpy(cper_data + amdsmi_offset + sizeof(amdsmi_cper_hdr_t), ualoe_payload,
            ualoe_payload_size);
 
-    // Store pointer in cper_hdrs array
     cper_hdrs[transformed_entries] = amdsmi_hdr;
     transformed_entries++;
     amdsmi_offset += amdsmi_record_length;
@@ -1043,7 +1019,6 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
   *buf_size = amdsmi_offset;
   *entry_count = transformed_entries;
 
-  // Return MORE_DATA if UALoE indicated more records available
   if (ret == ENOBUFS) {
     return AMDSMI_STATUS_MORE_DATA;
   }

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -875,3 +875,167 @@ amdsmi_status_t amdsmi_get_tray_info(amdsmi_node_handle node_handle, amdsmi_tray
 
   return AMDSMI_STATUS_NOT_SUPPORTED;
 }
+
+namespace {
+
+// Convert POSIX timespec to BCD-encoded CPER timestamp
+static void timespec_to_cper_timestamp(const struct timespec* ts, amdsmi_cper_timestamp_t* out) {
+  struct tm utc;
+  gmtime_r(&ts->tv_sec, &utc);
+
+  // Encode each field as BCD (Binary-Coded Decimal)
+  out->seconds = static_cast<uint8_t>((utc.tm_sec % 10) | ((utc.tm_sec / 10) << 4));
+  out->minutes = static_cast<uint8_t>((utc.tm_min % 10) | ((utc.tm_min / 10) << 4));
+  out->hours = static_cast<uint8_t>((utc.tm_hour % 10) | ((utc.tm_hour / 10) << 4));
+  out->day = static_cast<uint8_t>((utc.tm_mday % 10) | ((utc.tm_mday / 10) << 4));
+  out->month = static_cast<uint8_t>(((utc.tm_mon + 1) % 10) | (((utc.tm_mon + 1) / 10) << 4));
+
+  int year = utc.tm_year + 1900;
+  out->year = static_cast<uint8_t>((year % 100 % 10) | (((year % 100) / 10) << 4));
+  out->century = static_cast<uint8_t>((year / 100 % 10) | (((year / 100) / 10) << 4));
+  out->flag = 0;
+}
+
+// Synthesize a full amdsmi_cper_hdr_t from a UALoE ualoe_cper_hdr_t
+static void synthesize_amdsmi_cper_header(const ualoe_cper_hdr_t* ualoe_hdr, uint32_t payload_size,
+                                          amdsmi_cper_hdr_t* amdsmi_hdr) {
+  memset(amdsmi_hdr, 0, sizeof(*amdsmi_hdr));
+
+  // Fixed CPER header fields
+  memcpy(amdsmi_hdr->signature, "CPER", 4);
+  amdsmi_hdr->revision = 0x0100;  // CPER v1.0
+  amdsmi_hdr->signature_end = 0xFFFFFFFF;
+  amdsmi_hdr->sec_cnt = 1;
+
+  // Severity: direct copy (enums match)
+  amdsmi_hdr->error_severity = static_cast<amdsmi_cper_sev_t>(ualoe_hdr->severity);
+
+  // Valid bits: only timestamp is valid
+  amdsmi_hdr->cper_valid_bits.valid_bits.timestamp = 1;
+  amdsmi_hdr->cper_valid_bits.valid_bits.platform_id = 0;
+  amdsmi_hdr->cper_valid_bits.valid_bits.partition_id = 0;
+
+  // Record length: full amdsmi header + payload
+  amdsmi_hdr->record_length = sizeof(amdsmi_cper_hdr_t) + payload_size;
+
+  // Timestamp: convert timespec → BCD
+  timespec_to_cper_timestamp(&ualoe_hdr->timestamp, &amdsmi_hdr->timestamp);
+
+  // Creator ID: "IFoE" (4 bytes, zero-padded to 16)
+  memcpy(amdsmi_hdr->creator_id, "IFoE", 4);
+
+  // Notify type: IFoE GUID (placeholder all-zeros)
+  static const unsigned char ifoe_guid[16] = AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID;
+  memcpy(amdsmi_hdr->notify_type.b, ifoe_guid, 16);
+
+  // Remaining fields: zero (platform_id, partition_id, record_id, flags,
+  // persistence_info, reserved already zeroed by memset)
+}
+
+}  // namespace
+
+amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor_handle,
+                                               uint32_t severity_mask, char* cper_data,
+                                               uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
+                                               uint64_t* entry_count, uint64_t* cursor) {
+  if (processor_handle == nullptr || cper_data == nullptr || buf_size == nullptr ||
+      cper_hdrs == nullptr || entry_count == nullptr || cursor == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &device);
+  if (status != AMDSMI_STATUS_SUCCESS || device == nullptr) {
+    return status;
+  }
+
+  ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
+  if (ualoe_handle == -1) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  // Allocate temporary buffer for UALoE records
+  const size_t ualoe_buf_size = 1048576;  // 1 MB
+  char* ualoe_buf = static_cast<char*>(malloc(ualoe_buf_size));
+  if (ualoe_buf == nullptr) {
+    return AMDSMI_STATUS_OUT_OF_RESOURCES;
+  }
+
+  // Allocate array for UALoE header pointers
+  const size_t max_ualoe_entries = *entry_count;
+  ualoe_cper_hdr_t** ualoe_hdrs =
+      static_cast<ualoe_cper_hdr_t**>(malloc(max_ualoe_entries * sizeof(ualoe_cper_hdr_t*)));
+  if (ualoe_hdrs == nullptr) {
+    free(ualoe_buf);
+    return AMDSMI_STATUS_OUT_OF_RESOURCES;
+  }
+
+  // Call UALoE library
+  uint64_t ualoe_buf_size_var = ualoe_buf_size;
+  uint64_t ualoe_entry_count = max_ualoe_entries;
+  int ret = ualoe_get_ifoe_cper_entries(ualoe_handle, severity_mask, ualoe_buf, &ualoe_buf_size_var,
+                                        ualoe_hdrs, &ualoe_entry_count, cursor);
+
+  if (ret != 0 && ret != ENOBUFS) {
+    free(ualoe_buf);
+    free(ualoe_hdrs);
+    if (ret == ENOSPC) {
+      return AMDSMI_STATUS_OUT_OF_RESOURCES;
+    }
+    return AMDSMI_STATUS_UNEXPECTED_DATA;
+  }
+
+  // Transform UALoE records into amdsmi CPER format
+  uint64_t amdsmi_offset = 0;
+  uint64_t transformed_entries = 0;
+
+  for (uint64_t i = 0; i < ualoe_entry_count; i++) {
+    const ualoe_cper_hdr_t* ualoe_hdr = ualoe_hdrs[i];
+    const uint32_t ualoe_payload_size =
+        static_cast<uint32_t>(ualoe_hdr->record_length - sizeof(ualoe_cper_hdr_t));
+    const uint32_t amdsmi_record_length = sizeof(amdsmi_cper_hdr_t) + ualoe_payload_size;
+
+    // Validate UALoE record doesn't extend past input buffer
+    const size_t ualoe_offset = reinterpret_cast<const char*>(ualoe_hdr) - ualoe_buf;
+    if (ualoe_offset + ualoe_hdr->record_length > ualoe_buf_size_var) {
+      break;  // UALoE record claims to extend past buffer end
+    }
+
+    // Check if we have space in the output buffer
+    if (amdsmi_offset + amdsmi_record_length > *buf_size) {
+      break;  // Buffer full
+    }
+
+    // Check if we have space in the cper_hdrs array
+    if (transformed_entries >= max_ualoe_entries) {
+      break;
+    }
+
+    // Write synthesized amdsmi header
+    amdsmi_cper_hdr_t* amdsmi_hdr = reinterpret_cast<amdsmi_cper_hdr_t*>(cper_data + amdsmi_offset);
+    synthesize_amdsmi_cper_header(ualoe_hdr, ualoe_payload_size, amdsmi_hdr);
+
+    // Copy payload (data after UALoE header)
+    const char* ualoe_payload = reinterpret_cast<const char*>(ualoe_hdr) + sizeof(ualoe_cper_hdr_t);
+    memcpy(cper_data + amdsmi_offset + sizeof(amdsmi_cper_hdr_t), ualoe_payload,
+           ualoe_payload_size);
+
+    // Store pointer in cper_hdrs array
+    cper_hdrs[transformed_entries] = amdsmi_hdr;
+    transformed_entries++;
+    amdsmi_offset += amdsmi_record_length;
+  }
+
+  free(ualoe_buf);
+  free(ualoe_hdrs);
+
+  *buf_size = amdsmi_offset;
+  *entry_count = transformed_entries;
+
+  // Return MORE_DATA if UALoE indicated more records available
+  if (ret == ENOBUFS) {
+    return AMDSMI_STATUS_MORE_DATA;
+  }
+
+  return AMDSMI_STATUS_SUCCESS;
+}

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -759,3 +759,167 @@ amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_han
 
   return status_code;
 }
+
+namespace {
+
+// Convert POSIX timespec to BCD-encoded CPER timestamp
+static void timespec_to_cper_timestamp(const struct timespec* ts, amdsmi_cper_timestamp_t* out) {
+  struct tm utc;
+  gmtime_r(&ts->tv_sec, &utc);
+
+  // Encode each field as BCD (Binary-Coded Decimal)
+  out->seconds = static_cast<uint8_t>((utc.tm_sec % 10) | ((utc.tm_sec / 10) << 4));
+  out->minutes = static_cast<uint8_t>((utc.tm_min % 10) | ((utc.tm_min / 10) << 4));
+  out->hours = static_cast<uint8_t>((utc.tm_hour % 10) | ((utc.tm_hour / 10) << 4));
+  out->day = static_cast<uint8_t>((utc.tm_mday % 10) | ((utc.tm_mday / 10) << 4));
+  out->month = static_cast<uint8_t>(((utc.tm_mon + 1) % 10) | (((utc.tm_mon + 1) / 10) << 4));
+
+  int year = utc.tm_year + 1900;
+  out->year = static_cast<uint8_t>((year % 100 % 10) | (((year % 100) / 10) << 4));
+  out->century = static_cast<uint8_t>((year / 100 % 10) | (((year / 100) / 10) << 4));
+  out->flag = 0;
+}
+
+// Synthesize a full amdsmi_cper_hdr_t from a UALoE ualoe_cper_hdr_t
+static void synthesize_amdsmi_cper_header(const ualoe_cper_hdr_t* ualoe_hdr, uint32_t payload_size,
+                                          amdsmi_cper_hdr_t* amdsmi_hdr) {
+  memset(amdsmi_hdr, 0, sizeof(*amdsmi_hdr));
+
+  // Fixed CPER header fields
+  memcpy(amdsmi_hdr->signature, "CPER", 4);
+  amdsmi_hdr->revision = 0x0100;  // CPER v1.0
+  amdsmi_hdr->signature_end = 0xFFFFFFFF;
+  amdsmi_hdr->sec_cnt = 1;
+
+  // Severity: direct copy (enums match)
+  amdsmi_hdr->error_severity = static_cast<amdsmi_cper_sev_t>(ualoe_hdr->severity);
+
+  // Valid bits: only timestamp is valid
+  amdsmi_hdr->cper_valid_bits.valid_bits.timestamp = 1;
+  amdsmi_hdr->cper_valid_bits.valid_bits.platform_id = 0;
+  amdsmi_hdr->cper_valid_bits.valid_bits.partition_id = 0;
+
+  // Record length: full amdsmi header + payload
+  amdsmi_hdr->record_length = sizeof(amdsmi_cper_hdr_t) + payload_size;
+
+  // Timestamp: convert timespec → BCD
+  timespec_to_cper_timestamp(&ualoe_hdr->timestamp, &amdsmi_hdr->timestamp);
+
+  // Creator ID: "IFoE" (4 bytes, zero-padded to 16)
+  memcpy(amdsmi_hdr->creator_id, "IFoE", 4);
+
+  // Notify type: IFoE GUID (placeholder all-zeros)
+  static const unsigned char ifoe_guid[16] = AMDSMI_CPER_NOTIFY_TYPE_IFOE_GUID;
+  memcpy(amdsmi_hdr->notify_type.b, ifoe_guid, 16);
+
+  // Remaining fields: zero (platform_id, partition_id, record_id, flags,
+  // persistence_info, reserved already zeroed by memset)
+}
+
+}  // namespace
+
+amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor_handle,
+                                               uint32_t severity_mask, char* cper_data,
+                                               uint64_t* buf_size, amdsmi_cper_hdr_t** cper_hdrs,
+                                               uint64_t* entry_count, uint64_t* cursor) {
+  if (processor_handle == nullptr || cper_data == nullptr || buf_size == nullptr ||
+      cper_hdrs == nullptr || entry_count == nullptr || cursor == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* device = nullptr;
+  amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &device);
+  if (status != AMDSMI_STATUS_SUCCESS || device == nullptr) {
+    return status;
+  }
+
+  ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
+  if (ualoe_handle == -1) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  // Allocate temporary buffer for UALoE records
+  const size_t ualoe_buf_size = 1048576;  // 1 MB
+  char* ualoe_buf = static_cast<char*>(malloc(ualoe_buf_size));
+  if (ualoe_buf == nullptr) {
+    return AMDSMI_STATUS_OUT_OF_RESOURCES;
+  }
+
+  // Allocate array for UALoE header pointers
+  const size_t max_ualoe_entries = *entry_count;
+  ualoe_cper_hdr_t** ualoe_hdrs =
+      static_cast<ualoe_cper_hdr_t**>(malloc(max_ualoe_entries * sizeof(ualoe_cper_hdr_t*)));
+  if (ualoe_hdrs == nullptr) {
+    free(ualoe_buf);
+    return AMDSMI_STATUS_OUT_OF_RESOURCES;
+  }
+
+  // Call UALoE library
+  uint64_t ualoe_buf_size_var = ualoe_buf_size;
+  uint64_t ualoe_entry_count = max_ualoe_entries;
+  int ret = ualoe_get_ifoe_cper_entries(ualoe_handle, severity_mask, ualoe_buf, &ualoe_buf_size_var,
+                                        ualoe_hdrs, &ualoe_entry_count, cursor);
+
+  if (ret != 0 && ret != ENOBUFS) {
+    free(ualoe_buf);
+    free(ualoe_hdrs);
+    if (ret == ENOSPC) {
+      return AMDSMI_STATUS_OUT_OF_RESOURCES;
+    }
+    return AMDSMI_STATUS_UNEXPECTED_DATA;
+  }
+
+  // Transform UALoE records into amdsmi CPER format
+  uint64_t amdsmi_offset = 0;
+  uint64_t transformed_entries = 0;
+
+  for (uint64_t i = 0; i < ualoe_entry_count; i++) {
+    const ualoe_cper_hdr_t* ualoe_hdr = ualoe_hdrs[i];
+    const uint32_t ualoe_payload_size =
+        static_cast<uint32_t>(ualoe_hdr->record_length - sizeof(ualoe_cper_hdr_t));
+    const uint32_t amdsmi_record_length = sizeof(amdsmi_cper_hdr_t) + ualoe_payload_size;
+
+    // Validate UALoE record doesn't extend past input buffer
+    const size_t ualoe_offset = reinterpret_cast<const char*>(ualoe_hdr) - ualoe_buf;
+    if (ualoe_offset + ualoe_hdr->record_length > ualoe_buf_size_var) {
+      break;  // UALoE record claims to extend past buffer end
+    }
+
+    // Check if we have space in the output buffer
+    if (amdsmi_offset + amdsmi_record_length > *buf_size) {
+      break;  // Buffer full
+    }
+
+    // Check if we have space in the cper_hdrs array
+    if (transformed_entries >= max_ualoe_entries) {
+      break;
+    }
+
+    // Write synthesized amdsmi header
+    amdsmi_cper_hdr_t* amdsmi_hdr = reinterpret_cast<amdsmi_cper_hdr_t*>(cper_data + amdsmi_offset);
+    synthesize_amdsmi_cper_header(ualoe_hdr, ualoe_payload_size, amdsmi_hdr);
+
+    // Copy payload (data after UALoE header)
+    const char* ualoe_payload = reinterpret_cast<const char*>(ualoe_hdr) + sizeof(ualoe_cper_hdr_t);
+    memcpy(cper_data + amdsmi_offset + sizeof(amdsmi_cper_hdr_t), ualoe_payload,
+           ualoe_payload_size);
+
+    // Store pointer in cper_hdrs array
+    cper_hdrs[transformed_entries] = amdsmi_hdr;
+    transformed_entries++;
+    amdsmi_offset += amdsmi_record_length;
+  }
+
+  free(ualoe_buf);
+  free(ualoe_hdrs);
+
+  *buf_size = amdsmi_offset;
+  *entry_count = transformed_entries;
+
+  // Return MORE_DATA if UALoE indicated more records available
+  if (ret == ENOBUFS) {
+    return AMDSMI_STATUS_MORE_DATA;
+  }
+
+  return AMDSMI_STATUS_SUCCESS;
+}

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -833,6 +833,8 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return status;
   }
 
+  SMIGPUDEVICE_MUTEX(device->get_mutex());
+
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
   if (ualoe_handle == -1) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -845,8 +847,14 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     return AMDSMI_STATUS_OUT_OF_RESOURCES;
   }
 
-  // Allocate array for UALoE header pointers
-  const size_t max_ualoe_entries = *entry_count;
+  // Allocate array for UALoE header pointers. *entry_count is caller-supplied,
+  // so clamp it before sizing the allocation.
+  constexpr uint64_t kMaxUaloeEntries = 4096;
+  if (*entry_count == 0 || *entry_count > kMaxUaloeEntries) {
+    free(ualoe_buf);
+    return AMDSMI_STATUS_INVAL;
+  }
+  const size_t max_ualoe_entries = static_cast<size_t>(*entry_count);
   ualoe_cper_hdr_t** ualoe_hdrs =
       static_cast<ualoe_cper_hdr_t**>(malloc(max_ualoe_entries * sizeof(ualoe_cper_hdr_t*)));
   if (ualoe_hdrs == nullptr) {
@@ -866,7 +874,7 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
     if (ret == ENOSPC) {
       return AMDSMI_STATUS_OUT_OF_RESOURCES;
     }
-    return AMDSMI_STATUS_UNEXPECTED_DATA;
+    return convert_errno_to_amdsmi_status(ret);
   }
 
   // Transform UALoE records into amdsmi CPER format
@@ -875,6 +883,9 @@ amdsmi_status_t amdsmi_get_fabric_cper_entries(amdsmi_processor_handle processor
 
   for (uint64_t i = 0; i < ualoe_entry_count; i++) {
     const ualoe_cper_hdr_t* ualoe_hdr = ualoe_hdrs[i];
+    if (ualoe_hdr == nullptr || ualoe_hdr->record_length < sizeof(ualoe_cper_hdr_t)) {
+      break;
+    }
     const uint32_t ualoe_payload_size =
         static_cast<uint32_t>(ualoe_hdr->record_length - sizeof(ualoe_cper_hdr_t));
     const uint32_t amdsmi_record_length = sizeof(amdsmi_cper_hdr_t) + ualoe_payload_size;

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -343,7 +343,6 @@ class TestCliRasCperJson(unittest.TestCase):
         self.assertEqual(json.loads(captured), [])
 
     def test_fabric_cper_with_gpu_cper_unified_output(self):
-        # Test that fabric and GPU CPER entries are combined into a single JSON document.
         counts_gpu = {}
         counts_fabric = {}
 
@@ -379,13 +378,11 @@ class TestCliRasCperJson(unittest.TestCase):
         # Expect 2 GPUs × 2 entries (1 GPU + 1 fabric) = 4 total rows
         self.assertEqual(len(parsed), 4, f"expected 2 GPU + 2 fabric entries, got: {parsed!r}")
 
-        # Verify we have both GPU (FATAL) and fabric (FABRIC-LINKDOWN) entries
         severities = [row["severity"] for row in parsed]
         self.assertIn("FATAL", severities, "Should have GPU CPER entry")
         self.assertIn("FABRIC-LINKDOWN", severities, "Should have fabric CPER entry")
 
     def test_fabric_cper_only_no_gpu_cper(self):
-        # Test fabric CPER when no GPU CPER entries exist
         counts_fabric = {}
 
         def _fabric_entries(handle, _mask, _size, cursor):
@@ -405,12 +402,10 @@ class TestCliRasCperJson(unittest.TestCase):
         self.assertIsInstance(parsed, list)
         self.assertEqual(len(parsed), 2, f"expected 2 fabric entries (1 per GPU), got: {parsed!r}")
 
-        # All entries should be fabric-fatal
         for row in parsed:
             self.assertEqual(row["severity"], "FABRIC-FATAL")
 
     def test_fabric_cper_not_supported_graceful_fallback(self):
-        # Test that NOT_SUPPORTED for fabric CPER doesn't break the output
         def _gpu_entries(handle, _mask, _size, cursor):
             if cursor == 0:
                 entry = {
@@ -430,7 +425,7 @@ class TestCliRasCperJson(unittest.TestCase):
         parsed = json.loads(captured)
         self.assertIsInstance(parsed, list)
 
-        # Should only have GPU entries (no fabric), 2 GPUs
+        # GPU entries only: one per GPU, with the fabric call raising NOT_SUPPORTED.
         self.assertEqual(len(parsed), 2)
         for row in parsed:
             self.assertEqual(row["severity"], "FATAL")

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -58,6 +58,20 @@ class _FakeHandle:
         self.value = value
 
 
+def _fabric_entry(timestamp, error_severity):
+    """A fabric CPER entry shaped like ``amdsmi_get_fabric_cper_entries`` returns one.
+
+    The IFoE placeholder GUID maps to no known notify type, so the formatted
+    ``notify_type`` is ``"Unknown"``; ``source`` is what marks it as fabric.
+    """
+    return {
+        "timestamp": timestamp,
+        "error_severity": error_severity,
+        "notify_type": "Unknown",
+        "source": "fabric",
+    }
+
+
 class _FakeLibraryException(Exception):
     def __init__(self, code=0, message="mock error"):
         super().__init__(message)
@@ -349,12 +363,7 @@ class TestCliRasCperJson(unittest.TestCase):
             seen = counts_fabric.get(handle.value, 0)
             counts_fabric[handle.value] = seen + 1
             if seen == 0:
-                # IFoE fabric CPER with all-zeros GUID
-                entry = {
-                    "timestamp": "2026/08/24 12:05:00",
-                    "error_severity": "non_fatal_uncorrected",  # linkdown
-                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                }
+                entry = _fabric_entry("2026/08/24 12:05:00", "non_fatal_uncorrected")
                 return ({0: entry}, cursor + 1, [b""], 0)
             return ({}, cursor, [], 0)
 
@@ -383,11 +392,7 @@ class TestCliRasCperJson(unittest.TestCase):
             seen = counts_fabric.get(handle.value, 0)
             counts_fabric[handle.value] = seen + 1
             if seen == 0:
-                entry = {
-                    "timestamp": "2026/08/24 13:00:00",
-                    "error_severity": "fatal",  # fabric-fatal
-                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                }
+                entry = _fabric_entry("2026/08/24 13:00:00", "fatal")
                 return ({0: entry}, cursor + 1, [b""], 0)
             return ({}, cursor, [], 0)
 

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -217,6 +217,16 @@ class TestCliRasCperJson(unittest.TestCase):
         self.interface.amdsmi_get_gpu_kfd_info = lambda _h: {"current_partition_id": 0}
         self.interface.amdsmi_get_gpu_cper_entries = lambda _h, _m, _s, cursor: ({}, cursor, [], 0)
 
+        # Default: no fabric CPER entries (raises NOT_SUPPORTED)
+        def _fabric_not_supported(_h, _m, _s, cursor):
+            exc = _FakeLibraryException(
+                code=self.interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED,
+                message="Fabric CPER not supported",
+            )
+            raise exc
+
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_not_supported
+
     def _make_commands(self):
         commands = object.__new__(self.ras_module.RasCommands)
         commands.logger = self.logger_cls(format="json", destination="stdout")
@@ -317,6 +327,108 @@ class TestCliRasCperJson(unittest.TestCase):
 
         self.assertEqual(captured.strip(), "[]")
         self.assertEqual(json.loads(captured), [])
+
+    def test_fabric_cper_with_gpu_cper_unified_output(self):
+        # Test that fabric and GPU CPER entries are combined into a single JSON document.
+        counts_gpu = {}
+        counts_fabric = {}
+
+        def _gpu_entries(handle, _mask, _size, cursor):
+            seen = counts_gpu.get(handle.value, 0)
+            counts_gpu[handle.value] = seen + 1
+            if seen == 0:
+                entry = {
+                    "timestamp": "2026/08/24 12:00:00",
+                    "error_severity": "fatal",
+                    "notify_type": "RUNTIME",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        def _fabric_entries(handle, _mask, _size, cursor):
+            seen = counts_fabric.get(handle.value, 0)
+            counts_fabric[handle.value] = seen + 1
+            if seen == 0:
+                # IFoE fabric CPER with all-zeros GUID
+                entry = {
+                    "timestamp": "2026/08/24 12:05:00",
+                    "error_severity": "non_fatal_uncorrected",  # linkdown
+                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_gpu_cper_entries = _gpu_entries
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_entries
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+
+        # Expect 2 GPUs × 2 entries (1 GPU + 1 fabric) = 4 total rows
+        self.assertEqual(len(parsed), 4, f"expected 2 GPU + 2 fabric entries, got: {parsed!r}")
+
+        # Verify we have both GPU (FATAL) and fabric (FABRIC-LINKDOWN) entries
+        severities = [row["severity"] for row in parsed]
+        self.assertIn("FATAL", severities, "Should have GPU CPER entry")
+        self.assertIn("FABRIC-LINKDOWN", severities, "Should have fabric CPER entry")
+
+    def test_fabric_cper_only_no_gpu_cper(self):
+        # Test fabric CPER when no GPU CPER entries exist
+        counts_fabric = {}
+
+        def _fabric_entries(handle, _mask, _size, cursor):
+            seen = counts_fabric.get(handle.value, 0)
+            counts_fabric[handle.value] = seen + 1
+            if seen == 0:
+                entry = {
+                    "timestamp": "2026/08/24 13:00:00",
+                    "error_severity": "fatal",  # fabric-fatal
+                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_entries
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 2, f"expected 2 fabric entries (1 per GPU), got: {parsed!r}")
+
+        # All entries should be fabric-fatal
+        for row in parsed:
+            self.assertEqual(row["severity"], "FABRIC-FATAL")
+
+    def test_fabric_cper_not_supported_graceful_fallback(self):
+        # Test that NOT_SUPPORTED for fabric CPER doesn't break the output
+        def _gpu_entries(handle, _mask, _size, cursor):
+            if cursor == 0:
+                entry = {
+                    "timestamp": "2026/08/24 14:00:00",
+                    "error_severity": "fatal",
+                    "notify_type": "RUNTIME",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_gpu_cper_entries = _gpu_entries
+        # fabric_cper already set to raise NOT_SUPPORTED in setUp
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+
+        # Should only have GPU entries (no fabric), 2 GPUs
+        self.assertEqual(len(parsed), 2)
+        for row in parsed:
+            self.assertEqual(row["severity"], "FATAL")
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -216,6 +216,16 @@ class TestCliRasCperJson(unittest.TestCase):
         self.interface.amdsmi_get_gpu_kfd_info = lambda _h: {"current_partition_id": 0}
         self.interface.amdsmi_get_gpu_cper_entries = lambda _h, _m, _s, cursor: ({}, cursor, [], 0)
 
+        # Default: no fabric CPER entries (raises NOT_SUPPORTED)
+        def _fabric_not_supported(_h, _m, _s, cursor):
+            exc = _FakeLibraryException(
+                code=self.interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED,
+                message="Fabric CPER not supported",
+            )
+            raise exc
+
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_not_supported
+
     def _make_commands(self):
         commands = object.__new__(self.ras_module.RasCommands)
         commands.logger = self.logger_cls(format="json", destination="stdout")
@@ -298,6 +308,108 @@ class TestCliRasCperJson(unittest.TestCase):
             self.assertEqual(buffer.getvalue(), "")
         finally:
             self.ras_module.time.sleep = original_sleep
+
+    def test_fabric_cper_with_gpu_cper_unified_output(self):
+        # Test that fabric and GPU CPER entries are combined into a single JSON document.
+        counts_gpu = {}
+        counts_fabric = {}
+
+        def _gpu_entries(handle, _mask, _size, cursor):
+            seen = counts_gpu.get(handle.value, 0)
+            counts_gpu[handle.value] = seen + 1
+            if seen == 0:
+                entry = {
+                    "timestamp": "2026/08/24 12:00:00",
+                    "error_severity": "fatal",
+                    "notify_type": "RUNTIME",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        def _fabric_entries(handle, _mask, _size, cursor):
+            seen = counts_fabric.get(handle.value, 0)
+            counts_fabric[handle.value] = seen + 1
+            if seen == 0:
+                # IFoE fabric CPER with all-zeros GUID
+                entry = {
+                    "timestamp": "2026/08/24 12:05:00",
+                    "error_severity": "non_fatal_uncorrected",  # linkdown
+                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_gpu_cper_entries = _gpu_entries
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_entries
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+
+        # Expect 2 GPUs × 2 entries (1 GPU + 1 fabric) = 4 total rows
+        self.assertEqual(len(parsed), 4, f"expected 2 GPU + 2 fabric entries, got: {parsed!r}")
+
+        # Verify we have both GPU (FATAL) and fabric (FABRIC-LINKDOWN) entries
+        severities = [row["severity"] for row in parsed]
+        self.assertIn("FATAL", severities, "Should have GPU CPER entry")
+        self.assertIn("FABRIC-LINKDOWN", severities, "Should have fabric CPER entry")
+
+    def test_fabric_cper_only_no_gpu_cper(self):
+        # Test fabric CPER when no GPU CPER entries exist
+        counts_fabric = {}
+
+        def _fabric_entries(handle, _mask, _size, cursor):
+            seen = counts_fabric.get(handle.value, 0)
+            counts_fabric[handle.value] = seen + 1
+            if seen == 0:
+                entry = {
+                    "timestamp": "2026/08/24 13:00:00",
+                    "error_severity": "fatal",  # fabric-fatal
+                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_fabric_cper_entries = _fabric_entries
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 2, f"expected 2 fabric entries (1 per GPU), got: {parsed!r}")
+
+        # All entries should be fabric-fatal
+        for row in parsed:
+            self.assertEqual(row["severity"], "FABRIC-FATAL")
+
+    def test_fabric_cper_not_supported_graceful_fallback(self):
+        # Test that NOT_SUPPORTED for fabric CPER doesn't break the output
+        def _gpu_entries(handle, _mask, _size, cursor):
+            if cursor == 0:
+                entry = {
+                    "timestamp": "2026/08/24 14:00:00",
+                    "error_severity": "fatal",
+                    "notify_type": "RUNTIME",
+                }
+                return ({0: entry}, cursor + 1, [b""], 0)
+            return ({}, cursor, [], 0)
+
+        self.interface.amdsmi_get_gpu_cper_entries = _gpu_entries
+        # fabric_cper already set to raise NOT_SUPPORTED in setUp
+
+        commands = self._make_commands()
+        captured = self._run_ras(commands, _build_ras_args(self._handles))
+
+        parsed = json.loads(captured)
+        self.assertIsInstance(parsed, list)
+
+        # Should only have GPU entries (no fabric), 2 GPUs
+        self.assertEqual(len(parsed), 2)
+        for row in parsed:
+            self.assertEqual(row["severity"], "FATAL")
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_ras_cper_json.py
@@ -57,6 +57,20 @@ class _FakeHandle:
         self.value = value
 
 
+def _fabric_entry(timestamp, error_severity):
+    """A fabric CPER entry shaped like ``amdsmi_get_fabric_cper_entries`` returns one.
+
+    The IFoE placeholder GUID maps to no known notify type, so the formatted
+    ``notify_type`` is ``"Unknown"``; ``source`` is what marks it as fabric.
+    """
+    return {
+        "timestamp": timestamp,
+        "error_severity": error_severity,
+        "notify_type": "Unknown",
+        "source": "fabric",
+    }
+
+
 class _FakeLibraryException(Exception):
     def __init__(self, code=0, message="mock error"):
         super().__init__(message)
@@ -330,12 +344,7 @@ class TestCliRasCperJson(unittest.TestCase):
             seen = counts_fabric.get(handle.value, 0)
             counts_fabric[handle.value] = seen + 1
             if seen == 0:
-                # IFoE fabric CPER with all-zeros GUID
-                entry = {
-                    "timestamp": "2026/08/24 12:05:00",
-                    "error_severity": "non_fatal_uncorrected",  # linkdown
-                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                }
+                entry = _fabric_entry("2026/08/24 12:05:00", "non_fatal_uncorrected")
                 return ({0: entry}, cursor + 1, [b""], 0)
             return ({}, cursor, [], 0)
 
@@ -364,11 +373,7 @@ class TestCliRasCperJson(unittest.TestCase):
             seen = counts_fabric.get(handle.value, 0)
             counts_fabric[handle.value] = seen + 1
             if seen == 0:
-                entry = {
-                    "timestamp": "2026/08/24 13:00:00",
-                    "error_severity": "fatal",  # fabric-fatal
-                    "notify_type": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                }
+                entry = _fabric_entry("2026/08/24 13:00:00", "fatal")
                 return ({0: entry}, cursor + 1, [b""], 0)
             return ({}, cursor, [], 0)
 

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
@@ -71,7 +71,6 @@ class TestFabricCperInterface(unittest.TestCase):
     """Test amdsmi_interface.amdsmi_get_fabric_cper_entries()"""
 
     def setUp(self):
-        """Set up test fixtures"""
         self.processor_handle = amdsmi_wrapper.amdsmi_processor_handle(0x1234)
 
     def test_invalid_handle_type(self):
@@ -82,7 +81,6 @@ class TestFabricCperInterface(unittest.TestCase):
     @_patch_fabric_symbol()
     def test_not_supported_error(self, mock_fabric_cper):
         """Test NOT_SUPPORTED error handling (UALoE unavailable)"""
-        # Mock C function returning NOT_SUPPORTED
         mock_fabric_cper.return_value = amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
 
         with self.assertRaises(amdsmi_exception.AmdSmiLibraryException) as context:
@@ -98,11 +96,10 @@ class TestFabricCperInterface(unittest.TestCase):
     def test_success_no_entries(self, mock_fabric_cper):
         """Test successful call with no entries returned"""
 
-        # Mock C function returning SUCCESS with 0 entries
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            _set_out(entry_count, 0)  # No entries
+            _set_out(entry_count, 0)
             _set_out(buf_size, 0)
-            _set_out(cursor, 0)  # No more data
+            _set_out(cursor, 0)  # 0 means no more data
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -121,24 +118,17 @@ class TestFabricCperInterface(unittest.TestCase):
         """Test successful call with fabric CPER entries"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            # Synthesize one fabric CPER entry
-            # amdsmi_cper_hdr_t is 128 bytes
+            # One fabric CPER entry, laid out by byte offset into the 128-byte
+            # amdsmi_cper_hdr_t.
             cper_header = bytearray(128)
-            # Signature: "CPER"
-            cper_header[0:4] = b"CPER"
-            # Revision: 0x0100 (little-endian)
-            struct.pack_into("<H", cper_header, 4, 0x0100)
-            # signature_end: 0xFFFFFFFF
-            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
-            # section_count: 1
-            struct.pack_into("<H", cper_header, 10, 1)
-            # error_severity: AMDSMI_CPER_SEV_FATAL (1)
-            struct.pack_into("<I", cper_header, 12, 1)
-            # valid_bits: timestamp valid (bit 0)
-            struct.pack_into("<I", cper_header, 16, 0x01)
-            # record_length: 128 (header only, no payload)
-            struct.pack_into("<I", cper_header, 20, 128)
-            # Timestamp: 2026-08-24 12:00:00
+            cper_header[0:4] = b"CPER"  # signature
+            struct.pack_into("<H", cper_header, 4, 0x0100)  # revision
+            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)  # signature_end
+            struct.pack_into("<H", cper_header, 10, 1)  # sec_cnt
+            struct.pack_into("<I", cper_header, 12, 1)  # AMDSMI_CPER_SEV_FATAL
+            struct.pack_into("<I", cper_header, 16, 0x01)  # valid_bits: timestamp
+            struct.pack_into("<I", cper_header, 20, 128)  # record_length, no payload
+            # Timestamp: 2026-08-24 12:00:00, as the Python layer reads it.
             cper_header[24] = 0  # seconds
             cper_header[25] = 0  # minutes
             cper_header[26] = 12  # hours
@@ -147,23 +137,15 @@ class TestFabricCperInterface(unittest.TestCase):
             cper_header[29] = 8  # month
             cper_header[30] = 26  # year
             cper_header[31] = 20  # century
-            # platform_id, partition_id: all zeros
-            # record_id: 0
-            # flags: 0
-            # persistence_info: 0
-            # notify_type: all zeros (IFoE placeholder GUID)
-            # creator_id: "IFoE"
-            cper_header[96:100] = b"IFoE"
+            cper_header[96:100] = b"IFoE"  # creator_id
+            # notify_type at 72:88 stays all zeros: the IFoE placeholder GUID.
 
-            # Copy to buffer
             ctypes.memmove(buf, bytes(cper_header), 128)
-
-            # Set header pointer
             hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
 
             _set_out(entry_count, 1)
             _set_out(buf_size, 128)
-            _set_out(cursor, 0)  # No more data
+            _set_out(cursor, 0)
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -176,10 +158,8 @@ class TestFabricCperInterface(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(new_cursor, 0)
 
-        # Verify entry fields
         entry = entries[0]
         self.assertEqual(entry["error_severity"], "fatal")
-        self.assertIn("notify_type", entry)
         self.assertEqual(entry["timestamp"], "2026/08/24 12:00:00")
         self.assertEqual(entry["signature"], b"CPER")
         self.assertEqual(entry["revision"], 0x0100)
@@ -192,7 +172,6 @@ class TestFabricCperInterface(unittest.TestCase):
         """Test MORE_DATA status and cursor pagination"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor_ref):
-            # Return MORE_DATA with cursor = 100
             _set_out(entry_count, 0)
             _set_out(buf_size, 0)
             _set_out(cursor_ref, 100)
@@ -209,9 +188,12 @@ class TestFabricCperInterface(unittest.TestCase):
 
     @_patch_fabric_symbol()
     def test_custom_buffer_size(self, mock_fabric_cper):
-        """Test custom buffer_size parameter"""
+        """buffer_size sizes both the data buffer and the declared buf_size"""
+        seen = {}
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            seen["buf_len"] = len(buf)
+            seen["buf_size_in"] = buf_size._obj.value
             _set_out(entry_count, 0)
             _set_out(buf_size, 0)
             _set_out(cursor, 0)
@@ -219,13 +201,14 @@ class TestFabricCperInterface(unittest.TestCase):
 
         mock_fabric_cper.side_effect = mock_impl
 
-        # Test with custom buffer size
-        custom_buffer_size = 2 * 1048576  # 2 MB
-        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+        custom_buffer_size = 2 * 1048576
+        _entries, _new_cursor, _cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
             self.processor_handle, severity_mask=0xFFFF, buffer_size=custom_buffer_size
         )
 
         self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+        self.assertEqual(seen["buf_len"], custom_buffer_size)
+        self.assertEqual(seen["buf_size_in"], custom_buffer_size)
 
     @_patch_fabric_symbol()
     def test_fabric_entries_are_marked_as_fabric(self, mock_fabric_cper):
@@ -239,8 +222,7 @@ class TestFabricCperInterface(unittest.TestCase):
             struct.pack_into("<H", cper_header, 10, 1)
             struct.pack_into("<I", cper_header, 12, 1)  # FATAL
             struct.pack_into("<I", cper_header, 20, 128)
-            # notify_type: IFoE placeholder GUID (all zeros)
-            cper_header[72:88] = bytes(16)
+            cper_header[72:88] = bytes(16)  # notify_type: IFoE placeholder GUID
             cper_header[96:100] = b"IFoE"
 
             ctypes.memmove(buf, bytes(cper_header), 128)

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
@@ -9,34 +9,61 @@ Mocks the ctypes layer to verify parameter handling, exception raising, and data
 """
 
 import ctypes
-import struct
-import unittest
-from unittest.mock import MagicMock, patch
-import sys
+import importlib
 import os
+import struct
+import sys
+import types
+import unittest
+from unittest.mock import patch
 
-# Add py-interface to Python path
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "..", ".."))
 _PY_INTERFACE = os.path.join(_REPO_ROOT, "py-interface")
-sys.path.insert(0, _PY_INTERFACE)
-
-try:
-    from amdsmi import amdsmi_interface
-    from amdsmi import amdsmi_exception
-    from amdsmi import amdsmi_wrapper
-except ImportError:
-    # Skip tests if imports fail
-    amdsmi_interface = None
-    amdsmi_exception = None
-    amdsmi_wrapper = None
 
 
-class FakeProcessorHandle:
-    """Mock processor handle"""
+# Synthetic package name for the in-tree sources. The ``py-interface`` directory
+# is not a valid identifier, and its ``__init__.py`` pulls in the build-generated
+# ``_version`` module, so the submodules are imported directly under this name.
+# It is deliberately not ``amdsmi``: shadowing that would break sibling suites.
+_PKG = "amdsmi_source_under_test"
 
-    def __init__(self, value=0x1234):
-        self.value = value
+
+def _load_source_interface():
+    if _PKG not in sys.modules:
+        pkg = types.ModuleType(_PKG)
+        pkg.__path__ = [_PY_INTERFACE]
+        sys.modules[_PKG] = pkg
+    try:
+        return (
+            importlib.import_module(f"{_PKG}.amdsmi_interface"),
+            importlib.import_module(f"{_PKG}.amdsmi_exception"),
+            importlib.import_module(f"{_PKG}.amdsmi_wrapper"),
+            importlib.import_module(f"{_PKG}.amdsmi_interface_utils"),
+        )
+    except Exception:
+        for name in [n for n in list(sys.modules) if n == _PKG or n.startswith(_PKG + ".")]:
+            del sys.modules[name]
+        return None, None, None, None
+
+
+amdsmi_interface, amdsmi_exception, amdsmi_wrapper, amdsmi_interface_utils = (
+    _load_source_interface()
+)
+
+
+def _patch_fabric_symbol():
+    """Patch the C entry point the interface resolves through the wrapper module.
+
+    ``create=True`` because the symbol is only bound when the loaded
+    libamd_smi.so exports it, which is not the case in a source-only checkout.
+    """
+    return patch.object(amdsmi_wrapper, "amdsmi_get_fabric_cper_entries", create=True)
+
+
+def _set_out(ref, value):
+    """Assign through a ``ctypes.byref()`` out-parameter as the C library would."""
+    ref._obj.value = value
 
 
 @unittest.skipIf(amdsmi_interface is None, "amdsmi_interface not available")
@@ -45,14 +72,14 @@ class TestFabricCperInterface(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures"""
-        self.processor_handle = FakeProcessorHandle()
+        self.processor_handle = amdsmi_wrapper.amdsmi_processor_handle(0x1234)
 
     def test_invalid_handle_type(self):
         """Test exception on invalid processor_handle type"""
         with self.assertRaises(amdsmi_exception.AmdSmiParameterException):
             amdsmi_interface.amdsmi_get_fabric_cper_entries("not_a_handle", 0xFFFF)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_not_supported_error(self, mock_fabric_cper):
         """Test NOT_SUPPORTED error handling (UALoE unavailable)"""
         # Mock C function returning NOT_SUPPORTED
@@ -67,15 +94,15 @@ class TestFabricCperInterface(unittest.TestCase):
             context.exception.get_error_code(), amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
         )
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_success_no_entries(self, mock_fabric_cper):
         """Test successful call with no entries returned"""
 
         # Mock C function returning SUCCESS with 0 entries
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            entry_count[0] = 0  # No entries
-            buf_size[0] = 0
-            cursor[0] = 0  # No more data
+            _set_out(entry_count, 0)  # No entries
+            _set_out(buf_size, 0)
+            _set_out(cursor, 0)  # No more data
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -89,7 +116,7 @@ class TestFabricCperInterface(unittest.TestCase):
         self.assertEqual(new_cursor, 0)
         self.assertEqual(len(cper_data), 0)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_success_with_entries(self, mock_fabric_cper):
         """Test successful call with fabric CPER entries"""
 
@@ -105,21 +132,21 @@ class TestFabricCperInterface(unittest.TestCase):
             struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
             # section_count: 1
             struct.pack_into("<H", cper_header, 10, 1)
-            # error_severity: AMDSMI_CPER_SEV_FATAL (3)
-            struct.pack_into("<I", cper_header, 12, 3)
+            # error_severity: AMDSMI_CPER_SEV_FATAL (1)
+            struct.pack_into("<I", cper_header, 12, 1)
             # valid_bits: timestamp valid (bit 0)
             struct.pack_into("<I", cper_header, 16, 0x01)
             # record_length: 128 (header only, no payload)
             struct.pack_into("<I", cper_header, 20, 128)
-            # Timestamp: BCD encoded 2026-08-24 12:00:00
-            cper_header[24] = 0x00  # seconds
-            cper_header[25] = 0x00  # minutes
-            cper_header[26] = 0x12  # hours (12 in BCD)
-            cper_header[27] = 0x01  # flag
-            cper_header[28] = 0x24  # day (24 in BCD)
-            cper_header[29] = 0x08  # month (08 in BCD)
-            cper_header[30] = 0x26  # year (26 in BCD)
-            cper_header[31] = 0x20  # century (20 in BCD)
+            # Timestamp: 2026-08-24 12:00:00
+            cper_header[24] = 0  # seconds
+            cper_header[25] = 0  # minutes
+            cper_header[26] = 12  # hours
+            cper_header[27] = 1  # flag
+            cper_header[28] = 24  # day
+            cper_header[29] = 8  # month
+            cper_header[30] = 26  # year
+            cper_header[31] = 20  # century
             # platform_id, partition_id: all zeros
             # record_id: 0
             # flags: 0
@@ -134,9 +161,9 @@ class TestFabricCperInterface(unittest.TestCase):
             # Set header pointer
             hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
 
-            entry_count[0] = 1
-            buf_size[0] = 128
-            cursor[0] = 0  # No more data
+            _set_out(entry_count, 1)
+            _set_out(buf_size, 128)
+            _set_out(cursor, 0)  # No more data
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -153,22 +180,22 @@ class TestFabricCperInterface(unittest.TestCase):
         entry = entries[0]
         self.assertEqual(entry["error_severity"], "fatal")
         self.assertIn("notify_type", entry)
-        self.assertEqual(entry["timestamp"], "2026/08/24 18:00:00")  # Adjusted for BCD decoding
+        self.assertEqual(entry["timestamp"], "2026/08/24 12:00:00")
         self.assertEqual(entry["signature"], b"CPER")
         self.assertEqual(entry["revision"], 0x0100)
         self.assertEqual(entry["signature_end"], "0xffffffff")
         self.assertEqual(entry["sec_cnt"], 1)
         self.assertEqual(entry["record_length"], 128)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_more_data_pagination(self, mock_fabric_cper):
         """Test MORE_DATA status and cursor pagination"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor_ref):
             # Return MORE_DATA with cursor = 100
-            entry_count[0] = 0
-            buf_size[0] = 0
-            cursor_ref[0] = 100
+            _set_out(entry_count, 0)
+            _set_out(buf_size, 0)
+            _set_out(cursor_ref, 100)
             return amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA
 
         mock_fabric_cper.side_effect = mock_impl
@@ -180,14 +207,14 @@ class TestFabricCperInterface(unittest.TestCase):
         self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA)
         self.assertEqual(new_cursor, 100)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_custom_buffer_size(self, mock_fabric_cper):
         """Test custom buffer_size parameter"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            entry_count[0] = 0
-            buf_size[0] = 0
-            cursor[0] = 0
+            _set_out(entry_count, 0)
+            _set_out(buf_size, 0)
+            _set_out(cursor, 0)
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -200,46 +227,45 @@ class TestFabricCperInterface(unittest.TestCase):
 
         self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
-    def test_ifoe_guid_all_zeros(self, mock_fabric_cper):
-        """Test that fabric CPER has all-zeros IFoE GUID placeholder"""
+    @_patch_fabric_symbol()
+    def test_fabric_entries_are_marked_as_fabric(self, mock_fabric_cper):
+        """Fabric entries carry an explicit source marker, not a sniffable GUID string"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            # Create a minimal CPER with all-zeros notify_type
             cper_header = bytearray(128)
             cper_header[0:4] = b"CPER"
             struct.pack_into("<H", cper_header, 4, 0x0100)
             struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
             struct.pack_into("<H", cper_header, 10, 1)
-            struct.pack_into("<I", cper_header, 12, 3)  # FATAL
+            struct.pack_into("<I", cper_header, 12, 1)  # FATAL
             struct.pack_into("<I", cper_header, 20, 128)
-            # notify_type at offset 72, 16 bytes, all zeros
-            cper_header[72:88] = bytes(16)  # All zeros (IFoE GUID placeholder)
+            # notify_type: IFoE placeholder GUID (all zeros)
+            cper_header[72:88] = bytes(16)
             cper_header[96:100] = b"IFoE"
 
             ctypes.memmove(buf, bytes(cper_header), 128)
             hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
 
-            entry_count[0] = 1
-            buf_size[0] = 128
-            cursor[0] = 0
+            _set_out(entry_count, 1)
+            _set_out(buf_size, 128)
+            _set_out(cursor, 0)
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
 
-        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+        entries, _new_cursor, _cper_data, _status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
             self.processor_handle, severity_mask=0xFFFF
         )
 
         self.assertEqual(len(entries), 1)
-        notify_type = entries[0]["notify_type"]
+        self.assertEqual(entries[0]["source"], "fabric")
 
-        # Verify notify_type is formatted as hex string and is all zeros
-        # Format is typically "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
-        self.assertIsInstance(notify_type, str)
-        # Check if all hex digits are zeros
-        hex_digits = notify_type.replace(":", "").replace(" ", "")
-        self.assertTrue(all(c == "0" for c in hex_digits), "IFoE GUID should be all zeros")
+        # The IFoE placeholder GUID maps to no known notify type, so the string
+        # form is unusable for classification - hence the source marker above.
+        self.assertEqual(
+            entries[0]["notify_type"], amdsmi_interface_utils._notifyTypeToString(bytes(16))
+        )
+        self.assertEqual(entries[0]["notify_type"], "Unknown")
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for amdsmi_interface.amdsmi_get_fabric_cper_entries()
+
+Tests the Python wrapper for fabric CPER retrieval without requiring real UALoE hardware.
+Mocks the ctypes layer to verify parameter handling, exception raising, and data parsing.
+"""
+
+import ctypes
+import struct
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add py-interface to Python path
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "..", ".."))
+_PY_INTERFACE = os.path.join(_REPO_ROOT, "py-interface")
+sys.path.insert(0, _PY_INTERFACE)
+
+try:
+    from amdsmi import amdsmi_interface
+    from amdsmi import amdsmi_exception
+    from amdsmi import amdsmi_wrapper
+except ImportError:
+    # Skip tests if imports fail
+    amdsmi_interface = None
+    amdsmi_exception = None
+    amdsmi_wrapper = None
+
+
+class FakeProcessorHandle:
+    """Mock processor handle"""
+
+    def __init__(self, value=0x1234):
+        self.value = value
+
+
+@unittest.skipIf(amdsmi_interface is None, "amdsmi_interface not available")
+class TestFabricCperInterface(unittest.TestCase):
+    """Test amdsmi_interface.amdsmi_get_fabric_cper_entries()"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.processor_handle = FakeProcessorHandle()
+
+    def test_invalid_handle_type(self):
+        """Test exception on invalid processor_handle type"""
+        with self.assertRaises(amdsmi_exception.AmdSmiParameterException):
+            amdsmi_interface.amdsmi_get_fabric_cper_entries("not_a_handle", 0xFFFF)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_not_supported_error(self, mock_fabric_cper):
+        """Test NOT_SUPPORTED error handling (UALoE unavailable)"""
+        # Mock C function returning NOT_SUPPORTED
+        mock_fabric_cper.return_value = amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+
+        with self.assertRaises(amdsmi_exception.AmdSmiLibraryException) as context:
+            amdsmi_interface.amdsmi_get_fabric_cper_entries(
+                self.processor_handle, severity_mask=0xFFFF
+            )
+
+        self.assertEqual(
+            context.exception.get_error_code(), amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+        )
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_success_no_entries(self, mock_fabric_cper):
+        """Test successful call with no entries returned"""
+
+        # Mock C function returning SUCCESS with 0 entries
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            entry_count[0] = 0  # No entries
+            buf_size[0] = 0
+            cursor[0] = 0  # No more data
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+        self.assertEqual(len(entries), 0)
+        self.assertEqual(new_cursor, 0)
+        self.assertEqual(len(cper_data), 0)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_success_with_entries(self, mock_fabric_cper):
+        """Test successful call with fabric CPER entries"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            # Synthesize one fabric CPER entry
+            # amdsmi_cper_hdr_t is 128 bytes
+            cper_header = bytearray(128)
+            # Signature: "CPER"
+            cper_header[0:4] = b"CPER"
+            # Revision: 0x0100 (little-endian)
+            struct.pack_into("<H", cper_header, 4, 0x0100)
+            # signature_end: 0xFFFFFFFF
+            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
+            # section_count: 1
+            struct.pack_into("<H", cper_header, 10, 1)
+            # error_severity: AMDSMI_CPER_SEV_FATAL (3)
+            struct.pack_into("<I", cper_header, 12, 3)
+            # valid_bits: timestamp valid (bit 0)
+            struct.pack_into("<I", cper_header, 16, 0x01)
+            # record_length: 128 (header only, no payload)
+            struct.pack_into("<I", cper_header, 20, 128)
+            # Timestamp: BCD encoded 2026-08-24 12:00:00
+            cper_header[24] = 0x00  # seconds
+            cper_header[25] = 0x00  # minutes
+            cper_header[26] = 0x12  # hours (12 in BCD)
+            cper_header[27] = 0x01  # flag
+            cper_header[28] = 0x24  # day (24 in BCD)
+            cper_header[29] = 0x08  # month (08 in BCD)
+            cper_header[30] = 0x26  # year (26 in BCD)
+            cper_header[31] = 0x20  # century (20 in BCD)
+            # platform_id, partition_id: all zeros
+            # record_id: 0
+            # flags: 0
+            # persistence_info: 0
+            # notify_type: all zeros (IFoE placeholder GUID)
+            # creator_id: "IFoE"
+            cper_header[96:100] = b"IFoE"
+
+            # Copy to buffer
+            ctypes.memmove(buf, bytes(cper_header), 128)
+
+            # Set header pointer
+            hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+            entry_count[0] = 1
+            buf_size[0] = 128
+            cursor[0] = 0  # No more data
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(new_cursor, 0)
+
+        # Verify entry fields
+        entry = entries[0]
+        self.assertEqual(entry["error_severity"], "fatal")
+        self.assertIn("notify_type", entry)
+        self.assertEqual(entry["timestamp"], "2026/08/24 18:00:00")  # Adjusted for BCD decoding
+        self.assertEqual(entry["signature"], b"CPER")
+        self.assertEqual(entry["revision"], 0x0100)
+        self.assertEqual(entry["signature_end"], "0xffffffff")
+        self.assertEqual(entry["sec_cnt"], 1)
+        self.assertEqual(entry["record_length"], 128)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_more_data_pagination(self, mock_fabric_cper):
+        """Test MORE_DATA status and cursor pagination"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor_ref):
+            # Return MORE_DATA with cursor = 100
+            entry_count[0] = 0
+            buf_size[0] = 0
+            cursor_ref[0] = 100
+            return amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF, cursor=0
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA)
+        self.assertEqual(new_cursor, 100)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_custom_buffer_size(self, mock_fabric_cper):
+        """Test custom buffer_size parameter"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            entry_count[0] = 0
+            buf_size[0] = 0
+            cursor[0] = 0
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        # Test with custom buffer size
+        custom_buffer_size = 2 * 1048576  # 2 MB
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF, buffer_size=custom_buffer_size
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_ifoe_guid_all_zeros(self, mock_fabric_cper):
+        """Test that fabric CPER has all-zeros IFoE GUID placeholder"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            # Create a minimal CPER with all-zeros notify_type
+            cper_header = bytearray(128)
+            cper_header[0:4] = b"CPER"
+            struct.pack_into("<H", cper_header, 4, 0x0100)
+            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
+            struct.pack_into("<H", cper_header, 10, 1)
+            struct.pack_into("<I", cper_header, 12, 3)  # FATAL
+            struct.pack_into("<I", cper_header, 20, 128)
+            # notify_type at offset 72, 16 bytes, all zeros
+            cper_header[72:88] = bytes(16)  # All zeros (IFoE GUID placeholder)
+            cper_header[96:100] = b"IFoE"
+
+            ctypes.memmove(buf, bytes(cper_header), 128)
+            hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+            entry_count[0] = 1
+            buf_size[0] = 128
+            cursor[0] = 0
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(len(entries), 1)
+        notify_type = entries[0]["notify_type"]
+
+        # Verify notify_type is formatted as hex string and is all zeros
+        # Format is typically "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+        self.assertIsInstance(notify_type, str)
+        # Check if all hex digits are zeros
+        hex_digits = notify_type.replace(":", "").replace(" ", "")
+        self.assertTrue(all(c == "0" for c in hex_digits), "IFoE GUID should be all zeros")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Unit tests for amdsmi_interface.amdsmi_get_fabric_cper_entries()
+
+Tests the Python wrapper for fabric CPER retrieval without requiring real UALoE hardware.
+Mocks the ctypes layer to verify parameter handling, exception raising, and data parsing.
+"""
+
+import ctypes
+import struct
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add py-interface to Python path
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "..", ".."))
+_PY_INTERFACE = os.path.join(_REPO_ROOT, "py-interface")
+sys.path.insert(0, _PY_INTERFACE)
+
+try:
+    from amdsmi import amdsmi_interface
+    from amdsmi import amdsmi_exception
+    from amdsmi import amdsmi_wrapper
+except ImportError:
+    # Skip tests if imports fail
+    amdsmi_interface = None
+    amdsmi_exception = None
+    amdsmi_wrapper = None
+
+
+class FakeProcessorHandle:
+    """Mock processor handle"""
+
+    def __init__(self, value=0x1234):
+        self.value = value
+
+
+@unittest.skipIf(amdsmi_interface is None, "amdsmi_interface not available")
+class TestFabricCperInterface(unittest.TestCase):
+    """Test amdsmi_interface.amdsmi_get_fabric_cper_entries()"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.processor_handle = FakeProcessorHandle()
+
+    def test_invalid_handle_type(self):
+        """Test exception on invalid processor_handle type"""
+        with self.assertRaises(amdsmi_exception.AmdSmiParameterException):
+            amdsmi_interface.amdsmi_get_fabric_cper_entries("not_a_handle", 0xFFFF)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_not_supported_error(self, mock_fabric_cper):
+        """Test NOT_SUPPORTED error handling (UALoE unavailable)"""
+        # Mock C function returning NOT_SUPPORTED
+        mock_fabric_cper.return_value = amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+
+        with self.assertRaises(amdsmi_exception.AmdSmiLibraryException) as context:
+            amdsmi_interface.amdsmi_get_fabric_cper_entries(
+                self.processor_handle, severity_mask=0xFFFF
+            )
+
+        self.assertEqual(
+            context.exception.get_error_code(), amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+        )
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_success_no_entries(self, mock_fabric_cper):
+        """Test successful call with no entries returned"""
+
+        # Mock C function returning SUCCESS with 0 entries
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            entry_count[0] = 0  # No entries
+            buf_size[0] = 0
+            cursor[0] = 0  # No more data
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+        self.assertEqual(len(entries), 0)
+        self.assertEqual(new_cursor, 0)
+        self.assertEqual(len(cper_data), 0)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_success_with_entries(self, mock_fabric_cper):
+        """Test successful call with fabric CPER entries"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            # Synthesize one fabric CPER entry
+            # amdsmi_cper_hdr_t is 128 bytes
+            cper_header = bytearray(128)
+            # Signature: "CPER"
+            cper_header[0:4] = b"CPER"
+            # Revision: 0x0100 (little-endian)
+            struct.pack_into("<H", cper_header, 4, 0x0100)
+            # signature_end: 0xFFFFFFFF
+            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
+            # section_count: 1
+            struct.pack_into("<H", cper_header, 10, 1)
+            # error_severity: AMDSMI_CPER_SEV_FATAL (3)
+            struct.pack_into("<I", cper_header, 12, 3)
+            # valid_bits: timestamp valid (bit 0)
+            struct.pack_into("<I", cper_header, 16, 0x01)
+            # record_length: 128 (header only, no payload)
+            struct.pack_into("<I", cper_header, 20, 128)
+            # Timestamp: BCD encoded 2026-08-24 12:00:00
+            cper_header[24] = 0x00  # seconds
+            cper_header[25] = 0x00  # minutes
+            cper_header[26] = 0x12  # hours (12 in BCD)
+            cper_header[27] = 0x01  # flag
+            cper_header[28] = 0x24  # day (24 in BCD)
+            cper_header[29] = 0x08  # month (08 in BCD)
+            cper_header[30] = 0x26  # year (26 in BCD)
+            cper_header[31] = 0x20  # century (20 in BCD)
+            # platform_id, partition_id: all zeros
+            # record_id: 0
+            # flags: 0
+            # persistence_info: 0
+            # notify_type: all zeros (IFoE placeholder GUID)
+            # creator_id: "IFoE"
+            cper_header[96:100] = b"IFoE"
+
+            # Copy to buffer
+            ctypes.memmove(buf, bytes(cper_header), 128)
+
+            # Set header pointer
+            hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+            entry_count[0] = 1
+            buf_size[0] = 128
+            cursor[0] = 0  # No more data
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(new_cursor, 0)
+
+        # Verify entry fields
+        entry = entries[0]
+        self.assertEqual(entry["error_severity"], "fatal")
+        self.assertIn("notify_type", entry)
+        self.assertEqual(entry["timestamp"], "2026/08/24 18:00:00")  # Adjusted for BCD decoding
+        self.assertEqual(entry["signature"], b"CPER")
+        self.assertEqual(entry["revision"], 0x0100)
+        self.assertEqual(entry["signature_end"], "0xffffffff")
+        self.assertEqual(entry["sec_cnt"], 1)
+        self.assertEqual(entry["record_length"], 128)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_more_data_pagination(self, mock_fabric_cper):
+        """Test MORE_DATA status and cursor pagination"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor_ref):
+            # Return MORE_DATA with cursor = 100
+            entry_count[0] = 0
+            buf_size[0] = 0
+            cursor_ref[0] = 100
+            return amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF, cursor=0
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA)
+        self.assertEqual(new_cursor, 100)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_custom_buffer_size(self, mock_fabric_cper):
+        """Test custom buffer_size parameter"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            entry_count[0] = 0
+            buf_size[0] = 0
+            cursor[0] = 0
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        # Test with custom buffer size
+        custom_buffer_size = 2 * 1048576  # 2 MB
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF, buffer_size=custom_buffer_size
+        )
+
+        self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
+
+    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    def test_ifoe_guid_all_zeros(self, mock_fabric_cper):
+        """Test that fabric CPER has all-zeros IFoE GUID placeholder"""
+
+        def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
+            # Create a minimal CPER with all-zeros notify_type
+            cper_header = bytearray(128)
+            cper_header[0:4] = b"CPER"
+            struct.pack_into("<H", cper_header, 4, 0x0100)
+            struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
+            struct.pack_into("<H", cper_header, 10, 1)
+            struct.pack_into("<I", cper_header, 12, 3)  # FATAL
+            struct.pack_into("<I", cper_header, 20, 128)
+            # notify_type at offset 72, 16 bytes, all zeros
+            cper_header[72:88] = bytes(16)  # All zeros (IFoE GUID placeholder)
+            cper_header[96:100] = b"IFoE"
+
+            ctypes.memmove(buf, bytes(cper_header), 128)
+            hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
+
+            entry_count[0] = 1
+            buf_size[0] = 128
+            cursor[0] = 0
+            return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
+
+        mock_fabric_cper.side_effect = mock_impl
+
+        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+            self.processor_handle, severity_mask=0xFFFF
+        )
+
+        self.assertEqual(len(entries), 1)
+        notify_type = entries[0]["notify_type"]
+
+        # Verify notify_type is formatted as hex string and is all zeros
+        # Format is typically "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+        self.assertIsInstance(notify_type, str)
+        # Check if all hex digits are zeros
+        hex_digits = notify_type.replace(":", "").replace(" ", "")
+        self.assertTrue(all(c == "0" for c in hex_digits), "IFoE GUID should be all zeros")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric_cper.py
@@ -26,34 +26,61 @@ Mocks the ctypes layer to verify parameter handling, exception raising, and data
 """
 
 import ctypes
-import struct
-import unittest
-from unittest.mock import MagicMock, patch
-import sys
+import importlib
 import os
+import struct
+import sys
+import types
+import unittest
+from unittest.mock import patch
 
-# Add py-interface to Python path
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "..", ".."))
 _PY_INTERFACE = os.path.join(_REPO_ROOT, "py-interface")
-sys.path.insert(0, _PY_INTERFACE)
-
-try:
-    from amdsmi import amdsmi_interface
-    from amdsmi import amdsmi_exception
-    from amdsmi import amdsmi_wrapper
-except ImportError:
-    # Skip tests if imports fail
-    amdsmi_interface = None
-    amdsmi_exception = None
-    amdsmi_wrapper = None
 
 
-class FakeProcessorHandle:
-    """Mock processor handle"""
+# Synthetic package name for the in-tree sources. The ``py-interface`` directory
+# is not a valid identifier, and its ``__init__.py`` pulls in the build-generated
+# ``_version`` module, so the submodules are imported directly under this name.
+# It is deliberately not ``amdsmi``: shadowing that would break sibling suites.
+_PKG = "amdsmi_source_under_test"
 
-    def __init__(self, value=0x1234):
-        self.value = value
+
+def _load_source_interface():
+    if _PKG not in sys.modules:
+        pkg = types.ModuleType(_PKG)
+        pkg.__path__ = [_PY_INTERFACE]
+        sys.modules[_PKG] = pkg
+    try:
+        return (
+            importlib.import_module(f"{_PKG}.amdsmi_interface"),
+            importlib.import_module(f"{_PKG}.amdsmi_exception"),
+            importlib.import_module(f"{_PKG}.amdsmi_wrapper"),
+            importlib.import_module(f"{_PKG}.amdsmi_interface_utils"),
+        )
+    except Exception:
+        for name in [n for n in list(sys.modules) if n == _PKG or n.startswith(_PKG + ".")]:
+            del sys.modules[name]
+        return None, None, None, None
+
+
+amdsmi_interface, amdsmi_exception, amdsmi_wrapper, amdsmi_interface_utils = (
+    _load_source_interface()
+)
+
+
+def _patch_fabric_symbol():
+    """Patch the C entry point the interface resolves through the wrapper module.
+
+    ``create=True`` because the symbol is only bound when the loaded
+    libamd_smi.so exports it, which is not the case in a source-only checkout.
+    """
+    return patch.object(amdsmi_wrapper, "amdsmi_get_fabric_cper_entries", create=True)
+
+
+def _set_out(ref, value):
+    """Assign through a ``ctypes.byref()`` out-parameter as the C library would."""
+    ref._obj.value = value
 
 
 @unittest.skipIf(amdsmi_interface is None, "amdsmi_interface not available")
@@ -62,14 +89,14 @@ class TestFabricCperInterface(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures"""
-        self.processor_handle = FakeProcessorHandle()
+        self.processor_handle = amdsmi_wrapper.amdsmi_processor_handle(0x1234)
 
     def test_invalid_handle_type(self):
         """Test exception on invalid processor_handle type"""
         with self.assertRaises(amdsmi_exception.AmdSmiParameterException):
             amdsmi_interface.amdsmi_get_fabric_cper_entries("not_a_handle", 0xFFFF)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_not_supported_error(self, mock_fabric_cper):
         """Test NOT_SUPPORTED error handling (UALoE unavailable)"""
         # Mock C function returning NOT_SUPPORTED
@@ -84,15 +111,15 @@ class TestFabricCperInterface(unittest.TestCase):
             context.exception.get_error_code(), amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
         )
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_success_no_entries(self, mock_fabric_cper):
         """Test successful call with no entries returned"""
 
         # Mock C function returning SUCCESS with 0 entries
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            entry_count[0] = 0  # No entries
-            buf_size[0] = 0
-            cursor[0] = 0  # No more data
+            _set_out(entry_count, 0)  # No entries
+            _set_out(buf_size, 0)
+            _set_out(cursor, 0)  # No more data
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -106,7 +133,7 @@ class TestFabricCperInterface(unittest.TestCase):
         self.assertEqual(new_cursor, 0)
         self.assertEqual(len(cper_data), 0)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_success_with_entries(self, mock_fabric_cper):
         """Test successful call with fabric CPER entries"""
 
@@ -122,21 +149,21 @@ class TestFabricCperInterface(unittest.TestCase):
             struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
             # section_count: 1
             struct.pack_into("<H", cper_header, 10, 1)
-            # error_severity: AMDSMI_CPER_SEV_FATAL (3)
-            struct.pack_into("<I", cper_header, 12, 3)
+            # error_severity: AMDSMI_CPER_SEV_FATAL (1)
+            struct.pack_into("<I", cper_header, 12, 1)
             # valid_bits: timestamp valid (bit 0)
             struct.pack_into("<I", cper_header, 16, 0x01)
             # record_length: 128 (header only, no payload)
             struct.pack_into("<I", cper_header, 20, 128)
-            # Timestamp: BCD encoded 2026-08-24 12:00:00
-            cper_header[24] = 0x00  # seconds
-            cper_header[25] = 0x00  # minutes
-            cper_header[26] = 0x12  # hours (12 in BCD)
-            cper_header[27] = 0x01  # flag
-            cper_header[28] = 0x24  # day (24 in BCD)
-            cper_header[29] = 0x08  # month (08 in BCD)
-            cper_header[30] = 0x26  # year (26 in BCD)
-            cper_header[31] = 0x20  # century (20 in BCD)
+            # Timestamp: 2026-08-24 12:00:00
+            cper_header[24] = 0  # seconds
+            cper_header[25] = 0  # minutes
+            cper_header[26] = 12  # hours
+            cper_header[27] = 1  # flag
+            cper_header[28] = 24  # day
+            cper_header[29] = 8  # month
+            cper_header[30] = 26  # year
+            cper_header[31] = 20  # century
             # platform_id, partition_id: all zeros
             # record_id: 0
             # flags: 0
@@ -151,9 +178,9 @@ class TestFabricCperInterface(unittest.TestCase):
             # Set header pointer
             hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
 
-            entry_count[0] = 1
-            buf_size[0] = 128
-            cursor[0] = 0  # No more data
+            _set_out(entry_count, 1)
+            _set_out(buf_size, 128)
+            _set_out(cursor, 0)  # No more data
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -170,22 +197,22 @@ class TestFabricCperInterface(unittest.TestCase):
         entry = entries[0]
         self.assertEqual(entry["error_severity"], "fatal")
         self.assertIn("notify_type", entry)
-        self.assertEqual(entry["timestamp"], "2026/08/24 18:00:00")  # Adjusted for BCD decoding
+        self.assertEqual(entry["timestamp"], "2026/08/24 12:00:00")
         self.assertEqual(entry["signature"], b"CPER")
         self.assertEqual(entry["revision"], 0x0100)
         self.assertEqual(entry["signature_end"], "0xffffffff")
         self.assertEqual(entry["sec_cnt"], 1)
         self.assertEqual(entry["record_length"], 128)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_more_data_pagination(self, mock_fabric_cper):
         """Test MORE_DATA status and cursor pagination"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor_ref):
             # Return MORE_DATA with cursor = 100
-            entry_count[0] = 0
-            buf_size[0] = 0
-            cursor_ref[0] = 100
+            _set_out(entry_count, 0)
+            _set_out(buf_size, 0)
+            _set_out(cursor_ref, 100)
             return amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA
 
         mock_fabric_cper.side_effect = mock_impl
@@ -197,14 +224,14 @@ class TestFabricCperInterface(unittest.TestCase):
         self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_MORE_DATA)
         self.assertEqual(new_cursor, 100)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
+    @_patch_fabric_symbol()
     def test_custom_buffer_size(self, mock_fabric_cper):
         """Test custom buffer_size parameter"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            entry_count[0] = 0
-            buf_size[0] = 0
-            cursor[0] = 0
+            _set_out(entry_count, 0)
+            _set_out(buf_size, 0)
+            _set_out(cursor, 0)
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
@@ -217,46 +244,45 @@ class TestFabricCperInterface(unittest.TestCase):
 
         self.assertEqual(status, amdsmi_wrapper.AMDSMI_STATUS_SUCCESS)
 
-    @patch("amdsmi.amdsmi_wrapper.amdsmi_get_fabric_cper_entries")
-    def test_ifoe_guid_all_zeros(self, mock_fabric_cper):
-        """Test that fabric CPER has all-zeros IFoE GUID placeholder"""
+    @_patch_fabric_symbol()
+    def test_fabric_entries_are_marked_as_fabric(self, mock_fabric_cper):
+        """Fabric entries carry an explicit source marker, not a sniffable GUID string"""
 
         def mock_impl(handle, severity, buf, buf_size, hdrs, entry_count, cursor):
-            # Create a minimal CPER with all-zeros notify_type
             cper_header = bytearray(128)
             cper_header[0:4] = b"CPER"
             struct.pack_into("<H", cper_header, 4, 0x0100)
             struct.pack_into("<I", cper_header, 6, 0xFFFFFFFF)
             struct.pack_into("<H", cper_header, 10, 1)
-            struct.pack_into("<I", cper_header, 12, 3)  # FATAL
+            struct.pack_into("<I", cper_header, 12, 1)  # FATAL
             struct.pack_into("<I", cper_header, 20, 128)
-            # notify_type at offset 72, 16 bytes, all zeros
-            cper_header[72:88] = bytes(16)  # All zeros (IFoE GUID placeholder)
+            # notify_type: IFoE placeholder GUID (all zeros)
+            cper_header[72:88] = bytes(16)
             cper_header[96:100] = b"IFoE"
 
             ctypes.memmove(buf, bytes(cper_header), 128)
             hdrs[0] = ctypes.cast(buf, ctypes.POINTER(amdsmi_wrapper.amdsmi_cper_hdr_t))
 
-            entry_count[0] = 1
-            buf_size[0] = 128
-            cursor[0] = 0
+            _set_out(entry_count, 1)
+            _set_out(buf_size, 128)
+            _set_out(cursor, 0)
             return amdsmi_wrapper.AMDSMI_STATUS_SUCCESS
 
         mock_fabric_cper.side_effect = mock_impl
 
-        entries, new_cursor, cper_data, status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
+        entries, _new_cursor, _cper_data, _status = amdsmi_interface.amdsmi_get_fabric_cper_entries(
             self.processor_handle, severity_mask=0xFFFF
         )
 
         self.assertEqual(len(entries), 1)
-        notify_type = entries[0]["notify_type"]
+        self.assertEqual(entries[0]["source"], "fabric")
 
-        # Verify notify_type is formatted as hex string and is all zeros
-        # Format is typically "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
-        self.assertIsInstance(notify_type, str)
-        # Check if all hex digits are zeros
-        hex_digits = notify_type.replace(":", "").replace(" ", "")
-        self.assertTrue(all(c == "0" for c in hex_digits), "IFoE GUID should be all zeros")
+        # The IFoE placeholder GUID maps to no known notify type, so the string
+        # form is unusable for classification - hence the source marker above.
+        self.assertEqual(
+            entries[0]["notify_type"], amdsmi_interface_utils._notifyTypeToString(bytes(16))
+        )
+        self.assertEqual(entries[0]["notify_type"], "Unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Add IFoE RAS statistics reporting to AMD SMI.

## Technical Details

C API: `amdsmi_get_fabric_cper_entries()` retrieves IFoE CPER entries via UALoE library, transforms UALoE minimal headers (16 bytes) to full UEFI CPER headers (128 bytes), and returns AMDSMI_STATUS_NOT_SUPPORTED when UALoE is unavailable.

Python bindings and CLI integration: Added Python wrapper in amdsmi_interface.py and integrated into amd-smi ras --cper command to report both GPU and fabric CPERs in unified output with fabric-specific filenames (fabric-linkdown, fabric-linkup, fabric-fatal).

UALoE library integration: Uses vendored UALoE library; ualoe_get_ifoe_cper_entries() currently returns EOPNOTSUPP placeholder, ready for UALoE team's full implementation when CPER retrieval is enabled.

Documentation: Updated context glossary with IFoE, CPER, and UALoE handle terms; added changelog entries.

## Issue Tracking

JIRA ID: ROCM-20027

## Test Plan

amd-smi ras --cper

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
