### PR TITLE
fix(rccl): LL protocol explicit 128-bit vector loads/stores (stacked on #10666)

### DIFF
--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -7,6 +7,38 @@
  ************************************************************************/
 
 #include "rccl_ptr.h"
+
+// Non-temporal 128-bit load for LL communication (FIFO) buffers. Comm buffers
+// are uncached; a single explicit vector load avoids relying on the backend to
+// fuse two independent 64-bit nontemporal loads into one 16-byte op.
+inline __device__ void loadLLLine(const union ncclLLFifoLine* src, union ncclLLFifoLine& dst) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_nontemporal_load((v4u_gptr)src->v);
+  dst.v[0] = u.u64[0];
+  dst.v[1] = u.u64[1];
+}
+
+// Plain 128-bit vector store for LL FIFO lines. Like LL128 store128Plain, a
+// single 128-bit store keeps data and flag words in one memory transaction so
+// the reader's flag poll cannot observe flags before their paired data.
+inline __device__ void storeLLLine(union ncclLLFifoLine* dst, const union ncclLLFifoLine& src) {
+#if !RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__gfx1200__) || defined(__gfx1201__))
+  __hip_atomic_store((u64_gptr)dst->v, src.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  __hip_atomic_store((u64_gptr)dst->v + 1, src.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.u64[0] = src.v[0];
+  u.u64[1] = src.v[1];
+  *((v4u_gptr)dst->v) = u.v;
+#endif
+}
+
 // UserRegMode is accepted only to match the Primitives primary template (which
 // carries it for LL128, see primitives.h/prims_ll128.h). The LL protocol path is
 // unchanged from the baseline and ignores it.
@@ -156,14 +188,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
                    "s_waitcnt vmcnt(0)\n"
                    : "=v"(i4.i4)
                    : "v"(&src->i4));
-#elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+#else
       // Comm FIFO buffers are uncached; use non-temporal loads so the flag poll
       // never observes a stale cache line (no system-scope cache-bypass needed).
-      *((u64_gptr)i4.v) = __builtin_nontemporal_load((u64_gptr)src->v);
-      *((u64_gptr)i4.v + 1) = __builtin_nontemporal_load((u64_gptr)src->v + 1);
-#else
-      *((u64_gptr)i4.v) = __builtin_nontemporal_load((u64_gptr)src->v);
-      *((u64_gptr)i4.v + 1) = __builtin_nontemporal_load((u64_gptr)src->v + 1);
+      loadLLLine(src, i4);
 #endif
       if (checkAbort(abort, 1, spins)) break;
     } while ((i4.flag1 != flag) || (i4.flag2 != flag));
@@ -196,13 +224,9 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
                      "s_waitcnt vmcnt(0)\n"
                      : "=v"(line[i].i4)
                      : "v"(&src->i4));
-#elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-        // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
-        line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
-        line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #else
-        line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
-        line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
+        // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
+        loadLLLine(src, line[i]);
 #endif
 #else
         asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
@@ -225,13 +249,9 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
                    "s_waitcnt vmcnt(0)\n"
                    : "=v"(line[i].i4)
                    : "v"(&src->i4));
-#elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-      // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
-      line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
-      line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #else
-      line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
-      line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
+      // Comm FIFO buffers are uncached; use non-temporal loads (no bypass).
+      loadLLLine(src, line[i]);
 #endif
 #else
       asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
@@ -253,20 +273,9 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     i4.flag1 = flag;
     i4.data2 = (val >> 32);
     i4.flag2 = flag;
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // Comm FIFO buffers are uncached; use plain stores (no system-scope cache
-    // bypass) for higher store throughput and lower register pressure.
-    *((u64_gptr)dst->v) = *((u64_gptr)i4.v);
-    *((u64_gptr)dst->v + 1) = *((u64_gptr)i4.v + 1);
-#else
-#if defined(__gfx1200__) || defined(__gfx1201__)
-    __hip_atomic_store((u64_gptr)dst->v, i4.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    __hip_atomic_store((u64_gptr)dst->v + 1, i4.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-#else
-    *((u64_gptr)dst->v) = *((u64_gptr)i4.v);
-    *((u64_gptr)dst->v + 1) = *((u64_gptr)i4.v + 1);
-#endif
-#endif
+    // Comm FIFO buffers are uncached; use plain vector stores (no system-scope
+    // cache bypass) for higher store throughput and lower register pressure.
+    storeLLLine(dst, i4);
 #if defined(__gfx950__) && ROCM_VERSION < 70002
     __builtin_amdgcn_fence(
       __ATOMIC_RELEASE,

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -12,13 +12,7 @@
 // are uncached; a single explicit vector load avoids relying on the backend to
 // fuse two independent 64-bit nontemporal loads into one 16-byte op.
 inline __device__ void loadLLLine(const union ncclLLFifoLine* src, union ncclLLFifoLine& dst) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.v = __builtin_nontemporal_load((v4u_gptr)src->v);
-  dst.v[0] = u.u64[0];
-  dst.v[1] = u.u64[1];
+  dst.v4u = __builtin_nontemporal_load((v4u_gptr)&src->v4u);
 }
 
 // Plain 128-bit vector store for LL FIFO lines. Like LL128 store128Plain, a
@@ -29,13 +23,7 @@ inline __device__ void storeLLLine(union ncclLLFifoLine* dst, const union ncclLL
   __hip_atomic_store((u64_gptr)dst->v, src.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   __hip_atomic_store((u64_gptr)dst->v + 1, src.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
 #else
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.u64[0] = src.v[0];
-  u.u64[1] = src.v[1];
-  *((v4u_gptr)dst->v) = u.v;
+  *((v4u_gptr)&dst->v4u) = src.v4u;
 #endif
 }
 

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -96,9 +96,8 @@ struct ncclDevRedOpFull {
   uint64_t scalarArg;
 };
 
-#ifdef __HIP_DEVICE_COMPILE__
+
 #include "rccl_ptr.h"
-#endif
 
 union ncclLLFifoLine {
   /* Flags have to be *after* data, because otherwise, an incomplete receive
@@ -113,9 +112,7 @@ union ncclLLFifoLine {
   };
   uint64_t v[2];
   int4 i4;
-#if defined(__HIP_DEVICE_COMPILE__) && RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   v4u v4u; /* same layout as data1,flag1,data2,flag2 for b128 load/store */
-#endif
 };
 
 #if __HIP_DEVICE_COMPILE__

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -97,7 +97,7 @@ struct ncclDevRedOpFull {
 };
 
 
-#include "rccl_ptr.h"
+#include "nccl_device/rccl_ptr.h"
 
 union ncclLLFifoLine {
   /* Flags have to be *after* data, because otherwise, an incomplete receive


### PR DESCRIPTION
## Summary

Stacked on #10666 (`users/abreslow/ll128_cleanup`).

- Add `loadLLLine` / `storeLLLine` helpers in `prims_ll.h`, mirroring the LL128 `load128NT` / `store128Plain` approach
- Replace paired 64-bit nontemporal loads and plain stores in LL FIFO access (`readLL`, `readLLBeginAll`, `readLLFinish`, `storeLL`) with single explicit `v4u` vector operations
- Preserve GFX11 inline-asm b128 paths and the gfx1200/gfx1201 dual `__hip_atomic_store` fallback when b128 builtins are unavailable

A single 128-bit store keeps data and flag words in one memory transaction, so the reader's flag poll cannot observe flags before their paired data.

## Test plan

- [x] RCCL release build succeeds with existing `build/release` tree
- [ ] LL protocol collectives on gfx942/gfx950/gfx1250
- [ ] Verify assembly emits `global_load/store_dwordx4` rather than paired flat/dword ops on HIP paths


Made with [Cursor](https://cursor.com)