### PR TITLE
fix(rccl): honor NCCL_MAX_P2P_NCHANNELS as a downward cap for send/recv UT

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1325,6 +1325,12 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     {
       bool userOptedHigher = false;
       int upper = ncclP2pChannelsUpperBound(comm, &userOptedHigher);
+      // When the user set MAX_P2P_NCHANNELS, it is also a downward cap. pow2Up(p2pnChannelsPerPeer)
+      // (single-node doubling on gfx942/950/1250) would otherwise raise the pool above a small
+      // request such as NCCL_MAX_P2P_NCHANNELS=1. pow2Up of the user max keeps the existing
+      // non-pow2 rounding (48 -> 64).
+      if (ncclParamMaxP2pNChannels() != -2)
+        upper = std::min(upper, pow2Up(std::max(1, ncclMaxP2pNchannels())));
       comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), upper);
       if (!userOptedHigher) {
         // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1330,7 +1330,14 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
       // request such as NCCL_MAX_P2P_NCHANNELS=1. pow2Up of the user max keeps the existing
       // non-pow2 rounding (48 -> 64).
       if (ncclParamMaxP2pNChannels() != -2) {
-        upper = std::min(upper, pow2Up(std::max(1, ncclMaxP2pNchannels())));
+        int userMax = pow2Up(std::max(1, ncclMaxP2pNchannels()));
+        int minP2p = (int)ncclParamMinP2pNChannels();
+        if (minP2p > userMax) {
+          INFO(NCCL_GRAPH | NCCL_ENV,
+               "NCCL_MAX_P2P_NCHANNELS=%d overrides NCCL_MIN_P2P_NCHANNELS=%d; using %d P2P channels",
+               (int)ncclParamMaxP2pNChannels(), minP2p, userMax);
+        }
+        upper = std::min(upper, userMax);
       }
       comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), upper);
       if (!userOptedHigher) {

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1329,8 +1329,9 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
       // (single-node doubling on gfx942/950/1250) would otherwise raise the pool above a small
       // request such as NCCL_MAX_P2P_NCHANNELS=1. pow2Up of the user max keeps the existing
       // non-pow2 rounding (48 -> 64).
-      if (ncclParamMaxP2pNChannels() != -2)
+      if (ncclParamMaxP2pNChannels() != -2) {
         upper = std::min(upper, pow2Up(std::max(1, ncclMaxP2pNchannels())));
+      }
       comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), upper);
       if (!userOptedHigher) {
         // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS

--- a/projects/rccl/test/ChannelDefaultsTests.cpp
+++ b/projects/rccl/test/ChannelDefaultsTests.cpp
@@ -217,6 +217,23 @@ TEST(ChannelDefaults, Gfx950_RequestedBelow64IsHonored)
         {{"NCCL_MAX_P2P_NCHANNELS", "32"}});
 }
 
+// Single-node doubling raises p2pnChannelsPerPeer; a user max of 1 must still win.
+TEST(ChannelDefaults, Gfx1250_Requested1CapsDoubling)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "ChannelDefaults_Gfx1250_Requested1",
+        []()
+        {
+            const ResolvedChannels r =
+              ResolveP2pChannels("gfx1250", /*nRanks=*/4, kDefaultCollChannels, /*nNodes=*/1,
+                                 /*allRanksLocal=*/true);
+            EXPECT_EQ(r.p2pnChannels, 1);
+            EXPECT_EQ(r.p2pnChannelsPerPeer, 1);
+            ExpectPoolInvariant(r);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "1"}});
+}
+
 TEST(ChannelDefaults, Gfx1250_RequestedOverridesArchDefault)
 {
     RUN_ISOLATED_TEST_WITH_ENV(

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -83,6 +83,24 @@ namespace RcclUnitTesting
     globfree(&g);
   }
 
+  // Force a lightweight NET loopback for P2P+SHM-disabled tests. IB-CAST on this path treats
+  // each GPU as its own node and ibv_create_qp fails (EAGAIN); GIN still opens IB QPs even when
+  // NCCL_NET=Socket. Socket + GIN off still goes through net.cc staging-buffer allocation.
+  static void PinNetLoopbackTransport()
+  {
+    setenv("NCCL_NET", "Socket", 1);
+    setenv("NCCL_GIN_ENABLE", "0", 1);
+    setenv("NCCL_MIN_NCHANNELS", "1", 1);
+    setenv("NCCL_MAX_NCHANNELS", "2", 1);
+  }
+  static void UnpinNetLoopbackTransport()
+  {
+    unsetenv("NCCL_MAX_NCHANNELS");
+    unsetenv("NCCL_MIN_NCHANNELS");
+    unsetenv("NCCL_GIN_ENABLE");
+    unsetenv("NCCL_NET");
+  }
+
   TEST(SendRecv, SinglePairs)
   {
     TestBed testBed;
@@ -271,6 +289,7 @@ namespace RcclUnitTesting
                         {1,2}, //two group, second group sendrecv to self, has 2 coll
                         testBed.GetNumStreamsPerGroup(1,2),
                         2);
+      if (::testing::Test::HasFatalFailure()) return;
 
       for (int dataIdx = 0; dataIdx < dataTypes.size() && isCorrect; ++dataIdx)
       for (int numIdx = 0; numIdx < numElements.size() && isCorrect; ++numIdx)
@@ -446,6 +465,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "0", 1); // disabled case
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
     setenv("NCCL_P2P_LL_THRESHOLD", "16384", 1);     // legacy-LL threshold governs when the LL128 path is off
@@ -466,6 +486,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_P2P_LL_THRESHOLD");
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }
@@ -480,6 +501,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("RCCL_LL128_FORCE_ENABLE", "1", 1);       // ll128Enabled=true (required by the P2P LL128 gate)
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "1", 1); // enabled case
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
@@ -509,6 +531,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
     unsetenv("RCCL_LL128_FORCE_ENABLE");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }
@@ -596,6 +619,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("RCCL_LL128_FORCE_ENABLE", "1", 1);       // ll128Enabled=true (required by the P2P LL128 gate)
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "1", 1); // enable the LL128 staging buffer
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
@@ -623,6 +647,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
     unsetenv("RCCL_LL128_FORCE_ENABLE");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -93,6 +93,7 @@ namespace RcclUnitTesting
     setenv("NCCL_MIN_NCHANNELS", "1", 1);
     setenv("NCCL_MAX_NCHANNELS", "2", 1);
   }
+
   static void UnpinNetLoopbackTransport()
   {
     unsetenv("NCCL_MAX_NCHANNELS");

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -86,20 +86,80 @@ namespace RcclUnitTesting
   // Force a lightweight NET loopback for P2P+SHM-disabled tests. IB-CAST on this path treats
   // each GPU as its own node and ibv_create_qp fails (EAGAIN); GIN still opens IB QPs even when
   // NCCL_NET=Socket. Socket + GIN off still goes through net.cc staging-buffer allocation.
+  struct NetLoopbackEnvBackup {
+    bool        hadNet           = false;
+    bool        hadGinEnable     = false;
+    bool        hadMinNchannels  = false;
+    bool        hadMaxNchannels  = false;
+    std::string net;
+    std::string ginEnable;
+    std::string minNchannels;
+    std::string maxNchannels;
+  };
+
+  static NetLoopbackEnvBackup netLoopbackEnvBackup;
+
   static void PinNetLoopbackTransport()
   {
-    setenv("NCCL_NET", "Socket", 1);
-    setenv("NCCL_GIN_ENABLE", "0", 1);
-    setenv("NCCL_MIN_NCHANNELS", "1", 1);
-    setenv("NCCL_MAX_NCHANNELS", "2", 1);
+    if (const char* v = ::getenv("NCCL_NET")) {
+      netLoopbackEnvBackup.hadNet = true;
+      netLoopbackEnvBackup.net    = v;
+    } else {
+      netLoopbackEnvBackup.hadNet = false;
+      netLoopbackEnvBackup.net.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_GIN_ENABLE")) {
+      netLoopbackEnvBackup.hadGinEnable = true;
+      netLoopbackEnvBackup.ginEnable    = v;
+    } else {
+      netLoopbackEnvBackup.hadGinEnable = false;
+      netLoopbackEnvBackup.ginEnable.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_MIN_NCHANNELS")) {
+      netLoopbackEnvBackup.hadMinNchannels = true;
+      netLoopbackEnvBackup.minNchannels    = v;
+    } else {
+      netLoopbackEnvBackup.hadMinNchannels = false;
+      netLoopbackEnvBackup.minNchannels.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_MAX_NCHANNELS")) {
+      netLoopbackEnvBackup.hadMaxNchannels = true;
+      netLoopbackEnvBackup.maxNchannels    = v;
+    } else {
+      netLoopbackEnvBackup.hadMaxNchannels = false;
+      netLoopbackEnvBackup.maxNchannels.clear();
+    }
+
+    ::setenv("NCCL_NET", "Socket", 1);
+    ::setenv("NCCL_GIN_ENABLE", "0", 1);
+    ::setenv("NCCL_MIN_NCHANNELS", "1", 1);
+    ::setenv("NCCL_MAX_NCHANNELS", "2", 1);
   }
 
   static void UnpinNetLoopbackTransport()
   {
-    unsetenv("NCCL_MAX_NCHANNELS");
-    unsetenv("NCCL_MIN_NCHANNELS");
-    unsetenv("NCCL_GIN_ENABLE");
-    unsetenv("NCCL_NET");
+    if (netLoopbackEnvBackup.hadMaxNchannels)
+      ::setenv("NCCL_MAX_NCHANNELS", netLoopbackEnvBackup.maxNchannels.c_str(), 1);
+    else
+      ::unsetenv("NCCL_MAX_NCHANNELS");
+
+    if (netLoopbackEnvBackup.hadMinNchannels)
+      ::setenv("NCCL_MIN_NCHANNELS", netLoopbackEnvBackup.minNchannels.c_str(), 1);
+    else
+      ::unsetenv("NCCL_MIN_NCHANNELS");
+
+    if (netLoopbackEnvBackup.hadGinEnable)
+      ::setenv("NCCL_GIN_ENABLE", netLoopbackEnvBackup.ginEnable.c_str(), 1);
+    else
+      ::unsetenv("NCCL_GIN_ENABLE");
+
+    if (netLoopbackEnvBackup.hadNet)
+      ::setenv("NCCL_NET", netLoopbackEnvBackup.net.c_str(), 1);
+    else
+      ::unsetenv("NCCL_NET");
   }
 
   TEST(SendRecv, SinglePairs)

--- a/projects/rccl/test/common/TestBedChild.cpp
+++ b/projects/rccl/test/common/TestBedChild.cpp
@@ -404,8 +404,17 @@ namespace RcclUnitTesting
       {
         CollectiveArgs& collArg = this->collArgs[groupId][localRank][collIdx];
         CHECK_CALL(collArg.AllocateMem(inPlace, useManagedMem, userRegistered));
-        if (collArg.userRegistered && (collArg.funcType == ncclCollSend || collArg.funcType == ncclCollRecv))
-          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr, collArg.numInputBytesAllocated, &(collArg.commRegHandle)),"ncclCommRegister");
+        if (collArg.userRegistered && collArg.funcType == ncclCollSend) {
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr,
+                                           collArg.numInputBytesAllocated, &(collArg.commRegHandle)),
+                          "ncclCommRegister");
+        } else if (collArg.userRegistered && collArg.funcType == ncclCollRecv) {
+          // ncclRecv writes outputGpu; registering inputGpu leaves the recv buffer
+          // unregistered and SIMPLE/IPC can write into the wrong mapping (zeros + fault).
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.outputGpu.ptr,
+                                           collArg.numOutputBytesAllocated, &(collArg.commRegHandle)),
+                          "ncclCommRegister");
+        }
         if (this->verbose) TEST_INFO("Rank %d on child %d allocates memory for collective %d in group %d on device %d (%s,%s,%s) Input: %p Output %p",
                                 globalRank, this->childId, collIdx, groupId, this->deviceIds[localRank],
                                 inPlace ? "in-place" : "out-of-place",


### PR DESCRIPTION
## Motivation

Fix UT failure on gfx1250

## Technical Details

Per-peer doubling was raising p2pnChannels above a user max of 1, and P2P+SHM-disabled NET tests failed init by exhausting IB QPs. Cap the pool to the requested max and pin those tests to Socket loopback with GIN off.

ncclRecv writes outputGpu, but the harness registered inputGpu, so SIMPLE/IPC landed in the unused mapping and UserBufferRegister saw zeros then a GPU page fault.

## Issue Tracking

JIRA ID : ROCM-29722

## Test Plan

Run RCCL UT on gfx1250

## Test Result

Test should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
