### PR TITLE
test(amdsmi): blacklist unsupported temp/frequency subtests on gfx1103

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -93,3 +93,13 @@ FILTER[gfx1150]=${FILTER[strix_point]}
 FILTER[gfx1151]=${FILTER[strix_point]}
 FILTER[gfx1152]=${FILTER[strix_point]}
 FILTER[gfx1153]=${FILTER[strix_point]}
+
+# Hawk Point (gfx1103) APU shares the same unsupported driver metrics v3.0
+# read/write paths as the gfx115X APUs above, so these temperature and
+# frequency subtests fail. Blacklist until driver metrics support is available.
+FILTER[hawk_point]=\
+$BLACKLIST_ALL_ASICS\
+"GpuFunctionalReadOnly.TempRead:"\
+"GpuFunctionalReadOnly.TestFrequenciesRead:"\
+"GpuFunctionalReadWrite.TestFrequenciesReadWrite"
+FILTER[gfx1103]=${FILTER[hawk_point]}

--- a/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
+++ b/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
@@ -23,6 +23,7 @@ declare -A GFX_TO_ASIC=(
     [gfx942]=90402
     [gfx1030]=sienna_cichlid
     [gfx1100]=strix_point
+    [gfx1103]=gfx1103
     [gfx1150]=gfx1150
     [gfx1151]=gfx1151
     [gfx1152]=gfx1152


### PR DESCRIPTION
## Summary
Extends the `amdsmitst` device-specific blacklist (added in #3210 for gfx115X / Strix Point) to cover **gfx1103 / Hawk Point** APUs, which reproduce the same 3-subtest failure signature.

## Background
gfx1103 (Hawk Point) APUs expose the same unsupported driver metrics v3.0 read/write paths as the gfx115X APUs. The driver returns `AMDSMI_STATUS_UNEXPECTED_DATA` (43) instead of `NOT_SUPPORTED` for HBM/VRAM temperatures and several clock domains, so these subtests fail:

- `GpuFunctionalReadOnly.TempRead`
- `GpuFunctionalReadOnly.TestFrequenciesRead`
- `GpuFunctionalReadWrite.TestFrequenciesReadWrite`

Observed on AMD Radeon 780M, gfx1103 with a TheRock 10.1.0 build: 63 pass / 3 fail / 1 skip.

## Changes
- `tests/amd_smi_test/amdsmitst.exclude`: add `FILTER[hawk_point]` (identical 3-test set to `strix_point`) plus a `FILTER[gfx1103]` alias.
- `tests/amd_smi_test/detect_asic_filter.sh`: map the `gfx1103` target-graphics string to the new filter so ASIC detection selects it (the box's `amd-smi` reports `gfx1103`).

## Validation
- `bash -n` syntax check passes; sourcing yields `FILTER[gfx1103]` == `FILTER[hawk_point]` == `FILTER[strix_point]`.
- End-to-end `gfx1103 -> GFX_TO_ASIC -> FILTER` resolves to the device-specific blacklist.

## Notes
- Follow-up to #3210 (ROCM-9738). Re-validate once driver metrics support lands (SWDEV-565971).

JIRA ID: ROCM-29359
