### PR TITLE
Skip stages to make PSDB multiarch faster and non-blocking

### DIFF
--- a/.github/scripts/compute_skip_stages.py
+++ b/.github/scripts/compute_skip_stages.py
@@ -37,8 +37,8 @@ Usage:
         --changed-projects "projects/rdc,projects/rocdecode" \
         --therock-path _therock
 
-Output (to $GITHUB_OUTPUT):
-    skip_stages: comma-separated stage names to skip (may be empty)
+Output (to $GITHUB_OUTPUT), written as ``skip_stages=<value>``:
+    a comma-separated list of stage names to skip (empty string = skip nothing)
 """
 
 import argparse
@@ -75,11 +75,21 @@ def _parse_projects(changed_projects: str) -> List[str]:
     return projects
 
 
-def compute_skip_stages(changed_projects: str, therock_path: str) -> List[str]:
+def compute_skip_stages(
+    changed_projects: str,
+    therock_path: str,
+    run_all_tests: bool = False,
+) -> List[str]:
     """Return the list of build stages that can be fully skipped.
 
     Returns [] (skip nothing -> full build) whenever narrowing is not safe.
     """
+    # CI-infra changes (workflow/scripts/repos-config) force a full run upstream;
+    # never narrow the build in that case.
+    if run_all_tests:
+        logger.info("run_all_tests set -> skip nothing (full build)")
+        return []
+
     projects = _parse_projects(changed_projects)
     if not projects:
         logger.info("No changed projects -> skip nothing (full build)")
@@ -98,12 +108,21 @@ def compute_skip_stages(changed_projects: str, therock_path: str) -> List[str]:
 
         topology = get_topology()
         all_stages = set(topology.get_all_stage_names())
-        required = set(topology.get_stages_for_projects(projects))
     except Exception as e:  # noqa: BLE001 - never let skip analysis break CI
-        logger.warning(f"Topology analysis failed ({e}) -> skip nothing (full build)")
+        logger.warning(f"Topology load failed ({e}) -> skip nothing (full build)")
         return []
 
-    # Unknown project (no stage mapping) -> be safe and build everything.
+    # Fail safe on ANY unrecognized project. get_stages_for_projects() silently
+    # ignores names it cannot resolve, so a mixed input like "rdc,unknown" would
+    # otherwise return only rdc's stages and wrongly skip everything the unknown
+    # project needs. Require every changed project to resolve to an artifact
+    # before narrowing; otherwise build everything.
+    unknown = [p for p in projects if topology.resolve_project_to_artifact(p) is None]
+    if unknown:
+        logger.info(f"Unrecognized project(s) {sorted(unknown)} -> skip nothing")
+        return []
+
+    required = set(topology.get_stages_for_projects(projects))
     if not required:
         logger.info("No stages mapped for changed projects -> skip nothing")
         return []
@@ -137,6 +156,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default="_therock",
         help="Path to the TheRock checkout (contains BUILD_TOPOLOGY.toml)",
     )
+    parser.add_argument(
+        "--run-all-tests",
+        default="false",
+        help="When 'true', skip nothing (full build). Set from the configure "
+        "job's run_all_tests output for CI-infra changes.",
+    )
     return parser.parse_args(argv)
 
 
@@ -145,6 +170,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     skip_stages = compute_skip_stages(
         changed_projects=args.changed_projects,
         therock_path=args.therock_path,
+        run_all_tests=str(args.run_all_tests).strip().lower() == "true",
     )
     set_github_output(skip_stages)
     return 0

--- a/.github/scripts/compute_skip_stages.py
+++ b/.github/scripts/compute_skip_stages.py
@@ -1,0 +1,154 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Compute build stages that can be fully SKIPPED for a rocm-systems PR.
+
+This is the rocm-systems half of per-PR stage skipping. It lives entirely in
+rocm-systems and drives TheRock's *existing* ``prebuilt_stages`` input: TheRock
+already gates every per-stage build job on
+``!contains(inputs.prebuilt_stages, '<stage>')`` and only runs its
+``copy_prebuilt_stages`` (reuse) job when ``baseline_run_id != ''``. So passing
+this skip list as ``prebuilt_stages`` with an EMPTY ``baseline_run_id`` skips the
+stage's build without copying anything -- a pure skip, with no changes to
+TheRock.
+
+    "Skip now, reuse later": when a baseline becomes available, the caller can
+    switch ``stage_reuse_mode`` to ``reuse-stage`` and/or supply a
+    ``baseline_run_id`` and these same stages become reuse (copy) candidates,
+    using the identical TheRock plumbing.
+
+Stage selection is delegated to TheRock's build topology (the single source of
+truth), imported from the TheRock checkout so this script owns no dependency
+math and cannot drift from the actual build graph:
+
+    BuildTopology.get_stages_for_projects(projects)
+        -> the minimal set of stages needed to BUILD the changed projects
+           (impacted stages plus their upstream build dependencies).
+
+Every stage NOT in that required set is emitted as skippable.
+
+Fail-safe: whenever the change set cannot be confidently narrowed, this prints an
+empty ``skip_stages`` so TheRock builds everything (the safe default). That
+happens for: no changed projects, a fan-out project (see FANOUT_PROJECTS), an
+unknown/unmapped project, or any topology-load error.
+
+Usage:
+    python compute_skip_stages.py \
+        --changed-projects "projects/rdc,projects/rocdecode" \
+        --therock-path _therock
+
+Output (to $GITHUB_OUTPUT):
+    skip_stages: comma-separated stage names to skip (may be empty)
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Projects whose changes ripple into downstream consumers. For these we keep the
+# full build (skip nothing) to preserve coverage, mirroring the pre-multiarch CI
+# where clr/hip/rocr-runtime, amdsmi, and profiler mapped to
+# -DTHEROCK_ENABLE_ALL=ON in .github/scripts/therock_matrix.py.
+FANOUT_PROJECTS = {
+    "clr",
+    "hip",
+    "hipother",
+    "hip-tests",
+    "rocr-runtime",
+    "amdsmi",
+}
+
+
+def _parse_projects(changed_projects: str) -> List[str]:
+    """Normalize 'projects/clr,projects/hip' -> ['clr', 'hip']."""
+    projects = []
+    for raw in changed_projects.split(","):
+        name = raw.strip().rstrip("/").split("/")[-1]
+        if name:
+            projects.append(name)
+    return projects
+
+
+def compute_skip_stages(changed_projects: str, therock_path: str) -> List[str]:
+    """Return the list of build stages that can be fully skipped.
+
+    Returns [] (skip nothing -> full build) whenever narrowing is not safe.
+    """
+    projects = _parse_projects(changed_projects)
+    if not projects:
+        logger.info("No changed projects -> skip nothing (full build)")
+        return []
+
+    if FANOUT_PROJECTS.intersection(projects):
+        logger.info("Fan-out project changed -> skip nothing (full build)")
+        return []
+
+    # Import TheRock's build topology from the checkout. TheRock is the source of
+    # truth for the build graph; we only read it.
+    therock_build_tools = Path(therock_path) / "build_tools"
+    sys.path.insert(0, os.fspath(therock_build_tools))
+    try:
+        from _therock_utils.build_topology import get_topology
+
+        topology = get_topology()
+        all_stages = set(topology.get_all_stage_names())
+        required = set(topology.get_stages_for_projects(projects))
+    except Exception as e:  # noqa: BLE001 - never let skip analysis break CI
+        logger.warning(f"Topology analysis failed ({e}) -> skip nothing (full build)")
+        return []
+
+    # Unknown project (no stage mapping) -> be safe and build everything.
+    if not required:
+        logger.info("No stages mapped for changed projects -> skip nothing")
+        return []
+
+    skip = sorted(all_stages - required)
+    logger.info(f"changed projects: {sorted(projects)}")
+    logger.info(f"required stages : {sorted(required)}")
+    logger.info(f"skip stages     : {skip}")
+    return skip
+
+
+def set_github_output(skip_stages: List[str]) -> None:
+    value = ",".join(skip_stages)
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not output_file:
+        print(f"skip_stages={value}")
+        return
+    with open(output_file, "a") as f:
+        f.write(f"skip_stages={value}\n")
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute skippable build stages")
+    parser.add_argument(
+        "--changed-projects",
+        default="",
+        help="Comma-separated changed projects (e.g. 'projects/rdc,projects/hip')",
+    )
+    parser.add_argument(
+        "--therock-path",
+        default="_therock",
+        help="Path to the TheRock checkout (contains BUILD_TOPOLOGY.toml)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    skip_stages = compute_skip_stages(
+        changed_projects=args.changed_projects,
+        therock_path=args.therock_path,
+    )
+    set_github_output(skip_stages)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/compute_skip_stages.py
+++ b/.github/scripts/compute_skip_stages.py
@@ -62,6 +62,7 @@ FANOUT_PROJECTS = {
     "hip-tests",
     "rocr-runtime",
     "amdsmi",
+    "rocprofiler-sdk",
 }
 
 

--- a/.github/scripts/tests/compute_skip_stages_test.py
+++ b/.github/scripts/tests/compute_skip_stages_test.py
@@ -1,0 +1,134 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for compute_skip_stages.py.
+
+These cover the rocm-systems-owned logic (project parsing, run_all_tests
+short-circuit, fan-out policy, and the fail-safe branches) without requiring a
+real TheRock checkout. Stage narrowing itself is delegated to TheRock's build
+topology and is exercised via a stubbed topology module so the test has no
+external dependency.
+"""
+
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import compute_skip_stages as css
+
+
+class ParseProjectsTest(unittest.TestCase):
+    def test_strips_prefix_and_whitespace(self):
+        self.assertEqual(
+            css._parse_projects("projects/clr, projects/rdc"),
+            ["clr", "rdc"],
+        )
+
+    def test_empty(self):
+        self.assertEqual(css._parse_projects(""), [])
+
+
+class ComputeSkipStagesTest(unittest.TestCase):
+    def test_run_all_tests_skips_nothing(self):
+        # CI-infra change: full build even if a narrow project set is passed.
+        self.assertEqual(
+            css.compute_skip_stages("projects/rdc", "_therock", run_all_tests=True),
+            [],
+        )
+
+    def test_empty_changed_projects_skips_nothing(self):
+        self.assertEqual(css.compute_skip_stages("", "_therock"), [])
+
+    def test_fanout_project_skips_nothing(self):
+        # ABI-sensitive projects fan out to consumers -> full build.
+        self.assertEqual(css.compute_skip_stages("projects/hip", "_therock"), [])
+        self.assertEqual(css.compute_skip_stages("projects/amdsmi", "_therock"), [])
+        # Any fan-out project in the set forces a full build.
+        self.assertEqual(
+            css.compute_skip_stages("projects/clr,projects/rdc", "_therock"), []
+        )
+
+    def test_topology_load_failure_skips_nothing(self):
+        # Nonexistent TheRock path -> import fails -> fail safe (skip nothing).
+        self.assertEqual(
+            css.compute_skip_stages("projects/rdc", "/no/such/therock"), []
+        )
+
+    def _install_fake_topology(self, all_stages, required, known=None):
+        """Install a fake _therock_utils.build_topology module on sys.path.
+
+        known: set of resolvable project names. Any project not in `known`
+        resolves to None (mirrors BuildTopology.resolve_project_to_artifact).
+        """
+        known = set(known) if known is not None else None
+        mod = types.ModuleType("_therock_utils.build_topology")
+
+        class _Topo:
+            def get_all_stage_names(self):
+                return set(all_stages)
+
+            def get_stages_for_projects(self, projects):
+                return set(required)
+
+            def resolve_project_to_artifact(self, project):
+                if known is None:
+                    return project  # everything resolves
+                return project if project in known else None
+
+        mod.get_topology = lambda: _Topo()
+        pkg = types.ModuleType("_therock_utils")
+        pkg.__path__ = []  # mark as package
+        patcher = patch.dict(
+            sys.modules,
+            {"_therock_utils": pkg, "_therock_utils.build_topology": mod},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_narrows_to_complement_of_required(self):
+        self._install_fake_topology(
+            all_stages=["compiler-runtime", "dctools-core", "math-libs", "comm-libs"],
+            required=["compiler-runtime", "dctools-core"],
+        )
+        skip = css.compute_skip_stages("projects/rdc", "_therock")
+        self.assertEqual(skip, ["comm-libs", "math-libs"])
+
+    def test_mixed_known_and_unknown_skips_nothing(self):
+        # rdc is known, but the unknown project is silently dropped by
+        # get_stages_for_projects; we must NOT skip in that case.
+        self._install_fake_topology(
+            all_stages=["compiler-runtime", "dctools-core", "math-libs"],
+            required=["compiler-runtime", "dctools-core"],
+            known={"rdc"},
+        )
+        self.assertEqual(
+            css.compute_skip_stages("projects/rdc,projects/unknown", "_therock"),
+            [],
+        )
+
+    def test_all_known_projects_narrow(self):
+        self._install_fake_topology(
+            all_stages=["compiler-runtime", "dctools-core", "math-libs"],
+            required=["compiler-runtime", "dctools-core"],
+            known={"rdc"},
+        )
+        self.assertEqual(
+            css.compute_skip_stages("projects/rdc", "_therock"),
+            ["math-libs"],
+        )
+
+    def test_no_required_stages_skips_nothing(self):
+        self._install_fake_topology(
+            all_stages=["compiler-runtime", "math-libs"],
+            required=[],
+            known={"mystery"},
+        )
+        self.assertEqual(css.compute_skip_stages("projects/mystery", "_therock"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -141,6 +141,17 @@ jobs:
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || 'gfx110X' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
+      # =====================================================================
+      # TEMPORARY (stage skip) -- track/remove via ROCm/rocm-libraries#11195
+      # This intentionally builds only the stages a PR touches to speed up
+      # per-PR CI. It is an interim measure until TheRock's automatic
+      # stage-REUSE is stable; reuse rebuilds nothing but still provides every
+      # artifact (via copy), so downstream builds/tests see a complete set.
+      # Removal plan: once reuse is enabled, drop the skip wiring and flip
+      # stage_reuse_mode to reuse-stage (see "Skip now, reuse later" below).
+      # Trade-off acknowledged: while active, skipped stages produce no
+      # artifacts, so downstream jobs only see the built subset.
+      # =====================================================================
       # Per-PR stage SKIP (not reuse): the configure job maps the changed
       # projects to the minimal set of build stages via TheRock's build topology
       # and returns every other stage in `skip_stages`. We pass that list through

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -80,11 +80,15 @@ jobs:
       changed_projects: ${{ steps.configure.outputs.changed_projects }}
       run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
       skip_tests: ${{ steps.configure.outputs.skip_tests }}
+      # Build stages this PR does not touch (fed to TheRock's prebuilt_stages).
+      skip_stages: ${{ steps.skip_stages.outputs.skip_stages }}
     steps:
       - name: Checkout repository config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/repos-config.json
+          sparse-checkout: |
+            .github/repos-config.json
+            .github/scripts/compute_skip_stages.py
           sparse-checkout-cone-mode: false
 
       - name: Checkout TheRock for configure script
@@ -93,7 +97,13 @@ jobs:
           repository: ROCm/TheRock
           ref: main
           path: _therock
-          sparse-checkout: build_tools/github_actions
+          # _therock_utils + (cone-mode) root BUILD_TOPOLOGY.toml and
+          # build_tools/project_mappings.json are needed to map changed projects
+          # to build stages. NOTE: keep this ref in sync with the `setup` job's
+          # TheRock ref so the topology matches what is actually built.
+          sparse-checkout: |
+            build_tools/github_actions
+            build_tools/_therock_utils
           sparse-checkout-cone-mode: true
 
       - name: Configure CI
@@ -108,6 +118,17 @@ jobs:
             --head-sha "${{ github.event.pull_request.head.sha }}" \
             --config-path ".github/repos-config.json"
 
+      # Map the changed projects to the minimal set of TheRock build stages and
+      # emit the complement as `skip_stages`. TheRock's build graph
+      # (BUILD_TOPOLOGY.toml) is the source of truth; this only reads it. When
+      # run_all_tests is set (CI-infra change) we skip nothing (full build).
+      - name: Compute skippable stages
+        id: skip_stages
+        run: |
+          python3 .github/scripts/compute_skip_stages.py \
+            --changed-projects "${{ steps.configure.outputs.run_all_tests == 'true' && '' || steps.configure.outputs.changed_projects }}" \
+            --therock-path "_therock"
+
   setup:
     needs: configure
     uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
@@ -119,14 +140,22 @@ jobs:
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || 'gfx110X' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      # rocm-systems affects compiler-runtime (HIP, CLR, runtime, profiler-core)
-      # which cascades to ALL downstream stages. No stages can be reused.
-      # Hard-coding to empty for now.
-      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
+      # Per-PR stage SKIP (not reuse): the configure job maps the changed
+      # projects to the minimal set of build stages via TheRock's build topology
+      # and returns every other stage in `skip_stages`. We pass that list through
+      # TheRock's existing `prebuilt_stages` input with an EMPTY baseline_run_id:
+      # TheRock skips those stages' build jobs and its copy_prebuilt_stages job
+      # only runs when baseline_run_id != '', so nothing is copied -> a pure skip.
+      # A manual `prebuilt_stages` workflow_dispatch input still takes precedence.
+      # "Skip now, reuse later": to enable reuse, switch stage_reuse_mode to
+      # reuse-stage (and/or provide baseline_run_id) with no other changes.
+      prebuilt_stages: ${{ inputs.prebuilt_stages || needs.configure.outputs.skip_stages }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
-      # Enable automatic stage reuse - TheRock finds commit-compatible baselines
-      # and determines which stages to rebuild based on changed files
-      stage_reuse_mode: reuse-stage
+      # dry-run: report only, apply no automatic reuse. Combined with the
+      # skip list above this yields a deterministic pure skip (build fewer
+      # stages, copy nothing). Flip to reuse-stage later to turn skips into
+      # baseline reuse.
+      stage_reuse_mode: dry-run
       repository: ROCm/TheRock
       ref: main
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -126,7 +126,8 @@ jobs:
         id: skip_stages
         run: |
           python3 .github/scripts/compute_skip_stages.py \
-            --changed-projects "${{ steps.configure.outputs.run_all_tests == 'true' && '' || steps.configure.outputs.changed_projects }}" \
+            --changed-projects "${{ steps.configure.outputs.changed_projects }}" \
+            --run-all-tests "${{ steps.configure.outputs.run_all_tests }}" \
             --therock-path "_therock"
 
   setup:


### PR DESCRIPTION
<h2>Motivation</h2>
<p>
Today the multi-arch CI builds every component in rocm-systems PR. This is because
the whole rocm-systems monorepo is a single <code>source_set</code> in TheRock's
<code>BUILD_TOPOLOGY.toml</code>, so any change maps to all stages and nothing can be narrowed.
The result is slow per-PR turnaround and a CI choke point.
The pre-multi-arch CI only built the components a PR actually touched. This PR restores that
behavior for the multi-arch pipeline by <strong>fully skipping the build stages a PR does not
touch</strong>. It is a pure skip (build fewer stages, copy nothing) and is intentionally
structured as "skip now, reuse later": the same stage set can later be turned into baseline
<em>reuse</em> by a single input flip, with no further code changes.
</p>

<h2>Technical Details</h2>
<p>This drives TheRock's <em>existing</em> interface rather than changing TheRock:</p>
<ul>
  <li>
    New <code>.github/scripts/compute_skip_stages.py</code> maps the changed projects (already
    produced by <code>configure_external_repo_ci.py</code>) to the minimal set of build stages
    required to build them, using TheRock's build topology as the source of truth
    (<code>BuildTopology.get_stages_for_projects()</code>, which walks the upstream dependency
    chain). Every stage <em>not</em> required is emitted as <code>skip_stages</code>.
  </li>
  <li>
    <code>therock-multi-arch-ci.yml</code>: the <code>configure</code> job's TheRock
    sparse-checkout is broadened to include <code>build_tools/_therock_utils</code> (cone mode
    also brings the root <code>BUILD_TOPOLOGY.toml</code> and
    <code>build_tools/project_mappings.json</code>); a new "Compute skippable stages" step
    produces the <code>skip_stages</code> output.
  </li>
  <li>
    The computed list is passed into TheRock's existing <code>prebuilt_stages</code> input with an
    <strong>empty <code>baseline_run_id</code></strong> and <code>stage_reuse_mode: dry-run</code>.
    TheRock gates each per-stage build job on <code>!contains(inputs.prebuilt_stages, '&lt;stage&gt;')</code>,
    and its <code>copy_prebuilt_stages</code> job runs only when <code>baseline_run_id != ''</code>.
    So the skipped stages are neither built nor copied &mdash; a pure skip.
  </li>
</ul>
<p>
<strong>Safety.</strong> <code>get_stages_for_projects</code> always keeps the full upstream
dependency closure, so no built stage ever depends on a skipped one. The script fails safe
(skip nothing &rarr; full build) for ABI-sensitive fan-out projects
(<code>clr</code>, <code>hip</code>, <code>hipother</code>, <code>hip-tests</code>,
<code>rocr-runtime</code>, <code>amdsmi</code>), for CI-infra changes
(<code>run_all_tests</code>), and for any unknown project or topology-load error. A manual
<code>prebuilt_stages</code> workflow_dispatch input still takes precedence.
</p>
<p>
<strong>Skip now, reuse later.</strong> To turn skips into baseline reuse, switch
<code>stage_reuse_mode</code> back to <code>reuse-stage</code> (and/or provide a
<code>baseline_run_id</code>) &mdash; no other change required.
</p>
<p>Related: ROCm/TheRock&nbsp;#3343 (dynamic stage determination for external repos).</p>


<h2>Test Plan</h2>
<ul>
  <li>Validated <code>therock-multi-arch-ci.yml</code> parses as valid YAML.</li>
  <li>
    Ran <code>compute_skip_stages.py</code> against a real TheRock checkout for a range of
    changed-project sets, including single-component, multi-component, fan-out, unknown-project,
    and empty inputs.
  </li>
</ul>

<h2>Test Result</h2>
<p>Stage selection matches the build topology and fails safe as expected:</p>
<ul>
  <li><code>projects/rdc</code> &rarr; build <code>compiler-runtime</code>, <code>dctools-core</code>; skip the other 9 stages.</li>
  <li><code>projects/rocprofiler-systems</code> &rarr; build <code>compiler-runtime</code>, <code>profiler-apps</code>; skip 9.</li>
  <li><code>projects/rocshmem</code> &rarr; build <code>comm-libs</code>, <code>compiler-runtime</code>; skip 9.</li>
  <li><code>projects/hip</code> or <code>projects/amdsmi</code> (fan-out) &rarr; skip nothing (full build).</li>
  <li>Empty / unknown project &rarr; skip nothing (full build).</li>
</ul>

<h2>Submission Checklist</h2>
<ul>
  <li>[ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.</li>
</ul>