### PR TITLE
AIRUNTIME-2310 - Support SDMA user queue

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -791,6 +791,11 @@ typedef struct _HsaQueueResource
     };
 
     volatile HSAint64* ErrorReason;  /** exception bits signal payload */
+
+    /** GPU virtual address of the WDDM HwQueue progress fence backing a native
+     *  SDMA user queue (Windows/DXG only). ROCr reads this to emit a matching
+     *  SDMA FENCE packet into the ring. 0 for every other queue type/platform. */
+    HSAuint64 SdmaProgressFenceVA;
 } HsaQueueResource;
 
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -791,6 +791,17 @@ typedef struct _HsaQueueResource
     };
 
     volatile HSAint64* ErrorReason;  /** exception bits signal payload */
+
+    /** GPU virtual address of the WDDM HwQueue progress fence backing a native
+     *  SDMA user queue (Windows/DXG only). ROCr reads this to emit a matching
+     *  SDMA FENCE packet into the ring. 0 for every other queue type/platform. */
+    HSAuint64 SdmaProgressFenceVA;
+
+    /** Byte count of the FENCE+TRAP epilogue that libhsakmt appends to the ring on
+     *  every native SDMA HwQueue doorbell (Windows/DXG only). The producer must
+     *  reserve this many extra bytes per submit so its write index stays in step
+     *  with the submitted wptr. 0 for every other queue type/platform. */
+    HSAuint32 SdmaHwQueueEpilogueBytes;
 } HsaQueueResource;
 
 

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
@@ -161,6 +161,7 @@ public:
   bool SupportStateShadowingByCpFw(void) const { return device_info_.state_shadowing_by_cpfw; }
   bool SupportPlatformAtomic(void) const { return device_info_.platform_atomic_support; }
   bool IsAqlSupported() const { return device_info_.hwsInfo.hwsMask.aql_queue != 0; }
+  bool IsSdmaSupported() const { return device_info_.hwsInfo.hwsMask.sdma_queue != 0; }
 
   uint32_t GetSdmaEngine(uint32_t idx) {
     assert(idx < NumSdmaEngine());
@@ -193,6 +194,9 @@ public:
                       uint64_t command_size, uint64_t fence_value);
   bool SubmitToAqlQueue(WDDMQueue* queue, uint64_t command_addr, uint64_t command_size,
                         uint64_t SubmitToAqlQueue);
+  // Native HSA SDMA user-queue submit: rings the WDDM HwQueue doorbell for a
+  // ring whose packets (including the progress FENCE/TRAP) were written by ROCr.
+  bool SubmitToSdmaHwQueue(WDDMQueue* queue, uint64_t wptr_in_bytes);
 
   bool WaitPagingFence(WDDMQueue *queue) {
     uint64_t value = page_fence_value_;
@@ -259,7 +263,8 @@ private:
   bool DestroyPagingQueue(void);
   void *Lock(D3DKMT_HANDLE handle);
   bool Unlock(D3DKMT_HANDLE handle);
-  bool CreateContext(int engine, D3DKMT_HANDLE *handle, uint64_t debugger_data = 0);
+  bool CreateContext(int engine, D3DKMT_HANDLE *handle, uint64_t debugger_data = 0,
+                     bool rocr_client = false);
   bool DestroyContext(D3DKMT_HANDLE handle);
 
   void SetPowerOptimization(bool restore);

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
@@ -165,6 +165,7 @@ public:
   bool SupportStateShadowingByCpFw(void) const { return device_info_.state_shadowing_by_cpfw; }
   bool SupportPlatformAtomic(void) const { return device_info_.platform_atomic_support; }
   bool IsAqlSupported() const { return device_info_.hwsInfo.hwsMask.aql_queue != 0; }
+  bool IsSdmaSupported() const { return device_info_.hwsInfo.hwsMask.sdma_queue != 0; }
 
   uint32_t GetSdmaEngine(uint32_t idx) {
     assert(idx < NumSdmaEngine());
@@ -197,6 +198,9 @@ public:
                       uint64_t command_size, uint64_t fence_value);
   bool SubmitToAqlQueue(WDDMQueue* queue, uint64_t command_addr, uint64_t command_size,
                         uint64_t SubmitToAqlQueue);
+  // Native HSA SDMA user-queue submit: rings the WDDM HwQueue doorbell for a
+  // ring whose packets (including the progress FENCE/TRAP) were written by ROCr.
+  bool SubmitToSdmaHwQueue(WDDMQueue* queue, uint64_t wptr_in_bytes);
 
   bool WaitPagingFence(WDDMQueue *queue) {
     uint64_t value = page_fence_value_;
@@ -267,7 +271,8 @@ private:
   bool DestroyPagingQueue(void);
   void *Lock(D3DKMT_HANDLE handle);
   bool Unlock(D3DKMT_HANDLE handle);
-  bool CreateContext(int engine, D3DKMT_HANDLE *handle, uint64_t debugger_data = 0);
+  bool CreateContext(int engine, D3DKMT_HANDLE *handle, uint64_t debugger_data = 0,
+                     bool rocr_client = false);
   bool DestroyContext(D3DKMT_HANDLE handle);
 
   void SetPowerOptimization(bool restore);

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -88,6 +88,11 @@ public:
   virtual void RingDoorbell(uint64_t value) { }
   virtual void* GetHsaQueueAddr(void) const { return reinterpret_cast<void*>(GetCmdbufAddr()); }
 
+  //!< True only for a native WDDM SDMA user queue; false for every other queue
+  //!< kind. Overridden by SDMAQueue so callers can discriminate without an RTTI
+  //!< down-cast.
+  virtual bool IsNativeSdma(void) const { return false; }
+
   hsa_status_t SwsInit(void);
   hsa_status_t SwsFini(void);
   hsa_status_t SwsSubmit(uint64_t command_addr,
@@ -141,6 +146,13 @@ public:
   std::atomic<uint64_t>* ring_rptr = nullptr;
 
   uint32_t aql_doorbell_offset_ = 0; //!< Doorbell offset for this AQL queue
+
+  //!< GPU VA of the WDDM HwQueue progress fence (native SDMA user queue only).
+  //!< Populated by WDDMDevice::CreateHwQueue and surfaced to ROCr so the SDMA
+  //!< ring can emit a matching FENCE packet. 0 when not a native SDMA queue.
+  uint64_t hwqueue_progress_fence_va_ = 0;
+  //!< Monotonic HwQueue progress fence id, incremented per native SDMA submit.
+  uint64_t hwqueue_fence_id_ = 0;
 };
 
 class ComputeQueue : public WDDMQueue {
@@ -300,7 +312,13 @@ public:
   void RingDoorbell(uint64_t value);
   void* GetHsaQueueAddr(void) const { return reinterpret_cast<void*>(GetCmdbufAddr()); }
 
+  //!< True when this queue submits via the native WDDM SDMA HwQueue path
+  //!< (KMD advertises support and HWS is enabled) instead of the SWS thread.
+  //!< Overrides WDDMQueue::IsNativeSdma so callers need no RTTI down-cast.
+  bool IsNativeSdma(void) const { return native_sdma_; }
+
 private:
+  bool native_sdma_ = false;
   uint64_t wptr_next_;
   uint64_t wptr_pre_;
   uint64_t rptr_next;

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/queue.h
@@ -91,6 +91,11 @@ public:
   // amd_queue_t backing memory; only ComputeQueue has one, SDMAQueue returns nullptr.
   virtual GpuMemory* GetAmdQueueMemory(void) const { return nullptr; }
 
+  //!< True only for a native WDDM SDMA user queue; false for every other queue
+  //!< kind. Overridden by SDMAQueue so callers can discriminate without an RTTI
+  //!< down-cast.
+  virtual bool IsNativeSdma(void) const { return false; }
+
   hsa_status_t SwsInit(void);
   hsa_status_t SwsFini(void);
   hsa_status_t SwsSubmit(uint64_t command_addr,
@@ -150,6 +155,13 @@ public:
   D3DKMT_HANDLE cwsr_mem_handle_ = 0;           //!< KMT allocation handle of CWSR region (passed as CwsrMemHandle)
   volatile int64_t* error_reason_ = nullptr;     //!< ErrorReason payload ptr (QueueResource::ErrorReason)
   HSAuint32 error_event_id_ = 0;                 //!< ErrorEventId from HsaEvent::EventId (0 if no event)
+
+  //!< GPU VA of the WDDM HwQueue progress fence (native SDMA user queue only).
+  //!< Populated by WDDMDevice::CreateHwQueue and surfaced to ROCr so the SDMA
+  //!< ring can emit a matching FENCE packet. 0 when not a native SDMA queue.
+  uint64_t hwqueue_progress_fence_va_ = 0;
+  //!< Monotonic HwQueue progress fence id, incremented per native SDMA submit.
+  uint64_t hwqueue_fence_id_ = 0;
 };
 
 class ComputeQueue : public WDDMQueue {
@@ -310,7 +322,26 @@ public:
   void RingDoorbell(uint64_t value);
   void* GetHsaQueueAddr(void) const { return reinterpret_cast<void*>(GetCmdbufAddr()); }
 
+  //!< True when this queue submits via the native WDDM SDMA HwQueue path
+  //!< (KMD advertises support and HWS is enabled) instead of the SWS thread.
+  //!< Overrides WDDMQueue::IsNativeSdma so callers need no RTTI down-cast.
+  bool IsNativeSdma(void) const { return native_sdma_; }
+
+  //!< Bytes appended per native-SDMA doorbell: one SDMA_PKT_FENCE_CONDITIONAL_INTERRUPT
+  //!< (8 dwords). Single source of truth for RingDoorbell (writes it) and the
+  //!< producer-reserved headroom advertised via HsaQueueResource::SdmaHwQueueEpilogueBytes.
+  static constexpr uint32_t kHwQueueEpilogueBytes = 8 * 4;
+
+  //!< GpuMemory backing the amd_queue_t the KMD's SDMA-AQL HwQueue reports read_dispatch_id
+  //!< (rptr) into. The KMD requires a valid AmdQueueT allocation for an SDMA-AQL queue;
+  //!< allocated in the ctor before CreateQueue so the handle exists at CreateHwQueue time.
+  //!< nullptr for the legacy SWS path.
+  GpuMemory* GetAmdQueueMemory(void) const { return amd_queue_memory_; }
+
 private:
+  GpuMemory* amd_queue_memory_ = nullptr;
+  uint64_t amd_queue_addr_ = 0;
+  bool native_sdma_ = false;
   uint64_t wptr_next_;
   uint64_t wptr_pre_;
   uint64_t rptr_next;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
@@ -141,6 +141,13 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateQueueV2(HSAuint32 NodeId,
     QueueResource->Queue_DoorBell_aql = queue_->GetDoorbellPtr();
     QueueResource->Queue_write_ptr_aql = queue_->GetRingWptr();
     QueueResource->Queue_read_ptr_aql = queue_->GetRingRptr();
+    // Native SDMA user queue exposes the HwQueue progress-fence VA so ROCr can
+    // emit a matching FENCE packet; 0 for the SWS-thread path.
+    QueueResource->SdmaProgressFenceVA = queue_->hwqueue_progress_fence_va_;
+    // Tell the producer how many epilogue bytes RingDoorbell will append per submit
+    // so it reserves matching headroom. Only the native HwQueue path appends them.
+    QueueResource->SdmaHwQueueEpilogueBytes =
+        queue_->IsNativeSdma() ? wsl::thunk::SDMAQueue::kHwQueueEpilogueBytes : 0;
   } break;
   default:
     assert(false);
@@ -260,6 +267,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtQueueRingDoorbell(HSA_QUEUEID QueueId, uint64_t va
   if (!queue_)
     return HSAKMT_STATUS_INVALID_PARAMETER;
 
+  fprintf(stderr, "[sdma] hsaKmtQueueRingDoorbell QueueId=%p value=0x%llx\n",
+          (void*)QueueId, (unsigned long long)value);
+  fflush(stderr);
   queue_->RingDoorbell(value);
   return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
@@ -141,6 +141,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateQueueV2(HSAuint32 NodeId,
     QueueResource->Queue_DoorBell_aql = queue_->GetDoorbellPtr();
     QueueResource->Queue_write_ptr_aql = queue_->GetRingWptr();
     QueueResource->Queue_read_ptr_aql = queue_->GetRingRptr();
+    // Native SDMA user queue exposes the HwQueue progress-fence VA so ROCr can
+    // emit a matching FENCE packet; 0 for the SWS-thread path.
+    QueueResource->SdmaProgressFenceVA = queue_->hwqueue_progress_fence_va_;
   } break;
   default:
     assert(false);
@@ -260,6 +263,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtQueueRingDoorbell(HSA_QUEUEID QueueId, uint64_t va
   if (!queue_)
     return HSAKMT_STATUS_INVALID_PARAMETER;
 
+  fprintf(stderr, "[sdma] hsaKmtQueueRingDoorbell QueueId=%p value=0x%llx\n",
+          (void*)QueueId, (unsigned long long)value);
+  fflush(stderr);
   queue_->RingDoorbell(value);
   return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -70,9 +70,14 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   NTSTATUS ret = ParseDeviceInfo();
   pr_rocr_info("kmd_version:%" PRIu32 "\n", device_info_.kmd_version);
   device_info_.hwsInfo.hwsMask.aql_queue &= !dxg_runtime->use_pm4_;
-  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%" PRIu64 "\n",
+  // When PM4 mode is forced, COMPUTE1-only machines can't create PM4 HwQueues
+  // on COMPUTE1 — switch the schedid back to COMPUTE0 (pm4_compute_schedid).
+  if (dxg_runtime->use_pm4_)
+    device_info_.compute_schedid = device_info_.pm4_compute_schedid;
+  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d sdma_queue=%d use_pm4_override=%" PRIu64 "\n",
            device_info_.hwsInfo.hwsMask.aql_queue,
            device_info_.hwsInfo.hwsMask.computeHwsEnabled,
+           device_info_.hwsInfo.hwsMask.sdma_queue,
            (uint64_t)dxg_runtime->use_pm4_);
 
   if (ret == STATUS_OBJECT_NAME_NOT_FOUND || ret == STATUS_REVISION_MISMATCH) {
@@ -483,7 +488,8 @@ bool WDDMDevice::Unlock(D3DKMT_HANDLE handle) {
   return false;
 }
 
-bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debugger_data) {
+bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debugger_data,
+                               bool rocr_client) {
   void *priv_data;
   int priv_size;
 
@@ -491,12 +497,25 @@ bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debug
   if (ordinal < 0)
     return false;
 
+  // For SDMA contexts, KMD needs the SDMA scheduler ID in osQueueId (not the
+  // compute schedid). DRMDMA=4, DRMDMA1=7 per DXUMD_SCHEDULERIDENTIFIER enum.
+  constexpr int kDRMDMA = 4, kDRMDMA1 = 7;
+  int schedid = device_info_.compute_schedid;
+  pr_err("[dbg] CreateContext sdma_schedid.size=%zu compute_schedid=%d\n",
+         device_info_.sdma_schedid.size(), device_info_.compute_schedid);
+  for (size_t i = 0; i < device_info_.sdma_schedid.size(); i++)
+    pr_err("[dbg]   sdma_schedid[%zu]=%d\n", i, device_info_.sdma_schedid[i]);
+  if (engine == kDRMDMA && device_info_.sdma_schedid.size() >= 1)
+    schedid = device_info_.sdma_schedid[0];
+  else if (engine == kDRMDMA1 && device_info_.sdma_schedid.size() >= 2)
+    schedid = device_info_.sdma_schedid[1];
+
   priv_size = Wkmi::GetContextPrivDataSize();
   priv_data = malloc(priv_size);
   assert(priv_data);
   memset(priv_data, 0, priv_size);
   Wkmi::FillinContextPrivData(priv_data, SupportStateShadowingByCpFw(),
-                              device_info_.compute_schedid, debugger_data);
+                              schedid, debugger_data, rocr_client);
 
   D3DKMT_CREATECONTEXTVIRTUAL args = {0};
   args.hDevice = device_;
@@ -511,8 +530,11 @@ bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debug
   else
     args.Flags.DisableGpuTimeout = Wkmi::ShouldDisableGpuTimeout(engine, &device_info_);
 
+  pr_err("[dbg] CreateContext engine=%d ordinal=%d schedid=%d hws=%d rocr=%d\n",
+         engine, ordinal, schedid, (int)IsHwsEnabled(engine), (int)rocr_client);
   NTSTATUS ret = DXCORE_CALL(D3DKMTCreateContextVirtual(&args));
   if (ret == STATUS_SUCCESS) {
+    pr_err("[dbg] CreateContext ok hContext=0x%x\n", args.hContext);
     *handle = args.hContext;
     free(priv_data);
     return true;
@@ -801,7 +823,11 @@ void WDDMDevice::GetClockCounters(uint64_t *gpu, uint64_t *cpu) {
 }
 
 bool WDDMDevice::CreateQueue(WDDMQueue* queue, uint64_t debugger_data) {
-  if (!CreateContext(queue->queue_engine, &queue->context, debugger_data)) return false;
+  // A native SDMA user queue tags its context with the ROCr client id; the KMD
+  // uses that tag (rather than a dedicated flag) to recognize the SDMA ring.
+  bool rocr_client = queue->IsNativeSdma();
+  if (!CreateContext(queue->queue_engine, &queue->context, debugger_data, rocr_client))
+    return false;
 
   GpuMemory *gpu_mem = nullptr;
   if (queue->cmdbuf_addr == 0) {
@@ -889,13 +915,20 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   // be down-cast to ComputeQueue here -- doing so reads garbage and crashes.
   ComputeQueue* compute_queue = dynamic_cast<ComputeQueue*>(queue);
   D3DKMT_HANDLE resource = 0;
-  bool is_aql = false;
+  Wkmi::HwQueueKind kind = Wkmi::kHwQueuePm4;
   if (compute_queue != nullptr && IsAqlSupported()) {
     auto queue_memory = compute_queue->GetAmdQueueMemory();
     resource = queue_memory->KmtHandle();
-    is_aql = true;
+    kind = Wkmi::kHwQueueAql;
   }
-  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, is_aql,
+  // Native SDMA user queue: the ROCr-owned ring (cmdbuf_addr/cmdbuf_size) is the
+  // SDMA queue itself, so no AQL amd_queue_t handle is set; only the doorbell
+  // offset and progress-fence VA are returned by the KMD. IsNativeSdma() already
+  // encodes (use_hws && IsSdmaSupported()), so no capability re-check is needed.
+  if (queue->IsNativeSdma()) {
+    kind = Wkmi::kHwQueueSdma;
+  }
+  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, kind,
       queue->cmdbuf_addr, queue->cmdbuf_size, reinterpret_cast<uintptr_t>(queue->ring_wptr),
       reinterpret_cast<uintptr_t>(queue->ring_rptr), resource, &doorbell_loc);
 
@@ -905,9 +938,12 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   createHwQueue.pPrivateDriverData = priv_data;
   createHwQueue.PrivateDriverDataSize = priv_size;
 
+  pr_err("[dbg] CreateHwQueue kind=%d aql=%d sdma=%d cmdbuf_addr=0x%" PRIx64 " cmdbuf_size=0x%" PRIx64 " schedid=%d engine=%d\n",
+         (int)kind, (int)IsAqlSupported(), (int)IsSdmaSupported(),
+         queue->cmdbuf_addr, (uint64_t)queue->cmdbuf_size, (int)device_info_.compute_schedid, (int)queue->queue_engine);
   NTSTATUS ret = DXCORE_CALL(D3DKMTCreateHwQueue(&createHwQueue));
   if (ret != STATUS_SUCCESS) {
-    pr_err("fail %x\n", ret);
+    pr_err("fail %x kind=%d\n", ret, (int)kind);
     free(priv_data);
     return false;
   }
@@ -920,6 +956,13 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   queue->queue = createHwQueue.hHwQueue;
   queue->syncobj = createHwQueue.hHwQueueProgressFence;
   queue->sync_addr = (uint64_t *)createHwQueue.HwQueueProgressFenceCPUVirtualAddress;
+  if (kind == Wkmi::kHwQueueSdma) {
+    queue->hwqueue_progress_fence_va_ = createHwQueue.HwQueueProgressFenceGPUVirtualAddress;
+    pr_err("[sdma] CreateHwQueue SDMA fence: cpu_va=0x%" PRIx64 " gpu_va=0x%" PRIx64 " fence_handle=0x%x\n",
+           (uint64_t)createHwQueue.HwQueueProgressFenceCPUVirtualAddress,
+           (uint64_t)createHwQueue.HwQueueProgressFenceGPUVirtualAddress,
+           (unsigned)createHwQueue.hHwQueueProgressFence);
+  }
 
   return true;
 }
@@ -1014,6 +1057,58 @@ bool WDDMDevice::SubmitToAqlQueue(WDDMQueue* queue, uint64_t command_addr, uint6
   }
 #endif
   return true;
+}
+
+// ================================================================================================
+bool WDDMDevice::SubmitToSdmaHwQueue(WDDMQueue* queue, uint64_t wptr_in_bytes) {
+#if defined(WIN32)
+  int priv_size = Wkmi::GetSdmaSubmitPrivDataSize();
+  void* priv_data = alloca(priv_size);
+  memset(priv_data, 0, priv_size);
+  Wkmi::FillinSdmaSubmitPrivData(priv_data, wptr_in_bytes);
+
+  // The SDMA ring already carries a FENCE packet that writes this same id to the
+  // progress-fence VA; the two must agree for the OS fence to advance.
+  // fence_id was already incremented by RingDoorbell before appending the FENCE packet.
+  uint64_t fence_id = queue->hwqueue_fence_id_;
+  uint64_t sync_before = queue->sync_addr ? *queue->sync_addr : 0xDEADULL;
+  pr_err("[sdma] SubmitToSdmaHwQueue wptr=0x%" PRIx64 " fence_id=%" PRIu64 " hwqueue=0x%x sync_before=%" PRIu64 "\n",
+         wptr_in_bytes, fence_id, queue->queue, sync_before);
+
+  // Pass the ring GPU VA as CommandBuffer and wptr as CommandLength so the KMD
+  // knows the ring location (mirroring the AQL path).
+  D3DKMT_SUBMITCOMMANDTOHWQUEUE args = {
+      .hHwQueue = queue->queue,
+      .HwQueueProgressFenceId = fence_id,
+      .CommandBuffer = 0,
+      .CommandLength = 0,
+      .PrivateDriverDataSize = static_cast<UINT>(priv_size),
+      .pPrivateDriverData = priv_data};
+  pr_err("[sdma] D3DKMTSubmitCommandToHwQueue entering...\n");
+  NTSTATUS ret = DXCORE_CALL(D3DKMTSubmitCommandToHwQueue(&args));
+  pr_err("[sdma] D3DKMTSubmitCommandToHwQueue returned 0x%lx\n", (long)ret);
+  if (ret != STATUS_SUCCESS) {
+    pr_err("fail %lx\n", (long)ret);
+    return false;
+  }
+  // Poll progress fence for up to 200ms to see if GPU executes the ring.
+  if (queue->sync_addr) {
+    uint64_t expected = fence_id;
+    bool advanced = false;
+    for (int i = 0; i < 200; ++i) {
+      uint64_t cur = *queue->sync_addr;
+      if (cur >= expected) { advanced = true; break; }
+      Sleep(1);
+    }
+    pr_err("[sdma] fence poll after submit: expected=%" PRIu64 " got=%" PRIu64 " advanced=%d\n",
+           expected, *queue->sync_addr, (int)advanced);
+  }
+  return true;
+#else
+  (void)queue;
+  (void)wptr_in_bytes;
+  return false;
+#endif
 }
 
 // ================================================================================================

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -70,6 +70,7 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   NTSTATUS ret = ParseDeviceInfo();
   pr_rocr_info("kmd_version:%" PRIu32 "\n", device_info_.kmd_version);
   device_info_.hwsInfo.hwsMask.aql_queue &= !dxg_runtime->use_pm4_;
+
   // The KMD only accepts PM4 packets on COMPUTE0, but wkmi defaults compute_schedid
   // to COMPUTE1 whenever AQL-on-compute1 is supported. Override to COMPUTE0 for the
   // PM4 path.
@@ -81,10 +82,11 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
               kSchedulerIdCompute0, device_info_.compute_schedid);
      }
   }
-  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%" PRIu64
+  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d sdma_queue=%d use_pm4_override=%" PRIu64
            " compute_schedid=%" PRIu32 "\n",
            device_info_.hwsInfo.hwsMask.aql_queue,
            device_info_.hwsInfo.hwsMask.computeHwsEnabled,
+           device_info_.hwsInfo.hwsMask.sdma_queue,
            (uint64_t)dxg_runtime->use_pm4_, device_info_.compute_schedid);
 
   if (ret == STATUS_OBJECT_NAME_NOT_FOUND || ret == STATUS_REVISION_MISMATCH) {
@@ -495,7 +497,8 @@ bool WDDMDevice::Unlock(D3DKMT_HANDLE handle) {
   return false;
 }
 
-bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debugger_data) {
+bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debugger_data,
+                               bool rocr_client) {
   void *priv_data;
   int priv_size;
 
@@ -503,12 +506,25 @@ bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debug
   if (ordinal < 0)
     return false;
 
+  // For SDMA contexts, KMD needs the SDMA scheduler ID in osQueueId (not the
+  // compute schedid). DRMDMA=4, DRMDMA1=7 per DXUMD_SCHEDULERIDENTIFIER enum.
+  constexpr int kDRMDMA = 4, kDRMDMA1 = 7;
+  int schedid = device_info_.compute_schedid;
+  pr_err("[dbg] CreateContext sdma_schedid.size=%zu compute_schedid=%d\n",
+         device_info_.sdma_schedid.size(), device_info_.compute_schedid);
+  for (size_t i = 0; i < device_info_.sdma_schedid.size(); i++)
+    pr_err("[dbg]   sdma_schedid[%zu]=%d\n", i, device_info_.sdma_schedid[i]);
+  if (engine == kDRMDMA && device_info_.sdma_schedid.size() >= 1)
+    schedid = device_info_.sdma_schedid[0];
+  else if (engine == kDRMDMA1 && device_info_.sdma_schedid.size() >= 2)
+    schedid = device_info_.sdma_schedid[1];
+
   priv_size = Wkmi::GetContextPrivDataSize();
   priv_data = malloc(priv_size);
   assert(priv_data);
   memset(priv_data, 0, priv_size);
   Wkmi::FillinContextPrivData(priv_data, SupportStateShadowingByCpFw(),
-                              device_info_.compute_schedid, debugger_data);
+                              schedid, debugger_data, rocr_client);
 
   D3DKMT_CREATECONTEXTVIRTUAL args = {0};
   args.hDevice = device_;
@@ -523,8 +539,11 @@ bool WDDMDevice::CreateContext(int engine, D3DKMT_HANDLE* handle, uint64_t debug
   else
     args.Flags.DisableGpuTimeout = Wkmi::ShouldDisableGpuTimeout(engine, &device_info_);
 
+  pr_err("[dbg] CreateContext engine=%d ordinal=%d schedid=%d hws=%d rocr=%d\n",
+         engine, ordinal, schedid, (int)IsHwsEnabled(engine), (int)rocr_client);
   NTSTATUS ret = DXCORE_CALL(D3DKMTCreateContextVirtual(&args));
   if (ret == STATUS_SUCCESS) {
+    pr_err("[dbg] CreateContext ok hContext=0x%x\n", args.hContext);
     *handle = args.hContext;
     free(priv_data);
     return true;
@@ -813,7 +832,11 @@ void WDDMDevice::GetClockCounters(uint64_t *gpu, uint64_t *cpu) {
 }
 
 bool WDDMDevice::CreateQueue(WDDMQueue* queue, uint64_t debugger_data) {
-  if (!CreateContext(queue->queue_engine, &queue->context, debugger_data)) return false;
+  // A native SDMA user queue tags its context with the ROCr client id; the KMD
+  // uses that tag (rather than a dedicated flag) to recognize the SDMA ring.
+  bool rocr_client = queue->IsNativeSdma();
+  if (!CreateContext(queue->queue_engine, &queue->context, debugger_data, rocr_client))
+    return false;
 
   GpuMemory *gpu_mem = nullptr;
   if (queue->cmdbuf_addr == 0) {
@@ -1070,12 +1093,25 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   // returns nullptr -> resource=0. resource must NOT be gated on is_aql (that zeroed it -> KMD c0000001).
   GpuMemory* queue_memory = queue->GetAmdQueueMemory();
   D3DKMT_HANDLE resource = 0;
-  bool is_aql = false;
-  if (queue_memory != nullptr) {
+
+  Wkmi::HwQueueKind kind = Wkmi::kHwQueuePm4;
+  if (compute_queue != nullptr && IsAqlSupported()) {
+    auto queue_memory = compute_queue->GetAmdQueueMemory();
     resource = queue_memory->KmtHandle();
-    is_aql = IsAqlSupported();
+    kind = Wkmi::kHwQueueAql;
   }
-  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, is_aql,
+  // Native SDMA user queue: the ROCr-owned ring (cmdbuf_addr/cmdbuf_size) is the
+  // SDMA queue itself, so no AQL amd_queue_t handle is set; only the doorbell
+  // offset and progress-fence VA are returned by the KMD. IsNativeSdma() already
+  // encodes (use_hws && IsSdmaSupported()), so no capability re-check is needed.
+  if (queue->IsNativeSdma()) {
+    kind = Wkmi::kHwQueueSdma;
+    // SDMA-AQL queues need a valid AmdQueueT allocation (read_dispatch_id report). The
+    // SDMAQueue allocated its own amd_queue_t page; pass its KMT handle like the AQL path.
+    if (GpuMemory* aq = static_cast<SDMAQueue*>(queue)->GetAmdQueueMemory())
+      resource = aq->KmtHandle();
+  }
+  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, kind,
       queue->cmdbuf_addr, queue->cmdbuf_size, reinterpret_cast<uintptr_t>(queue->ring_wptr),
       reinterpret_cast<uintptr_t>(queue->ring_rptr), resource, &doorbell_loc,
       queue->cwsr_mem_handle_);
@@ -1086,9 +1122,12 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   createHwQueue.pPrivateDriverData = priv_data;
   createHwQueue.PrivateDriverDataSize = priv_size;
 
+  pr_err("[dbg] CreateHwQueue kind=%d aql=%d sdma=%d cmdbuf_addr=0x%" PRIx64 " cmdbuf_size=0x%" PRIx64 " schedid=%d engine=%d amdQueueT=0x%x\n",
+         (int)kind, (int)IsAqlSupported(), (int)IsSdmaSupported(),
+         queue->cmdbuf_addr, (uint64_t)queue->cmdbuf_size, (int)device_info_.compute_schedid, (int)queue->queue_engine, (unsigned)resource);
   NTSTATUS ret = DXCORE_CALL(D3DKMTCreateHwQueue(&createHwQueue));
   if (ret != STATUS_SUCCESS) {
-    pr_err("fail %x\n", ret);
+    pr_err("fail %x kind=%d\n", ret, (int)kind);
     free(priv_data);
     if (queue->cwsr_mem_ != nullptr) {
       delete GpuMemory::Convert(queue->cwsr_mem_);
@@ -1106,6 +1145,13 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   queue->queue = createHwQueue.hHwQueue;
   queue->syncobj = createHwQueue.hHwQueueProgressFence;
   queue->sync_addr = (uint64_t *)createHwQueue.HwQueueProgressFenceCPUVirtualAddress;
+  if (kind == Wkmi::kHwQueueSdma) {
+    queue->hwqueue_progress_fence_va_ = createHwQueue.HwQueueProgressFenceGPUVirtualAddress;
+    pr_err("[sdma] CreateHwQueue SDMA fence: cpu_va=0x%" PRIx64 " gpu_va=0x%" PRIx64 " fence_handle=0x%x\n",
+           (uint64_t)createHwQueue.HwQueueProgressFenceCPUVirtualAddress,
+           (uint64_t)createHwQueue.HwQueueProgressFenceGPUVirtualAddress,
+           (unsigned)createHwQueue.hHwQueueProgressFence);
+  }
 
   return true;
 }
@@ -1207,6 +1253,62 @@ bool WDDMDevice::SubmitToAqlQueue(WDDMQueue* queue, uint64_t command_addr, uint6
   }
 #endif
   return true;
+}
+
+// ================================================================================================
+bool WDDMDevice::SubmitToSdmaHwQueue(WDDMQueue* queue, uint64_t wptr_in_bytes) {
+#if defined(WIN32)
+  int priv_size = Wkmi::GetSdmaSubmitPrivDataSize();
+  void* priv_data = alloca(priv_size);
+  memset(priv_data, 0, priv_size);
+  Wkmi::FillinSdmaSubmitPrivData(priv_data, wptr_in_bytes);
+
+  // The SDMA ring already carries a FENCE packet that writes this same id to the
+  // progress-fence VA; the two must agree for the OS fence to advance.
+  // fence_id was already incremented by RingDoorbell before appending the FENCE packet.
+  uint64_t fence_id = queue->hwqueue_fence_id_;
+  uint64_t sync_before = queue->sync_addr ? *queue->sync_addr : 0xDEADULL;
+  pr_err("[sdma] SubmitToSdmaHwQueue wptr=0x%" PRIx64 " fence_id=%" PRIu64 " hwqueue=0x%x sync_before=%" PRIu64 "\n",
+         wptr_in_bytes, fence_id, queue->queue, sync_before);
+
+  // CommandBuffer/CommandLength MUST be non-zero: the KMD classifies a zero-length
+  // submit as IFH (null-render) and, with modern null-render handling, SKIPS the
+  // user-queue SubmitCommand entirely -> the wptr-poll mem is never written and MES
+  // never consumes the ring. A non-zero length routes it to the EXTERNAL_IB path which
+  // does call CS_SdmaUserQueue_AQL::SubmitCommand (that path ignores the IB and drives
+  // execution purely from the AQL wptr private data). Pass the ring VA + wptr span.
+  D3DKMT_SUBMITCOMMANDTOHWQUEUE args = {
+      .hHwQueue = queue->queue,
+      .HwQueueProgressFenceId = fence_id,
+      .CommandBuffer = queue->cmdbuf_addr,
+      .CommandLength = static_cast<UINT>(wptr_in_bytes),
+      .PrivateDriverDataSize = static_cast<UINT>(priv_size),
+      .pPrivateDriverData = priv_data};
+  pr_err("[sdma] D3DKMTSubmitCommandToHwQueue entering...\n");
+  NTSTATUS ret = DXCORE_CALL(D3DKMTSubmitCommandToHwQueue(&args));
+  pr_err("[sdma] D3DKMTSubmitCommandToHwQueue returned 0x%lx\n", (long)ret);
+  if (ret != STATUS_SUCCESS) {
+    pr_err("fail %lx\n", (long)ret);
+    return false;
+  }
+  // Poll progress fence for up to 200ms to see if GPU executes the ring.
+  if (queue->sync_addr) {
+    uint64_t expected = fence_id;
+    bool advanced = false;
+    for (int i = 0; i < 200; ++i) {
+      uint64_t cur = *queue->sync_addr;
+      if (cur >= expected) { advanced = true; break; }
+      Sleep(1);
+    }
+    pr_err("[sdma] fence poll after submit: expected=%" PRIu64 " got=%" PRIu64 " advanced=%d\n",
+           expected, *queue->sync_addr, (int)advanced);
+  }
+  return true;
+#else
+  (void)queue;
+  (void)wptr_in_bytes;
+  return false;
+#endif
 }
 
 // ================================================================================================

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -1147,24 +1147,101 @@ SDMAQueue::SDMAQueue(WDDMDevice* device, void* ring, uint64_t cmdbuf_size, uint3
       thread_stop_(false),
       ib_size(0),
       ib_start_addr(0) {
+  // Native SDMA user queue: submit through the WDDM HwQueue path instead of the
+  // SWS translation thread when HWS is enabled and the KMD advertises support.
+  native_sdma_ = use_hws && device->IsSdmaSupported();
   bool ret = device->CreateQueue(this);
   assert(ret);
 
-  thread_ = std::thread(SdmaThread, this);
+  if (!native_sdma_)
+    thread_ = std::thread(SdmaThread, this);
 }
 
 SDMAQueue::~SDMAQueue() {
-  thread_cond_lock_.lock();
-  thread_stop_ = true;
-  thread_cond_lock_.unlock();
-  thread_cond_.notify_one();
-  thread_.join();
+  if (!native_sdma_) {
+    thread_cond_lock_.lock();
+    thread_stop_ = true;
+    thread_cond_lock_.unlock();
+    thread_cond_.notify_one();
+    thread_.join();
+  }
 
   device->DestroyQueue(this);
 }
 
+// Write SDMA NOP fill to pad the ring to a boundary.
+static void SdmaNopFill(void* dst, size_t size_bytes) {
+  std::memset(dst, 0, size_bytes);
+  *reinterpret_cast<uint32_t*>(dst) = static_cast<uint32_t>((size_bytes / 4 - 1) << 16);
+}
+
+// Write a SDMA FENCE packet (16 bytes) at dst. Returns 16.
+static size_t SdmaFencePacket(void* dst, int gfx_major, uint64_t fence_va, uint32_t fence_id) {
+  uint32_t* dw = reinterpret_cast<uint32_t*>(dst);
+  // op=5 (FENCE), mtype=3 in bits[17:16], sys=1 in bit[20] for gfx12
+  if (gfx_major >= 12)
+    dw[0] = 5u | (3u << 16) | (1u << 20);
+  else
+    dw[0] = 5u | (3u << 16);  // mtype=3 for gfx10+
+  dw[1] = static_cast<uint32_t>(fence_va);
+  dw[2] = static_cast<uint32_t>(fence_va >> 32);
+  dw[3] = fence_id;
+  return 16;
+}
+
+// Write a SDMA TRAP packet (8 bytes) at dst. Returns 8.
+static size_t SdmaTrapPacket(void* dst) {
+  uint32_t* dw = reinterpret_cast<uint32_t*>(dst);
+  dw[0] = 6u;  // op=6 (TRAP)
+  dw[1] = 0;
+  return 8;
+}
+
 void SDMAQueue::RingDoorbell(uint64_t value) {
-  pr_debug("ringdoorbell %#" PRIx64 " %#" PRIx64 "\n", wptr_pre_, wptr_next_);
+  if (native_sdma_) {
+    // Append FENCE+TRAP to the ring at `value` (byte offset from ring base),
+    // then hand the advanced wptr to KMD via SubmitToSdmaHwQueue.
+    // BlitSdma writes DMA payload into the ring and calls hsaKmtQueueRingDoorbell
+    // which lands here; it does NOT call SdmaQueue::RingDoorbell (ROCr signal path),
+    // so the FENCE/TRAP must be emitted here, not in ROCr.
+    uint64_t wptr = value;  // byte offset past user payload
+    const uint64_t ring_size = cmdbuf_size;
+    char* ring_base = reinterpret_cast<char*>(cmdbuf_addr);
+    const uint64_t fence_va = hwqueue_progress_fence_va_;
+    const uint32_t fence_id = static_cast<uint32_t>(++hwqueue_fence_id_);
+    const int gfx_major = device->Major();
+
+    // Emit FENCE (16 bytes) then TRAP (8 bytes), padding with NOPs if a packet
+    // would straddle the ring end.
+    auto emit = [&](size_t pkt_size, auto build_fn) {
+      size_t off = static_cast<size_t>(wptr % ring_size);
+      if (off + pkt_size > static_cast<size_t>(ring_size)) {
+        size_t tail = static_cast<size_t>(ring_size) - off;
+        SdmaNopFill(ring_base + off, tail);
+        wptr += tail;
+        off = 0;
+      }
+      wptr += build_fn(ring_base + off);
+    };
+
+    emit(16, [&](char* dst) { return SdmaFencePacket(dst, gfx_major, fence_va, fence_id); });
+    emit(8,  [&](char* dst) { return SdmaTrapPacket(dst); });
+
+    pr_err("[sdma] RingDoorbell native wptr=0x%" PRIx64 "->0x%" PRIx64
+           " fence_va=0x%" PRIx64 " fence_id=%u gfx%d\n",
+           value, wptr, fence_va, fence_id, gfx_major);
+
+    // Update wptr_next_ so ROCr's queue_wptr_ (which points here) reflects the
+    // bytes we consumed for FENCE+TRAP.  Without this, ROCr sees wptr < GPU rptr
+    // and believes the ring is nearly full, deadlocking the next blit submission.
+    wptr_next_ = wptr;
+
+    if (!device->SubmitToSdmaHwQueue(this, wptr))
+      assert(!"SDMA doorbell failed!");
+    return;
+  }
+
+  pr_err("[sdma] RingDoorbell SWS wptr_pre=0x%" PRIx64 " wptr_next=0x%" PRIx64 "\n", wptr_pre_, wptr_next_);
   thread_cond_lock_.lock();
 
   wptr_queue_.emplace_back(wptr_pre_, wptr_next_);
@@ -1175,11 +1252,16 @@ void SDMAQueue::RingDoorbell(uint64_t value) {
 }
 
 hsa_status_t SDMAQueue::Init(void) {
-  hsa_status_t ret = use_hws ? HwsInit() : SwsInit();
-  if (ret) return ret;
+  if (native_sdma_)
+    pr_rocr_info("SDMA queue: native user queue (WDDM HwQueue submit)\n");
+  else
+    pr_rocr_info("SDMA queue: legacy SWS translation thread\n");
 
+  // Zero the ring before HwsInit so the init FENCE+TRAP written by CreateHwQueue
+  // is not overwritten.  For the SWS path the order doesn't matter.
   std::memset((char*)cmdbuf_addr, 0, cmdbuf_size);
 
+  hsa_status_t ret = use_hws ? HwsInit() : SwsInit();
   return ret;
 }
 
@@ -1194,6 +1276,8 @@ int SDMAQueue::PreparePacket(uint32_t offset, uint64_t size) {
 }
 
 hsa_status_t SDMAQueue::Submit(void) {
+  pr_err("[sdma] Submit native=%d hws=%d ib_start=0x%" PRIx64 " ib_size=0x%" PRIx64 " rptr_next=0x%" PRIx64 "\n",
+         (int)native_sdma_, (int)use_hws, ib_start_addr, ib_size, rptr_next);
   if (!device->WaitPagingFence(this)) return HSA_STATUS_ERROR;
 
   int ret = use_hws ? HwsSubmit(ib_start_addr, ib_size, rptr_next)

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -1148,26 +1148,134 @@ SDMAQueue::SDMAQueue(WDDMDevice* device, void* ring, uint64_t cmdbuf_size, uint3
       rptr_next(0),
       thread_stop_(false),
       ib_size(0),
-      ib_start_addr(0) {
-  needs_cwsr_ = false;
+      ib_start_addr(0), needs_cwsr_(false) {
+  // Native SDMA user queue: submit through the WDDM HwQueue path instead of the
+  // SWS translation thread when HWS is enabled and the KMD advertises support.
+  // Env override for A/B testing: HSA_ENABLE_SDMA_USER_QUEUE=0 forces the legacy
+  // SWS path even when the native HwQueue path is available (unset/1 = native).
+  // This single gate also drives HsaQueueResource::SdmaHwQueueEpilogueBytes and the
+  // producer's epilogue reservation, so both paths stay self-consistent.
+  bool env_native = true;
+  if (const char* e = getenv("HSA_ENABLE_SDMA_USER_QUEUE")) env_native = (atoi(e) != 0);
+  native_sdma_ = use_hws && device->IsSdmaSupported() && env_native;
+
+  // The KMD's SDMA-AQL user queue requires a valid AmdQueueT (amd_queue_t) allocation for
+  // its read_dispatch_id (rptr) report; ROCr does not provide one for SDMA queues. Allocate
+  // a private page here, BEFORE CreateQueue (which runs CreateHwQueue), so its KMT handle is
+  // available to pass as AmdQueueT. Without it CreateHwQueue fails with STATUS_UNSUCCESSFUL.
+  if (native_sdma_) {
+    GpuMemoryCreateInfo create_info{};
+    create_info.size = dxg_runtime->page_size;
+    create_info.domain = Wkmi::kSystem;
+    // Must be a queue-object allocation so wkmi sets AllocRequest3Flags.AmdQueueT; the KMD
+    // rejects the SDMA-AQL HwQueue ("AmdQueueT flag not set") unless the amd_queue_t
+    // allocation carries that flag (CS_Context.cpp GetAllocRequestFlags()->flags3.AmdQueueT).
+    create_info.mem_flags = Wkmi::kQueueObject;
+    GpuMemory* gpu_mem = nullptr;
+    auto code = device->CreateGpuMemory(create_info, &gpu_mem);
+    assert(code == ErrorCode::Success);
+    amd_queue_memory_ = gpu_mem;
+    amd_queue_addr_ = gpu_mem->GpuAddress();
+    std::memset(reinterpret_cast<void*>(amd_queue_addr_), 0, dxg_runtime->page_size);
+    pr_err("[sdma] alloc amd_queue_t gpu_va=0x%" PRIx64 " handle=0x%x\n",
+           amd_queue_addr_, (unsigned)gpu_mem->KmtHandle());
+  }
+
   bool ret = device->CreateQueue(this);
   assert(ret);
 
-  thread_ = std::thread(SdmaThread, this);
+  if (!native_sdma_)
+    thread_ = std::thread(SdmaThread, this);
 }
 
 SDMAQueue::~SDMAQueue() {
-  thread_cond_lock_.lock();
-  thread_stop_ = true;
-  thread_cond_lock_.unlock();
-  thread_cond_.notify_one();
-  thread_.join();
+  if (!native_sdma_) {
+    thread_cond_lock_.lock();
+    thread_stop_ = true;
+    thread_cond_lock_.unlock();
+    thread_cond_.notify_one();
+    thread_.join();
+  }
 
   device->DestroyQueue(this);
+
+  if (amd_queue_memory_) {
+    delete amd_queue_memory_;
+    amd_queue_memory_ = nullptr;
+  }
+}
+
+// Write SDMA NOP fill to pad the ring to a boundary.
+static void SdmaNopFill(void* dst, size_t size_bytes) {
+  std::memset(dst, 0, size_bytes);
+  *reinterpret_cast<uint32_t*>(dst) = static_cast<uint32_t>((size_bytes / 4 - 1) << 16);
+}
+
+// Write a single Navi4+ SDMA FENCE_CONDITIONAL_INTERRUPT packet (8 dwords / 32 bytes) at dst.
+// Per the "SDMA User Queue for native ROCr" spec (Sheng Ming En): on Navi4+ (gfx12) one packet
+// both writes the 64-bit progress fence and raises the queue's fence interrupt (pre-Navi4 needs
+// a separate TRAP). Header is exactly 0x80000105: op=FENCE(5), sub_op=CONDITIONAL_INTERRUPT(1),
+// ddw=1 (64-bit fence write); sys/snp/gpa/mall_policy all 0. Per the spec pseudo-code:
+//   FENCE_ADDR = FENCE_REF_ADDR = INTERRUPT_CONTEXT = HwQueueProgressFenceGPUVirtualAddress
+//   FENCE_DATA = HwQueueProgressFenceId
+// The HW writes FENCE_DATA to FENCE_ADDR, then (FENCE_DATA >= *FENCE_REF_ADDR) raises the
+// interrupt so the KMD's existing WDDM fence-reporting path advances the OS fence.
+static size_t SdmaFenceCondIntPacket(void* dst, uint64_t fence_va, uint64_t fence_val) {
+  uint32_t* dw = reinterpret_cast<uint32_t*>(dst);
+  dw[0] = 0x80000105u;                               // op=5, sub_op=1, ddw=1 (sys=0)
+  dw[1] = static_cast<uint32_t>(fence_va);          // FENCE_ADDR lo
+  dw[2] = static_cast<uint32_t>(fence_va >> 32);    // FENCE_ADDR hi
+  dw[3] = static_cast<uint32_t>(fence_val);         // FENCE_DATA lo
+  dw[4] = static_cast<uint32_t>(fence_val >> 32);   // FENCE_DATA hi
+  dw[5] = static_cast<uint32_t>(fence_va);          // FENCE_REF_ADDR lo
+  dw[6] = static_cast<uint32_t>(fence_va >> 32);    // FENCE_REF_ADDR hi
+  dw[7] = static_cast<uint32_t>(fence_va);          // INTERRUPT_CONTEXT (low 32 of fence VA)
+  return 32;
 }
 
 void SDMAQueue::RingDoorbell(uint64_t value) {
-  pr_debug("ringdoorbell %#" PRIx64 " %#" PRIx64 "\n", wptr_pre_, wptr_next_);
+  if (native_sdma_) {
+    // BlitSdma writes the DMA payload into the ring, reserves kHwQueueEpilogueBytes of
+    // trailing headroom (advertised to it via HsaQueueResource::SdmaHwQueueEpilogueBytes),
+    // and lands here through hsaKmtQueueRingDoorbell with `value` already past that
+    // reserved region. We fill [value-epilogue, value) with the FENCE+FENCE+TRAP
+    // progress-fence epilogue and submit `value` UNCHANGED. The producer already
+    // accounted for these bytes, so we must NOT advance the wptr independently —
+    // doing so would drift the producer's write index and corrupt the ring.
+    const uint32_t epilogue = kHwQueueEpilogueBytes;
+    const uint64_t ring_size = cmdbuf_size;
+    char* ring_base = reinterpret_cast<char*>(cmdbuf_addr);
+    const uint64_t fence_va = hwqueue_progress_fence_va_;
+    const uint64_t fence_id = ++hwqueue_fence_id_;
+    const int gfx_major = device->Major();
+
+    // The producer reserves [.., value) contiguously (PadRingToEnd), so the epilogue
+    // region never straddles the ring end; write it directly, no NOP padding.
+    assert(value >= epilogue && "SDMA submit smaller than reserved epilogue");
+    const size_t base = static_cast<size_t>((value - epilogue) % ring_size);
+    assert(base + epilogue <= ring_size && "reserved SDMA epilogue straddles ring end");
+    char* ep = ring_base + base;
+    size_t n = 0;
+    // One Navi4+ FENCE_CONDITIONAL_INTERRUPT packet writes the 64-bit HwQueueProgressFenceId
+    // and raises the queue's fence interrupt (INTERRUPT_CONTEXT = fence VA per spec), so the
+    // KMD's existing WDDM fence-reporting path advances the OS fence for this HwQueue.
+    n += SdmaFenceCondIntPacket(ep + n, fence_va, fence_id);
+
+    pr_err("[sdma] RingDoorbell native epilogue@0x%" PRIx64 " wptr=0x%" PRIx64
+           " fence_va=0x%" PRIx64 " fence_id=%" PRIu64 " gfx%d\n",
+           value - epilogue, value, fence_va, fence_id, gfx_major);
+
+    // Overrun is prevented at the producer: its AcquireWriteAddress free-space check
+    // now includes the reserved epilogue, so it never submits a span larger than the
+    // ring. wptr_next_ already equals `value` (aliases the producer's queue_wptr_).
+    wptr_next_ = value;
+
+    if (!device->SubmitToSdmaHwQueue(this, value))
+      assert(!"SDMA doorbell failed!");
+    return;
+  }
+
+  pr_err("[sdma] RingDoorbell SWS wptr_pre=0x%" PRIx64 " wptr_next=0x%" PRIx64 "\n", wptr_pre_, wptr_next_);
   thread_cond_lock_.lock();
 
   wptr_queue_.emplace_back(wptr_pre_, wptr_next_);
@@ -1178,11 +1286,16 @@ void SDMAQueue::RingDoorbell(uint64_t value) {
 }
 
 hsa_status_t SDMAQueue::Init(void) {
-  hsa_status_t ret = use_hws ? HwsInit() : SwsInit();
-  if (ret) return ret;
+  if (native_sdma_)
+    pr_rocr_info("SDMA queue: native user queue (WDDM HwQueue submit)\n");
+  else
+    pr_rocr_info("SDMA queue: legacy SWS translation thread\n");
 
+  // Zero the ring before HwsInit so the init FENCE+TRAP written by CreateHwQueue
+  // is not overwritten.  For the SWS path the order doesn't matter.
   std::memset((char*)cmdbuf_addr, 0, cmdbuf_size);
 
+  hsa_status_t ret = use_hws ? HwsInit() : SwsInit();
   return ret;
 }
 
@@ -1197,6 +1310,8 @@ int SDMAQueue::PreparePacket(uint32_t offset, uint64_t size) {
 }
 
 hsa_status_t SDMAQueue::Submit(void) {
+  pr_err("[sdma] Submit native=%d hws=%d ib_start=0x%" PRIx64 " ib_size=0x%" PRIx64 " rptr_next=0x%" PRIx64 "\n",
+         (int)native_sdma_, (int)use_hws, ib_start_addr, ib_size, rptr_next);
   if (!device->WaitPagingFence(this)) return HSA_STATUS_ERROR;
 
   int ret = use_hws ? HwsSubmit(ib_start_addr, ib_size, rptr_next)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
@@ -135,6 +135,13 @@ class SdmaQueue : public core::Queue, private core::LocalSignal, public core::Do
   HsaQueueResource queue_resource_;
   int32_t sdma_engine_id_;
   bool active_;
+
+  // GPU VA of the WDDM HwQueue progress fence (native SDMA user queue on
+  // Windows/DXG only). When non-zero, RingDoorbell appends a FENCE+TRAP sequence
+  // that writes progress_fence_id_ here so the OS scheduler tracks completion.
+  // Zero on Linux/KFD and on the legacy SWS-thread path -> no packets appended.
+  uint64_t progress_fence_va_;
+  uint64_t progress_fence_id_;
 };
 
 }  // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -612,6 +612,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCommand(const void* cmd, size_
   }
 
   // After transfer is completed, decrement the signal value.
+  fprintf(stderr, "[blit] SubmitCommand: signal decrement: platform_atomic=%d"
+          " completion_val=0x%llx signal_loc=%p\n",
+          (int)platform_atomic_support_, (unsigned long long)completion_signal_value,
+          out_signal.ValueLocation());
   if (platform_atomic_support_) {
     BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
     command_addr += atomic_command_size_;
@@ -1952,25 +1956,32 @@ template <bool useGCR, bool scopeFields> hsa_status_t BlitSdma<useGCR, scopeFiel
 
 template <bool useGCR, bool scopeFields>
 char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint64_t& curr_index) {
+  // Reserve the caller's packets plus the native-SDMA FENCE/TRAP epilogue that
+  // libhsakmt appends on the doorbell (0 on non-native paths), so this producer's
+  // write index stays in step with the submitted wptr and the free-space check
+  // below accounts for those bytes.
+  const uint32_t reserve_size = cmd_size + queue_resource_.SdmaHwQueueEpilogueBytes;
   // Ring is full when all but one byte is written.
-  if (cmd_size >= kQueueSize) {
+  if (reserve_size >= kQueueSize) {
     return nullptr;
   }
 
   curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
+  fprintf(stderr, "[blit] AcquireWriteAddress cmd_size=%u curr_index=0x%llx rptr=0x%llx\n",
+          cmd_size, (unsigned long long)curr_index, (unsigned long long)*queue_rptr_);
 
   while (true) {
     // Check whether a linear region of the requested size is available.
     // If == cmd_size: region is at beginning of ring.
     // If < cmd_size: region intersects end of ring, pad with no-ops and retry.
-    if (WrapIntoRing(curr_index + cmd_size) < cmd_size) {
+    if (WrapIntoRing(curr_index + reserve_size) < reserve_size) {
       PadRingToEnd(curr_index);
       curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
       continue;
     }
 
     // Check whether the engine has finished using this region.
-    const uint64_t new_index = curr_index + cmd_size;
+    const uint64_t new_index = curr_index + reserve_size;
 
     if (CanWriteUpto(new_index) == false) {
       // Wait for read index to move and try again.
@@ -1996,10 +2007,13 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
 
 template <bool useGCR, bool scopeFields>
 void BlitSdma<useGCR, scopeFields>::UpdateWriteAndDoorbellRegister(uint64_t curr_index, uint64_t new_index) {
+  fprintf(stderr, "[blit] UpdateWriteAndDoorbellRegister curr=0x%llx new=0x%llx\n",
+          (unsigned long long)curr_index, (unsigned long long)new_index);
   while (true) {
     // Make sure that the address before ::curr_index is already released.
     // Otherwise the CP may read invalid packets.
     uint64_t commit_index = atomic::Load(&cached_commit_index_, std::memory_order_acquire);
+    fprintf(stderr, "[blit] commit_index=0x%llx\n", (unsigned long long)commit_index);
     if (commit_index == curr_index) {
       if (sdma_wait_idle_) {
         // TODO: remove when sdma wpointer issue is resolved.
@@ -2047,12 +2061,16 @@ void BlitSdma<useGCR, scopeFields>::UpdateWriteAndDoorbellRegister(uint64_t curr
 
 template <bool useGCR, bool scopeFields>
 void BlitSdma<useGCR, scopeFields>::ReleaseWriteAddress(uint64_t curr_index, uint32_t cmd_size) {
-  if (cmd_size > kQueueSize) {
+  // Advance by the caller's packets plus the reserved native-SDMA epilogue so the
+  // doorbell wptr matches what AcquireWriteAddress reserved; libhsakmt fills the
+  // reserved [end-epilogue, end) region with FENCE+TRAP.
+  const uint32_t reserve_size = cmd_size + queue_resource_.SdmaHwQueueEpilogueBytes;
+  if (reserve_size > kQueueSize) {
     assert(false && "cmd_addr is outside the queue buffer range");
     return;
   }
 
-  UpdateWriteAndDoorbellRegister(curr_index, curr_index + cmd_size);
+  UpdateWriteAndDoorbellRegister(curr_index, curr_index + reserve_size);
 }
 
 template <bool useGCR, bool scopeFields>
@@ -2555,6 +2573,8 @@ void BlitSdma<useGCR, scopeFields>::BuildCopyRectCommand(const std::function<voi
           pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR_RECT;
           if (scopeFields) pkt->HEADER_UNION.npd = 1;
           pkt->HEADER_UNION.element = element;
+          fprintf(stderr, "[blit] BuildCopyRect sbase=0x%llx dbase=0x%llx element=%d\n",
+                  (unsigned long long)sbase, (unsigned long long)dbase, element);
           pkt->SRC_ADDR_LO_UNION.src_addr_31_0 = sbase;
           pkt->SRC_ADDR_HI_UNION.src_addr_63_32 = sbase >> 32;
           pkt->SRC_PARAMETER_1_UNION.src_offset_x = soff;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -612,6 +612,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCommand(const void* cmd, size_
   }
 
   // After transfer is completed, decrement the signal value.
+  fprintf(stderr, "[blit] SubmitCommand: signal decrement: platform_atomic=%d"
+          " completion_val=0x%llx signal_loc=%p\n",
+          (int)platform_atomic_support_, (unsigned long long)completion_signal_value,
+          out_signal.ValueLocation());
   if (platform_atomic_support_) {
     BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
     command_addr += atomic_command_size_;
@@ -1958,6 +1962,8 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
   }
 
   curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
+  fprintf(stderr, "[blit] AcquireWriteAddress cmd_size=%u curr_index=0x%llx rptr=0x%llx\n",
+          cmd_size, (unsigned long long)curr_index, (unsigned long long)*queue_rptr_);
 
   while (true) {
     // Check whether a linear region of the requested size is available.
@@ -1996,10 +2002,13 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
 
 template <bool useGCR, bool scopeFields>
 void BlitSdma<useGCR, scopeFields>::UpdateWriteAndDoorbellRegister(uint64_t curr_index, uint64_t new_index) {
+  fprintf(stderr, "[blit] UpdateWriteAndDoorbellRegister curr=0x%llx new=0x%llx\n",
+          (unsigned long long)curr_index, (unsigned long long)new_index);
   while (true) {
     // Make sure that the address before ::curr_index is already released.
     // Otherwise the CP may read invalid packets.
     uint64_t commit_index = atomic::Load(&cached_commit_index_, std::memory_order_acquire);
+    fprintf(stderr, "[blit] commit_index=0x%llx\n", (unsigned long long)commit_index);
     if (commit_index == curr_index) {
       if (sdma_wait_idle_) {
         // TODO: remove when sdma wpointer issue is resolved.
@@ -2555,6 +2564,8 @@ void BlitSdma<useGCR, scopeFields>::BuildCopyRectCommand(const std::function<voi
           pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR_RECT;
           if (scopeFields) pkt->HEADER_UNION.npd = 1;
           pkt->HEADER_UNION.element = element;
+          fprintf(stderr, "[blit] BuildCopyRect sbase=0x%llx dbase=0x%llx element=%d\n",
+                  (unsigned long long)sbase, (unsigned long long)dbase, element);
           pkt->SRC_ADDR_LO_UNION.src_addr_31_0 = sbase;
           pkt->SRC_ADDR_HI_UNION.src_addr_63_32 = sbase >> 32;
           pkt->SRC_PARAMETER_1_UNION.src_offset_x = soff;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2229,7 +2229,11 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
   lazy_ptr<core::Blit>& blit = GetBlitObject((dir == hsaHostToDevice) ? BlitHostToDev :
                                                                         BlitDevToHost);
 
+  fprintf(stderr, "[dmacpy] DmaCopyRect dir=%d blit_is_sdma=%d\n", (int)dir, (int)blit->isSDMA());
+  fflush(stderr);
   if (!blit->isSDMA()) {
+    fprintf(stderr, "[dmacpy] DmaCopyRect: blit is not SDMA, returning error\n");
+    fflush(stderr);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -2240,8 +2244,33 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
   }
 
   BlitSdmaBase* sdmaBlit = static_cast<BlitSdmaBase*>((*blit).get());
+  fprintf(stderr, "[dmacpy] DmaCopyRect calling SubmitCopyRectCommand out_signal_val=%lld\n",
+          (long long)out_signal.LoadRelaxed());
+  fflush(stderr);
   hsa_status_t stat = sdmaBlit->SubmitCopyRectCommand(dst, dst_offset, src, src_offset, range,
                                                       dep_signals, out_signal);
+  fprintf(stderr, "[dmacpy] DmaCopyRect SubmitCopyRectCommand returned %d\n", (int)stat);
+  fflush(stderr);
+
+  // Poll signal for 2 seconds to see if GPU decrement arrives.
+  for (int i = 0; i < 2000; i++) {
+    hsa_signal_value_t v = out_signal.LoadRelaxed();
+    if (v != 1 && v != 0) {
+      fprintf(stderr, "[dmacpy] signal changed after %d ms: val=%lld\n", i, (long long)v);
+      fflush(stderr);
+      break;
+    }
+    if (i % 200 == 0) {
+      fprintf(stderr, "[dmacpy] signal poll %d ms: val=%lld loc=%p\n",
+              i, (long long)v, out_signal.ValueLocation());
+      fflush(stderr);
+    }
+#ifdef _WIN32
+    Sleep(1);
+#else
+    usleep(1000);
+#endif
+  }
 
   return stat;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -875,7 +875,13 @@ core::Blit* GpuAgent::CreateBlitSdma(bool use_xgmi, int rec_eng) {
     case 11:
     case 12:
       if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
-        sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV4());
+        // DXG wraps SDMA packets in GCR itself, so useGCR=false for both. But gfx12
+        // requires explicit SDMA_MEMORY_SCOPE_SYS on writes to system memory (e.g. the
+        // completion-signal atomic) to be visible to the host CPU; without it the host
+        // poll never observes the decrement. gfx11 does not need the scope field.
+        sdma = (supported_isas()[0]->GetMajorVersion() >= 12)
+                   ? static_cast<BlitSdmaBase*>(new BlitSdmaV6())
+                   : static_cast<BlitSdmaBase*>(new BlitSdmaV4());
       } else if (supported_isas()[0]->GetMinorVersion() >= 5) {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV6());
       } else {
@@ -2243,7 +2249,11 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
   lazy_ptr<core::Blit>& blit = GetBlitObject((dir == hsaHostToDevice) ? BlitHostToDev :
                                                                         BlitDevToHost);
 
+  fprintf(stderr, "[dmacpy] DmaCopyRect dir=%d blit_is_sdma=%d\n", (int)dir, (int)blit->isSDMA());
+  fflush(stderr);
   if (!blit->isSDMA()) {
+    fprintf(stderr, "[dmacpy] DmaCopyRect: blit is not SDMA, returning error\n");
+    fflush(stderr);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -2254,8 +2264,34 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
   }
 
   BlitSdmaBase* sdmaBlit = static_cast<BlitSdmaBase*>((*blit).get());
+  fprintf(stderr, "[dmacpy] DmaCopyRect calling SubmitCopyRectCommand out_signal_val=%lld\n",
+          (long long)out_signal.LoadRelaxed());
+  fflush(stderr);
   hsa_status_t stat = sdmaBlit->SubmitCopyRectCommand(dst, dst_offset, src, src_offset, range,
                                                       dep_signals, out_signal);
+  fprintf(stderr, "[dmacpy] DmaCopyRect SubmitCopyRectCommand returned %d\n", (int)stat);
+  fflush(stderr);
+
+  // Poll signal for 2 seconds to see if GPU decrement arrives.
+  for (int i = 0; i < 2000; i++) {
+    hsa_signal_value_t v = out_signal.LoadRelaxed();
+    if (v != 1 && v != 0) {
+      fprintf(stderr, "[dmacpy] signal changed after %d ms: val=%lld\n", i, (long long)v);
+      fflush(stderr);
+      break;
+    }
+    if (i % 200 == 0) {
+      fprintf(stderr, "[dmacpy] signal poll %d ms: val=%lld loc=%p\n",
+              i, (long long)v, out_signal.ValueLocation());
+      fflush(stderr);
+    } 
+    if (v==0) break;
+#ifdef _WIN32
+    Sleep(1);
+#else
+    usleep(1000);
+#endif
+  }
 
   return stat;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
@@ -64,7 +64,9 @@ SdmaQueue::SdmaQueue(core::Agent* agent, size_t size_bytes, uint64_t flags, int3
       queue_rptr_(nullptr),
       queue_doorbell_(nullptr),
       sdma_engine_id_(sdma_engine_id),
-      active_(false) {
+      active_(false),
+      progress_fence_va_(0),
+      progress_fence_id_(0) {
   memset(&queue_resource_, 0, sizeof(queue_resource_));
 }
 
@@ -166,6 +168,10 @@ hsa_status_t SdmaQueue::Initialize() {
   queue_wptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_write_ptr);
   queue_rptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_read_ptr);
   queue_doorbell_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_DoorBell);
+  // Native SDMA user queue (Windows/DXG): the thunk hands back the HwQueue
+  // progress-fence GPU VA so RingDoorbell can emit a matching FENCE packet.
+  // 0 for KFD/SWS paths, which leaves fence emission disabled below.
+  progress_fence_va_ = queue_resource_.SdmaProgressFenceVA;
   if (queue_wptr_ == nullptr || queue_rptr_ == nullptr || queue_doorbell_ == nullptr) {
     Inactivate();
     FreeQueueBuffer();
@@ -231,19 +237,27 @@ hsa_status_t SdmaQueue::RingDoorbell(uint64_t write_index) {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
+  // FENCE+TRAP for the native SDMA HwQueue path is emitted inside libhsakmt's
+  // SDMAQueue::RingDoorbell, which writes them into [publish_index-epilogue,
+  // publish_index). Reserve that epilogue here by advancing the published wptr past
+  // the caller's packets, so the submitted wptr matches the region libhsakmt fills
+  // and libhsakmt does NOT advance again. SdmaHwQueueEpilogueBytes is 0 unless this
+  // is a native SDMA HwQueue, so the legacy/SWS path is unchanged.
+  uint64_t publish_index = write_index + queue_resource_.SdmaHwQueueEpilogueBytes;
+
   // Publish step of the submission protocol. SDMA queues are externally
   // synchronized: by the time the doorbell is stored the caller must have
   // written complete packets into the ring and handled wrap/space checks.
   //
   // The public write-index operations use queue_wptr_ directly. Ensure the
   // canonical write pointer and packet stores are visible before the doorbell.
-  atomic::Store(queue_wptr_, write_index, std::memory_order_release);
+  atomic::Store(queue_wptr_, publish_index, std::memory_order_release);
   std::atomic_thread_fence(std::memory_order_release);
-  *queue_doorbell_ = write_index;
+  *queue_doorbell_ = publish_index;
 
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG() ||
       core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF()) {
-    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, write_index));
+    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, publish_index));
   }
 
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
@@ -64,7 +64,9 @@ SdmaQueue::SdmaQueue(core::Agent* agent, size_t size_bytes, uint64_t flags, int3
       queue_rptr_(nullptr),
       queue_doorbell_(nullptr),
       sdma_engine_id_(sdma_engine_id),
-      active_(false) {
+      active_(false),
+      progress_fence_va_(0),
+      progress_fence_id_(0) {
   memset(&queue_resource_, 0, sizeof(queue_resource_));
 }
 
@@ -166,6 +168,10 @@ hsa_status_t SdmaQueue::Initialize() {
   queue_wptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_write_ptr);
   queue_rptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_read_ptr);
   queue_doorbell_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_DoorBell);
+  // Native SDMA user queue (Windows/DXG): the thunk hands back the HwQueue
+  // progress-fence GPU VA so RingDoorbell can emit a matching FENCE packet.
+  // 0 for KFD/SWS paths, which leaves fence emission disabled below.
+  progress_fence_va_ = queue_resource_.SdmaProgressFenceVA;
   if (queue_wptr_ == nullptr || queue_rptr_ == nullptr || queue_doorbell_ == nullptr) {
     Inactivate();
     FreeQueueBuffer();
@@ -231,19 +237,25 @@ hsa_status_t SdmaQueue::RingDoorbell(uint64_t write_index) {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
+  uint64_t publish_index = write_index;
+
+  // FENCE+TRAP for the native SDMA HwQueue path is emitted inside libhsakmt's
+  // SDMAQueue::RingDoorbell, so we must NOT emit them here — doing so would
+  // produce double packets and corrupt the ring for subsequent submissions.
+
   // Publish step of the submission protocol. SDMA queues are externally
   // synchronized: by the time the doorbell is stored the caller must have
   // written complete packets into the ring and handled wrap/space checks.
   //
   // The public write-index operations use queue_wptr_ directly. Ensure the
   // canonical write pointer and packet stores are visible before the doorbell.
-  atomic::Store(queue_wptr_, write_index, std::memory_order_release);
+  atomic::Store(queue_wptr_, publish_index, std::memory_order_release);
   std::atomic_thread_fence(std::memory_order_release);
-  *queue_doorbell_ = write_index;
+  *queue_doorbell_ = publish_index;
 
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG() ||
       core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF()) {
-    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, write_index));
+    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, publish_index));
   }
 
   return HSA_STATUS_SUCCESS;

--- a/shared/amdgpu-windows-interop/wkmi/wkmi.h
+++ b/shared/amdgpu-windows-interop/wkmi/wkmi.h
@@ -44,6 +44,13 @@ enum SchedLevel {
   kHigh = 2,    ///< High priority scheduling
 };
 
+/// @brief Kind of hardware queue to create. AQL and SDMA are mutually exclusive.
+enum HwQueueKind {
+  kHwQueuePm4 = 0,  ///< PM4 / compute queue (AQL->PM4 translation); default
+  kHwQueueAql,      ///< Native AQL queue
+  kHwQueueSdma,     ///< Native HSA SDMA user queue
+};
+
 /// @brief Hardware scheduling information
 /// Contains hardware scheduling (HWS) capabilities and engine support information
 struct HwsInfo {
@@ -54,7 +61,8 @@ struct HwsInfo {
       uint32_t dmaHwsEnabled     : 1;  ///< DMA engine HWS enabled
       uint32_t dma1HwsEnabled    : 1;  ///< DMA1 engine HWS enabled
       uint32_t aql_queue         : 1;  ///< Kernel mode driver supports native AQL queue
-      uint32_t reserved : 27;          ///< Reserved for future use
+      uint32_t sdma_queue        : 1;  ///< Kernel mode driver supports native HSA SDMA user queue
+      uint32_t reserved : 26;          ///< Reserved for future use
     } hwsMask;                         ///< Hardware scheduling mask bitfield
     uint32_t osHwsEnableFlags;         ///< OS HWS enable flags (raw value)
   };
@@ -129,7 +137,8 @@ struct DeviceInfo {
   uint32_t num_cp_queues;                     ///< Number of command processor queues
   HwsInfo hwsInfo;                            ///< Hardware scheduling information
   std::vector<int> sdma_schedid;              ///< SDMA scheduler IDs
-  uint32_t compute_schedid;                   ///< Compute scheduler ID
+  uint32_t compute_schedid;                   ///< Compute scheduler ID (AQL-preferred: COMPUTE1 if AQL-on-COMPUTE1 is supported, else COMPUTE0)
+  uint32_t pm4_compute_schedid;              ///< Compute scheduler ID for PM4 queues (always COMPUTE0 when present, else same as compute_schedid)
   
   // Advanced features
   bool state_shadowing_by_cpfw;               ///< True if CP firmware supports state shadowing
@@ -319,13 +328,13 @@ int GetHwQueuePrivDataSize();
 void FillinHwQueuePrivData(void* priv_data,              ///< Pointer to HW queue private data structure
                            bool FwManagedGfxState,       ///< True to enable firmware-managed graphics state
                            SchedLevel level = kNormal,   ///< Queue scheduling priority level (default: kNormal)
-                           bool aql = false,             ///< True if creating an AQL queue (default: false)
-                           uint64_t queue_va = 0,        ///< Virtual address of AQL queue memory (for AQL queues)
-                           uint64_t queue_size = 0,      ///< Size of AQL queue memory in bytes (for AQL queues)
+                           HwQueueKind kind = kHwQueuePm4, ///< Queue kind: PM4 (default), AQL, or SDMA
+                           uint64_t queue_va = 0,        ///< Virtual address of queue memory (AQL queue memory, or the SDMA ring)
+                           uint64_t queue_size = 0,      ///< Size of queue memory in bytes (AQL queue memory, or the SDMA ring)
                            uint64_t wptr = 0,            ///< Initial write pointer value (for AQL queues)
                            uint64_t rptr = 0,            ///< Initial read pointer value (for AQL queues)
                            D3DKMT_HANDLE aql_queue_desc = 0, ///< Handle to AQL queue descriptor (for AQL queues)
-                           uint32_t** doorbell_ptr = nullptr, ///< [out] Pointer to receive doorbell offset address (for AQL queues)
+                           uint32_t** doorbell_ptr = nullptr, ///< [out] Pointer to receive doorbell offset address (for AQL/SDMA queues)
                            D3DKMT_HANDLE cwsr_mem_handle = 0); ///< Allocation handle of CWSR region (UMDKMDIF_CREATEHWQUEUE_PRIVATE_DATA::CwsrMemHandle)
 
 // ============================================================================
@@ -345,7 +354,8 @@ NTSTATUS ParseAdapterInfo(D3DKMT_HANDLE adapter,      ///< Handle to the D3DKMT 
 void FillinContextPrivData(void* priv_data,                ///< Pointer to context private data structure
                            bool FwManagedGfxState,         ///< True to enable firmware-managed graphics state
                            uint32_t schedId = 0,           ///< Scheduler ID for the context (default: 0)
-                           uint64_t debuggerData = 0);
+                           uint64_t debuggerData = 0,      ///< Debugger AQL packet list data (default: 0)
+                           bool rocr_client = false);      ///< True to tag the context with the ROCr client id (native SDMA queue support)
 
 // ============================================================================
 // AQL Queue Submit Interfaces (Windows only)
@@ -358,6 +368,14 @@ int GetAqlSubmitPrivDataSize();
 /// @brief Configure AQL packet submission with doorbell value
 void FillinAqlSubmitPrivData(void* priv_data,              ///< Pointer to AQL submission private data structure
                              uint64_t doorbell_value);     ///< Write pointer (doorbell) value for AQL submission
+
+/// @brief Get the size of native HSA SDMA submission private data structure
+/// @return Size in bytes of the SDMA submission private data structure
+int GetSdmaSubmitPrivDataSize();
+
+/// @brief Configure native HSA SDMA queue submission with the write pointer byte offset
+void FillinSdmaSubmitPrivData(void* priv_data,             ///< Pointer to SDMA submission private data structure
+                              uint64_t wptr_in_bytes);     ///< SDMA write pointer as a byte offset (WptrInBytes)
 
 // ============================================================================
 // Queue CU Mask Interface (Windows only)

--- a/shared/amdgpu-windows-interop/wkmi/wkmi.h
+++ b/shared/amdgpu-windows-interop/wkmi/wkmi.h
@@ -44,6 +44,13 @@ enum SchedLevel {
   kHigh = 2,    ///< High priority scheduling
 };
 
+/// @brief Kind of hardware queue to create. AQL and SDMA are mutually exclusive.
+enum HwQueueKind {
+  kHwQueuePm4 = 0,  ///< PM4 / compute queue (AQL->PM4 translation); default
+  kHwQueueAql,      ///< Native AQL queue
+  kHwQueueSdma,     ///< Native HSA SDMA user queue
+};
+
 /// @brief Hardware scheduling information
 /// Contains hardware scheduling (HWS) capabilities and engine support information
 struct HwsInfo {
@@ -54,7 +61,8 @@ struct HwsInfo {
       uint32_t dmaHwsEnabled     : 1;  ///< DMA engine HWS enabled
       uint32_t dma1HwsEnabled    : 1;  ///< DMA1 engine HWS enabled
       uint32_t aql_queue         : 1;  ///< Kernel mode driver supports native AQL queue
-      uint32_t reserved : 27;          ///< Reserved for future use
+      uint32_t sdma_queue        : 1;  ///< Kernel mode driver supports native HSA SDMA user queue
+      uint32_t reserved : 26;          ///< Reserved for future use
     } hwsMask;                         ///< Hardware scheduling mask bitfield
     uint32_t osHwsEnableFlags;         ///< OS HWS enable flags (raw value)
   };
@@ -129,7 +137,8 @@ struct DeviceInfo {
   uint32_t num_cp_queues;                     ///< Number of command processor queues
   HwsInfo hwsInfo;                            ///< Hardware scheduling information
   std::vector<int> sdma_schedid;              ///< SDMA scheduler IDs
-  uint32_t compute_schedid;                   ///< Compute scheduler ID
+  uint32_t compute_schedid;                   ///< Compute scheduler ID (AQL-preferred: COMPUTE1 if AQL-on-COMPUTE1 is supported, else COMPUTE0)
+  uint32_t pm4_compute_schedid;              ///< Compute scheduler ID for PM4 queues (always COMPUTE0 when present, else same as compute_schedid)
   
   // Advanced features
   bool state_shadowing_by_cpfw;               ///< True if CP firmware supports state shadowing
@@ -319,13 +328,14 @@ int GetHwQueuePrivDataSize();
 void FillinHwQueuePrivData(void* priv_data,              ///< Pointer to HW queue private data structure
                            bool FwManagedGfxState,       ///< True to enable firmware-managed graphics state
                            SchedLevel level = kNormal,   ///< Queue scheduling priority level (default: kNormal)
-                           bool aql = false,             ///< True if creating an AQL queue (default: false)
-                           uint64_t queue_va = 0,        ///< Virtual address of AQL queue memory (for AQL queues)
-                           uint64_t queue_size = 0,      ///< Size of AQL queue memory in bytes (for AQL queues)
+                           HwQueueKind kind = kHwQueuePm4, ///< Queue kind: PM4 (default), AQL, or SDMA
+                           uint64_t queue_va = 0,        ///< Virtual address of queue memory (AQL queue memory, or the SDMA ring)
+                           uint64_t queue_size = 0,      ///< Size of queue memory in bytes (AQL queue memory, or the SDMA ring)
                            uint64_t wptr = 0,            ///< Initial write pointer value (for AQL queues)
                            uint64_t rptr = 0,            ///< Initial read pointer value (for AQL queues)
                            D3DKMT_HANDLE aql_queue_desc = 0, ///< Handle to AQL queue descriptor (for AQL queues)
-                           uint32_t** doorbell_ptr = nullptr); ///< [out] Pointer to receive doorbell offset address (for AQL queues)
+                           uint32_t** doorbell_ptr = nullptr, ///< [out] Pointer to receive doorbell offset address (for AQL/SDMA queues)
+                           D3DKMT_HANDLE cwsr_mem_handle = 0); ///< Allocation handle of CWSR region (UMDKMDIF_CREATEHWQUEUE_PRIVATE_DATA::CwsrMemHandle)
 
 // ============================================================================
 // Context Management Functions
@@ -344,7 +354,8 @@ NTSTATUS ParseAdapterInfo(D3DKMT_HANDLE adapter,      ///< Handle to the D3DKMT 
 void FillinContextPrivData(void* priv_data,                ///< Pointer to context private data structure
                            bool FwManagedGfxState,         ///< True to enable firmware-managed graphics state
                            uint32_t schedId = 0,           ///< Scheduler ID for the context (default: 0)
-                           uint64_t debuggerData = 0);
+                           uint64_t debuggerData = 0,      ///< Debugger AQL packet list data (default: 0)
+                           bool rocr_client = false);      ///< True to tag the context with the ROCr client id (native SDMA queue support)
 
 // ============================================================================
 // AQL Queue Submit Interfaces (Windows only)
@@ -357,6 +368,14 @@ int GetAqlSubmitPrivDataSize();
 /// @brief Configure AQL packet submission with doorbell value
 void FillinAqlSubmitPrivData(void* priv_data,              ///< Pointer to AQL submission private data structure
                              uint64_t doorbell_value);     ///< Write pointer (doorbell) value for AQL submission
+
+/// @brief Get the size of native HSA SDMA submission private data structure
+/// @return Size in bytes of the SDMA submission private data structure
+int GetSdmaSubmitPrivDataSize();
+
+/// @brief Configure native HSA SDMA queue submission with the write pointer byte offset
+void FillinSdmaSubmitPrivData(void* priv_data,             ///< Pointer to SDMA submission private data structure
+                              uint64_t wptr_in_bytes);     ///< SDMA write pointer as a byte offset (WptrInBytes)
 
 // ============================================================================
 // Queue CU Mask Interface (Windows only)


### PR DESCRIPTION
Support SDMA user queue in Rocr in windows

## Motivation

To support native sdma queue in Windows

## Technical Details

Use KMD provided interface

## Issue Tracking
AIRUNTIME-2310

## Test Plan
All memory copy cases should pass

## Test Result
pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
