### PR TITLE
[RCCL] Refactor QP sharing code for modularity and readability

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -7,6 +7,7 @@
 
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
+#include "qp_sharing.h"
 
 char IbCastIfName[MAX_IF_NAME_SIZE + 1];
 union ncclSocketAddress IbCastIfAddr;
@@ -24,7 +25,6 @@ NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS",
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
 extern int ncclParamIbCastResiliencyPortFailover();
-extern int64_t rcclParamIbCastCommNGroups();
 
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
@@ -87,17 +87,6 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
-#if 0
-  if (rcclParamIbCastCommNGroups() > 0) {
-    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
-    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
-    // which is correct for a shared RQ.
-    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
-    }
-    recvComm->prepostReceiveWorkRequests = true;
-  }
-#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -80,7 +80,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
     return BY_ORDER;
   }
 
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     return BY_ID;
   }
 
@@ -814,7 +814,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -908,11 +908,11 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     comm->remCommId = remMeta->commId;
 
     // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
-    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+    if (IbCastCommIsSecondary(&comm->base)) {
       // Just assign remDevIdx from remote metadata
       uint nqps = comm->base.nqps;
       for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -988,6 +988,175 @@ int IbCastGetTrafficClass(void* ctx) {
 void IbCastSetTrafficClass(void* ctx, int trafficClass) {
   ncclNetCommConfig_t* config = (ncclNetCommConfig_t*)ctx;
   if (config) config->trafficClass = trafficClass;
+}
+
+// Determine QP sharing role for sender and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastSenderQpsCreate
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingSenderSetup(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    struct ncclIbConnectionMetadata* meta,
+    const ncclNetVDeviceProps_t* remoteVProps,
+    int depthMult,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || handle->isRMA) {
+    return ncclSuccess;
+  }
+
+  int ngroups = rcclParamIbCastCommNGroups();
+
+  // Allocate commId for this comm
+  comm->base.commId = IbCastAllocCommId(comm, true);
+  if (comm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  IbCastSharedQpKey probeKey;
+  memset(&probeKey, 0, sizeof(probeKey));
+  memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&probeKey.peerAddr);
+
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  //        handle for Fusion/Cast where remoteVProps->ndevs > 1
+  int probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+  int probeRemIbDevIdx = remoteVProps->devs[0];
+
+  // Count existing refs to determine groupIdx
+  int totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+  int groupIdx = totalRefs % ngroups;
+  comm->base.sharedGroupIdx = groupIdx;
+  comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+  probeKey.ibDevN = probeIbDevN;
+  probeKey.remIbDevIdx = probeRemIbDevIdx;
+  probeKey.isSend = true;
+  probeKey.groupIdx = groupIdx;
+  probeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* existingSlot = IbCastFindSharedQp(&probeKey);
+
+  if (existingSlot != NULL) {
+    // SECONDARY: reuse existing QPs from pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+         __func__, comm->base.commId, groupIdx, totalRefs);
+
+    comm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+    comm->base.sharedPrimaryNqps = primaryNqps;
+
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+    key.isSend = true;
+    key.groupIdx = groupIdx;
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQP = q % primaryNqps;
+      key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps->devs[mappedQP % remoteVProps->ndevs];
+      key.qpIdx = mappedQP;
+
+      struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+      if (slot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+        // Fallback: free commId and go non-sharing
+        IbCastFreeCommId(comm->base.commId);
+        comm->base.commId = 0;
+        comm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      // Copy QP info from shared pool to this comm
+      comm->base.qps[q].qp = slot->qp;
+      comm->base.qps[q].devIndex = slot->devIndex;
+      comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+      comm->base.activeQps[q] = &comm->base.qps[q];
+
+      // Populate metadata with shared QP info
+      meta->qpInfo[q].qpn = slot->qp->qp_num;
+      meta->qpInfo[q].devIndex = slot->devIndex;
+
+      slot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+      comm->devs[i].base.cq = existingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = comm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    existingSlot->cqRefcount++;
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY: create QPs with scaled depth, then register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+         __func__, comm->base.commId, groupIdx, depthMult);
+    comm->base.isSharedQpPrimary = true;
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary sender's QPs in the shared pool.
+// Called after IbCastSenderQpsCreate when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingSenderRegisterPrimary(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    const ncclNetVDeviceProps_t* remoteVProps) {
+
+  union ncclSocketAddress peerAddr;
+  memcpy(&peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&peerAddr);
+
+  int nqps = comm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    key.peerAddr = peerAddr;
+    key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+    key.remIbDevIdx = remoteVProps->devs[q % remoteVProps->ndevs];
+    key.groupIdx = comm->base.sharedGroupIdx;
+    key.isSend = true;
+    key.qpIdx = q;
+
+    int devIdx = q % comm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+        comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+        comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+    entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+  }
+
+  return ncclSuccess;
 }
 
 ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** sendComm,
@@ -1102,21 +1271,15 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
-  // Initialize QP sharing fields
-  comm->base.commId = 0;
-  comm->base.isSharedQpPrimary = false;
-  comm->base.sharedGroupIdx = -1;
-  comm->base.remIbDevIdx = -1;
-  comm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&comm->base);
   comm->remCommId = 0;
 
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
 
-  // Compute depth multiplier for QP sharing
   int depthMult;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  depthMult = IbCastQpSharingDepthMultiplier();
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1156,194 +1319,48 @@ ib_recv_dev_list:
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
   meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
-  // QP Sharing: sender-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
-    int ngroups = rcclParamIbCastCommNGroups();
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingSenderSetup(comm, handle, &meta, &remoteVProps, depthMult, &sharingRole), ret, fail);
 
-    // Allocate commId for this comm
-    comm->base.commId = IbCastAllocCommId(comm, true);
-    if (comm->base.commId == 0) {
-      // Fallback to non-sharing if pool exhausted
-      goto qp_sharing_skip_sender;
-    }
+  // Set sharedGroupIdx before IbCastSenderQpsCreate which needs it
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-    // Check if primary exists for this group
-    IbCastSharedQpKey probeKey;
-    memset(&probeKey, 0, sizeof(probeKey));
-    // Build probe key from peer address
-    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-    IbCastStripPort(&probeKey.peerAddr);
-
-    // Use first device's ibDevN for the probe
-    int probeIbDevN;
-    int probeRemIbDevIdx;
-    // TODO - QP sharing
-    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
-    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
-    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
-    probeRemIbDevIdx = remoteVProps.devs[0];
-
-    // Count existing refs to determine groupIdx
-    int totalRefs;
-    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
-    int groupIdx;
-    groupIdx = totalRefs % ngroups;
-    comm->base.sharedGroupIdx = groupIdx;
-    comm->base.remIbDevIdx = probeRemIbDevIdx;
-
-    probeKey.ibDevN = probeIbDevN;
-    probeKey.remIbDevIdx = probeRemIbDevIdx;
-    probeKey.isSend = true;
-    probeKey.groupIdx = groupIdx;
-    probeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* existingSlot;
-    existingSlot = IbCastFindSharedQp(&probeKey);
-
-    if (existingSlot != NULL) {
-      // SECONDARY: reuse existing QPs from pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
-           __func__, comm->base.commId, groupIdx, totalRefs);
-
-      comm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
-      comm->base.sharedPrimaryNqps = primaryNqps;
-
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
-      key.isSend = true;
-      key.groupIdx = groupIdx;
-
-      int nqps = comm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-        int mappedQP = q % primaryNqps;
-        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
-        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
-        key.qpIdx = mappedQP;
-
-        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
-        if (slot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
-          // Fallback: free commId and go non-sharing
-          IbCastFreeCommId(comm->base.commId);
-          comm->base.commId = 0;
-          comm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_sender;
-        }
-
-        // Copy QP info from shared pool to this comm
-        comm->base.qps[q].qp = slot->qp;
-        comm->base.qps[q].devIndex = slot->devIndex;
-        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
-        comm->base.activeQps[q] = &comm->base.qps[q];
-
-        // Populate metadata with shared QP info
-        meta.qpInfo[q].qpn = slot->qp->qp_num;
-        meta.qpInfo[q].devIndex = slot->devIndex;
-
-        slot->refcount++;
-      }
-
-      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
+    comm->telChId = channelId;
+    comm->telChStats = NULL;
+  
+    // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
+    // the untracked value the hooks expect.
+    if (rcclTelemetryOn()) {
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
-        comm->devs[i].base.cq = existingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = comm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        int ibDevN = comm->base.vProps.devs[i];
+        int numQpsForDev = 0;
+        for (int q = 0; q < comm->base.nqps; q++)
+          if (comm->base.qps[q].devIndex == i) numQpsForDev++;
+        int numSlots = 0;
+        int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
+        if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
+        int slotOffset = 0;
+        for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
+          if (comm->base.qps[q].devIndex != i) continue;
+          // QPs past the granted slots keep telQpStats == NULL (untracked).
+          int telSlot = startSlot + slotOffset++;
+          rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
+          comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
         }
       }
-      existingSlot->cqRefcount++;
-
-      // Skip QP creation; metadata is already populated
-      goto qp_sharing_done_sender;
-    } else {
-      // PRIMARY: create QPs with scaled depth, then register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
-           __func__, comm->base.commId, groupIdx, depthMult);
-
-      comm->base.isSharedQpPrimary = true;
+      // Request completions are charged to the comm's first device.
+      comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
     }
-  }
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-qp_sharing_skip_sender:
-  // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
-
-  comm->telChId = channelId;
-  comm->telChStats = NULL;
-
-  // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
-  // the untracked value the hooks expect.
-  if (rcclTelemetryOn()) {
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      int ibDevN = comm->base.vProps.devs[i];
-      int numQpsForDev = 0;
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].devIndex == i) numQpsForDev++;
-      int numSlots = 0;
-      int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
-      if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
-      int slotOffset = 0;
-      for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
-        if (comm->base.qps[q].devIndex != i) continue;
-        // QPs past the granted slots keep telQpStats == NULL (untracked).
-        int telSlot = startSlot + slotOffset++;
-        rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
-        comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
-      }
-    }
-    // Request completions are charged to the comm's first device.
-    comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
-  }
-
-  // If primary, register QPs in shared pool
-  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
-    union ncclSocketAddress peerAddr;
-    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
-    IbCastStripPort(&peerAddr);
-
-    int nqps = comm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-      IbCastStripPort(&key.peerAddr);
-      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
-      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
-      key.groupIdx = comm->base.sharedGroupIdx;
-      key.isSend = true;
-      key.qpIdx = q;
-
-      int devIdx = q % comm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
-          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingSenderRegisterPrimary(comm, handle, &remoteVProps), ret, fail);
     }
   }
 
-qp_sharing_done_sender:
-  // Populate QP sharing metadata
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  // Populate remaining QP sharing metadata
   meta.commId = comm->base.commId;
   // TODO - QP sharing
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
@@ -1599,7 +1616,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
 
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -1744,10 +1761,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
-      // QP sharing is disabled for flush QP
-      qpCreateAttrs.isQpSharingEnabled = false;
-      qpCreateAttrs.qpSharingGroupIdx = -1;
-      qpCreateAttrs.cqDepthMultiplier = 1;
+      IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1815,6 +1829,221 @@ ncclResult_t IbCastReceiverPrePostReceiveWorkRequests(struct ncclIbRecvComm* rec
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, &recvComm->base.qps[i]));
   }
+  return ncclSuccess;
+}
+
+// Determine QP sharing role for receiver and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastReceiverQpsCreateToRts
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingReceiverSetup(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta,
+    struct ncclIbConnectionMetadata* meta,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || remMeta->isRMA || remMeta->sharedGroupIdx < 0) {
+    return ncclSuccess;
+  }
+
+  int recvGroupIdx = remMeta->sharedGroupIdx;
+
+  // Allocate commId for this comm
+  rComm->base.commId = IbCastAllocCommId(rComm, false);
+  if (rComm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  rComm->base.sharedGroupIdx = recvGroupIdx;
+  rComm->base.remIbDevIdx = remMeta->senderIbDevIdx;
+  int recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+  IbCastSharedQpKey recvProbeKey;
+  memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+  recvProbeKey.ibDevN = recvProbeIbDevN;
+  recvProbeKey.peerAddr = recvPeerAddr;
+  recvProbeKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvProbeKey.isSend = false;
+  recvProbeKey.groupIdx = recvGroupIdx;
+  recvProbeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+  if (recvExistingSlot != NULL) {
+    // SECONDARY receiver: reuse existing QPs
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+
+    rComm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta->senderIbDevIdx, false, remMeta->sharedGroupIdx);
+    rComm->base.sharedPrimaryNqps = primaryNqps;
+    rComm->useCtsOffload = false;
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.isSend = false;
+    recvKey.groupIdx = recvGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQ = q % primaryNqps;
+      int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+      recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+      recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      recvKey.qpIdx = mappedQ;
+
+      struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+      if (recvSlot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+        IbCastFreeCommId(rComm->base.commId);
+        rComm->base.commId = 0;
+        rComm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      rComm->base.qps[q].qp = recvSlot->qp;
+      rComm->base.qps[q].devIndex = recvSlot->devIndex;
+      rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+      // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+      // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+      rComm->base.qps[q].remDevIdx = remMeta->qpInfo[q].devIndex;
+      rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+      meta->qpInfo[q].qpn = recvSlot->qp->qp_num;
+      meta->qpInfo[q].devIndex = recvSlot->devIndex;
+
+      recvSlot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+      rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = rComm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    recvExistingSlot->cqRefcount++;
+
+    // Share flush QPs from primary
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = recvGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+        if (flushSlot) {
+          rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+          flushSlot->refcount++;
+          INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+               __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+        } else {
+          WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+               __func__, i, recvGroupIdx, rComm->base.commId);
+        }
+      }
+    }
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY receiver: create QPs with scaled depth, register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+    rComm->base.isSharedQpPrimary = true;
+    rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary receiver's QPs (and flush QPs) in the shared pool.
+// Called after IbCastReceiverQpsCreateToRts when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingReceiverRegisterPrimary(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta) {
+
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  IbCastSharedQpKey recvKey;
+  memset(&recvKey, 0, sizeof(recvKey));
+  recvKey.peerAddr = recvPeerAddr;
+  recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvKey.isSend = false;
+  recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+  int nqps = rComm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+    recvKey.qpIdx = q;
+
+    int devIdx = q % rComm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+        rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+        rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+  }
+
+  // Register flush QPs in shared pool (primary only)
+  if (rComm->flushEnabled) {
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      IbCastSharedQpKey flushKey;
+      memset(&flushKey, 0, sizeof(flushKey));
+      flushKey.ibDevN = rComm->base.vProps.devs[i];
+      flushKey.peerAddr = recvPeerAddr;
+      flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      flushKey.isSend = false;
+      flushKey.groupIdx = rComm->base.sharedGroupIdx;
+      flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+      struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+          rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+      if (flushEntry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+             "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+             __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+        continue;
+      }
+      INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+           __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+           rComm->base.sharedGroupIdx, rComm->base.commId);
+    }
+  }
+
   return ncclSuccess;
 }
 
@@ -1953,15 +2182,9 @@ ib_recv:
     }
   }
 
-  // Initialize QP sharing fields on receiver
-  rComm->base.commId = 0;
-  rComm->base.isSharedQpPrimary = false;
-  rComm->base.sharedGroupIdx = -1;
-  rComm->base.remIbDevIdx = -1;
-  rComm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&rComm->base);
 
   // IB setup
-  // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
   int ibDevN;
   struct ncclIbRecvCommDev* rCommDev;
@@ -1977,9 +2200,8 @@ ib_recv:
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
 
-  // Compute depth multiplier for receiver QP sharing
   int recvDepthMult;
-  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  recvDepthMult = IbCastQpSharingDepthMultiplier();
 
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
@@ -2056,202 +2278,17 @@ ib_recv:
                           1 :
                           0;
 
-  // QP Sharing: receiver-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
-    int recvGroupIdx = remMeta.sharedGroupIdx;
-    int recvProbeIbDevN;
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingReceiverSetup(rComm, &remMeta, &meta, &sharingRole), ret, fail);
 
-    rComm->base.commId = IbCastAllocCommId(rComm, false);
-    if (rComm->base.commId == 0) {
-      goto qp_sharing_skip_recv;
-    }
-    // Build probe key from peer address
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    rComm->base.sharedGroupIdx = recvGroupIdx;
-	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
-
-    IbCastSharedQpKey recvProbeKey;
-    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
-    recvProbeKey.ibDevN = recvProbeIbDevN;
-    recvProbeKey.peerAddr = recvPeerAddr;
-    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeKey.isSend = false;
-    recvProbeKey.groupIdx = recvGroupIdx;
-    recvProbeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* recvExistingSlot;
-    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
-
-    if (recvExistingSlot != NULL) {
-      // SECONDARY receiver: reuse existing QPs
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
-           __func__, rComm->base.commId, recvGroupIdx);
-
-      rComm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
-
-      rComm->base.sharedPrimaryNqps = primaryNqps;
-      rComm->useCtsOffload = false;
-
-      IbCastSharedQpKey recvKey;
-      memset(&recvKey, 0, sizeof(recvKey));
-      recvKey.peerAddr = recvPeerAddr;
-      recvKey.isSend = false;
-      recvKey.groupIdx = recvGroupIdx;
-
-      int nqps = rComm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-		int mappedQ = q % primaryNqps;
-		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
-		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
-        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        recvKey.qpIdx = mappedQ;
-
-        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
-        if (recvSlot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
-          IbCastFreeCommId(rComm->base.commId);
-          rComm->base.commId = 0;
-          rComm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_recv;
-        }
-
-        rComm->base.qps[q].qp = recvSlot->qp;
-        rComm->base.qps[q].devIndex = recvSlot->devIndex;
-        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
-        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
-        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
-        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
-        rComm->base.activeQps[q] = &rComm->base.qps[q];
-
-        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
-        meta.qpInfo[q].devIndex = recvSlot->devIndex;
-
-        recvSlot->refcount++;
-      }
-
-      // Redirect CQs
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
-        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = rComm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
-        }
-      }
-      recvExistingSlot->cqRefcount++;
-
-      // Share flush QPs from primary
-      if (rComm->flushEnabled) {
-        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-          IbCastSharedQpKey flushKey;
-          memset(&flushKey, 0, sizeof(flushKey));
-          flushKey.ibDevN = rComm->base.vProps.devs[i];
-          flushKey.peerAddr = recvPeerAddr;
-          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-          flushKey.isSend = false;
-          flushKey.groupIdx = recvGroupIdx;
-          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
-          if (flushSlot) {
-            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
-            flushSlot->refcount++;
-            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
-                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
-          } else {
-            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
-                 __func__, i, recvGroupIdx, rComm->base.commId);
-          }
-        }
-      }
-
-      goto qp_sharing_done_recv;
-    } else {
-      // PRIMARY receiver: create QPs with scaled depth, register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
-           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
-      rComm->base.isSharedQpPrimary = true;
-      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingReceiverRegisterPrimary(rComm, &remMeta), ret, fail);
     }
   }
 
-qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
-
-  // If primary receiver, register QPs in shared pool
-  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    IbCastSharedQpKey recvKey;
-    memset(&recvKey, 0, sizeof(recvKey));
-    recvKey.peerAddr = recvPeerAddr;
-    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvKey.isSend = false;
-    recvKey.groupIdx = rComm->base.sharedGroupIdx;
-
-    int nqps = rComm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
-      recvKey.qpIdx = q;
-
-      int devIdx = q % rComm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
-          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-    }
-
-    // Register flush QPs in shared pool (primary only)
-    if (rComm->flushEnabled) {
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        IbCastSharedQpKey flushKey;
-        memset(&flushKey, 0, sizeof(flushKey));
-        flushKey.ibDevN = rComm->base.vProps.devs[i];
-        flushKey.peerAddr = recvPeerAddr;
-        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        flushKey.isSend = false;
-        flushKey.groupIdx = rComm->base.sharedGroupIdx;
-        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
-        if (flushEntry == NULL) {
-          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
-               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
-               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
-          continue;
-        }
-        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
-             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
-             rComm->base.sharedGroupIdx, rComm->base.commId);
-      }
-    }
-  }
-
-qp_sharing_done_recv:
   // Populate QP sharing metadata in response
   meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
   meta.commId = rComm->base.commId;
@@ -2419,20 +2456,37 @@ fail:
   goto exit;
 }
 
+// Per-device MR cleanup for sender comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseSendCommDevResources(struct ncclIbSendComm* comm, int devIndex) {
+  struct ncclIbSendCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (commDev->putSignalScratchpadMr != NULL)
+    NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseSend(void* sendComm) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, true);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2443,53 +2497,33 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
+
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(IbCastCloseSendCommDevResources(comm, i));
+      if (!isSharing) {
+        NCCLCHECK(IbCastDestroyBase(&comm->devs[i].base));
       }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    }
 
-      // Deregister per-comm MRs (not shared)
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
-      }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them, or ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them, or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
       }
     }
 
@@ -2502,20 +2536,48 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   return ncclSuccess;
 }
 
+// Per-device flush memory cleanup (common between shared/non-shared paths).
+// Releases GPU memory, MRs, and dma-buf FDs. Does NOT destroy the flush QP.
+static ncclResult_t IbCastCloseRecvFlushMem(struct ncclIbRecvCommDev* commDev) {
+  if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+    CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+    commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+    if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+    commDev->gpuFlush.gpuMr = nullptr;
+    if (commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd); }
+  }
+  return ncclSuccess;
+}
+
+// Per-device MR cleanup for receiver comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseRecvCommDevResources(struct ncclIbRecvComm* comm, int devIndex) {
+  struct ncclIbRecvCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseRecv(void* recvComm) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // Data QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, false);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2526,27 +2588,28 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
 
-      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          // Per-comm flush memory cleanup (always done)
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          // Shared flush QP teardown (refcount-based)
-          if (commDev->gpuFlush.qp.qp != NULL) {
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup: flush QP/memory and MR teardown
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      struct ncclIbRecvCommDev* commDev = comm->devs + i;
+      if (comm->flushEnabled) {
+        // Flush memory is always per-comm
+        NCCLCHECK(IbCastCloseRecvFlushMem(commDev));
+        // Flush QP teardown: refcount-based for shared, direct destroy for non-shared
+        if (commDev->gpuFlush.qp.qp != NULL) {
+          if (isSharing) {
             struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
                 commDev->gpuFlush.qp.qp->qp_num, false);
             if (flushSlot) {
@@ -2556,65 +2619,34 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
+                IbCastUnregisterSharedQpLocked(flushSlot);
               }
             } else {
-              // Not in pool -- e.g. registration hit the pool-exhaustion
-              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
-              // flush QP was never pool-tracked, so just destroy it directly.
+              // Not in pool (pool-exhaustion fallback) — destroy directly
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
-            commDev->gpuFlush.qp.qp = NULL;
+          } else {
+            NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
           }
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+          commDev->gpuFlush.qp.qp = NULL;
         }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them (data QPs above, this comm's own flush QP just above), or
-      // ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
-        }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
+      NCCLCHECK(IbCastCloseRecvCommDevResources(comm, i));
+      if (!isSharing) {
         NCCLCHECK(IbCastDestroyBase(&commDev->base));
       }
     }
+
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them (data QPs and flush QPs above), or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
+      }
+    }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -115,6 +115,13 @@ struct ncclIbConnectionMetadata {
   int      senderIbDevIdx;      // sender's IB device index
 };
 
+// Initialize QP sharing fields to defaults (sharing disabled)
+static inline void IbCastQpCreateAttrInitSharing(struct ncclIbQpCreateAttr* attr) {
+  attr->isQpSharingEnabled = false;
+  attr->qpSharingGroupIdx = -1;
+  attr->cqDepthMultiplier = 1;
+}
+
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -360,6 +360,10 @@ ncclResult_t IbCastFinalizeDevices(void) {
   // No telemetry flush here: netRefCount reaching 0 is not process exit, and
   // the flush is one-shot. atexit(rcclTelemetryFlush) covers the process.
   --netRefCount;
+  if (netRefCount == 0) {
+    // debug validation
+    IbCastValidateSharedQpPool();
+  }
   return ncclSuccess;
 }
 
@@ -635,7 +639,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       IbCastAinicCtsInlineData = IbCastUseInline;
 
       // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
-      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+      if (IbCastOffloadEnabled && IbCastQpSharingEnabled()) {
         INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
         IbCastOffloadEnabled = false;
       }
@@ -655,7 +659,7 @@ exit:
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
   }
-  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && IbCastQpSharingEnabled()) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -117,8 +117,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
     } else {
       wr->wr_id = wr_id;
     }
@@ -152,9 +152,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
-      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
-                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      if (IbCastCommIsSharing(&comm->base) && comm->remCommId != 0) {
+        immData = IbCastEncodeCommIdImmData((uint32_t)reqs[0]->id, comm->remCommId);
       }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
@@ -182,8 +181,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
   // route the send completion to the right comm on a shared QP. The scheduler
   // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
-  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  if (IbCastCommIsSharing(&comm->base)) {
+    lastWr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
   } else {
     lastWr->wr_id = wr_id;
   }
@@ -597,8 +596,8 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
     // QP Sharing: encode commId in upper bits of CTS wr_id
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
@@ -779,8 +778,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
@@ -838,7 +837,7 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     uint32_t immDataHost = be32toh(wc->imm_data);
-    if (rcclParamIbCastCommNGroups() > 0) {
+    if (IbCastQpSharingEnabled()) {
       uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
       *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
     } else {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -9,6 +9,7 @@
 #include "p2p_cast.h" // For replay (IbCastMultiSend() and IbCastPostFifo())
 #include "connect_cast.h" // For IbCastQpCreate()
 #include "p2p_resiliency_recovery_cast.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastResiliencyPortFailover, "IB_RESILIENCY_PORT_FAILOVER", 0);
 NCCL_PARAM(IbCastResiliencyPortFailoverMaxAttempts, "IB_RESILIENCY_PORT_FAILOVER_MAX_ATTEMPTS", 1);
@@ -17,7 +18,6 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
-extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -599,12 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || IbCastQpSharingEnabled()) {
     // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
     // when QP sharing is enabled.
     INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
          baseComm->isSend ? "send" : "recv", baseComm,
-         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
+         IbCastQpSharingEnabled() ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -814,9 +814,7 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -906,9 +904,7 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,9 +313,7 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -387,9 +385,7 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -50,9 +50,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     //        as of now QP sharing disabled during recovery restore.
     //        to analyze and set sharing accordingly for this QP during recovery restore.
     //        identify if it is primary or secondary comm and set sharing attributes accordingly.
-    createAttr.isQpSharingEnabled = false;
-    createAttr.qpSharingGroupIdx = -1;
-    createAttr.cqDepthMultiplier = 1;
+    IbCastQpCreateAttrInitSharing(&createAttr);
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
     localQp->telQpStats = telQpStats;
 
@@ -87,9 +85,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.isDataQp = flushQp->isDataQp;
         // TODO - QP sharing:
         //        disabled for flush QP
-        flushCreateAttr.isQpSharingEnabled = false;
-        flushCreateAttr.qpSharingGroupIdx = -1;
-        flushCreateAttr.cqDepthMultiplier = 1;
+        IbCastQpCreateAttrInitSharing(&flushCreateAttr);
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "qp_sharing.h"
+#include <cassert>
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -163,7 +164,7 @@ struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
 }
 
 struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
     //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
     if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
@@ -190,6 +191,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
 
     for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
         if (!g_IbCastSharedQpPool[i].used) continue;
+        // Skip flush QP slots — they are torn down separately before CQ cleanup
+        if (g_IbCastSharedQpPool[i].key.qpIdx == IBCAST_FLUSH_QP_IDX) continue;
         if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
         if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
         if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
@@ -226,5 +229,42 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
         }
         g_IbCastSharedQpPool[i].used = false;
         g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
+    }
+}
+
+void IbCastValidateSharedQpPool(void) {
+    if (!IbCastQpSharingEnabled()) return;
+
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int leakedSlots = 0;
+    int leakedCommIds = 0;
+
+    // Check QP pool for leaked entries
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        struct IbCastSharedQp* slot = &g_IbCastSharedQpPool[i];
+        if (slot->used) {
+            WARN("IB CAST POOL LEAK: slot=%d qpIdx=%d group=%d isSend=%d refcount=%d cqRefcount=%d qp=%p",
+                 i, slot->key.qpIdx, slot->key.groupIdx, slot->key.isSend,
+                 slot->refcount, slot->cqRefcount, (void*)slot->qp);
+            leakedSlots++;
+        }
+    }
+
+    // Check comm table for leaked commIds
+    for (int i = 1; i < IBCAST_MAX_COMMS; i++) {
+        if (g_IbCastCommTable[i].used) {
+            WARN("IB CAST POOL LEAK: commId=%d isSend=%d comm=%p still in use",
+                 i, g_IbCastCommTable[i].isSend, g_IbCastCommTable[i].comm);
+            leakedCommIds++;
+        }
+    }
+
+    if (leakedSlots == 0 && leakedCommIds == 0) {
+        INFO(NCCL_NET, "IB CAST POOL VALIDATE: clean shutdown — pool=%d/%d slots used, freeStack=%d, nextCommId=%u",
+             0, g_IbCastSharedQpPoolCount, g_IbCastCommIdFreeTop, g_IbCastNextCommId);
+    } else {
+        WARN("IB CAST POOL VALIDATE: UNCLEAN shutdown — %d leaked QP slots, %d leaked commIds", leakedSlots, leakedCommIds);
+        assert(leakedSlots == 0 && "QP sharing pool has leaked QP slots at shutdown");
+        assert(leakedCommIds == 0 && "QP sharing pool has leaked commIds at shutdown");
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -22,6 +22,51 @@ extern int64_t rcclParamIbCastCommNGroups();
 // CQ/WR depth scaling for primary QPs
 extern int64_t rcclParamIbCastQpDepthMultiplier();
 
+// QP sharing role for a comm during connection setup.
+// Returned by IbCastQpSharing{Sender,Receiver}Setup() to tell the caller
+// whether to create QPs, register them, or skip both.
+enum IbCastQpSharingRole {
+  QP_SHARING_NONE,       // sharing disabled or fallback — normal QP creation
+  QP_SHARING_PRIMARY,    // primary — create QPs with scaled depth, then register
+  QP_SHARING_SECONDARY,  // secondary — QPs already assigned, skip creation
+};
+
+// Returns true when QP sharing is enabled (NCCL_IB_COMM_NGROUPS > 0)
+static inline bool IbCastQpSharingEnabled(void) {
+  return rcclParamIbCastCommNGroups() > 0;
+}
+
+// Returns true when this comm is actively sharing QPs (sharing enabled AND
+// commId was successfully allocated; commId==0 means fallback to non-sharing).
+static inline bool IbCastCommIsSharing(const struct ncclIbNetCommBase* base) {
+  return IbCastQpSharingEnabled() && base->commId != 0;
+}
+
+// Returns true when this comm is the primary (owner) of shared QPs in its group.
+static inline bool IbCastCommIsPrimary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && base->isSharedQpPrimary;
+}
+
+// Returns true when this comm is a secondary (reuses QPs owned by a primary).
+static inline bool IbCastCommIsSecondary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && !base->isSharedQpPrimary;
+}
+
+// Initialize QP sharing fields on a comm base to defaults (sharing disabled).
+static inline void IbCastCommInitSharingFields(struct ncclIbNetCommBase* base) {
+  base->commId = 0;
+  base->isSharedQpPrimary = false;
+  base->sharedGroupIdx = -1;
+  base->remIbDevIdx = -1;
+  base->sharedPrimaryNqps = 0;
+}
+
+// Compute CQ/WR depth multiplier for shared QPs.
+// Returns 1 when sharing is disabled.
+static inline int IbCastQpSharingDepthMultiplier(void) {
+  return IbCastQpSharingEnabled() ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+}
+
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
@@ -111,6 +156,23 @@ void IbCastFreeCommIdLocked(uint16_t commId);
 
 // Destroy all CQs for a group when cqRefcount reaches 0
 void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Validate that all shared QP pool entries and commIds are cleaned up.
+// Logs leaked entries and asserts on non-zero counts. Call at finalize time.
+void IbCastValidateSharedQpPool(void);
+
+// Encode commId into wr_id[63:48]. When commId==0 (sharing disabled or
+// fallback) this is a no-op (OR with zero).
+static inline uint64_t IbCastEncodeCommId(uint64_t wr_id, uint16_t commId) {
+  return wr_id | ((uint64_t)commId << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Encode receiver commId into immData for BY_ID matching scheme:
+//   bits[7:0]  = reqId,  bits[23:8] = remCommId.
+static inline uint32_t IbCastEncodeCommIdImmData(uint32_t reqId, uint16_t remCommId) {
+  return (reqId & WR_IMM_BYID_REQ_ID_MASK) |
+         (((uint32_t)remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+}
 
 // Strip the commId from wr_id[63:48], recovering the original index. Safe when
 // sharing is disabled (commId==0, so the mask is a no-op).


### PR DESCRIPTION
## Motivation

Consolidate QP sharing code for better modularity & readability.

## Technical Details
Consolidate scattered QP sharing checks into inline helpers and extract large QP sharing code blocks from IbCastConnectImpl/IbCastAccept into dedicated functions, improving readability and maintainability.

Inline helpers added to qp_sharing.h:
- IbCastQpSharingEnabled(): replaces raw rcclParamIbCastCommNGroups() > 0
- IbCastCommIsSharing(): replaces ngroups > 0 && commId != 0
- IbCastCommIsPrimary/IsSecondary(): replaces commId != 0 && isSharedQpPrimary
- IbCastCommInitSharingFields(): zeroes all sharing fields on comm base
- IbCastQpSharingDepthMultiplier(): computes CQ/WR depth multiplier
- IbCastEncodeCommId/ImmData(): encodes commId into wr_id/immData
- IbCastQpCreateAttrInitSharing(): initializes QP create attr sharing fields
- IbCastQpSharingRole enum: NONE/PRIMARY/SECONDARY for role-based branching

QP sharing setup/registration extracted from connect/accept:
- IbCastQpSharingSenderSetup(): primary/secondary determination + secondary setup
- IbCastQpSharingSenderRegisterPrimary(): primary QP pool registration
- IbCastQpSharingReceiverSetup(): same for receiver side + flush QP sharing
- IbCastQpSharingReceiverRegisterPrimary(): receiver QP + flush QP registration

Close path consolidation:
- IbCastCloseSend/IbCastCloseRecv: merged shared/non-shared if/else branches into single linear flow with conditional handling via std::unique_lock

All goto labels (qp_sharing_skip_*, qp_sharing_done_*) eliminated from IbCastConnectImpl and IbCastAccept, replaced by role-based if/else.

## Issue Tracking
JIRA ID: AICOMNET-375

## Test Plan

RCCL benchmark tests

## Test Result

RCCL benchmark tests results are inline with the parent PR # 10251.

[report_consolidated_4node4N-G4-M8-10runs-24-Aug-2026-run2.xlsx](https://github.com/user-attachments/files/31432785/report_consolidated_4node4N-G4-M8-10runs-24-Aug-2026-run2.xlsx)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
