### PR TITLE
hipGraph: propagate UpdateAQLPacket failure out of hipGraphExecUpdate

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2830,6 +2830,17 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
         auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
         if (newGraphNodes[i]->GraphCaptureEnabled()) {
           status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(oldGraphExecNodes[i]));
+          if (status != hipSuccess) {
+            // A packet re-capture failure (e.g. kernarg allocation under device-memory
+            // exhaustion) leaves the exec holding the previously captured packet.
+            // Reporting success here makes the next launch execute that stale packet:
+            // silent wrong output, and with kernarg-pool recycling a malformed AQL
+            // packet (see issue #10021). Surface the failure instead, matching the
+            // SetParams failure paths above.
+            *hErrorNode_out = reinterpret_cast<hipGraphNode_t>(newGraphNodes[i]);
+            *updateResult_out = hipGraphExecUpdateError;
+            HIP_RETURN(hipErrorGraphExecUpdateFailure);
+          }
         }
       }
     } else {

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -8,6 +8,7 @@
 # But this exposes several problems with hipcc and build system on windows.
 # While those are fixed, this hack should allow us to pass windows CI.
 set(TEST_SRC
+  hipGraphExecUpdate_error_propagation_test.cc
   hipGraphAddEmptyNode.cc
   hipGraphAddDependencies.cc
   hipGraphAddEventRecordNode.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate_error_propagation_test.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate_error_propagation_test.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipGraphExecUpdate hipGraphExecUpdate
+ * @{
+ * @ingroup GraphTest
+ * Regression test for the hipGraphExecUpdate error-propagation contract under
+ * kernel-argument exhaustion (companion to
+ * https://github.com/ROCm/rocm-systems/issues/10021: the bulk update loop
+ * previously assigned the UpdateAQLPacket failure to a local and returned
+ * hipSuccess, leaving the previously captured packet to launch).
+ */
+
+#include <hip_test_common.hh>
+
+#include <vector>
+
+namespace {
+__global__ void WriteValue(int* out, int value) { *out = value; }
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Exhausts device memory, then repeatedly modifies a one-kernel graph and
+ *    calls hipGraphExecUpdate + hipGraphLaunch until the update path fails.
+ *    The contract under test:
+ *      1. The failure MUST surface from hipGraphExecUpdate itself as
+ *         hipErrorGraphExecUpdateFailure, with hErrorNode_out and
+ *         updateResult_out set — never as hipSuccess (the propagation defect:
+ *         a stale kernel-argument packet then launches silently).
+ *      2. Every iteration whose calls all report success must produce the
+ *         freshly-updated value (no stale packet).
+ *      3. Destroying and re-instantiating the exec after the failure must
+ *         recover: the rebuild reclaims kernarg pool space, and a subsequent
+ *         update + launch succeeds and verifies (the framework fallback
+ *         pattern, e.g. ggml's destroy+reinstantiate on this error code).
+ * Test source
+ * ------------------------
+ *  - unit/graph/hipGraphExecUpdate_error_propagation_test.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+HIP_TEST_CASE(Unit_hipGraphExecUpdate_ExhaustionErrorPropagation) {
+  int* d_out{nullptr};
+  HIP_CHECK(hipMalloc(&d_out, sizeof(int)));
+
+  hipGraph_t graph{};
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  int value = 0;
+  void* kernelArgs[] = {&d_out, &value};
+  hipKernelNodeParams nodeParams{};
+  nodeParams.func = reinterpret_cast<void*>(WriteValue);
+  nodeParams.gridDim = dim3(1);
+  nodeParams.blockDim = dim3(1);
+  nodeParams.sharedMemBytes = 0;
+  nodeParams.kernelParams = kernelArgs;
+  nodeParams.extra = nullptr;
+  hipGraphNode_t kNode{};
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, graph, nullptr, 0, &nodeParams));
+
+  hipGraphExec_t graphExec{};
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  value = 1;
+  HIP_CHECK(hipGraphLaunch(graphExec, nullptr));
+  HIP_CHECK(hipStreamSynchronize(nullptr));
+
+  // Exhaust device memory: greedy halving-probe allocation, keeping every block.
+  std::vector<void*> hogs;
+  size_t chunk = size_t{1} << 30;
+  while (chunk >= (size_t{4} << 10)) {
+    void* p{nullptr};
+    if (hipMalloc(&p, chunk) == hipSuccess) {
+      hogs.push_back(p);
+    } else {
+      chunk >>= 1;
+    }
+  }
+  static_cast<void>(hipGetLastError());  // clear the expected final OOM
+
+  // Drive updates until the update path fails (budget as in
+  // hipGraphExecUpdate_oom_test.cc; observed on a 24 GB gfx1100 well inside it).
+  constexpr int kIters = 262144;
+  bool sawUpdateFailure = false;
+  int lastGood = 1;
+  for (int i = 2; i <= kIters; ++i) {
+    value = i;
+    HIP_CHECK(hipGraphKernelNodeSetParams(kNode, &nodeParams));
+    hipGraphNode_t errorNode{};
+    hipGraphExecUpdateResult updateResult{};
+    const hipError_t status =
+        hipGraphExecUpdate(graphExec, graph, &errorNode, &updateResult);
+    if (status != hipSuccess) {
+      // Contract 1: the exhaustion failure surfaces as the update-failure
+      // code with the out-parameters populated.
+      REQUIRE(status == hipErrorGraphExecUpdateFailure);
+      REQUIRE(errorNode != nullptr);
+      REQUIRE(updateResult == hipGraphExecUpdateError);
+      sawUpdateFailure = true;
+      break;
+    }
+    hipError_t rc = hipGraphLaunch(graphExec, nullptr);
+    if (rc == hipSuccess) rc = hipStreamSynchronize(nullptr);
+    if (rc != hipSuccess) break;  // exhaustion may also surface here: clean, acceptable
+    int seen = -1;
+    HIP_CHECK(hipMemcpy(&seen, d_out, sizeof(int), hipMemcpyDeviceToHost));
+    // Contract 2: success means the NEW packet ran (no stale kernel args).
+    REQUIRE(seen == i);
+    lastGood = i;
+  }
+
+  if (sawUpdateFailure) {
+    // Contract 3: destroy + re-instantiate recovers (the rebuild reclaims
+    // the exec's kernarg pool), and the next update + launch verifies.
+    HIP_CHECK(hipGraphExecDestroy(graphExec));
+    graphExec = nullptr;
+    HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    value = lastGood + 1;
+    HIP_CHECK(hipGraphKernelNodeSetParams(kNode, &nodeParams));
+    hipGraphNode_t errorNode{};
+    hipGraphExecUpdateResult updateResult{};
+    HIP_CHECK(hipGraphExecUpdate(graphExec, graph, &errorNode, &updateResult));
+    HIP_CHECK(hipGraphLaunch(graphExec, nullptr));
+    HIP_CHECK(hipStreamSynchronize(nullptr));
+    int seen = -1;
+    HIP_CHECK(hipMemcpy(&seen, d_out, sizeof(int), hipMemcpyDeviceToHost));
+    REQUIRE(seen == lastGood + 1);
+  }
+
+  for (void* p : hogs) {
+    static_cast<void>(hipFree(p));
+  }
+  static_cast<void>(hipGraphExecDestroy(graphExec));
+  static_cast<void>(hipGraphDestroy(graph));
+  static_cast<void>(hipFree(d_out));
+}
+
+/**
+ * End doxygen group GraphTest.
+ * @}
+ */


### PR DESCRIPTION
## Motivation

Fix the silent stale-packet execution behind https://github.com/ROCm/rocm-systems/issues/10021: hipGraphExecUpdate's bulk update loop assigns UpdateAQLPacket()'s error to `status` without checking it and falls through to HIP_RETURN(hipSuccess) (hip_graph.cpp:2829 at the therock-7.14 tag; 2832 on current develop, where this PR applies). Under device-memory exhaustion the packet re-capture legitimately fails (with the checks from PR #10022); the API reports success while the exec keeps the previously captured packet, and the next launch executes it: silent wrong output, and with kernarg-pool recycling eventually a malformed AQL packet (CP fault + queue abort observed on gfx1100).

Stated up front, what this PR does not fix: the allocation behavior that makes the failure inevitable. GraphKernelArgManager allocates bump-style; slots are never reclaimed within an exec's lifetime, so a long-lived exec updated per token exhausts its pool by design — filed separately as #10713. The right long-term fix is slot reuse on update; this PR makes the failure survivable and honest until then.

## Technical Details

Surface the failure as hipErrorGraphExecUpdateFailure with hErrorNode_out and hipGraphExecUpdateError set, matching the SetParams failure paths in the same function and the de-facto contract frameworks code against. All other UpdateAQLPacket call sites already propagate their status; this is the only drop, and it is the path graph-reusing frameworks call per token.

Consequences by consumer type, measured on gfx1100: frameworks that destroy + re-instantiate on this code (llama.cpp/ggml) recover in place — 25 consecutive recovery cycles at 0 MiB free, one failure per ~4.1k updates, 102,600 verified-bit-exact launches, no resource creep, and no reoccurrence of the #10021-addendum residual defect (the rebuild resets the pool state it required). Frameworks that do not re-instantiate see persistent clean errors instead of corruption.

Patches and standalone reproducers: https://github.com/OhgurLabs/rocm-hipgraph-fixes

## Issue Tracking

GitHub issue: https://github.com/ROCm/rocm-systems/issues/10021
GitHub issue: https://github.com/ROCm/rocm-systems/issues/10713

## Test Plan

The PR #10022 regression test scenario, run standalone on gfx1100/therock-7.14 across three configurations (stock, #10022 only, #10022 + this change), plus a headroom control with no exhaustion, plus a sustained-inference soak at c=217088 (llama.cpp master, GGML_HIP_GRAPHS on, MTP speculative decode) at the VRAM floor.

## Test Result

Stock: SIGSEGV. #10022 only: silent value mismatch (rounds 85,159 / 148,771). #10022 + this change: clean failure with errorNode set. Headroom control: 262,144/262,144 rounds bit-exact. Soak: 23 cells / 32 deep runs, zero segfaults, zero mismatches, deepest 209,439 tokens.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.