### PR TITLE
fix(rccl): use MI450 cooperative 128-bit builtins and explicit vector loads/stores in LL128

### DIFF
--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -13,32 +13,36 @@
 #include "rccl_ptr.h"
 
 inline __device__ void load128(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   union {
     v4u v;
+    v4i vi;
     uint64_t u64[2];
   } u;
-  u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)ptr, RCCL_SYSTEM_SYNCSCOPE);
+#if __has_builtin(__builtin_amdgcn_cooperative_atomic_load_8x16B) && defined(__gfx1250__)
+  u.vi = __builtin_amdgcn_cooperative_atomic_load_8x16B((v4i_gptr)ptr, __ATOMIC_RELAXED, RCCL_DEVICE_SYNCSCOPE);
+#elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+  u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)ptr, RCCL_DEVICE_SYNCSCOPE);
+#else
+  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
+#endif
   v0 = u.u64[0];
   v1 = u.u64[1];
-#else
-  v0 = __builtin_nontemporal_load((u64_gptr)ptr);
-  v1 = __builtin_nontemporal_load((u64_gptr)ptr + 1);
-#endif
 }
 
 inline __device__ void store128(uint64_t* ptr, uint64_t v0, uint64_t v1) {
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   union {
     v4u v;
+    v4i vi;
     uint64_t u64[2];
   } u;
   u.u64[0] = v0;
   u.u64[1] = v1;
+#if __has_builtin(__builtin_amdgcn_cooperative_atomic_store_8x16B) && defined(__gfx1250__)
+  __builtin_amdgcn_cooperative_atomic_store_8x16B((v4i_gptr)ptr, u.vi, __ATOMIC_RELAXED, RCCL_SYSTEM_SYNCSCOPE);
+#elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   __builtin_amdgcn_global_store_b128((v4u_gptr)ptr, u.v, RCCL_SYSTEM_SYNCSCOPE);
 #else
-  *((u64_gptr)ptr) = v0;
-  *((u64_gptr)ptr + 1) = v1;
+  *((v4u_gptr)ptr) = u.v;
 #endif
 }
 
@@ -370,8 +374,7 @@ DEFINE_ld_st__size(1, uint8_t, b8, r) DEFINE_ld_st__size(2, uint16_t, b16, h) DE
 #elif defined(__gfx950__)
   *(v4u_gptr)addr = value.v4u;
 #else
-  __builtin_nontemporal_store(value.u64[0], (u64_gptr)addr);
-  __builtin_nontemporal_store(value.u64[1], (u64_gptr)addr + 1);
+  __builtin_nontemporal_store(value.v4u, (v4u_gptr)addr);
 #endif
 }
 
@@ -381,8 +384,7 @@ __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr) {
   // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
   ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr)addr, RCCL_SYSTEM_SYNCSCOPE);
 #else
-  *(u64_gptr)ans.u64 = __builtin_nontemporal_load((u64_gptr)addr);
-  *((u64_gptr)ans.u64 + 1) = __builtin_nontemporal_load((u64_gptr)addr + 1);
+  (*(v4u_gptr)ans.u64) = __builtin_nontemporal_load((v4u_gptr)addr);
 #endif
   return ans;
 }
@@ -391,8 +393,7 @@ __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr) {
   template <> \
   __device__ __forceinline__ BytePack<16> ld_##space<16>(addr_cxx_ty addr) { \
     BytePack<16> ans; \
-    ans.u64[0] = *((uint64_t*)addr); \
-    ans.u64[1] = *((uint64_t*)addr + 1); \
+    ans.v4u = *((v4u_gptr)addr); \
     return ans; \
   } \
   template <> \

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -23,8 +23,13 @@
 // builtins introduce in the LL128 reduce kernels. The cache-bypassing load128/
 // store128 remain in use for user buffers (loadRegsBegin/storeRegs).
 inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
-  v0 = __builtin_nontemporal_load((u64_gptr)ptr);
-  v1 = __builtin_nontemporal_load((u64_gptr)ptr + 1);
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
+  v0 = u.u64[0];
+  v1 = u.u64[1];
 }
 
 // Plain (cacheable) 128-bit store. This is the pre-cache-bypass February store

--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -50,8 +50,11 @@ using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 #endif
 
 typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int v4u;
+typedef __attribute__((__vector_size__(4 * sizeof(int)))) int v4i;
 typedef __attribute__((address_space(1))) v4u* v4u_gptr;
+typedef __attribute__((address_space(1))) v4i* v4i_gptr;
 
 // "" means system scope, "agent" means device.  Adding this here because I don't think it's obvious otherwise that
 // "" means system scope.
 #define RCCL_SYSTEM_SYNCSCOPE ""
+#define RCCL_DEVICE_SYNCSCOPE "agent"


### PR DESCRIPTION
## Summary

- Add gfx1250 (MI450) cooperative atomic 128-bit load/store builtins for user-registered buffers in LL128, gated behind `__has_builtin` and `__gfx1250__`
- Define `RCCL_DEVICE_SYNCSCOPE` (`"agent"`) and signed `v4i`/`v4i_gptr` types needed by the cooperative atomics, while keeping unsigned `v4u` for existing global b128 intrinsics
- Replace unsafe paired 8-byte load/store patterns that relied on the compiler fusing two lanes into a single 16-byte vector op with explicit `v4u` vector nontemporal loads/stores in `load128`, `load128NT`, `load16global`, and related paths

This is still technically unsafe in the sense that correctness depends on the compiler emitting the intended global vector instructions, but it is a meaningful improvement over issuing two independent 8-byte operations per lane and hoping they get fused into a single 16-byte operation per lane.  Currently, we depend on the compiler optimizing that.  If it doesn't we're hosed.  This fixes that.

I'm not sure why, but some of the builtins operate on a vector of signed integers (new cooperative atomics builtins), while the previous ones expect a vector of unsigned integers.  This explains why the code is a bit gross with both v4i and v4u and their associated global pointer types floating around.

## Changes

- **`rccl_ptr.h`**: add `v4i`/`v4i_gptr` and `RCCL_DEVICE_SYNCSCOPE`
- **`op128.h`**: gfx1250 registered-buffer path uses cooperative atomic load/store; fallback paths use explicit 16-byte vector ops instead of two 8-byte ops; loads use agent scope, stores use system scope
- **`prims_ll128.h`**: `load128NT` uses a single explicit 16-byte nontemporal vector load

## Test plan

- [x] `ONLY_FUNCS=SendRecv ./install.sh -l` builds cleanly for gfx1250
- [ ] LL128 collectives on MI450 with user-registered buffers
- [ ] LL128 collectives on gfx942/gfx950 (non-gfx1250 fallback paths unchanged aside from explicit vector loads/stores)
- [ ] Verify assembly emits `global_load/store_dwordx4` or cooperative atomic 128-bit ops rather than paired flat/dword loads


Made with [Cursor](https://cursor.com)