### PR TITLE
perf(rocjitsu): use native SIMD width for f32 WMMA

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2329,10 +2329,11 @@ constexpr bool wmma_f32_f32_native_width_supported(uint32_t n, uint32_t width) {
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
 /// F16C convert — the hoist reads each operand word straight through observed
 /// register-access regions. Compile-time M/N/K fully unroll the matmul, looped
-/// over N in native-width chunks. The specialization requires a usable native
-/// SIMD width that evenly divides N. Otherwise it delegates to exec_wmma_f32,
-/// whose generic implementation may still use native-width SIMD with a scalar
-/// tail.
+/// over N in native-width chunks. The specialization is bypassed when host SIMD
+/// is unavailable, the native width is one or does not evenly divide N, or
+/// force-scalar is enabled. The generic exec_wmma_f32 path may still use
+/// native-width SIMD with a scalar tail when SIMD is available but N is not
+/// divisible by the native width.
 template <uint32_t M, uint32_t N, uint32_t K>
 void exec_wmma_f32_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc = ACC_FROM_VGPR, uint32_t c_modifier = 0) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2322,12 +2322,17 @@ void exec_wmma_f32_f8_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uin
   }
 }
 
+constexpr bool wmma_f32_f32_native_width_supported(uint32_t n, uint32_t width) {
+  return width > 1 && n % width == 0;
+}
+
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
 /// F16C convert — the hoist reads each operand word straight through observed
 /// register-access regions. Compile-time M/N/K fully unroll the matmul, looped
-/// over N in native-width chunks. Falls back to generic exec_wmma_f32 without
-/// host SIMD, when N is not divisible by the native width, or under
-/// force-scalar.
+/// over N in native-width chunks. The specialization requires a usable native
+/// SIMD width that evenly divides N. Otherwise it delegates to exec_wmma_f32,
+/// whose generic implementation may still use native-width SIMD with a scalar
+/// tail.
 template <uint32_t M, uint32_t N, uint32_t K>
 void exec_wmma_f32_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc = ACC_FROM_VGPR, uint32_t c_modifier = 0) {
@@ -2338,7 +2343,7 @@ void exec_wmma_f32_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, ui
     return;
   } else {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
-    if (util::force_scalar() || W <= 1 || N % W != 0) {
+    if (util::force_scalar() || !wmma_f32_f32_native_width_supported(N, W)) {
       exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
                     const_acc, c_modifier);
       return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2324,27 +2324,26 @@ void exec_wmma_f32_f8_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uin
 
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
 /// F16C convert — the hoist reads each operand word straight through observed
-/// register-access regions.
-/// Compile-time M/N/K fully unroll the matmul, looped over N in zmm-width chunks
-/// (N a multiple of 16). Falls back to generic exec_wmma_f32 without AVX-512 /
-/// under force-scalar.
+/// register-access regions. Compile-time M/N/K fully unroll the matmul, looped
+/// over N in native-width chunks. Falls back to generic exec_wmma_f32 without
+/// host SIMD, when N is not divisible by the native width, or under
+/// force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K>
 void exec_wmma_f32_f32_spec(auto &cu, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                             uint32_t const_acc = ACC_FROM_VGPR, uint32_t c_modifier = 0) {
   constexpr uint32_t in_bits = 32;
-  static_assert(N % 16 == 0, "specialized f32 WMMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
                   const_acc, c_modifier);
     return;
   } else {
-    if (util::force_scalar() || util::native<float>::size() != 16) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    if (util::force_scalar() || W <= 1 || N % W != 0) {
       exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
                     const_acc, c_modifier);
       return;
     }
     require_wmma_wave32(cu);
-    constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
     auto reads = read_wmma_fast_path_regions(cu, s0, s1, s2, M, N, K, in_bits, /*acc_bits=*/32,
                                              const_acc, wf);

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3020,6 +3020,39 @@ TEST(ExecutionPluginTest, WmmaReadObservationSkipsConstantAccumulator) {
                        0xFFFF'FFFFu);
 }
 
+TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "stdx SIMD is unavailable";
+  } else {
+    constexpr uint32_t M = 16, N = 16, K = 4;
+    constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
+    if (width <= 1 || N % width != 0)
+      GTEST_SKIP() << "f32 WMMA shape is not divisible by the native SIMD width";
+
+    ForceScalarOverride force_simd(false);
+    Wave32PluginFixture f;
+    auto *plugin = f.attach_ordering_plugin();
+    auto *cu = f.cu.get();
+    auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+    ASSERT_NE(wf, nullptr);
+    ASSERT_EQ(wf->wf_size(), 32u);
+
+    const uint32_t vb = wf->vgpr_alloc().base;
+    constexpr uint32_t S0 = 0, S1 = 16, ACC = 32, DST = 48;
+    for (uint32_t reg = 0; reg < 64; ++reg)
+      for (uint32_t lane = 0; lane < 32; ++lane)
+        cu->write_vgpr(vb + reg, lane, 0x3f80'0000u);
+
+    amdgpu::exec_wmma_f32_f32_spec<M, N, K>(*cu, vb + DST, vb + S0, vb + S1, vb + ACC,
+                                            amdgpu::ACC_FROM_VGPR);
+
+    expect_vgpr_read_set(vgpr_read_events(*plugin), vb,
+                         {S0 + 0, S0 + 1, S1 + 0, S1 + 1, ACC + 0, ACC + 1, ACC + 2, ACC + 3,
+                          ACC + 4, ACC + 5, ACC + 6, ACC + 7},
+                         0xFFFF'FFFFu);
+  }
+}
+
 TEST(ExecutionPluginTest, MfmaReadObservationReportsRace) {
   PluginFixture f(/*num_wf_slots=*/1);
   f.plugin_group_ = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3020,13 +3020,19 @@ TEST(ExecutionPluginTest, WmmaReadObservationSkipsConstantAccumulator) {
                        0xFFFF'FFFFu);
 }
 
+static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 1));
+static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 4));
+static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 8));
+static_assert(amdgpu::wmma_f32_f32_native_width_supported(16, 16));
+static_assert(!amdgpu::wmma_f32_f32_native_width_supported(16, 32));
+
 TEST(ExecutionPluginTest, WmmaF32NativeWidthFastPathUsesRegionReads) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "stdx SIMD is unavailable";
   } else {
     constexpr uint32_t M = 16, N = 16, K = 4;
     constexpr uint32_t width = static_cast<uint32_t>(util::native<float>::size());
-    if (width <= 1 || N % width != 0)
+    if (!amdgpu::wmma_f32_f32_native_width_supported(N, width))
       GTEST_SKIP() << "f32 WMMA shape is not divisible by the native SIMD width";
 
     ForceScalarOverride force_simd(false);


### PR DESCRIPTION
rocJITsu has a specialized SIMD implementation for f32-input WMMA instructions. It snapshots the input and accumulator register regions, performs the matrix multiplication in host SIMD chunks, and then publishes the results.

The implementation previously required `native_simd<float>` to have exactly 16 lanes. This enabled the fast path in an AVX-512-targeted build, but portable and AVX2-targeted builds fell back to the generic implementation even when host SIMD was available.

This change uses the SIMD width selected by the compiler, provided the WMMA column count divides evenly into that width. Builds without usable SIMD, incompatible shapes, and executions with `RJ_FORCE_SCALAR=1` continue to use the existing generic path. The register-observation behavior used by execution plugins is preserved and covered by a focused test.

No rocJITsu-specific build option or environment variable is required to enable the path. `std::experimental::native_simd` selects the width at compile time from the compiler target. A portable x86-64 build may use four f32 lanes, an AVX2-targeted build commonly uses eight, and an AVX-512-targeted build commonly uses sixteen. CPU capability alone does not widen an already-compiled binary. `RJ_FORCE_SCALAR=1` explicitly disables SIMD at runtime.

This is the WMMA part of a broader matrix-execution optimization effort. The related PRs are:

- #8594 — the original combined MFMA/WMMA optimization explored by atgutier; now closed.
- #10702 — enables native-width SIMD for the f32 MFMA path.
- #10706 — snapshots operands in the scalar f32 MFMA path.
- This PR — enables native-width SIMD for the separate f32 WMMA path.

The three replacement PRs are independent and may be reviewed and merged in any order.

Performance was measured against exact parent `a733524822` on a 12-core, 24-thread AMD host with AVX2 and AVX-512 support. Both revisions were built in Release mode using AMD Clang 22 from ROCm 7.2.0, with `-O3 -DNDEBUG` and no explicit `-march`. This portable build uses four-lane `native_simd<float>`. The gfx1250 tests ran with SIMD enabled and `RJ_FORCE_SCALAR` unset.

Each measured process executes six GEMMs: one cold iteration followed by five timed iterations. The wall time measures the complete process. The hipBLASLt time is the reported time for one timed GEMM, averaged within that process. Consequently, the wall-time saving includes the improvement across all six GEMM executions.

One additional process per revision was used as a warm-up and excluded. The order of the parent and candidate processes was alternated between measured pairs.

| GEMM | Pair | Parent wall (s) | Candidate wall (s) | Parent per-GEMM (s) | Candidate per-GEMM (s) |
|---|---:|---:|---:|---:|---:|
| 512³ | 1 | 8.526 | 7.024 | 1.19402 | 0.924448 |
| 512³ | 2 | 8.481 | 6.966 | 1.17552 | 0.918438 |
| 512³ | 3 | 8.543 | 6.941 | 1.16983 | 0.919613 |
| 512³ | 4 | 8.615 | 7.054 | 1.18641 | 0.921321 |
| 512³ | 5 | 8.603 | 7.024 | 1.19105 | 0.913132 |
| **512³ median** | **5 runs** | **8.543** | **7.024** | **1.18641** | **0.919613** |
| 768³ | 1 | 24.758 | 19.571 | 3.84933 | 2.99213 |
| 768³ | 2 | 25.291 | 20.028 | 3.93806 | 3.04712 |
| 768³ | 3 | 24.953 | 20.016 | 3.89094 | 3.06302 |
| **768³ median** | **3 runs** | **24.953** | **20.016** | **3.89094** | **3.04712** |

Speedups are calculated by dividing the displayed parent median by the candidate median:

| f32 GEMM | Complete-process speedup | Per-GEMM speedup |
|---|---:|---:|
| 512×512×512 | **1.22x** | **1.29x** |
| 768×768×768 | **1.25x** | **1.28x** |

A separate nonzero 256×256×256 verification run completed with `norm_error=0` for both the exact parent and candidate. Focused WMMA, gfx1250, and execution-plugin validation selected 64 tests: 63 passed and one unrelated configuration-dependent test was skipped. Pre-commit passed.

The instruction-throughput plugin was also run separately from the wall-time benchmark. MIPS here means millions of executed wave instructions per host second; one instruction is counted when a wavefront reaches the execution hook, without multiplying by the number of active lanes.

| Throughput-plugin metric | Parent median | Candidate median | Speedup |
|---|---:|---:|---:|
| Active-dispatch throughput | 1.779 MIPS | 2.156 MIPS | **1.21x** |
| Matrix-handler throughput | 0.1725 MIPS | 0.3630 MIPS | **2.10x** |

Active-dispatch throughput uses all wave instructions divided by the sum of completed dispatch durations. Matrix-handler throughput uses only matrix instructions and the time measured inside their execution callbacks. The values are medians from four balanced, valid 512×512×512 parent/candidate pairs after one excluded warm-up, with the throughput plugin enabled alone and fixed CPU affinity. Every included sample contained the same 13 dispatches, 24,202,321 total wave instructions, and 786,432 matrix instructions. The plugin adds observer overhead, so these values should be compared with each other rather than with the no-plugin wall-time results above.

Related: #9577

