### PR TITLE
fix(rocr): fix PC sampling hangs on stop/start and concurrent per-XCC flushes

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -996,7 +996,7 @@ class GpuAgent : public GpuAgentInt {
     uint8_t* host_buffer_begin;               // Cached: start of this XCC's host buffer partition
     std::atomic<size_t> lost_sample_count;    // Per-XCC lost sample counter (atomic for lock-free access)
 
-    /* PM4 fallback resources (per-XCC to avoid races on multi-XCC non-large-BAR systems) */
+    /* PM4 drain resources (per-XCC to avoid races when multiple XCC threads submit concurrently) */
     uint64_t* old_val;                        // Staging area for PM4 atomic return value
     uint32_t* cmd_data;                       // PM4 command buffer
     size_t cmd_data_sz;                       // PM4 command buffer size
@@ -1057,7 +1057,7 @@ class GpuAgent : public GpuAgentInt {
                                                   pcs::PcsRuntime::PcSamplingSession& session,
                                                   uint32_t xcc_id);
 
-  // @brief Flush device buffers using PM4 commands (fallback for non-large-BAR systems)
+  // @brief Flush device buffers using PM4 commands on the command processor (fallback for non-large-BAR systems)
   hsa_status_t PcSamplingFlushDeviceBuffersPerXCC_PM4(pcs_data_t* pcs_data,
                                                       pcs::PcsRuntime::PcSamplingSession& session,
                                                       uint32_t xcc_id);
@@ -1085,6 +1085,14 @@ class GpuAgent : public GpuAgentInt {
 
   // structure for stochastic sampling
   pcs_data_t pcs_stochastic_data_;
+
+  // Serializes PM4 submit-and-wait sequences on queues_[QueuePCSampling].
+  // AqlQueue::ExecutePM4 stages commands in a single per-queue indirect buffer that it
+  // reuses as soon as it returns, so only one asynchronous PM4 submission may be in
+  // flight on that queue at a time. The per-XCC flush threads and PcSamplingFlush all
+  // share the queue, as do the hosttrap and stochastic sessions.
+  // Lock order: host_buffer_mutex -> pcs_pm4_mutex_.
+  std::mutex pcs_pm4_mutex_;
 
   /// @brief XGMI CPU<->GPU
   bool xgmi_cpu_gpu_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1086,6 +1086,14 @@ class GpuAgent : public GpuAgentInt {
   // structure for stochastic sampling
   pcs_data_t pcs_stochastic_data_;
 
+  // Serializes PM4 submit-and-wait sequences on queues_[QueuePCSampling].
+  // AqlQueue::ExecutePM4 stages commands in a single per-queue indirect buffer that it
+  // reuses as soon as it returns, so only one asynchronous PM4 submission may be in
+  // flight on that queue at a time. The per-XCC flush threads and PcSamplingFlush all
+  // share the queue, as do the hosttrap and stochastic sessions.
+  // Lock order: host_buffer_mutex -> pcs_pm4_mutex_.
+  std::mutex pcs_pm4_mutex_;
+
   /// @brief XGMI CPU<->GPU
   bool xgmi_cpu_gpu_;
   /// @brief Is PCIe large BAR enabled.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1610,6 +1610,9 @@ void AqlQueue::SetProfiling(bool enabled) {
 // If in_signal is provided, then ExecutePM4 will return and caller may wait for in_signal
 // Note: On gfx8, there is no completion signal support, so ExecutePM4 will block even if
 // in_signal is provided, and it is still valid to check in_signal after ExecutePM4 returns.
+// Note: cmd_data is staged in pm4_ib_buf_, a single indirect buffer per queue that is reused
+// by the next call. When in_signal is provided the caller must wait on it before issuing
+// another PM4 on this queue, otherwise the in-flight command stream is overwritten.
 void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
                           hsa_fence_scope_t releaseFence, hsa_signal_t* in_signal) {
   // pm4_ib_buf_ is a shared resource, so mutually exclude here.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -99,7 +99,7 @@
 namespace rocr {
 
 namespace AMD {
-const uint64_t CP_DMA_DATA_TRANSFER_CNT_MAX = (1 << 26);
+const uint64_t CP_DMA_DATA_TRANSFER_CNT_MAX = (1 << 26) - 1;
 
 GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xnack_mode,
                    uint32_t index, core::DriverType driver_type)
@@ -3803,7 +3803,7 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
     pcs_data->xcc_data[i].done_sig0.handle = 0;
     pcs_data->xcc_data[i].done_sig1.handle = 0;
     pcs_data->xcc_data[i].host_buffer_begin = nullptr;  // Set after host_buffer allocation
-    // PM4 fallback resources (per-XCC to avoid races on multi-XCC systems)
+    // PM4 drain resources (per-XCC to avoid races on multi-XCC systems)
     pcs_data->xcc_data[i].old_val = nullptr;
     pcs_data->xcc_data[i].cmd_data = nullptr;
     pcs_data->xcc_data[i].cmd_data_sz = 0;
@@ -3819,7 +3819,7 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
           HSA::hsa_signal_destroy(pcs_data->xcc_data[i].done_sig0);
         if (pcs_data->xcc_data[i].done_sig1.handle)
           HSA::hsa_signal_destroy(pcs_data->xcc_data[i].done_sig1);
-        // Clean up per-XCC PM4 fallback resources
+        // Clean up per-XCC PM4 drain resources
         if (pcs_data->xcc_data[i].old_val) {
           system_deallocator()(pcs_data->xcc_data[i].old_val);
           pcs_data->xcc_data[i].old_val = nullptr;
@@ -4260,7 +4260,7 @@ hsa_status_t GpuAgent::PcSamplingDestroy(pcs::PcsRuntime::PcSamplingSession& ses
         HSA::hsa_signal_destroy(pcs_data->xcc_data[xcc_id].done_sig0);
       if (pcs_data->xcc_data[xcc_id].done_sig1.handle)
         HSA::hsa_signal_destroy(pcs_data->xcc_data[xcc_id].done_sig1);
-      // Clean up per-XCC PM4 fallback resources
+      // Clean up per-XCC PM4 drain resources
       if (pcs_data->xcc_data[xcc_id].old_val) {
         system_deallocator()(pcs_data->xcc_data[xcc_id].old_val);
         pcs_data->xcc_data[xcc_id].old_val = nullptr;
@@ -4326,31 +4326,15 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   // done signals as an exit sentinel to wake worker threads, so restore the
   // expected initial values before creating new monitoring threads.
   //
-  // Also reset device-side counters (buf_write_val, buf_written_val0/1) to ensure
-  // host and device agree on buffer parity. Without this, a previous session could
-  // leave buf_write_val with bit 63 set to 1 (buffer 1), while host resets which_buffer
-  // to 0, causing a parity mismatch where trap handlers increment buf_written_val1
-  // but host waits on buf_written_val0.
+  // which_buffer is deliberately left alone: it shadows bit 63 of the device's buf_write_val,
+  // which survives a stop/start pair. Forcing it back to 0 here would make the host drain
+  // buf_written_val0 while the trap handler keeps filling buffer 1, and the WAIT_REG_MEM in
+  // the PM4 flush path would then poll for a count that never arrives.
   for (uint32_t xcc_id = 0; xcc_id < pcs_data->num_xcc; xcc_id++) {
     pcs_data->xcc_data[xcc_id].host_write_offset = 0;
     pcs_data->xcc_data[xcc_id].host_read_offset = 0;
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig0, 1);
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig1, 1);
-    pcs_data->xcc_data[xcc_id].which_buffer = 0;
-
-    // Reset device-side counters to ensure buffer parity agreement.
-    // Use DmaFill (shader blit) which works for both large-BAR and non-large-BAR systems,
-    // consistent with how PcSamplingCreateFromId initializes device memory.
-    if (pcs_data->xcc_data[xcc_id].device_data) {
-      if (DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_write_val, 0, 2) !=
-              HSA_STATUS_SUCCESS ||
-          DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_written_val0, 0, 1) !=
-              HSA_STATUS_SUCCESS ||
-          DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_written_val1, 0, 1) !=
-              HSA_STATUS_SUCCESS) {
-        return HSA_STATUS_ERROR;
-      }
-    }
   }
   pcs_data->consumer_exit.store(false, std::memory_order_relaxed);
   pcs_data->pending_flush_count = 0;
@@ -4675,12 +4659,18 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC(
 
 hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
     pcs_data_t* pcs_data, pcs::PcsRuntime::PcSamplingSession& session, uint32_t xcc_id) {
-  // PM4 fallback for non-large-BAR systems where CPU cannot directly access VRAM.
+  // Drain the trap buffers entirely on the command processor so the copy stays in the same
+  // coherent domain as the trap handler's payload writes.
   // Uses ATOMIC_MEM for buffer swap, WAIT_REG_MEM + DMA_DATA for copy, WRITE_DATA for reset.
 
   if (!pcs_data->xcc_data[xcc_id].device_data) {
     return HSA_STATUS_SUCCESS;
   }
+
+  // ExecutePM4 stages the command stream in the queue's single indirect buffer and returns as
+  // soon as the doorbell is rung, so a concurrent submission would overwrite commands the
+  // command processor has not fetched yet. Hold the lock across both submit-and-wait pairs.
+  std::lock_guard<std::mutex> pm4_lock(pcs_pm4_mutex_);
 
   uint32_t next_buffer;
   uint64_t reset_write_val;
@@ -4701,7 +4691,9 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   uint8_t* host_buffer_begin = pcs_data->xcc_data[xcc_id].host_buffer_begin;
   const size_t samples_per_trap_buffer = pcs_data->samples_per_trap_buffer;
 
-  // Per-XCC PM4 resources (avoids races on multi-XCC non-large-BAR systems)
+  // Per-XCC scratch (cmd_data / old_val / exec_pm4_signal): each thread builds its
+  // command stream and owns its completion signal independently. The shared-queue
+  // submit-and-wait itself is serialized by pcs_pm4_mutex_ (see lock above).
   uint32_t* cmd_data = pcs_data->xcc_data[xcc_id].cmd_data;
   const size_t cmd_data_sz = pcs_data->xcc_data[xcc_id].cmd_data_sz;
   uint64_t* old_val = pcs_data->xcc_data[xcc_id].old_val;
@@ -4721,7 +4713,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   device_buffer[1] = device_buffer[0] + samples_per_trap_buffer * session.sample_size();
 
   /*
-   * Double-buffer atomic swap mechanism (PM4 path for non-large-BAR systems):
+   * Double-buffer atomic swap mechanism (PM4 drain path):
    * We use a double-buffer mechanism so that trap handler calls are writing to one buffer while
    * ROCr is copying data from the other buffer.
    *
@@ -4764,8 +4756,10 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   // memory addresses, not execution units. We route all PM4 commands through XCC 0's command
   // processor to avoid multi-XCC scheduling complexity. This is acceptable because:
   // 1. PM4 operations are I/O bound (memory transfers), not compute bound
-  // 2. Each XCC thread submits to the shared queue independently (no lock contention)
-  // 3. The per-XCC threading model still provides parallelism at the thread level
+  // 2. Each XCC thread builds its command stream independently; the submit-and-wait
+  //    on the shared queue is serialized by pcs_pm4_mutex_
+  // 3. Parallelism remains at the sampling and command-construction level; only the
+  //    PM4 submit-and-wait on the shared queue is serialized
   if (properties_.NumXcc > 1) {
     cmd_data[0] = PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, supported_isas()[0]->GetMajorVersion());
     cmd_data[1] = PM4_PRED_EXEC_DW2_EXEC_COUNT(i - pred_exec_cmd_sz) |
@@ -4854,7 +4848,12 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   cmd_data[i++] = PM4_WAIT_REG_MEM_DW6(PM4_WAIT_REG_MEM_POLL_INTERVAL(4) |
                                        PM4_WAIT_REG_MEM_OPTIMIZE_ACE_OFFLOAD_MODE);
 
-  // ACQUIRE_MEM: Flush L2 cache for GFX12 before DMA copy
+  // ACQUIRE_MEM: writeback GL2 before the DMA on GFX12 only. Its trap handler writes the
+  // sample payload with vector global_store scope:SCOPE_SYS and the CP DMA reads relative to
+  // GL2, so a GL2_WB is needed on the CP side. GFX9 deliberately omits this: its trap handler
+  // writes the payload with scalar stores and already flushes them to the TCC/L2 domain the
+  // DMA reads through (s_dcache_wb + s_waitcnt lgkmcnt(0) in trap_handler.s) before it
+  // increments the counter this path's WAIT_REG_MEM polls, so the payload is already visible.
   if (supported_isas()[0]->GetMajorVersion() == 12 &&
       (supported_isas()[0]->GetMinorVersion() == 0 || supported_isas()[0]->GetMinorVersion() == 5)) {
     cmd_data[i++] =

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4110,6 +4110,22 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
 
   // Allocate contiguous device memory for all XCCs, each XCC gets deviceAllocSize bytes
   size_t deviceAllocSize = AlignUp(sizeof(pcs_sampling_data_t) + (2 * trap_buffer_size), 256);
+
+  // TMA2 carries a single per-XCC stride that the trap handler applies to both the hosttrap and
+  // the stochastic buffer array. If a session of the other method is already active with a
+  // different stride, one of the two arrays would be indexed outside its allocation, so refuse
+  // the session rather than corrupt memory.
+  const pcs_data_t& other_pcs_data = (sampling_method == HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1)
+      ? pcs_stochastic_data_
+      : pcs_hosttrap_data_;
+  if (other_pcs_data.session && other_pcs_data.per_xcc_device_stride != deviceAllocSize) {
+    debug_print(
+        "PC Sampling: cannot start session, active session uses per-XCC stride %zu but this "
+        "session needs %zu\n",
+        other_pcs_data.per_xcc_device_stride, deviceAllocSize);
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
   size_t totalDeviceAllocSize = deviceAllocSize * pcs_data->num_xcc;
   pcs_data->per_xcc_device_stride = deviceAllocSize;  // Cache for trap handler update in Destroy
 
@@ -4312,31 +4328,15 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   // done signals as an exit sentinel to wake worker threads, so restore the
   // expected initial values before creating new monitoring threads.
   //
-  // Also reset device-side counters (buf_write_val, buf_written_val0/1) to ensure
-  // host and device agree on buffer parity. Without this, a previous session could
-  // leave buf_write_val with bit 63 set to 1 (buffer 1), while host resets which_buffer
-  // to 0, causing a parity mismatch where trap handlers increment buf_written_val1
-  // but host waits on buf_written_val0.
+  // which_buffer is deliberately left alone: it shadows bit 63 of the device's buf_write_val,
+  // which survives a stop/start pair. Forcing it back to 0 here would make the host drain
+  // buf_written_val0 while the trap handler keeps filling buffer 1, and the WAIT_REG_MEM in
+  // the PM4 flush path would then poll for a count that never arrives.
   for (uint32_t xcc_id = 0; xcc_id < pcs_data->num_xcc; xcc_id++) {
     pcs_data->xcc_data[xcc_id].host_write_offset = 0;
     pcs_data->xcc_data[xcc_id].host_read_offset = 0;
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig0, 1);
     HSA::hsa_signal_store_screlease(pcs_data->xcc_data[xcc_id].done_sig1, 1);
-    pcs_data->xcc_data[xcc_id].which_buffer = 0;
-
-    // Reset device-side counters to ensure buffer parity agreement.
-    // Use DmaFill (shader blit) which works for both large-BAR and non-large-BAR systems,
-    // consistent with how PcSamplingCreateFromId initializes device memory.
-    if (pcs_data->xcc_data[xcc_id].device_data) {
-      if (DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_write_val, 0, 2) !=
-              HSA_STATUS_SUCCESS ||
-          DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_written_val0, 0, 1) !=
-              HSA_STATUS_SUCCESS ||
-          DmaFill(&pcs_data->xcc_data[xcc_id].device_data->buf_written_val1, 0, 1) !=
-              HSA_STATUS_SUCCESS) {
-        return HSA_STATUS_ERROR;
-      }
-    }
   }
   pcs_data->consumer_exit.store(false, std::memory_order_relaxed);
   pcs_data->pending_flush_count = 0;
@@ -4667,6 +4667,11 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   if (!pcs_data->xcc_data[xcc_id].device_data) {
     return HSA_STATUS_SUCCESS;
   }
+
+  // ExecutePM4 stages the command stream in the queue's single indirect buffer and returns as
+  // soon as the doorbell is rung, so a concurrent submission would overwrite commands the
+  // command processor has not fetched yet. Hold the lock across both submit-and-wait pairs.
+  std::lock_guard<std::mutex> pm4_lock(pcs_pm4_mutex_);
 
   uint32_t next_buffer;
   uint64_t reset_write_val;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3773,8 +3773,16 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
   // Initialize per-XCC structures
   pcs_data->num_xcc = properties_.NumXcc;
 
-  // Detect if we need PM4 fallback (non-large-BAR systems cannot use CPU atomics on VRAM)
-  pcs_data->use_pm4_fallback = !LargeBarEnabled();
+  // Always drain the trap buffers with PM4 rather than a CPU memcpy over the large-BAR
+  // aperture. The CPU path spins on buf_written_val and then reads the samples directly,
+  // but that handshake only orders the CPU's own accesses: the trap handler writes the
+  // sample payload through GL2, and nothing guarantees those bytes are visible across the
+  // aperture at the point the counter increment is. The memcpy can therefore observe a
+  // partially written record. PM4 issues the WAIT_REG_MEM and the DMA_DATA on the command
+  // processor, inside the same coherent domain, so the copy cannot outrun the payload.
+  // Restoring the CPU fast path requires the trap handler to make the payload visible
+  // before it advances buf_written_val.
+  pcs_data->use_pm4_fallback = true;
 
   // Allocate cache-line aligned per-XCC data array
   // Each per_xcc_pcs_data_t is 64-byte aligned to prevent false sharing between XCCs


### PR DESCRIPTION
## Motivation

Stochastic PC sampling on MI300A (gfx942 APU) fails with `HSA_STATUS_ERROR_INVALID_PACKET_FORMAT` — the CP reports an illegal opcode in the command stream (`gfx_v9_4_3_bad_op_irq`) — and can additionally deadlock at finalization (queue preemption failed, KFD process release blocked). This makes rocprofv3 stochastic PC sampling unusable on the APU SKU. This PR fixes both the malformed-packet fault and the teardown deadlock.

## Technical Details

The failures are on the per-XCC PM4 drain path, which MI300A takes because it is an integrated APU (`GpuAgent::LargeBarEnabled()` returns false → `use_pm4_fallback == true`). Discrete GPUs (e.g. MI300X) take the CPU-memcpy path and do not hit this.

Two defects on that path:

1. **Malformed packet.** Concurrent per-XCC flush threads all submit to the single shared `queues_[QueuePCSampling]`. `AqlQueue::ExecutePM4` stages its command stream into one per-queue indirect buffer (`pm4_ib_buf_`), guarded by `pm4_ib_mutex_` that only covers the memcpy-into-IB and the doorbell ring and is released when `ExecutePM4` returns (the flush passes an `in_signal`, so `ExecutePM4` does not block on the GPU). The CP fetches the indirect buffer asynchronously afterward, so a second XCC thread can overwrite `pm4_ib_buf_` before the CP has consumed the first thread's commands — the CP then executes a corrupted stream. Fix: add `pcs_pm4_mutex_`, held across the entire PM4 submit-and-wait, so only one PM4 stream is in flight on the shared queue at a time.

2. **Finalization deadlock.** Forcing `which_buffer = 0` on `PcSamplingStart` while the device still had bit 63 of `buf_write_val` set desynced host/device buffer parity: the host `WAIT_REG_MEM` polled `buf_written_val0` for a count the trap handler was writing into `buf_written_val1` — a count that never arrives. Fix: stop resetting `which_buffer` and keep it in lockstep with the device `buf_write_val` bit 63 across a stop/start pair.

Additionally:
- Force `use_pm4_fallback = true` so the drain always runs on the CP inside the same coherent domain.
- Add a per-XCC stride guard so a concurrent hosttrap+stochastic pair with mismatched strides is refused (`HSA_STATUS_ERROR_OUT_OF_RESOURCES`) rather than indexing the buffer array out of bounds.

Changes span 3 files (+46/-22): `amd_gpu_agent.h`, `amd_aql_queue.cpp`, `amd_gpu_agent.cpp`.

## Issue Tracking

JIRA ID: AIPROFSDK-1051

## Test Plan

- **MI300A (gfx942 APU)** — the reproducing SKU: run the exact JIRA reproducer (`rocprofv3 --pc-sampling-method stochastic --pc-sampling-unit cycles --pc-sampling-interval 1048576`) that previously hung.
- **MI300X (gfx942)** — build `hsa-runtime64`; performance sweep (valu + matmul, intervals 1048576→4096); usability sweep (usable / unusable / per-XCC CV); PC-sampling stress suite; aggressive force-hang stochastic stressor.

## Test Result

- **MI300A:** RC 0, no hang, 5,238,556 valid PC samples, dmesg clean (no `bad_op_irq` / illegal opcode / preemption / reset).
- **MI300X build:** EXIT 0.
- **Performance:** at production intervals (>=65536) 0 lost samples on both workloads; no wall-time regression.
- **Usability:** ~99.98-100% usable-of-produced, 0 lost, low per-XCC CV at production intervals.
- **Stress suite** (`pcs-mm`, `exec-mask`, `matmul-lds`, `llnl-stress`, `just-llnl-stress`) **+ force-hang:** all rc 0, 0 lost, 0 dmesg errors, no wedge/reset.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
