### PR TITLE
fix(rocr): serialize bootstrap_lock init to fix concurrent hsa_init race

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -817,7 +817,15 @@ class Runtime {
   static __forceinline std::mutex& bootstrap_lock() {
     // This allocation is meant to last until the last thread has exited.
     // It is intentionally not freed.
-    static std::mutex* bootstrap_lock_ = new std::mutex;
+    // Built with -fno-threadsafe-statics, so a function-local static with a
+    // dynamic initializer is NOT thread-safe: concurrent first-time hsa_init()
+    // callers could each run 'new std::mutex' and serialize on different mutex
+    // objects, defeating Acquire/Release mutual exclusion. Guard the one-time
+    // init with a constant-initialized std::once_flag (its constexpr ctor makes
+    // it immune to -fno-threadsafe-statics) so all callers share one mutex.
+    static std::once_flag bootstrap_once;
+    static std::mutex* bootstrap_lock_ = nullptr;
+    std::call_once(bootstrap_once, []() { bootstrap_lock_ = new std::mutex; });
     return *bootstrap_lock_;
   }
   Runtime();


### PR DESCRIPTION
## Motivation

`rocrtstFunc.Concurrent_Init_Shutdown_Test` intermittently fails on gfx1250 (ROCm 10.1.0): `hsa_init()` returns `OUT_OF_RESOURCES` (0x1008), `hsa_shut_down()` returns `NOT_INITIALIZED` (0x100B), and the process intermittently SIGSEGVs. The test spawns 100 threads that each repeatedly call `hsa_init()` then `hsa_shut_down()`. Run as separate processes it passes, so this is a concurrency race in the runtime start/stop path, not resource exhaustion.

## Technical Details

The runtime start/stop path is meant to be serialized by a single process-global lock obtained via `Runtime::bootstrap_lock()` (`core/inc/runtime.h`), which lazily constructs the mutex through a function-local static with a dynamic initializer:

```cpp
static std::mutex* bootstrap_lock_ = new std::mutex;
```

The library is compiled with `-fno-threadsafe-statics` (`runtime/hsa-runtime/CMakeLists.txt`), which strips the compiler-emitted `__cxa_guard_acquire/release` guard around statics with dynamic initializers. Under concurrent first-ever `hsa_init()`, multiple threads each execute `new std::mutex` and end up locking **different** mutex objects, so the "single global bootstrap lock" no longer serializes `Acquire`/`Release`. Two threads then enter `Load()` concurrently, producing a second `Runtime` instance and a NULL `thunkLoader_` dereference (core dump: `KfdDriver::Open`, `amd_kfd_driver.cpp`), along with the `OUT_OF_RESOURCES` / `NOT_INITIALIZED` cascade.

Fix: guard the one-time init with a constant-initialized `std::once_flag` + `std::call_once`. `std::once_flag` has a `constexpr` constructor, so it is constant-initialized and immune to `-fno-threadsafe-statics`; `std::call_once` runs the allocation exactly once and blocks all other callers until it completes, so every caller observes the same mutex. The mutex is still allocated with `new` and never freed, preserving the original "outlive misbehaving shutdown-after-main" intent. One function, one header; no API/ABI change.

## Issue Tracking

JIRA ID: ROCM-29750

## Test Plan

Same-node A/B on the gfx1250 target: two runtime libraries built from an identical source tree and toolchain, differing **only** in `bootstrap_lock()` (stock `new std::mutex` vs `once_flag`). Both exercised with the same `rocrtst64` binary, alternating arm-by-arm every iteration to cancel machine-state noise. Ran `rocrtstFunc.Concurrent_Init_Shutdown_Test` for 100 and 1000 iterations per arm. Each run classified PASS (exit 0) / CRASH (killed by signal) / FAIL (soft error).

## Test Result

100-iteration A/B:

| Build | PASS | CRASH | FAIL |
|-------|------|-------|------|
| Stock | 53   | 8     | 39   |
| Fixed | 100  | 0     | 0    |

1000-iteration A/B:

| Build | PASS | CRASH | FAIL |
|-------|------|-------|------|
| Stock | 522  | 56    | 422  |
| Fixed | 1000 | 0     | 0    |

The fixed build was 100% clean across all 1000 iterations. The broader `rocrtstFunc` suite showed no new failures (the single pre-existing `BarrierPkt_TimeStamp` failure occurs identically on stock and fixed builds).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
