### PR TITLE
fix(rccl): correct GPU generation parsing for generic gfx targets

### DIFF
--- a/projects/rccl/tools/asm_extract/patch_dispatcher.py
+++ b/projects/rccl/tools/asm_extract/patch_dispatcher.py
@@ -32,6 +32,13 @@ _MAX_NUMBERED_SGPR = {
 
 def _gfx_generation(gpu_target):
     """Extract the major generation number from a target like 'gfx942' -> 9, 'gfx1200' -> 12."""
+    # Generic targets are named like 'gfx9-4-generic', 'gfx10-3-generic',
+    # 'gfx11-generic', 'gfx12-generic'. The number right after "gfx" is
+    # already the generation number.
+    m = re.match(r'gfx(\d+)(?:-\d+)?-generic$', gpu_target)
+    if m:
+        return int(m.group(1))
+
     m = re.match(r'gfx(\d+)', gpu_target)
     if not m:
         sys.exit(f"ERROR: cannot parse GPU target '{gpu_target}'")

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -215,6 +215,13 @@ def aggregate_resources(resource_list, gpu_target):
 
 
 def _gfx_generation(gpu_target):
+    # Generic targets are named like 'gfx9-4-generic', 'gfx10-3-generic',
+    # 'gfx11-generic', 'gfx12-generic'. The number right after "gfx" is
+    # already the generation number.
+    m = re.match(r'gfx(\d+)(?:-\d+)?-generic$', gpu_target)
+    if m:
+        return int(m.group(1))
+
     m = re.match(r'gfx(\d+)', gpu_target)
     if not m:
         raise RuntimeError(f"Cannot parse GPU target '{gpu_target}'")


### PR DESCRIPTION
## Motivation

`_gfx_generation()` parsed the generation number by taking the digits after "gfx" and dividing by 10 or 100. This breaks the build for "generic" targets such as 'gfx9-4-generic', 'gfx10-3-generic', 'gfx11-generic' and 'gfx12-generic', where the digits after "gfx" are already the generation number, not a numbered target like 'gfx1030'. Dividing by 10 collapsed 'gfx10-3-generic' to generation 1 and 'gfx11-generic' to generation 1, which are not keys in the SGPR-limit table, causing:

  RuntimeError: Unknown SGPR limit for generation gfx1xx (target  'gfx10-3-generic')
  RuntimeError: Unknown SGPR limit for generation gfx1xx (target  'gfx11-generic')

## Technical Details

Detect the "-generic" suffix (with an optional "-<n>" minor-version segment before it) explicitly and use the leading number as the generation directly, before falling back to the numbered-target parsing logic. Applied to both tools/rccl-device-compile (device link resource aggregation) and tools/asm_extract/patch_dispatcher.py (dispatcher patching), which contain the same parsing logic.


## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan
Verifiy `_gfx_generation()` now correctly resolves the generation for generic targets (`gfx9-4-generic` -> 9, `gfx10-3-generic` -> 10, `gfx11-generic` -> 11, `gfx12-generic` -> 12) while preserving existing behavior for numbered targets (`gfx942` -> 9, `gfx1200` -> 12).

## Test Result

Generic gfx targets no longer raise `RuntimeError: Unknown SGPR limit for generation gfx1xx`; generation parsing matches the expected SGPR-limit table keys for both generic and numbered targets.

Successful Ubuntu Stonking [build](https://launchpad.net/~b0b0a/+archive/ubuntu/rccl-7.14-generics) with `DGPU_TARGETS="gfx908;gfx90a;gfx942;gfx950;gfx10-3-generic;gfx1030;gfx11-generic;gfx1100;gfx1101;gfx1151;gfx1200;gfx1201"`. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
