### PR TITLE
[rocshmem] Add per-peer GDA queue-pair introspection

### DIFF
--- a/projects/rocshmem/include/rocshmem/qp_introspect.hpp
+++ b/projects/rocshmem/include/rocshmem/qp_introspect.hpp
@@ -1,0 +1,168 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+/**
+ * Per-peer GDA queue-pair introspection for external WQE builders.
+ *
+ * rocSHMEM's GDA backend already creates, connects and registers an RC QP per
+ * peer. This exposes the device-visible resources of that QP -- send/completion
+ * ring addresses, doorbell, live producer counter, and the memory keys -- so a
+ * consumer that compiles its own device code (e.g. a Triton kernel) can post
+ * work requests into a QP rocSHMEM set up, instead of duplicating connection
+ * establishment.
+ *
+ * The NIC providers do not have the same shape, so the payload is a
+ * vendor-neutral core plus a tagged union:
+ *
+ *   ionic  doorbell register + a base doorbell value, and a UDMA index
+ *          selecting which of the NIC's two engines the QP is bound to.
+ *   mlx5   doorbell record + BlueFlame register; the WQE is written to BF.
+ *   bnxt   a single doorbell record pointer.
+ *
+ * Callers switch on `vendor`. Reading a union arm other than the one `vendor`
+ * names is undefined.
+ *
+ * Only ionic is implemented. mlx5 and bnxt are TODO: their union arms are
+ * declared so adding them later does not change this struct's ABI, but
+ * rocshmem_query_qp_info returns false for those providers today.
+ *
+ * Deliberately a flat POD plus a free function: callers (including language
+ * bindings) need no internal rocSHMEM headers.
+ *
+ * IMPORTANT -- choosing ctx_id. ctx_id 0 is the default context, which is the
+ * one rocSHMEM's own collectives use. Posting raw WQEs into that QP corrupts
+ * rocSHMEM's producer/consumer bookkeeping, after which its collectives (e.g.
+ * rocshmem_barrier_all) deadlock. Pass ctx_id > 0 to borrow a user-context QP
+ * that rocSHMEM does not drive itself; then an external builder and rocSHMEM's
+ * own collectives can run concurrently.
+ *
+ * This is enforced, not merely advised: rocshmem_query_qp_info() returns false
+ * for ctx_id <= 0. Describing the default-context QP is the one thing this API
+ * must not do, so a caller cannot opt into the deadlock by mistake.
+ */
+#ifndef ROCSHMEM_QP_INTROSPECT_HPP
+#define ROCSHMEM_QP_INTROSPECT_HPP
+
+#include <cstdint>
+
+namespace rocshmem {
+
+/**
+ * @brief Which NIC provider owns the QP described by a QpInfo.
+ *
+ * Mirrors the internal GDAProvider enum. Duplicated here so the public header
+ * stays free of internal includes; kept in sync by a static_assert in
+ * qp_introspect.cpp.
+ */
+enum class QpInfoVendor : uint32_t {
+  UNKNOWN = 0,
+  IONIC   = 1,
+  BNXT    = 2,
+  MLX5    = 3,
+};
+
+/**
+ * @brief Device-visible resources of one peer's RC QP.
+ *
+ * All addresses are device virtual addresses, valid in the address space of the
+ * GPU that owns the QP. Depths are in ring slots, not bytes.
+ */
+struct QpInfo {
+  /* ---- vendor-neutral ------------------------------------------------- */
+  uint64_t sq_buf;     //!< Send queue ring buffer.
+  uint64_t sq_prod;    //!< Address of the live SQ producer counter. An external
+                       //!<   builder must continue this sequence, not restart
+                       //!<   it, or it will collide with rocSHMEM's own posts.
+  uint64_t cq_buf;     //!< Completion queue ring buffer.
+  uint64_t base_heap;  //!< Local symmetric heap base for this QP.
+  uint32_t sq_depth;   //!< SQ capacity in WQE slots.
+  uint32_t cq_depth;   //!< CQ capacity in CQE slots.
+  uint32_t lkey;       //!< Local heap memory key.
+  uint32_t rkey;       //!< Peer heap memory key for this QP's connection.
+  uint32_t qpn;        //!< QP number.
+  QpInfoVendor vendor; //!< Selects the valid union arm below.
+
+  /* ---- provider-specific ---------------------------------------------- */
+  union {
+    struct {
+      uint64_t dbrec;  //!< SQ doorbell record.
+      uint64_t bf;     //!< BlueFlame register; the WQE itself is written here.
+    } mlx5;
+
+    struct {
+      uint64_t db;        //!< SQ doorbell register.
+      uint64_t dbval;     //!< Base doorbell value; the producer index is OR'ed
+                          //!<   in when ringing.
+      uint64_t sq_mask;   //!< SQ index wrap mask (depth - 1).
+      uint64_t cq_mask;   //!< CQ index wrap mask (depth - 1).
+      uint8_t  udma_idx;  //!< Which of the NIC's two UDMA engines this QP uses.
+    } ionic;
+
+    struct {
+      uint64_t dbr;    //!< Doorbell record.
+    } bnxt;
+  };
+};
+
+/**
+ * @brief Which GDA provider is active, whether or not it is supported here.
+ *
+ * Returns QpInfoVendor::UNKNOWN when rocSHMEM is not initialised or the active
+ * backend is not GDA. Otherwise returns the detected provider, including mlx5
+ * and bnxt, which this API does not yet describe.
+ *
+ * Pair with rocshmem_qp_introspect_available() to tell the two failure modes
+ * apart: UNKNOWN means there is no GDA backend to introspect, while a known
+ * provider with available() == false means the NIC was detected but is not
+ * implemented yet. A caller that only sees a null result cannot distinguish
+ * them, and the remedy for each is different.
+ *
+ * @return the detected provider, or QpInfoVendor::UNKNOWN. Host-side, safe to
+ *         call before init.
+ */
+QpInfoVendor rocshmem_qp_introspect_provider();
+
+/**
+ * @brief Whether QP introspection is usable in this process.
+ *
+ * True only when rocSHMEM is initialised, the active backend is the GDA
+ * backend, and its RDMA provider is one this API can describe -- today that
+ * means ionic. Everything here is specific to GDA's RC queue pairs, so on any
+ * other backend (IPC, reverse offload) there is nothing to introspect.
+ *
+ * This deliberately checks the provider and not merely the backend: reporting
+ * "available" on an mlx5 or bnxt GDA backend would promise a capability that
+ * rocshmem_query_qp_info then refuses.
+ *
+ * Callers should use this to branch up front rather than inferring capability
+ * from a null result: rocshmem_query_qp_info() returns false both when the
+ * environment cannot support the call and when a particular peer/ctx_id names
+ * no QP, and those deserve different handling.
+ *
+ * @return true if rocshmem_query_qp_info() can succeed for some peer/ctx_id.
+ *         Host-side, collective-independent, safe to call before init (returns
+ *         false).
+ */
+bool rocshmem_qp_introspect_available();
+
+/**
+ * @brief Describe the RC QP connecting this PE to @p peer within @p ctx_id.
+ *
+ * @param peer   Destination PE.
+ * @param ctx_id Context whose QP to describe. Must be > 0; ctx_id <= 0 is
+ *               rejected -- see the header comment on why the default-context
+ *               QP is unsafe for external WQE posting.
+ * @param out    Filled on success; untouched on failure.
+ *
+ * @return false if the active backend is not the GDA backend, if ctx_id <= 0,
+ *         if the provider is unrecognised, or if peer/ctx_id do not name a QP.
+ *         Host-side and collective-independent.
+ */
+bool rocshmem_query_qp_info(int peer, int ctx_id, QpInfo* out);
+
+}  // namespace rocshmem
+
+#endif  // ROCSHMEM_QP_INTROSPECT_HPP

--- a/projects/rocshmem/include/rocshmem/qp_introspect.hpp
+++ b/projects/rocshmem/include/rocshmem/qp_introspect.hpp
@@ -32,16 +32,24 @@
  * Deliberately a flat POD plus a free function: callers (including language
  * bindings) need no internal rocSHMEM headers.
  *
- * IMPORTANT -- choosing ctx_id. ctx_id 0 is the default context, which is the
- * one rocSHMEM's own collectives use. Posting raw WQEs into that QP corrupts
- * rocSHMEM's producer/consumer bookkeeping, after which its collectives (e.g.
- * rocshmem_barrier_all) deadlock. Pass ctx_id > 0 to borrow a user-context QP
- * that rocSHMEM does not drive itself; then an external builder and rocSHMEM's
- * own collectives can run concurrently.
+ * IMPORTANT -- choosing ctx_id. ctx_id 0 is the default context, the queue
+ * rocSHMEM drives for its own operations. Its producer index, send-queue lock
+ * and cached doorbell position are private to rocSHMEM, and an external builder
+ * updates none of them: it bumps the shared producer index and rings the
+ * doorbell on its own. Pass ctx_id > 0 to borrow a user-context QP that
+ * rocSHMEM does not drive itself, so the two never share that state.
+ *
+ * Measured on gfx950/ionic, sharing ctx 0 does not fail the way one might
+ * guess. Posting external descriptors and then calling rocshmem_barrier_all
+ * is fine -- the barrier completes. But a full workload that mixes external
+ * posts with the caller's own completion polling on that same queue does not
+ * run to completion, while the identical workload on a user context does.
+ * The exact stall was not characterised; the queue is simply not safely
+ * shared.
  *
  * This is enforced, not merely advised: rocshmem_query_qp_info() returns false
  * for ctx_id <= 0. Describing the default-context QP is the one thing this API
- * must not do, so a caller cannot opt into the deadlock by mistake.
+ * must not do, so a caller cannot opt into that state by mistake.
  */
 #ifndef ROCSHMEM_QP_INTROSPECT_HPP
 #define ROCSHMEM_QP_INTROSPECT_HPP

--- a/projects/rocshmem/src/gda/CMakeLists.txt
+++ b/projects/rocshmem/src/gda/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(
     ibv_wrapper.cpp
     gda_team.cpp
     queue_pair.cpp
+    qp_introspect.cpp
     topology.cpp
 )
 

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -76,6 +76,8 @@ struct NicDevice {
   struct ibv_pd *pd_uxdma[2] = {nullptr, nullptr};
 };
 
+struct QpInfo;  // rocshmem/qp_introspect.hpp
+
 class GDABackend : public Backend {
  private:
   typedef struct dest_info {
@@ -216,6 +218,13 @@ class GDABackend : public Backend {
 
  public:
   GDAProvider get_gda_provider() const { return gda_provider; }
+
+  /**
+   * @brief Describe the RC QP to @p peer within @p ctx_id.
+   *        Implementation of rocshmem_query_qp_info; see
+   *        include/rocshmem/qp_introspect.hpp.
+   */
+  bool fill_qp_info(int peer, int ctx_id, QpInfo *out);
 
   friend GDAContext;
 

--- a/projects/rocshmem/src/gda/qp_introspect.cpp
+++ b/projects/rocshmem/src/gda/qp_introspect.cpp
@@ -1,0 +1,171 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+/**
+ * Per-peer GDA queue-pair introspection.
+ * See include/rocshmem/qp_introspect.hpp for the public contract.
+ *
+ * Lives in a library TU where the GDA internals are in scope; the public
+ * surface is only the flat POD plus the free function.
+ */
+#include "rocshmem/qp_introspect.hpp"
+
+#include <hip/hip_runtime.h>
+
+#include "backend_bc.hpp"
+#include "backend_type.hpp"
+#include "gda/backend_gda.hpp"
+#include "gda/gda_enums.hpp"
+#include "gda/queue_pair.hpp"
+#include "log.hpp"
+
+namespace rocshmem {
+
+extern Backend *backend;
+
+// The public QpInfoVendor duplicates the internal GDAProvider so that
+// qp_introspect.hpp needs no internal includes. Pin them together so the two
+// cannot drift silently.
+static_assert(static_cast<uint32_t>(QpInfoVendor::IONIC) ==
+                  static_cast<uint32_t>(GDAProvider::IONIC),
+              "QpInfoVendor::IONIC must match GDAProvider::IONIC");
+static_assert(static_cast<uint32_t>(QpInfoVendor::BNXT) ==
+                  static_cast<uint32_t>(GDAProvider::BNXT),
+              "QpInfoVendor::BNXT must match GDAProvider::BNXT");
+static_assert(static_cast<uint32_t>(QpInfoVendor::MLX5) ==
+                  static_cast<uint32_t>(GDAProvider::MLX5),
+              "QpInfoVendor::MLX5 must match GDAProvider::MLX5");
+
+bool GDABackend::fill_qp_info(int peer, int ctx_id, QpInfo *out) {
+  if (out == nullptr) return false;
+  if (peer < 0 || peer >= static_cast<int>(num_pes)) return false;
+  if (ctx_id < 0) return false;
+  if (gpu_qps == nullptr) return false;
+
+  // Index math mirrors GDAContext's constructor (context_gda_device.cpp): a
+  // context's QPs form a contiguous run in the backend's array, with the
+  // default context first and each user context after it.
+  const size_t qps_per_pe =
+      ctx_id ? qps_per_pe_usr_ctx_ : qps_per_pe_default_ctx_;
+  size_t offset = (ctx_id > 0) ? (qps_per_pe_default_ctx_ +
+                                  qps_per_pe_usr_ctx_ * (ctx_id - 1))
+                               : 0;
+  offset *= num_pes;
+
+  const size_t conn = offset + static_cast<size_t>(peer) * qps_per_pe;
+  if (conn >= static_cast<size_t>(num_qps)) return false;
+
+  // initialize_gpu_qp writes the field VALUES straight into gpu_qps[conn] in
+  // device memory; host_qps[conn] holds only the initial construct. So read the
+  // device copy. QueuePair has no default constructor -- copy the bytes
+  // into raw aligned storage and read POD members from it; no constructor
+  // or destructor runs on this buffer.
+  alignas(QueuePair) unsigned char storage[sizeof(QueuePair)];
+  if (hipMemcpy(storage, &gpu_qps[conn], sizeof(QueuePair),
+                hipMemcpyDeviceToHost) != hipSuccess) {
+    return false;
+  }
+  const QueuePair *qp = reinterpret_cast<const QueuePair *>(storage);
+
+  out->base_heap = static_cast<uint64_t>(qp->base_heap);
+  out->lkey = qp->lkey;
+  out->rkey = qp->rkey;
+  out->qpn = qp->qp_num;
+  out->vendor = static_cast<QpInfoVendor>(gda_provider);
+
+  switch (gda_provider) {
+    case GDAProvider::IONIC: {
+      out->sq_buf = reinterpret_cast<uint64_t>(qp->ionic_sq_buf);
+      out->cq_buf = reinterpret_cast<uint64_t>(qp->ionic_cq_buf);
+      // Live producer index, taken from the device array itself rather than the
+      // host copy: an external builder has to continue this sequence.
+      out->sq_prod = reinterpret_cast<uint64_t>(&gpu_qps[conn].sq_prod);
+      out->sq_depth = static_cast<uint32_t>(qp->sq_mask + 1);
+      out->cq_depth = static_cast<uint32_t>(qp->cq_mask + 1);
+      out->ionic.db = reinterpret_cast<uint64_t>(qp->sq_dbreg);
+      out->ionic.dbval = qp->sq_dbval;
+      out->ionic.sq_mask = qp->sq_mask;
+      out->ionic.cq_mask = qp->cq_mask;
+      // Which UDMA engine this QP is bound to. Not derivable from the device
+      // struct; query the verbs QP the same way setup_gpu_qp does.
+      if (qps.size() <= conn || qps[conn] == nullptr) return false;
+      if (ionic_dv.qp_get_udma_idx == nullptr) return false;
+      out->ionic.udma_idx = ionic_dv.qp_get_udma_idx(qps[conn]);
+      return true;
+    }
+
+    case GDAProvider::MLX5:
+    case GDAProvider::BNXT:
+      // Declared in QpInfo's union but not implemented (TODO). Publishing
+      // untested ring or doorbell addresses that a consumer would post work
+      // requests into is worse than reporting failure: a wrong address surfaces
+      // as silent data corruption or a NIC error far from its cause.
+      //
+      // The caller-facing warning lives in rocshmem_query_qp_info(), which now
+      // rejects unsupported providers before reaching here.
+      return false;
+
+    case GDAProvider::UNSET:
+    default:
+      return false;
+  }
+}
+
+QpInfoVendor rocshmem_qp_introspect_provider() {
+  if (backend == nullptr) return QpInfoVendor::UNKNOWN;
+  if (backend->get_type() != BackendType::GDA_BACKEND) {
+    return QpInfoVendor::UNKNOWN;
+  }
+  // Reports what was detected, including providers this API cannot describe --
+  // that is the point: it lets a caller distinguish "no GDA here" from
+  // "GDA on a NIC we have not implemented yet", which otherwise look the
+  // same.
+  return static_cast<QpInfoVendor>(
+      static_cast<GDABackend *>(backend)->get_gda_provider());
+}
+
+bool rocshmem_qp_introspect_available() {
+  // Must check the provider, not just the backend. Only ionic is
+  // implemented, so reporting "available" on an mlx5 or bnxt GDA backend
+  // would promise a capability that rocshmem_query_qp_info then refuses --
+  // the caller is told to go ahead and gets nothing back, with no way to
+  // tell why.
+  return rocshmem_qp_introspect_provider() == QpInfoVendor::IONIC;
+}
+
+bool rocshmem_query_qp_info(int peer, int ctx_id, QpInfo *out) {
+  const QpInfoVendor provider = rocshmem_qp_introspect_provider();
+  if (provider != QpInfoVendor::IONIC) {
+    // A provider was detected, we just cannot describe it. Say so, once: to a
+    // caller this failure is otherwise indistinguishable from "no GDA backend",
+    // and the fix for each is completely different.
+    if (provider != QpInfoVendor::UNKNOWN) {
+      static bool warned = false;  // benign race: at worst the warning repeats
+      if (!warned) {
+        warned = true;
+        LOG_WARN("QP introspection is not implemented for the detected GDA "
+                 "provider (%s), so no queue pair will be reported. Only ionic "
+                 "is supported today.",
+                 provider == QpInfoVendor::MLX5 ? "mlx5" : "bnxt");
+      }
+    }
+    return false;
+  }
+  // Refuse the default context. ctx_id 0 is the QP rocSHMEM drives for its own
+  // collectives, and it keeps private send-queue bookkeeping for it. A caller
+  // that posts its own WQEs there corrupts that state and deadlocks operations
+  // like rocshmem_barrier_all. Handing the descriptor out is the whole risk, so
+  // the refusal belongs here rather than in a doc comment. Callers must
+  // create a user context (ctx_id > 0) and introspect that.
+  //
+  // fill_qp_info() itself still accepts ctx_id 0: it is the backend's own
+  // accessor and the default context is legitimate internally. Only this
+  // published entry point is restricted.
+  if (ctx_id <= 0) return false;
+  return static_cast<GDABackend *>(backend)->fill_qp_info(peer, ctx_id, out);
+}
+
+}  // namespace rocshmem

--- a/projects/rocshmem/src/gda/qp_introspect.cpp
+++ b/projects/rocshmem/src/gda/qp_introspect.cpp
@@ -185,11 +185,14 @@ bool rocshmem_query_qp_info(int peer, int ctx_id, QpInfo *out) {
     return false;
   }
   // Refuse the default context. ctx_id 0 is the QP rocSHMEM drives for its own
-  // collectives, and it keeps private send-queue bookkeeping for it. A caller
-  // that posts its own WQEs there corrupts that state and deadlocks operations
-  // like rocshmem_barrier_all. Handing the descriptor out is the whole risk, so
-  // the refusal belongs here rather than in a doc comment. Callers must
-  // create a user context (ctx_id > 0) and introspect that.
+  // operations, keeping a private producer index, send-queue lock and cached
+  // doorbell position that an external builder updates none of. Measured on
+  // ionic: external posts alone do not break collectives (barrier_all still
+  // completes), but a workload mixing external posts with its own completion
+  // polling on that queue fails to finish, where the same workload on a user
+  // context does. Handing the descriptor out is the whole risk, so the refusal
+  // belongs here rather than in a doc comment. Callers must create a user
+  // context (ctx_id > 0) and introspect that.
   //
   // fill_qp_info() itself still accepts ctx_id 0: it is the backend's own
   // accessor and the default context is legitimate internally. Only this

--- a/projects/rocshmem/src/gda/qp_introspect.cpp
+++ b/projects/rocshmem/src/gda/qp_introspect.cpp
@@ -15,6 +15,8 @@
 
 #include <hip/hip_runtime.h>
 
+#include <atomic>
+
 #include "backend_bc.hpp"
 #include "backend_type.hpp"
 #include "gda/backend_gda.hpp"
@@ -59,36 +61,62 @@ bool GDABackend::fill_qp_info(int peer, int ctx_id, QpInfo *out) {
   if (conn >= static_cast<size_t>(num_qps)) return false;
 
   // initialize_gpu_qp writes the field VALUES straight into gpu_qps[conn] in
-  // device memory; host_qps[conn] holds only the initial construct. So read the
-  // device copy. QueuePair has no default constructor -- copy the bytes
-  // into raw aligned storage and read POD members from it; no constructor
-  // or destructor runs on this buffer.
-  alignas(QueuePair) unsigned char storage[sizeof(QueuePair)];
-  if (hipMemcpy(storage, &gpu_qps[conn], sizeof(QueuePair),
-                hipMemcpyDeviceToHost) != hipSuccess) {
-    return false;
-  }
-  const QueuePair *qp = reinterpret_cast<const QueuePair *>(storage);
+  // device memory; host_qps[conn] holds only the initial construct, so the
+  // device copy is the one to read.
+  //
+  // Copy the individual members rather than the whole object. QueuePair is
+  // polymorphic (virtual destructor), so it is not trivially copyable: memcpy
+  // of the object bytes followed by reinterpret_cast to QueuePair* would be
+  // undefined behaviour, and the copied vtable pointer would be meaningless on
+  // the host anyway. Each member read below is a POD, which is well defined.
+  const QueuePair *dev_qp = &gpu_qps[conn];  // device address, never
+                                             // dereferenced on the host
+  auto fetch = [](auto *dst, const auto *device_src) {
+    return hipMemcpy(dst, device_src, sizeof(*dst),
+                     hipMemcpyDeviceToHost) == hipSuccess;
+  };
 
-  out->base_heap = static_cast<uint64_t>(qp->base_heap);
-  out->lkey = qp->lkey;
-  out->rkey = qp->rkey;
-  out->qpn = qp->qp_num;
+  decltype(QueuePair::base_heap) base_heap{};
+  decltype(QueuePair::lkey) lkey{};
+  decltype(QueuePair::rkey) rkey{};
+  decltype(QueuePair::qp_num) qp_num{};
+  if (!fetch(&base_heap, &dev_qp->base_heap)) return false;
+  if (!fetch(&lkey, &dev_qp->lkey)) return false;
+  if (!fetch(&rkey, &dev_qp->rkey)) return false;
+  if (!fetch(&qp_num, &dev_qp->qp_num)) return false;
+
+  out->base_heap = static_cast<uint64_t>(base_heap);
+  out->lkey = lkey;
+  out->rkey = rkey;
+  out->qpn = qp_num;
   out->vendor = static_cast<QpInfoVendor>(gda_provider);
 
   switch (gda_provider) {
     case GDAProvider::IONIC: {
-      out->sq_buf = reinterpret_cast<uint64_t>(qp->ionic_sq_buf);
-      out->cq_buf = reinterpret_cast<uint64_t>(qp->ionic_cq_buf);
+      decltype(QueuePair::ionic_sq_buf) ionic_sq_buf{};
+      decltype(QueuePair::ionic_cq_buf) ionic_cq_buf{};
+      decltype(QueuePair::sq_mask) sq_mask{};
+      decltype(QueuePair::cq_mask) cq_mask{};
+      decltype(QueuePair::sq_dbreg) sq_dbreg{};
+      decltype(QueuePair::sq_dbval) sq_dbval{};
+      if (!fetch(&ionic_sq_buf, &dev_qp->ionic_sq_buf)) return false;
+      if (!fetch(&ionic_cq_buf, &dev_qp->ionic_cq_buf)) return false;
+      if (!fetch(&sq_mask, &dev_qp->sq_mask)) return false;
+      if (!fetch(&cq_mask, &dev_qp->cq_mask)) return false;
+      if (!fetch(&sq_dbreg, &dev_qp->sq_dbreg)) return false;
+      if (!fetch(&sq_dbval, &dev_qp->sq_dbval)) return false;
+
+      out->sq_buf = reinterpret_cast<uint64_t>(ionic_sq_buf);
+      out->cq_buf = reinterpret_cast<uint64_t>(ionic_cq_buf);
       // Live producer index, taken from the device array itself rather than the
       // host copy: an external builder has to continue this sequence.
       out->sq_prod = reinterpret_cast<uint64_t>(&gpu_qps[conn].sq_prod);
-      out->sq_depth = static_cast<uint32_t>(qp->sq_mask + 1);
-      out->cq_depth = static_cast<uint32_t>(qp->cq_mask + 1);
-      out->ionic.db = reinterpret_cast<uint64_t>(qp->sq_dbreg);
-      out->ionic.dbval = qp->sq_dbval;
-      out->ionic.sq_mask = qp->sq_mask;
-      out->ionic.cq_mask = qp->cq_mask;
+      out->sq_depth = static_cast<uint32_t>(sq_mask + 1);
+      out->cq_depth = static_cast<uint32_t>(cq_mask + 1);
+      out->ionic.db = reinterpret_cast<uint64_t>(sq_dbreg);
+      out->ionic.dbval = sq_dbval;
+      out->ionic.sq_mask = sq_mask;
+      out->ionic.cq_mask = cq_mask;
       // Which UDMA engine this QP is bound to. Not derivable from the device
       // struct; query the verbs QP the same way setup_gpu_qp does.
       if (qps.size() <= conn || qps[conn] == nullptr) return false;
@@ -143,9 +171,11 @@ bool rocshmem_query_qp_info(int peer, int ctx_id, QpInfo *out) {
     // caller this failure is otherwise indistinguishable from "no GDA backend",
     // and the fix for each is completely different.
     if (provider != QpInfoVendor::UNKNOWN) {
-      static bool warned = false;  // benign race: at worst the warning repeats
-      if (!warned) {
-        warned = true;
+      // Atomic, not a plain bool: this entry point can be called from several
+      // threads, and a non-atomic read/write pair would be a data race, which
+      // is undefined behaviour however harmless the intent.
+      static std::atomic<bool> warned{false};
+      if (!warned.exchange(true, std::memory_order_relaxed)) {
         LOG_WARN("QP introspection is not implemented for the detected GDA "
                  "provider (%s), so no queue pair will be reported. Only ionic "
                  "is supported today.",

--- a/python/rocshmem/rocshmem4py/__init__.py
+++ b/python/rocshmem/rocshmem4py/__init__.py
@@ -48,6 +48,11 @@ try:
         rocshmem_buffer_unregister,
         rocshmem_buffer_unregister_all,
         rocshmem_ptr,
+        rocshmem_query_qp_info,
+        rocshmem_qp_introspect_available,
+        rocshmem_qp_introspect_provider,
+        QpInfo,
+        QpInfoVendor,
         rocshmem_barrier_all,
         rocshmem_barrier,
         rocshmem_barrier_all_on_stream,
@@ -237,6 +242,9 @@ __all__ = [
     'ROCSHMEM_TEAM_INVALID',
     'ROCSHMEM_TEAM_WORLD',
     'TeamConfig',
+    # GDA queue-pair introspection
+    'QpInfo',
+    'QpInfoVendor',
     # Core framework-agnostic symmetric memory
     'SymmetricBuffer',
     'rocshmem_create_buffer',

--- a/python/rocshmem/src/rocshmem4py.cc
+++ b/python/rocshmem/src/rocshmem4py.cc
@@ -8,6 +8,7 @@
  */
 #include <nanobind/nanobind.h>
 #include <rocshmem/rocshmem.hpp>
+#include <rocshmem/qp_introspect.hpp>
 #include <hip/hip_runtime.h>
 #include <cstdint>
 #include <cstring>
@@ -21,6 +22,32 @@
 using namespace nanobind;
 using namespace rocshmem;
 using rocshmem4py::resolve_team_handle;
+
+namespace {
+
+// QpInfo carries a tagged union: only the arm named by `vendor` holds a defined
+// value. Reading another arm is undefined in C++, so the Python accessors gate
+// on the tag and raise instead of handing back whatever bytes happen to be
+// there. This is the whole reason the vendor fields are properties rather than
+// plain def_ro members.
+void require_vendor(const rocshmem::QpInfo &info, rocshmem::QpInfoVendor want,
+                    const char *field) {
+  if (info.vendor != want) {
+    std::ostringstream oss;
+    oss << "QpInfo." << field << " is only valid when vendor is "
+        << static_cast<uint32_t>(want) << "; this QP reports vendor "
+        << static_cast<uint32_t>(info.vendor);
+    // AttributeError, not RuntimeError: these are properties, and Python
+    // expects a failed attribute access to raise AttributeError. It is also
+    // what makes hasattr() answer correctly -- hasattr swallows only
+    // AttributeError, so with RuntimeError it propagates and
+    // hasattr(qp, "mlx5_dbrec") raises instead of returning False.
+    // nanobind maps attribute_error to Python's AttributeError.
+    throw nanobind::attribute_error(oss.str().c_str());
+  }
+}
+
+}  // namespace
 
 NB_MODULE(_rocshmem4py, m) {
   m.doc() = "Python bindings for ROCSHMEM library";
@@ -499,4 +526,134 @@ NB_MODULE(_rocshmem4py, m) {
   m.attr("ROCSHMEM_CMP_GE") = int_(static_cast<int>(ROCSHMEM_CMP_GE));
   m.attr("ROCSHMEM_CMP_LT") = int_(static_cast<int>(ROCSHMEM_CMP_LT));
   m.attr("ROCSHMEM_CMP_LE") = int_(static_cast<int>(ROCSHMEM_CMP_LE));
+
+  // -------------------------------------------------------------------------
+  // GDA queue-pair introspection
+  // -------------------------------------------------------------------------
+
+  enum_<QpInfoVendor>(m, "QpInfoVendor",
+      "NIC provider owning a QpInfo. Selects which vendor-specific "
+      "attributes are readable.")
+    .value("UNKNOWN", QpInfoVendor::UNKNOWN)
+    .value("IONIC", QpInfoVendor::IONIC)
+    .value("BNXT", QpInfoVendor::BNXT)
+    .value("MLX5", QpInfoVendor::MLX5);
+
+  class_<QpInfo>(m, "QpInfo",
+      "Device-visible resources of one peer's RC queue pair.\n\n"
+      "Addresses are device virtual addresses in the address space of the GPU "
+      "owning the QP; depths are in ring slots. The vendor-specific attributes "
+      "raise RuntimeError unless `vendor` matches.")
+    .def_ro("sq_buf", &QpInfo::sq_buf, "Send queue ring buffer.")
+    .def_ro("sq_prod", &QpInfo::sq_prod,
+        "Address of the live SQ producer counter. An external WQE builder must "
+        "continue this sequence rather than restart it, or its posts collide "
+        "with rocSHMEM's own.")
+    .def_ro("cq_buf", &QpInfo::cq_buf, "Completion queue ring buffer.")
+    .def_ro("base_heap", &QpInfo::base_heap,
+        "Local symmetric heap base for this QP.")
+    .def_ro("sq_depth", &QpInfo::sq_depth, "SQ capacity in WQE slots.")
+    .def_ro("cq_depth", &QpInfo::cq_depth, "CQ capacity in CQE slots.")
+    .def_ro("lkey", &QpInfo::lkey, "Local heap memory key.")
+    .def_ro("rkey", &QpInfo::rkey, "Peer heap memory key for this connection.")
+    .def_ro("qpn", &QpInfo::qpn, "QP number.")
+    .def_ro("vendor", &QpInfo::vendor, "Provider owning this QP.")
+
+    // ionic
+    .def_prop_ro("ionic_db", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::IONIC, "ionic_db");
+        return i.ionic.db;
+      }, "ionic: SQ doorbell register.")
+    .def_prop_ro("ionic_dbval", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::IONIC, "ionic_dbval");
+        return i.ionic.dbval;
+      }, "ionic: base doorbell value; the producer index is OR'ed in.")
+    .def_prop_ro("ionic_sq_mask", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::IONIC, "ionic_sq_mask");
+        return i.ionic.sq_mask;
+      }, "ionic: SQ index wrap mask (depth - 1).")
+    .def_prop_ro("ionic_cq_mask", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::IONIC, "ionic_cq_mask");
+        return i.ionic.cq_mask;
+      }, "ionic: CQ index wrap mask (depth - 1).")
+    .def_prop_ro("ionic_udma_idx", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::IONIC, "ionic_udma_idx");
+        return i.ionic.udma_idx;
+      }, "ionic: which of the NIC's two UDMA engines this QP is bound to.")
+
+    // mlx5
+    .def_prop_ro("mlx5_dbrec", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::MLX5, "mlx5_dbrec");
+        return i.mlx5.dbrec;
+      }, "mlx5: SQ doorbell record.")
+    .def_prop_ro("mlx5_bf", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::MLX5, "mlx5_bf");
+        return i.mlx5.bf;
+      }, "mlx5: BlueFlame register; the WQE itself is written here.")
+
+    // bnxt
+    .def_prop_ro("bnxt_dbr", [](const QpInfo &i) {
+        require_vendor(i, QpInfoVendor::BNXT, "bnxt_dbr");
+        return i.bnxt.dbr;
+      }, "bnxt: doorbell record.");
+
+  m.def("rocshmem_qp_introspect_provider",
+    []() { return rocshmem_qp_introspect_provider(); },
+    "The active GDA provider, whether or not it is supported here.\n\n"
+    "QpInfoVendor.UNKNOWN means rocSHMEM is not initialized or the backend is\n"
+    "not GDA. A known vendor together with rocshmem_qp_introspect_available()\n"
+    "== False means the NIC was detected but introspection is not implemented\n"
+    "for it yet (mlx5 and bnxt are TODO). Those two situations need different\n"
+    "fixes and are indistinguishable from a None result alone.\n\n"
+    "Safe to call before rocshmem_init().");
+
+  m.def("rocshmem_qp_introspect_available",
+    []() { return rocshmem_qp_introspect_available(); },
+    "True if QP introspection is usable here: rocSHMEM is initialized, the\n"
+    "active backend is GDA, and its provider is one this API can describe\n"
+    "(today, ionic). Check this to branch on capability rather than inferring\n"
+    "it from a None result -- None also means 'this peer/ctx_id names no QP',\n"
+    "which is a different situation.\n\n"
+    "False on an mlx5 or bnxt GDA backend: the NIC is detected but unsupported.\n"
+    "Use rocshmem_qp_introspect_provider() to tell that apart from 'no GDA'.\n\n"
+    "Safe to call before rocshmem_init() (returns False).");
+
+  m.def("rocshmem_query_qp_info",
+    [](int peer, int ctx_id) -> object {
+      // Caller errors raise; None is reserved for "not applicable in this
+      // environment". Collapsing both into None makes a bad argument
+      // indistinguishable from an unsupported backend, which is precisely the
+      // ambiguity that lets a broken caller look like an inactive one.
+      if (ctx_id <= 0) {
+        throw value_error(
+            "ctx_id must be > 0; ctx_id 0 is the default context that "
+            "rocSHMEM's own collectives drive, and posting external WQEs there "
+            "corrupts its bookkeeping and deadlocks subsequent collectives");
+      }
+      // Check the environment before the peer bound: without an active backend
+      // rocshmem_n_pes() is not meaningful, and "wrong backend" is the more
+      // useful answer than "bad peer".
+      if (!rocshmem_qp_introspect_available()) return none();
+
+      const int n_pes = rocshmem_n_pes();
+      if (peer < 0 || peer >= n_pes) {
+        std::ostringstream oss;
+        oss << "peer " << peer << " is out of range [0, " << n_pes << ")";
+        throw value_error(oss.str().c_str());
+      }
+
+      QpInfo info{};
+      if (!rocshmem_query_qp_info(peer, ctx_id, &info)) return none();
+      return cast(info);
+    },
+    "Describe the RC QP to `peer` within `ctx_id`.\n\n"
+    "Returns a QpInfo on success, or None when introspection does not apply in\n"
+    "this environment -- the backend is not GDA, the provider is unsupported, or\n"
+    "`ctx_id` names no QP (e.g. beyond the configured context count). Use\n"
+    "rocshmem_qp_introspect_available() to distinguish 'wrong backend' up front.\n\n"
+    "Raises ValueError for caller errors: ctx_id <= 0, or peer outside\n"
+    "[0, n_pes). ctx_id 0 is the default context that rocSHMEM's own collectives\n"
+    "drive; posting external WQEs there corrupts its bookkeeping and subsequent\n"
+    "collectives deadlock.",
+    arg("peer"), arg("ctx_id"));
 }

--- a/python/rocshmem/src/rocshmem4py.cc
+++ b/python/rocshmem/src/rocshmem4py.cc
@@ -543,7 +543,8 @@ NB_MODULE(_rocshmem4py, m) {
       "Device-visible resources of one peer's RC queue pair.\n\n"
       "Addresses are device virtual addresses in the address space of the GPU "
       "owning the QP; depths are in ring slots. The vendor-specific attributes "
-      "raise RuntimeError unless `vendor` matches.")
+      "raise AttributeError unless `vendor` matches, so hasattr() reports False "
+      "for the arms that do not apply.")
     .def_ro("sq_buf", &QpInfo::sq_buf, "Send queue ring buffer.")
     .def_ro("sq_prod", &QpInfo::sq_prod,
         "Address of the live SQ producer counter. An external WQE builder must "

--- a/python/rocshmem/src/rocshmem4py.cc
+++ b/python/rocshmem/src/rocshmem4py.cc
@@ -627,9 +627,10 @@ NB_MODULE(_rocshmem4py, m) {
       // ambiguity that lets a broken caller look like an inactive one.
       if (ctx_id <= 0) {
         throw value_error(
-            "ctx_id must be > 0; ctx_id 0 is the default context that "
-            "rocSHMEM's own collectives drive, and posting external WQEs there "
-            "corrupts its bookkeeping and deadlocks subsequent collectives");
+            "ctx_id must be > 0; ctx_id 0 is the default context whose "
+            "producer index, send-queue lock and cached doorbell position "
+            "rocSHMEM keeps to itself, and a queue shared with an external "
+            "builder does not run a workload to completion");
       }
       // Check the environment before the peer bound: without an active backend
       // rocshmem_n_pes() is not meaningful, and "wrong backend" is the more
@@ -653,8 +654,7 @@ NB_MODULE(_rocshmem4py, m) {
     "`ctx_id` names no QP (e.g. beyond the configured context count). Use\n"
     "rocshmem_qp_introspect_available() to distinguish 'wrong backend' up front.\n\n"
     "Raises ValueError for caller errors: ctx_id <= 0, or peer outside\n"
-    "[0, n_pes). ctx_id 0 is the default context that rocSHMEM's own collectives\n"
-    "drive; posting external WQEs there corrupts its bookkeeping and subsequent\n"
-    "collectives deadlock.",
+    "[0, n_pes). ctx_id 0 is the default context rocSHMEM drives itself; its\n"
+    "queue state is not safely shared with an external descriptor builder.",
     arg("peer"), arg("ctx_id"));
 }

--- a/python/rocshmem/tests/test_qp_introspect.py
+++ b/python/rocshmem/tests/test_qp_introspect.py
@@ -189,11 +189,13 @@ def test_available_implies_a_supported_provider(gda_qp):
 def test_default_context_raises(gda_qp):
     """ctx_id <= 0 is a caller error: that QP is the one rocSHMEM drives itself.
 
-    Posting external WQEs into the default context corrupts rocSHMEM's
-    send-queue bookkeeping and deadlocks collectives such as
-    rocshmem_barrier_all, so this is rejected rather than left to documentation.
-    It raises rather than returning None because it is a mistake in the call,
-    not a property of the environment.
+    The default context's producer index, send-queue lock and cached doorbell
+    position are private to rocSHMEM, and an external descriptor builder updates
+    none of them. Measured on ionic, external posts alone leave collectives
+    working, but a workload that also polls completions on that shared queue
+    does not finish, where the same workload on a user context does. Rejected
+    rather than left to documentation. It raises rather than returning None
+    because it is a mistake in the call, not a property of the environment.
     """
     for ctx_id in (0, -1):
         with pytest.raises(ValueError, match="ctx_id"):

--- a/python/rocshmem/tests/test_qp_introspect.py
+++ b/python/rocshmem/tests/test_qp_introspect.py
@@ -1,0 +1,218 @@
+"""Test GDA queue-pair introspection API (C and Python bindings).
+
+Validates :func:`rocshmem4py.rocshmem_query_qp_info`, which exposes GDA RC QP
+metadata for external WQE construction (see ``rocshmem/qp_introspect.hpp``).
+The C API returns false when the GDA backend is not active; the Python binding
+returns ``None`` in that case.
+
+Only the ionic vendor fields are implemented; mlx5 and bnxt are declared but
+unimplemented and return false at the C layer.
+
+Every test depends on the ``gda_qp`` fixture, which skips the module when
+introspection is unavailable. That is deliberate: without it an implementation
+that always returned ``None`` would satisfy this whole file -- the positive
+assertions would be skipped and the negative ones ("invalid input yields None")
+would hold trivially. Gating on a known-good QP means a stub cannot pass.
+
+The API splits its failure modes, and the tests check both halves:
+  * ``ValueError``    -- caller error (ctx_id <= 0, peer outside [0, n_pes)).
+  * ``None``          -- not applicable here: backend is not GDA, provider
+                         unsupported, or the ctx_id names no QP.
+  * ``rocshmem_qp_introspect_available()`` answers the environment question up
+    front, so callers need not infer capability from a null result.
+
+Run under torchrun (conftest selects init_with_torch when torch is present):
+
+    torchrun --nnodes=2 --node_rank=<0|1> --nproc_per_node=1 \
+      --master_addr=<ip> --master_port=<port> \
+      -m pytest python/rocshmem/tests/test_qp_introspect.py -v
+
+conftest's mpi4py path works as well. Plain ``mpirun`` + ``rocshmem_init()``
+needs an MPI that can create shared-memory windows, which is not available in
+every container.
+"""
+
+import pytest
+import rocshmem4py
+from conftest import requires_multi_pe, requires_torch
+
+# ctx_id 0 is the default context and is rejected by the C API; user contexts
+# start at 1. See qp_introspect.hpp on why describing the default-context QP is
+# unsafe for external WQE posting.
+USER_CTX = 1
+
+
+@pytest.fixture(scope="module")
+def gda_qp():
+    """A known-good QpInfo, or skip the module.
+
+    Guarantees every other test runs against a live GDA backend, so none of them
+    can pass vacuously.
+    """
+    qp = rocshmem4py.rocshmem_query_qp_info(0, USER_CTX)
+    if qp is None:
+        pytest.skip(
+            "GDA introspection unavailable (rocshmem_query_qp_info returned "
+            "None for peer 0, ctx 1) -- not the GDA backend, or built without it"
+        )
+    return qp
+
+
+def test_qp_info_core_fields_populated(gda_qp):
+    """Every vendor-neutral field is present and plausibly initialised."""
+    assert isinstance(gda_qp, rocshmem4py.QpInfo)
+    assert isinstance(gda_qp.vendor, rocshmem4py.QpInfoVendor)
+
+    assert gda_qp.sq_buf > 0, "sq_buf should be a valid device address"
+    assert gda_qp.sq_prod > 0, "sq_prod should be a valid device address"
+    assert gda_qp.cq_buf > 0, "cq_buf should be a valid device address"
+    assert gda_qp.base_heap > 0, "base_heap should be a valid device address"
+    assert gda_qp.sq_depth > 0, "sq_depth should be positive"
+    assert gda_qp.cq_depth > 0, "cq_depth should be positive"
+    assert gda_qp.lkey != 0, "lkey should be set"
+    assert gda_qp.rkey != 0, "rkey should be set"
+    assert gda_qp.qpn != 0, "qpn should be set"
+
+
+def test_qp_info_distinct_per_peer_and_context(gda_qp):
+    """Each (peer, ctx) names its own QP, so the descriptors must not collide.
+
+    A plausible implementation bug is to ignore ctx_id, or to return the same
+    connection for every peer; either would show up as duplicate qpn/sq_buf.
+    """
+    n_pes = rocshmem4py.rocshmem_n_pes()
+    seen = {}
+    for peer in range(n_pes):
+        for ctx_id in (1, 2):
+            qp = rocshmem4py.rocshmem_query_qp_info(peer, ctx_id)
+            if qp is None:
+                continue
+            key = (qp.qpn, qp.sq_buf)
+            assert key not in seen, (
+                f"(peer={peer}, ctx={ctx_id}) returned the same QP as "
+                f"{seen[key]}: qpn={qp.qpn} sq_buf={qp.sq_buf:#x}"
+            )
+            seen[key] = (peer, ctx_id)
+
+    assert len(seen) >= 2, "expected several distinct QPs across peers/contexts"
+
+
+@requires_torch
+@requires_multi_pe
+def test_rkey_matches_peer_lkey(gda_qp):
+    """The rkey this PE holds for a peer must equal that peer's own lkey.
+
+    This is the one assertion here that checks the values are *correct* rather
+    than merely present: the rkey is what a remote NIC quotes when writing into
+    our memory region, so if the key exchange were wrong the numbers would not
+    line up -- and no amount of non-zero checking would notice.
+    """
+    import torch.distributed as dist
+
+    me = rocshmem4py.rocshmem_my_pe()
+    n_pes = rocshmem4py.rocshmem_n_pes()
+
+    mine = {"pe": me, "lkey": gda_qp.lkey, "rkey_for": {}}
+    for peer in range(n_pes):
+        qp = rocshmem4py.rocshmem_query_qp_info(peer, USER_CTX)
+        if qp is not None:
+            mine["rkey_for"][peer] = qp.rkey
+
+    gathered = [None] * n_pes
+    dist.all_gather_object(gathered, mine)
+    by_pe = {g["pe"]: g for g in gathered if g is not None}
+
+    checked = 0
+    for peer, rkey in mine["rkey_for"].items():
+        if peer == me or peer not in by_pe:
+            continue
+        assert rkey == by_pe[peer]["lkey"], (
+            f"pe{me} holds rkey={rkey:#x} for pe{peer}, but pe{peer} reports "
+            f"lkey={by_pe[peer]['lkey']:#x} -- key exchange is inconsistent"
+        )
+        checked += 1
+
+    assert checked > 0, "no remote peer to check against"
+
+
+def test_vendor_fields_raise_attribute_error_on_mismatch(gda_qp):
+    """Vendor-specific properties raise AttributeError on the wrong vendor.
+
+    QpInfo is a tagged union: only the arm named by ``vendor`` is defined, so the
+    accessors gate on the tag rather than returning whatever bytes are there.
+    AttributeError (not RuntimeError) is required -- ``hasattr`` swallows only
+    AttributeError, so any other type makes ``hasattr(qp, "mlx5_dbrec")`` raise
+    instead of answering False.
+    """
+    if gda_qp.vendor != rocshmem4py.QpInfoVendor.IONIC:
+        pytest.skip(f"vendor {gda_qp.vendor} is implemented; test needs updating")
+
+    for field in ("ionic_db", "ionic_dbval", "ionic_sq_mask",
+                  "ionic_cq_mask", "ionic_udma_idx"):
+        assert hasattr(gda_qp, field), f"ionic QpInfo should expose {field}"
+
+    for field in ("mlx5_dbrec", "mlx5_bf", "bnxt_dbr"):
+        with pytest.raises(AttributeError, match=field.split("_")[0]):
+            getattr(gda_qp, field)
+        assert not hasattr(gda_qp, field), (
+            f"hasattr({field}) must be False on an ionic QpInfo; if this fails "
+            "the accessor is raising something other than AttributeError"
+        )
+
+
+def test_introspection_reports_available(gda_qp):
+    """The capability predicate agrees with the fixture that got a real QP."""
+    assert rocshmem4py.rocshmem_qp_introspect_available() is True
+
+
+def test_available_implies_a_supported_provider(gda_qp):
+    """available() must track the provider, not merely the backend.
+
+    Checking only for a GDA backend would report True on mlx5 or bnxt, where
+    query_qp_info then returns None -- the caller is told to go ahead and gets
+    nothing back, with no way to see why. available() is therefore true only for
+    providers this API implements, and provider() reports what was detected so a
+    caller can tell "no GDA here" from "GDA on a NIC we do not support yet".
+    """
+    provider = rocshmem4py.rocshmem_qp_introspect_provider()
+    assert provider != rocshmem4py.QpInfoVendor.UNKNOWN, (
+        "a QP was obtained, so a provider must have been detected"
+    )
+    assert provider == gda_qp.vendor, "provider() disagrees with the QP's vendor tag"
+
+    if rocshmem4py.rocshmem_qp_introspect_available():
+        assert rocshmem4py.rocshmem_query_qp_info(0, USER_CTX) is not None, (
+            "available() promised introspection but query_qp_info refused it"
+        )
+
+
+def test_default_context_raises(gda_qp):
+    """ctx_id <= 0 is a caller error: that QP is the one rocSHMEM drives itself.
+
+    Posting external WQEs into the default context corrupts rocSHMEM's
+    send-queue bookkeeping and deadlocks collectives such as
+    rocshmem_barrier_all, so this is rejected rather than left to documentation.
+    It raises rather than returning None because it is a mistake in the call,
+    not a property of the environment.
+    """
+    for ctx_id in (0, -1):
+        with pytest.raises(ValueError, match="ctx_id"):
+            rocshmem4py.rocshmem_query_qp_info(0, ctx_id)
+
+
+def test_out_of_range_peer_raises(gda_qp):
+    """A peer outside [0, n_pes) is a caller error and raises."""
+    n_pes = rocshmem4py.rocshmem_n_pes()
+    for peer in (n_pes + 10, -1):
+        with pytest.raises(ValueError, match="peer"):
+            rocshmem4py.rocshmem_query_qp_info(peer, USER_CTX)
+
+
+def test_unnamed_context_returns_none(gda_qp):
+    """A ctx_id past the configured context count names no QP -> None.
+
+    Distinct from the ValueError cases: the argument is well-formed, there just
+    is no such queue pair in this configuration. That is a property of the
+    environment, so it is reported the same way an unsupported backend is.
+    """
+    assert rocshmem4py.rocshmem_query_qp_info(0, 999) is None


### PR DESCRIPTION
> **Status: draft.** Held while an alternative is evaluated: reaching the queue pairs from device code via the already-public `rocshmem_get_device_ctx()`, which needs no new rocSHMEM API. If that path covers the same use case, this PR may be withdrawn rather than merged.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Expose the RC queue-pair state of the GDA backend so a caller can build and post its own RDMA descriptors into the queue pairs rocSHMEM has already established: SQ ring and producer counter, CQ ring, memory keys, QP number, and the provider-specific doorbell. Adds the C API (rocshmem_query_qp_info, rocshmem_qp_introspect_available, rocshmem_qp_introspect_provider), the rocshmem4py bindings, and tests.

**When this is needed**
For consumers that cannot link rocSHMEM's device bitcode into their own kernels but still want GPU-initiated transfers. The high-level device API (rocshmem_putmem_nbi() and friends) ships as bitcode; introspection lets such a consumer emit its own descriptors instead, with rocSHMEM still owning connection setup.
Also for consumers that already have a hand-rolled RDMA transport and would rather drive it over rocSHMEM's established connections than stand up queue pairs, memory registration and key exchange of their own.

**When it is NOT needed**
Calling rocSHMEM from device code does not need any of this, and does not need any change to rocSHMEM. The device API already ships as bitcode, and rocshmem_hipmodule_init() initialises the device globals in a JIT-compiled module, so a consumer can link the bitcode and call rocshmem_putmem_nbi() and friends directly. That path was confirmed working end to end on gfx950 against an unmodified rocSHMEM in a Triton-based consumer.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
**Choosing a context**
 ctx_id must be > 0. ctx_id 0 is the queue rocSHMEM drives itself,  with a producer index, send-queue lock and cached doorbell position private to it. Measured on ionic: a workload sharing that queue does not run to completion, while the same workload on a user context does.

**Reporting**
Failure modes are kept distinct so a caller can tell "this environment cannot do this" from "the arguments are wrong":
```
    rocshmem_qp_introspect_provider()   the detected GDA provider, or UNKNOWN when
                                        there is no GDA backend
    rocshmem_qp_introspect_available()  true only when the provider is one this
                                        API implements, so it does not promise a
                                        capability that query_qp_info refuses
    ValueError                          ctx_id <= 0, or peer outside [0, n_pes)
    None                                introspection does not apply here, or the
                                        ctx_id names no queue pair
 ```                                       
 On a detected-but-unimplemented provider, query_qp_info also logs a warning naming it once: to a caller that failure is otherwise indistinguishable from "no GDA backend", and the two need different fixes.

Vendor-specific fields are a tagged union: only the arm named by .vendor holds a defined value, and the Python accessors raise AttributeError on the others rather than returning whatever bytes are present. AttributeError specifically, so hasattr() answers False instead of propagating.

**Scope**
ionic (Pensando) is implemented. mlx5 and bnxt are TODO: their union arms are declared so adding them later does not change the ABI, but query_qp_info returns false for those providers today.

## Issue Tracking

JIRA ID: AIROCSHMEM-499

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested on gfx950 with the GDA(ionic) backend, 2 PEs, both single-node and across two nodes. Beyond the unit tests, a downstream Triton-based consumer used these fields to build ionic RDMA WRITE descriptors inside a GPU kernel and complete a 2-node all-to-all, which exercises every exposed field for its intended purpose, including completion detection through the CQ. The tests here gate on rocshmem_qp_introspect_available() so they skip, rather than silently pass, where GDA is not active.


## Test Result

Passed the unit tests and was able to confirm results of an all2all test using this feature.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

