### PR TITLE
fix(hip-tests): correct amd_linux disable typo for cross-device graph…

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1408,7 +1408,7 @@ graph:
     <<: *level_2
     tags: [exec]
     # ROCM-22772: Temporarily disabled until multi-device graph is added
-    disabled: [amd_windows. amd_linux]
+    disabled: [amd_windows, amd_linux]
   Unit_hipGraphCrossDeviceLaunch_ExplicitNodes:
     <<: *level_2
     tags: [exec]


### PR DESCRIPTION
… test

A period instead of a comma in the disabled list prevented Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering from being disabled on amd_linux, causing nightly hipErrorNotSupported (801) failures.

ROCM-30026 / ROCM-22772

## Motivation

Correct yaml syntax

## Technical Details

Need , delimeter

## Issue Tracking
JIRA ID: ROCM-30026

## Test Plan

Rebuild hip-tests and run Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering 

## Test Result

Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering not found.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
