### PR TITLE
perf(rocjitsu): snapshot scalar f32 MFMA operands

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1352,6 +1352,33 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
   // Scalar reference: D[i][j] = C[i][j] + sum_k A[i][k] * B[k][j], accumulated
   // per output in K order (non-fused multiply-add).
   auto run_scalar = [&]() {
+    const size_t a_count = static_cast<size_t>(M) * K * B;
+    const size_t b_count = static_cast<size_t>(N) * K * B;
+    std::vector<float> operand_values(a_count + b_count);
+    std::span<float> a_values(operand_values.data(), a_count);
+    std::span<float> b_values(operand_values.data() + a_count, b_count);
+
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = input_loc(M, K, B, row, k, b, a_bits);
+          if (cbsz != 0)
+            al.lane = permute_a_lane(al.lane, cbsz, abid);
+          a_values[(static_cast<size_t>(b) * M + row) * K + k] =
+              ea(cu, s0, physicalize_loc(al, wf));
+        }
+      }
+      for (uint32_t col = 0; col < N; ++col) {
+        for (uint32_t k = 0; k < K; ++k) {
+          auto bl = input_loc(N, K, B, col, k, b, b_bits);
+          if (blgp != 0)
+            bl.lane = permute_b_lane(bl.lane, blgp);
+          b_values[(static_cast<size_t>(b) * N + col) * K + k] =
+              eb(cu, s1, physicalize_loc(bl, wf));
+        }
+      }
+    }
+
     for (uint32_t b = 0; b < B; ++b) {
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t col = 0; col < N; ++col) {
@@ -1362,17 +1389,8 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
                   ? std::bit_cast<float>(const_acc)
                   : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
           for (uint32_t k = 0; k < K; ++k) {
-            auto al = input_loc(M, K, B, row, k, b, a_bits);
-            auto bl = input_loc(N, K, B, col, k, b, b_bits);
-            // Apply cbsz/abid lane permutation to A input.
-            if (cbsz != 0)
-              al.lane = permute_a_lane(al.lane, cbsz, abid);
-            // Apply blgp lane permutation to B input.
-            if (blgp != 0)
-              bl.lane = permute_b_lane(bl.lane, blgp);
-            float a_val = ea(cu, s0, physicalize_loc(al, wf));
-            float b_val = eb(cu, s1, physicalize_loc(bl, wf));
-            acc += a_val * b_val;
+            acc += a_values[(static_cast<size_t>(b) * M + row) * K + k] *
+                   b_values[(static_cast<size_t>(b) * N + col) * K + k];
           }
           results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1349,37 +1349,51 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
   std::vector<Result> results;
   results.reserve(M * N * B);
 
+  constexpr size_t MAX_AB = 2048;      // max M*K over all MFMA shapes
+  constexpr size_t MAX_BSTRIDE = 4096; // max K*stride over all MFMA shapes
+  constexpr size_t MAX_C = 1024;       // max M*stride over all MFMA shapes
+  static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(float) <= 48 * 1024,
+                "MFMA staging buffers exceed the 48 KiB stack budget");
+
+  auto stage_operands = [&](uint32_t block, uint32_t b_stride, float *a_values, float *b_values) {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = input_loc(M, K, B, row, k, block, a_bits);
+        if (cbsz != 0)
+          al.lane = permute_a_lane(al.lane, cbsz, abid);
+        a_values[static_cast<size_t>(row) * K + k] = ea(cu, s0, physicalize_loc(al, wf));
+      }
+    }
+    for (uint32_t k = 0; k < K; ++k) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = input_loc(N, K, B, col, k, block, b_bits);
+        if (blgp != 0)
+          bl.lane = permute_b_lane(bl.lane, blgp);
+        b_values[static_cast<size_t>(k) * b_stride + col] = eb(cu, s1, physicalize_loc(bl, wf));
+      }
+    }
+  };
+
   // Scalar reference: D[i][j] = C[i][j] + sum_k A[i][k] * B[k][j], accumulated
   // per output in K order (non-fused multiply-add).
   auto run_scalar = [&]() {
-    const size_t a_count = static_cast<size_t>(M) * K * B;
-    const size_t b_count = static_cast<size_t>(N) * K * B;
-    std::vector<float> operand_values(a_count + b_count);
-    std::span<float> a_values(operand_values.data(), a_count);
-    std::span<float> b_values(operand_values.data() + a_count, b_count);
-
-    for (uint32_t b = 0; b < B; ++b) {
-      for (uint32_t row = 0; row < M; ++row) {
-        for (uint32_t k = 0; k < K; ++k) {
-          auto al = input_loc(M, K, B, row, k, b, a_bits);
-          if (cbsz != 0)
-            al.lane = permute_a_lane(al.lane, cbsz, abid);
-          a_values[(static_cast<size_t>(b) * M + row) * K + k] =
-              ea(cu, s0, physicalize_loc(al, wf));
-        }
-      }
-      for (uint32_t col = 0; col < N; ++col) {
-        for (uint32_t k = 0; k < K; ++k) {
-          auto bl = input_loc(N, K, B, col, k, b, b_bits);
-          if (blgp != 0)
-            bl.lane = permute_b_lane(bl.lane, blgp);
-          b_values[(static_cast<size_t>(b) * N + col) * K + k] =
-              eb(cu, s1, physicalize_loc(bl, wf));
-        }
-      }
+    const size_t a_count = static_cast<size_t>(M) * K;
+    const size_t b_count = static_cast<size_t>(K) * N;
+    // Real ISA shapes use bounded per-block stack storage. Preserve support
+    // for direct callers with larger dimensions through one overflow buffer.
+    alignas(64) float a_stack[MAX_AB];
+    alignas(64) float b_stack[MAX_BSTRIDE];
+    std::vector<float> overflow;
+    float *a_values = a_stack;
+    float *b_values = b_stack;
+    if (a_count > MAX_AB || b_count > MAX_BSTRIDE) {
+      overflow.resize(a_count + b_count);
+      a_values = overflow.data();
+      b_values = overflow.data() + a_count;
     }
 
     for (uint32_t b = 0; b < B; ++b) {
+      stage_operands(b, N, a_values, b_values);
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t col = 0; col < N; ++col) {
           // AMD convention: i=row (register dimension), j=col (lane dimension).
@@ -1389,8 +1403,8 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
                   ? std::bit_cast<float>(const_acc)
                   : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
           for (uint32_t k = 0; k < K; ++k) {
-            acc += a_values[(static_cast<size_t>(b) * M + row) * K + k] *
-                   b_values[(static_cast<size_t>(b) * N + col) * K + k];
+            acc += a_values[static_cast<size_t>(row) * K + k] *
+                   b_values[static_cast<size_t>(k) * N + col];
           }
           results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }
@@ -1413,13 +1427,6 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
     // (no per-call heap allocation). MAX_* bound every real MFMA shape;
     // anything larger (or a forced-scalar run) falls back to the scalar path.
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    constexpr size_t MAX_AB = 2048;      // max M*K over all MFMA shapes
-    constexpr size_t MAX_BSTRIDE = 4096; // max K*stride
-    constexpr size_t MAX_C = 1024;       // max M*stride
-    // Combined stack frame for the three staging buffers below (currently 28
-    // KiB); tripwire so an added/larger shape can't silently blow the stack.
-    static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(float) <= 48 * 1024,
-                  "MFMA SIMD staging buffers exceed the 48 KiB stack budget");
     const uint32_t stride = ((N + W - 1) / W) * W;
     if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
@@ -1432,6 +1439,7 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
       alignas(64) float Bbuf[MAX_BSTRIDE] = {};
       alignas(64) float Cbuf[MAX_C] = {};
       for (uint32_t b = 0; b < B; ++b) {
+        stage_operands(b, stride, Abuf, Bbuf);
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
             auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
@@ -1439,20 +1447,6 @@ void exec_f32_mixed(auto &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B, ui
                 (const_acc != ACC_FROM_VGPR)
                     ? std::bit_cast<float>(const_acc)
                     : std::bit_cast<float>(RegisterAccess(cu).read_vgpr(s2 + out.reg, out.lane));
-          }
-        for (uint32_t row = 0; row < M; ++row)
-          for (uint32_t k = 0; k < K; ++k) {
-            auto al = input_loc(M, K, B, row, k, b, a_bits);
-            if (cbsz != 0)
-              al.lane = permute_a_lane(al.lane, cbsz, abid);
-            Abuf[row * K + k] = ea(cu, s0, physicalize_loc(al, wf));
-          }
-        for (uint32_t k = 0; k < K; ++k)
-          for (uint32_t col = 0; col < N; ++col) {
-            auto bl = input_loc(N, K, B, col, k, b, b_bits);
-            if (blgp != 0)
-              bl.lane = permute_b_lane(bl.lane, blgp);
-            Bbuf[k * stride + col] = eb(cu, s1, physicalize_loc(bl, wf));
           }
         wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
         for (uint32_t row = 0; row < M; ++row)

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -1140,6 +1140,57 @@ TEST(MfmaExecTest, ResolveAccAccVgpr) {
   EXPECT_EQ(result, 100u + amdgpu::ACC_VGPR_OFFSET + 2u);
 }
 
+TEST(MfmaExecTest, ScalarF32ReadsEachMatrixOperandOnce) {
+  constexpr uint32_t wf_size = 64;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
+  constexpr uint32_t sgprs_per_wf = 106, vgprs_per_wf = 256;
+  constexpr uint32_t source_a = 0, source_b = 16, accumulator = 32, destination = 48;
+
+  amdgpu::GpuMemory gpu_mem("mfma_scalar_snapshot_mem");
+  amdgpu::L2Cache l2("mfma_scalar_snapshot_l2");
+  amdgpu::ComputeUnitCore::Config config{};
+  config.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  config.num_wf_slots = 1;
+  config.sgprs_per_wf = sgprs_per_wf;
+  config.vgprs_per_wf = vgprs_per_wf;
+  config.lds_size_kb = 64;
+  auto cu = amdgpu::ComputeUnitCore::create("mfma_scalar_snapshot_cu", config, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, sgprs_per_wf, vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), wf_size);
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  for (uint32_t lane = 0; lane < wf_size; ++lane) {
+    cu->write_vgpr(vb + source_a, lane, std::bit_cast<uint32_t>(1.0f));
+    cu->write_vgpr(vb + source_b, lane, std::bit_cast<uint32_t>(2.0f));
+  }
+  for (uint32_t reg = 0; reg < 4; ++reg)
+    for (uint32_t lane = 0; lane < wf_size; ++lane)
+      cu->write_vgpr(vb + accumulator + reg, lane, std::bit_cast<uint32_t>(3.0f));
+
+  size_t source_a_reads = 0;
+  size_t source_b_reads = 0;
+  auto extract_a = [&](auto &source_cu, uint32_t base, const amdgpu::InputLoc &loc) {
+    ++source_a_reads;
+    return amdgpu::extract_f32(source_cu, base, loc);
+  };
+  auto extract_b = [&](auto &source_cu, uint32_t base, const amdgpu::InputLoc &loc) {
+    ++source_b_reads;
+    return amdgpu::extract_f32(source_cu, base, loc);
+  };
+
+  ForceScalarGuard force_scalar(/*force_scalar=*/true);
+  amdgpu::exec_f32(*cu, M, N, K, B, /*in_bits=*/32, vb + destination, vb + source_a, vb + source_b,
+                   vb + accumulator, extract_a, extract_b);
+
+  EXPECT_EQ(source_a_reads, static_cast<size_t>(M) * K * B);
+  EXPECT_EQ(source_b_reads, static_cast<size_t>(N) * K * B);
+  for (uint32_t reg = 0; reg < 4; ++reg)
+    for (uint32_t lane = 0; lane < wf_size; ++lane)
+      EXPECT_FLOAT_EQ(std::bit_cast<float>(cu->read_vgpr(vb + destination + reg, lane)), 11.0f);
+}
+
 // ---------------------------------------------------------------------------
 // L2 cache tests
 // ---------------------------------------------------------------------------

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -1142,9 +1142,12 @@ TEST(MfmaExecTest, ResolveAccAccVgpr) {
 
 TEST(MfmaExecTest, ScalarF32ReadsEachMatrixOperandOnce) {
   constexpr uint32_t wf_size = 64;
-  constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 2;
   constexpr uint32_t sgprs_per_wf = 106, vgprs_per_wf = 256;
   constexpr uint32_t source_a = 0, source_b = 16, accumulator = 32, destination = 48;
+  constexpr uint32_t source_a_regs = (M * K * B + wf_size - 1) / wf_size;
+  constexpr uint32_t source_b_regs = (N * K * B + wf_size - 1) / wf_size;
+  constexpr uint32_t destination_regs = (M * N * B + wf_size - 1) / wf_size;
 
   amdgpu::GpuMemory gpu_mem("mfma_scalar_snapshot_mem");
   amdgpu::L2Cache l2("mfma_scalar_snapshot_l2");
@@ -1161,11 +1164,13 @@ TEST(MfmaExecTest, ScalarF32ReadsEachMatrixOperandOnce) {
   ASSERT_EQ(wf->wf_size(), wf_size);
   const uint32_t vb = wf->vgpr_alloc().base;
 
-  for (uint32_t lane = 0; lane < wf_size; ++lane) {
-    cu->write_vgpr(vb + source_a, lane, std::bit_cast<uint32_t>(1.0f));
-    cu->write_vgpr(vb + source_b, lane, std::bit_cast<uint32_t>(2.0f));
-  }
-  for (uint32_t reg = 0; reg < 4; ++reg)
+  for (uint32_t reg = 0; reg < source_a_regs; ++reg)
+    for (uint32_t lane = 0; lane < wf_size; ++lane)
+      cu->write_vgpr(vb + source_a + reg, lane, std::bit_cast<uint32_t>(1.0f));
+  for (uint32_t reg = 0; reg < source_b_regs; ++reg)
+    for (uint32_t lane = 0; lane < wf_size; ++lane)
+      cu->write_vgpr(vb + source_b + reg, lane, std::bit_cast<uint32_t>(2.0f));
+  for (uint32_t reg = 0; reg < destination_regs; ++reg)
     for (uint32_t lane = 0; lane < wf_size; ++lane)
       cu->write_vgpr(vb + accumulator + reg, lane, std::bit_cast<uint32_t>(3.0f));
 
@@ -1182,11 +1187,12 @@ TEST(MfmaExecTest, ScalarF32ReadsEachMatrixOperandOnce) {
 
   ForceScalarGuard force_scalar(/*force_scalar=*/true);
   amdgpu::exec_f32(*cu, M, N, K, B, /*in_bits=*/32, vb + destination, vb + source_a, vb + source_b,
-                   vb + accumulator, extract_a, extract_b);
+                   vb + accumulator, extract_a, extract_b, amdgpu::ACC_FROM_VGPR,
+                   /*cbsz=*/1, /*abid=*/0, /*blgp=*/1);
 
   EXPECT_EQ(source_a_reads, static_cast<size_t>(M) * K * B);
   EXPECT_EQ(source_b_reads, static_cast<size_t>(N) * K * B);
-  for (uint32_t reg = 0; reg < 4; ++reg)
+  for (uint32_t reg = 0; reg < destination_regs; ++reg)
     for (uint32_t lane = 0; lane < wf_size; ++lane)
       EXPECT_FLOAT_EQ(std::bit_cast<float>(cu->read_vgpr(vb + destination + reg, lane)), 11.0f);
 }


### PR DESCRIPTION
rocJITsu’s scalar f32 MFMA implementation evaluates each output element independently. Although matrix operands are shared across many outputs, the existing loop repeatedly calculates their register locations and extracts the same VGPR values for every multiply. This makes operand extraction scale with M×N×K×B rather than with the number of architectural source elements.

This change snapshots the A and B operands once before entering the matrix multiplication loop. The scalar calculation retains its existing accumulation order and continues to stage all results before publishing destination writes, but each matrix source element is now extracted exactly once. A focused test verifies both the resulting values and the number of operand reads.

The change applies to the scalar fallback selected when `RJ_FORCE_SCALAR=1`, when host SIMD is unavailable, or when an instruction cannot use the SIMD specialization. The existing SIMD implementation is unchanged. This is the scalar MFMA part of a broader matrix-execution optimization effort. The related PRs are:

- #8594 — the original combined MFMA/WMMA optimization explored by atgutier; now closed.
- #10702 — enables native-width SIMD for the f32 MFMA path.
- This PR (#10706) — snapshots operands in the scalar f32 MFMA path.
- #10710 — enables native-width SIMD for the separate f32 WMMA path.

The three replacement PRs are independent and may be reviewed and merged in any order.

Performance was measured against exact parent `c1f7873001` on a 12-core, 24-thread AMD host. Both revisions were built in Release mode using AMD Clang 22 from ROCm 7.2.0, with `-O3 -DNDEBUG` and no explicit `-march`. The gfx950 tests ran `hipblaslt-bench` with `RJ_FORCE_SCALAR=1`.

Each measured process executes six GEMMs: one cold iteration followed by five timed iterations. The wall time measures that complete process. The hipBLASLt time is the reported time for one timed GEMM, averaged within that process. Consequently, the wall-time saving is expected to be approximately six times the reported per-GEMM saving; this does not indicate a separate optimization outside GEMM execution.

One additional process per revision was used as a warm-up and excluded. The order of the parent and candidate processes was alternated between measured pairs.

| GEMM | Pair | Parent wall (s) | Candidate wall (s) | Parent per-GEMM (s) | Candidate per-GEMM (s) |
|---|---:|---:|---:|---:|---:|
| 512³ | 1 | 23.882 | 15.255 | 3.08342 | 1.69719 |
| 512³ | 2 | 23.034 | 15.068 | 3.00622 | 1.66087 |
| 512³ | 3 | 23.012 | 15.121 | 3.00739 | 1.68552 |
| 512³ | 4 | 22.985 | 14.941 | 3.00613 | 1.66376 |
| 512³ | 5 | 22.873 | 14.968 | 2.99580 | 1.65162 |
| **512³ median** | **5 runs** | **23.012** | **15.068** | **3.00622** | **1.66376** |
| 768³ | 1 | 56.123 | 29.402 | 8.52014 | 4.06906 |
| 768³ | 2 | 58.989 | 29.465 | 9.02696 | 4.06252 |
| 768³ | 3 | 64.313 | 32.939 | 9.71975 | 4.48432 |
| **768³ median** | **3 runs** | **58.989** | **29.465** | **9.02696** | **4.06906** |

Speedups are calculated by dividing the displayed parent median by the candidate median:

| f32 GEMM | Complete-process speedup | Per-GEMM speedup |
|---|---:|---:|
| 512×512×512 | **1.53x** | **1.81x** |
| 768×768×768 | **2.00x** | **2.22x** |

A separate nonzero 256×256×256 verification run completed with `norm_error=0` for both the exact parent and candidate. Focused validation selected 95 MFMA, execution-plugin, and lazy-storage tests: 89 passed and six configuration-dependent tests were skipped. Pre-commit passed.

The instruction-throughput plugin was also run separately from the wall-time benchmark. MIPS here means millions of executed wave instructions per host second; one instruction is counted when a wavefront reaches the execution hook, without multiplying by the number of active lanes.

| Throughput-plugin metric | Parent median | Candidate median | Speedup |
|---|---:|---:|---:|
| Active-dispatch throughput | 0.294 MIPS | 0.470 MIPS | **1.60x** |
| Matrix-handler throughput | 0.0394 MIPS | 0.1209 MIPS | **3.07x** |

Active-dispatch throughput uses all wave instructions divided by the sum of completed dispatch durations. Matrix-handler throughput uses only matrix instructions and the time measured inside their execution callbacks. The values are medians from four balanced 512×512×512 parent/candidate pairs after one excluded warm-up, with the throughput plugin enabled alone and fixed CPU affinity. Every sample contained the same 13 dispatches, 10,652,218 total wave instructions, and 786,432 matrix instructions. The plugin adds observer overhead, so these values should be compared with each other rather than with the no-plugin wall-time results above.

Related: #9577


