### PR TITLE
(rocDecode)(windows) update FindFFMpeg.cmake: user does not have to pass FFMPEG_ROOT 

### DIFF
--- a/projects/rocdecode/README.md
+++ b/projects/rocdecode/README.md
@@ -73,7 +73,7 @@ On Windows, rocDecode uses the [vaon12](https://devblogs.microsoft.com/directx/v
 
 **Windows:**
 
-  Use pre-built FFmpeg libraries or build from source. Pass `-DFFMPEG_ROOT=<path>` to CMake when configuring.
+  Use pre-built FFmpeg libraries or build from source. CMake searches your `PATH` and common install locations automatically; pass `-DFFMPEG_ROOT=<path>` only to override that search or point to a non-standard install.
 
 ## Install
 
@@ -145,7 +145,7 @@ cmake --install . --config Release
 > [!NOTE]
 > * Set `VAON12_ROOT` to the vaon12 NuGet package or custom build directory.
 > * Set `ROCM_PATH` to the TheRock build output directory.
-> * To include FFmpeg support, add `-DFFMPEG_ROOT=<path-to-ffmpeg>`.
+> * FFmpeg support (samples and the host decoder) is detected automatically from your `PATH` and common install locations; add `-DFFMPEG_ROOT=<path-to-ffmpeg>` only to override that search or point to a non-standard install.
 
 ### Run tests
 

--- a/projects/rocdecode/cmake/FindFFmpeg.cmake
+++ b/projects/rocdecode/cmake/FindFFmpeg.cmake
@@ -61,11 +61,34 @@ else()
     endif()
   endif()
 
-  # On Windows, allow FFMPEG_ROOT to point to a pre-built FFmpeg installation
-  # (e.g. -DFFMPEG_ROOT=C:/ffmpeg)
+  # Collect hints from FFMPEG_ROOT (CMake var or env var).
+  set(_FFMPEG_ROOT_HINTS
+    ${FFMPEG_ROOT}
+    $ENV{FFMPEG_ROOT}
+  )
+
+  # On Windows, if no root was given, probe PATH for ffmpeg.exe and derive the
+  # prefix from it (bin/../).  All common Windows FFmpeg distributions — winget,
+  # Chocolatey, Scoop, and manual extracts — put their bin/ on PATH.
+  if(WIN32 AND NOT _FFMPEG_ROOT_HINTS)
+    find_program(_FFMPEG_EXECUTABLE NAMES ffmpeg ffmpeg.exe)
+    if(_FFMPEG_EXECUTABLE)
+      get_filename_component(_FFMPEG_BIN "${_FFMPEG_EXECUTABLE}" DIRECTORY)
+      get_filename_component(_FFMPEG_ROOT_FROM_PATH "${_FFMPEG_BIN}" DIRECTORY)
+      list(APPEND _FFMPEG_ROOT_HINTS "${_FFMPEG_ROOT_FROM_PATH}")
+    endif()
+    # Fallback: well-known package-manager install locations
+    list(APPEND _FFMPEG_ROOT_HINTS
+      "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg"
+      "$ENV{USERPROFILE}/scoop/apps/ffmpeg/current"
+      "C:/Program Files/ffmpeg"
+      "C:/ffmpeg"
+    )
+  endif()
+
   if(WIN32)
-    set(_FFMPEG_SEARCH_INCLUDE ${FFMPEG_ROOT}/include)
-    set(_FFMPEG_SEARCH_LIB ${FFMPEG_ROOT}/lib)
+    set(_FFMPEG_SEARCH_INCLUDE)
+    set(_FFMPEG_SEARCH_LIB)
   else()
     set(_FFMPEG_SEARCH_INCLUDE
       ${_FFMPEG_AVCODEC_INCLUDE_DIRS}
@@ -84,12 +107,15 @@ else()
   # AVCODEC
   find_path(AVCODEC_INCLUDE_DIR
     NAMES libavcodec/avcodec.h
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES include ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
-    PATH_SUFFIXES ffmpeg libav
   )
   mark_as_advanced(AVCODEC_INCLUDE_DIR)
   find_library(AVCODEC_LIBRARY
     NAMES avcodec
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES lib
     PATHS ${_FFMPEG_SEARCH_LIB}
   )
   mark_as_advanced(AVCODEC_LIBRARY)
@@ -97,12 +123,15 @@ else()
   # AVFORMAT
   find_path(AVFORMAT_INCLUDE_DIR
     NAMES libavformat/avformat.h
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES include ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
-    PATH_SUFFIXES ffmpeg libav
   )
   mark_as_advanced(AVFORMAT_INCLUDE_DIR)
   find_library(AVFORMAT_LIBRARY
     NAMES avformat
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES lib
     PATHS ${_FFMPEG_SEARCH_LIB}
   )
   mark_as_advanced(AVFORMAT_LIBRARY)
@@ -110,12 +139,15 @@ else()
   # AVUTIL
   find_path(AVUTIL_INCLUDE_DIR
     NAMES libavutil/avutil.h
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES include ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
-    PATH_SUFFIXES ffmpeg libav
   )
   mark_as_advanced(AVUTIL_INCLUDE_DIR)
   find_library(AVUTIL_LIBRARY
     NAMES avutil
+    HINTS ${_FFMPEG_ROOT_HINTS}
+    PATH_SUFFIXES lib
     PATHS ${_FFMPEG_SEARCH_LIB}
   )
   mark_as_advanced(AVUTIL_LIBRARY)

--- a/projects/rocdecode/cmake/FindFFmpeg.cmake
+++ b/projects/rocdecode/cmake/FindFFmpeg.cmake
@@ -82,8 +82,10 @@ else()
       endif()
     endforeach()
     # Fallback: well-known package-manager install locations
-    list(APPEND _FFMPEG_ROOT_HINTS
+    file(GLOB _chocolatey_ffmpeg_roots
       "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg"
+      "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg-*")
+    list(APPEND _FFMPEG_ROOT_HINTS ${_chocolatey_ffmpeg_roots}
       "$ENV{USERPROFILE}/scoop/apps/ffmpeg/current"
       "$ENV{ProgramFiles}/ffmpeg"
       "C:/ffmpeg"

--- a/projects/rocdecode/cmake/FindFFmpeg.cmake
+++ b/projects/rocdecode/cmake/FindFFmpeg.cmake
@@ -112,7 +112,7 @@ else()
   find_path(AVCODEC_INCLUDE_DIR
     NAMES libavcodec/avcodec.h
     HINTS ${_FFMPEG_ROOT_HINTS}
-    PATH_SUFFIXES include ffmpeg libav
+    PATH_SUFFIXES include include/ffmpeg include/libav ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
   )
   mark_as_advanced(AVCODEC_INCLUDE_DIR)
@@ -128,7 +128,7 @@ else()
   find_path(AVFORMAT_INCLUDE_DIR
     NAMES libavformat/avformat.h
     HINTS ${_FFMPEG_ROOT_HINTS}
-    PATH_SUFFIXES include ffmpeg libav
+    PATH_SUFFIXES include include/ffmpeg include/libav ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
   )
   mark_as_advanced(AVFORMAT_INCLUDE_DIR)
@@ -144,7 +144,7 @@ else()
   find_path(AVUTIL_INCLUDE_DIR
     NAMES libavutil/avutil.h
     HINTS ${_FFMPEG_ROOT_HINTS}
-    PATH_SUFFIXES include ffmpeg libav
+    PATH_SUFFIXES include include/ffmpeg include/libav ffmpeg libav
     PATHS ${_FFMPEG_SEARCH_INCLUDE}
   )
   mark_as_advanced(AVUTIL_INCLUDE_DIR)
@@ -197,6 +197,14 @@ else()
 
   if(FFMPEG_FOUND)
     message("-- ${White}Using FFMPEG -- \n\tLibraries:${FFMPEG_LIBRARIES} \n\tIncludes:${FFMPEG_INCLUDE_DIR}${ColourReset}")
+    if(WIN32)
+      # The import libraries above only satisfy link time. At run time the
+      # matching avcodec/avformat/avutil DLLs must be resolvable, so the FFmpeg
+      # bin directory needs to be on PATH (or the DLLs copied next to the exe).
+      get_filename_component(_FFMPEG_LIB_DIR "${AVCODEC_LIBRARY}" DIRECTORY)
+      get_filename_component(_FFMPEG_BIN_DIR "${_FFMPEG_LIB_DIR}/../bin" ABSOLUTE)
+      message("-- ${Yellow}NOTE: at run time the FFmpeg DLLs must be on PATH, e.g. add \"${_FFMPEG_BIN_DIR}\" to PATH${ColourReset}")
+    endif()
   else()
     if(FFmpeg_FIND_REQUIRED)
       message(FATAL_ERROR "{Red}FindFFmpeg -- libavcodec or libavformat or libavutil NOT FOUND${ColourReset}")

--- a/projects/rocdecode/cmake/FindFFmpeg.cmake
+++ b/projects/rocdecode/cmake/FindFFmpeg.cmake
@@ -62,21 +62,25 @@ else()
   endif()
 
   # Collect hints from FFMPEG_ROOT (CMake var or env var).
-  set(_FFMPEG_ROOT_HINTS
-    ${FFMPEG_ROOT}
-    $ENV{FFMPEG_ROOT}
-  )
+  set(_FFMPEG_ROOT_HINTS ${FFMPEG_ROOT} $ENV{FFMPEG_ROOT})
+  list(FILTER _FFMPEG_ROOT_HINTS EXCLUDE REGEX "^$")
 
-  # On Windows, if no root was given, probe PATH for ffmpeg.exe and derive the
-  # prefix from it (bin/../).  All common Windows FFmpeg distributions — winget,
-  # Chocolatey, Scoop, and manual extracts — put their bin/ on PATH.
-  if(WIN32 AND NOT _FFMPEG_ROOT_HINTS)
-    find_program(_FFMPEG_EXECUTABLE NAMES ffmpeg ffmpeg.exe)
-    if(_FFMPEG_EXECUTABLE)
-      get_filename_component(_FFMPEG_BIN "${_FFMPEG_EXECUTABLE}" DIRECTORY)
-      get_filename_component(_FFMPEG_ROOT_FROM_PATH "${_FFMPEG_BIN}" DIRECTORY)
-      list(APPEND _FFMPEG_ROOT_HINTS "${_FFMPEG_ROOT_FROM_PATH}")
-    endif()
+  # On Windows, if no root was explicitly given, try to locate an FFmpeg/libav
+  # install automatically. We probe PATH for the libav runtime libraries
+  # (avcodec/avformat/avutil DLLs) and derive the install prefix from their
+  # directory (bin/../), then add well-known package-manager / manual install
+  # locations. Headers and import libraries are resolved by the
+  # find_path/find_library calls below.
+  if(WIN32 AND "${_FFMPEG_ROOT_HINTS}" STREQUAL "")
+    foreach(_dir $ENV{PATH})
+      file(GLOB _avcodec_dll "${_dir}/avcodec*.dll")
+      file(GLOB _avformat_dll "${_dir}/avformat*.dll")
+      file(GLOB _avutil_dll "${_dir}/avutil*.dll")
+      if(_avcodec_dll AND _avformat_dll AND _avutil_dll)
+        get_filename_component(_FFMPEG_ROOT_FROM_PATH "${_dir}" DIRECTORY)
+        list(APPEND _FFMPEG_ROOT_HINTS "${_FFMPEG_ROOT_FROM_PATH}")
+      endif()
+    endforeach()
     # Fallback: well-known package-manager install locations
     list(APPEND _FFMPEG_ROOT_HINTS
       "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg"
@@ -155,7 +159,7 @@ else()
   if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY)
     set(FFMPEG_FOUND TRUE)
   endif()
-  
+
   if(NOT WIN32 AND (_FFMPEG_AVCODEC_VERSION VERSION_LESS 58.18.100 OR _FFMPEG_AVFORMAT_VERSION VERSION_LESS 58.12.100 OR _FFMPEG_AVUTIL_VERSION VERSION_LESS 56.14.100))
     if(FFMPEG_FOUND)
       message("-- ${White}FFMPEG   required min version - 4.0.4 Found:${FFMPEG_VERSION}")
@@ -166,7 +170,7 @@ else()
     set(FFMPEG_FOUND FALSE)
     message( "-- ${Yellow}NOTE: FindFFmpeg failed to find -- FFMPEG${ColourReset}" )
   endif()
-  
+
   # When pkg-config is not available (e.g. Windows), parse the version from headers
   if(FFMPEG_FOUND AND NOT _FFMPEG_AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
     file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version_major.h" _avcodec_major_line
@@ -199,4 +203,3 @@ else()
     endif()
   endif()
 endif()
-

--- a/projects/rocdecode/cmake/FindFFmpeg.cmake
+++ b/projects/rocdecode/cmake/FindFFmpeg.cmake
@@ -85,7 +85,7 @@ else()
     list(APPEND _FFMPEG_ROOT_HINTS
       "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg"
       "$ENV{USERPROFILE}/scoop/apps/ffmpeg/current"
-      "C:/Program Files/ffmpeg"
+      "$ENV{ProgramFiles}/ffmpeg"
       "C:/ffmpeg"
     )
   endif()

--- a/projects/rocdecode/docs/conceptual/rocDecode-decoding-pipelines.rst
+++ b/projects/rocdecode/docs/conceptual/rocDecode-decoding-pipelines.rst
@@ -8,7 +8,7 @@ rocDecode decode pipelines
 
 The rocDecode video decoder pipeline takes video data, extracts it, parses it, and decodes it.
 
-The FFMpeg demultiplexer (demuxer) extracts a segment of video data and sends it to a decoder. 
+The FFMpeg demultiplexer (demuxer) extracts a segment of video data and sends it to a decoder.
 
 .. note::
 
@@ -24,5 +24,4 @@ When FFMpeg-based software decoding is used, no separate parsing step is require
 
   On Linux: ``sudo apt install libavcodec-dev libavformat-dev libavutil-dev``
 
-  On Windows: use pre-built FFmpeg libraries or build from source, and pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` to CMake when configuring.
-
+  On Windows: use pre-built FFmpeg libraries or build from source. CMake searches your ``PATH`` and common install locations automatically; pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` only to override that search or point to a non-standard install.

--- a/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
+++ b/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
@@ -15,7 +15,7 @@ Alternatively, you can build rocDecode standalone using the following
 instructions.
 
 .. note::
-   
+
    To use the rocDecode samples and tutorials, the ``ROCM_PATH`` environment variable needs to point to the location of your ROCm installation:
 
    .. code:: shell
@@ -123,7 +123,7 @@ Build on Windows
 
       * Set ``VAON12_ROOT`` to the vaon12 NuGet package or custom build directory.
       * Set ``ROCM_PATH`` to the TheRock build output directory.
-      * To include FFmpeg support for samples and the host decoder, add ``-DFFMPEG_ROOT=<path-to-ffmpeg>``.
+      * FFmpeg support (samples and the host decoder) is detected automatically from your ``PATH`` and common install locations. Add ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` only to override that search or point to a non-standard install.
 
 4. To verify the build, run a sample:
 
@@ -135,4 +135,3 @@ Build on Windows
       cmake --build . --config Release
       cd Release
       videodecoderaw.exe -i <input_stream> -f 5
-

--- a/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
+++ b/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
@@ -124,6 +124,7 @@ Build on Windows
       * Set ``VAON12_ROOT`` to the vaon12 NuGet package or custom build directory.
       * Set ``ROCM_PATH`` to the TheRock build output directory.
       * FFmpeg support (samples and the host decoder) is detected automatically from your ``PATH`` and common install locations. Add ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` only to override that search or point to a non-standard install.
+      * The detected FFmpeg libraries are used for linking only. At run time, the FFmpeg ``bin`` directory (containing ``avcodec``, ``avformat``, and ``avutil`` DLLs) must be on ``PATH``, otherwise the samples and host decoder fail to launch with missing DLL errors.
 
 4. To verify the build, run a sample:
 

--- a/projects/rocdecode/docs/reference/rocDecode-demux.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-demux.rst
@@ -6,15 +6,15 @@
 The rocDecode VideoDemuxer utility class
 ********************************************************************
 
-The rocDecode FFMpeg demuxer utility class, `VideoDemuxer <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/video_demuxer.h>`_, is used to demultiplex (demux) frames that can then be consumed by the :doc:`FFMpeg decoder <./rocDecode-ffmpeg-decoder>` or the :doc:`hardware decoder <./rocDecode-hw-decoder>`. 
+The rocDecode FFMpeg demuxer utility class, `VideoDemuxer <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/video_demuxer.h>`_, is used to demultiplex (demux) frames that can then be consumed by the :doc:`FFMpeg decoder <./rocDecode-ffmpeg-decoder>` or the :doc:`hardware decoder <./rocDecode-hw-decoder>`.
 
 The ``VideoDemuxer()`` constructor takes either a file path or a StreamProvider object. The StreamProvider class is an abstract class that feeds a stream of packets to the demuxer. The StreamProvider ``GetData()`` and ``GetBufferSize()`` functions must be implemented to use a StreamProvider.
 
-The VideoDemuxer ``Demux()`` function extracts the next video packet from the stream, and returns a pointer to the packet data, the packet size, and optionally the presentation timestamp. 
+The VideoDemuxer ``Demux()`` function extracts the next video packet from the stream, and returns a pointer to the packet data, the packet size, and optionally the presentation timestamp.
 
 ``Demux()`` demuxes frames sequentially starting at the beginning of the stream. The ``seek()`` function is used to start demuxing from a different frame.
 
-A ``VideoSeekContext`` is passed to ``seek()``. The seek context specifies a seek criteria and a seek mode. The seek criteria describe whether the demuxer needs to seek to a specific frame or seek to a specific timestamp. The seek mode indicates whether the demuxer should seek to the exact frame or to the previous keyframe. 
+A ``VideoSeekContext`` is passed to ``seek()``. The seek context specifies a seek criteria and a seek mode. The seek criteria describe whether the demuxer needs to seek to a specific frame or seek to a specific timestamp. The seek mode indicates whether the demuxer should seek to the exact frame or to the previous keyframe.
 
 .. note::
 
@@ -22,4 +22,4 @@ A ``VideoSeekContext`` is passed to ``seek()``. The seek context specifies a see
 
   On Linux: ``sudo apt install libavcodec-dev libavformat-dev libavutil-dev``
 
-  On Windows: use pre-built FFmpeg libraries or build from source, and pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` to CMake when configuring.
+  On Windows: use pre-built FFmpeg libraries or build from source. CMake searches your ``PATH`` and common install locations automatically; pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` only to override that search or point to a non-standard install.

--- a/projects/rocdecode/docs/reference/rocDecode-ffmpeg-decoder.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-ffmpeg-decoder.rst
@@ -6,9 +6,9 @@
 The rocDecode FFMpeg decoder utility class
 ***********************************************
 
-The rocDecode FFMpeg decoder utility class, `FFMpegVideoDecoder <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.h>`_, is used to decode demultiplexed (demuxed) frames on the CPU. 
+The rocDecode FFMpeg decoder utility class, `FFMpegVideoDecoder <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.h>`_, is used to decode demultiplexed (demuxed) frames on the CPU.
 
-FFMpegVideoDecoder uses the FFMpeg video decoding backend to decode frame packets output by the FFMpeg demultiplexer (demuxer). It inherits from :doc:`the RocVideoDecode utility class <./rocDecode-util-decoder>` and uses many of the same functions. 
+FFMpegVideoDecoder uses the FFMpeg video decoding backend to decode frame packets output by the FFMpeg demultiplexer (demuxer). It inherits from :doc:`the RocVideoDecode utility class <./rocDecode-util-decoder>` and uses many of the same functions.
 
 The ``FFMpegVideoDecoder()`` constructor takes the same parameters as ``RocVideoDecoder`` except for the first parameter, which is the number of CPU threads rather than the device ID, and the force zero latency parameter, which isn't supported with the FFMpeg decoder.
 
@@ -18,7 +18,7 @@ Six functions are implemented in FFMpegVideoDecoder: ``DecodeFrame()``, ``GetFra
 
 Once decoding is done, ``GetFrame()`` returns the decoded frame and its timestamp and ``GetOutputSurfaceInfo()`` returns a pointer to the metadata associated with the decoded frame.
 
-``SaveFrameToFile()`` saves the decoded output surface to a file. 
+``SaveFrameToFile()`` saves the decoded output surface to a file.
 
 Once processing is complete, ``ReleaseFrame()`` is used to release the frame.
 
@@ -33,7 +33,7 @@ For information about using the FFMpeg decoder, see :doc:`Understanding the rocD
 
   On Linux: ``sudo apt install libavcodec-dev libavformat-dev libavutil-dev``
 
-  On Windows: use pre-built FFmpeg libraries or build from source, and pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` to CMake when configuring.
+  On Windows: use pre-built FFmpeg libraries or build from source. CMake searches your ``PATH`` and common install locations automatically; pass ``-DFFMPEG_ROOT=<path-to-ffmpeg>`` only to override that search or point to a non-standard install.
 
 .. |ffmpeg| replace:: ``utils/ffmpegvideodecode/ffmpeg_video_dec.h``
 .. _ffmpeg: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.h


### PR DESCRIPTION
## Motivation

Currently to build the samples that depend on ffmpeg in rocdecode, we need to pass `-DFFMPEG_ROOT` as a flag when building. Same applies for building host backend. This PR removes the need to pass the flag if FFMPEG is set in windows `PATH` or available in standard windows paths.

## Technical Details

Check and see if FFMPEG is set in windows PATH. If not fall back and look in well-known package-manager install locations like `chocolatey` or `ProgramFiles`

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

Test without passing FFMPEG_ROOT in `cmake` command. Needs to be available in standard install locations or windows user `PATH`

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
