### PR TITLE
test(rocprofiler-compute): Regen golden workloads to out/{pass}/ per-process artifacts (Phase C-2)

### DIFF
--- a/projects/rocprofiler-compute/tests/workloads/REGEN_PHASE_C.md
+++ b/projects/rocprofiler-compute/tests/workloads/REGEN_PHASE_C.md
@@ -1,0 +1,41 @@
+# Golden workload regeneration for Phase C
+
+Golden workloads in this directory still carry `results_*.csv.gz` and `pmc_perf.csv.gz`.
+Re-profile each arch on matching hardware, then commit the new `out/{pass}/` trees.
+
+Delete this file once regeneration is complete.
+
+## Checklist per arch
+
+1. Re-profile on matching hardware.
+2. Delete `results_*.csv.gz` and `pmc_perf.csv.gz` from each workload directory.
+3. Confirm `out/` artifacts stage correctly:
+
+```bash
+git check-ignore -v tests/workloads/<name>/<arch>/out/<pass>/<pid>/<pid>.db
+# should match the negation rule in .gitignore, not '**/out'
+```
+
+4. Verify:
+
+```bash
+python3 -m pytest tests/integration/test_analyze_workloads.py -k <ARCH> -q
+```
+
+## Expected layout
+
+```
+tests/workloads/<name>/<arch>/
+├── out/
+│   └── <pass>/
+│       ├── <pid>_native_counter_collection.csv.gz
+│       └── <pid>/
+│           └── <pid>.db
+├── profiling_config.yaml
+├── sysinfo.csv
+└── timestamps.csv
+```
+
+## Hardware
+
+MI100, MI200, MI300A, MI300A_A1, MI300X_A1, MI350, and RDNA35_HALO.


### PR DESCRIPTION
## Motivation

#10647 removes profile-side data merge so profile keeps per process per PID profiling data in separate lanes (SDK kernel rocpd and native counter compressed CSV) under `out/{pass}/`, and analyze merges them at read time. Analyze no longer reads legacy `results_*.csv.gz`.

This PR is fixture data only, no functional changes. It is stacked on #10647 and should merge with it so CI is green for the stack.

## Technical Details

Stack: `compress-pmcperf` (#10488) → `remove-data-merge` (#10647) → this PR

Current diff: adds `tests/workloads/REGEN_PHASE_C.md` (regen checklist; delete when done).

Regen commits (pending) will, for each golden workload arch:

1. Re-profile on matching hardware.
2. Add `out/{pass}/` per-process artifacts:
   - `{pid}_native_counter_collection.csv.gz` (native counter lane)
   - `{hostname}/{pid}.db` (SDK kernel rocpd lane)
3. Remove legacy `results_*.csv.gz` and stale `pmc_perf.csv.gz`.
4. Remove `REGEN_PHASE_C.md` when complete.

Target layout (per [profile interface architecture](projects/rocprofiler-compute/docs/design/profile_interface_architecture.md), Phase C):
