### PR TITLE
[rocjitsu] Add four-GPU MI455X daemon config

### DIFF
--- a/emulation/rocjitsu/configs/gfx1250_mi455x_kmd_4gpu.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x_kmd_4gpu.json
@@ -1,0 +1,129 @@
+{
+  "max_ticks": 0,
+  "num_threads": 1,
+  "exec_mode": "functional",
+  "vm": {
+    "arch": "cdna5",
+    "gpu": {
+      "num_gpus": 4,
+      "device": {
+        "gpu_id": 1250,
+        "gfx_target_version": 120500,
+        "vendor_id": 4098,
+        "device_id": 1250,
+        "family_id": 0,
+        "unique_id": 1250,
+        "revision_id": 1,
+        "marketing_name": "AMD Instinct MI455X",
+        "drm_render_minor": 128,
+        "simd_count": 1024,
+        "max_waves_per_simd": 16,
+        "num_shader_engines": 2,
+        "num_shader_arrays_per_engine": 2,
+        "num_cu_per_sh": 8,
+        "simd_per_cu": 4,
+        "wave_front_size": 32,
+        "max_slots_scratch_cu": 32,
+        "local_mem_size": 463856467968,
+        "lds_size_kb": 320,
+        "mem_width": 24576,
+        "mem_clk_max": 1600,
+        "l1_size_kb": 64,
+        "l1_line_size": 128,
+        "l1_assoc": 4,
+        "l2_size_kb": 196608,
+        "l2_line_size": 128,
+        "l2_assoc": 16,
+        "num_sdma_engines": 5,
+        "num_sdma_xgmi_engines": 12,
+        "num_cp_queues": 128,
+        "max_engine_clk_fcompute": 2700,
+        "location_id": 768,
+        "hive_id": 1
+      }
+    }
+  },
+  "topology": {
+    "root": {
+      "name": "soc", "type": "soc",
+      "children": [
+        { "name": "vram", "type": "gpu_memory" },
+        {
+          "name": "iod[0:2]", "type": "iod",
+          "config": [{ "key": "num_hbm_stacks", "value": "6" }]
+        },
+        {
+          "name": "xcd[0:8]", "type": "xcd",
+          "children": [
+            { "name": "l2", "type": "l2_cache" },
+            { "name": "cp", "type": "command_processor" },
+            {
+              "name": "se[0:2]", "type": "shader_engine",
+              "children": [{
+                "name": "cu[0:16]", "type": "compute_unit",
+                "config": [
+                  { "key": "num_wf_slots", "value": "64" },
+                  { "key": "sgprs_per_wf", "value": "128" },
+                  { "key": "vgprs_per_wf", "value": "1024" },
+                  { "key": "lds_size_kb", "value": "320" }
+                ]
+              }]
+            }
+          ]
+        }
+      ]
+    },
+    "links": [
+      {
+        "pattern": "xcd[i].cp.req_[j*16+k] -> xcd[i].se[j].cu[k].cpl",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 8 },
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 16 }
+        ],
+        "latency": 1, "weight": 2
+      },
+      {
+        "pattern": "xcd[i].se[j].cu[k].req -> xcd[i].l2.cpl_[j*16+k]",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 8 },
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 16 }
+        ],
+        "latency": 1, "weight": 10
+      },
+      {
+        "pattern": "xcd[i].l2.req -> iod[i/4].msc.cpl_[i%4]",
+        "for_ranges": [{ "var_name": "i", "start": 0, "end": 8 }],
+        "latency": 1, "weight": 3
+      },
+      {
+        "pattern": "iod[i].peer_req -> iod[j].peer_cpl",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 2 },
+          { "var_name": "j", "start": 0, "end": 2 }
+        ],
+        "where_expr": "i != j",
+        "latency": 1, "weight": 1
+      },
+      {
+        "pattern": "xcd[i].se[j].cu[k].adj_req -> xcd[i].se[j].cu[k+1].adj_cpl",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 8 },
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 15 }
+        ],
+        "latency": 1, "weight": 2
+      },
+      {
+        "pattern": "xcd[i].se[j].cu[k+1].adj_req_r -> xcd[i].se[j].cu[k].adj_cpl_r",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 8 },
+          { "var_name": "j", "start": 0, "end": 2 },
+          { "var_name": "k", "start": 0, "end": 15 }
+        ],
+        "latency": 1, "weight": 2
+      }
+    ]
+  }
+}

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -16,6 +16,7 @@ Pre-built simulator configs are in `configs/`:
 | `gfx950_mi355x_kmd.json` | Single CDNA4 GPU (daemon/KFD mode) |
 | `gfx950_mi355x_kmd_2gpu.json` | Two CDNA4 GPUs (multi-GPU daemon mode) |
 | `gfx1250_mi455x.json` | Single CDNA5 GPU (standalone simulation, no KMD) |
+| `gfx1250_mi455x_kmd_4gpu.json` | Four MI455X GPUs (multi-GPU daemon mode) |
 | `gfx1100_w7900.json` | Single RDNA3 GPU (standalone simulation) |
 | `gfx1151.json` | Single RDNA3.5 GPU (standalone simulation) |
 | `gfx1201_r9700.json` | Single RDNA4 GPU (standalone simulation) |
@@ -121,5 +122,6 @@ location IDs. Each GPU gets its own command processor, memory, and
 cache hierarchy. The daemon manages all GPUs and routes KFD ioctls
 to the correct device based on `gpu_id`.
 
-See `configs/gfx950_mi355x_kmd_2gpu.json` for a working two-GPU
-configuration used by the RCCL collective tests.
+`configs/gfx950_mi355x_kmd_2gpu.json` is the default multi-GPU
+configuration for RCCL tests. `configs/gfx1250_mi455x_kmd_4gpu.json`
+provides a four-GPU daemon topology for explicit multi-GPU runs.

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -76,6 +76,43 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
   EXPECT_EQ(soc->assign_queue_cp(soc->num_xcds()), soc->xcd(0)->command_processor());
 }
 
+TEST(ConfigLoaderTest, LoadFourGpuMi455xKmdConfig) {
+  auto loaded = config::load_config(CONFIG_DIR_PATH + "/gfx1250_mi455x_kmd_4gpu.json",
+                                    rocjitsu::kEmbeddedSchema);
+  auto standalone =
+      config::load_config(CONFIG_DIR_PATH + "/gfx1250_mi455x.json", rocjitsu::kEmbeddedSchema);
+
+  EXPECT_EQ(loaded.num_gpus, 4u);
+  ASSERT_EQ(loaded.devices.size(), 4u);
+  ASSERT_EQ(loaded.extra_gpu_builds.size(), 3u);
+
+  EXPECT_EQ(loaded.device.revision_id, standalone.device.revision_id);
+  EXPECT_EQ(loaded.device.simd_count, standalone.device.simd_count);
+  EXPECT_EQ(loaded.device.num_shader_engines, standalone.device.num_shader_engines);
+  EXPECT_EQ(loaded.device.num_shader_arrays_per_engine,
+            standalone.device.num_shader_arrays_per_engine);
+  EXPECT_EQ(loaded.device.num_cu_per_sh, standalone.device.num_cu_per_sh);
+  EXPECT_EQ(loaded.device.simd_per_cu, standalone.device.simd_per_cu);
+  EXPECT_EQ(loaded.device.l1_size_kb, standalone.device.l1_size_kb);
+  EXPECT_EQ(loaded.device.l1_line_size, standalone.device.l1_line_size);
+  EXPECT_EQ(loaded.device.l1_assoc, standalone.device.l1_assoc);
+  EXPECT_EQ(loaded.device.l2_size_kb, standalone.device.l2_size_kb);
+  EXPECT_EQ(loaded.device.l2_line_size, standalone.device.l2_line_size);
+  EXPECT_EQ(loaded.device.l2_assoc, standalone.device.l2_assoc);
+
+  for (uint32_t i = 0; i < loaded.num_gpus; ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_EQ(loaded.devices[i].gpu_id, 1250u + i);
+    EXPECT_EQ(loaded.devices[i].location_id, 0x0300u + (i << 8));
+    EXPECT_EQ(loaded.devices[i].drm_render_minor, 128u + i);
+    EXPECT_EQ(loaded.devices[i].unique_id, 1250u + i);
+    EXPECT_EQ(loaded.devices[i].revision_id, 1u);
+  }
+
+  for (const auto &build : loaded.extra_gpu_builds)
+    EXPECT_NE(dynamic_cast<SoC *>(build.root.get()), nullptr);
+}
+
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   auto rdna4 =
       config::load_config(CONFIG_DIR_PATH + "/gfx1201_r9700.json", rocjitsu::kEmbeddedSchema);


### PR DESCRIPTION
Add a daemon/KFD configuration for four native gfx1250 MI455X GPUs. Reuse the existing MI455X SoC topology and publish the device identity and cache properties needed by multi-process clients.

Document the config and pin four-device cloning and derived identities with a focused loader test. Qualify the topology with four-rank RCCL collectives and four-device JAX discovery on a fresh TheRock nightly.