### PR TITLE
perf(rocjitsu): use native SIMD width for f32 MFMA

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -4250,30 +4250,14 @@ void exec_smfmac_f32_32x32x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
     RegisterAccess(cu).write_vgpr(dst + r.reg, r.lane, r.val);
 }
 
-/// Fast path for v_mfma_f32_16x16x32_f16. This single MFMA shape is the only
-/// MFMA variant fired by OPT-125M fp16 eager forward (488k invocations per
-/// forward; ~4B internal MACs). Kept as a dedicated specialization (rather
-/// than forwarding to generic exec_f32) because the compile-time M/N/K/B let
-/// the compiler fully unroll the 16-row x 32-K inner matmul into straight-line
-/// AVX-512 FMAs — a runtime-dimension loop is materially slower on this hot
-/// path. Hoists A and B into dense f32 buffers via extract_f16, runs the
-/// matmul as 16 zmm-wide f32 FMA rows (512 zmm FMAs per MFMA). Batched shapes
-/// stage every result on the stack and publish only after all operand reads,
-/// preserving destructive-overlap semantics without a heap-backed Result
-/// vector. VGPR access is batched through observed register-access regions
-/// (one view per operand, no per-element virtual read_vgpr/write_vgpr). Falls
-/// back to the generic exec_f32 when:
-///   - <experimental/simd> is unavailable
-///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
-///   - cbsz/blgp lane permutation is non-default
-///   - RJ_FORCE_SCALAR is set
 /// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
 /// specialization but the inputs are already f32, so there is no F16C convert —
 /// the hoist reads each operand word straight through observed register-access
 /// regions. BATCH covers the batched shapes (e.g. 32x32x1x2). Compile-time
 /// M/N/K/BATCH fully unroll the matmul; it loops over N in native-width chunks.
-/// Falls back to the generic exec_f32 without host SIMD, when N is not divisible
-/// by the native width, under force-scalar, or with cbsz/blgp.
+/// Falls back to the generic exec_f32 without host SIMD, when the native width
+/// is one or does not divide N, for non-wave64 execution, under force-scalar,
+/// or with cbsz/blgp.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH>
 void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp) {
@@ -4358,6 +4342,23 @@ void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
   }
 }
 
+/// Fast path for v_mfma_f32_16x16x32_f16. This single MFMA shape is the only
+/// MFMA variant fired by OPT-125M fp16 eager forward (488k invocations per
+/// forward; ~4B internal MACs). Kept as a dedicated specialization (rather
+/// than forwarding to generic exec_f32) because the compile-time M/N/K/B let
+/// the compiler fully unroll the 16-row x 32-K inner matmul into straight-line
+/// AVX-512 FMAs — a runtime-dimension loop is materially slower on this hot
+/// path. Hoists A and B into dense f32 buffers via extract_f16, runs the
+/// matmul as 16 zmm-wide f32 FMA rows (512 zmm FMAs per MFMA). Batched shapes
+/// stage every result on the stack and publish only after all operand reads,
+/// preserving destructive-overlap semantics without a heap-backed Result
+/// vector. VGPR access is batched through observed register-access regions
+/// (one view per operand, no per-element virtual read_vgpr/write_vgpr). Falls
+/// back to the generic exec_f32 when:
+///   - <experimental/simd> is unavailable
+///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
+///   - cbsz/blgp lane permutation is non-default
+///   - RJ_FORCE_SCALAR is set
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 void exec_f32_mfma_f16_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -4270,27 +4270,26 @@ void exec_smfmac_f32_32x32x64_fp8(auto &cu, uint32_t dst, uint32_t s0, uint32_t 
 /// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
 /// specialization but the inputs are already f32, so there is no F16C convert —
 /// the hoist reads each operand word straight through observed register-access
-/// regions. BATCH covers the batched shapes (e.g. 32x32x1x2). Compile-time M/N/K/BATCH fully unroll
-/// the matmul; it loops over N in zmm-width chunks (N must be a multiple of 16,
-/// so the 4x4 shape stays on the generic path). Falls back to the generic
-/// exec_f32 without AVX-512 / under force-scalar / with cbsz|blgp.
+/// regions. BATCH covers the batched shapes (e.g. 32x32x1x2). Compile-time
+/// M/N/K/BATCH fully unroll the matmul; it loops over N in native-width chunks.
+/// Falls back to the generic exec_f32 without host SIMD, when N is not divisible
+/// by the native width, under force-scalar, or with cbsz/blgp.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH>
 void exec_f32_mfma_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc, uint32_t cbsz, uint32_t abid, uint32_t blgp) {
   constexpr uint32_t in_bits = 32;
-  static_assert(N % 16 == 0, "specialized f32 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || W <= 1 || N % W != 0 ||
         cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32,
                amdgpu::extract_f32, const_acc, cbsz, abid, blgp);
       return;
     }
-    constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
     auto reads =
         read_mfma_fast_path_regions(cu, s0, s1, s2, M, N, K, BATCH, in_bits, const_acc, wf);

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3052,6 +3052,38 @@ TEST(ExecutionPluginTest, MfmaReadObservationReportsRace) {
   EXPECT_EQ(violation.lane, 0);
 }
 
+TEST(ExecutionPluginTest, MfmaF32NativeWidthFastPathUsesRegionReads) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "stdx SIMD is unavailable";
+  } else {
+    constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
+    constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+    if (width <= 1 || N % width != 0)
+      GTEST_SKIP() << "f32 MFMA shape is not divisible by the native SIMD width";
+
+    ForceScalarOverride force_simd(false);
+    PluginFixture f(/*num_wf_slots=*/1);
+    auto *plugin = f.attach_ordering_plugin();
+    auto *cu = f.cu();
+    auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+    ASSERT_NE(wf, nullptr);
+    ASSERT_EQ(wf->wf_size(), 64u);
+
+    const uint32_t vb = wf->vgpr_alloc().base;
+    constexpr uint32_t S0 = 0, S1 = 16, ACC = 32, DST = 48;
+    for (uint32_t reg = 0; reg < 64; ++reg)
+      for (uint32_t lane = 0; lane < 64; ++lane)
+        cu->write_vgpr(vb + reg, lane, 0x3f80'0000u);
+
+    amdgpu::exec_f32_mfma_f32_spec<M, N, K, B>(*cu, vb + DST, vb + S0, vb + S1, vb + ACC,
+                                               amdgpu::ACC_FROM_VGPR,
+                                               /*cbsz=*/0, /*abid=*/0, /*blgp=*/0);
+
+    expect_vgpr_read_set(vgpr_read_events(*plugin), vb,
+                         {S0, S1, ACC + 0, ACC + 1, ACC + 2, ACC + 3}, ~uint64_t{0});
+  }
+}
+
 TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -203,6 +203,8 @@ TEST(MfmaSimdExact, F32Spec_AllShapes) {
       fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
     });
   };
+  spec(amdgpu::exec_f32_mfma_f32_spec<16, 16, 8, 1>, "spec_f32_16x16x8");
+  spec(amdgpu::exec_f32_mfma_f32_spec<32, 32, 4, 1>, "spec_f32_32x32x4");
   spec(amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>, "spec_f32_32x32x2");
   spec(amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>, "spec_f32_16x16x4");
   spec(amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>, "spec_f32_32x32x1x2");
@@ -211,8 +213,9 @@ TEST(MfmaSimdExact, F32Spec_AllShapes) {
 
 TEST(MfmaSimdExact, F32SpecDestructiveSourceOverlap) {
   SKIP_IF_NO_SIMD();
-  if (util::native<float>::size() <= 1)
-    GTEST_SKIP() << "test requires native SIMD";
+  constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+  if (W <= 1 || 32 % W != 0)
+    GTEST_SKIP() << "test requires a supported native SIMD width";
   constexpr uint32_t source_b = 0;
   constexpr uint32_t destination_and_source_a = 64;
   constexpr uint32_t accumulator = 128;

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -211,8 +211,8 @@ TEST(MfmaSimdExact, F32Spec_AllShapes) {
 
 TEST(MfmaSimdExact, F32SpecDestructiveSourceOverlap) {
   SKIP_IF_NO_SIMD();
-  if (util::native<float>::size() != 16)
-    GTEST_SKIP() << "test requires the 16-lane matrix fast path";
+  if (util::native<float>::size() <= 1)
+    GTEST_SKIP() << "test requires native SIMD";
   constexpr uint32_t source_b = 0;
   constexpr uint32_t destination_and_source_a = 64;
   constexpr uint32_t accumulator = 128;


### PR DESCRIPTION
rocJITsu emulates GPU matrix instructions on the host CPU. Its f32 MFMA implementation already has a specialized path that snapshots register operands, performs the matrix multiplication with native host SIMD, and publishes the results without per-element register access or heap-backed result staging. However, that path was restricted to builds where `native_simd<float>` is exactly 16 lanes wide. Portable builds therefore fell back to the slower generic implementation even when host SIMD was available.

This change makes the specialized f32 MFMA implementation use the SIMD width available in the compiled binary, provided the matrix columns divide cleanly into SIMD chunks. Hosts without usable SIMD, unsupported shapes, operand permutations, and explicitly forced-scalar execution continue to use the existing generic path.

Host SIMD width is selected at compile time by `std::experimental::native_simd`. No special rocJitsu CMake option is required: when `<experimental/simd>` is available and `RJ_FORCE_SCALAR` is unset or `0`, rocJitsu may use its SIMD paths. Compiler target options determine the width. A portable x86-64 build may use four f32 lanes, an AVX2-targeted build commonly uses eight, and an AVX-512-targeted build commonly uses sixteen. CPU capability alone does not widen an already-compiled binary; builds intended to use a wider ISA must target CPUs that support it. Setting `RJ_FORCE_SCALAR=1` before launching rocJitsu disables SIMD and retains the existing scalar fallback.

For a supported instruction, execution flows from the generated CDNA handler into the compile-time f32 MFMA specialization, which obtains observed VGPR-region snapshots, processes the output columns in native-width FMA chunks, and publishes the result through an observed VGPR write region.

This is the MFMA SIMD part of a broader matrix-execution optimization effort. The related PRs are:

- #8594 — the original combined MFMA/WMMA optimization explored by atgutier; now closed.
- This PR (#10702) — enables native-width SIMD for the f32 MFMA path.
- #10706 — snapshots operands in the scalar f32 MFMA path.
- #10710 — enables native-width SIMD for the separate f32 WMMA path.

The three replacement PRs are independent and may be reviewed and merged in any order.

Performance was measured on a 12-core, 24-thread AMD engineering-sample CPU with AVX2 and AVX-512 support. The tested rocJitsu binary was intentionally portable: AMD Clang 22 from ROCm 7.2.0, `Release`, `-O3 -DNDEBUG`, and no `-march`, AVX2, or AVX-512 build flag. This produced a four-lane `native_simd<float>`.

The gfx950 workload used `hipblaslt-bench` with an f32 512x512x512 GEMM, one cold iteration, and five timed iterations. After one excluded warm-up process per build, five baseline/candidate pairs were run in alternating order against exact parent `0bc9df3279`.

Whole-process wall time improved from a median 17.278 seconds to 12.189 seconds, a 1.418x paired speedup. hipBLASLt's median timed GEMM value improved from 2.41741 seconds to 1.56563 seconds, a 1.544x paired speedup.

The measured wall times were:

```text
Parent:    17.198, 17.367, 17.246, 17.278, 17.455 seconds
Candidate: 12.215, 12.227, 12.165, 12.186, 12.189 seconds
```

A separate nonzero 256x256x256 verification run completed with `norm_error=0`. Focused validation selected 95 MFMA, plugin, and lazy-storage tests: 90 passed and five unrelated 16-lane-only cases were skipped. Pre-commit passed.

The instruction-throughput plugin was also run separately from the wall-time benchmark. MIPS here means millions of executed wave instructions per host second; one instruction is counted when a wavefront reaches the execution hook, without multiplying by the number of active lanes.

| Throughput-plugin metric | Parent median | Candidate median | Speedup |
|---|---:|---:|---:|
| Active-dispatch throughput | 0.619 MIPS | 1.010 MIPS | **1.63x** |
| Matrix-handler throughput | 0.0890 MIPS | 0.3543 MIPS | **3.98x** |

Active-dispatch throughput uses all wave instructions divided by the sum of completed dispatch durations. Matrix-handler throughput uses only matrix instructions and the time measured inside their execution callbacks. The values are medians from four balanced 512×512×512 parent/candidate pairs after one excluded warm-up, with the throughput plugin enabled alone and fixed CPU affinity. Every sample contained the same 13 dispatches, 10,652,218 total wave instructions, and 786,432 matrix instructions. The plugin adds observer overhead, so these values should be compared with each other rather than with the no-plugin wall-time results above.

Related: #9577


