### PR TITLE
[rocjitsu] Model gfx1250 DS byte transpose routing

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -7735,8 +7735,8 @@ class CodeGenerator:
         raw read.
         """
         # amdgpu::TransposeKind: TR_B4=1, TR_B6=2, B64_TR_B8=3,
-        # TR16_B128=4, B64_TR_B16=5, WMMA_TR_B8=6. Defaults describe the
-        # B64 (num_elems=2) forms.
+        # TR16_B128=4, B64_TR_B16=5, WMMA_TR_B8=6,
+        # CDNA5_DS_TR_B8=7. Defaults describe the B64 (num_elems=2) forms.
         tr_map = {
             'ds_read_tr_b4': (4, 2, 1),  # elem_size=4, num_elems=2, transpose=1
             'ds_read_tr_b6': (4, 3, 2),  # elem_size=4, num_elems=3, transpose=2

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -574,8 +574,8 @@ class IsaProfile(ABC):
         """Cross-lane routing used by 8-bit B64 DS transpose loads.
 
         CDNA4 and older targets use the MFMA-oriented B64_TR_B8 routing.
-        Architectures with the 16x16 WMMA routing override this property so
-        opcode aliases cannot acquire different behavior from their spelling.
+        Architectures with target-specific DS B8 routing override this property
+        so opcode aliases cannot acquire different behavior from their spelling.
         """
         return 3
 
@@ -2315,9 +2315,9 @@ class Cdna5Profile(Rdna4Profile):
 
     @property
     def ds_b8_transpose_kind(self) -> int:
-        # gfx1250 opcode 0xfd retains the B64_TR_B8 routing. All of its
-        # mnemonic aliases must resolve through this one profile value.
-        return 3
+        # gfx1250 groups source lanes by four rows and two eight-column halves.
+        # Keep every mnemonic alias on the corresponding CDNA5 DS routing.
+        return 7
 
     @property
     def semantic_overrides(self) -> dict[str, tuple[str, ...]]:

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -1822,9 +1822,9 @@ _TRANSPOSE_LOAD_MAP: dict[str, tuple[str, int, int, int]] = {
     # suffix -> (semantic suffix, elem_size, num_elems, transpose kind)
     # elem_size/num_elems describe the raw VGPR result size in dwords.
     # transpose kind is amdgpu::TransposeKind: TR_B4=1, TR_B6=2,
-    # B64_TR_B8=3 (CDNA4 MFMA / CDNA5 DS layout), TR16_B128=4,
-    # B64_TR_B16=5,
-    # WMMA_TR_B8=6 (RDNA4 16x16 matrix layout). All textual aliases use the
+    # B64_TR_B8=3 (CDNA4 MFMA default), TR16_B128=4, B64_TR_B16=5,
+    # WMMA_TR_B8=6 (RDNA4 16x16 matrix layout), and
+    # CDNA5_DS_TR_B8=7 (gfx1250 DS matrix layout). All textual aliases use the
     # same default here; instruction-family and ISA-profile overrides below
     # select the architecture's routing.
     'B64_TR_B4': ('b4', 4, 2, 1),

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -399,7 +399,7 @@ def test_gfx1250_profile_scopes_special_ds_semantics() -> None:
     [
         (Cdna4Profile(), 3),
         (Rdna4Profile(), 6),
-        (Cdna5Profile(), 3),
+        (Cdna5Profile(), 7),
     ],
 )
 def test_b8_transpose_aliases_share_profile_routing(profile, expected_kind) -> None:
@@ -468,7 +468,7 @@ def test_gfx1250_ds_b8_transpose_uses_profile_routing(
 ) -> None:
     vds = (gfx1250_generated_root / 'vds_exec.cpp').read_text()
     body = _generated_method_body(vds, 'DsLoadTr8B64Vds', 'DsLoadB96Vds')
-    assert 'd->transpose = 3;' in body
+    assert 'd->transpose = 7;' in body
 
 
 @pytest.mark.parametrize(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -2236,8 +2236,8 @@ class TestDeriveDsRead:
         [
             ('DS_LOAD_TR4_B64', 'ds_read_tr_b4', 2, 1),
             ('DS_LOAD_TR6_B96', 'ds_read_tr_b6', 3, 2),
-            ('DS_LOAD_TR8_B64', 'ds_read_tr_b8', 2, 3),
-            ('DS_LOAD_TR_B64', 'ds_read_tr_b8', 2, 3),
+            ('DS_LOAD_TR8_B64', 'ds_read_tr_b8', 2, 7),
+            ('DS_LOAD_TR_B64', 'ds_read_tr_b8', 2, 7),
             ('DS_LOAD_TR16_B128', 'ds_read_tr_b16', 4, 4),
             ('DS_LOAD_TR_B128', 'ds_read_tr_b16', 4, 4),
             ('DS_READ_B64_TR_B16', 'ds_read_tr_b16', 2, 5),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/generated/cdna5/vds_exec.cpp
@@ -3239,7 +3239,7 @@ void DsLoadTr8B64Vds::execute_impl(amdgpu::Wavefront &wf) {
   d->num_elems = 2;
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::DSCNT;
-  d->transpose = 3;
+  d->transpose = 7;
   ds_calculate_addresses_all_lanes(inst_, wf, *d);
   set_data(std::move(d));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h
@@ -11,8 +11,9 @@
 /// cross-lane shuffle to produce the transposed matrix layout expected by
 /// matrix instructions.
 ///
-/// B64_TR_B8 is the CDNA4 MFMA and CDNA5 DS byte transpose within 16-lane
-/// groups. WMMA_TR_B8 is used by RDNA4 and CDNA5 global loads.
+/// B64_TR_B8 is the CDNA4 MFMA byte transpose within 16-lane groups.
+/// WMMA_TR_B8 is used by RDNA4 and CDNA5 global loads. CDNA5_DS_TR_B8
+/// handles the four-row, two-column-half request grouping of gfx1250 DS loads.
 /// TR16_B128 (gfx1250 ds/global_load_tr16_b128, RDNA4 global_load_tr_b128)
 /// transposes 16-bit elements within groups of 8 consecutive lanes.
 /// B64_TR_B16 (CDNA4 ds_read_b64_tr_b16) is a 4x16-lane halfword transpose
@@ -36,9 +37,10 @@ enum class TransposeKind : uint8_t {
   TR16_B128 = 4,
   B64_TR_B16 = 5,
   WMMA_TR_B8 = 6,
+  CDNA5_DS_TR_B8 = 7,
 };
 
-/// @brief CDNA4 MFMA / CDNA5 DS B64 byte-level transpose (B64_TR_B8 only).
+/// @brief CDNA4 MFMA B64 byte-level transpose (B64_TR_B8 only).
 ///
 /// Within each 16-lane group, destination lane `l` byte `n` comes from source
 /// lane `((l & ~0xf) | ((l >> 3) & 1)) + 2 * n`, byte `l & 7`.
@@ -104,6 +106,33 @@ inline void transpose_wmma_tr_b8(std::vector<uint8_t> &response_data, uint32_t &
 
   response_data = std::move(output);
   num_elems = dest_stride / 4;
+}
+
+/// @brief gfx1250 DS B64 byte-level transpose.
+/// @details Destination lane `l` byte `n` comes from source lane
+/// `((l & ~0xf) | (((l >> 3) & 1) * 4)) + (n & 3) + 8 * (n >> 2)`, byte
+/// `l & 7`. The instruction has an eight-byte lane payload and requires wave32.
+inline void transpose_cdna5_ds_tr_b8(std::vector<uint8_t> &response_data, uint32_t num_elems,
+                                     uint32_t wf_size) {
+  assert(num_elems == 2 && "CDNA5 DS TR_B8 requires an eight-byte lane payload");
+  assert(wf_size == 32 && "CDNA5 DS transpose loads require wave32");
+  const uint32_t bytes_per_lane = num_elems * 4;
+  std::vector<uint8_t> output(response_data.size(), 0);
+
+  // Each 16-lane half loads an 8x16 matrix. Four adjacent lanes address
+  // consecutive rows of one eight-column half; lanes 8..15 address rows 4..7.
+  // Destination lane half*16+column receives rows 0..7 of that column.
+  for (uint32_t dest_lane = 0; dest_lane < wf_size; ++dest_lane) {
+    const uint32_t source_byte = dest_lane & 7u;
+    const uint32_t source_base = (dest_lane & ~0xfu) | (((dest_lane >> 3) & 1u) * 4u);
+    for (uint32_t dest_byte = 0; dest_byte < bytes_per_lane; ++dest_byte) {
+      const uint32_t source_lane = source_base + (dest_byte & 3u) + 8u * (dest_byte >> 2);
+      output[dest_lane * bytes_per_lane + dest_byte] =
+          response_data[source_lane * bytes_per_lane + source_byte];
+    }
+  }
+
+  response_data = std::move(output);
 }
 
 /// @brief Return the lanes that issue a transpose-load memory request.
@@ -324,6 +353,9 @@ inline void transpose_response(VectorMemState &d) {
     break;
   case TransposeKind::WMMA_TR_B8:
     transpose_wmma_tr_b8(d.response_data, d.num_elems, d.wf_size);
+    break;
+  case TransposeKind::CDNA5_DS_TR_B8:
+    transpose_cdna5_ds_tr_b8(d.response_data, d.num_elems, d.wf_size);
     break;
   case TransposeKind::TR16_B128:
     transpose_tr16_b128(d.response_data, d.num_elems, d.wf_size, compact_wave64);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -3792,6 +3792,10 @@ constexpr uint32_t tr_b8_byte_value(uint32_t lane, uint32_t byte) {
   return (0x40u + lane * 7u + byte) & 0xffu;
 }
 
+constexpr uint32_t cdna5_tr_b8_matrix_value(uint32_t row, uint32_t col) {
+  return (0x20u + row * 17u + col * 3u) & 0xffu;
+}
+
 constexpr uint32_t pack_tr_b8_word(uint32_t source_base, uint32_t source_byte,
                                    uint32_t dest_byte_base) {
   uint32_t word = 0;
@@ -3800,7 +3804,7 @@ constexpr uint32_t pack_tr_b8_word(uint32_t source_base, uint32_t source_byte,
   return word;
 }
 
-void verify_b64_tr_b8_lane_layout(std::string_view arch, uint32_t wave_size) {
+void verify_ds_b8_transpose_lane_layout(std::string_view arch, uint32_t wave_size) {
   VmFixture f(arch, 1, 10);
   auto *snap = f.capture_halts();
 
@@ -3846,9 +3850,18 @@ void verify_b64_tr_b8_lane_layout(std::string_view arch, uint32_t wave_size) {
   for (uint32_t lane = 0; lane < wave_size; ++lane) {
     uint32_t lo = 0;
     uint32_t hi = 0;
-    for (uint32_t byte = 0; byte < 4; ++byte) {
-      lo |= tr_b8_byte_value(lane, byte) << (byte * 8);
-      hi |= tr_b8_byte_value(lane, byte + 4) << (byte * 8);
+    if (arch == "cdna5") {
+      const uint32_t row = 8u * (lane >> 4) + (lane & 3u) + 4u * ((lane >> 3) & 1u);
+      const uint32_t col_base = 8u * ((lane >> 2) & 1u);
+      for (uint32_t byte = 0; byte < 4; ++byte) {
+        lo |= cdna5_tr_b8_matrix_value(row, col_base + byte) << (byte * 8);
+        hi |= cdna5_tr_b8_matrix_value(row, col_base + byte + 4) << (byte * 8);
+      }
+    } else {
+      for (uint32_t byte = 0; byte < 4; ++byte) {
+        lo |= tr_b8_byte_value(lane, byte) << (byte * 8);
+        hi |= tr_b8_byte_value(lane, byte + 4) << (byte * 8);
+      }
     }
     cu->lds().write32(lane * BYTES_PER_LANE, lo);
     cu->lds().write32(lane * BYTES_PER_LANE + 4, hi);
@@ -3862,6 +3875,19 @@ void verify_b64_tr_b8_lane_layout(std::string_view arch, uint32_t wave_size) {
   const auto &wf = snap->snapshots().front();
 
   for (uint32_t lane = 0; lane < wave_size; ++lane) {
+    if (arch == "cdna5") {
+      const uint32_t row_base = 8u * (lane >> 4);
+      const uint32_t col = lane & 15u;
+      uint32_t expected_lo = 0;
+      uint32_t expected_hi = 0;
+      for (uint32_t byte = 0; byte < 4; ++byte) {
+        expected_lo |= cdna5_tr_b8_matrix_value(row_base + byte, col) << (byte * 8);
+        expected_hi |= cdna5_tr_b8_matrix_value(row_base + byte + 4, col) << (byte * 8);
+      }
+      EXPECT_EQ(wf.vgpr(VDST, lane), expected_lo) << "lane " << lane << " v" << VDST;
+      EXPECT_EQ(wf.vgpr(VDST + 1, lane), expected_hi) << "lane " << lane << " v" << (VDST + 1);
+      continue;
+    }
     const uint32_t source_byte = lane & 7u;
     const uint32_t source_base = (lane & ~0xfu) | ((lane >> 3) & 1u);
     EXPECT_EQ(wf.vgpr(VDST, lane), pack_tr_b8_word(source_base, source_byte, 0))
@@ -3872,11 +3898,11 @@ void verify_b64_tr_b8_lane_layout(std::string_view arch, uint32_t wave_size) {
 }
 
 TEST(DsTransposeTest, ReadB64TrB8_LaneLayout) {
-  verify_b64_tr_b8_lane_layout("cdna4", /*wave_size=*/64);
+  verify_ds_b8_transpose_lane_layout("cdna4", /*wave_size=*/64);
 }
 
 TEST(DsTransposeTest, Gfx1250LoadTr8B64_LaneLayout) {
-  verify_b64_tr_b8_lane_layout("cdna5", /*wave_size=*/32);
+  verify_ds_b8_transpose_lane_layout("cdna5", /*wave_size=*/32);
 }
 
 // Verify the ds_read_b64_tr_b16 cross-lane layout: within each 16-lane group,

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -594,6 +594,34 @@ TEST(TransposeLoadTest, Cdna4B64TrB8MatchesMfmaLaneLayout) {
   }
 }
 
+TEST(TransposeLoadTest, Cdna5DsTrB8MatchesMatrixLayout) {
+  amdgpu::VectorMemState state(amdgpu::LOCAL_MEM);
+  state.wf_size = 32;
+  state.num_elems = 2;
+  state.lane_mask = 0xFFFF'FFFFULL;
+  state.transpose = static_cast<uint8_t>(amdgpu::TransposeKind::CDNA5_DS_TR_B8);
+  state.response_data.resize(32 * 8);
+  for (uint32_t source_lane = 0; source_lane < 32; ++source_lane) {
+    const uint32_t row =
+        8u * (source_lane >> 4) + (source_lane & 3u) + 4u * ((source_lane >> 3) & 1u);
+    const uint32_t col_base = 8u * ((source_lane >> 2) & 1u);
+    for (uint32_t byte = 0; byte < 8; ++byte)
+      state.response_data[source_lane * 8 + byte] =
+          static_cast<uint8_t>(row * 16 + col_base + byte);
+  }
+
+  amdgpu::transpose_response(state);
+
+  ASSERT_EQ(state.num_elems, 2u);
+  for (uint32_t dest_lane = 0; dest_lane < 32; ++dest_lane) {
+    const uint32_t row_base = 8u * (dest_lane >> 4);
+    const uint32_t col = dest_lane & 15u;
+    for (uint32_t byte = 0; byte < 8; ++byte)
+      EXPECT_EQ(state.response_data[dest_lane * 8 + byte],
+                static_cast<uint8_t>((row_base + byte) * 16 + col));
+  }
+}
+
 TEST(MfmaExecTest, Gfx12Wave64WmmaLocSplitsKAcrossFourLaneGroups) {
   auto a_k8 = amdgpu::gfx12_wmma_input_loc(amdgpu::WMMA_WAVE64, 16, 16, /*i=*/3, /*k=*/8, 16);
   EXPECT_EQ(a_k8.lane, 35u);


### PR DESCRIPTION
CDNA5 DS byte transpose loads group source lanes by four rows across two eight-column halves. Add a target-specific routing mode instead of reusing the CDNA4 MFMA layout.

Keep the generated semantic on the ISA profile and cover the routing with generator and simulator tests.