### PR TITLE
[Rel 7.2][rocprofiler-sdk] Fail attach when attachment library is not loaded

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/ptrace_session.cpp
@@ -748,6 +748,13 @@ PTraceSession::find_library(void*& addr, int inpid, const std::string& library)
 }
 
 bool
+PTraceSession::has_library(const std::string& library) const
+{
+    void* library_addr = nullptr;
+    return find_library(library_addr, m_pid, library);
+}
+
+bool
 PTraceSession::find_symbol(void*& addr, const std::string& library, const std::string& symbol)
 {
     auto searchname = std::stringstream{};

--- a/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/ptrace_session.hpp
@@ -47,6 +47,7 @@ public:
     bool detach();
     bool simple_mmap(void*& addr, size_t length) const;
     bool simple_munmap(void*& addr, size_t length) const;
+    bool has_library(const std::string& library) const;
 
     bool write(size_t addr, const std::vector<uint8_t>& data, size_t size) const;
     bool read(size_t addr, std::vector<uint8_t>& data, size_t size) const;

--- a/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/rocprofv3_attach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofv3-attach/rocprofv3_attach.cpp
@@ -150,6 +150,18 @@ handle_ptrace_operations(uint32_t pid)
     // Setup attachement for rocprofiler
     ROCP_TRACE << "Attachment library called for pid " << pid;
     ptrace_session = std::make_unique<rocprofiler::attach::PTraceSession>(pid);
+
+    if(!ptrace_session->has_library("librocprofiler-sdk-attach.so"))
+    {
+        ROCP_ERROR << "Target process " << pid
+                   << " does not have the rocprofiler attachment library loaded. Start the "
+                      "target with ROCP_TOOL_ATTACH=1 or build rocprofiler-register with "
+                      "ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON";
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+
     ROCP_TRACE << "Attempting attachment to pid " << pid;
     if(!ptrace_session->attach())
     {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
@@ -4,3 +4,4 @@
 
 add_subdirectory(attach-once)
 add_subdirectory(attach-twice)
+add_subdirectory(attach-without-env)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-without-env/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-without-env/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# rocprofv3 attachment test without ROCP_TOOL_ATTACH
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-without-env
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
+               "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
+
+set(attachment-env
+    "${PRELOAD_ENV}"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+add_test(
+    NAME rocprofv3-test-attachment-without-env-execute
+    COMMAND
+        bash ${CMAKE_CURRENT_SOURCE_DIR}/run_attachment_without_env_test.sh
+        $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(
+    rocprofv3-test-attachment-without-env-execute
+    PROPERTIES TIMEOUT 30 LABELS "integration-tests;attachment" ENVIRONMENT
+               "${attachment-env}" DISABLED "${IS_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-without-env/run_attachment_without_env_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-without-env/run_attachment_without_env_test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -euo pipefail
+
+TEST_APP=$1
+ROCPROFV3=$2
+OUTPUT_DIR=$3
+TARGET_LOG=${OUTPUT_DIR}/target.log
+ATTACH_LOG=${OUTPUT_DIR}/attach.log
+
+unset ROCP_TOOL_ATTACH
+mkdir -p "${OUTPUT_DIR}"
+
+cleanup()
+{
+    if [[ -n "${APP_PID:-}" ]] && kill -0 "${APP_PID}" 2>/dev/null; then
+        kill "${APP_PID}" 2>/dev/null || true
+        wait "${APP_PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+LD_PRELOAD="${ROCPROF_PRELOAD:-}" "${TEST_APP}" 1 1 1 >"${TARGET_LOG}" 2>&1 &
+APP_PID=$!
+
+for _ in $(seq 1 50); do
+    if grep -q "After first call" "${TARGET_LOG}"; then
+        break
+    fi
+    if ! kill -0 "${APP_PID}" 2>/dev/null; then
+        echo "Test application exited before attachment"
+        cat "${TARGET_LOG}"
+        exit 1
+    fi
+    sleep 0.1
+done
+
+if ! grep -q "After first call" "${TARGET_LOG}"; then
+    echo "Test application did not become ready"
+    cat "${TARGET_LOG}"
+    exit 1
+fi
+
+set +e
+LD_PRELOAD="${ROCPROF_PRELOAD:-}" "${ROCPROFV3}" --attach "${APP_PID}" \
+    --attach-duration-msec 100 -s -d "${OUTPUT_DIR}" -o attach-without-env \
+    >"${ATTACH_LOG}" 2>&1
+ATTACH_STATUS=$?
+set -e
+
+if [[ ${ATTACH_STATUS} -eq 0 ]]; then
+    echo "rocprofv3 attach succeeded without ROCP_TOOL_ATTACH=1"
+    cat "${ATTACH_LOG}"
+    exit 1
+fi
+
+if ! grep -q "does not have the rocprofiler attachment library loaded" "${ATTACH_LOG}"; then
+    echo "rocprofv3 attach failed without reporting why attachment is unavailable"
+    cat "${ATTACH_LOG}"
+    exit 1
+fi
+
+if ! kill -0 "${APP_PID}" 2>/dev/null; then
+    echo "Test application did not survive the failed attachment"
+    cat "${TARGET_LOG}"
+    cat "${ATTACH_LOG}"
+    exit 1
+fi
+
+echo "rocprofv3 attach failed as expected and the target remained alive"


### PR DESCRIPTION
## Motivation

This issue was originally observed on a DigitalOcean MI300X instance while profiling vLLM running in a ROCm 7.2 container.

When the vLLM target process was not started with `ROCP_TOOL_ATTACH=1`, `rocprofv3 --attach` printed `success` and returned exit code 0, but no trace files were produced.

The same false-success behavior was subsequently reproduced locally with a ROCm 7.2.3 vLLM container on a `gfx1201` system, isolating the problem to the legacy ROCm 7.2 attachment path rather than vLLM or MI300X hardware.

The legacy ptrace-based implementation can proceed even though `librocprofiler-sdk-attach.so` is not loaded in the target process. This change detects that condition before ptrace injection and returns an actionable error instead of reporting a successful attachment.

This is specific to the ROCm 7.2 implementation. The equivalent unsupported-target failure mode on `develop` was addressed by #6557 using the newer `rocp-bg-attach` helper-thread architecture, which cannot be directly applied to the legacy 7.2 ptrace implementation.

## Technical Details

- Add `PTraceSession::has_library()` using the existing target `/proc/<pid>/maps` library lookup.
- Check for `librocprofiler-sdk-attach.so` before `PTRACE_SEIZE` and remote memory allocation.
- Return `ROCPROFILER_STATUS_ERROR` when the attachment library is not loaded.
- Report that the target should be started with `ROCP_TOOL_ATTACH=1`, or use a `rocprofiler-register` build configured with `ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON`.
- Add an integration regression test that starts the target without `ROCP_TOOL_ATTACH=1` and verifies that attachment fails without terminating the target process.

The existing generic error status is retained to avoid changing the public status API in a release-branch regression fix.

## Issue Tracking

JIRA ID: ROCM-24403

## Test Plan

1. Start the existing attachment test application without `ROCP_TOOL_ATTACH=1`.
2. Run `rocprofv3 --attach` against the target.
3. Verify that:
   - `rocprofv3` returns a non-zero status.
   - The diagnostic explains why attachment is unavailable.
   - The target process remains alive.
4. Run the existing attach-once and attach-twice integration tests to verify that supported attachment remains functional.
5. Repeat the new negative regression test to check for intermittent behavior.

## Test Result

Original failure environment:

- DigitalOcean MI300X instance.
- vLLM running in a ROCm 7.2 container.
- Without `ROCP_TOOL_ATTACH=1`, `rocprofv3 --attach` reported success and returned exit code 0, but produced no trace.

Local reproduction and fix validation:

- ROCm 7.2.3 vLLM container on a `gfx1201` system.
- The original false-success/no-trace behavior was reproduced before applying the fix.
- With `ROCP_TOOL_ATTACH=1`, attachment produced non-empty, parseable trace files.
- Full source build completed with CI/developer settings and `-Werror`.
- Changed C++ translation units passed `clang-tidy-15`.
- `clang-format-11`, `cmake-format`, ShellCheck, and `git diff --check` passed.
- Attachment test suite: 7/7 passed.
- New attachment-without-environment regression test: 10/10 repeated runs passed.
- Existing attach-once and attach-twice positive paths continued to pass.

The patched source was validated locally on `gfx1201`; post-fix validation on the original MI300X instance was not available.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.