### PR TITLE
[kpack] Add emitted family dependencies to target device wheels

### DIFF
--- a/shared/kpack/python/rocm_kpack/wheel_splitter.py
+++ b/shared/kpack/python/rocm_kpack/wheel_splitter.py
@@ -321,6 +321,7 @@ def generate_device_metadata(
     bundle_key: str,
     device_package_prefix: str,
     device_requires_dist: list[str],
+    available_bundle_keys: set[str] | None = None,
 ) -> str:
     """Generate METADATA content for a device wheel.
 
@@ -329,6 +330,9 @@ def generate_device_metadata(
         bundle_key: Bundle key, e.g. "gfx942", "gfx11", "gfx12_0".
         device_package_prefix: Package name prefix, e.g. "amd-torch-device".
         device_requires_dist: Additional Requires-Dist entries (may contain @GFXARCH@).
+        available_bundle_keys: Bundle keys emitted by this split. Target wheels
+            depend on any available parent family/sub-family wheels in their
+            packaging chain.
 
     Returns:
         METADATA file content.
@@ -351,6 +355,17 @@ def generate_device_metadata(
             continue
         expanded = dep.replace("@GFXARCH@", bundle_key)
         lines.append(f"Requires-Dist: {expanded}")
+    if (
+        available_bundle_keys is not None
+        and bundle.level == rocm_bootstrap.PackagingLevel.TARGET
+    ):
+        for parent_bundle in rocm_bootstrap.packaging_chain(bundle_key)[1:]:
+            if parent_bundle.key not in available_bundle_keys:
+                continue
+            parent_name = rocm_bootstrap.device_dist_name(
+                device_package_prefix, parent_bundle
+            )
+            lines.append(f"Requires-Dist: {parent_name} == {host_identity.version}")
     return "\n".join(lines) + "\n"
 
 
@@ -803,6 +818,7 @@ class WheelSplitter:
         bundle_keys = sorted(
             set(kpacks_by_bundle.keys()) | set(db_refs_by_bundle.keys())
         )
+        available_bundle_keys = set(bundle_keys)
 
         if self.verbose and bundle_keys != architectures:
             print(f"  Bundle keys (after xnack collapse): {', '.join(bundle_keys)}")
@@ -830,7 +846,10 @@ class WheelSplitter:
 
         # Rewrite host METADATA (classic: extras only, no variant markers)
         self._rewrite_host_metadata(
-            host_staging, identity, set(bundle_keys), include_variant_markers=False
+            host_staging,
+            identity,
+            available_bundle_keys,
+            include_variant_markers=False,
         )
 
         # Regenerate RECORD for host wheel
@@ -860,7 +879,7 @@ class WheelSplitter:
             variant_output = self._create_variant_wheel(
                 host_staging if output_format == "wheel" else host_output,
                 identity,
-                set(bundle_keys),
+                available_bundle_keys,
                 output_dir,
                 output_format,
             )
@@ -878,6 +897,7 @@ class WheelSplitter:
                 group_name,
                 kpacks_by_bundle.get(bundle_key, []),
                 db_refs_by_bundle.get(bundle_key, []),
+                available_bundle_keys,
                 output_dir,
                 output_format,
             )
@@ -1568,6 +1588,7 @@ class WheelSplitter:
         group_name: str,
         kpack_entries: list[tuple[str, Path]],
         db_refs: list[DatabaseFileRef],
+        available_bundle_keys: set[str],
         output_dir: Path,
         output_format: str,
     ) -> Path:
@@ -1578,6 +1599,7 @@ class WheelSplitter:
             kpack_entries: List of (arch, kpack_path) tuples. Multiple entries
                 occur when xnack variants collapse into the same bundle key.
             db_refs: Database files to include for this bundle.
+            available_bundle_keys: All bundle keys emitted by this split.
 
         Returns:
             Path to the generated device wheel (file or directory).
@@ -1622,6 +1644,7 @@ class WheelSplitter:
             bundle_key,
             self.device_package_prefix,
             self.device_requires_dist,
+            available_bundle_keys,
         )
         (dist_info_dir / "METADATA").write_text(metadata_content, encoding="utf-8")
 

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -221,6 +221,86 @@ class TestGenerateDeviceMetadata:
         assert "Version: 2.10.0+rocm7.1" in metadata
         assert "Requires-Dist: torch == 2.10.0+rocm7.1" in metadata
 
+    def test_target_depends_on_available_family_wheels(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(
+            identity,
+            "gfx1100",
+            "amd-torch-device",
+            [],
+            {"gfx1100", "gfx110x", "gfx11"},
+        )
+        assert "Requires-Dist: amd-torch-device-gfx110x == 2.10.0+rocm7.1" in metadata
+        assert "Requires-Dist: amd-torch-device-gfx11 == 2.10.0+rocm7.1" in metadata
+
+    def test_target_omits_unavailable_family_wheels(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(
+            identity,
+            "gfx1100",
+            "amd-torch-device",
+            [],
+            {"gfx1100"},
+        )
+        assert "amd-torch-device-gfx110x" not in metadata
+        assert "Requires-Dist: amd-torch-device-gfx11 ==" not in metadata
+
+    def test_target_wheel_contains_available_family_dependencies(
+        self, tmp_path: Path, toolchain
+    ):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        kpack_path = tmp_path / "torch_gfx1100.kpack"
+        kpack_path.write_bytes(b"test kpack")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+        )
+
+        wheel_path = splitter._create_device_wheel(
+            "gfx1100",
+            identity,
+            "torch",
+            [("gfx1100", kpack_path)],
+            [],
+            {"gfx1100", "gfx11"},
+            output_dir,
+            "wheel",
+        )
+
+        with zipfile.ZipFile(wheel_path) as wheel:
+            metadata_name = next(
+                name
+                for name in wheel.namelist()
+                if name.endswith(".dist-info/METADATA")
+            )
+            metadata = wheel.read(metadata_name).decode()
+        assert "Requires-Dist: amd-torch-device-gfx11 == 2.10.0+rocm7.1" in metadata
+        assert "amd-torch-device-gfx110x" not in metadata
+
     def test_family_level(self):
         identity = WheelIdentity(
             name="torch",


### PR DESCRIPTION
## Summary

- Make target device wheels depend on parent family/sub-family wheels emitted by the same split.
- Pin parent dependencies to the host-wheel version.
- Add metadata and generated-wheel tests.

## Problem

`amd-torch-device-gfx1100` can be installed without `amd-torch-device-gfx11`, although the family wheel contains the AOTriton gfx11xx images. The incomplete installation leaves MATH working while FLASH and EFFICIENT fail with `hipErrorInvalidValue`.

Related issue: https://github.com/pytorch/pytorch/issues/194498

## Change

For target bundles, walk `rocm_bootstrap.packaging_chain()` and add `Requires-Dist` entries for parent bundles present in the current split. Unavailable parents are omitted, and family wheels do not depend on targets.

## Validation

- Kpack wheel-splitter tests: 53/53 passed.
- Black and `git diff --check`: passed.
- Official gfx1100 leaf: MATH passed; FLASH/EFFICIENT reproduced the failure.
- Repaired leaf: pip installed gfx11 automatically, `pip check` passed, and MATH/FLASH/EFFICIENT all passed the issue shape.
- Tested on RX 7900 GRE / gfx1100 with torch `2.12.0+rocm7.14.0`.

Made with [Cursor](https://cursor.com)