### PR TITLE
fix(rocprofiler-sdk): Prevent bundled rocprofiler-sdk in PyTorch from initializing with rocprofv3

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -169,7 +169,7 @@ include(rocprofiler_memcheck)
 
 # default FAIL_REGULAR_EXPRESSION for tests
 set(ROCPROFILER_DEFAULT_FAIL_REGEX
-    "threw an exception|Permission denied|failed with error code|Subprocess aborted"
+    "threw an exception|Permission denied|failed with error code|Subprocess aborted|Failed to resolve rocprofiler-sdk shared library path"
     CACHE INTERNAL "Default FAIL_REGULAR_EXPRESSION for tests" FORCE)
 
 # this should be defaulted to OFF by ROCm 7.0.1 or 7.1 this should only used to disable

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -163,7 +163,7 @@ include(rocprofiler_memcheck)
 
 # default FAIL_REGULAR_EXPRESSION for tests
 set(ROCPROFILER_DEFAULT_FAIL_REGEX
-    "threw an exception|Permission denied|failed with error code|Subprocess aborted"
+    "threw an exception|Permission denied|failed with error code|Subprocess aborted|Failed to resolve rocprofiler-sdk shared library path"
     CACHE INTERNAL "Default FAIL_REGULAR_EXPRESSION for tests" FORCE)
 
 # this should be defaulted to OFF by ROCm 7.0.1 or 7.1 this should only used to disable

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
@@ -127,6 +127,44 @@ install(
 
 # ----------------------------------------------------------------------------------------#
 #
+# unversioned shared library used to test loading two instances of rocprofiler-sdk
+#
+# ----------------------------------------------------------------------------------------#
+
+if(ROCPROFILER_BUILD_TESTS)
+    add_library(rocprofiler-sdk-test-duplicate-shared-library SHARED)
+
+    target_sources(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PRIVATE $<TARGET_OBJECTS:rocprofiler-sdk::rocprofiler-sdk-object-library>
+                shared_library.cpp)
+    target_link_libraries(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PUBLIC rocprofiler-sdk::rocprofiler-sdk-headers
+        PRIVATE rocprofiler-sdk::rocprofiler-sdk-build-flags
+                rocprofiler-sdk::rocprofiler-sdk-memcheck
+                rocprofiler-sdk::rocprofiler-sdk-common-library
+                rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem
+                rocprofiler-sdk::rocprofiler-sdk-dl
+                rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+                rocprofiler-sdk::rocprofiler-sdk-object-library)
+
+    set_target_properties(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PROPERTIES OUTPUT_NAME rocprofiler-sdk
+                   LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tests/duplicate-sdk"
+                   BUILD_RPATH "\$ORIGIN"
+                   DEFINE_SYMBOL rocprofiler_EXPORTS)
+
+    install(
+        TARGETS rocprofiler-sdk-test-duplicate-shared-library
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/tests/duplicate-sdk
+            COMPONENT tests)
+endif()
+
+# ----------------------------------------------------------------------------------------#
+#
 # static library (only built if another target links to it)
 #
 # ----------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/CMakeLists.txt
@@ -125,6 +125,44 @@ install(
 
 # ----------------------------------------------------------------------------------------#
 #
+# unversioned shared library used to test loading two instances of rocprofiler-sdk
+#
+# ----------------------------------------------------------------------------------------#
+
+if(ROCPROFILER_BUILD_TESTS)
+    add_library(rocprofiler-sdk-test-duplicate-shared-library SHARED)
+
+    target_sources(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PRIVATE $<TARGET_OBJECTS:rocprofiler-sdk::rocprofiler-sdk-object-library>
+                shared_library.cpp)
+    target_link_libraries(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PUBLIC rocprofiler-sdk::rocprofiler-sdk-headers
+        PRIVATE rocprofiler-sdk::rocprofiler-sdk-build-flags
+                rocprofiler-sdk::rocprofiler-sdk-memcheck
+                rocprofiler-sdk::rocprofiler-sdk-common-library
+                rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem
+                rocprofiler-sdk::rocprofiler-sdk-dl
+                rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+                rocprofiler-sdk::rocprofiler-sdk-object-library)
+
+    set_target_properties(
+        rocprofiler-sdk-test-duplicate-shared-library
+        PROPERTIES OUTPUT_NAME rocprofiler-sdk
+                   LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tests/duplicate-sdk"
+                   BUILD_RPATH "\$ORIGIN"
+                   DEFINE_SYMBOL rocprofiler_EXPORTS)
+
+    install(
+        TARGETS rocprofiler-sdk-test-duplicate-shared-library
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/tests/duplicate-sdk
+            COMPONENT tests)
+endif()
+
+# ----------------------------------------------------------------------------------------#
+#
 # static library (only built if another target links to it)
 #
 # ----------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -59,6 +59,7 @@ struct library_info
     library_info(std::string_view sym_name, void* sym);
 
     std::string as_string() const;
+                operator bool() const { return (handle != nullptr || !fname.empty()); }
     friend bool operator==(const library_info& lhs, const library_info& rhs);
 
     std::string fname  = {};
@@ -97,14 +98,17 @@ library_info::as_string() const
 bool
 operator==(const library_info& lhs, const library_info& rhs)
 {
-    // if both handles are resolved, compare the handles
+    // if both handles are resolved, compare only the handles
     if(lhs.handle != nullptr && rhs.handle != nullptr) return (lhs.handle == rhs.handle);
 
-    // if both have names, compare the file names
+    // if both have names, compare the file names as a fallback
     if(!lhs.fname.empty() && !rhs.fname.empty()) return (lhs.fname == rhs.fname);
 
-    // comparison not possible, return false
-    return false;
+    // if neither are populated, this should be a warning or a failure in CI.
+    ROCP_CI_LOG_IF(WARNING, !lhs && !rhs)
+        << "Comparing two empty rocprofiler-sdk library_info objects";
+
+    return std::tie(lhs.handle, lhs.fname) == std::tie(rhs.handle, rhs.fname);
 }
 
 auto
@@ -137,14 +141,12 @@ struct lifetime
 lifetime::lifetime()
 {
     registration::init_logging();
-    local_shared_library_resolver();  // effectively a no-op but references the symbol to prevent
-                                      // unused func warnings, etc.
 
     if(common::get_env("ROCPROFILER_LIBRARY_CTOR", false))
     {
         auto _this = get_this_library_info();
         auto _glob = get_global_library_info();
-        if(_this == _glob)
+        if(_this == _glob || (_this && !_glob))
         {
             ROCP_INFO << "Initializing rocprofiler-sdk library...";
             registration::initialize();
@@ -158,6 +160,9 @@ lifetime::lifetime()
                 _this.as_string(),
                 _glob.as_string());
         }
+        // this is needed when one of the rocprofiler-sdk libraries doesn't have the _this == _glob
+        // check
+        common::set_env("ROCPROFILER_LIBRARY_CTOR", false, 1);
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -77,13 +77,16 @@ library_info::library_info(std::string_view sym_name, void* sym)
     }
     else
     {
+        const char* _fname = (_info.dli_fname) ? _info.dli_fname : "(null)";
+        const char* _sname = (_info.dli_sname) ? _info.dli_sname : "(null)";
+
         ROCP_WARNING << fmt::format(
             "Failed to resolve rocprofiler-sdk shared library path to symbol '{}' ({}) :: "
             "file_name={}, symbol_name={}, load_address={}, nearest_symbol={}",
             sym_name,
             sdk::utility::as_hex(sym),
-            _info.dli_fname,
-            _info.dli_sname,
+            _fname,
+            _sname,
             sdk::utility::as_hex(_info.dli_fbase),
             sdk::utility::as_hex(_info.dli_saddr));
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -59,21 +59,21 @@ struct library_info
     library_info(std::string_view sym_name, void* sym);
 
     std::string as_string() const;
-                operator bool() const { return (handle != nullptr || !fname.empty()); }
+                operator bool() const { return (load_address != nullptr); }
     friend bool operator==(const library_info& lhs, const library_info& rhs);
 
-    std::string fname  = {};
-    void*       handle = nullptr;
+    std::string fname        = {};
+    void*       load_address = nullptr;
 };
 
 library_info::library_info(std::string_view sym_name, void* sym)
 {
     auto _info = Dl_info{};
     auto _ec   = ::dladdr(sym, &_info);
-    if(_ec != 0 && _info.dli_fname != nullptr)
+    if(_ec != 0 && _info.dli_fbase != nullptr)
     {
-        fname  = _info.dli_fname;
-        handle = ::dlopen(_info.dli_fname, RTLD_NOW | RTLD_NOLOAD);
+        if(_info.dli_fname != nullptr) fname = _info.dli_fname;
+        load_address = _info.dli_fbase;
     }
     else
     {
@@ -95,23 +95,13 @@ library_info::library_info(std::string_view sym_name, void* sym)
 std::string
 library_info::as_string() const
 {
-    return fmt::format("fname='{}', handle={}", fname, sdk::utility::as_hex(handle));
+    return fmt::format("fname='{}', load_address={}", fname, sdk::utility::as_hex(load_address));
 }
 
 bool
 operator==(const library_info& lhs, const library_info& rhs)
 {
-    // if both handles are resolved, compare only the handles
-    if(lhs.handle != nullptr && rhs.handle != nullptr) return (lhs.handle == rhs.handle);
-
-    // if both have names, compare the file names as a fallback
-    if(!lhs.fname.empty() && !rhs.fname.empty()) return (lhs.fname == rhs.fname);
-
-    // if neither are populated, this should be a warning or a failure in CI.
-    ROCP_CI_LOG_IF(WARNING, !lhs && !rhs)
-        << "Comparing two empty rocprofiler-sdk library_info objects";
-
-    return std::tie(lhs.handle, lhs.fname) == std::tie(rhs.handle, rhs.fname);
+    return (lhs && rhs && lhs.load_address == rhs.load_address);
 }
 
 auto
@@ -149,7 +139,7 @@ lifetime::lifetime()
     {
         auto _this = get_this_library_info();
         auto _glob = get_global_library_info();
-        if(_this == _glob || (_this && !_glob))
+        if(!_this || !_glob || _this == _glob)
         {
             ROCP_INFO << "Initializing rocprofiler-sdk library...";
             registration::initialize();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -20,19 +20,114 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#define _GNU_SOURCE 1
+
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 
+#include <rocprofiler-sdk/cxx/utility.hpp>
+
+#include <dlfcn.h>
 #include <iostream>
 
 namespace rocprofiler
 {
 namespace shared_library
 {
+// Hidden visibility so references to it always resolve to the local instance. Ensure the symbol
+// is not inlined via noinline attribute. When the library is stripped, using dladdr on this symbol
+// will typically return non-zero (success) and dli_fname will give the correct .so path but
+// dli_sname will often be NULL or name the *nearest* exported symbol and dli_saddr may point to a
+// different exported symbol.
+ROCPROFILER_NOINLINE void
+local_shared_library_resolver(void) ROCPROFILER_HIDDEN_API;
+
+void
+local_shared_library_resolver(void)
+{
+    rocprofiler::registration::init_logging();
+}
+
 namespace
 {
+// used in determining whether this rocprofiler-sdk shared library is the global one
+struct library_info
+{
+    library_info() = default;
+    library_info(std::string_view sym_name, void* sym);
+
+    std::string as_string() const;
+    friend bool operator==(const library_info& lhs, const library_info& rhs);
+
+    std::string fname  = {};
+    void*       handle = nullptr;
+};
+
+library_info::library_info(std::string_view sym_name, void* sym)
+{
+    auto _info = Dl_info{};
+    auto _ec   = ::dladdr(sym, &_info);
+    if(_ec != 0 && _info.dli_fname != nullptr)
+    {
+        fname  = _info.dli_fname;
+        handle = ::dlopen(_info.dli_fname, RTLD_NOW | RTLD_NOLOAD);
+    }
+    else
+    {
+        ROCP_WARNING << fmt::format(
+            "Failed to resolve rocprofiler-sdk shared library path to symbol '{}' ({}) :: "
+            "file_name={}, symbol_name={}, load_address={}, nearest_symbol={}",
+            sym_name,
+            sdk::utility::as_hex(sym),
+            _info.dli_fname,
+            _info.dli_sname,
+            sdk::utility::as_hex(_info.dli_fbase),
+            sdk::utility::as_hex(_info.dli_saddr));
+    }
+}
+
+std::string
+library_info::as_string() const
+{
+    return fmt::format("fname='{}', handle={}", fname, sdk::utility::as_hex(handle));
+}
+
+bool
+operator==(const library_info& lhs, const library_info& rhs)
+{
+    // if both handles are resolved, compare the handles
+    if(lhs.handle != nullptr && rhs.handle != nullptr) return (lhs.handle == rhs.handle);
+
+    // if both have names, compare the file names
+    if(!lhs.fname.empty() && !rhs.fname.empty()) return (lhs.fname == rhs.fname);
+
+    // comparison not possible, return false
+    return false;
+}
+
+auto
+get_this_library_info()
+{
+    return library_info{
+        "local_shared_library_resolver",
+        reinterpret_cast<void*>(&::rocprofiler::shared_library::local_shared_library_resolver)};
+}
+
+auto
+get_global_library_info()
+{
+    void* _global_addr = dlsym(RTLD_DEFAULT, "rocprofiler_set_api_table");
+    if(!_global_addr)
+    {
+        ROCP_WARNING << "Failed to resolve global symbol 'rocprofiler_set_api_table'";
+        return library_info{};
+    }
+
+    return library_info{"rocprofiler_set_api_table", _global_addr};
+}
+
 struct lifetime
 {
     lifetime();
@@ -42,12 +137,27 @@ struct lifetime
 lifetime::lifetime()
 {
     registration::init_logging();
+    local_shared_library_resolver();  // effectively a no-op but references the symbol to prevent
+                                      // unused func warnings, etc.
 
     if(common::get_env("ROCPROFILER_LIBRARY_CTOR", false))
     {
-        ROCP_INFO << "Initializing rocprofiler-sdk library...";
-        registration::initialize();
-        ROCP_INFO << "rocprofiler-sdk library initialized";
+        auto _this = get_this_library_info();
+        auto _glob = get_global_library_info();
+        if(_this == _glob)
+        {
+            ROCP_INFO << "Initializing rocprofiler-sdk library...";
+            registration::initialize();
+            ROCP_INFO << "rocprofiler-sdk library initialized";
+        }
+        else
+        {
+            ROCP_INFO << fmt::format(
+                "Skipping rocprofiler-sdk shared library initialization within it is already "
+                "initialized in the global context. Local: [{}], Global: [{}]",
+                _this.as_string(),
+                _glob.as_string());
+        }
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -46,9 +46,7 @@ local_shared_library_resolver(void) ROCPROFILER_HIDDEN_API;
 
 void
 local_shared_library_resolver(void)
-{
-    rocprofiler::registration::init_logging();
-}
+{}
 
 namespace
 {
@@ -148,7 +146,7 @@ lifetime::lifetime()
         else
         {
             ROCP_INFO << fmt::format(
-                "Skipping rocprofiler-sdk shared library initialization within it is already "
+                "Skipping rocprofiler-sdk shared library initialization because it is already "
                 "initialized in the global context. Local: [{}], Global: [{}]",
                 _this.as_string(),
                 _glob.as_string());

--- a/projects/rocprofiler-sdk/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/CMakeLists.txt
@@ -126,6 +126,9 @@ add_subdirectory(late-start-tracing)
 # multiple anytime tool configuration validation tests
 add_subdirectory(multi-tool-test)
 
+# duplicate rocprofiler-sdk initialization validation test
+add_subdirectory(duplicate-sdk-initialization)
+
 # anytime tool configuration (force_configure) validation tests
 add_subdirectory(anytime-tool-config)
 

--- a/projects/rocprofiler-sdk/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/CMakeLists.txt
@@ -111,6 +111,9 @@ add_subdirectory(late-start-tracing)
 # multiple anytime tool configuration validation tests
 add_subdirectory(multi-tool-test)
 
+# duplicate rocprofiler-sdk initialization validation test
+add_subdirectory(duplicate-sdk-initialization)
+
 # anytime tool configuration (force_configure) validation tests
 add_subdirectory(anytime-tool-config)
 

--- a/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/CMakeLists.txt
@@ -16,8 +16,9 @@ if(TARGET rocprofiler-sdk-test-duplicate-shared-library)
         rocprofiler-sdk-duplicate-initialization-test rocprofiler-sdk-shared-library
         rocprofiler-sdk-test-duplicate-shared-library)
 else()
+    find_package(rocprofiler-sdk-tests REQUIRED)
     set(_duplicate_sdk
-        "${ROCPROFILER_SDK_TESTS_SOURCE_DIR}/duplicate-sdk/librocprofiler-sdk.so")
+        "${rocprofiler-sdk-tests_ROOT_DIR}/duplicate-sdk/librocprofiler-sdk.so")
     if(NOT EXISTS "${_duplicate_sdk}")
         message(
             FATAL_ERROR "Missing installed duplicate rocprofiler-sdk: ${_duplicate_sdk}")

--- a/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Duplicate rocprofiler-sdk initialization integration test
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(rocprofiler-sdk-tests-duplicate-sdk-initialization LANGUAGES CXX)
+
+add_executable(rocprofiler-sdk-duplicate-initialization-test)
+target_sources(rocprofiler-sdk-duplicate-initialization-test PRIVATE main.cpp)
+target_link_libraries(rocprofiler-sdk-duplicate-initialization-test
+                      PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers ${CMAKE_DL_LIBS})
+
+if(TARGET rocprofiler-sdk-test-duplicate-shared-library)
+    set(_duplicate_sdk "$<TARGET_FILE:rocprofiler-sdk-test-duplicate-shared-library>")
+    add_dependencies(
+        rocprofiler-sdk-duplicate-initialization-test rocprofiler-sdk-shared-library
+        rocprofiler-sdk-test-duplicate-shared-library)
+else()
+    set(_duplicate_sdk
+        "${ROCPROFILER_SDK_TESTS_SOURCE_DIR}/duplicate-sdk/librocprofiler-sdk.so")
+    if(NOT EXISTS "${_duplicate_sdk}")
+        message(
+            FATAL_ERROR "Missing installed duplicate rocprofiler-sdk: ${_duplicate_sdk}")
+    endif()
+endif()
+
+rocprofiler_add_integration_execute_test(
+    duplicate-sdk-initialization
+    TARGET rocprofiler-sdk-duplicate-initialization-test
+    ARGS "${_duplicate_sdk}"
+    PRELOAD "$<TARGET_FILE:rocprofiler-sdk::rocprofiler-sdk-shared-library>"
+    ENVIRONMENT "ROCPROFILER_LIBRARY_CTOR=1"
+    TIMEOUT 30
+    LABELS "integration-tests;duplicate-sdk"
+    PASS_REGULAR_EXPRESSION "PASS: only the preloaded SDK initialized"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}|FAIL:")

--- a/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/main.cpp
+++ b/projects/rocprofiler-sdk/tests/duplicate-sdk-initialization/main.cpp
@@ -1,0 +1,77 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <rocprofiler-sdk/registration.h>
+
+#include <dlfcn.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+using is_initialized_func_t = rocprofiler_status_t (*)(int*);
+
+int
+get_initialization_status(void* handle)
+{
+    auto is_initialized =
+        reinterpret_cast<is_initialized_func_t>(dlsym(handle, "rocprofiler_is_initialized"));
+    if(is_initialized == nullptr) return -1;
+
+    auto status = int{-1};
+    if(is_initialized(&status) != ROCPROFILER_STATUS_SUCCESS) return -1;
+    return status;
+}
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+    if(argc != 2)
+    {
+        std::cerr << "FAIL: expected the path to the second rocprofiler-sdk\n";
+        return EXIT_FAILURE;
+    }
+
+    if(get_initialization_status(RTLD_DEFAULT) != 1)
+    {
+        std::cerr << "FAIL: the preloaded rocprofiler-sdk did not initialize\n";
+        return EXIT_FAILURE;
+    }
+
+    auto* duplicate_handle = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+    if(duplicate_handle == nullptr)
+    {
+        std::cerr << "FAIL: failed to load the second rocprofiler-sdk: " << dlerror() << '\n';
+        return EXIT_FAILURE;
+    }
+
+    if(get_initialization_status(duplicate_handle) != 0)
+    {
+        std::cerr << "FAIL: the second rocprofiler-sdk initialized\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "PASS: only the preloaded SDK initialized\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- due to rocprofv3 setting ROCPROFILER_LIBRARY_CTOR=1 env variable, then the bundled rocprofiler-sdk in pytorch loads, it runs initialization even though all calls will be routed through the globally pre-loaded rocprofiler-sdk library.
- This fix ensures that initialization does not run if the rocprofiler-sdk library is not the global one.

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.

@venkat1361 