### PR TITLE
test(rccl): add LL/LL128 vector ops coverage and op128 refactor

### DIFF
--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -46,6 +46,47 @@ inline __device__ void store128(uint64_t* ptr, uint64_t v0, uint64_t v1) {
 #endif
 }
 
+// ---------------------------------------------------------------------------
+// Comm-FIFO 128-bit loads/stores (uncached LL / LL128 protocol buffers).
+// Kept separate from load128/store128 above: no cooperative-atomic or
+// system-scope global_load/store_b128. Those paths are for registered user
+// buffers; comm FIFO traffic always uses the plain variants below.
+// ---------------------------------------------------------------------------
+
+inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
+  v0 = u.u64[0];
+  v1 = u.u64[1];
+}
+
+// Plain vector store for comm-FIFO writes. A single 128-bit store keeps data
+// and flag words in one memory transaction so the reader's flag poll cannot
+// observe flags before their paired data.
+inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.u64[0] = v0;
+  u.u64[1] = v1;
+  *((v4u_gptr)ptr) = u.v;
+}
+
+// LL FIFO store: plain b128 on most targets; on gfx1200/gfx1201 without global
+// b128 builtins, paired system-scope atomic stores preserve flag/data ordering.
+inline __device__ void store128LLFifo(uint64_t* v, uint64_t v0, uint64_t v1) {
+#if !RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__gfx1200__) || defined(__gfx1201__))
+  __hip_atomic_store((u64_gptr)v, v0, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  __hip_atomic_store((u64_gptr)v + 1, v1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  store128Plain(v, v0, v1);
+#endif
+}
+
 inline __device__ uint64_t* shmemCvtPtr(volatile uint64_t* shmemGenericPtr) {
   return (uint64_t*)shmemGenericPtr;
 }

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -7,36 +7,14 @@
  ************************************************************************/
 
 #include "rccl_ptr.h"
+#include "op128.h"
 
-// Non-temporal 128-bit load for LL communication (FIFO) buffers. Comm buffers
-// are uncached; a single explicit vector load avoids relying on the backend to
-// fuse two independent 64-bit nontemporal loads into one 16-byte op.
 inline __device__ void loadLLLine(const union ncclLLFifoLine* src, union ncclLLFifoLine& dst) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.v = __builtin_nontemporal_load((v4u_gptr)src->v);
-  dst.v[0] = u.u64[0];
-  dst.v[1] = u.u64[1];
+  load128NT(src->v, dst.v[0], dst.v[1]);
 }
 
-// Plain 128-bit vector store for LL FIFO lines. Like LL128 store128Plain, a
-// single 128-bit store keeps data and flag words in one memory transaction so
-// the reader's flag poll cannot observe flags before their paired data.
 inline __device__ void storeLLLine(union ncclLLFifoLine* dst, const union ncclLLFifoLine& src) {
-#if !RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__gfx1200__) || defined(__gfx1201__))
-  __hip_atomic_store((u64_gptr)dst->v, src.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  __hip_atomic_store((u64_gptr)dst->v + 1, src.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-#else
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.u64[0] = src.v[0];
-  u.u64[1] = src.v[1];
-  *((v4u_gptr)dst->v) = u.v;
-#endif
+  store128LLFifo(dst->v, src.v[0], src.v[1]);
 }
 
 // UserRegMode is accepted only to match the Primitives primary template (which

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -16,46 +16,6 @@
 #endif
 #endif
 
-// Non-temporal 128-bit load/store for LL128 communication (FIFO) buffers.
-// Comm buffers are already allocated uncached, so there is no cache to bypass;
-// using the plain non-temporal path here (the pre-cache-bypass behavior) avoids
-// the extra register pressure that the system-scope global_load/store_b128
-// builtins introduce in the LL128 reduce kernels. The cache-bypassing load128/
-// store128 remain in use for user buffers (loadRegsBegin/storeRegs).
-inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
-  v0 = u.u64[0];
-  v1 = u.u64[1];
-}
-
-// Plain (cacheable) 128-bit store. This is the pre-cache-bypass February store
-// behavior: comm-FIFO writes and non-registered user-buffer writes go through
-// the normal cache with ordinary global_store_dwordx4, which delivers higher
-// store throughput and lower register pressure than the non-temporal or
-// system-scope variants. Reads remain non-temporal (load128NT) so the LL128
-// flag poll never observes a stale cache line.
-//
-// The width is correctness-load-bearing, not just a throughput choice: the LL128
-// reader re-checks only the flag word, so the data words must become visible no
-// later than their flag. A single 128-bit vector store keeps data+flag in one
-// instruction and one memory transaction, guaranteeing that ordering rather than
-// leaving it to backend coalescing of two scalar stores (which two separate
-// `*u64` writes rely on, and which is especially fragile with gfx1250 ordering
-// still to be revisited). Emit the b128 vector store explicitly here.
-inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.u64[0] = v0;
-  u.u64[1] = v1;
-  *((v4u_gptr)ptr) = u.v;
-}
-
 template <typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline,
           int useAcc, int UserRegMode>
 class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode>

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -309,6 +309,8 @@ if(BUILD_TESTS)
       CheapPostSendFenceTests.cpp
       VersionInfoTests.cpp
       device/TestOp128.cpp
+      device/TestLLFifo.cpp
+      device/TestLL128Vector.cpp
       device/TestTDM.cpp
       device/TestTdmCopy.cpp
       device/TestAsyncCopy.cpp
@@ -682,6 +684,7 @@ if(BUILD_TESTS)
       CommMPITests.cpp
       NChannelsPerNetPeerMPITests.cpp
       RegistrationMPITests.cpp
+      LL128VectorMPITests.cpp
       HostApiMPITests.cpp
       RmaExternalPluginPutSignalMPITests.cpp
       plugin/net_reload_plugin.cpp

--- a/projects/rccl/test/LL128VectorMPITests.cpp
+++ b/projects/rccl/test/LL128VectorMPITests.cpp
@@ -1,0 +1,207 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file LL128VectorMPITests.cpp
+ * @brief Integration tests for explicit 128-bit vector load/store paths in LL / LL128.
+ *
+ * Run examples:
+ *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter=LL128VectorMPITest.*
+ *   mpirun -np 2 -x NCCL_LOCAL_REGISTER=1 -x RCCL_LL128_FORCE_ENABLE=1 \
+ *     ./rccl-UnitTestsMPI --gtest_filter=LL128VectorMPITest.RegisteredAllReduce_LL128_IntraNode
+ */
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "MPIHelpers.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+static bool deviceArchIsGfx1250() {
+  int device = 0;
+  if (hipGetDevice(&device) != hipSuccess) return false;
+  hipDeviceProp_t prop{};
+  if (hipGetDeviceProperties(&prop, device) != hipSuccess) return false;
+  return std::string(prop.gcnArchName).rfind("gfx1250", 0) == 0;
+}
+
+static void initSendBuffer(float* buf, size_t count, int rank) {
+  for (size_t i = 0; i < count; ++i) {
+    buf[i] = static_cast<float>(rank + 1) + static_cast<float>(i) * 0.001f;
+  }
+}
+
+static bool verifyAllReduceResult(float* buf, size_t count, int nRanks) {
+  const float expectedScale = static_cast<float>(nRanks * (nRanks + 1)) / 2.0f;
+  std::vector<float> h(count);
+  if (hipMemcpy(h.data(), buf, count * sizeof(float), hipMemcpyDeviceToHost) != hipSuccess) {
+    return false;
+  }
+  for (size_t i = 0; i < count; ++i) {
+    const float expected = expectedScale + static_cast<float>(i) * 0.001f * static_cast<float>(nRanks);
+    if (h[i] != expected) return false;
+  }
+  return true;
+}
+
+class LL128VectorMPITest : public MPITestBase
+{
+};
+
+} // namespace
+
+TEST_F(LL128VectorMPITest, RegisteredAllReduce_LL128_IntraNode) {
+  if (!validateTestPrerequisites(2, kNoProcessLimit, kNoPowerOfTwoRequired, 1, kRequireSingleNode)) {
+    GTEST_SKIP() << "Requires 2+ ranks on a single node";
+  }
+
+  MPIHelpers::MpiEnvGuard protoGuard("NCCL_PROTO", "LL128");
+  MPIHelpers::MpiEnvGuard algoGuard("NCCL_ALGO", "Ring");
+  MPIHelpers::MpiEnvGuard ll128ForceGuard("RCCL_LL128_FORCE_ENABLE", "1");
+  MPIHelpers::MpiEnvGuard localRegGuard("NCCL_LOCAL_REGISTER", "1");
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+  int rank = 0, nRanks = 0;
+  ncclCommUserRank(getActiveCommunicator(), &rank);
+  ncclCommCount(getActiveCommunicator(), &nRanks);
+
+  // Small enough to stay in the LL128 latency window on typical configs.
+  const size_t count = 4096;
+  void* sendBuf = nullptr;
+  void* recvBuf = nullptr;
+  void* sendHandle = nullptr;
+  void* recvHandle = nullptr;
+
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, count * sizeof(float)));
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, count * sizeof(float)));
+  auto cleanup = makeScopeGuard([&]() {
+    if (sendHandle) ncclCommDeregister(getActiveCommunicator(), sendHandle);
+    if (recvHandle) ncclCommDeregister(getActiveCommunicator(), recvHandle);
+    if (sendBuf) freeDeviceBuffer(sendBuf);
+    if (recvBuf) freeDeviceBuffer(recvBuf);
+  });
+
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommRegister(getActiveCommunicator(), sendBuf, count * sizeof(float), &sendHandle));
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommRegister(getActiveCommunicator(), recvBuf, count * sizeof(float), &recvHandle));
+
+  initSendBuffer(static_cast<float*>(sendBuf), count, rank);
+
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, getActiveCommunicator(),
+                                getActiveStream()));
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+  ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+}
+
+TEST_F(LL128VectorMPITest, AllReduce_LL_IntraNode) {
+  if (!validateTestPrerequisites(2, kNoProcessLimit, kNoPowerOfTwoRequired, 1, kRequireSingleNode)) {
+    GTEST_SKIP() << "Requires 2+ ranks on a single node";
+  }
+
+  MPIHelpers::MpiEnvGuard protoGuard("NCCL_PROTO", "LL");
+  MPIHelpers::MpiEnvGuard algoGuard("NCCL_ALGO", "Ring");
+  MPIHelpers::MpiEnvGuard llBufGuard("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "0");
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+  int rank = 0, nRanks = 0;
+  ncclCommUserRank(getActiveCommunicator(), &rank);
+  ncclCommCount(getActiveCommunicator(), &nRanks);
+
+  const size_t count = 2048;
+  void* sendBuf = nullptr;
+  void* recvBuf = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, count * sizeof(float)));
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, count * sizeof(float)));
+  auto cleanup = makeScopeGuard([&]() {
+    if (sendBuf) freeDeviceBuffer(sendBuf);
+    if (recvBuf) freeDeviceBuffer(recvBuf);
+  });
+
+  initSendBuffer(static_cast<float*>(sendBuf), count, rank);
+
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, getActiveCommunicator(),
+                                getActiveStream()));
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+  ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+}
+
+TEST_F(LL128VectorMPITest, RegisteredAllReduce_LL128_Gfx1250Only) {
+#if !__has_builtin(__builtin_amdgcn_cooperative_atomic_load_8x16B)
+  GTEST_SKIP() << "Cooperative atomic 128-bit builtins unavailable in this toolchain";
+#endif
+  if (!deviceArchIsGfx1250()) {
+    GTEST_SKIP() << "Registered LL128 cooperative-atomic path is gfx1250-specific";
+  }
+
+  if (!validateTestPrerequisites(2, kNoProcessLimit, kNoPowerOfTwoRequired, 1, kRequireSingleNode)) {
+    GTEST_SKIP() << "Requires 2+ ranks on a single node";
+  }
+
+  MPIHelpers::MpiEnvGuard protoGuard("NCCL_PROTO", "LL128");
+  MPIHelpers::MpiEnvGuard algoGuard("NCCL_ALGO", "Ring");
+  MPIHelpers::MpiEnvGuard ll128ForceGuard("RCCL_LL128_FORCE_ENABLE", "1");
+  MPIHelpers::MpiEnvGuard localRegGuard("NCCL_LOCAL_REGISTER", "1");
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+  int rank = 0, nRanks = 0;
+  ncclCommUserRank(getActiveCommunicator(), &rank);
+  ncclCommCount(getActiveCommunicator(), &nRanks);
+
+  const size_t count = 8192;
+  void* sendBuf = nullptr;
+  void* recvBuf = nullptr;
+  void* sendHandle = nullptr;
+  void* recvHandle = nullptr;
+
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&sendBuf, count * sizeof(float)));
+  ASSERT_MPI_EQ(ncclSuccess, allocateDeviceBuffer(&recvBuf, count * sizeof(float)));
+  auto cleanup = makeScopeGuard([&]() {
+    if (sendHandle) ncclCommDeregister(getActiveCommunicator(), sendHandle);
+    if (recvHandle) ncclCommDeregister(getActiveCommunicator(), recvHandle);
+    if (sendBuf) freeDeviceBuffer(sendBuf);
+    if (recvBuf) freeDeviceBuffer(recvBuf);
+  });
+
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommRegister(getActiveCommunicator(), sendBuf, count * sizeof(float), &sendHandle));
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommRegister(getActiveCommunicator(), recvBuf, count * sizeof(float), &recvHandle));
+
+  initSendBuffer(static_cast<float*>(sendBuf), count, rank);
+
+  ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, getActiveCommunicator(),
+                                getActiveStream()));
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+  ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+}
+
+} // namespace RcclUnitTesting
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/LL128VectorMPITests.cpp
+++ b/projects/rccl/test/LL128VectorMPITests.cpp
@@ -22,6 +22,7 @@
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -61,8 +62,39 @@ static bool verifyAllReduceResult(float* buf, size_t count, int nRanks) {
   return true;
 }
 
+// enqueue.cc emits NCCL_TUNING lines like:
+//   AllReduce: 16384 Bytes -> Algo RING proto LL128 channel{Lo..Hi}={0..0}
+static bool logsContainForcedProto(const std::string& log, const char* proto) {
+  if (log.find("AllReduce:") == std::string::npos) return false;
+  const std::string protoTag = std::string("proto ") + proto + " ";
+  return log.find(protoTag) != std::string::npos;
+}
+
 class LL128VectorMPITest : public MPITestBase
 {
+protected:
+  std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugGuard_;
+  std::unique_ptr<MPIHelpers::MpiEnvGuard>             tuningGuard_;
+  std::unique_ptr<MPIHelpers::TestLogAssertionContext> logCtx_;
+
+  void SetUp() override {
+    MPITestBase::SetUp();
+    debugGuard_  = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG", "INFO");
+    tuningGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG_SUBSYS", "TUNING");
+    logCtx_ = std::make_unique<MPIHelpers::TestLogAssertionContext>(
+        MPIHelpers::makeCombinedAssertionLogOptions(getTestMpiRank()));
+  }
+
+  void TearDown() override {
+    MPITestBase::TearDown();
+    logCtx_.reset();
+    tuningGuard_.reset();
+    debugGuard_.reset();
+  }
+
+  std::string readAllLogs() const {
+    return logCtx_->readNcclDebugLog() + logCtx_->readPerRankStderrLog();
+  }
 };
 
 } // namespace
@@ -112,6 +144,8 @@ TEST_F(LL128VectorMPITest, RegisteredAllReduce_LL128_IntraNode) {
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
   ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+  ASSERT_TRUE(logsContainForcedProto(readAllLogs(), "LL128"))
+      << "Expected NCCL_TUNING AllReduce line with forced LL128 protocol";
 }
 
 TEST_F(LL128VectorMPITest, AllReduce_LL_IntraNode) {
@@ -147,6 +181,8 @@ TEST_F(LL128VectorMPITest, AllReduce_LL_IntraNode) {
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
   ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+  ASSERT_TRUE(logsContainForcedProto(readAllLogs(), "LL"))
+      << "Expected NCCL_TUNING AllReduce line with forced LL protocol";
 }
 
 TEST_F(LL128VectorMPITest, RegisteredAllReduce_LL128_Gfx1250Only) {
@@ -200,6 +236,8 @@ TEST_F(LL128VectorMPITest, RegisteredAllReduce_LL128_Gfx1250Only) {
   ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
   ASSERT_TRUE(verifyAllReduceResult(static_cast<float*>(recvBuf), count, nRanks));
+  ASSERT_TRUE(logsContainForcedProto(readAllLogs(), "LL128"))
+      << "Expected NCCL_TUNING AllReduce line with forced LL128 protocol on gfx1250";
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/device/TestLL128Vector.cpp
+++ b/projects/rccl/test/device/TestLL128Vector.cpp
@@ -1,0 +1,133 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for LL128 comm-buffer vector load/store helpers (prims_ll128.h) and
+// the shared load128/store128 paths in op128.h.
+
+#include "DeviceTestBase.hpp"
+
+#include <string>
+
+#include "device.h"
+#include "op128.h"
+#include "rccl_ptr.h"
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+// Keep in sync with projects/rccl/src/device/prims_ll128.h
+inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
+  v0 = u.u64[0];
+  v1 = u.u64[1];
+}
+
+inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.u64[0] = v0;
+  u.u64[1] = v1;
+  *((v4u_gptr)ptr) = u.v;
+}
+
+static bool deviceArchIsGfx1250() {
+  hipDeviceProp_t prop{};
+  if (hipGetDeviceProperties(&prop, 0) != hipSuccess) return false;
+  return std::string(prop.gcnArchName).rfind("gfx1250", 0) == 0;
+}
+
+} // namespace
+
+class LL128VectorTest : public DeviceTestBase
+{
+};
+
+__global__ void kernelLL128Load128NTStore128Plain(const uint64_t* src, uint64_t* dst) {
+  uint64_t v0, v1;
+  load128NT(src, v0, v1);
+  store128Plain(dst, v0, v1);
+}
+
+TEST_F(LL128VectorTest, Load128NTStore128PlainRoundtrip) {
+  const uint64_t h_src[2] = {0xAAAABBBBCCCCDDDDULL, 0x1111222233334444ULL};
+  DeviceBuffer<uint64_t> d_src(2), d_dst(2);
+  d_src.copyFrom(h_src, 2);
+
+  kernelLL128Load128NTStore128Plain<<<1, 1>>>(d_src.ptr, d_dst.ptr);
+  syncAndCheck();
+
+  auto h_dst = d_dst.copyTo();
+  EXPECT_EQ(h_dst[0], h_src[0]);
+  EXPECT_EQ(h_dst[1], h_src[1]);
+}
+
+__global__ void kernelLL128Load128Store128(const uint64_t* src, uint64_t* dst) {
+  uint64_t v0, v1;
+  load128(src, v0, v1);
+  store128(dst, v0, v1);
+}
+
+TEST_F(LL128VectorTest, Load128Store128Roundtrip) {
+  const uint64_t h_src[2] = {0xFEDCBA9876543210ULL, 0x0123456789ABCDEFULL};
+  DeviceBuffer<uint64_t> d_src(2), d_dst(2);
+  d_src.copyFrom(h_src, 2);
+
+  kernelLL128Load128Store128<<<1, 1>>>(d_src.ptr, d_dst.ptr);
+  syncAndCheck();
+
+  auto h_dst = d_dst.copyTo();
+  EXPECT_EQ(h_dst[0], h_src[0]);
+  EXPECT_EQ(h_dst[1], h_src[1]);
+}
+
+TEST_F(LL128VectorTest, Load128Store128Gfx1250CooperativePath) {
+#if !__has_builtin(__builtin_amdgcn_cooperative_atomic_load_8x16B)
+  GTEST_SKIP() << "Cooperative atomic 128-bit builtins unavailable in this toolchain";
+#endif
+  if (!deviceArchIsGfx1250()) {
+    GTEST_SKIP() << "Cooperative atomic load128/store128 path is gfx1250-specific";
+  }
+
+  const uint64_t h_src[2] = {0x0F0E0D0C0B0A0908ULL, 0x0706050403020100ULL};
+  DeviceBuffer<uint64_t> d_src(2), d_dst(2);
+  d_src.copyFrom(h_src, 2);
+
+  kernelLL128Load128Store128<<<1, 1>>>(d_src.ptr, d_dst.ptr);
+  syncAndCheck();
+
+  auto h_dst = d_dst.copyTo();
+  EXPECT_EQ(h_dst[0], h_src[0]);
+  EXPECT_EQ(h_dst[1], h_src[1]);
+}
+
+__global__ void kernelLL128Store16Load16Global(const uint64_t* in, uint64_t* out) {
+  store16global(cvta_to_global(out),
+                load16global(cvta_to_global(in)));
+}
+
+TEST_F(LL128VectorTest, Load16Store16GlobalRoundtrip) {
+  uint64_t h_in[2] = {0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  DeviceBuffer<uint64_t> d_in(2), d_out(2);
+  d_in.copyFrom(h_in, 2);
+
+  kernelLL128Store16Load16Global<<<1, 1>>>(d_in.ptr, d_out.ptr);
+  syncAndCheck();
+
+  auto h_out = d_out.copyTo();
+  EXPECT_EQ(h_out[0], h_in[0]);
+  EXPECT_EQ(h_out[1], h_in[1]);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/device/TestLL128Vector.cpp
+++ b/projects/rccl/test/device/TestLL128Vector.cpp
@@ -4,43 +4,19 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Unit tests for LL128 comm-buffer vector load/store helpers (prims_ll128.h) and
-// the shared load128/store128 paths in op128.h.
+// Unit tests for comm-FIFO and registered-user-buffer 128-bit helpers in op128.h.
 
 #include "DeviceTestBase.hpp"
 
 #include <string>
 
-#include "device.h"
 #include "op128.h"
-#include "rccl_ptr.h"
 
 namespace RcclUnitTesting
 {
 
 namespace
 {
-
-// Keep in sync with projects/rccl/src/device/prims_ll128.h
-inline __device__ void load128NT(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.v = __builtin_nontemporal_load((v4u_gptr)ptr);
-  v0 = u.u64[0];
-  v1 = u.u64[1];
-}
-
-inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.u64[0] = v0;
-  u.u64[1] = v1;
-  *((v4u_gptr)ptr) = u.v;
-}
 
 static bool deviceArchIsGfx1250() {
   hipDeviceProp_t prop{};
@@ -77,19 +53,6 @@ __global__ void kernelLL128Load128Store128(const uint64_t* src, uint64_t* dst) {
   uint64_t v0, v1;
   load128(src, v0, v1);
   store128(dst, v0, v1);
-}
-
-TEST_F(LL128VectorTest, Load128Store128Roundtrip) {
-  const uint64_t h_src[2] = {0xFEDCBA9876543210ULL, 0x0123456789ABCDEFULL};
-  DeviceBuffer<uint64_t> d_src(2), d_dst(2);
-  d_src.copyFrom(h_src, 2);
-
-  kernelLL128Load128Store128<<<1, 1>>>(d_src.ptr, d_dst.ptr);
-  syncAndCheck();
-
-  auto h_dst = d_dst.copyTo();
-  EXPECT_EQ(h_dst[0], h_src[0]);
-  EXPECT_EQ(h_dst[1], h_src[1]);
 }
 
 TEST_F(LL128VectorTest, Load128Store128Gfx1250CooperativePath) {

--- a/projects/rccl/test/device/TestLLFifo.cpp
+++ b/projects/rccl/test/device/TestLLFifo.cpp
@@ -1,0 +1,146 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for LL protocol FIFO 128-bit vector load/store helpers (prims_ll.h).
+// Mirrors loadLLLine/storeLLLine so we can exercise them without pulling in the
+// full Primitives<> template.
+
+#include "DeviceTestBase.hpp"
+
+#include "device.h"
+#include "rccl_ptr.h"
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+// Keep in sync with projects/rccl/src/device/prims_ll.h
+inline __device__ void loadLLLine(const union ncclLLFifoLine* src, union ncclLLFifoLine& dst) {
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_nontemporal_load((v4u_gptr)src->v);
+  dst.v[0] = u.u64[0];
+  dst.v[1] = u.u64[1];
+}
+
+inline __device__ void storeLLLine(union ncclLLFifoLine* dst, const union ncclLLFifoLine& src) {
+#if !RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__gfx1200__) || defined(__gfx1201__))
+  __hip_atomic_store((u64_gptr)dst->v, src.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  __hip_atomic_store((u64_gptr)dst->v + 1, src.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.u64[0] = src.v[0];
+  u.u64[1] = src.v[1];
+  *((v4u_gptr)dst->v) = u.v;
+#endif
+}
+
+inline __host__ __device__ void makeFifoLine(union ncclLLFifoLine& line, uint64_t payload, uint32_t flag) {
+  line.data1 = static_cast<uint32_t>(payload);
+  line.data2 = static_cast<uint32_t>(payload >> 32);
+  line.flag1 = flag;
+  line.flag2 = flag;
+}
+
+} // namespace
+
+class LLFifoVectorTest : public DeviceTestBase
+{
+};
+
+__global__ void kernelFifoLayoutRoundtrip(const union ncclLLFifoLine* src, union ncclLLFifoLine* dst) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    storeLLLine(dst, *src);
+    loadLLLine(dst, *dst);
+  }
+}
+
+TEST_F(LLFifoVectorTest, FifoLineLayoutRoundtrip) {
+  union ncclLLFifoLine h_in {};
+  makeFifoLine(h_in, 0x0123456789ABCDEFULL, 0xA5A5A5A5u);
+
+  DeviceBuffer<ncclLLFifoLine> d_in(1), d_out(1);
+  d_in.upload(h_in);
+
+  kernelFifoLayoutRoundtrip<<<1, 1>>>(d_in.ptr, d_out.ptr);
+  syncAndCheck();
+
+  union ncclLLFifoLine h_out = d_out.download();
+  EXPECT_EQ(h_out.data1, h_in.data1);
+  EXPECT_EQ(h_out.data2, h_in.data2);
+  EXPECT_EQ(h_out.flag1, h_in.flag1);
+  EXPECT_EQ(h_out.flag2, h_in.flag2);
+  EXPECT_EQ(h_out.v[0], h_in.v[0]);
+  EXPECT_EQ(h_out.v[1], h_in.v[1]);
+}
+
+__global__ void kernelFifoFlagPoll(union ncclLLFifoLine* fifo, uint32_t expectFlag, int* ready) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+
+  union ncclLLFifoLine published {};
+  makeFifoLine(published, 0xDEADBEEFCAFEBABEULL, expectFlag);
+  storeLLLine(fifo, published);
+
+  union ncclLLFifoLine observed {};
+  for (int spins = 0; spins < 32; ++spins) {
+    loadLLLine(fifo, observed);
+    if (observed.flag1 == expectFlag && observed.flag2 == expectFlag) {
+      *ready = 1;
+      return;
+    }
+  }
+  *ready = 0;
+}
+
+TEST_F(LLFifoVectorTest, FifoLineFlagPollSeesMatchingFlags) {
+  DeviceBuffer<ncclLLFifoLine> d_fifo(1);
+  DeviceBuffer<int> d_ready(1);
+  d_ready.zero();
+
+  const uint32_t flag = 0x12345678u;
+  kernelFifoFlagPoll<<<1, 1>>>(d_fifo.ptr, flag, d_ready.ptr);
+  syncAndCheck();
+
+  EXPECT_EQ(d_ready.download(), 1);
+
+  union ncclLLFifoLine h_line = d_fifo.download();
+  EXPECT_EQ(h_line.flag1, flag);
+  EXPECT_EQ(h_line.flag2, flag);
+  EXPECT_EQ(h_line.data1, 0xCAFEBABEu);
+  EXPECT_EQ(h_line.data2, 0xDEADBEEFu);
+}
+
+__global__ void kernelFifoZeroCleanup(union ncclLLFifoLine* fifo) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  union ncclLLFifoLine zero {};
+  makeFifoLine(zero, 0, 0x2u);
+  storeLLLine(fifo, zero);
+}
+
+TEST_F(LLFifoVectorTest, FifoLineZeroCleanup) {
+  DeviceBuffer<ncclLLFifoLine> d_fifo(1);
+  union ncclLLFifoLine dirty {};
+  makeFifoLine(dirty, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFu);
+  d_fifo.upload(dirty);
+
+  kernelFifoZeroCleanup<<<1, 1>>>(d_fifo.ptr);
+  syncAndCheck();
+
+  union ncclLLFifoLine h_line = d_fifo.download();
+  EXPECT_EQ(h_line.data1, 0u);
+  EXPECT_EQ(h_line.data2, 0u);
+  EXPECT_EQ(h_line.flag1, 2u);
+  EXPECT_EQ(h_line.flag2, 2u);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/device/TestLLFifo.cpp
+++ b/projects/rccl/test/device/TestLLFifo.cpp
@@ -4,46 +4,19 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-// Unit tests for LL protocol FIFO 128-bit vector load/store helpers (prims_ll.h).
-// Mirrors loadLLLine/storeLLLine so we can exercise them without pulling in the
-// full Primitives<> template.
+// Unit tests for LL FIFO comm-buffer vector load/store helpers in op128.h
+// (load128NT / store128LLFifo), using the same ncclLLFifoLine layout as prims_ll.h.
 
 #include "DeviceTestBase.hpp"
 
 #include "device.h"
-#include "rccl_ptr.h"
+#include "op128.h"
 
 namespace RcclUnitTesting
 {
 
 namespace
 {
-
-// Keep in sync with projects/rccl/src/device/prims_ll.h
-inline __device__ void loadLLLine(const union ncclLLFifoLine* src, union ncclLLFifoLine& dst) {
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.v = __builtin_nontemporal_load((v4u_gptr)src->v);
-  dst.v[0] = u.u64[0];
-  dst.v[1] = u.u64[1];
-}
-
-inline __device__ void storeLLLine(union ncclLLFifoLine* dst, const union ncclLLFifoLine& src) {
-#if !RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__gfx1200__) || defined(__gfx1201__))
-  __hip_atomic_store((u64_gptr)dst->v, src.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  __hip_atomic_store((u64_gptr)dst->v + 1, src.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-#else
-  union {
-    v4u v;
-    uint64_t u64[2];
-  } u;
-  u.u64[0] = src.v[0];
-  u.u64[1] = src.v[1];
-  *((v4u_gptr)dst->v) = u.v;
-#endif
-}
 
 inline __host__ __device__ void makeFifoLine(union ncclLLFifoLine& line, uint64_t payload, uint32_t flag) {
   line.data1 = static_cast<uint32_t>(payload);
@@ -60,8 +33,8 @@ class LLFifoVectorTest : public DeviceTestBase
 
 __global__ void kernelFifoLayoutRoundtrip(const union ncclLLFifoLine* src, union ncclLLFifoLine* dst) {
   if (threadIdx.x == 0 && blockIdx.x == 0) {
-    storeLLLine(dst, *src);
-    loadLLLine(dst, *dst);
+    store128LLFifo(dst->v, src->v[0], src->v[1]);
+    load128NT(dst->v, dst->v[0], dst->v[1]);
   }
 }
 
@@ -89,11 +62,11 @@ __global__ void kernelFifoFlagPoll(union ncclLLFifoLine* fifo, uint32_t expectFl
 
   union ncclLLFifoLine published {};
   makeFifoLine(published, 0xDEADBEEFCAFEBABEULL, expectFlag);
-  storeLLLine(fifo, published);
+  store128LLFifo(fifo->v, published.v[0], published.v[1]);
 
   union ncclLLFifoLine observed {};
   for (int spins = 0; spins < 32; ++spins) {
-    loadLLLine(fifo, observed);
+    load128NT(fifo->v, observed.v[0], observed.v[1]);
     if (observed.flag1 == expectFlag && observed.flag2 == expectFlag) {
       *ready = 1;
       return;
@@ -124,7 +97,7 @@ __global__ void kernelFifoZeroCleanup(union ncclLLFifoLine* fifo) {
   if (threadIdx.x != 0 || blockIdx.x != 0) return;
   union ncclLLFifoLine zero {};
   makeFifoLine(zero, 0, 0x2u);
-  storeLLLine(fifo, zero);
+  store128LLFifo(fifo->v, zero.v[0], zero.v[1]);
 }
 
 TEST_F(LLFifoVectorTest, FifoLineZeroCleanup) {


### PR DESCRIPTION
## Summary
- Move comm-FIFO 128-bit helpers (`load128NT`, `store128Plain`, `store128LLFifo`) into `op128.h` as the single source of truth
- Thin wrappers in `prims_ll.h`; `prims_ll128.h` uses `op128.h` via existing include chain
- Add device unit tests that `#include "op128.h"` directly (no duplicated helper source)
- Add MPI AllReduce tests forcing LL / registered LL128, with NCCL_TUNING log checks confirming protocol selection
- Stack: depends on #10670 → #10666

## Files changed
| Area | Files |
|---|---|
| Production | `op128.h`, `prims_ll.h`, `prims_ll128.h` |
| Unit tests | `test/device/TestLLFifo.cpp`, `test/device/TestLL128Vector.cpp` |
| MPI tests | `test/LL128VectorMPITests.cpp`, `test/CMakeLists.txt` |

## Test plan
- [ ] `./test/rccl-UnitTestsFixtures --gtest_filter='LLFifoVectorTest.*:LL128VectorTest.*'`
- [ ] `mpirun -np 2 ./test/rccl-UnitTestsMPI --gtest_filter=LL128VectorMPITest.*`
- [ ] On gfx1250: confirm `Load128Store128Gfx1250CooperativePath` and `RegisteredAllReduce_LL128_Gfx1250Only` pass