### PR TITLE
fix(clr): add explicit cast for fp4 types

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -263,7 +263,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(
-        u.ui32, internal::half2_to_f16x2(__half2{x, 0}), 1.0f /* scale */, 0);
+        u.ui32, internal::half2_to_f16x2(__half2{x, __half_raw{0u}}), 1.0f /* scale */, 0);
   return u.fp4[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   auto val = internal::half2_to_f16x2(__half2{x, x});

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
@@ -68,8 +68,7 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
 
   // Inputs: every value below is exactly representable in FP4 E2M1, so no
   // rounding occurs in either direction.
-  std::vector<float> in = {0.0f,  0.5f, -0.5f, 1.0f, -1.0f,
-                           1.5f, -1.5f,  2.0f, 3.0f,  4.0f};
+  std::vector<float> in = {0.0f, 0.5f, -0.5f, 1.0f, -1.0f, 1.5f, -1.5f, 2.0f, 3.0f, 4.0f};
   const size_t size = in.size();
 
   float *d_in, *d_out;
@@ -111,3 +110,56 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
 
   HIP_CHECK(hipModuleUnload(module));
 }
+
+#if HT_AMD
+TEST_CASE("Unit_hiprtc_check_hide_op_flag") {
+  constexpr const char* source = R"(
+extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t size) {
+  size_t i = threadIdx.x;
+  // do nothing
+}
+)";
+
+  // We basically check for static archs.
+  // Just want to make sure operators are correctly visible for different archs
+  std::vector<std::string> archs{"gfx942", "gfx950", "gfx1250"};
+
+  for (const auto& arch : archs) {
+    std::string sarg = std::string("--offload-arch=") + arch;
+    CAPTURE(sarg);
+
+    // Not consexpr since we need pointers
+    std::array all_options{
+        "-D__HIP_NO_HALF_CONVERSIONS__=1",         "-D__HIP_NO_HALF_OPERATORS__=1",
+        "-D__HIP_NO_FP4_CONVERSION_OPERATORS__=1", "-D__HIP_NO_FP4_CONVERSIONS__=1",
+        "-D__HIP_NO_FP6_CONVERSIONS__=1",          "-D__HIP_NO_FP6_CONVERSION_OPERATORS__=1"};
+
+    constexpr unsigned N = all_options.size();
+
+    for (unsigned mask = 0; mask < (1u << N); ++mask) {
+      std::vector<const char*> opts{sarg.data()};
+      // Basically generate combinations of the options to mix and match it
+      for (unsigned i = 0; i < N; ++i) {
+        if (mask & (1u << i)) {
+          opts.push_back(all_options[i]);
+        }
+      }
+
+      CAPTURE(opts);
+
+      hiprtcProgram prog{};
+      HIPRTC_CHECK(hiprtcCreateProgram(&prog, source, "kernel.cu", 0, nullptr, nullptr));
+      hiprtcResult compileResult{hiprtcCompileProgram(prog, opts.size(), opts.data())};
+      size_t logSize{};
+      HIPRTC_CHECK(hiprtcGetProgramLogSize(prog, &logSize));
+      if (logSize) {
+        std::string log(logSize, '\0');
+        HIPRTC_CHECK(hiprtcGetProgramLog(prog, &log[0]));
+        std::cout << log << '\n';
+      }
+      REQUIRE(compileResult == HIPRTC_SUCCESS);
+      HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+    }
+  }
+}
+#endif

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
@@ -122,13 +122,13 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
 
   // We basically check for static archs.
   // Just want to make sure operators are correctly visible for different archs
-  std::vector<std::string> archs{"gfx942", "gfx950", "gfx1250"};
+  std::vector<std::string> archs{"gfx950", "gfx1250"};
 
   for (const auto& arch : archs) {
     std::string sarg = std::string("--offload-arch=") + arch;
     CAPTURE(sarg);
 
-    // Not consexpr since we need pointers
+    // Not constexpr since we need pointers
     std::array all_options{
         "-D__HIP_NO_HALF_CONVERSIONS__=1",         "-D__HIP_NO_HALF_OPERATORS__=1",
         "-D__HIP_NO_FP4_CONVERSION_OPERATORS__=1", "-D__HIP_NO_FP4_CONVERSIONS__=1",
@@ -137,7 +137,7 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
     constexpr unsigned N = all_options.size();
 
     for (unsigned mask = 0; mask < (1u << N); ++mask) {
-      std::vector<const char*> opts{sarg.data()};
+      std::vector<const char*> opts{sarg.c_str()};
       // Basically generate combinations of the options to mix and match it
       for (unsigned i = 0; i < N; ++i) {
         if (mask & (1u << i)) {


### PR DESCRIPTION
## Motivation

Add explicit cast for fp4 operators when user might hide some operators in rtc

## Technical Details

Users can hide some operators with some defines in rtc, so this might fail when conversion operators are hidden. We add an explicit cast to fix it.

## Issue Tracking

JIRA ID: AIRUNTIME-2707

## Test Plan

Added new test for it

## Test Result

It passes locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
