### PR TITLE
ci: add nightly CLR language-runtime tests on OrchestrAI

### DIFF
--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -1,0 +1,247 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Configuration for the CLR language-runtime OrchestrAI CI
+# (.github/workflows/clr-orchestrai-nightly.yml).
+#
+# This is the ONE place that holds environment-specific values. Everything the
+# workflow needs to know about the upstream TheRock build and the OrchestrAI test
+# fleet lives here, so the workflow YAML and the .github/scripts/orchestrai_*.py
+# helpers stay generic.
+#
+# NOTE: this repo is PUBLIC. Internal coordinates (pipeline host, MAAS broker
+# tags, driver package URLs) are NOT committed here — they are injected at run
+# time from repo variables/secrets and take precedence over the empty fallbacks
+# below. See the workflow header for the full list.
+
+# ---------------------------------------------------------------------------
+# OrchestrAI pipeline entry point
+# ---------------------------------------------------------------------------
+# Set as repo variables (Settings -> Secrets and variables -> Actions -> Variables):
+#   ORCHESTRAI_PIPELINE_URL   e.g. https://<pipeline-host>
+#   ORCHESTRAI_PIPELINE_JOB   e.g. <pipeline-job>
+# The pipeline URL MUST be a variable, not a secret: the build URL derived from
+# it is passed between jobs as a job output, and GitHub redacts secret values
+# from job outputs, which would blank the build_urls handed to the test jobs.
+pipeline:
+  url: ""
+  job: ""
+
+# ---------------------------------------------------------------------------
+# Upstream TheRock build to test
+# ---------------------------------------------------------------------------
+# We do not build anything here. Each run picks up the most recent
+# TheRock Multi-Arch CI run on this repo that actually published artifacts for
+# the families we need, and points the test machines at those artifacts.
+#
+# Artifacts land at:
+#   {artifact_base_url}/{artifact_prefix_template}/<artifact>.tar.zst
+# e.g.
+#   https://therock-ci-artifacts-external.s3.us-east-2.amazonaws.com/
+#     ROCm-rocm-systems/32676513434-linux/core-hiptests_test_generic.tar.zst
+source_build:
+  # Workflow whose artifacts we consume. therock-multi-arch-ci.yml is the one
+  # that builds the client families (gfx110X / gfx120X) on BOTH Linux and
+  # Windows. therock-multi-arch-ci-nightly.yml is data-center only
+  # (gfx94X/gfx950/gfx125X + Windows gfx1151) and is deliberately NOT used here.
+  workflow: "therock-multi-arch-ci.yml"
+  branch: "develop"
+
+  # Repo that runs the workflow above. Empty = this repo, which is what we want
+  # once this lands on ROCm/rocm-systems. Set the ORCHESTRAI_SOURCE_REPOSITORY
+  # repo variable to "ROCm/rocm-systems" when running from a FORK, so a test run
+  # reads the real builds instead of the fork's (empty) workflow history. Using a
+  # variable rather than editing this line keeps a fork's branch byte-identical
+  # to what eventually merges.
+  repository: ""
+
+  # How far back to look for a usable run. The build jobs of a Multi-Arch CI run
+  # frequently succeed while some downstream test job fails, so the run's overall
+  # conclusion is NOT a useful signal — a run is usable when its artifacts exist.
+  # Runs are scanned newest-first and the first one carrying every required
+  # artifact wins.
+  max_runs_to_scan: 40
+  max_age_hours: 48
+
+  artifact_base_url: "https://therock-ci-artifacts-external.s3.us-east-2.amazonaws.com"
+  artifact_prefix_template: "ROCm-rocm-systems/{run_id}-{platform}"
+
+  # Artifacts that must exist for a run to count as usable on a platform. These
+  # are the CLR/language-runtime pieces the suites below consume.
+  # NOTE: core-runtime (ROCr) is Linux-only — Windows gets its GPU runtime from
+  # the AMD display driver — so it is deliberately absent from the Windows list.
+  required_artifacts:
+    linux:
+      - "core-hip_lib_generic.tar.zst"
+      - "core-runtime_lib_generic.tar.zst"
+      - "core-hiptests_test_generic.tar.zst"
+      - "core-ocl_test_generic.tar.zst"
+    windows:
+      - "core-hip_lib_generic.tar.zst"
+      - "core-hiptests_test_generic.tar.zst"
+      - "core-ocl_test_generic.tar.zst"
+
+  # Per-family marker proving the family was part of that run's dist. The core-*
+  # artifacts above are family-independent ("generic"), so they cannot tell us
+  # which GPU families a run actually built. Any artifact carrying the family's
+  # gfx suffix works; blas_lib_<target> is published on both platforms.
+  family_markers:
+    gfx110X-all: "blas_lib_gfx1100.tar.zst"
+    gfx120X-all: "blas_lib_gfx1200.tar.zst"
+    gfx1151: "blas_lib_gfx1151.tar.zst"
+
+# ---------------------------------------------------------------------------
+# Test suites
+# ---------------------------------------------------------------------------
+# Each suite becomes one group in the OrchestrAI pipeline plan and one GitHub
+# Actions job. `test` is a path in the OrchestrAI test library; {platform} is
+# filled in (linux|windows).
+#
+# Adding a suite is a config-only change: import the test into the test library,
+# then add an entry here. `required: true` makes a failure fail the run's gate;
+# start new suites at false while they stabilise.
+suites:
+  hip-catch2:
+    description: "HIP Catch2 unit tests (projects/hip-tests/catch)"
+    test: "L1-whb/hip/{platform}/unit_func-hip_catch2"
+    platforms: ["linux"]
+    devices: ["navi3x", "navi4x"]
+    required: false
+
+  # Placeholders for the suites the language-runtime CQE team is still migrating
+  # out of Skynet. Uncomment each one once its test exists in the test library
+  # under the path below; the workflow needs no change.
+  #
+  # hip-catch2-windows:
+  #   description: "HIP Catch2 unit tests on Windows"
+  #   test: "L1-whb/hip/{platform}/unit_func-hip_catch2"
+  #   platforms: ["windows"]
+  #   devices: ["navi3x", "navi4x"]
+  #   required: false
+  #
+  # opencl-conformance:
+  #   description: "OpenCL CTS subset against the CLR OpenCL runtime"
+  #   test: "L1-whb/opencl/{platform}/unit_func-opencl_cts"
+  #   platforms: ["linux", "windows"]
+  #   devices: ["navi3x", "navi4x"]
+  #   required: false
+
+# ---------------------------------------------------------------------------
+# Device fleet
+# ---------------------------------------------------------------------------
+# Device -> MAAS broker tags. These are internal fleet tag names, so they are
+# NOT committed to this public repo — set them via the ORCHESTRAI_DEVICE_TAGS
+# repo variable as a JSON map, e.g.
+#   {"navi3x":["gpuarch_rdna3"],"navi4x":["gpuarch_rdna4"],"stxh":["apu_stxh"]}
+# A device with no entry is skipped with a warning (the broker could never
+# satisfy a batch tagged with a raw device name — it would queue and time out).
+device_to_tags: {}
+
+# Device -> TheRock AMDGPU family. Selects which per-family artifacts are
+# installed on the machine, and which family_marker above must be present in the
+# source run for this device to be scheduled.
+# Device keys are GPU ARCHITECTURES, not SKUs. The OrchestrAI broker selects by
+# architecture tag (gpuarch_rdna3 matches every RDNA3 board in the fleet), so
+# naming a device "rx7900xt" here would imply a precision the tag does not have.
+device_to_family:
+  navi3x: "gfx110X-all"
+  navi4x: "gfx120X-all"
+  stxh: "gfx1151" # Strix Halo APU
+
+# Device family controls Linux kernel-driver policy. Radeon discrete GPUs use
+# AMD's packaged amdgpu/DKMS driver; Ryzen APUs use the Ubuntu inbox amdgpu
+# module. An unclassified Linux device is rejected before hardware is acquired
+# rather than silently getting the wrong driver policy.
+device_families:
+  navi3x: "radeon"
+  navi4x: "radeon"
+  stxh: "ryzen_apu"
+
+# Devices to skip entirely (e.g. temporarily offline hardware).
+#
+# stxh is skipped because therock-multi-arch-ci.yml does not build gfx1151
+# today. To light up the APU leg: add gfx1151 to the workflow's
+# linux_amdgpu_families / windows_amdgpu_families, then remove it from this list
+# and add it to the relevant suites' `devices`. Until then the resolver would
+# drop it anyway (no gfx1151 family marker), so skipping keeps the log quiet.
+skip_devices: ["stxh"]
+
+# ---------------------------------------------------------------------------
+# Per-run pipeline settings
+# ---------------------------------------------------------------------------
+run_settings:
+  max_duration: 300 # minutes, whole batch
+  max_test_case_duration: 120 # minutes, single suite
+  acquire_timeout: 30 # minutes, machine acquire
+  # Machines to acquire per hardware group. 1 = all suites on the same device
+  # share one machine and run sequentially (saves scarce hardware). Overridable
+  # per run via the machines_per_hw_group workflow_dispatch input.
+  default_machines_per_hw_group: 1
+
+# ---------------------------------------------------------------------------
+# Provisioning: GPU stack installed on the acquired machine before the tests.
+# ---------------------------------------------------------------------------
+# Script paths resolve inside the OrchestrAI provisioning repository.
+#
+# linux-therock-artifacts.sh is the artifact-based counterpart of the existing
+# linux-therock-tarball.sh, and is what makes these runs possible: TheRock's
+# Multi-Arch CI publishes per-component artifacts but no single dist tarball,
+# so a host cannot be provisioned from one URL. Its Windows equivalent,
+# windows-therock-artifacts.ps1, is not written yet — which is why no suite
+# below lists windows.
+#
+# The script receives these env vars from `vars` in the pipeline build payload
+# and installs ROCm by running TheRock's own installer:
+#
+#   THEROCK_RUN_ID            GitHub Actions run id of the source build
+#   THEROCK_RUN_REPO          repo that run belongs to (ROCm/rocm-systems)
+#   THEROCK_AMDGPU_FAMILY     e.g. gfx110X-all
+#   THEROCK_ARTIFACT_BASE_URL fully-resolved S3 prefix for that run+platform
+#
+#   git clone --depth 1 https://github.com/ROCm/TheRock
+#   python build_tools/install_rocm_from_artifacts.py \
+#     --run-id "$THEROCK_RUN_ID" --run-github-repo "$THEROCK_RUN_REPO" \
+#     --amdgpu-family "$THEROCK_AMDGPU_FAMILY" \
+#     --output-dir "${DEPS_DIR:-/var/tmp/_testdeps}/therock_sdk"
+#
+# The output dir matters: the test library's app.hip.catch2-tests hard-codes
+# SDK_DIR="${DEPS_DIR}/therock_sdk" and only checks that the directory exists.
+# Installing there means the existing HIP Catch2 test needs no change, and its
+# app.therock.sdk-test-collection dependency (which wants a THEROCK_SDK_URL
+# tarball we deliberately do not produce) is skipped by its own
+# only_if_missing guard on "${DEPS_DIR}/therock_sdk/bin".
+provisioning:
+  linux_install_scripts:
+    - script: "InstallationScripts/gfx/linux-therock-artifacts.sh"
+      reboot_after: false
+
+  # Two ways to supply the amdgpu package, both injected from repo variables:
+  #   ORCHESTRAI_LINUX_DRIVER_SOURCE        a single URL (all Radeon hosts)
+  #   ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON  a per-release map, e.g.
+  #     {"ubuntu:24.04":"https://.../ubuntu/noble/amdgpu-install_X_all.deb"}
+  # The map is resolved ON each machine from /etc/os-release, so an allocation
+  # that returns different Ubuntu releases still installs the right package.
+  # These install_scripts run BEFORE linux_install_scripts: the kernel driver
+  # must be active before TheRock user-space is installed.
+  linux_kernel_driver:
+    source: ""
+    sources_json: ""
+    install_scripts:
+      - script: "InstallationScripts/common/install-kernel-headers.sh"
+        reboot_after: false
+      - script: "InstallationScripts/gfx/linux.sh"
+        reboot_after: true
+
+  # Windows gets its GPU runtime from the AMD display driver (windows.ps1),
+  # which needs a reboot; TheRock user-space is layered on after it.
+  windows_install_scripts:
+    - script: "InstallationScripts/gfx/windows.ps1"
+      reboot_after: true
+    - script: "InstallationScripts/gfx/windows-therock-artifacts.ps1"
+      reboot_after: false
+
+  # Windows AMD GPU driver source (UNC path) copied onto the machine. Internal —
+  # set it as the ORCHESTRAI_WINDOWS_DRIVER_SOURCE repo secret, not here.
+  windows_driver:
+    source: ""
+    copy: "direct"

--- a/.github/scripts/orchestrai_matrix.py
+++ b/.github/scripts/orchestrai_matrix.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Build the OrchestrAI test matrix and batches.
+
+Turns the configured suites plus the resolved TheRock build into:
+
+  * matrix  - one entry per (suite, platform, device); each becomes one GitHub
+              Actions job that waits for its pipeline build and reports a verdict.
+  * batches - the same entries grouped by (platform, device); each batch becomes
+              ONE OrchestrAI pipeline build whose suites share one machine.
+
+Everything environment-specific (suites, device -> broker tags, device -> AMDGPU
+family, skips) comes from .github/orchestrai-config.yml so this stays generic.
+
+A (suite, platform, device) is dropped — with a warning, never silently — when:
+  * the device is in skip_devices;
+  * the device has no device_to_family entry;
+  * the device has no broker-tag mapping (the MAAS broker could never satisfy the
+    batch; it would queue and time out hours later);
+  * the resolved build for that platform did not include the device's family.
+
+Usage:
+    orchestrai_matrix.py [--config .github/orchestrai-config.yml] [--print]
+
+Env:
+    BUILD_SOURCE             JSON from orchestrai_resolve_build.py
+    ORCHESTRAI_DEVICE_TAGS   JSON {device: [maas tags]} (overrides device_to_tags)
+    SUITES / DEVICES / PLATFORMS   comma-separated workflow_dispatch filters
+
+Outputs (to $GITHUB_OUTPUT):
+    matrix=[...]  batches={...}  has_entries=true|false
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import yaml
+
+
+def load_config(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def parse_csv(value: str) -> set[str] | None:
+    """None means "no filter"; that is different from an empty selection."""
+    value = (value or "").strip()
+    if not value or value.lower() == "all":
+        return None
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def build(
+    cfg: dict[str, Any],
+    build_source: dict[str, Any],
+    suites: set[str] | None = None,
+    devices: set[str] | None = None,
+    platforms: set[str] | None = None,
+) -> tuple[list[dict], dict[str, dict]]:
+    device_to_tags = cfg.get("device_to_tags") or {}
+    device_to_family = cfg.get("device_to_family") or {}
+    skip_devices = set(cfg.get("skip_devices") or [])
+
+    matrix: list[dict] = []
+    # Collect reasons and report once per (kind, subject) so a device that is
+    # unusable for six suites produces one warning, not six.
+    dropped: dict[str, set[str]] = {}
+
+    def drop(reason: str, subject: str) -> None:
+        dropped.setdefault(reason, set()).add(subject)
+
+    for suite_id, suite in (cfg.get("suites") or {}).items():
+        if suites is not None and suite_id not in suites:
+            continue
+        for platform in suite.get("platforms") or []:
+            if platforms is not None and platform not in platforms:
+                continue
+            source = build_source.get(platform)
+            if not source:
+                drop("no resolved TheRock build for platform", platform)
+                continue
+            available = set(source.get("families") or [])
+            for device in suite.get("devices") or []:
+                if devices is not None and device not in devices:
+                    continue
+                if device in skip_devices:
+                    drop("listed in skip_devices", device)
+                    continue
+                family = device_to_family.get(device)
+                if not family:
+                    drop("no device_to_family mapping", device)
+                    continue
+                if device not in device_to_tags:
+                    drop("no broker-tag mapping (ORCHESTRAI_DEVICE_TAGS)", device)
+                    continue
+                if family not in available:
+                    drop(
+                        f"family not built by the resolved {platform} build "
+                        f"(has: {','.join(sorted(available)) or 'none'})",
+                        f"{device} ({family})",
+                    )
+                    continue
+                matrix.append(
+                    {
+                        "suite": suite_id,
+                        "platform": platform,
+                        "device": device,
+                        "family": family,
+                        "batch_id": f"{platform}/{device}",
+                        "required": bool(suite.get("required", False)),
+                    }
+                )
+
+    for reason, subjects in sorted(dropped.items()):
+        print(
+            f"::warning::skipped {', '.join(sorted(subjects))}: {reason}",
+            file=sys.stderr,
+        )
+
+    batches: dict[str, dict] = {}
+    for entry in matrix:
+        batch_id = entry["batch_id"]
+        source = build_source[entry["platform"]]
+        if batch_id not in batches:
+            batches[batch_id] = {
+                "platform": entry["platform"],
+                "device": entry["device"],
+                "family": entry["family"],
+                "tags": sorted(device_to_tags[entry["device"]]),
+                "suites": [],
+                "run_repo": source.get("repository", ""),
+                "run_id": source["run_id"],
+                "run_url": source.get("run_url", ""),
+                "sha": source.get("sha", ""),
+                "artifact_base_url": source["artifact_base_url"],
+            }
+        if entry["suite"] not in batches[batch_id]["suites"]:
+            batches[batch_id]["suites"].append(entry["suite"])
+
+    return matrix, batches
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--print", action="store_true", dest="do_print")
+    args = ap.parse_args()
+
+    cfg = load_config(args.config)
+
+    # Internal MAAS broker tags are not committed to this public repo; they come
+    # from the ORCHESTRAI_DEVICE_TAGS variable (a JSON device -> tags map).
+    raw_tags = os.environ.get("ORCHESTRAI_DEVICE_TAGS")
+    if raw_tags:
+        try:
+            cfg["device_to_tags"] = json.loads(raw_tags)
+        except json.JSONDecodeError:
+            print(
+                "::warning::ORCHESTRAI_DEVICE_TAGS is not valid JSON — "
+                "falling back to device_to_tags in the config",
+                file=sys.stderr,
+            )
+
+    raw_source = (os.environ.get("BUILD_SOURCE") or "").strip()
+    build_source = json.loads(raw_source) if raw_source else {}
+
+    matrix, batches = build(
+        cfg,
+        build_source,
+        suites=parse_csv(os.environ.get("SUITES", "")),
+        devices=parse_csv(os.environ.get("DEVICES", "")),
+        platforms=parse_csv(os.environ.get("PLATFORMS", "")),
+    )
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"matrix={json.dumps(matrix)}\n")
+            f.write(f"batches={json.dumps(batches)}\n")
+            f.write(f"has_entries={'true' if matrix else 'false'}\n")
+
+    print(f"Matrix: {len(matrix)} entries, Batches: {len(batches)}", file=sys.stderr)
+    for batch_id, batch in batches.items():
+        print(
+            f"  {batch_id}: {', '.join(batch['suites'])}  "
+            f"family={batch['family']} run={batch['run_id']} tags={batch['tags']}",
+            file=sys.stderr,
+        )
+
+    if args.do_print:
+        print(json.dumps({"matrix": matrix, "batches": batches}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_resolve_build.py
+++ b/.github/scripts/orchestrai_resolve_build.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolve the TheRock build that the OrchestrAI run should test.
+
+The OrchestrAI nightly does not build anything. It picks up the artifacts of a
+recent TheRock Multi-Arch CI run on this repo and points the test machines at
+them.
+
+A Multi-Arch CI run's overall conclusion is NOT a usable signal: the build jobs
+routinely succeed while some downstream test job fails, which marks the whole
+run "failure" even though every artifact was published. So runs are scanned
+newest-first and the first one whose artifacts are actually present in S3 wins.
+
+Resolution is per platform, because a run may have built only one of them.
+
+Usage:
+    orchestrai_resolve_build.py [--config .github/orchestrai-config.yml]
+                               [--platforms linux,windows] [--print]
+
+Env:
+    GH_TOKEN            token for the GitHub API (github.token is enough)
+    GITHUB_REPOSITORY   this repo; the default source of the builds
+    ORCHESTRAI_SOURCE_REPOSITORY  read builds from another repo instead
+                        (set to ROCm/rocm-systems when testing from a fork)
+    SOURCE_RUN_ID       optional: pin an explicit run id instead of scanning
+    PLATFORMS           optional: comma-separated platform filter
+
+Outputs (to $GITHUB_OUTPUT):
+    build_source={"linux": {...}, "windows": {...}}
+    has_source=true|false
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Iterable
+
+import yaml
+
+PLATFORMS = ("linux", "windows")
+
+API_TIMEOUT = 60
+PROBE_TIMEOUT = 30
+PROBE_ATTEMPTS = 3
+
+
+def load_config(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def gh_api(path: str, token: str) -> dict[str, Any]:
+    """GET a GitHub REST API path and return the decoded JSON body."""
+    req = urllib.request.Request(f"https://api.github.com/{path.lstrip('/')}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=API_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8", "replace"))
+
+
+def artifact_exists(url: str) -> bool:
+    """True when the S3 object exists.
+
+    A HEAD is used rather than a bucket listing: a Multi-Arch CI run publishes
+    well over 1000 keys, so a listing would need pagination while the exact
+    object names are already known.
+    """
+    for attempt in range(1, PROBE_ATTEMPTS + 1):
+        req = urllib.request.Request(url, method="HEAD")
+        try:
+            with urllib.request.urlopen(req, timeout=PROBE_TIMEOUT) as resp:
+                return 200 <= resp.status < 300
+        except urllib.error.HTTPError as exc:
+            # 403 is what a public bucket returns for a missing key when the
+            # caller may not ListBucket, so treat it as "absent" like a 404.
+            if exc.code in (403, 404):
+                return False
+            if attempt == PROBE_ATTEMPTS:
+                print(
+                    f"::warning::HEAD {url} failed with HTTP {exc.code}; "
+                    "treating the artifact as absent",
+                    file=sys.stderr,
+                )
+                return False
+        except Exception as exc:  # network hiccup — retry, then give up
+            if attempt == PROBE_ATTEMPTS:
+                print(
+                    f"::warning::HEAD {url} failed ({exc}); "
+                    "treating the artifact as absent",
+                    file=sys.stderr,
+                )
+                return False
+    return False
+
+
+def artifact_prefix_url(cfg: dict[str, Any], run_id: str, platform: str) -> str:
+    src = cfg["source_build"]
+    prefix = src["artifact_prefix_template"].format(run_id=run_id, platform=platform)
+    return f"{src['artifact_base_url'].rstrip('/')}/{prefix}"
+
+
+def probe_run(
+    cfg: dict[str, Any], run_id: str, platform: str
+) -> tuple[bool, list[str]]:
+    """Return (usable, families) for one run on one platform.
+
+    `usable` means every required artifact for the platform is present.
+    `families` are the AMDGPU families whose marker artifact is also present —
+    i.e. what this run can actually be tested on.
+    """
+    src = cfg["source_build"]
+    base = artifact_prefix_url(cfg, run_id, platform)
+
+    required = (src.get("required_artifacts") or {}).get(platform) or []
+    if not required:
+        print(
+            f"::warning::source_build.required_artifacts.{platform} is empty — "
+            f"cannot verify run {run_id}",
+            file=sys.stderr,
+        )
+        return False, []
+
+    for name in required:
+        if not artifact_exists(f"{base}/{name}"):
+            return False, []
+
+    families = [
+        family
+        for family, marker in (src.get("family_markers") or {}).items()
+        if artifact_exists(f"{base}/{marker}")
+    ]
+    return True, sorted(families)
+
+
+def candidate_runs(cfg: dict[str, Any], repo: str, token: str) -> list[dict[str, Any]]:
+    """Runs of the source workflow, newest first.
+
+    Deliberately NOT filtered on status. A Multi-Arch CI run publishes its
+    artifacts when the build stages finish, but the run stays in_progress for
+    many more hours while the downstream test jobs execute — recent runs took
+    anywhere from 8h to 20h end to end. Waiting for `completed` would mean always
+    testing yesterday's build. The artifact probe below is the real completeness
+    check, and it is a sound one: the family marker comes from math-libs, the
+    last build stage, so its presence implies the core runtime artifacts landed.
+
+    Queued runs are skipped outright — they cannot have artifacts yet.
+    """
+    src = cfg["source_build"]
+    limit = int(src.get("max_runs_to_scan", 40))
+    query = urllib.parse.urlencode(
+        {"branch": src["branch"], "per_page": min(limit, 100)}
+    )
+    workflow = urllib.parse.quote(src["workflow"], safe="")
+    payload = gh_api(f"repos/{repo}/actions/workflows/{workflow}/runs?{query}", token)
+    runs = payload.get("workflow_runs") or []
+    return [run for run in runs if run.get("status") != "queued"][:limit]
+
+
+def source_repository(cfg: dict[str, Any]) -> str:
+    """Repo whose Multi-Arch CI runs we read.
+
+    Normally this repo. A fork has no Multi-Arch CI history of its own, so a test
+    run there sets ORCHESTRAI_SOURCE_REPOSITORY=ROCm/rocm-systems and reads the
+    real builds. Env wins over config so the committed file never has to change.
+    """
+    return (
+        os.environ.get("ORCHESTRAI_SOURCE_REPOSITORY")
+        or (cfg.get("source_build") or {}).get("repository")
+        or os.environ.get("GITHUB_REPOSITORY", "")
+    )
+
+
+def run_summary(
+    cfg: dict[str, Any], run: dict[str, Any], platform: str, repo: str
+) -> dict:
+    return {
+        "repository": repo,
+        "run_id": str(run["id"]),
+        "run_url": run.get("html_url", ""),
+        "sha": run.get("head_sha", ""),
+        "branch": run.get("head_branch", ""),
+        "created_at": run.get("created_at", ""),
+        "status": run.get("status", ""),
+        "conclusion": run.get("conclusion") or "",
+        "artifact_base_url": artifact_prefix_url(cfg, str(run["id"]), platform),
+    }
+
+
+def resolve(
+    cfg: dict[str, Any], repo: str, token: str, platforms: Iterable[str]
+) -> dict[str, Any]:
+    pinned = (os.environ.get("SOURCE_RUN_ID") or "").strip()
+    resolved: dict[str, Any] = {}
+
+    if pinned:
+        run = gh_api(f"repos/{repo}/actions/runs/{pinned}", token)
+        for platform in platforms:
+            usable, families = probe_run(cfg, pinned, platform)
+            if not usable:
+                print(
+                    f"::warning::pinned run {pinned} has no usable {platform} "
+                    "artifacts — skipping that platform",
+                    file=sys.stderr,
+                )
+                continue
+            resolved[platform] = run_summary(cfg, run, platform, repo) | {
+                "families": families
+            }
+        return resolved
+
+    runs = candidate_runs(cfg, repo, token)
+    if not runs:
+        print(
+            "::warning::no completed runs found for "
+            f"{cfg['source_build']['workflow']} on {cfg['source_build']['branch']}",
+            file=sys.stderr,
+        )
+        return resolved
+
+    for platform in platforms:
+        for run in runs:
+            usable, families = probe_run(cfg, str(run["id"]), platform)
+            if not usable:
+                continue
+            if not families:
+                print(
+                    f"::warning::run {run['id']} has {platform} artifacts but no "
+                    "known family markers — skipping",
+                    file=sys.stderr,
+                )
+                continue
+            resolved[platform] = run_summary(cfg, run, platform, repo) | {
+                "families": families
+            }
+            break
+        else:
+            print(
+                f"::warning::no {platform} build with usable artifacts in the last "
+                f"{len(runs)} run(s) of {cfg['source_build']['workflow']}",
+                file=sys.stderr,
+            )
+    return resolved
+
+
+def check_age(cfg: dict[str, Any], resolved: dict[str, Any]) -> None:
+    """Warn (do not fail) when the chosen build is older than the policy allows.
+
+    Testing a stale build is still more useful than testing nothing, so this is
+    surfaced as a warning in the job log rather than an error.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    max_age = cfg["source_build"].get("max_age_hours")
+    if not max_age:
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=float(max_age))
+    for platform, info in resolved.items():
+        created = info.get("created_at") or ""
+        try:
+            when = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when < cutoff:
+            age_h = (datetime.now(timezone.utc) - when).total_seconds() / 3600
+            print(
+                f"::warning::{platform} build {info['run_id']} is {age_h:.0f}h old "
+                f"(policy: {max_age}h) — the source workflow may not be running",
+                file=sys.stderr,
+            )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--platforms", default=os.environ.get("PLATFORMS", ""))
+    ap.add_argument("--print", action="store_true", dest="do_print")
+    args = ap.parse_args()
+
+    wanted = (args.platforms or "").strip().lower()
+    platforms = (
+        list(PLATFORMS)
+        if not wanted or wanted == "all"
+        else [p for p in PLATFORMS if p in {x.strip() for x in wanted.split(",")}]
+    )
+
+    cfg = load_config(args.config)
+    repo = source_repository(cfg)
+    if not repo:
+        print(
+            "::error::no source repository — set ORCHESTRAI_SOURCE_REPOSITORY, "
+            "source_build.repository, or GITHUB_REPOSITORY",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    resolved = resolve(cfg, repo, os.environ.get("GH_TOKEN", ""), platforms)
+    check_age(cfg, resolved)
+
+    for platform, info in resolved.items():
+        print(
+            f"{platform}: run {info['run_id']} ({info['sha'][:12]}, "
+            f"{info['created_at']}) families={','.join(info['families'])}",
+            file=sys.stderr,
+        )
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"build_source={json.dumps(resolved)}\n")
+            f.write(f"has_source={'true' if resolved else 'false'}\n")
+
+    if args.do_print:
+        print(json.dumps(resolved, indent=2))
+
+    if not resolved:
+        print(
+            "::error::No TheRock build with usable artifacts was found — nothing "
+            "to test. Check that the source workflow is still producing builds.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_trigger.py
+++ b/.github/scripts/orchestrai_trigger.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Trigger OrchestrAI pipeline builds for the resolved test batches.
+
+For each batch (one per platform/device) this builds a pipeline plan — one group
+per suite, all sharing the batch's hardware — and POSTs it to the OrchestrAI
+pipeline job (buildWithParameters). It then polls the queue item until the build
+starts and records its URL so the matrix job can wait on it.
+
+Environment-specific values (pipeline URL/job, provisioning scripts, driver
+sources, run settings) come from .github/orchestrai-config.yml, overridden by
+repo variables. Credentials come from env.
+
+Fails fast (exit 1) on a misconfigured run rather than acquiring scarce hardware
+that cannot provision: missing config keys, missing credentials, or a batch whose
+required provisioning value is unset.
+
+Usage:
+    orchestrai_trigger.py [--config .github/orchestrai-config.yml] [--dry-run]
+
+Env:
+    BATCHES_JSON            batches from orchestrai_matrix.py
+    GIT_REF                 github.ref (recorded as ROCM_SYSTEMS_REF)
+    GIT_SHA                 github.sha of this repo (the tests' own revision)
+    MACHINES_PER_HW_GROUP   override; falls back to the config default
+    ORCHESTRAI_PIPELINE_USER / ORCHESTRAI_PIPELINE_TOKEN
+
+Outputs (to $GITHUB_OUTPUT):
+    build_urls={batch_id: build url}
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+import yaml
+
+# Finite ceilings so a stalled pipeline can never hang the job (the urllib
+# default is to wait forever). Generous values; the point is a bound, not an SLA.
+POST_TIMEOUT = 120
+POLL_TIMEOUT = 30
+
+# Only the submit is retried: a submit that fails before the pipeline creates a
+# queue item leaves nothing behind, so re-sending is safe. Once a queue item
+# exists we hold that one URL, so a slow queue can never produce a duplicate
+# build on scarce hardware.
+SUBMIT_ATTEMPTS = 3
+SUBMIT_BACKOFF = 5  # seconds, multiplied by the attempt number
+
+QUEUE_POLL_ATTEMPTS = 60
+QUEUE_POLL_INTERVAL = 10
+
+
+# --- Public-repo log hygiene --------------------------------------------------
+# rocm-systems is public, so every workflow log and uploaded artifact is
+# world-readable. Credentials are secrets and GitHub masks those, but the
+# pipeline URL MUST be a variable (secrets are redacted from job outputs, which
+# would blank build_urls) and variables are never masked. So anything carrying
+# internal infrastructure detail is redacted before it is printed.
+_SECRET_KEY_HINTS = (
+    "token",
+    "password",
+    "driver_source",
+    "driver_sources_json",
+    "url",
+    "share",
+)
+# Deliberately NOT redacted: maas_tags. GPU architecture tags (gpuarch_rdna3 and
+# friends) are not considered sensitive, and seeing which hardware a batch asked
+# for is the single most useful thing in the log when a run lands on the wrong
+# machine — which has happened. Hiding them would cost real debuggability to
+# conceal nothing worth concealing.
+
+
+def build_number(url: str) -> str:
+    """Trailing build number of a pipeline build URL, for logging without the host."""
+    return url.rstrip("/").rsplit("/", 1)[-1] or "?"
+
+
+def redact(value):
+    """Deep-copy `value` with internal coordinates replaced by a placeholder.
+
+    Keys are matched on substrings rather than an exact list so a new
+    provisioning variable is redacted by default instead of leaking until
+    someone remembers to add it.
+    """
+    if isinstance(value, dict):
+        out = {}
+        for k, v in value.items():
+            if any(h in k.lower() for h in _SECRET_KEY_HINTS):
+                out[k] = "<redacted>"
+            else:
+                out[k] = redact(v)
+        return out
+    if isinstance(value, list):
+        return [redact(v) for v in value]
+    return value
+
+
+def load_config(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def apply_env_overrides(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Internal coordinates are kept out of this public repo and supplied at run
+    time via repo variables/secrets. Env values win over the config fallbacks."""
+    pipeline = cfg.setdefault("pipeline", {})
+    pipeline["url"] = os.environ.get("ORCHESTRAI_PIPELINE_URL") or pipeline.get(
+        "url", ""
+    )
+    pipeline["job"] = os.environ.get("ORCHESTRAI_PIPELINE_JOB") or pipeline.get(
+        "job", ""
+    )
+
+    prov = cfg.setdefault("provisioning", {})
+    linux_driver = os.environ.get("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+    if linux_driver:
+        prov.setdefault("linux_kernel_driver", {})["source"] = linux_driver
+    linux_driver_map = os.environ.get("ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON")
+    if linux_driver_map:
+        prov.setdefault("linux_kernel_driver", {})["sources_json"] = linux_driver_map
+    windows_driver = os.environ.get("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+    if windows_driver:
+        prov.setdefault("windows_driver", {})["source"] = windows_driver
+    return cfg
+
+
+def validate_config(cfg: dict[str, Any], batches: dict[str, Any]) -> list[str]:
+    """Return the required config keys that are missing for these batches."""
+    errors = []
+    run_settings = cfg.get("run_settings") or {}
+    for key in ("max_duration", "max_test_case_duration", "acquire_timeout"):
+        if key not in run_settings:
+            errors.append(f"run_settings.{key}")
+    if not (cfg.get("suites") or {}):
+        errors.append("suites")
+
+    prov = cfg.get("provisioning") or {}
+    platforms = {b.get("platform") for b in batches.values()}
+    if "linux" in platforms and not prov.get("linux_install_scripts"):
+        errors.append("provisioning.linux_install_scripts")
+    if "windows" in platforms and not prov.get("windows_install_scripts"):
+        errors.append("provisioning.windows_install_scripts")
+    return errors
+
+
+def normalise_driver_map(raw: str) -> tuple[str, list[str]]:
+    """Validate the per-release amdgpu map, returning (value, errors).
+
+    Validated HERE, before any hardware is acquired: a malformed map would
+    otherwise fail on the machine after the acquire wait. Pasting into the
+    repo-variable UI commonly introduces wrapping quotes or line breaks, so both
+    are repaired when what is underneath is genuinely valid JSON.
+    """
+    value = raw.strip()
+
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        inner = value[1:-1].strip()
+        try:
+            json.loads(inner)
+        except ValueError:
+            pass
+        else:
+            print(
+                "::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON was wrapped in "
+                f"{value[0]} quotes; using the value inside them",
+                file=sys.stderr,
+            )
+            value = inner
+
+    try:
+        json.loads(value)
+    except ValueError:
+        # A URL cannot contain a raw newline or tab, so dropping them is safe —
+        # and only attempted when the value does not already parse.
+        rejoined = re.sub(r"[\n\r\t]+", "", value)
+        try:
+            json.loads(rejoined)
+        except ValueError:
+            pass
+        else:
+            print(
+                "::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON contained line "
+                "breaks; they were removed. Set it as a single line to avoid this.",
+                file=sys.stderr,
+            )
+            value = rejoined
+
+    try:
+        parsed = json.loads(value)
+    except ValueError as exc:
+        hint = ""
+        if any(c in value for c in "“”‘’"):
+            hint = ' — it contains smart quotes; retype it with plain " quotes'
+        elif "'" in value and '"' not in value:
+            hint = " — JSON requires double quotes, not single quotes"
+        return value, [
+            f"ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON (not valid JSON: {exc}{hint}; "
+            f"{len(value)} chars, begins {value[:24]!r})"
+        ]
+
+    if not (
+        isinstance(parsed, dict)
+        and parsed
+        and all(
+            isinstance(k, str) and isinstance(v, str) and v for k, v in parsed.items()
+        )
+    ):
+        return value, [
+            "ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON (expected a non-empty object of "
+            '"<id>:<version_id>" -> URL)'
+        ]
+
+    # Finish repairing a value broken across lines: the newline is gone but the
+    # indentation that followed it is still inside the string, so the JSON parses
+    # while the URL is unusable ("curl: (3) URL rejected") much later, on the
+    # machine. A URL cannot contain whitespace, so strip it there and nowhere else.
+    repaired = [
+        k
+        for k, v in parsed.items()
+        if v.startswith(("http://", "https://")) and re.search(r"\s", v)
+    ]
+    if repaired:
+        for key in repaired:
+            parsed[key] = re.sub(r"\s+", "", parsed[key])
+        print(
+            "::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON: removed whitespace from "
+            f"the URL(s) for {', '.join(sorted(repaired))}; set the variable as a "
+            "single line to avoid this",
+            file=sys.stderr,
+        )
+        value = json.dumps(parsed, separators=(",", ":"))
+
+    return value, []
+
+
+def make_plan(
+    batch: dict[str, Any],
+    cfg: dict[str, Any],
+    machines_per_hw_group: int,
+    git_ref: str,
+    git_sha: str,
+) -> dict[str, Any]:
+    platform = batch["platform"]
+    # The repo the build came from — not necessarily the repo running this
+    # workflow (a fork test run reads ROCm/rocm-systems builds).
+    repo = batch["run_repo"]
+    suites_cfg = cfg["suites"]
+    run_settings = cfg["run_settings"]
+
+    groups = []
+    for suite_id in batch["suites"]:
+        test = suites_cfg[suite_id]["test"].format(platform=platform)
+        groups.append(
+            {
+                "id": f"suite-{suite_id}",
+                # The level is the first segment of the test-library path
+                # (L1-whb, L4-sys, ...), so a suite can move between levels
+                # without a code change.
+                "level": test.split("/", 1)[0],
+                "tests": [test],
+                "maas_tags": batch["tags"],
+                "variables": {
+                    "SUITE_ID": suite_id,
+                    "TEST_PLATFORM": platform,
+                    "TEST_DEVICE": batch["device"],
+                    # The revision of THIS repo, so a suite that builds tests from
+                    # source (e.g. hip-tests catch2) can match the build under test.
+                    "ROCM_SYSTEMS_REPO": f"https://github.com/{repo}",
+                    "ROCM_SYSTEMS_SHA": batch.get("sha") or git_sha,
+                    "ROCM_SYSTEMS_REF": git_ref,
+                    # Which TheRock build the machine was provisioned from.
+                    "THEROCK_RUN_ID": batch["run_id"],
+                    "THEROCK_AMDGPU_FAMILY": batch["family"],
+                },
+            }
+        )
+
+    return {
+        "source": "rocm-systems-clr-nightly",
+        "groups": groups,
+        "run_settings": {
+            "max_duration": run_settings["max_duration"],
+            "max_test_case_duration": run_settings["max_test_case_duration"],
+            "acquire_timeout": run_settings["acquire_timeout"],
+            "machines_per_hw_group": machines_per_hw_group,
+        },
+    }
+
+
+def make_builds(
+    batch: dict[str, Any], cfg: dict[str, Any]
+) -> tuple[dict[str, Any], list[str]]:
+    """Return (builds, missing) — missing names unset required provisioning."""
+    platform = batch["platform"]
+    prov = cfg.get("provisioning") or {}
+    missing: list[str] = []
+
+    # Every key here reaches the install script as an upper-cased env var. These
+    # four are what the artifact-based installer needs to run TheRock's
+    # install_rocm_from_artifacts.py on the machine.
+    build_vars = {
+        "THEROCK_RUN_ID": batch["run_id"],
+        "THEROCK_RUN_REPO": batch["run_repo"],
+        "THEROCK_AMDGPU_FAMILY": batch["family"],
+        "THEROCK_ARTIFACT_BASE_URL": batch["artifact_base_url"],
+    }
+
+    # install_rocm_from_artifacts.py ALWAYS calls the GitHub API to resolve the
+    # artifact bucket, and neither it nor fetch_artifacts.py offers a way to
+    # supply the bucket directly and skip the lookup. Unauthenticated it shares
+    # the fleet's egress IP quota and reliably returns HTTP 429 (build 42018
+    # died there). Treated as required so the run fails here rather than after
+    # acquiring and rebooting a machine. Read-only public-repo scope is enough;
+    # in the workflow this is ${{ github.token }}.
+    github_token = os.environ.get("ORCHESTRAI_GITHUB_TOKEN", "")
+    if github_token:
+        build_vars["GITHUB_TOKEN"] = github_token
+    else:
+        missing.append("ORCHESTRAI_GITHUB_TOKEN")
+
+    if platform == "windows":
+        # Copy so the config is never mutated across batches.
+        scripts = list(prov.get("windows_install_scripts") or [])
+        driver = prov.get("windows_driver") or {}
+        source = driver.get("source", "")
+        if not source:
+            missing.append("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+        build_vars["driver_source"] = source
+        build_vars["driver_copy"] = driver.get("copy", "direct")
+    else:
+        scripts = list(prov.get("linux_install_scripts") or [])
+        device_family = (cfg.get("device_families") or {}).get(batch["device"])
+        if device_family not in {"radeon", "ryzen_apu"}:
+            missing.append(f"device_families.{batch['device']}")
+        if device_family == "radeon":
+            kernel_driver = prov.get("linux_kernel_driver") or {}
+            source = kernel_driver.get("source", "")
+            sources_json = kernel_driver.get("sources_json", "")
+            # Either form is sufficient: one URL for every Radeon host, or a
+            # per-release map. The map wins on the host when both are present.
+            if not source and not sources_json:
+                missing.append("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+            if sources_json:
+                sources_json, errors = normalise_driver_map(sources_json)
+                missing.extend(errors)
+                build_vars["driver_sources_json"] = sources_json
+            if source:
+                build_vars["driver_source"] = source
+            # The kernel driver must be active before TheRock user-space is
+            # installed. Kept device-specific so APUs keep the inbox amdgpu
+            # module they are validated with.
+            scripts = list(kernel_driver.get("install_scripts") or []) + scripts
+
+    return {"install_scripts": scripts, "vars": build_vars}, missing
+
+
+def auth_header(user: str, token: str) -> str:
+    """Basic-auth header value, built in memory.
+
+    SECURITY: the credentials are deliberately NOT handed to a `curl -u
+    user:token` subprocess. argv is world-readable via /proc/<pid>/cmdline and
+    `ps` for the lifetime of the process, so on a shared self-hosted runner any
+    other local process could read the pipeline token.
+    """
+    return "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode()
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Match curl's default (no -L) so the queue URL is read from the original
+    response's Location header instead of being followed."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def submit(
+    plan: dict, builds: dict, platform: str, pipeline: dict, user: str, token: str
+) -> str | None:
+    """POST the build request; return the queue-item URL, or None on failure.
+
+    None means no queue item was created (network error, timeout, or a
+    non-redirect HTTP error), so the caller may retry without risking a duplicate.
+    """
+    body = urllib.parse.urlencode(
+        {
+            "PLAN_JSON": json.dumps(plan),
+            "BUILDS_JSON": json.dumps(builds),
+            "OS_IMAGE": "windows" if platform == "windows" else "ubuntu",
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        f"{pipeline['url'].rstrip('/')}/job/{pipeline['job']}/buildWithParameters",
+        data=body,
+        method="POST",
+    )
+    req.add_header("Authorization", auth_header(user, token))
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        opener = urllib.request.build_opener(_NoRedirect)
+        with opener.open(req, timeout=POST_TIMEOUT) as resp:
+            return (resp.headers.get("Location") or "").strip() or None
+    except urllib.error.HTTPError as exc:
+        # Redirects surface as HTTPError because they are disabled above; a 3xx
+        # still carries the queue item in Location. Anything else is a failure.
+        if 300 <= exc.code < 400:
+            return (exc.headers.get("Location") or "").strip() or None
+        return None
+    except Exception:
+        return None
+
+
+def await_build(queue_url: str, user: str, token: str) -> str | None:
+    """Poll a queue item until the pipeline assigns it an executable."""
+    for _ in range(QUEUE_POLL_ATTEMPTS):
+        time.sleep(QUEUE_POLL_INTERVAL)
+        try:
+            req = urllib.request.Request(f"{queue_url}api/json")
+            req.add_header("Authorization", auth_header(user, token))
+            with urllib.request.urlopen(req, timeout=POLL_TIMEOUT) as resp:
+                payload = json.loads(resp.read().decode("utf-8", "replace"))
+            executable = payload.get("executable") or {}
+            if executable.get("url"):
+                return executable["url"]
+        except Exception:
+            pass
+    return None
+
+
+def trigger(
+    plan: dict, builds: dict, platform: str, pipeline: dict, user: str, token: str
+) -> str | None:
+    queue_url = None
+    for attempt in range(1, SUBMIT_ATTEMPTS + 1):
+        queue_url = submit(plan, builds, platform, pipeline, user, token)
+        if queue_url:
+            break
+        if attempt < SUBMIT_ATTEMPTS:
+            print(
+                f"  submit attempt {attempt}/{SUBMIT_ATTEMPTS} failed; retrying",
+                file=sys.stderr,
+            )
+            time.sleep(SUBMIT_BACKOFF * attempt)
+    if not queue_url:
+        return None
+    return await_build(queue_url, user, token)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    cfg = apply_env_overrides(load_config(args.config))
+    batches = json.loads(os.environ.get("BATCHES_JSON") or "{}")
+    git_ref = os.environ.get("GIT_REF", "")
+    git_sha = os.environ.get("GIT_SHA", "")
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+
+    config_errors = validate_config(cfg, batches)
+    if config_errors:
+        print(
+            "::error::orchestrai-config.yml missing required keys: "
+            f"{', '.join(config_errors)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not args.dry_run:
+        need = [f"pipeline.{k}" for k in ("url", "job") if not cfg["pipeline"].get(k)]
+        if not user:
+            need.append("ORCHESTRAI_PIPELINE_USER")
+        if not token:
+            need.append("ORCHESTRAI_PIPELINE_TOKEN")
+        if need:
+            print(
+                f"::error::OrchestrAI not configured — missing: {', '.join(need)} "
+                "(set the ORCHESTRAI_PIPELINE_URL/JOB variables and the "
+                "ORCHESTRAI_PIPELINE_USER/TOKEN secrets)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    run_settings = cfg["run_settings"]
+    try:
+        machines_per_hw_group = int(
+            os.environ.get("MACHINES_PER_HW_GROUP", "")
+            or run_settings.get("default_machines_per_hw_group", 1)
+        )
+    except ValueError:
+        machines_per_hw_group = 1
+
+    # Prepare every batch first and fail before any POST, so a misconfigured run
+    # never acquires a scarce machine that cannot install its GPU stack and only
+    # fails much later on hardware.
+    prepared = []
+    provisioning_missing: dict[str, list[str]] = {}
+    for batch_id, batch in batches.items():
+        builds, missing = make_builds(batch, cfg)
+        if missing:
+            provisioning_missing[batch_id] = missing
+        prepared.append(
+            (
+                batch_id,
+                batch,
+                make_plan(batch, cfg, machines_per_hw_group, git_ref, git_sha),
+                builds,
+            )
+        )
+
+    if not args.dry_run and provisioning_missing:
+        for batch_id, missing in provisioning_missing.items():
+            print(
+                f"::error::batch {batch_id}: unset provisioning {missing} — "
+                "set the corresponding repo variable(s)/secret(s)",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+
+    build_urls: dict[str, str] = {}
+    failed: list[str] = []
+    for batch_id, batch, plan, builds in prepared:
+        print(
+            f"Batch {batch_id}: {', '.join(batch['suites'])} "
+            f"(TheRock run {batch['run_id']}, {batch['family']})",
+            file=sys.stderr,
+        )
+        if args.dry_run:
+            print(f"--- plan for {batch_id} ---")
+            print(json.dumps(redact(plan), indent=2))
+            print(f"--- builds for {batch_id} ---")
+            print(json.dumps(redact(builds), indent=2))
+            continue
+        url = trigger(plan, builds, batch["platform"], cfg["pipeline"], user, token)
+        if url:
+            # Number only — see redact() above.
+            print(f"  Build #{build_number(url)}", file=sys.stderr)
+            build_urls[batch_id] = url
+        else:
+            failed.append(batch_id)
+            print(
+                f"  WARNING: trigger failed / timed out for {batch_id}", file=sys.stderr
+            )
+
+    if args.dry_run:
+        return
+
+    print(f"\nTriggered {len(build_urls)} pipeline build(s)", file=sys.stderr)
+
+    # Emit the URLs FIRST so batches that did trigger still run downstream even
+    # if we exit non-zero below.
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"build_urls={json.dumps(build_urls)}\n")
+
+    # Surface dropped batches HERE rather than letting each downstream test job
+    # discover the gap one by one as "No build URL".
+    if not build_urls:
+        print(
+            "::error::No pipeline builds were triggered — every batch failed to "
+            f"submit ({len(failed)}: {', '.join(failed)}). The pipeline was likely "
+            "unreachable or rejecting builds.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if failed:
+        # Do NOT exit non-zero: downstream jobs `needs` this one, so that would
+        # skip the batches that did trigger. Their own jobs still fail, so the
+        # run as a whole is not reported green.
+        print(
+            f"::error::{len(failed)} batch(es) failed to trigger and will report no "
+            f"build URL downstream: {', '.join(failed)}. The other "
+            f"{len(build_urls)} batch(es) were triggered and will run.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_verdict.py
+++ b/.github/scripts/orchestrai_verdict.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolve one suite's verdict from a batch pipeline build.
+
+A batch build runs several suites on one machine, so the build's overall result
+cannot tell us whether THIS suite passed. The pipeline writes a per-group rollup
+to its summary.json:
+
+    groups["suite-<id>"] = {passed, failed, skipped, errors, status}
+
+keyed by the submission group id (independent of completion order). This script
+prefers that rollup and falls back to the build console's per-suite lifecycle if
+the rollup is absent.
+
+Usage:
+    orchestrai_verdict.py     (all inputs via env)
+
+Env:
+    BUILD_URL, ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN,
+    SUITE_ID, PLATFORM, DEVICE
+
+Outputs:
+    test-results/summary.json         per-suite counts, for artifact upload
+    rp_url=<reportportal launch url>  -> $GITHUB_OUTPUT
+    exit 0 if PASSED, 1 otherwise (including: no verdict found for this suite)
+"""
+
+import base64
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+COUNT_KEYS = ("passed", "failed", "skipped", "errors")
+FETCH_TIMEOUT = 60
+
+
+def fetch(url: str, user: str, token: str) -> str:
+    """GET `url` with basic auth, returning "" on any failure.
+
+    SECURITY: the credentials are deliberately NOT handed to a `curl -u
+    user:token` subprocess. argv is world-readable via /proc/<pid>/cmdline and
+    `ps` for the lifetime of the process, so on a shared self-hosted runner any
+    other local process could read the pipeline token. Doing the HTTP in-process
+    (stdlib only — this job has no pip install step) keeps the secret in this
+    process's memory only.
+    """
+    req = urllib.request.Request(url)
+    req.add_header(
+        "Authorization",
+        "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode(),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as resp:
+            return resp.read().decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+def status_from_group(group: dict) -> str | None:
+    """PASSED/FAILED from a group rollup, or None when it carries no verdict
+    (no status field and zero counts — i.e. nothing actually ran)."""
+    status = group.get("status")
+    if status:
+        return status
+    counts = {k: group.get(k) or 0 for k in COUNT_KEYS}
+    if sum(counts.values()) == 0:
+        return None  # ambiguous: the group exists but ran nothing — not a PASS
+    return "FAILED" if (counts["failed"] or counts["errors"]) else "PASSED"
+
+
+def status_from_console(console: str, suite_id: str) -> str | None:
+    """Fallback: the console exposes the per-suite lifecycle even when
+    summary.json has no group for it:
+        Started suite "suite-<id> #<n>" ... id=<sid>
+        Finished item <sid> -> PASSED|FAILED
+    """
+    started = re.search(
+        rf'Started suite "suite-{re.escape(suite_id)} #\d+".*?id=([0-9a-fA-F-]+)',
+        console,
+    )
+    if not started:
+        return None
+    # The separator between the item id and the status renders differently across
+    # console encodings (Unicode "→", ASCII "->", or mojibake if the log was
+    # decoded wrong). Match any run of non-alphanumerics rather than one arrow.
+    finished = re.findall(
+        rf"Finished item {re.escape(started.group(1))}[^A-Za-z0-9]+([A-Z]+)", console
+    )
+    return finished[-1] if finished else None
+
+
+def main() -> None:
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+    build_url = os.environ.get("BUILD_URL", "")
+    suite_id = os.environ.get("SUITE_ID", "")
+    platform = os.environ.get("PLATFORM", "")
+    device = os.environ.get("DEVICE", "")
+
+    if not suite_id or not platform:
+        print(
+            "::error::orchestrai_verdict.py: SUITE_ID and PLATFORM must be set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    group_key = f"suite-{suite_id}"
+    results_dir = Path("test-results")
+    results_dir.mkdir(exist_ok=True)
+
+    def write_summary(ok: bool, counts: dict | None = None) -> None:
+        (results_dir / "summary.json").write_text(
+            json.dumps(
+                {
+                    "suite_id": suite_id,
+                    "platform": platform,
+                    "device": device,
+                    "passed": 1 if ok else 0,
+                    "failed": 0 if ok else 1,
+                    "counts": counts or {},
+                },
+                indent=2,
+            )
+        )
+
+    if not build_url:
+        write_summary(False)
+        print(f"::error::No pipeline build URL for {suite_id} ({platform}/{device})")
+        sys.exit(1)
+
+    raw = fetch(f"{build_url}artifact/.pipeline/summary.json", user, token) or "{}"
+    try:
+        summary = json.loads(raw)
+    except ValueError:
+        summary = {}
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"rp_url={summary.get('rp_launch_url', '')}\n")
+
+    status, how = None, ""
+    group = (summary.get("groups") or {}).get(group_key)
+    if isinstance(group, dict):
+        status = status_from_group(group)
+        if status:
+            how = "summary.json groups"
+
+    if status is None:
+        console = fetch(f"{build_url}consoleText", user, token)
+        status = status_from_console(console, suite_id)
+        if status:
+            how = "console suite lifecycle"
+
+    if status is None:
+        write_summary(False)
+        print(
+            f"::error::No verdict for {suite_id} ({platform}/{device}): no "
+            f"groups['{group_key}'] in summary.json and no suite result in the "
+            f"console. groups present: {list((summary.get('groups') or {}).keys())}"
+        )
+        sys.exit(1)
+
+    counts = {k: group.get(k) for k in COUNT_KEYS} if isinstance(group, dict) else {}
+    ok = status == "PASSED"
+    write_summary(ok, counts)
+    print(
+        f"{suite_id} ({platform}/{device}): {'PASS' if ok else 'FAIL'} "
+        f"(status={status}, via {how}, counts={counts})"
+    )
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/clr-orchestrai-nightly.yml
+++ b/.github/workflows/clr-orchestrai-nightly.yml
@@ -1,0 +1,353 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# CLR language-runtime tests on OrchestrAI (opt-in, additive).
+#
+# Every night this picks up the artifacts of a recent TheRock Multi-Arch CI run
+# on this repo and runs the language-runtime (HIP / OpenCL / CLR) suites against
+# them on real AMD hardware, via the OrchestrAI pipeline and its MAAS broker,
+# instead of on a device-attached GitHub runner.
+#
+# Nothing is built here and no existing workflow is touched. The whole
+# integration is .github/workflows/clr-orchestrai-nightly.yml +
+# .github/scripts/orchestrai_*.py + .github/orchestrai-config.yml, and it no-ops
+# on a fork that lacks the secrets.
+#
+# Required repo secrets:
+#   ORCHESTRAI_PIPELINE_USER   pipeline basic-auth user (presence gates the run)
+#   ORCHESTRAI_PIPELINE_TOKEN  pipeline basic-auth token
+#   ORCHESTRAI_WINDOWS_DRIVER_SOURCE  UNC path to the AMD GPU driver share
+#     (Windows batches only; consumed inside the trigger job, never re-emitted)
+#
+# Required repo variables (these must NOT be secrets — see below):
+#   ORCHESTRAI_PIPELINE_URL    pipeline host base URL
+#   ORCHESTRAI_PIPELINE_JOB    pipeline job name/path
+#   ORCHESTRAI_DEVICE_TAGS     JSON {device: [maas tags]}, e.g.
+#                              {"navi3x":["gpuarch_rdna3"],"navi4x":["gpuarch_rdna4"]}
+#   ORCHESTRAI_LINUX_DRIVER_SOURCE (or ..._SOURCES_JSON)  amdgpu-install package
+#     for Radeon Linux hosts
+#
+# Optional repo variables:
+#   ORCHESTRAI_CONTROL_RUNNER  runner for resolve/trigger/gate (default ubuntu-latest)
+#   ORCHESTRAI_WAIT_RUNNER     runner for the wait/verdict jobs (default ubuntu-latest)
+#     -> both must be able to reach ORCHESTRAI_PIPELINE_URL.
+#
+# WHY THE PIPELINE URL MUST BE A VARIABLE: orchestrai_trigger.py turns it into
+# `build_urls`, a job output the downstream wait job reads. GitHub redacts secret
+# values from job outputs, so a secret URL arrives blank and every test job fails
+# with "No pipeline build URL for batch ...".
+#
+# Everything else lives in .github/orchestrai-config.yml.
+
+name: CLR Runtime Tests (OrchestrAI)
+
+on:
+  schedule:
+    # 09:37 UTC. The source build (TheRock Multi-Arch CI) starts around 00:22
+    # UTC; its build stages publish artifacts well before the run finishes, and
+    # recent runs completed anywhere between 08:00 and 20:00 UTC. The resolver
+    # scans back up to source_build.max_age_hours, so a late source build simply
+    # means the previous day's artifacts are tested rather than nothing at all.
+    #
+    # For a weekly cadence on a wider suite set, add a second cron here and pass
+    # the suite list via the config's `suites` map — no workflow change needed.
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "TheRock Multi-Arch CI run ID to test (empty = newest with artifacts)"
+        required: false
+        type: string
+      suites:
+        description: "Suite ID(s) to run, comma-separated (empty = all configured)"
+        required: false
+        type: string
+      device:
+        description: "Device(s), comma-separated e.g. navi3x,navi4x (empty = all)"
+        required: false
+        type: string
+      platform:
+        description: "OS to test on"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - windows
+      machines_per_hw_group:
+        description: "Machines per hardware group (1 = suites on a device share one machine)"
+        required: false
+        type: string
+        default: "1"
+      dry_run:
+        description: "Plan only: print the pipeline payloads, lease no hardware"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never pile runs up on the shared hardware fleet: one run per ref per event.
+# cancel-in-progress is deliberately off — cancelling an in-flight run would
+# strand the machines it has already acquired.
+concurrency:
+  group: orchestrai-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  resolve-and-trigger:
+    name: Resolve Build & Trigger
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_entries: ${{ steps.build-matrix.outputs.has_entries }}
+      build_urls: ${{ steps.trigger.outputs.build_urls }}
+      build_source: ${{ steps.resolve.outputs.build_source }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install --quiet pyyaml
+
+      - name: Check OrchestrAI is configured
+        id: gate
+        env:
+          PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          if [ -n "$PIPELINE_USER" ] && [ -n "$PIPELINE_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OrchestrAI secrets (ORCHESTRAI_PIPELINE_USER/ORCHESTRAI_PIPELINE_TOKEN) not set — skipping."
+          fi
+
+      - name: Resolve TheRock build to test
+        id: resolve
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          PLATFORMS: ${{ inputs.platform }}
+          # Empty on ROCm/rocm-systems (builds come from this repo). A fork sets
+          # it to ROCm/rocm-systems so a test run reads the real build history
+          # instead of the fork's empty one.
+          ORCHESTRAI_SOURCE_REPOSITORY: ${{ vars.ORCHESTRAI_SOURCE_REPOSITORY }}
+        run: python3 .github/scripts/orchestrai_resolve_build.py
+
+      # Written before the matrix/trigger steps run, so "which build was under
+      # test" is on the summary even when a later step fails — that is exactly
+      # when it is needed.
+      - name: Build source summary
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          BUILD_SOURCE: ${{ steps.resolve.outputs.build_source }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, os
+          src = json.loads(os.environ.get("BUILD_SOURCE") or "{}")
+          print("### TheRock build under test\n")
+          if not src:
+              print("No build with usable artifacts was found.")
+          else:
+              print("| Platform | Run | Commit | Built | Families |")
+              print("|---|---|---|---|---|")
+              for platform, info in sorted(src.items()):
+                  run = f"[{info['run_id']}]({info['run_url']})" if info.get("run_url") else info["run_id"]
+                  print(
+                      f"| {platform} | {run} | `{info.get('sha', '')[:12]}` | "
+                      f"{info.get('created_at', '')} | {', '.join(info.get('families', []))} |"
+                  )
+          PY
+
+      - name: Build matrix and batches
+        id: build-matrix
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          BUILD_SOURCE: ${{ steps.resolve.outputs.build_source }}
+          ORCHESTRAI_DEVICE_TAGS: ${{ vars.ORCHESTRAI_DEVICE_TAGS }}
+          SUITES: ${{ inputs.suites }}
+          DEVICES: ${{ inputs.device }}
+          PLATFORMS: ${{ inputs.platform }}
+        run: python3 .github/scripts/orchestrai_matrix.py
+
+      - name: Trigger OrchestrAI pipeline builds
+        id: trigger
+        if: steps.gate.outputs.enabled == 'true' && steps.build-matrix.outputs.has_entries == 'true'
+        env:
+          BATCHES_JSON: ${{ steps.build-matrix.outputs.batches }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+          MACHINES_PER_HW_GROUP: ${{ inputs.machines_per_hw_group }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+          ORCHESTRAI_PIPELINE_URL: ${{ vars.ORCHESTRAI_PIPELINE_URL }}
+          ORCHESTRAI_PIPELINE_JOB: ${{ vars.ORCHESTRAI_PIPELINE_JOB }}
+          # Handed to the test machine so TheRock's artifact installer can
+          # authenticate its bucket lookup. Unauthenticated it shares the fleet's
+          # egress IP quota and fails with HTTP 429; the lookup cannot be
+          # bypassed. Read-only public-repo scope is all it needs.
+          ORCHESTRAI_GITHUB_TOKEN: ${{ github.token }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCE }}
+          # Optional per-release amdgpu map; overrides the single URL above on
+          # hosts whose release has an entry.
+          ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON }}
+          ORCHESTRAI_WINDOWS_DRIVER_SOURCE: ${{ secrets.ORCHESTRAI_WINDOWS_DRIVER_SOURCE }}
+        # dry_run plans every batch and prints the exact PLAN_JSON / BUILDS_JSON
+        # without POSTing, so the whole workflow can be exercised on a fork
+        # without occupying a machine from the shared fleet.
+        run: python3 .github/scripts/orchestrai_trigger.py ${{ inputs.dry_run && '--dry-run' || '' }}
+
+  test:
+    name: "${{ matrix.suite }} (${{ matrix.platform }}/${{ matrix.device }})${{ matrix.required && ' ✦' || '' }}"
+    needs: resolve-and-trigger
+    # No pipeline build exists on a dry run, so there is nothing to wait for.
+    if: needs.resolve-and-trigger.outputs.has_entries == 'true' && !inputs.dry_run
+    runs-on: ${{ vars.ORCHESTRAI_WAIT_RUNNER || 'ubuntu-latest' }}
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include: ${{ fromJson(needs.resolve-and-trigger.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Wait for pipeline build
+        id: wait
+        env:
+          BUILD_URLS_JSON: ${{ needs.resolve-and-trigger.outputs.build_urls }}
+          BATCH_ID: ${{ matrix.batch_id }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          BUILD_URL=$(python3 -c "import json,os;print(json.loads(os.environ.get('BUILD_URLS_JSON','{}') or '{}').get(os.environ['BATCH_ID'],''))")
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No pipeline build URL for batch ${BATCH_ID}"; exit 1
+          fi
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+          echo "Waiting for pipeline build ..."
+          # SECURITY: credentials go in a 0600 netrc file, never `curl -u
+          # user:token` — argv is world-readable (/proc/<pid>/cmdline, ps) for the
+          # life of each curl, which would leak the pipeline token to any other
+          # process on a shared self-hosted runner. mktemp creates the file 0600
+          # and printf is a shell builtin, so the token never hits argv.
+          NETRC="$(mktemp)"
+          trap 'rm -f "$NETRC"' EXIT
+          NETRC_HOST=$(printf '%s' "$BUILD_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#[:/].*$##')
+          printf 'machine %s login %s password %s\n' \
+            "$NETRC_HOST" "$ORCHESTRAI_PIPELINE_USER" "$ORCHESTRAI_PIPELINE_TOKEN" > "$NETRC"
+          # Bounded poll: ~5.5h (1320 * 15s) covers run_settings.max_duration (300m)
+          # plus provisioning and queue time, but never hangs to the job timeout.
+          MAX=1320
+          FAIL_MAX=20       # ~5 min of consecutive unreachable polls -> give up
+          i=0; fails=0
+          while [ "$i" -lt "$MAX" ]; do
+            if data=$(curl -sf --connect-timeout 10 --max-time 30 --netrc-file "$NETRC" "${BUILD_URL}api/json?tree=result,building" 2>/dev/null); then
+              fails=0
+              building=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('building',True))" 2>/dev/null || echo "True")
+              result=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || echo "")
+              # The batch result reflects ALL its suites; this job's verdict is
+              # resolved per-suite in the next step from summary.json.
+              if [ "$building" = "False" ] && [ -n "$result" ]; then
+                echo "Batch build finished: $result (per-suite verdict resolved next)"; break
+              fi
+            else
+              fails=$((fails + 1))
+              if [ "$fails" -ge "$FAIL_MAX" ]; then
+                echo "::error::Pipeline unreachable ($FAIL_MAX consecutive failures)"; exit 1
+              fi
+            fi
+            i=$((i + 1))
+            sleep 15
+          done
+          if [ "$i" -ge "$MAX" ]; then
+            echo "::error::Timed out waiting for the pipeline build"; exit 1
+          fi
+
+      - name: Resolve per-suite verdict
+        id: results
+        if: always()
+        env:
+          BUILD_URL: ${{ steps.wait.outputs.build_url }}
+          SUITE_ID: ${{ matrix.suite }}
+          PLATFORM: ${{ matrix.platform }}
+          DEVICE: ${{ matrix.device }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: python3 .github/scripts/orchestrai_verdict.py
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-${{ matrix.suite }}-${{ matrix.platform }}-${{ matrix.device }}
+          path: test-results/
+          if-no-files-found: ignore
+
+      - name: Test summary
+        if: always()
+        env:
+          RP_URL: ${{ steps.results.outputs.rp_url }}
+        run: |
+          {
+            echo "### \`${{ matrix.suite }}\` (${{ matrix.platform }}/${{ matrix.device }})"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| AMDGPU family | \`${{ matrix.family }}\` |"
+            # This repo is PUBLIC, so the job summary is world-readable. Show the
+            # ReportPortal launch id rather than the full URL: it is the useful
+            # part for anyone who can reach ReportPortal, and it does not publish
+            # an internal hostname to the world. Set ORCHESTRAI_PUBLIC_LOGS=false
+            # on a private mirror to get the clickable link back.
+            if [ -n "${RP_URL}" ]; then
+              if [ "${{ vars.ORCHESTRAI_PUBLIC_LOGS }}" = "false" ]; then
+                echo "| ReportPortal | [View results](${RP_URL}) |"
+              else
+                echo "| ReportPortal launch | \`$(basename "${RP_URL}")\` |"
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  gate:
+    name: OrchestrAI Gate
+    needs: [resolve-and-trigger, test]
+    if: always()
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Check required suites
+        run: |
+          echo "resolve-and-trigger: ${{ needs.resolve-and-trigger.result }}"
+          echo "test:                ${{ needs.test.result }}"
+          # A failure in resolve/matrix/trigger skips the test job, so gate on it
+          # too — otherwise a trigger failure would leave this check green.
+          if [ "${{ needs.resolve-and-trigger.result }}" = "failure" ]; then
+            echo "::error::Resolve/trigger failed — the pipeline did not run"; exit 1
+          fi
+          # A configured run that schedules nothing is a misconfiguration, not a
+          # pass: every device was dropped (missing ORCHESTRAI_DEVICE_TAGS entry,
+          # skip_devices, or a family the source build did not produce). Without
+          # this check the nightly would go green while testing nothing at all.
+          # The warnings in the matrix step name the exact cause.
+          if [ "${{ needs.resolve-and-trigger.outputs.enabled }}" = "true" ] \
+             && [ "${{ needs.resolve-and-trigger.outputs.has_entries }}" != "true" ]; then
+            echo "::error::A build was resolved but no suite was scheduled — see the 'Build matrix and batches' warnings"; exit 1
+          fi
+          if [ "${{ needs.test.result }}" = "failure" ]; then
+            echo "::error::One or more required suites failed"; exit 1
+          fi
+          echo "All required suites passed (or none were needed)"


### PR DESCRIPTION
Adds a nightly workflow that runs the language-runtime (HIP / OpenCL / CLR) suites against a recent TheRock Multi-Arch CI build **on real AMD hardware**, via the OrchestrAI pipeline and its hardware broker, instead of on a device-attached GitHub runner.

**Nothing is built here.** The workflow finds a Multi-Arch CI run whose artifacts are actually present in S3, then points leased machines at those artifacts. It is additive and opt-in: six new files under `.github/`, no existing workflow touched, and it no-ops on a fork that lacks the secrets.

## How it works

```
TheRock Multi-Arch CI ──▶ S3 artifacts        (someone else's build)
                              │
   1. resolve_build.py  ──────┘  which run actually has the files?
   2. matrix.py            suites × GPUs × OS  →  one job each
   3. trigger.py           hand batches to the pipeline
        └─▶ leased GPU box: driver → ROCm from those artifacts → verify → run
   4. verdict.py           per-suite PASS/FAIL  →  one gate
```

## Verified before submission

| | |
|---|---|
| **On hardware** | An OrchestrAI pipeline build ran `hip-catch2` on a real RX 7900 XTX (gfx1100): **PASSED**, `1P / 0F / 0S / 0E`, 33 min |
| **In Actions** | A `dry_run` dispatch on a fork resolved the real build, expanded the matrix and printed the pipeline payload while leasing no hardware |

## Design points worth a reviewer's attention

**A source run's pass/fail is deliberately ignored.** Multi-Arch CI runs are marked `failure` most nights because a late test job fails while every artifact built fine. So the resolver probes S3 for the artifacts themselves. That also lets it pick up the *same day's* build, since artifacts land hours before a run finishes.

**One leased machine runs several suites**, so the batch result cannot be the answer. Each suite's verdict is resolved individually from the pipeline's `summary.json`.

**Failing before hardware is acquired is a theme throughout.** Missing credentials, an unset driver source, an unclassified device or a malformed driver map all stop the trigger *before* a machine is leased — the alternative is discovering the problem ten minutes into a box you are already holding.

**The machine verifies its own GPU** against the artifacts it just installed, and refuses to run on a mismatch. Testing binaries on silicon they were not built for produces results that look real and are not.

## Scheduling is config, not code

Everything lives in `.github/orchestrai-config.yml`. Adding a suite is about five lines; a device is three plus one repo variable. Either can be checked with `orchestrai_matrix.py --print` or a `dry_run` dispatch, neither of which leases hardware.

Anything unschedulable is dropped with a **named** warning rather than silently — missing broker tag, unmapped device, or a GPU family the source build did not produce. A run that resolves a build but schedules nothing **fails** rather than going green.

## This repository is public, and the code assumes it

Internal coordinates — pipeline host, broker tags, driver package URLs — are never committed. They arrive from repo variables and secrets, and the committed config carries empty fallbacks.

GitHub Actions echoes each step's `env:` block and never masks variables, so log hygiene is deliberate: the pipeline build URL is logged as a bare build number, driver URLs and tokens are redacted from `dry_run` payloads, and the results host is reduced to a launch id. GPU architecture tags are **left visible on purpose** — they are not secret, and they are what tells you a run landed on the wrong machine.

## Before this can run on a schedule

- The repo secrets and variables listed in the workflow header.
- **A runner that can reach the pipeline.** The pipeline host resolves to an internal address and is unreachable from GitHub-hosted runners, so `ORCHESTRAI_CONTROL_RUNNER` / `ORCHESTRAI_WAIT_RUNNER` must name runners with that access. Worth confirming which label qualifies.
- Only the Linux HIP Catch2 suite exists in the test library today. The Windows suites, and the Windows provisioning script, are still to come — which is why no suite currently lists `windows`.

Depends on a companion provisioning change (already merged) that adds the artifact-based ROCm installer these runs use.
