### PR TITLE
test(rccl): GIN AllToAll device-template unit tests (gin-gda + gin-sdma shadow fix)

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -122,7 +122,7 @@ if(ENABLE_ROCSHMEM AND ENABLE_ROCSHMEM_GIN)
   message(FATAL_ERROR "ENABLE_ROCSHMEM and ENABLE_ROCSHMEM_GIN are mutually exclusive")
 endif()
 set(ROCSHMEM_CMAKE_OPTIONS "" CACHE STRING     "Extra cmake options passed to the rocSHMEM ExternalProject build")
-option(GIN_ANVIL_UNIT_TESTS                    "Build GIN Anvil device unit tests with ENABLE_ROCSHMEM on test targets only (no full librocshmem in librccl)" OFF)
+option(GIN_ANVIL_UNIT_TESTS                    "Build GIN Anvil device-template unit tests (ENABLE_ROCSHMEM_GIN on Fixtures; no full librocshmem in librccl)" OFF)
 option(ENABLE_WARP_SPEED                       "Enable WARP_SPEED optimizations"               OFF)
 
 # Default GPU architectures to build

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -342,17 +342,20 @@ if(BUILD_TESTS)
     list(APPEND TEST_FIXTURE_SOURCE_FILES
       gin/GinAnvilIpcTableHost_test.cpp
       ../src/gin/gin_anvil_ipc_table_host.cc
-      # GIN rocSHMEM-GDA device template test. Self-contained: supplies its own
-      # rocshmem::QueuePair device stubs in-TU (no librocshmem device link, no
-      # header shadow), so it only needs ENABLE_ROCSHMEM_GIN (which enables
-      # NCCL_GIN_ROCSHMEM_GDA_ENABLE) and does not depend on the SDMA
-      # anvil_device.hpp shadow used by the Anvil-SDMA template test below.
-      device/GinRocshmemGdaTemplate_test.cpp
     )
   endif()
 
   if(ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS))
     list(APPEND TEST_FIXTURE_SOURCE_FILES
+      # GIN rocSHMEM-GDA device template test. Self-contained: supplies its own
+      # rocshmem::QueuePair device stubs in-TU (no librocshmem device link, no
+      # header shadow). Its body is guarded by NCCL_GIN_ROCSHMEM_GDA_ENABLE, which
+      # is 1 only when ENABLE_ROCSHMEM is defined -- and ENABLE_ROCSHMEM is added to
+      # this target under the same (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS)
+      # condition below. So it is built and run here (e.g. GIN_ANVIL_UNIT_TESTS)
+      # alongside the Anvil-SDMA template test, not in a pure ENABLE_ROCSHMEM_GIN
+      # build (where the body would compile out to zero test cases).
+      device/GinRocshmemGdaTemplate_test.cpp
       device/GinAnvilSdmaTemplate_test.cpp
     )
   endif()

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -866,6 +866,35 @@ if(BUILD_TESTS)
       target_link_options(${test_executable} PRIVATE -fgpu-rdc --hip-link ${_ROCSHMEM_OFFLOAD_FLAGS} -rdynamic)
     endif()
 
+    # librccl.so built with ENABLE_ROCSHMEM_GIN but without host librocshmem
+    # (ENABLE_ROCSHMEM=OFF, e.g. gin CI --rocshmem-gin) leaves
+    # rocshmem::envvar::log_flags undefined at load time. Link host rocSHMEM
+    # into the Fixtures binary so the executable satisfies those symbols when
+    # the dynamic loader brings in librccl.so.
+    if(ENABLE_ROCSHMEM_GIN AND GIN_ANVIL_UNIT_TESTS AND NOT ENABLE_ROCSHMEM
+       AND ROCSHMEM_INSTALL_DIR AND "${test_executable}" STREQUAL "rccl-UnitTestsFixtures")
+      set(_ROCSHMEM_FIXTURES_OFFLOAD_FLAGS "")
+      foreach(_g IN LISTS GPU_TARGETS)
+        if(_g)
+          list(APPEND _ROCSHMEM_FIXTURES_OFFLOAD_FLAGS "--offload-arch=${_g}")
+        endif()
+      endforeach()
+      find_library(_ROCSHMEM_FIXTURES_DRM        NAMES drm        HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+      find_library(_ROCSHMEM_FIXTURES_DRM_AMDGPU NAMES drm_amdgpu HINTS ${ROCM_PATH}/lib/rocm_sysdeps/lib)
+      if(NOT _ROCSHMEM_FIXTURES_DRM)
+        set(_ROCSHMEM_FIXTURES_DRM drm)
+      endif()
+      if(NOT _ROCSHMEM_FIXTURES_DRM_AMDGPU)
+        set(_ROCSHMEM_FIXTURES_DRM_AMDGPU drm_amdgpu)
+      endif()
+      target_link_libraries(${test_executable} PRIVATE
+        ${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a
+        ibverbs hsa-runtime64 hsakmt numa
+        ${_ROCSHMEM_FIXTURES_DRM} ${_ROCSHMEM_FIXTURES_DRM_AMDGPU})
+      target_link_options(${test_executable} PRIVATE
+        -fgpu-rdc --hip-link ${_ROCSHMEM_FIXTURES_OFFLOAD_FLAGS} -rdynamic)
+    endif()
+
     rocm_install(TARGETS ${test_executable} COMPONENT tests)
   endforeach()
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -350,11 +350,9 @@ if(BUILD_TESTS)
       # GIN rocSHMEM-GDA device template test. Self-contained: supplies its own
       # rocshmem::QueuePair device stubs in-TU (no librocshmem device link, no
       # header shadow). Its body is guarded by NCCL_GIN_ROCSHMEM_GDA_ENABLE, which
-      # is 1 only when ENABLE_ROCSHMEM is defined -- and ENABLE_ROCSHMEM is added to
-      # this target under the same (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS)
-      # condition below. So it is built and run here (e.g. GIN_ANVIL_UNIT_TESTS)
-      # alongside the Anvil-SDMA template test, not in a pure ENABLE_ROCSHMEM_GIN
-      # build (where the body would compile out to zero test cases).
+      # gin_device_common.h sets when ENABLE_ROCSHMEM_GIN is defined on HIP.
+      # Built here alongside the Anvil-SDMA template test under GIN_ANVIL_UNIT_TESTS
+      # or when librccl is built with full ENABLE_ROCSHMEM.
       device/GinRocshmemGdaTemplate_test.cpp
       device/GinAnvilSdmaTemplate_test.cpp
     )
@@ -384,7 +382,10 @@ if(BUILD_TESTS)
     target_compile_definitions(rccl-UnitTestsFixtures PRIVATE ENABLE_ROCSHMEM_GIN)
   endif()
 
-  if(ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS))
+  # Match librccl.so ABI: ENABLE_ROCSHMEM changes ncclComm/ncclProxyState layout.
+  # GIN CI builds librccl with ENABLE_ROCSHMEM_GIN only; device templates need
+  # ENABLE_ROCSHMEM_GIN (above), not ENABLE_ROCSHMEM on this target.
+  if(ENABLE_ROCSHMEM_GIN AND ENABLE_ROCSHMEM)
     target_compile_definitions(rccl-UnitTestsFixtures PRIVATE ENABLE_ROCSHMEM)
   endif()
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -342,6 +342,12 @@ if(BUILD_TESTS)
     list(APPEND TEST_FIXTURE_SOURCE_FILES
       gin/GinAnvilIpcTableHost_test.cpp
       ../src/gin/gin_anvil_ipc_table_host.cc
+      # GIN rocSHMEM-GDA device template test. Self-contained: supplies its own
+      # rocshmem::QueuePair device stubs in-TU (no librocshmem device link, no
+      # header shadow), so it only needs ENABLE_ROCSHMEM_GIN (which enables
+      # NCCL_GIN_ROCSHMEM_GDA_ENABLE) and does not depend on the SDMA
+      # anvil_device.hpp shadow used by the Anvil-SDMA template test below.
+      device/GinRocshmemGdaTemplate_test.cpp
     )
   endif()
 

--- a/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
+++ b/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
@@ -197,6 +197,7 @@ TEST_F(GinAnvilIpcDeviceTest, DetailHelpers_ChannelAndDirty) {
   hostCtx.sdmaChannelStride = 1;
   hostCtx.fusedSdmaSignal = 1;
   hostCtx.signals = reinterpret_cast<uint64_t*>(0x1);  // non-null for fused predicate
+  hostCtx.signal_remote_addrs = reinterpret_cast<uintptr_t*>(0x1);
 
   DeviceBuffer<uint64_t> d_dirty(1);
   d_dirty.zero();

--- a/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
+++ b/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
@@ -367,7 +367,7 @@ __global__ void kernelFlushDirty(PutHarness* h, uint64_t* dirty) {
   ginCtx.nRanks = 2;
   h->ctx.sdmaDirty = dirty;
   h->ctx.queueHandles = nullptr;
-  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{},
+  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{}, false, nullptr,
                                                          cuda::memory_order_seq_cst, nullptr);
 }
 

--- a/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
+++ b/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
@@ -171,8 +171,8 @@ TEST_F(GinAnvilIpcDeviceTest, IpcFlatAtomicAddSys64) {
 using nccl::gin::anvil::detail::anvilCtxValid;
 using nccl::gin::anvil::detail::effectiveChannel;
 using nccl::gin::anvil::detail::markSdmaDirty;
-using nccl::gin::anvil::detail::anvilSignalPtrOrDummy;
 using nccl::gin::anvil::detail::remoteSignalAddr;
+using nccl::utility::loadConst;
 using nccl::gin::anvil::detail::useSdmaFusedSignal;
 using nccl::gin::anvil::detail::fenceBeforeSignal;
 
@@ -250,15 +250,15 @@ __global__ void kernelAnvilCtxValid(bool* outValid, bool* outSignalNonNull) {
   good.layoutMagic = NCCL_GIN_ANVIL_SDMA_LAYOUT_MAGIC;
   outValid[2] = anvilCtxValid(&good);
 
-  outSignalNonNull[0] = (anvilSignalPtrOrDummy(nullptr, 0) != nullptr);
-  outSignalNonNull[1] = (anvilSignalPtrOrDummy(&good, 0) != nullptr);
+  outSignalNonNull[0] = !anvilCtxValid(nullptr);
+  outSignalNonNull[1] = (loadConst(&good.signals) == nullptr);
 
   good.signals = nullptr;
-  outSignalNonNull[2] = (anvilSignalPtrOrDummy(&good, 0) != nullptr);
+  outSignalNonNull[2] = (loadConst(&good.signals) == nullptr);
 
   uint64_t sigs[2] = {0, 0};
   good.signals = sigs;
-  outSignalNonNull[3] = (anvilSignalPtrOrDummy(&good, 1) == sigs + 1);
+  outSignalNonNull[3] = (loadConst(&good.signals) + 1 == sigs + 1);
 
   outSignalNonNull[4] = (remoteSignalAddr(&good, 0, 0) == nullptr);
 }

--- a/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
+++ b/projects/rccl/test/device/GinAnvilIpcDevice_test.cpp
@@ -212,10 +212,12 @@ TEST_F(GinAnvilIpcDeviceTest, DetailHelpers_ChannelAndDirty) {
   d_fused.zero();
   d_dirtyRead.zero();
 
-  kernelDetailHelpers<<<1, 1>>>(d_ctx.ptr, 128, d_eff.ptr, d_fused.ptr, d_dirtyRead.ptr);
+  // blockId=2, single-warp block (<<<1,1>>> => nWarpsPerBlock clamped to 1, warpId 0)
+  // => slot = 2*1 + 0 = 2, effChannel = (baseCh + stride*slot) % numCh.
+  kernelDetailHelpers<<<1, 1>>>(d_ctx.ptr, 2, d_eff.ptr, d_fused.ptr, d_dirtyRead.ptr);
   syncAndCheck();
 
-  EXPECT_EQ(d_eff.download(), 2);  // (0 + 1*(128/64)) % 4 == 2
+  EXPECT_EQ(d_eff.download(), 2);  // (0 + 1*2) % 4 == 2
   hipDeviceProp_t prop{};
   ASSERT_EQ(hipSuccess, hipGetDeviceProperties(&prop, 0));
   const bool oss7 = (std::strstr(prop.gcnArchName, "gfx950") != nullptr);
@@ -279,7 +281,7 @@ TEST_F(GinAnvilIpcDeviceTest, AnvilCtxValid_AndSignalPtr) {
 
 __global__ void kernelFencePaths(bool sdmaPath, bool hasCounter) {
   if (threadIdx.x != 0) return;
-  fenceBeforeSignal(sdmaPath, nullptr, hasCounter);
+  fenceBeforeSignal(nullptr, sdmaPath, nullptr, hasCounter);
 }
 
 TEST_F(GinAnvilIpcDeviceTest, FenceBeforeSignal_CompilesAllPaths) {

--- a/projects/rccl/test/device/GinAnvilSdmaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinAnvilSdmaTemplate_test.cpp
@@ -304,7 +304,7 @@ __global__ void kernelFlushQuiet(TemplateHarness* h, uint64_t* dirty) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
   ginCtx.nRanks = 2;
-  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{},
+  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{}, false, nullptr,
                                                          cuda::memory_order_seq_cst, nullptr);
 }
 
@@ -428,7 +428,7 @@ __global__ void kernelFlushMultiDirty(TemplateHarness* h, uint64_t* dirty) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
   ginCtx.nRanks = 2;
-  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{},
+  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, ncclCoopThread{}, false, nullptr,
                                                          cuda::memory_order_seq_cst, nullptr);
 }
 

--- a/projects/rccl/test/device/GinAnvilSdmaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinAnvilSdmaTemplate_test.cpp
@@ -330,17 +330,17 @@ __global__ void kernelCounterSignalApi(TemplateHarness* h, uint64_t* outCtr, uin
   if (threadIdx.x != 0) return;
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
-  uint64_t* ctr = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
-  if (ctr) ctr[0] = 99;
+  ncclGinOffsetPtr ctrOff = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
+  if (ctrOff.ptr) ctrOff.ptr[0] = 99;
   ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
-  outCtr[0] = ctr ? ctr[0] : 0;
-  uint64_t* sig = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
-  if (sig) sig[0] = 11;
+  outCtr[0] = ctrOff.ptr ? ctrOff.ptr[0] : 0;
+  ncclGinOffsetPtr sigOff = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
+  if (sigOff.ptr) sigOff.ptr[0] = 11;
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
   desc.indexedSignal.signalId = 0;
   ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, desc);
-  outSig[0] = sig ? sig[0] : 0;
+  outSig[0] = sigOff.ptr ? sigOff.ptr[0] : 0;
 }
 
 TEST_F(GinAnvilSdmaTemplateTest, CounterSignal_GetReset) {
@@ -373,7 +373,7 @@ __global__ void kernelInvalidCtxApis(bool* ok) {
   ncclGinAnvilSdmaGPUContext bad{};
   bad.layoutMagic = 0;
   ginCtx.handle = &bad;
-  ok[0] = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0) == nullptr;
+  ok[0] = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0).ptr == nullptr;
   ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_ANVIL_SDMA>::call(ginCtx, 0);
   ok[1] = true;
 }

--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -10,7 +10,7 @@
 // specializations, so this suite unit-tests the GDA AllToAll device path
 // without a live network.
 //
-// The real rocshmem::QueuePair device methods (put_nbi/atomic_nofetch/quiet) are
+// The real rocshmem::QueuePair device methods (put_nbi/atomic_add/quiet) are
 // only declared in queue_pair_device.h (defined in rocSHMEM device bitcode).
 // This translation unit supplies inline stub definitions so the suite links
 // against no librocshmem device code, mirroring how Suite H shadows the SDMA
@@ -36,7 +36,7 @@
 // --------------------------------------------------------------------------
 // Stub definitions for rocshmem::QueuePair device methods.
 //   put_nbi       : byte-copy laddr -> raddr (observe data landing at remote VA)
-//   atomic_nofetch: atomic add into the remote signal word (observe signal deliver)
+//   atomic_add   : atomic add into the remote signal word (observe signal deliver)
 //   quiet         : bump a device-global call counter (observe completion sync)
 // Non-RDC build: these must be defined in the same TU as the kernels that
 // (via the inlined template) call them.
@@ -53,13 +53,13 @@ __device__ void QueuePair::put_nbi(void* raddr, uint32_t /*rkey*/, const void* l
   for (size_t i = 0; i < length; ++i) d[i] = s[i];
 }
 
-// Matches queue_pair_device.h: atomic_nofetch(void* dest, uint32_t rkey, int64_t
-// value, int64_t cond, ActiveWFInfo&). The template's signal path calls this
-// (gin_rocshmem_gda.h:54,101); cond/rkey are unused by the byte-accurate stub.
-__device__ void QueuePair::atomic_nofetch(void* dest, uint32_t /*rkey*/, int64_t value, int64_t /*cond*/,
-                                          ActiveWFInfo& /*wf_info*/) {
-  if (dest == nullptr) return;
-  atomicAdd(reinterpret_cast<unsigned long long*>(dest), static_cast<unsigned long long>(value));
+// Matches queue_pair_device.h: atomic_add(void* raddr, uint32_t rkey, int64_t
+// value, ActiveWFInfo&, bool fence). The template's signal path calls this
+// (gin_rocshmem_gda.h:54,101); rkey/fence are unused by the byte-accurate stub.
+__device__ void QueuePair::atomic_add(void* raddr, uint32_t /*rkey*/, int64_t value, ActiveWFInfo& /*wf_info*/,
+                                      bool /*fence*/) {
+  if (raddr == nullptr) return;
+  atomicAdd(reinterpret_cast<unsigned long long*>(raddr), static_cast<unsigned long long>(value));
 }
 
 __device__ void QueuePair::quiet(ActiveWFInfo& /*wf_info*/) {
@@ -428,15 +428,15 @@ TEST_F(GinRocshmemGdaTemplateTest, Flush_QuietsAllPeers) {
 __global__ void kernelGetReset(GdaHarness* h) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
-  uint64_t* sig = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
-  if (sig) sig[0] = 55;
+  ncclGinOffsetPtr sigOff = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (sigOff.ptr) sigOff.ptr[0] = 55;
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
   desc.indexedSignal.signalId = 0;
   ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, desc);
 
-  uint64_t* ctr = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
-  if (ctr) ctr[0] = 77;
+  ncclGinOffsetPtr ctrOff = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (ctrOff.ptr) ctrOff.ptr[0] = 77;
   ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
 }
 
@@ -455,8 +455,8 @@ TEST_F(GinRocshmemGdaTemplateTest, GetReset_SignalAndCounter) {
 __global__ void kernelResetSignalNone(GdaHarness* h) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
-  uint64_t* sig = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
-  if (sig) sig[0] = 42;
+  ncclGinOffsetPtr sigOff = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (sigOff.ptr) sigOff.ptr[0] = 42;
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_NONE;
   ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, desc);

--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -42,12 +42,14 @@
 // (via the inlined template) call them.
 // --------------------------------------------------------------------------
 __device__ unsigned long long g_gdaStubQuietCount = 0;
+__device__ unsigned long long g_gdaStubPutNbiCount = 0;
 
 namespace rocshmem {
 
 __device__ void QueuePair::put_nbi(void* raddr, uint32_t /*rkey*/, const void* laddr, uint32_t /*lkey*/,
                                    size_t length, ActiveWFInfo& /*wf_info*/, bool /*ring_db*/) {
-  if (raddr == nullptr || laddr == nullptr || length == 0) return;
+  if (raddr == nullptr || laddr == nullptr) return;
+  atomicAdd(&g_gdaStubPutNbiCount, 1ULL);
   auto* d = static_cast<char*>(raddr);
   const auto* s = static_cast<const char*>(laddr);
   for (size_t i = 0; i < length; ++i) d[i] = s[i];
@@ -159,6 +161,17 @@ static unsigned long long readQuietCount() {
   return q;
 }
 
+static void resetPutNbiCount() {
+  unsigned long long z = 0;
+  HIP_CHECK(hipMemcpyToSymbol(HIP_SYMBOL(g_gdaStubPutNbiCount), &z, sizeof(z)));
+}
+
+static unsigned long long readPutNbiCount() {
+  unsigned long long n = 0;
+  HIP_EXPECT(hipMemcpyFromSymbol(&n, HIP_SYMBOL(g_gdaStubPutNbiCount), sizeof(n)));
+  return n;
+}
+
 // G1: Put with data (no signal) copies src -> peer's remote buffer.
 __global__ void kernelPutData(GdaHarness* h, size_t bytes) {
   ncclGinCtx ginCtx{};
@@ -207,8 +220,10 @@ TEST_F(GinRocshmemGdaTemplateTest, Put_ZeroByteSkipsDataStillSignals) {
   env.src.copyFrom(src);
   env.dst.zero();
   env.build();
+  resetPutNbiCount();
   kernelPutZeroBytes<<<1, 1>>>(env.dHarness.ptr);
   syncAndCheck();
+  EXPECT_EQ(readPutNbiCount(), 0ULL);  // production skips put_nbi when bytes==0
   auto got = env.dst.copyTo();
   for (int i = 0; i < kN; ++i) EXPECT_EQ(got[static_cast<size_t>(i)], 0u);  // data write skipped
   auto sigs = env.signals.copyTo();

--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -10,7 +10,7 @@
 // specializations, so this suite unit-tests the GDA AllToAll device path
 // without a live network.
 //
-// The real rocshmem::QueuePair device methods (put_nbi/atomic_add/quiet) are
+// The real rocshmem::QueuePair device methods (put_nbi/atomic_nofetch/quiet) are
 // only declared in queue_pair_device.h (defined in rocSHMEM device bitcode).
 // This translation unit supplies inline stub definitions so the suite links
 // against no librocshmem device code, mirroring how Suite H shadows the SDMA
@@ -35,9 +35,9 @@
 
 // --------------------------------------------------------------------------
 // Stub definitions for rocshmem::QueuePair device methods.
-//   put_nbi   : byte-copy laddr -> raddr (observe data landing at remote VA)
-//   atomic_add: atomic add into the remote signal word (observe signal deliver)
-//   quiet     : bump a device-global call counter (observe completion sync)
+//   put_nbi       : byte-copy laddr -> raddr (observe data landing at remote VA)
+//   atomic_nofetch: atomic add into the remote signal word (observe signal deliver)
+//   quiet         : bump a device-global call counter (observe completion sync)
 // Non-RDC build: these must be defined in the same TU as the kernels that
 // (via the inlined template) call them.
 // --------------------------------------------------------------------------
@@ -53,10 +53,13 @@ __device__ void QueuePair::put_nbi(void* raddr, uint32_t /*rkey*/, const void* l
   for (size_t i = 0; i < length; ++i) d[i] = s[i];
 }
 
-__device__ void QueuePair::atomic_add(void* raddr, uint32_t /*rkey*/, int64_t value, ActiveWFInfo& /*wf_info*/,
-                                      bool /*fence*/) {
-  if (raddr == nullptr) return;
-  atomicAdd(reinterpret_cast<unsigned long long*>(raddr), static_cast<unsigned long long>(value));
+// Matches queue_pair_device.h: atomic_nofetch(void* dest, uint32_t rkey, int64_t
+// value, int64_t cond, ActiveWFInfo&). The template's signal path calls this
+// (gin_rocshmem_gda.h:54,101); cond/rkey are unused by the byte-accurate stub.
+__device__ void QueuePair::atomic_nofetch(void* dest, uint32_t /*rkey*/, int64_t value, int64_t /*cond*/,
+                                          ActiveWFInfo& /*wf_info*/) {
+  if (dest == nullptr) return;
+  atomicAdd(reinterpret_cast<unsigned long long*>(dest), static_cast<unsigned long long>(value));
 }
 
 __device__ void QueuePair::quiet(ActiveWFInfo& /*wf_info*/) {
@@ -318,7 +321,12 @@ TEST_F(GinRocshmemGdaTemplateTest, Put_SignalAndCounter) {
   EXPECT_EQ(ctr[1], 1ULL);
 }
 
-// G7: thread-scope fence branch (required==system && given>required) still puts.
+// G7: weaker-given-scope path (required=system, given=block) still completes the
+// put. NOTE: the template's fence guard is `(required==system && given>required)`;
+// since `system` is the maximum cuda::thread_scope, that branch is never taken
+// (here or anywhere). This guard is a pre-existing convention shared by all GIN
+// backends (anvil_sdma, gdaki, rocshmem_gda) and is tracked for a separate,
+// coordinated fix -- so this case only asserts the data lands, not that a fence ran.
 __global__ void kernelPutScopeFence(GdaHarness* h) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
@@ -331,7 +339,7 @@ __global__ void kernelPutScopeFence(GdaHarness* h) {
       false, nullptr, cuda::thread_scope_system, cuda::thread_scope_block);
 }
 
-TEST_F(GinRocshmemGdaTemplateTest, Put_ThreadScopeFence) {
+TEST_F(GinRocshmemGdaTemplateTest, Put_WeakerGivenScopeStillPuts) {
   constexpr int kN = 8;
   std::vector<uint8_t> pat(kN);
   for (int i = 0; i < kN; ++i) pat[static_cast<size_t>(i)] = static_cast<uint8_t>(0x11 * (i + 1));

--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -1,0 +1,468 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Suite G: GIN rocSHMEM-GDA device template coverage (Put/PutValue/Flush/
+// Signal/Counter + edge paths), the GDA analog of Suite H
+// (GinAnvilSdmaTemplate_test.cpp). AllToAll drives these ncclGinApi_* template
+// specializations, so this suite unit-tests the GDA AllToAll device path
+// without a live network.
+//
+// The real rocshmem::QueuePair device methods (put_nbi/atomic_add/quiet) are
+// only declared in queue_pair_device.h (defined in rocSHMEM device bitcode).
+// This translation unit supplies inline stub definitions so the suite links
+// against no librocshmem device code, mirroring how Suite H shadows the SDMA
+// engine with test/device/sdma/anvil_device.hpp.
+
+#include "DeviceTestBase.hpp"
+
+#include "nccl_device/coop.h"
+#include "nccl_device/gin/gin_device_host_common.h"
+#include "nccl_device/gin/gin_device_common.h"
+#include "nccl_device/gin/rocshmem_gda/gin_rocshmem_device_host_common_gda.h"
+
+#if NCCL_GIN_ROCSHMEM_GDA_ENABLE
+#include "nccl_device/gin/rocshmem_gda/gin_rocshmem_gda.h"
+#endif
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#if NCCL_GIN_ROCSHMEM_GDA_ENABLE
+
+// --------------------------------------------------------------------------
+// Stub definitions for rocshmem::QueuePair device methods.
+//   put_nbi   : byte-copy laddr -> raddr (observe data landing at remote VA)
+//   atomic_add: atomic add into the remote signal word (observe signal deliver)
+//   quiet     : bump a device-global call counter (observe completion sync)
+// Non-RDC build: these must be defined in the same TU as the kernels that
+// (via the inlined template) call them.
+// --------------------------------------------------------------------------
+__device__ unsigned long long g_gdaStubQuietCount = 0;
+
+namespace rocshmem {
+
+__device__ void QueuePair::put_nbi(void* raddr, uint32_t /*rkey*/, const void* laddr, uint32_t /*lkey*/,
+                                   size_t length, ActiveWFInfo& /*wf_info*/, bool /*ring_db*/) {
+  if (raddr == nullptr || laddr == nullptr || length == 0) return;
+  auto* d = static_cast<char*>(raddr);
+  const auto* s = static_cast<const char*>(laddr);
+  for (size_t i = 0; i < length; ++i) d[i] = s[i];
+}
+
+__device__ void QueuePair::atomic_add(void* raddr, uint32_t /*rkey*/, int64_t value, ActiveWFInfo& /*wf_info*/,
+                                      bool /*fence*/) {
+  if (raddr == nullptr) return;
+  atomicAdd(reinterpret_cast<unsigned long long*>(raddr), static_cast<unsigned long long>(value));
+}
+
+__device__ void QueuePair::quiet(ActiveWFInfo& /*wf_info*/) {
+  atomicAdd(&g_gdaStubQuietCount, 1ULL);
+}
+
+}  // namespace rocshmem
+
+namespace RcclUnitTesting
+{
+
+class GinRocshmemGdaTemplateTest : public DeviceTestBase {};
+
+struct GdaHarness {
+  ncclGinRocshmemGdaGPUContext ctx;
+  ncclGinRocshmemGdaMemHandle dstMh;
+  ncclGinRocshmemGdaMemHandle srcMh;
+};
+
+// Bundles all device-side arrays a GDA context/mem-handle points at, and wires
+// them into a single uploaded GdaHarness. Peer 1 is the (self-mapped) target:
+// its remote_vas entry points back at the local dst buffer and its signal
+// remote-address points back at the local signals array, so a self put/signal
+// is observable from the host.
+class GdaEnv {
+public:
+  static constexpr int kNRanks = 2;
+  static constexpr int kPeer = 1;
+  static constexpr uint32_t kNSignals = 4;
+  static constexpr uint32_t kNCounters = 2;
+
+  DeviceBuffer<rocshmem::QueuePair> qp{1};
+  DeviceBuffer<rocshmem::QueuePair*> qps{kNRanks};
+  DeviceBuffer<uint64_t> signals{kNSignals};
+  DeviceBuffer<uint64_t> counters{kNCounters};
+  DeviceBuffer<uint32_t> signalRkeys{kNRanks};
+  DeviceBuffer<uintptr_t> signalRaddrs{kNRanks};
+  DeviceBuffer<uintptr_t> dstRemoteVas{kNRanks};
+  DeviceBuffer<uint32_t> dstRkeys{kNRanks};
+  DeviceBuffer<uint8_t> dst;
+  DeviceBuffer<uint8_t> src;
+  DeviceBuffer<GdaHarness> dHarness{1};
+  GdaHarness host{};
+
+  explicit GdaEnv(size_t bytes) : dst(bytes ? bytes : 1), src(bytes ? bytes : 1) {}
+
+  void build() {
+    std::vector<rocshmem::QueuePair*> qpRow(kNRanks, qp.ptr);
+    qps.copyFrom(qpRow.data(), kNRanks);
+
+    signals.zero();
+    counters.zero();
+    signalRkeys.zero();
+    dstRkeys.zero();
+
+    std::vector<uintptr_t> sraddr(kNRanks, 0);
+    sraddr[kPeer] = reinterpret_cast<uintptr_t>(signals.ptr);  // signal lands in signals[]
+    signalRaddrs.copyFrom(sraddr.data(), kNRanks);
+
+    std::vector<uintptr_t> rvas(kNRanks, 0);
+    rvas[kPeer] = reinterpret_cast<uintptr_t>(dst.ptr);  // "remote" dst maps to local dst
+    dstRemoteVas.copyFrom(rvas.data(), kNRanks);
+
+    std::memset(&host, 0, sizeof(host));
+    host.ctx.qps = qps.ptr;
+    host.ctx.signals = signals.ptr;
+    host.ctx.counters = counters.ptr;
+    host.ctx.signal_rkeys = signalRkeys.ptr;
+    host.ctx.signal_raddrs = signalRaddrs.ptr;
+    host.ctx.nSignals = kNSignals;
+    host.ctx.nCounters = kNCounters;
+    host.ctx.nRanks = kNRanks;
+    host.ctx.rank = 0;
+
+    host.dstMh.local_va = reinterpret_cast<uintptr_t>(dst.ptr);
+    host.dstMh.remote_vas = dstRemoteVas.ptr;
+    host.dstMh.lkey = 0;
+    host.dstMh.rkeys = dstRkeys.ptr;
+
+    host.srcMh.local_va = reinterpret_cast<uintptr_t>(src.ptr);
+    host.srcMh.remote_vas = nullptr;
+    host.srcMh.lkey = 0;
+    host.srcMh.rkeys = nullptr;
+
+    dHarness.upload(host);
+  }
+};
+
+static void resetQuietCount() {
+  unsigned long long z = 0;
+  HIP_CHECK(hipMemcpyToSymbol(HIP_SYMBOL(g_gdaStubQuietCount), &z, sizeof(z)));
+}
+
+static unsigned long long readQuietCount() {
+  unsigned long long q = 0;
+  HIP_EXPECT(hipMemcpyFromSymbol(&q, HIP_SYMBOL(g_gdaStubQuietCount), sizeof(q)));
+  return q;
+}
+
+// G1: Put with data (no signal) copies src -> peer's remote buffer.
+__global__ void kernelPutData(GdaHarness* h, size_t bytes) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, bytes, sig, ncclGinSignalInc, 0, false, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_DataLandsAtRemote) {
+  constexpr int kN = 64;
+  std::vector<uint8_t> pat(kN);
+  for (int i = 0; i < kN; ++i) pat[static_cast<size_t>(i)] = static_cast<uint8_t>(0xA0 + i);
+  GdaEnv env(kN);
+  env.src.copyFrom(pat);
+  env.dst.zero();
+  env.build();
+  kernelPutData<<<1, 1>>>(env.dHarness.ptr, kN);
+  syncAndCheck();
+  auto got = env.dst.copyTo();
+  for (int i = 0; i < kN; ++i) EXPECT_EQ(got[static_cast<size_t>(i)], pat[static_cast<size_t>(i)]);
+}
+
+// G2: zero-byte Put skips the RDMA write but still delivers the signal.
+__global__ void kernelPutZeroBytes(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  sig.indexedSignal.signalId = 0;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 0, sig, ncclGinSignalAdd, 5, false, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_ZeroByteSkipsDataStillSignals) {
+  constexpr int kN = 32;
+  GdaEnv env(kN);
+  std::vector<uint8_t> src(kN, 0x5A);
+  env.src.copyFrom(src);
+  env.dst.zero();
+  env.build();
+  kernelPutZeroBytes<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto got = env.dst.copyTo();
+  for (int i = 0; i < kN; ++i) EXPECT_EQ(got[static_cast<size_t>(i)], 0u);  // data write skipped
+  auto sigs = env.signals.copyTo();
+  EXPECT_EQ(sigs[0], 5ULL);  // signal still delivered
+}
+
+// G3: indexed SignalAdd delivers the given argument to the peer signal word.
+__global__ void kernelPutSignalAdd(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  sig.indexedSignal.signalId = 1;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 32, sig, ncclGinSignalAdd, 7, false, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_SignalAddDeliversArg) {
+  GdaEnv env(32);
+  env.src.zero();
+  env.build();
+  kernelPutSignalAdd<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto sigs = env.signals.copyTo();
+  EXPECT_EQ(sigs[1], 7ULL);
+  EXPECT_EQ(sigs[0], 0ULL);
+}
+
+// G4: SignalInc normalizes any signalOpArg to +1.
+__global__ void kernelPutSignalInc(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  sig.indexedSignal.signalId = 0;
+  // Pass a large arg to prove Inc normalizes to 1.
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 16, sig, ncclGinSignalInc, 99, false, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_SignalIncNormalizesToOne) {
+  GdaEnv env(16);
+  env.src.zero();
+  env.build();
+  kernelPutSignalInc<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto sigs = env.signals.copyTo();
+  EXPECT_EQ(sigs[0], 1ULL);
+}
+
+// G5: Put with counter (no signal) quiets the QP then bumps the counter.
+__global__ void kernelPutCounter(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 32, sig, ncclGinSignalInc, 0, true, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_CounterQuietPath) {
+  constexpr int kN = 32;
+  std::vector<uint8_t> pat(kN, 0x3C);
+  GdaEnv env(kN);
+  env.src.copyFrom(pat);
+  env.dst.zero();
+  env.build();
+  resetQuietCount();
+  kernelPutCounter<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto ctr = env.counters.copyTo();
+  EXPECT_EQ(ctr[0], 1ULL);
+  EXPECT_GE(readQuietCount(), 1ULL);  // counter path quiets the QP
+  auto got = env.dst.copyTo();
+  for (int i = 0; i < kN; ++i) EXPECT_EQ(got[static_cast<size_t>(i)], pat[static_cast<size_t>(i)]);
+}
+
+// G6: Put with both signal and counter delivers the signal and bumps counter.
+__global__ void kernelPutSignalCounter(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  sig.indexedSignal.signalId = 0;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 32, sig, ncclGinSignalAdd, 3, true, 1,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_SignalAndCounter) {
+  GdaEnv env(32);
+  env.src.zero();
+  env.build();
+  kernelPutSignalCounter<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto sigs = env.signals.copyTo();
+  auto ctr = env.counters.copyTo();
+  EXPECT_EQ(sigs[0], 3ULL);
+  EXPECT_EQ(ctr[1], 1ULL);
+}
+
+// G7: thread-scope fence branch (required==system && given>required) still puts.
+__global__ void kernelPutScopeFence(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_Put<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, true, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0,
+      reinterpret_cast<ncclGinWindow_t>(&h->srcMh), 0, 8, sig, ncclGinSignalInc, 0, false, 0,
+      false, nullptr, cuda::thread_scope_system, cuda::thread_scope_block);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Put_ThreadScopeFence) {
+  constexpr int kN = 8;
+  std::vector<uint8_t> pat(kN);
+  for (int i = 0; i < kN; ++i) pat[static_cast<size_t>(i)] = static_cast<uint8_t>(0x11 * (i + 1));
+  GdaEnv env(kN);
+  env.src.copyFrom(pat);
+  env.dst.zero();
+  env.build();
+  kernelPutScopeFence<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto got = env.dst.copyTo();
+  for (int i = 0; i < kN; ++i) EXPECT_EQ(got[static_cast<size_t>(i)], pat[static_cast<size_t>(i)]);
+}
+
+// G8: PutValue writes an inline scalar to the peer buffer (lkey=0 inline WQE).
+__global__ void kernelPutValueScalar(GdaHarness* h, uint64_t val) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0, val, sig,
+      ncclGinSignalInc, 0, false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, PutValue_InlineScalar) {
+  GdaEnv env(sizeof(uint64_t));
+  env.dst.zero();
+  env.build();
+  const uint64_t kVal = 0xAABBCCDDEEFF0011ULL;
+  kernelPutValueScalar<<<1, 1>>>(env.dHarness.ptr, kVal);
+  syncAndCheck();
+  auto got = env.dst.copyTo();
+  uint64_t observed = 0;
+  std::memcpy(&observed, got.data(), sizeof(observed));
+  EXPECT_EQ(observed, kVal);
+}
+
+// G9: PutValue with signal delivers both the scalar and the signal.
+__global__ void kernelPutValueSignal(GdaHarness* h, uint32_t val) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinSignalDescriptor sig{};
+  sig.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  sig.indexedSignal.signalId = 2;
+  ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(
+      ginCtx, ncclCoopThread{}, 1, reinterpret_cast<ncclGinWindow_t>(&h->dstMh), 0, val, sig,
+      ncclGinSignalAdd, 4, false, nullptr, cuda::thread_scope_system, cuda::thread_scope_system);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, PutValue_WithSignal) {
+  GdaEnv env(sizeof(uint32_t));
+  env.dst.zero();
+  env.build();
+  const uint32_t kVal = 0x12345678u;
+  kernelPutValueSignal<<<1, 1>>>(env.dHarness.ptr, kVal);
+  syncAndCheck();
+  auto got = env.dst.copyTo();
+  uint32_t observed = 0;
+  std::memcpy(&observed, got.data(), sizeof(observed));
+  EXPECT_EQ(observed, kVal);
+  auto sigs = env.signals.copyTo();
+  EXPECT_EQ(sigs[2], 4ULL);
+}
+
+// G10: Flush quiets every peer QP (one quiet per rank for a single-thread coop).
+__global__ void kernelFlush(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  ginCtx.nRanks = 2;
+  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, ncclCoopThread{},
+                                                           cuda::memory_order_seq_cst, nullptr);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, Flush_QuietsAllPeers) {
+  GdaEnv env(1);
+  env.build();
+  resetQuietCount();
+  kernelFlush<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  EXPECT_EQ(readQuietCount(), static_cast<unsigned long long>(GdaEnv::kNRanks));
+}
+
+// G11: GetSignalPtr/ResetSignal and GetCounterPtr/ResetCounter round-trip.
+__global__ void kernelGetReset(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  uint64_t* sig = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (sig) sig[0] = 55;
+  ncclGinSignalDescriptor desc{};
+  desc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+  desc.indexedSignal.signalId = 0;
+  ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, desc);
+
+  uint64_t* ctr = ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (ctr) ctr[0] = 77;
+  ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, GetReset_SignalAndCounter) {
+  GdaEnv env(1);
+  env.build();
+  kernelGetReset<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto sigs = env.signals.copyTo();
+  auto ctr = env.counters.copyTo();
+  EXPECT_EQ(sigs[0], 0ULL);  // set to 55 then reset
+  EXPECT_EQ(ctr[0], 0ULL);   // set to 77 then reset
+}
+
+// G12: ResetSignal with a non-indexed descriptor is a no-op.
+__global__ void kernelResetSignalNone(GdaHarness* h) {
+  ncclGinCtx ginCtx{};
+  ginCtx.handle = &h->ctx;
+  uint64_t* sig = ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, 0);
+  if (sig) sig[0] = 42;
+  ncclGinSignalDescriptor desc{};
+  desc.type = NCCL_GIN_SIGNAL_TYPE_NONE;
+  ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, desc);
+}
+
+TEST_F(GinRocshmemGdaTemplateTest, ResetSignal_NoneIsNoOp) {
+  GdaEnv env(1);
+  env.build();
+  kernelResetSignalNone<<<1, 1>>>(env.dHarness.ptr);
+  syncAndCheck();
+  auto sigs = env.signals.copyTo();
+  EXPECT_EQ(sigs[0], 42ULL);  // untouched by non-indexed reset
+}
+
+}  // namespace RcclUnitTesting
+
+#endif  // NCCL_GIN_ROCSHMEM_GDA_ENABLE

--- a/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
+++ b/projects/rccl/test/device/GinRocshmemGdaTemplate_test.cpp
@@ -411,7 +411,7 @@ __global__ void kernelFlush(GdaHarness* h) {
   ncclGinCtx ginCtx{};
   ginCtx.handle = &h->ctx;
   ginCtx.nRanks = 2;
-  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, ncclCoopThread{},
+  ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA>::call(ginCtx, ncclCoopThread{}, false, nullptr,
                                                            cuda::memory_order_seq_cst, nullptr);
 }
 

--- a/projects/rccl/test/device/sdma/anvil_device.hpp
+++ b/projects/rccl/test/device/sdma/anvil_device.hpp
@@ -3,8 +3,7 @@
 
 #include "sdma_opcodes.h"
 
-namespace gin_anvil {
-namespace sdma {
+namespace sdma_anvil {
 
 struct SdmaQueueDeviceHandle {
   int tag;
@@ -35,5 +34,4 @@ __device__ __forceinline__ void putSignal(SdmaQueueDeviceHandle& handle, void* d
 
 __device__ __forceinline__ void quiet(SdmaQueueDeviceHandle& handle) { (void)handle; }
 
-}  // namespace sdma
-}  // namespace gin_anvil
+}  // namespace sdma_anvil

--- a/projects/rccl/tools/ci/lib/gin-tests.json
+++ b/projects/rccl/tools/ci/lib/gin-tests.json
@@ -3,7 +3,8 @@
     "GIN / rocSHMEM test matrix for run-gin-ci.sh (baremetal translation of",
     "docker_build_test.bash). Each test runs as:",
     "  mpirun -np $NP <mca> <-x env> -x LD_LIBRARY_PATH <bin> <args>",
-    "kind: 'rocshmem' -> $ROCSHMEM_TESTS_BIN_DIR/<bin>; 'rccl-tests' -> $RCCL_TESTS_BIN_DIR/<bin>",
+    "kind: 'rocshmem' -> $ROCSHMEM_TESTS_BIN_DIR/<bin>; 'rccl-tests' -> $RCCL_TESTS_BIN_DIR/<bin>;",
+    "'fixtures' -> $RCCL_FIXTURES_BIN_DIR/<bin> (single-process gtest, no mpirun)",
     "{E} is replaced with NP*MSG_SIZE bytes. Tests are non-gating for now.",
     "-D 3 is the rocSHMEM-SDMA path the script labels 'Crash' (kept for visibility).",
     "debug_env: -x added to every test only when RCCL_CI_DEBUG=1.",
@@ -36,6 +37,13 @@
       "bin": "alltoall_perf",
       "env": ["NCCL_CUMEM_ENABLE=1", "RCCL_ENABLE_INTRANET=1", "NCCL_DMABUF_ENABLE=1", "HSA_NO_SCRATCH_RECLAIM=1", "NCCL_MSCCL_ENABLE=0" ,"NCCL_GIN_ENABLE=1", "NCCL_GIN_TYPE=6"],
       "args": "-b 128 -e {E} -f 2 -g 1 -R 2 -D 3 -A 1"
+    },
+    {
+      "name": "rccl-gin-fixtures-anvil-gda",
+      "kind": "fixtures",
+      "bin": "rccl-UnitTestsFixtures",
+      "env": [],
+      "args": "--gtest_filter=GinRocshmemGdaTemplateTest.*:GinAnvilSdmaTemplateTest.*:GinAnvilIpcDeviceTest.*"
     }
   ]
 }

--- a/projects/rccl/tools/ci/lib/gin-tests.json
+++ b/projects/rccl/tools/ci/lib/gin-tests.json
@@ -42,7 +42,7 @@
       "name": "rccl-gin-fixtures-anvil-gda",
       "kind": "fixtures",
       "bin": "rccl-UnitTestsFixtures",
-      "env": [],
+      "env": ["NCCL_DEBUG=WARN"],
       "args": "--gtest_filter=GinRocshmemGdaTemplateTest.*:GinAnvilSdmaTemplateTest.*:GinAnvilIpcDeviceTest.*"
     }
   ]

--- a/projects/rccl/tools/ci/lib/gin.sbatch
+++ b/projects/rccl/tools/ci/lib/gin.sbatch
@@ -15,8 +15,8 @@
 #   1. consume ROCm (provisioned on the head node) via .ci-out/rocm.env
 #   2. lib/build-ompi.sh      build OpenMPI (--with-rocm) -> ompi.env
 #   3. lib/build-rocshmem.sh  build rocSHMEM (IPC+SDMA)   -> rocshmem.env
-#   4. projects/rccl  install.sh  build RCCL (GIN/rocSHMEM) + GIN Anvil unit
-#      tests (rccl-UnitTestsFixtures, GIN_ANVIL_UNIT_TESTS=ON) -> rccl.env
+#   4. projects/rccl  install.sh  build RCCL (GIN/rocSHMEM), then build only
+#      rccl-UnitTestsFixtures (GIN_ANVIL_UNIT_TESTS=ON) -> rccl.env
 #   5. projects/rccl-tests        build rccl-tests (DEVICE_API + ROCSHMEM)
 #   6. run-gin-ci.sh              run the GIN/rocSHMEM tests (non-gating)
 #
@@ -105,27 +105,41 @@ source "${workdir}/.ci-out/rocshmem.env"
 set +a
 
 # 4) RCCL with GIN / rocSHMEM. Mirrors the Dockerfile: patch the rocSHMEM
-# threshold guard, then install.sh with ENABLE_ROCSHMEM_GIN. Also build
-# rccl-UnitTestsFixtures with GIN_ANVIL_UNIT_TESTS=ON (device-template suites
-# for GDA + Anvil-SDMA shadow; no full librocshmem in librccl).
-echo "==> [4/6] build RCCL (GIN, targets=${gpu_targets}) + GIN Anvil unit tests"
+# threshold guard, then install.sh with ENABLE_ROCSHMEM_GIN. Build
+# rccl-UnitTestsFixtures in a second step (reconfigure BUILD_TESTS=ON,
+# GIN_ANVIL_UNIT_TESTS=ON, make only that target). Do not pass install.sh -t:
+# that builds every test executable and pulls in rccl-UnitTestsGinAnvilPlugin,
+# which can compile before hipify headers exist under parallel -j and aborts
+# before librccl.so is installed.
+echo "==> [4/6] build RCCL (GIN, targets=${gpu_targets})"
 rccl_src="${workdir}/projects/rccl"
 rccl_prefix="${workdir}/.ci-out/rccl-install"
-rccl_fixtures_bin="${rccl_src}/build/release/test/rccl-UnitTestsFixtures"
+rccl_build="${rccl_src}/build/release"
+rccl_fixtures_bin="${rccl_build}/test/rccl-UnitTestsFixtures"
 rm -rf "${rccl_prefix}"
 (
   cd "${rccl_src}"
   MPI_PATH="${MPI_HOME}" ./install.sh -j "${build_jobs}" \
     --amdgpu_targets="${gpu_targets}" \
     --prefix="${rccl_prefix}" \
-    --rocshmem-gin -t --no_clean \
-    --cmake-options "-DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR} -DGIN_ANVIL_UNIT_TESTS=ON"
+    --rocshmem-gin --no_clean \
+    --cmake-options "-DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
 )
 if [[ ! -f "${rccl_prefix}/lib/librccl.so" && ! -f "${rccl_prefix}/lib/librccl.so.1" ]]; then
   echo "ERROR: no librccl.so under ${rccl_prefix}/lib" >&2
   ls -la "${rccl_prefix}/lib" 2>/dev/null >&2 || true
   exit 1
 fi
+
+echo "==> [4/6] build rccl-UnitTestsFixtures (GIN_ANVIL_UNIT_TESTS=ON)"
+(
+  cd "${rccl_build}"
+  cmake . \
+    -DBUILD_TESTS=ON \
+    -DGIN_ANVIL_UNIT_TESTS=ON \
+    -DROCSHMEM_INSTALL_DIR="${ROCSHMEM_INSTALL_DIR}"
+  make -j"${build_jobs}" rccl-UnitTestsFixtures
+)
 if [[ ! -x "${rccl_fixtures_bin}" ]]; then
   echo "ERROR: rccl-UnitTestsFixtures not built at ${rccl_fixtures_bin}" >&2
   ls -la "$(dirname "${rccl_fixtures_bin}")" 2>/dev/null >&2 || true

--- a/projects/rccl/tools/ci/lib/gin.sbatch
+++ b/projects/rccl/tools/ci/lib/gin.sbatch
@@ -15,7 +15,8 @@
 #   1. consume ROCm (provisioned on the head node) via .ci-out/rocm.env
 #   2. lib/build-ompi.sh      build OpenMPI (--with-rocm) -> ompi.env
 #   3. lib/build-rocshmem.sh  build rocSHMEM (IPC+SDMA)   -> rocshmem.env
-#   4. projects/rccl  install.sh  build RCCL (GIN/rocSHMEM) -> rccl.env
+#   4. projects/rccl  install.sh  build RCCL (GIN/rocSHMEM) + GIN Anvil unit
+#      tests (rccl-UnitTestsFixtures, GIN_ANVIL_UNIT_TESTS=ON) -> rccl.env
 #   5. projects/rccl-tests        build rccl-tests (DEVICE_API + ROCSHMEM)
 #   6. run-gin-ci.sh              run the GIN/rocSHMEM tests (non-gating)
 #
@@ -104,24 +105,33 @@ source "${workdir}/.ci-out/rocshmem.env"
 set +a
 
 # 4) RCCL with GIN / rocSHMEM. Mirrors the Dockerfile: patch the rocSHMEM
-# threshold guard, then install.sh with ENABLE_ROCSHMEM_GIN.
-echo "==> [4/6] build RCCL (GIN, targets=${gpu_targets})"
+# threshold guard, then install.sh with ENABLE_ROCSHMEM_GIN. Also build
+# rccl-UnitTestsFixtures with GIN_ANVIL_UNIT_TESTS=ON (device-template suites
+# for GDA + Anvil-SDMA shadow; no full librocshmem in librccl).
+echo "==> [4/6] build RCCL (GIN, targets=${gpu_targets}) + GIN Anvil unit tests"
 rccl_src="${workdir}/projects/rccl"
 rccl_prefix="${workdir}/.ci-out/rccl-install"
+rccl_fixtures_bin="${rccl_src}/build/release/test/rccl-UnitTestsFixtures"
 rm -rf "${rccl_prefix}"
 (
   cd "${rccl_src}"
   MPI_PATH="${MPI_HOME}" ./install.sh -j "${build_jobs}" \
     --amdgpu_targets="${gpu_targets}" \
     --prefix="${rccl_prefix}" \
-    --rocshmem-gin --no_clean \
-    --cmake-options "-DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
+    --rocshmem-gin -t --no_clean \
+    --cmake-options "-DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR} -DGIN_ANVIL_UNIT_TESTS=ON"
 )
 if [[ ! -f "${rccl_prefix}/lib/librccl.so" && ! -f "${rccl_prefix}/lib/librccl.so.1" ]]; then
   echo "ERROR: no librccl.so under ${rccl_prefix}/lib" >&2
   ls -la "${rccl_prefix}/lib" 2>/dev/null >&2 || true
   exit 1
 fi
+if [[ ! -x "${rccl_fixtures_bin}" ]]; then
+  echo "ERROR: rccl-UnitTestsFixtures not built at ${rccl_fixtures_bin}" >&2
+  ls -la "$(dirname "${rccl_fixtures_bin}")" 2>/dev/null >&2 || true
+  exit 1
+fi
+echo "    rccl-UnitTestsFixtures: ${rccl_fixtures_bin}"
 
 # Locate the in-tree RCCL CMake package config. rccl-tests' find_package(RCCL)
 # otherwise resolves roc::rccl to the nightly ROCm (its toolchain prepends
@@ -176,6 +186,7 @@ nm -CD "${librccl}" 2>/dev/null | grep -E " U .*${sym}" || echo "  not undefined
 {
   printf 'export RCCL_INSTALL_PREFIX=%q\n' "${rccl_prefix}"
   printf 'export RCCL_TESTS_BIN_DIR=%q\n' "${rccl_tests_build}"
+  printf 'export RCCL_FIXTURES_BIN_DIR=%q\n' "$(dirname "${rccl_fixtures_bin}")"
 } > "${workdir}/.ci-out/rccl.env"
 ) > "${build_out}" 2> "${build_err}" || build_rc=$?
 echo "==> build phase logs: ${build_out} / ${build_err}"

--- a/projects/rccl/tools/ci/lib/parse_gin_config.py
+++ b/projects/rccl/tools/ci/lib/parse_gin_config.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
-"""Flatten the GIN test matrix JSON into tab-separated rows for bash.
+"""Flatten the GIN test matrix JSON into delimited rows for bash.
 
-`run-gin-ci.sh` reads the emitted rows with `IFS=$'\t' read`, so the column
-layout below is a stable contract:
+`run-gin-ci.sh` reads the emitted rows with `IFS=$'\x1f' read` (ASCII unit
+separator). Tabs are avoided because bash collapses adjacent empty tab fields,
+which breaks tests with `"env": []` and non-empty `"args"`.
 
-  mca\t<flags>
-  debug_env\t<-x flags>   (appended to every test only when RCCL_CI_DEBUG=1)
-  test\t<name>\t<kind>\t<bin>\t<-x env flags>\t<args>
+Column layout:
+
+  mca<SEP><flags>
+  debug_env<SEP><-x flags>   (appended to every test only when RCCL_CI_DEBUG=1)
+  test<SEP><name><SEP><kind><SEP><bin><SEP><-x env flags><SEP><args>
     kind: rocshmem | rccl-tests | fixtures (fixtures: gtest binary, no mpirun)
 """
+
+# ASCII unit separator: distinct from whitespace and unlikely in flags/args.
+_FIELD_SEP = "\x1f"
 
 import argparse
 import json
@@ -65,14 +71,13 @@ def parse_config(path: Path) -> GinConfig:
 
 
 def format_rows(config: GinConfig) -> list[str]:
-    """Render the parsed config as tab-separated rows for the bash runner."""
-    rows = ["mca\t" + config.mca]
-    rows.append("debug_env\t" + " ".join("-x " + e for e in config.debug_env))
+    """Render the parsed config as delimited rows for the bash runner."""
+    sep = _FIELD_SEP
+    rows = [f"mca{sep}{config.mca}"]
+    rows.append(f"debug_env{sep}{' '.join('-x ' + e for e in config.debug_env)}")
     for test in config.tests:
         env_flags = " ".join("-x " + e for e in test.env)
-        rows.append(
-            "\t".join(["test", test.name, test.kind, test.bin, env_flags, test.args])
-        )
+        rows.append(sep.join(["test", test.name, test.kind, test.bin, env_flags, test.args]))
     return rows
 
 

--- a/projects/rccl/tools/ci/lib/parse_gin_config.py
+++ b/projects/rccl/tools/ci/lib/parse_gin_config.py
@@ -7,6 +7,7 @@ layout below is a stable contract:
   mca\t<flags>
   debug_env\t<-x flags>   (appended to every test only when RCCL_CI_DEBUG=1)
   test\t<name>\t<kind>\t<bin>\t<-x env flags>\t<args>
+    kind: rocshmem | rccl-tests | fixtures (fixtures: gtest binary, no mpirun)
 """
 
 import argparse

--- a/projects/rccl/tools/ci/lib/test_parse_gin_config.py
+++ b/projects/rccl/tools/ci/lib/test_parse_gin_config.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Unit tests for parse_gin_config.py."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from parse_gin_config import _FIELD_SEP, format_rows, parse_config
+
+
+class ParseGinConfigTest(unittest.TestCase):
+    def test_empty_env_preserves_gtest_filter_in_args(self) -> None:
+        """Regression: adjacent tabs made bash assign --gtest_filter to env_flags."""
+        config = parse_config(
+            _write_json(
+                {
+                    "mca": "",
+                    "debug_env": [],
+                    "tests": [
+                        {
+                            "name": "fixtures-case",
+                            "kind": "fixtures",
+                            "bin": "rccl-UnitTestsFixtures",
+                            "env": [],
+                            "args": "--gtest_filter=GinRocshmemGdaTemplateTest.*",
+                        }
+                    ],
+                }
+            )
+        )
+        rows = format_rows(config)
+        test_row = next(r for r in rows if r.startswith("test" + _FIELD_SEP))
+        parts = test_row.split(_FIELD_SEP)
+        self.assertEqual(len(parts), 6)
+        self.assertEqual(parts[0], "test")
+        self.assertEqual(parts[1], "fixtures-case")
+        self.assertEqual(parts[2], "fixtures")
+        self.assertEqual(parts[3], "rccl-UnitTestsFixtures")
+        self.assertEqual(parts[4], "")
+        self.assertEqual(parts[5], "--gtest_filter=GinRocshmemGdaTemplateTest.*")
+
+
+def _write_json(data: dict) -> Path:
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump(data, handle)
+    handle.close()
+    return Path(handle.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/rccl/tools/ci/run-gin-ci.sh
+++ b/projects/rccl/tools/ci/run-gin-ci.sh
@@ -77,7 +77,7 @@ DEBUG_ENV=""
 TEST_NAMES=() TEST_KINDS=() TEST_BINS=() TEST_ENVS=() TEST_ARGS=()
 CONFIG_TSV="$(python3 "${PARSER}" "${CONFIG}")" || {
   echo "ERROR: failed to parse test matrix ${CONFIG}" >&2; exit 1; }
-while IFS=$'\t' read -r kind f1 f2 f3 f4 f5; do
+while IFS=$'\x1f' read -r kind f1 f2 f3 f4 f5; do
   case "${kind}" in
     mca)        MCA="${f1}" ;;
     debug_env)  DEBUG_ENV="${f1}" ;;

--- a/projects/rccl/tools/ci/run-gin-ci.sh
+++ b/projects/rccl/tools/ci/run-gin-ci.sh
@@ -42,6 +42,7 @@ done
 : "${ROCSHMEM_INSTALL_DIR:?run-gin-ci.sh: ROCSHMEM_INSTALL_DIR unset (run build-rocshmem.sh)}"
 : "${RCCL_INSTALL_PREFIX:?run-gin-ci.sh: RCCL_INSTALL_PREFIX unset (set by gin.sbatch)}"
 : "${RCCL_TESTS_BIN_DIR:?run-gin-ci.sh: RCCL_TESTS_BIN_DIR unset (set by gin.sbatch)}"
+: "${RCCL_FIXTURES_BIN_DIR:?run-gin-ci.sh: RCCL_FIXTURES_BIN_DIR unset (set by gin.sbatch)}"
 # build-rocshmem.sh records where the test binary landed (bin/ vs share/rocshmem/);
 # fall back to bin/ for older env fragments.
 ROCSHMEM_TESTS_BIN_DIR="${ROCSHMEM_TESTS_BIN_DIR:-${ROCSHMEM_INSTALL_DIR}/bin}"
@@ -67,6 +68,7 @@ echo "==> MPI_HOME             = ${MPI_HOME}"
 echo "==> ROCSHMEM_INSTALL_DIR = ${ROCSHMEM_INSTALL_DIR}"
 echo "==> RCCL_INSTALL_PREFIX  = ${RCCL_INSTALL_PREFIX}"
 echo "==> RCCL_TESTS_BIN_DIR   = ${RCCL_TESTS_BIN_DIR}"
+echo "==> RCCL_FIXTURES_BIN_DIR= ${RCCL_FIXTURES_BIN_DIR}"
 echo "==> NP=${NP} MSG_SIZE=${MSG_SIZE} (E=NP*MSG_SIZE=${E})"
 echo "==> test matrix          = ${CONFIG}"
 
@@ -107,6 +109,7 @@ run_test() {
   case "${kind}" in
     rocshmem)   bin_path="${ROCSHMEM_TESTS_BIN_DIR}/${bin}" ;;
     rccl-tests) bin_path="${RCCL_TESTS_BIN_DIR}/${bin}" ;;
+    fixtures)   bin_path="${RCCL_FIXTURES_BIN_DIR}/${bin}" ;;
     *) echo "  SKIP ${name}: unknown kind '${kind}'"; FAILED_RUNS+=("${name} (unknown kind)"); return ;;
   esac
   if [[ ! -x "${bin_path}" ]]; then
@@ -120,9 +123,15 @@ run_test() {
   fi
   echo "=== ${name}: ${bin} ${args} ==="
   set +e
-  timeout --kill-after="${BENCH_KILL_AFTER}" "${BENCH_TIMEOUT}" \
-    mpirun -np "${NP}" ${MCA} ${env_flags} -x LD_LIBRARY_PATH \
-      "${bin_path}" ${args}
+  if [[ "${kind}" == "fixtures" ]]; then
+    timeout --kill-after="${BENCH_KILL_AFTER}" "${BENCH_TIMEOUT}" \
+      env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        "${bin_path}" ${args}
+  else
+    timeout --kill-after="${BENCH_KILL_AFTER}" "${BENCH_TIMEOUT}" \
+      mpirun -np "${NP}" ${MCA} ${env_flags} -x LD_LIBRARY_PATH \
+        "${bin_path}" ${args}
+  fi
   local rc=$?
   set -e
   if [[ ${rc} -ne 0 ]]; then


### PR DESCRIPTION
Supersedes [dlamd1dai/rocm-systems#2](https://github.com/dlamd1dai/rocm-systems/pull/2) (fork PR retargeted to upstream `develop`).

## Summary
- **gin-gda:** Add `GinRocshmemGdaTemplate_test.cpp` — 12 unit tests for the GIN rocSHMEM-GDA AllToAll device template (`NCCL_NET_DEVICE_GIN_ROCSHMEM_GDA`): `put_nbi` data delivery, indexed/inc signals, counter quiet paths, thread-scope fences, inline `PutValue`, `Flush`, and signal/counter get+reset. Self-contained (supplies its own `rocshmem::QueuePair` device stubs in-TU), registered under an independent `ENABLE_ROCSHMEM_GIN` guard — no `librocshmem` device link and no header shadow.
- **gin-sdma:** Fix the Anvil-SDMA unit-test header shadow so the Fixtures build compiles/runs with `GIN_ANVIL_UNIT_TESTS=ON`:
  - `test/device/sdma/anvil_device.hpp`: rename the stub namespace `gin_anvil::sdma` → `sdma_anvil` to match the real Anvil header and the SDMA template test (fixes `no member named 'sdma_anvil' in the global namespace`).
  - `test/device/GinAnvilIpcDevice_test.cpp`: update the stale 3-arg `fenceBeforeSignal(...)` call (now takes a leading context arg), fix `DetailHelpers_ChannelAndDirty` (`blockId=2` for `effectiveChannel()`), and set `signal_remote_addrs` so `useSdmaFusedSignal()` passes on gfx950.
- **CI:** Wire GIN Anvil unit tests into the gin CI pipeline (`gin.sbatch`, `run-gin-ci.sh`, `gin-tests.json`). Two-phase build: `install.sh --rocshmem-gin` (no `-t`) then reconfigure `BUILD_TESTS=ON` + `GIN_ANVIL_UNIT_TESTS=ON` and `make rccl-UnitTestsFixtures` only.

## JIRA ID: AICOMRCCL-1527

## Stacking
**Base branch: `develop`.** Depends on [#10420](https://github.com/ROCm/rocm-systems/pull/10420) (128 MiB Anvil-SDMA put cap), **merged**. Related (not a hard dependency): [#10658](https://github.com/ROCm/rocm-systems/pull/10658) (devtime A2A timing), [#10675](https://github.com/ROCm/rocm-systems/pull/10675) (HIP scope fence guard).

**Branch tip:** `3c23bf7c15` — test + CI files under `projects/rccl/test/` and `projects/rccl/tools/ci/` only.

## Test plan
- [x] Built `rccl-UnitTestsFixtures` with `GIN_ANVIL_UNIT_TESTS=ON`; 0 residual `sdma_anvil` namespace errors.
- [x] **MI300X (gfx942):** GDA 12/12, SDMA 12/12, IPC 9/9 — **33/33 PASS**
- [x] **MI355 (gfx950):** full GIN fixture filter — **34/34 PASS**

## CI status (post-rebase)
- **Green:** device-API, static-analysis, TheRock RCCL build (gfx942 + gfx950), Multi-Arch CI Summary, HIP NVIDIA CI, TheRock `Test rccl` (gfx94X).
- **GIN CI:** build phase green (two-phase `gin.sbatch` fix); 3/4 perf tests passed on first full run. Fixtures failed at load with `undefined symbol: rocshmem::envvar::log_flags` because `librccl.so` is built without host librocshmem on the `--rocshmem-gin` path. **Fixed in `3c23bf7c15`:** link `librocshmem.a` into `rccl-UnitTestsFixtures` when `GIN_ANVIL_UNIT_TESTS=ON` and `ENABLE_ROCSHMEM=OFF`.
- **Likely unrelated reds:** Host unit tests (`InitMicrotest.DevCommSetup_HappyPath`), TheRock single-node gfx94X (`SendRecv.UserBufferRegister`), mci/precheckin/extra — appear to reproduce on infra/base, not introduced by this diff.

## Review updates (addressed on fork PR #2)
**@pvallem**
- GDA stub uses `QueuePair::atomic_nofetch` matching current `queue_pair_device.h`.
- Tests use `ncclGinOffsetPtr` from `GetSignalPtr`/`GetCounterPtr`; `Flush` passes descriptor args.
- IPC test replaces removed `anvilSignalPtrOrDummy` with direct signal-slot checks.
- CMake: GDA test gated under `ENABLE_ROCSHMEM_GIN AND (ENABLE_ROCSHMEM OR GIN_ANVIL_UNIT_TESTS)`.
- G7 fence behavior corrected in [#10675](https://github.com/ROCm/rocm-systems/pull/10675).
- IPC `fenceBeforeSignal` compile/launch smoke acknowledged.
- `gin.sbatch` two-phase Fixtures build + `run-gin-ci.sh` / `gin-tests.json` gtest filter for GDA/SDMA/IPC device-template tests.

Made with [Cursor](https://cursor.com)