### PR TITLE
Fix shell injection in git subrepo PRs

### DIFF
--- a/.github/scripts/import_subrepo_prs.py
+++ b/.github/scripts/import_subrepo_prs.py
@@ -1,13 +1,48 @@
 import os
+import shlex
 import sys
 import subprocess
+from urllib.parse import urlparse
+
 from github import Github
 from git import Repo
 
 
 def run(cmd, **kwargs):
-    print(f">> {cmd}")
-    subprocess.check_call(cmd, shell=True, **kwargs)
+    # Require argv lists so fork-controlled values (branch names, URLs) are never
+    # interpolated into a shell string. Reject str commands to prevent regressions
+    # back to shell=True f-string call sites.
+    if isinstance(cmd, str):
+        raise TypeError("run() requires an argv list; shell=True is not supported")
+    print(f">> {shlex.join(cmd)}")
+    # do not use shell=True to avoid injection bugs
+    subprocess.check_call(cmd, **kwargs)
+
+
+# Run a git command but ignore non-zero exit codes (e.g. merge --abort when no
+# merge is in progress).
+def run_allow_failure(cmd, **kwargs):
+    try:
+        run(cmd, **kwargs)
+    except subprocess.CalledProcessError:
+        pass
+
+# clone_url from the GitHub API is always HTTPS; reject other schemes (e.g. git@)
+# before passing the URL to git subtree pull.
+def validate_clone_url(url):
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError(f"Unsupported clone URL: {url!r}")
+
+    repo_path = parsed.path.removeprefix("/")
+    if not repo_path.endswith(".git"):
+        raise ValueError(f"Unexpected clone URL path: {url!r}")
+
+    owner, repo = repo_path[:-4].split("/", 1)
+    if not owner or not repo or "/" in repo:
+        raise ValueError(f"Unexpected clone URL path: {url!r}")
+
+    return url
 
 
 def main():
@@ -25,12 +60,12 @@ def main():
         sys.exit(1)
 
     pr_numbers = [p.strip() for p in pr_list.split(",") if p.strip()]
-    conflicted_prs = []  # 🔹 Track PRs with merge conflicts
+    conflicted_prs = []  # Track PRs with merge conflicts
 
     # 2) Init local repo and configure Git user
     repo = Repo(os.getcwd())
-    run("git config user.name  'systems-assistant[bot]'")
-    run("git config user.email 'systems-assistant[bot]@users.noreply.github.com'")
+    run(["git", "config", "user.name", "systems-assistant[bot]"])
+    run(["git", "config", "user.email", "systems-assistant[bot]@users.noreply.github.com"])
 
     # 3) Init GitHub clients
     gh = Github(token)
@@ -38,11 +73,11 @@ def main():
     sub_repo = gh.get_repo(upstream)
 
     # 4) Ensure target branch is checked out
-    run(f"git fetch origin {target}")
+    run(["git", "fetch", "origin", target])
     try:
-        run(f"git checkout {target}")
+        run(["git", "checkout", target])
     except subprocess.CalledProcessError:
-        run(f"git checkout -b {target} origin/{target}")
+        run(["git", "checkout", "-b", target, f"origin/{target}"])
 
     # 5) Loop over each PR
     for pr_num in pr_numbers:
@@ -52,7 +87,10 @@ def main():
         title = pr.title
         body = pr.body or ""
         head_ref = pr.head.ref
-        head_url = pr.head.repo.clone_url
+        # GitHub API clone_url is always HTTPS (e.g. https://github.com/o/r.git).
+        # SSH remotes are in pr.head.repo.ssh_url (git@host:o/r.git); we use
+        # clone_url here, so git@ URLs are never passed to git subtree pull.
+        head_url = validate_clone_url(pr.head.repo.clone_url)
         is_draft = pr.draft
         author = pr.user.login
 
@@ -61,22 +99,22 @@ def main():
         branch = f"import/{tclean}/{src_clean}/pr-{pr_num}"
 
         try:
-            run(f"git checkout -b {branch}")
+            run(["git", "checkout", "-b", branch])
         except subprocess.CalledProcessError:
-            run(f"git branch -D {branch}")
-            run(f"git checkout -b {branch}")
+            run(["git", "branch", "-D", branch])
+            run(["git", "checkout", "-b", branch])
 
         try:
-            run(f"git subtree pull --prefix={prefix} {head_url} {head_ref}")
+            run(["git", "subtree", "pull", f"--prefix={prefix}", head_url, head_ref])
         except subprocess.CalledProcessError:
             print(f"❌ Merge conflict: subtree pull failed for PR #{pr_num}, skipping.")
-            conflicted_prs.append(pr_num)  # 🔹 Track the failed PR
-            run(f"git merge --abort || true")  # Clean up merge state if needed
-            run(f"git reset --hard")  # Ensure clean state
-            run(f"git checkout {target}")
+            conflicted_prs.append(pr_num)
+            run_allow_failure(["git", "merge", "--abort"])
+            run(["git", "reset", "--hard"])
+            run(["git", "checkout", target])
             continue
 
-        run(f"git push origin {branch}")
+        run(["git", "push", "origin", branch])
 
         footer = (
             "\n\n---\n"
@@ -94,9 +132,8 @@ def main():
         )
         new_pr.add_to_labels("imported pr")
 
-        run(f"git checkout {target}")
+        run(["git", "checkout", target])
 
-    # 🔹 Summary of failed PRs due to conflict
     if conflicted_prs:
         print("\n⚠️ The following PRs failed due to merge conflicts:")
         for pr in conflicted_prs:

--- a/.github/scripts/import_subrepo_prs.py
+++ b/.github/scripts/import_subrepo_prs.py
@@ -8,6 +8,10 @@ from github import Github
 from git import Repo
 
 
+class InputValidationError(ValueError):
+    """Raised when workflow input is unsafe or malformed."""
+
+
 def run(cmd, **kwargs):
     # Require argv lists so fork-controlled values (branch names, URLs) are never
     # interpolated into a shell string. Reject str commands to prevent regressions
@@ -27,22 +31,40 @@ def run_allow_failure(cmd, **kwargs):
     except subprocess.CalledProcessError:
         pass
 
+
+# Validate Git branch syntax and reject option-like names starting with "-" so
+# untrusted branch names cannot be interpreted as command-line options.
+def validate_branch_name(branch):
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", branch],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or result.stdout.strip() != branch:
+        error = result.stderr.strip() or "branch name does not resolve literally"
+        raise InputValidationError(f"Invalid branch name {branch!r}: {error}")
+
+    ret = branch
+    return ret
+
+
 # clone_url from the GitHub API is always HTTPS; reject other schemes (e.g. git@)
 # before passing the URL to git subtree pull.
 def validate_clone_url(url):
     parsed = urlparse(url)
     if parsed.scheme != "https" or not parsed.netloc:
-        raise ValueError(f"Unsupported clone URL: {url!r}")
+        raise InputValidationError(f"Unsupported clone URL: {url!r}")
 
     repo_path = parsed.path.removeprefix("/")
     if not repo_path.endswith(".git"):
-        raise ValueError(f"Unexpected clone URL path: {url!r}")
+        raise InputValidationError(f"Unexpected clone URL path: {url!r}")
 
     owner, repo = repo_path[:-4].split("/", 1)
     if not owner or not repo or "/" in repo:
-        raise ValueError(f"Unexpected clone URL path: {url!r}")
+        raise InputValidationError(f"Unexpected clone URL path: {url!r}")
 
-    return url
+    ret = url
+    return ret
 
 
 def main():
@@ -59,6 +81,7 @@ def main():
         print("ERROR: Missing one or more required environment variables.")
         sys.exit(1)
 
+    target = validate_branch_name(target)
     pr_numbers = [p.strip() for p in pr_list.split(",") if p.strip()]
     conflicted_prs = []  # Track PRs with merge conflicts
 
@@ -86,7 +109,7 @@ def main():
 
         title = pr.title
         body = pr.body or ""
-        head_ref = pr.head.ref
+        head_ref = validate_branch_name(pr.head.ref)
         # GitHub API clone_url is always HTTPS (e.g. https://github.com/o/r.git).
         # SSH remotes are in pr.head.repo.ssh_url (git@host:o/r.git); we use
         # clone_url here, so git@ URLs are never passed to git subtree pull.
@@ -145,4 +168,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except InputValidationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

- Invoke Git commands with argument lists instead of `shell=True`.
- Validate clone URLs before passing them to `git subtree`.
- Validate target and pull request branch names with `git check-ref-format --branch`.
- Reject malformed and option-like branch names before running Git commands.
- Report validation failures clearly without a Python traceback.

## Motivation

The subrepo pull request importer passed externally controlled values through a shell, creating a potential shell-injection vulnerability.

Moving to argument-list execution prevents shell interpretation. However, branch names beginning with `-` could still be interpreted as Git options. Explicit branch validation closes that remaining argument-injection path.

## Technical Details

- Require argument lists in the Git command helper.
- Remove all uses of `shell=True`.
- Accept only expected HTTPS clone URL formats.
- Validate the target branch before checkout.
- Validate fork-controlled pull request branch names before `git subtree pull`.
- Use a dedicated validation exception.
- Print concise validation errors to stderr and exit with a nonzero status.
- Preserve intentional failure handling for `git merge --abort`.

## Test Plan

- Verify valid branch names are accepted.
- Verify malformed branch names are rejected.
- Verify option-like names such as `--detach` and `--squash` are rejected.
- Verify invalid input exits with status 1.
- Verify validation errors do not produce a Python traceback.
- Verify whitespace checks pass and the file retains Linux LF line endings.

- Tools used:
  - gpt-5.6
  
## Issue Tracking

JIRA ID: ROCM-26663
