### PR TITLE
hip-tests: run Unit_HRR_ZeroInitRoundtrip only on gfx950

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -191,6 +191,7 @@ hrr:
     tags: [capture, playback, roundtrip, repro]
   Unit_HRR_ZeroInitRoundtrip:
     <<: *level_2
+    disabled: [amd_linux, amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
     tags: [capture, playback, roundtrip, repro]
   Unit_HRR_DivergenceAbortRoundtrip:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -191,7 +191,8 @@ hrr:
     tags: [capture, playback, roundtrip, repro]
   Unit_HRR_ZeroInitRoundtrip:
     <<: *level_2
-    disabled: [amd_linux, amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
+    # Enabled only on gfx950; skipped on other compile-time arches/platforms.
+    disabled: [gfx900, gfx906, gfx908, gfx90a, gfx942, gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201, gfx1202, gfx1250, amdgcnspirv, windows, linux, amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
     tags: [capture, playback, roundtrip, repro]
   Unit_HRR_DivergenceAbortRoundtrip:
     <<: *level_2


### PR DESCRIPTION
## Summary
- Keep `Unit_HRR_ZeroInitRoundtrip` enabled on gfx950 catch builds.
- Disable it on other compile-time architectures and on Windows / WSL / NVIDIA platforms via the HRR YAML `disabled` list.

## Test plan
- [x] Rebuilt `HrrTest` for gfx950; generated config tags the case `[gfx950]` without `[disabled]`.
- [x] Earlier GPU 6 `ctest` run confirmed HrrTest still builds and executes; this change re-enables the ZeroInit case on gfx950 only.