### PR TITLE
rocjitsu: Model a PCI-attached GPU as a guest driver first sees it

### DIFF
--- a/emulation/rocjitsu/configs/gfx1250_mi455x.json
+++ b/emulation/rocjitsu/configs/gfx1250_mi455x.json
@@ -32,34 +32,70 @@
         "num_sdma_queues_per_engine": 2,
         "num_cp_queues": 128,
         "max_engine_clk_fcompute": 2700
+      },
+      "pci": {
+        "vram_aperture_bytes": 268435456
       }
     }
   },
   "topology": {
     "root": {
-      "name": "soc", "type": "soc",
+      "name": "soc",
+      "type": "soc",
       "children": [
-        { "name": "vram", "type": "gpu_memory" },
         {
-          "name": "iod[0:2]", "type": "iod",
-          "config": [{ "key": "num_hbm_stacks", "value": "6" }]
+          "name": "vram",
+          "type": "gpu_memory"
         },
         {
-          "name": "xcd[0:8]", "type": "xcd",
-          "children": [
-            { "name": "l2", "type": "l2_cache" },
-            { "name": "cp", "type": "command_processor" },
+          "name": "iod[0:2]",
+          "type": "iod",
+          "config": [
             {
-              "name": "se[0:2]", "type": "shader_engine",
-              "children": [{
-                "name": "cu[0:16]", "type": "compute_unit",
-                "config": [
-                  { "key": "num_wf_slots", "value": "64" },
-                  { "key": "sgprs_per_wf", "value": "128" },
-                  { "key": "vgprs_per_wf", "value": "1024" },
-                  { "key": "lds_size_kb", "value": "320" }
-                ]
-              }]
+              "key": "num_hbm_stacks",
+              "value": "6"
+            }
+          ]
+        },
+        {
+          "name": "xcd[0:8]",
+          "type": "xcd",
+          "children": [
+            {
+              "name": "l2",
+              "type": "l2_cache"
+            },
+            {
+              "name": "cp",
+              "type": "command_processor"
+            },
+            {
+              "name": "se[0:2]",
+              "type": "shader_engine",
+              "children": [
+                {
+                  "name": "cu[0:16]",
+                  "type": "compute_unit",
+                  "config": [
+                    {
+                      "key": "num_wf_slots",
+                      "value": "64"
+                    },
+                    {
+                      "key": "sgprs_per_wf",
+                      "value": "128"
+                    },
+                    {
+                      "key": "vgprs_per_wf",
+                      "value": "1024"
+                    },
+                    {
+                      "key": "lds_size_kb",
+                      "value": "320"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -69,52 +105,120 @@
       {
         "pattern": "xcd[i].cp.req_[j*16+k] -> xcd[i].se[j].cu[k].cpl",
         "for_ranges": [
-          { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 2 },
-          { "var_name": "k", "start": 0, "end": 16 }
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 8
+          },
+          {
+            "var_name": "j",
+            "start": 0,
+            "end": 2
+          },
+          {
+            "var_name": "k",
+            "start": 0,
+            "end": 16
+          }
         ],
-        "latency": 1, "weight": 2
+        "latency": 1,
+        "weight": 2
       },
       {
         "pattern": "xcd[i].se[j].cu[k].req -> xcd[i].l2.cpl_[j*16+k]",
         "for_ranges": [
-          { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 2 },
-          { "var_name": "k", "start": 0, "end": 16 }
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 8
+          },
+          {
+            "var_name": "j",
+            "start": 0,
+            "end": 2
+          },
+          {
+            "var_name": "k",
+            "start": 0,
+            "end": 16
+          }
         ],
-        "latency": 1, "weight": 10
+        "latency": 1,
+        "weight": 10
       },
       {
         "pattern": "xcd[i].l2.req -> iod[i/4].msc.cpl_[i%4]",
-        "for_ranges": [{ "var_name": "i", "start": 0, "end": 8 }],
-        "latency": 1, "weight": 3
+        "for_ranges": [
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 8
+          }
+        ],
+        "latency": 1,
+        "weight": 3
       },
       {
         "pattern": "iod[i].peer_req -> iod[j].peer_cpl",
         "for_ranges": [
-          { "var_name": "i", "start": 0, "end": 2 },
-          { "var_name": "j", "start": 0, "end": 2 }
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 2
+          },
+          {
+            "var_name": "j",
+            "start": 0,
+            "end": 2
+          }
         ],
         "where_expr": "i != j",
-        "latency": 1, "weight": 1
+        "latency": 1,
+        "weight": 1
       },
       {
         "pattern": "xcd[i].se[j].cu[k].adj_req -> xcd[i].se[j].cu[k+1].adj_cpl",
         "for_ranges": [
-          { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 2 },
-          { "var_name": "k", "start": 0, "end": 15 }
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 8
+          },
+          {
+            "var_name": "j",
+            "start": 0,
+            "end": 2
+          },
+          {
+            "var_name": "k",
+            "start": 0,
+            "end": 15
+          }
         ],
-        "latency": 1, "weight": 2
+        "latency": 1,
+        "weight": 2
       },
       {
         "pattern": "xcd[i].se[j].cu[k+1].adj_req_r -> xcd[i].se[j].cu[k].adj_cpl_r",
         "for_ranges": [
-          { "var_name": "i", "start": 0, "end": 8 },
-          { "var_name": "j", "start": 0, "end": 2 },
-          { "var_name": "k", "start": 0, "end": 15 }
+          {
+            "var_name": "i",
+            "start": 0,
+            "end": 8
+          },
+          {
+            "var_name": "j",
+            "start": 0,
+            "end": 2
+          },
+          {
+            "var_name": "k",
+            "start": 0,
+            "end": 15
+          }
         ],
-        "latency": 1, "weight": 2
+        "latency": 1,
+        "weight": 2
       }
     ]
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_CONFIG_CONFIG_COMMON_H_
 
 #include "rocjitsu/config/kfd_device_config.h"
+#include "rocjitsu/config/pci_device_config.h"
 
 #include "flatbuffers/idl.h"
 #include "simulation_config_generated.h"
@@ -53,6 +54,24 @@ with_parsed_simulation_config_json(const std::string &json, const std::string &s
   const fb::SimulationConfig *config =
       flatbuffers::GetRoot<fb::SimulationConfig>(parser.builder_.GetBufferPointer());
   return std::forward<Callback>(callback)(config);
+}
+
+/// @brief Convert a FlatBuffers PCI bus table into the runtime config form.
+///
+/// @details A config that says nothing about the bus gets the defaults, which
+/// describe a compute GPU with apertures big enough for the driver to work with.
+inline PciDeviceConfig pci_device_from_fb(const fb::PciDeviceInfo *pci) {
+  PciDeviceConfig config;
+  if (pci == nullptr)
+    return config;
+
+  config.class_code = pci->class_code();
+  config.subsystem_vendor_id = pci->subsystem_vendor_id();
+  config.subsystem_id = pci->subsystem_id();
+  config.vram_aperture_bytes = pci->vram_aperture_bytes();
+  config.doorbell_aperture_bytes = pci->doorbell_aperture_bytes();
+  config.register_aperture_bytes = pci->register_aperture_bytes();
+  return config;
 }
 
 /// @brief Convert a FlatBuffers KFD identity table into the runtime config form.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -695,6 +695,12 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
     result.device = kfd_device_from_fb(fb_config->vm()->gpu()->device(), "vm.gpu.device");
   }
 
+  // A config that describes no bus still yields usable defaults, so front ends
+  // that attach the GPU to a VMM work without every config being updated.
+  if (fb_config->vm() && fb_config->vm()->gpu()) {
+    result.pci = pci_device_from_fb(fb_config->vm()->gpu()->pci());
+  }
+
   result.dbt_guest = dbt_guest_from_fb(fb_config->dbt_guest());
 
   if (fb_config->vm() && fb_config->vm()->gpu())
@@ -780,6 +786,21 @@ const char *arch_to_string(rj_code_arch_t arch) {
   default:
     return "invalid";
   }
+}
+
+DeviceIdentityConfig load_device_identity(const std::string &json_path,
+                                          const std::string &schema_text) {
+  const std::string json = read_config_file(json_path);
+  return with_parsed_simulation_config_json(
+      json, schema_text, [](const fb::SimulationConfig *config) {
+        DeviceIdentityConfig identity;
+        if (config->vm() == nullptr || config->vm()->gpu() == nullptr) {
+          return identity;
+        }
+        identity.device = kfd_device_from_fb(config->vm()->gpu()->device(), "vm.gpu.device");
+        identity.pci = pci_device_from_fb(config->vm()->gpu()->pci());
+        return identity;
+      });
 }
 
 LoadedConfig load_config(const std::string &json_path, const std::string &schema_text) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/config/kfd_device_config.h"
+#include "rocjitsu/config/pci_device_config.h"
 
 #include "simdojo/sim/simulation.h"
 #include "simdojo/sim/topology.h"
@@ -74,6 +75,7 @@ struct LoadedConfig {
       extra_gpu_builds; ///< Additional GPU SoC trees (for num_gpus > 1).
   simdojo::ExecMode exec_mode = simdojo::ExecMode::FUNCTIONAL;
   KfdDeviceConfig device;               ///< KFD device identity from vm.gpu.device.
+  PciDeviceConfig pci;                  ///< PCI bus shape from vm.gpu.pci.
   DbtGuestConfig dbt_guest;             ///< Optional DBT guest-GPU discovery config.
   uint32_t num_gpus = 1;                ///< Number of simulated GPU instances.
   std::vector<KfdDeviceConfig> devices; ///< Per-GPU configs (populated when num_gpus > 1).
@@ -90,6 +92,23 @@ struct LoadedConfig {
   /// @brief Wire deferred link specs into a topology. Call after set_root().
   void wire_links(simdojo::Topology &topo) { topo.wire_links(build_result.link_specs, exec_mode); }
 };
+
+/// @brief The identity and bus shape of the GPU a config describes.
+struct DeviceIdentityConfig {
+  KfdDeviceConfig device; ///< GPU identity, as KFD also reports it.
+  PciDeviceConfig pci;    ///< Bus shape for PCI-attached front ends.
+};
+
+/// @brief Read only a config's device identity and bus shape.
+/// @param json_path Path to the JSON config file.
+/// @param schema_text FlatBuffers schema text (the .fbs content).
+/// @returns The identity and bus shape.
+/// @throws std::runtime_error when the file cannot be read or parsed.
+/// @details Building the topology allocates the whole simulated machine, which
+/// for a large part is gigabytes of register files. A front end that only needs
+/// to know which GPU to present should not pay for a machine it never runs.
+DeviceIdentityConfig load_device_identity(const std::string &json_path,
+                                          const std::string &schema_text);
 
 /// @brief Parse an architecture name string to an rj_code_arch_t enum value.
 rj_code_arch_t parse_arch(const std::string &arch_str);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/pci_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/pci_device_config.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file pci_device_config.h
+/// @brief How a simulated GPU presents itself on a PCI bus.
+///
+/// @details These are the values a front end needs that describe the bus rather
+/// than the GPU: the class a guest driver matches on, and the apertures it maps.
+/// Identity proper is not repeated here, because the vendor, device and revision
+/// a driver reads are the same values KFD reports and already live in
+/// @ref rocjitsu::config::KfdDeviceConfig.
+
+#pragma once
+
+#include <cstdint>
+
+namespace rocjitsu::config {
+
+/// @brief PCI bus shape from the simulation config.
+struct PciDeviceConfig {
+  /// @brief 24-bit PCI class, subclass and programming interface.
+  ///
+  /// @details The default presents a processing accelerator, which is what a
+  /// compute GPU without a display is, and is one of the classes amdgpu's PCI
+  /// table binds on.
+  uint32_t class_code = 0x120000;
+
+  uint32_t subsystem_vendor_id = 0; ///< Zero means the same as the vendor id.
+  uint32_t subsystem_id = 0;        ///< Zero means the same as the device id.
+
+  /// @brief Window onto video memory to expose as a BAR.
+  ///
+  /// @details Zero asks for an implementation-chosen legal window, currently the
+  /// largest power of two within 256 MiB and within local memory. Exposing all
+  /// of memory is usually neither legal as a BAR nor useful, and the indirect
+  /// register window reaches whatever the aperture does not.
+  uint64_t vram_aperture_bytes = 0;
+  uint64_t doorbell_aperture_bytes = 2 * 1024 * 1024; ///< Doorbell aperture size.
+  uint64_t register_aperture_bytes = 512 * 1024;      ///< Register aperture size.
+};
+
+} // namespace rocjitsu::config

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/CMakeLists.txt
@@ -2,12 +2,20 @@
 # SPDX-License-Identifier: MIT
 
 # Device-side model of a PCI-attached GPU: the bus surface a guest driver sees,
-# and the diagnostics for the registers it touches. Portable and free of any VMM
-# dependency, so every transport under vmm/ shares it and it is built and tested
-# in every configuration.
-rj_add_object_library(
-    rocjitsu_pci
+# and the diagnostics for the registers it touches. Free of any VMM dependency,
+# so every transport under vmm/ shares it.
+set(RJ_PCI_SOURCES
     register_symbols.cpp
     bar_access_trace.cpp
     scratch_pci_device.cpp
+    gpu_pci_device_spec.cpp
 )
+
+# The GPU model shares its video memory with a guest through a file descriptor,
+# which is a POSIX shared-memory facility with no portable equivalent, so it
+# builds only where a transport could use it. Everything else here is portable.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND RJ_PCI_SOURCES gpu_pci_device.cpp)
+endif()
+
+rj_add_object_library(rocjitsu_pci ${RJ_PCI_SOURCES})

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+
+#include "rocjitsu/vm/amdgpu/pci/mmio_registers.h"
+#include "util/log.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstring>
+#include <format>
+#include <limits>
+#include <utility>
+
+namespace rocjitsu {
+namespace {
+
+bool is_supported_width(std::size_t width) {
+  return width == 1 || width == 2 || width == 4 || width == 8;
+}
+
+bool is_power_of_two(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+/// @brief Address bits carried by the low index register.
+///
+/// @details Its top bit is the flag the driver sets to say it is addressing
+/// memory rather than a register, so the address continues in the high register
+/// from bit 31 rather than bit 32.
+constexpr uint32_t kIndirectLowMask = 0x7fffffff;
+/// @brief MM_INDEX bit selecting the memory space rather than the register space.
+constexpr uint32_t kIndirectMemorySelect = 0x80000000;
+
+/// @brief Address bit at which the high index register begins.
+constexpr unsigned kIndirectHighShift = 31;
+
+} // namespace
+
+GpuPciDevice::GpuPciDevice(std::string name, const GpuPciDeviceSpec &spec, BarAccessTrace *trace)
+    : simdojo::PciDevice(std::move(name), spec.id), spec_(spec), trace_(trace) {
+  if (spec_.vram_bytes == 0) {
+    // A device with no memory has nothing to present; an aperture cannot stand
+    // in for a capacity that was never described.
+    util::Logger::warn(std::format("{}: no video memory was configured", this->name()));
+    return;
+  }
+  // A BAR is a power-of-two window by definition; anything else is refused here
+  // rather than deeper in a transport that would reject it less clearly.
+  for (const auto &[what, size] : {std::pair{"video memory", spec_.vram_aperture_bytes},
+                                   std::pair{"doorbell", spec_.doorbell_aperture_bytes},
+                                   std::pair{"register", spec_.register_aperture_bytes}}) {
+    if (!is_power_of_two(size)) {
+      util::Logger::warn(std::format("{}: the {} aperture is {} bytes, which is not a power of two",
+                                     this->name(), what, size));
+      return;
+    }
+    if (size < kMinMemoryBarBytes) {
+      util::Logger::warn(
+          std::format("{}: the {} aperture is {} bytes, below the {}-byte minimum for a memory BAR",
+                      this->name(), what, size, kMinMemoryBarBytes));
+      return;
+    }
+  }
+  if (spec_.vram_aperture_bytes > spec_.vram_bytes) {
+    util::Logger::warn(std::format("{}: the video memory aperture is larger than the memory itself",
+                                   this->name()));
+    return;
+  }
+  if (spec_.register_aperture_bytes < kMinRegisterApertureBytes) {
+    util::Logger::warn(std::format(
+        "{}: a register aperture of {} bytes cannot reach the registers the driver reads before "
+        "discovery; at least {} are needed",
+        this->name(), spec_.register_aperture_bytes, kMinRegisterApertureBytes));
+    return;
+  }
+
+  // Video memory is a file so the guest can map it rather than trapping to us
+  // for every access, which is the only way an aperture of this size is usable.
+  // It stays sparse until written.
+  // The driver reads the capacity as a count of megabytes in a 32-bit register,
+  // and treats zero and all-ones as "there is no usable memory here". A capacity
+  // that cannot be said in those terms would produce a device that looks fine
+  // and then fails discovery.
+  // The driver reads the capacity as a count of megabytes, so anything finer is
+  // unrepresentable and rounds down here. That is not silently lossy: this
+  // rounded value is what the device reports, and everything else it derives --
+  // including where it later publishes a discovery table -- is derived from the
+  // same value rather than from the true byte count, so the driver never
+  // computes an address the device did not use. The remainder is simply memory
+  // the guest is never told about.
+  if ((spec_.vram_bytes & 0xfffffULL) != 0) {
+    util::Logger::warn(std::format(
+        "{}: {} bytes of video memory is not a whole number of megabytes; reporting {} MiB and "
+        "leaving the remaining {} bytes unreachable by the guest",
+        this->name(), spec_.vram_bytes, spec_.vram_bytes >> 20, spec_.vram_bytes & 0xfffffULL));
+  }
+  const uint64_t megabytes = spec_.vram_bytes >> 20;
+  if (megabytes == 0 || megabytes >= std::numeric_limits<uint32_t>::max()) {
+    util::Logger::warn(std::format(
+        "{}: {} bytes of video memory is {} megabytes, which the driver cannot read as a size",
+        this->name(), spec_.vram_bytes, megabytes));
+    return;
+  }
+  vram_megabytes_ = static_cast<uint32_t>(megabytes);
+
+  // The whole of memory is backed, sparsely, because the driver reaches past
+  // the window through the indirect registers; only the window is shared with
+  // the guest.
+  vram_fd_ = ::memfd_create("rocjitsu-vram", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (vram_fd_ < 0 || ::ftruncate(vram_fd_, static_cast<off_t>(spec_.vram_bytes)) != 0) {
+    util::Logger::warn(std::format("{}: cannot back the video memory aperture", this->name()));
+    return;
+  }
+  void *mapped =
+      ::mmap(nullptr, spec_.vram_aperture_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, vram_fd_, 0);
+  if (mapped == MAP_FAILED) {
+    util::Logger::warn(std::format("{}: cannot map the video memory aperture", this->name()));
+    ::close(vram_fd_);
+    vram_fd_ = -1;
+    return;
+  }
+  vram_ = static_cast<std::byte *>(mapped);
+
+  // The descriptor is shared with a client that could otherwise resize it and
+  // leave the server touching memory past the end of the file.
+  if (::fcntl(vram_fd_, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL) != 0) {
+    util::Logger::warn(std::format("{}: cannot seal the video memory backing", this->name()));
+    return;
+  }
+  doorbells_.resize(spec_.doorbell_aperture_bytes);
+
+  // One entry per dword of the aperture.
+  const auto register_count = static_cast<uint32_t>(spec_.register_aperture_bytes / 4);
+  registers_.assign(register_count, 0);
+  modelled_.assign(register_count, false);
+  reset_registers();
+  usable_ = true;
+}
+
+GpuPciDevice::~GpuPciDevice() {
+  if (vram_ != nullptr) {
+    ::munmap(vram_, spec_.vram_aperture_bytes);
+  }
+  if (vram_fd_ >= 0) {
+    ::close(vram_fd_);
+  }
+}
+
+std::vector<simdojo::BarSpec> GpuPciDevice::bars() const {
+  simdojo::BarSpec vram;
+  vram.index = kVramBar;
+  vram.size = spec_.vram_aperture_bytes;
+  vram.mem = true;
+  vram.prefetch = true;
+  vram.is_64bit = true;
+  vram.backing_fd = vram_fd_;
+  if (vram_fd_ >= 0) {
+    vram.mmap_areas.push_back({.offset = 0, .length = spec_.vram_aperture_bytes});
+  }
+
+  simdojo::BarSpec doorbell;
+  doorbell.index = kDoorbellBar;
+  doorbell.size = spec_.doorbell_aperture_bytes;
+  doorbell.mem = true;
+  doorbell.prefetch = true;
+  doorbell.is_64bit = true;
+
+  // Registers always trap: a doorbell can be a plain store to memory we scan,
+  // but a register read has to be answered by the model.
+  simdojo::BarSpec registers;
+  registers.index = kRegisterBar;
+  registers.size = spec_.register_aperture_bytes;
+  registers.mem = true;
+
+  return {vram, doorbell, registers};
+}
+
+void GpuPciDevice::reset_registers() {
+  // The registers the driver reads before it can locate the IP discovery table.
+  // Reporting no memory, or all-ones, makes it give up before it starts.
+  define_register(byte_offset_of(MmioRegister::RccConfigMemsize), vram_megabytes_);
+  define_register(byte_offset_of(MmioRegister::Mp0SmnC2pmsg33), kFirmwareInitDoneBit);
+  // Zero here tells the driver the discovery table is not published through
+  // these registers, so it looks for it at the top of video memory instead.
+  define_register(byte_offset_of(MmioRegister::DriverScratch0), 0);
+  define_register(byte_offset_of(MmioRegister::DriverScratch1), 0);
+  define_register(byte_offset_of(MmioRegister::DriverScratch2), 0);
+  // The indirect window and its data register are how memory outside the
+  // aperture is reached, so they are modelled rather than reading as absent.
+  define_register(byte_offset_of(MmioRegister::MmIndex), 0);
+  define_register(byte_offset_of(MmioRegister::MmIndexHi), 0);
+  define_register(byte_offset_of(MmioRegister::MmData), 0);
+  // Readable before discovery, like the registers above: it is inside the
+  // pre-discovery aperture and is named, so leaving it undefined would report it
+  // as a register this device does not model when in fact it has an answer.
+  define_register(byte_offset_of(MmioRegister::IpDiscoveryVersion), kIpDiscoveryVersion);
+}
+
+uint64_t GpuPciDevice::indirect_address() const {
+  const auto low = registers_[static_cast<uint32_t>(byte_offset_of(MmioRegister::MmIndex) / 4)];
+  const auto high = registers_[static_cast<uint32_t>(byte_offset_of(MmioRegister::MmIndexHi) / 4)];
+  return (static_cast<uint64_t>(low) & kIndirectLowMask) |
+         (static_cast<uint64_t>(high) << kIndirectHighShift);
+}
+
+bool GpuPciDevice::read_vram(uint64_t offset, uint32_t &value) const {
+  if (vram_fd_ < 0 || offset + sizeof(value) > spec_.vram_bytes) {
+    return false;
+  }
+  return ::pread(vram_fd_, &value, sizeof(value), static_cast<off_t>(offset)) ==
+         static_cast<ssize_t>(sizeof(value));
+}
+
+bool GpuPciDevice::write_vram(uint64_t offset, uint32_t value) {
+  if (vram_fd_ < 0 || offset + sizeof(value) > spec_.vram_bytes) {
+    return false;
+  }
+  return ::pwrite(vram_fd_, &value, sizeof(value), static_cast<off_t>(offset)) ==
+         static_cast<ssize_t>(sizeof(value));
+}
+
+void GpuPciDevice::define_register(uint64_t byte_offset, uint32_t value) {
+  const auto index = static_cast<uint32_t>(byte_offset / 4);
+  registers_[index] = value;
+  modelled_[index] = true;
+}
+
+int64_t GpuPciDevice::access_registers(std::span<std::byte> buf, uint64_t offset, bool write) {
+  // Registers are 32 bits wide and naturally aligned; anything else is a driver
+  // bug or a transport bug, and answering it would hide which.
+  if (buf.size() != 4 || (offset % 4) != 0 || offset + 4 > spec_.register_aperture_bytes) {
+    return -1;
+  }
+
+  const auto index = static_cast<uint32_t>(offset / 4);
+  const bool modelled = modelled_[index];
+  if (trace_ != nullptr) {
+    trace_->record(kRegisterBar, offset, buf.size(), write, modelled);
+  }
+
+  // Memory outside the aperture is reached by pointing the index registers at
+  // an address and then reading or writing the data register.
+  if (offset == byte_offset_of(MmioRegister::MmData)) {
+    // Bit 31 of MM_INDEX selects which space the window addresses. This stage
+    // models the memory side only, so a request for the register side is
+    // refused rather than quietly answered out of the framebuffer -- which
+    // would hand the driver bytes from an unrelated address and look like
+    // working hardware.
+    if ((registers_[static_cast<uint32_t>(byte_offset_of(MmioRegister::MmIndex) / 4)] &
+         kIndirectMemorySelect) == 0) {
+      if (trace_ != nullptr) {
+        trace_->record_rejected(kRegisterBar, offset, buf.size(), write);
+      }
+      return -1;
+    }
+    uint32_t value = 0;
+    if (write) {
+      std::memcpy(&value, buf.data(), sizeof(value));
+      (void)write_vram(indirect_address(), value);
+    } else {
+      (void)read_vram(indirect_address(), value);
+      std::memcpy(buf.data(), &value, sizeof(value));
+    }
+    return 4;
+  }
+
+  if (write) {
+    // A write to something the device does not model is dropped rather than
+    // remembered, so a later read still reports absent hardware instead of
+    // echoing back whatever the driver put there.
+    if (modelled) {
+      uint32_t value = 0;
+      std::memcpy(&value, buf.data(), sizeof(value));
+      registers_[index] = value;
+    }
+    return 4;
+  }
+
+  const uint32_t value = modelled ? registers_[index] : 0;
+  std::memcpy(buf.data(), &value, sizeof(value));
+  return 4;
+}
+
+int64_t GpuPciDevice::access_memory(std::span<std::byte> buf, uint64_t offset, bool write,
+                                    std::span<std::byte> backing) {
+  if (offset > backing.size() || buf.size() > backing.size() - offset) {
+    return -1;
+  }
+  const auto begin = backing.begin() + static_cast<std::ptrdiff_t>(offset);
+  if (write) {
+    std::ranges::copy(buf, begin);
+  } else {
+    std::copy_n(begin, buf.size(), buf.begin());
+  }
+  return static_cast<int64_t>(buf.size());
+}
+
+int64_t GpuPciDevice::bar_access(int bar, std::span<std::byte> buf, uint64_t offset, bool write) {
+  if (!is_supported_width(buf.size())) {
+    // Deliberately not traced. The trace answers "which registers does this
+    // device still not model", and an unsupported width is a malformed access
+    // rather than missing hardware: recording it as unmodelled would put an
+    // address into that report that may be modelled perfectly well, and send
+    // whoever reads it looking for a register that is not the problem.
+    return -1;
+  }
+
+  switch (bar) {
+  case kRegisterBar:
+    return access_registers(buf, offset, write);
+  case kDoorbellBar:
+    return access_memory(buf, offset, write, doorbells_);
+  case kVramBar:
+    // Reached only for a guest that did not map the aperture; a mapped one
+    // never traps here.
+    if (vram_ == nullptr) {
+      return -1;
+    }
+    return access_memory(buf, offset, write, {vram_, spec_.vram_aperture_bytes});
+  default:
+    break;
+  }
+
+  if (trace_ != nullptr) {
+    trace_->record_rejected(bar, offset, buf.size(), write);
+  }
+  return -1;
+}
+
+void GpuPciDevice::dma_map(const simdojo::DmaRegion & /*region*/) {}
+
+void GpuPciDevice::dma_unmap(const simdojo::DmaRegion & /*region*/) {}
+
+void GpuPciDevice::reset(simdojo::ResetKind kind) {
+  util::Logger::warn(std::format("{}: reset requested, kind {}", name(), static_cast<int>(kind)));
+  // Everything a client could have changed goes back to power-on state. Video
+  // memory is not cleared here: a mapping already handed out cannot be taken
+  // back, which is why a device that exports one is served to a single client.
+  std::ranges::fill(doorbells_, std::byte{0});
+  reset_registers();
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file gpu_pci_device.h
+/// @brief A simulated GPU as a guest driver first sees it on the bus.
+///
+/// @details This is the device an unmodified kernel driver attaches to. It
+/// presents an identity, the apertures the driver maps, and the few registers it
+/// reads before it knows anything else about the hardware.
+///
+/// Nothing here is specific to one ASIC. Which GPU is presented comes entirely
+/// from the simulation config, the same place the rest of the machine's shape
+/// comes from, so supporting a new part is a config file rather than a new class.
+
+#pragma once
+
+#include "rocjitsu/vm/amdgpu/pci/bar_access_trace.h"
+#include "simdojo/components/pci_device.h"
+#include "simdojo/components/register_file.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief The identity and bus shape a simulated GPU presents.
+struct GpuPciDeviceSpec {
+  simdojo::PciId id;       ///< Identity to present in configuration space.
+  uint64_t vram_bytes = 0; ///< Local memory, which the driver reads back.
+  /// @brief Aperture onto that memory. Must be a power of two; derive it with
+  /// @ref gpu_pci_spec_from_config rather than leaving it unset.
+  uint64_t vram_aperture_bytes = 0;
+  uint64_t doorbell_aperture_bytes = 0; ///< Doorbell aperture size.
+  uint64_t register_aperture_bytes = 0; ///< Register aperture size.
+};
+
+/// @brief PCI function presenting a simulated GPU to a guest driver.
+class GpuPciDevice final : public simdojo::PciDevice {
+public:
+  /// @brief BAR carrying the video memory aperture.
+  static constexpr int kVramBar = 0;
+
+  /// @brief BAR carrying the doorbell pages.
+  static constexpr int kDoorbellBar = 2;
+
+  /// @brief BAR carrying the register aperture.
+  static constexpr int kRegisterBar = 5;
+
+  /// @brief Smallest memory BAR the PCI specification allows.
+  ///
+  /// @details Checked here so a device reports its own configuration unusable
+  /// rather than being rejected later while a transport is built around it.
+  static constexpr uint64_t kMinMemoryBarBytes = 16;
+
+  /// @brief Smallest register aperture leaving every pre-discovery register
+  /// directly addressable.
+  ///
+  /// @details The furthest of them, the discovery table version, sits at byte
+  /// 0x5a800, and a BAR must be a power of two, so 512 KiB is the smallest legal
+  /// size that reaches it. Real hardware may expose less and serve the remainder
+  /// through the indirect window, but a device that advertises an aperture too
+  /// small to answer its own registers is refused rather than quietly broken.
+  static constexpr uint64_t kMinRegisterApertureBytes = 512 * 1024;
+
+  /// @brief Construct the function.
+  /// @param[in] name Component name, used in diagnostics.
+  /// @param[in] spec Identity and bus shape, from the simulation config.
+  /// @param[in] trace Access diagnostics to feed, or nullptr for none. Must
+  ///                  outlive this device.
+  GpuPciDevice(std::string name, const GpuPciDeviceSpec &spec, BarAccessTrace *trace);
+  ~GpuPciDevice() override;
+
+  [[nodiscard]] std::vector<simdojo::BarSpec> bars() const override;
+
+  [[nodiscard]] int64_t bar_access(int bar, std::span<std::byte> buf, uint64_t offset,
+                                   bool write) override;
+  void dma_map(const simdojo::DmaRegion &region) override;
+  void dma_unmap(const simdojo::DmaRegion &region) override;
+  void reset(simdojo::ResetKind kind) override;
+
+  /// @brief Whether the device is usable.
+  /// @retval false The configuration was rejected or its memory could not be
+  ///               backed; the reason has been logged and it must not be served.
+  [[nodiscard]] bool usable() const { return usable_; }
+
+private:
+  void define_register(uint64_t byte_offset, uint32_t value);
+  [[nodiscard]] int64_t access_registers(std::span<std::byte> buf, uint64_t offset, bool write);
+  [[nodiscard]] int64_t access_memory(std::span<std::byte> buf, uint64_t offset, bool write,
+                                      std::span<std::byte> backing);
+
+  void reset_registers();
+
+  /// @brief Address the index registers currently select.
+  ///
+  /// @details Recomputed from both registers on each access rather than tracked
+  /// as they are written, because the driver writes them in either order and
+  /// updates the high half only when it changes.
+  [[nodiscard]] uint64_t indirect_address() const;
+  [[nodiscard]] bool read_vram(uint64_t offset, uint32_t &value) const;
+  bool write_vram(uint64_t offset, uint32_t value);
+
+  GpuPciDeviceSpec spec_;
+  BarAccessTrace *trace_;
+
+  /// @brief Register storage, one entry per dword of the aperture.
+  /// @brief One dword per register in the aperture.
+  /// @details Plain dense storage rather than a simdojo::RegisterFile: that
+  /// type is a shader register file, whose operator[] requires the index to
+  /// fall in an allocated block, and this aperture allocates none -- every
+  /// index would fail that precondition and abort an assertion-enabled build
+  /// during construction.
+  std::vector<uint32_t> registers_;
+
+  /// @brief Memory capacity as the driver reads it, in megabytes.
+  ///
+  /// @details Validated once at construction, because the register is 32 bits
+  /// of megabytes and the configured capacity is 64 bits of bytes: not every
+  /// capacity has a representation the driver would accept.
+  uint32_t vram_megabytes_ = 0;
+
+  /// @brief Which of those registers the device actually models.
+  ///
+  /// @details Kept apart from the values because zero is a legitimate register
+  /// value as well as what absent hardware reads as, and telling the two apart
+  /// is the whole point of the unmodelled-register report.
+  std::vector<bool> modelled_;
+  int vram_fd_ = -1;
+  std::byte *vram_ = nullptr;
+
+  std::vector<std::byte> doorbells_;
+  bool usable_ = false;
+};
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
+
+#include <algorithm>
+
+namespace rocjitsu {
+namespace {
+
+/// @brief Largest power of two no larger than @p limit, or zero if there is
+/// none.
+///
+/// @details A limit of zero has no answer, and returning one would turn a
+/// missing memory size into a one-byte aperture that looks valid.
+uint64_t largest_power_of_two_within(uint64_t limit) {
+  if (limit == 0) {
+    return 0;
+  }
+  uint64_t size = 1;
+  while (size <= limit / 2) {
+    size *= 2;
+  }
+  return size;
+}
+
+/// @brief Largest window onto video memory chosen when a config asks for none.
+///
+/// @details Memory capacities are rarely powers of two and are often enormous,
+/// so exposing all of one as a BAR is neither legal nor necessary: the indirect
+/// window reaches whatever the aperture does not.
+constexpr uint64_t kDefaultVramApertureBytes = 256 * 1024 * 1024;
+
+} // namespace
+
+GpuPciDeviceSpec gpu_pci_spec_from_config(const config::KfdDeviceConfig &device,
+                                          const config::PciDeviceConfig &pci) {
+  GpuPciDeviceSpec spec;
+  spec.id.vendor = static_cast<uint16_t>(device.vendor_id);
+  spec.id.device = static_cast<uint16_t>(device.device_id);
+  // A subsystem that names itself after the device is the common case for a
+  // reference board, so an unset value follows the device rather than reading
+  // as an unrelated vendor.
+  spec.id.subsys_vendor = static_cast<uint16_t>(
+      pci.subsystem_vendor_id != 0 ? pci.subsystem_vendor_id : device.vendor_id);
+  spec.id.subsys =
+      static_cast<uint16_t>(pci.subsystem_id != 0 ? pci.subsystem_id : device.device_id);
+  spec.id.cls = static_cast<uint8_t>((pci.class_code >> 16) & 0xff);
+  spec.id.subcls = static_cast<uint8_t>((pci.class_code >> 8) & 0xff);
+  spec.id.prog_if = static_cast<uint8_t>(pci.class_code & 0xff);
+  spec.id.revision = static_cast<uint8_t>(device.pci_revision_id);
+
+  spec.vram_bytes = device.local_mem_size;
+  // An unset aperture is resolved here rather than left for each consumer to
+  // interpret, so everything downstream sees the same explicit window.
+  spec.vram_aperture_bytes =
+      pci.vram_aperture_bytes != 0
+          ? pci.vram_aperture_bytes
+          : largest_power_of_two_within(std::min(device.local_mem_size, kDefaultVramApertureBytes));
+  spec.doorbell_aperture_bytes = pci.doorbell_aperture_bytes;
+  spec.register_aperture_bytes = pci.register_aperture_bytes;
+  return spec;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file gpu_pci_device_spec.h
+/// @brief Builds a device's bus presentation from the simulation config.
+///
+/// @details The identity a guest driver reads and the identity KFD reports are
+/// the same GPU, so they come from one place in the config rather than two that
+/// could disagree. The bus-only values, such as the class code a driver matches
+/// on and the aperture sizes, come from the config's PCI section.
+
+#pragma once
+
+#include "rocjitsu/config/kfd_device_config.h"
+#include "rocjitsu/config/pci_device_config.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+
+namespace rocjitsu {
+
+/// @brief Combine the configured GPU identity and bus shape into a device spec.
+/// @param[in] device The GPU's identity, as KFD also reports it.
+/// @param[in] pci The bus shape to present it with.
+/// @returns The spec to construct a @ref GpuPciDevice from.
+[[nodiscard]] GpuPciDeviceSpec gpu_pci_spec_from_config(const config::KfdDeviceConfig &device,
+                                                        const config::PciDeviceConfig &pci);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/mmio_registers.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/mmio_registers.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mmio_registers.h
+/// @brief Register offsets the driver uses before it knows what device it has.
+///
+/// @details Almost every AMD GPU register lives at an offset the driver only
+/// learns from the IP discovery table, but a handful come first: they are how
+/// the driver finds that table in the first place. The kernel defines them
+/// locally rather than in a per-ASIC header, noting that they are the same
+/// across all SOCs, so they are the one set of offsets an emulated device can
+/// answer before it has an identity.
+///
+/// Offsets are dword indices, as the driver's register accessors take them; the
+/// byte offset within the aperture is four times the index.
+
+#pragma once
+
+#include <cstdint>
+
+namespace rocjitsu {
+
+/// @brief Register index, in dwords, as the driver's accessors take it.
+enum class MmioRegister : uint32_t {
+  MmIndex = 0x0,               ///< Selects a register for the indirect window.
+  MmData = 0x1,                ///< Reads or writes the register selected above.
+  MmIndexHi = 0x6,             ///< High half of the indirect window selector.
+  DriverScratch0 = 0x94,       ///< Low half of a discovery table offset, when nonzero.
+  DriverScratch1 = 0x95,       ///< High half of that offset.
+  DriverScratch2 = 0x96,       ///< Discovery table size; zero means it is not published here.
+  RccConfigMemsize = 0xde3,    ///< Video memory size in megabytes.
+  Mp0SmnC2pmsg33 = 0x16061,    ///< Firmware init status; bit 31 means initialization finished.
+  IpDiscoveryVersion = 0x16a00 ///< Version of the discovery table format.
+};
+
+/// @brief Byte offset of a register within the aperture.
+/// @param[in] reg The register.
+/// @returns Its byte offset.
+[[nodiscard]] constexpr uint64_t byte_offset_of(MmioRegister reg) {
+  return static_cast<uint64_t>(reg) * 4;
+}
+
+/// @brief Bit the driver polls in @ref MmioRegister::Mp0SmnC2pmsg33.
+///
+/// @details The driver waits up to two seconds for this, because on real
+/// hardware the firmware may still be starting. An emulated device has nothing
+/// to wait for and reports ready immediately.
+inline constexpr uint32_t kFirmwareInitDoneBit = 0x80000000;
+
+/// @brief Value reported by @ref MmioRegister::IpDiscoveryVersion.
+///
+/// @details Zero, which is what a device publishing its discovery table at the
+/// top of video memory reports: the register distinguishes formats that place
+/// the table elsewhere, and this device uses the memory-resident one. It is
+/// defined rather than left absent because the register sits inside the aperture
+/// the driver reads before discovery, so an undefined one would read as a
+/// register this device does not model.
+inline constexpr uint32_t kIpDiscoveryVersion = 0;
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/register_symbols.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/register_symbols.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/pci/register_symbols.h"
 
+#include "rocjitsu/vm/amdgpu/pci/mmio_registers.h"
+
 #include <utility>
 
 namespace rocjitsu {
@@ -29,15 +31,18 @@ std::string_view RegisterSymbols::lookup(int bar, uint64_t byte_offset) const {
 }
 
 void add_pre_discovery_symbols(RegisterSymbols &symbols, int bar) {
-  symbols.add_dword(bar, 0x0, "MM_INDEX");
-  symbols.add_dword(bar, 0x1, "MM_DATA");
-  symbols.add_dword(bar, 0x6, "MM_INDEX_HI");
-  symbols.add_dword(bar, 0x94, "DRIVER_SCRATCH_0");
-  symbols.add_dword(bar, 0x95, "DRIVER_SCRATCH_1");
-  symbols.add_dword(bar, 0x96, "DRIVER_SCRATCH_2");
-  symbols.add_dword(bar, 0xde3, "RCC_CONFIG_MEMSIZE");
-  symbols.add_dword(bar, 0x16061, "MP0_SMN_C2PMSG_33");
-  symbols.add_dword(bar, 0x16a00, "IP_DISCOVERY_VERSION");
+  const auto name_register = [&symbols, bar](MmioRegister reg, std::string name) {
+    symbols.add(bar, byte_offset_of(reg), std::move(name));
+  };
+  name_register(MmioRegister::MmIndex, "MM_INDEX");
+  name_register(MmioRegister::MmData, "MM_DATA");
+  name_register(MmioRegister::MmIndexHi, "MM_INDEX_HI");
+  name_register(MmioRegister::DriverScratch0, "DRIVER_SCRATCH_0");
+  name_register(MmioRegister::DriverScratch1, "DRIVER_SCRATCH_1");
+  name_register(MmioRegister::DriverScratch2, "DRIVER_SCRATCH_2");
+  name_register(MmioRegister::RccConfigMemsize, "RCC_CONFIG_MEMSIZE");
+  name_register(MmioRegister::Mp0SmnC2pmsg33, "MP0_SMN_C2PMSG_33");
+  name_register(MmioRegister::IpDiscoveryVersion, "IP_DISCOVERY_VERSION");
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/CMakeLists.txt
@@ -11,4 +11,10 @@ rj_add_object_library(
     vfio_device_host.cpp
     vfio_server.cpp
 )
-target_link_libraries(rocjitsu_vmm_vfu PRIVATE libvfio-user::libvfio-user)
+target_link_libraries(
+    rocjitsu_vmm_vfu
+    PRIVATE libvfio-user::libvfio-user flatbuffers
+)
+# The server reads the simulation config, whose parser is generated.
+target_include_directories(rocjitsu_vmm_vfu PRIVATE ${GENERATED_DIR})
+add_dependencies(rocjitsu_vmm_vfu flatbuffers_schemas)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
@@ -221,6 +221,7 @@ bool VfioDeviceHost::build() {
 
   for (const simdojo::BarSpec &bar : device_.bars()) {
     const BarRegionPlan plan = plan_bar_region(bar);
+    single_client_ = single_client_ || !plan.mmap_areas.empty();
     if (!plan.valid) {
       util::Logger::warn(
           std::format("vfu: device {} declared an unusable BAR{}", device_.name(), bar.index));
@@ -341,9 +342,14 @@ VfioDeviceHost::ServeResult VfioDeviceHost::run(std::stop_token stop_token) {
       util::Logger::warn(std::format("vfu: serving failed: {}", std::strerror(errno)));
       return ServeResult::Failed;
     }
-    // The client went away. Everything it had mapped is gone with it, so wait
-    // for a new one rather than tearing the server down: a VMM may be restarted
-    // against a server that keeps running.
+    if (single_client_) {
+      util::Logger::warn("vfu: client disconnected; this device shares memory by descriptor, "
+                         "which cannot be reclaimed, so serving ends here");
+      return ServeResult::Stopped;
+    }
+    // The client went away and had nothing mapped, so wait for a new one rather
+    // than tearing the server down: a VMM may be restarted against a server
+    // that keeps running.
     attached_ = false;
     guest_regions_.clear();
     if (declined_regions_ != 0) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.h
@@ -37,6 +37,11 @@
 /// practice a VMM shares guest RAM mmap-ably and the supported case is the
 /// ordinary one.
 ///
+/// A device that shares a BAR by descriptor is served to one client only. The
+/// mapping outlives the connection and cannot be taken back, so a later client
+/// would inherit whatever the first left behind, and the first could keep
+/// reading and writing it.
+///
 /// Teardown has a required order, because the device holds this host through
 /// raw sink pointers: stop the serving thread, join it, then destroy the host.
 /// @ref rocjitsu::VfioDeviceHost::detach clears the sinks so a device that
@@ -77,18 +82,24 @@ public:
 
   /// @brief Why serving ended.
   enum class ServeResult {
-    Stopped, ///< The stop token was signalled; an orderly shutdown.
+    Stopped, ///< An orderly end: the stop token was signalled, or the sole
+             ///< client of a descriptor-backed device disconnected.
     Failed   ///< The transport broke; the reason has been logged.
   };
 
   /// @brief Serve the socket until @p stop_token is signalled or serving fails.
   /// @param[in] stop_token Cooperative stop for the serving thread.
   /// @returns Why serving ended.
-  /// @details Blocks. Accepts one client at a time and returns to waiting for a
-  /// new one when a client disconnects, so a VMM can be restarted against a
-  /// running server. A caller must observe the result: once this returns, the
-  /// socket is no longer served, and a process that keeps running is advertising
-  /// a device nobody is behind.
+  /// @details Blocks, and accepts one client at a time. What a disconnect means
+  /// depends on the device. One whose BARs all trap can be served again, so this
+  /// returns to waiting and a VMM may be restarted against a running server. One
+  /// that shares a BAR by descriptor cannot: the mapping outlives the connection
+  /// and cannot be reclaimed, so serving ends and this returns @ref
+  /// ServeResult::Stopped.
+  ///
+  /// A caller must observe the result either way: once this returns, the socket
+  /// is no longer served, and a process that keeps running is advertising a
+  /// device nobody is behind.
   [[nodiscard]] ServeResult run(std::stop_token stop_token);
 
   /// @brief Detach this host from the device.
@@ -140,6 +151,14 @@ private:
   std::recursive_mutex vfu_mutex_;
   vfu_ctx *ctx_ = nullptr;
   bool attached_ = false;
+
+  /// @brief Whether serving ends when the client disconnects.
+  ///
+  /// @details Set when the device shares a BAR by descriptor. Closing the socket
+  /// cannot revoke a mapping the client already holds, so a second client could
+  /// neither be isolated from the first nor given clean state; refusing to serve
+  /// one is honest, where quietly reattaching is not.
+  bool single_client_ = false;
   GuestRegionMap guest_regions_;
   bool warned_unreachable_region_ = false;
   uint64_t declined_regions_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
@@ -3,16 +3,21 @@
 
 #include "rocjitsu/vmm/vfu/vfio_server.h"
 
+#include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/vm/amdgpu/pci/bar_access_trace.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
 #include "rocjitsu/vm/amdgpu/pci/register_symbols.h"
-#include "rocjitsu/vm/amdgpu/pci/scratch_pci_device.h"
 #include "rocjitsu/vmm/vfu/vfio_device_host.h"
 #include "util/log.h"
+
+#include "embedded_schema.h"
 
 #include <atomic>
 #include <cerrno>
 #include <csignal>
 #include <ctime>
+#include <exception>
 #include <format>
 #include <stop_token>
 #include <thread>
@@ -25,23 +30,24 @@ constexpr long kSignalPollNanoseconds = 100'000'000;
 
 } // namespace
 
-int run_vfio_server(const std::string &socket_path) {
+int run_vfio_server(const std::string &config_path, const std::string &socket_path) {
+  config::DeviceIdentityConfig identity;
+  try {
+    identity = config::load_device_identity(config_path, kEmbeddedSchema);
+  } catch (const std::exception &error) {
+    util::Logger::warn(std::format("vfu: cannot read {}: {}", config_path, error.what()));
+    return 1;
+  }
   RegisterSymbols symbols;
-  add_pre_discovery_symbols(symbols, ScratchPciDevice::kBarIndex);
+  add_pre_discovery_symbols(symbols, GpuPciDevice::kRegisterBar);
   BarAccessTrace trace(symbols);
 
-  // Vendor 0x1002 is AMD; the device ID is a placeholder until the emulated GPU
-  // supplies its own identity. Class 0x12/0x00 is a processing accelerator,
-  // which is what a compute GPU without a display presents as.
-  const simdojo::PciId id = {.vendor = 0x1002,
-                             .device = 0x0000,
-                             .subsys_vendor = 0x1002,
-                             .subsys = 0x0000,
-                             .cls = 0x12,
-                             .subcls = 0x00,
-                             .prog_if = 0x00,
-                             .revision = 0x00};
-  ScratchPciDevice device("rocjitsu-scratch", id, &trace);
+  const std::string device_name =
+      identity.device.marketing_name.empty() ? "gpu" : identity.device.marketing_name;
+  GpuPciDevice device(device_name, gpu_pci_spec_from_config(identity.device, identity.pci), &trace);
+  if (!device.usable()) {
+    return 1;
+  }
 
   // Shutdown signals are blocked and then consumed synchronously, the way the
   // daemon does it. Almost nothing is safe to touch from a signal handler, least

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.h
@@ -15,12 +15,12 @@
 namespace rocjitsu {
 
 /// @brief Serve a PCI function on @p socket_path until the process is signalled.
+/// @param[in] config_path Simulation config describing the GPU to present.
 /// @param[in] socket_path Filesystem path of the AF_UNIX socket to listen on.
 /// @returns A process exit status: zero on an orderly shutdown.
 /// @details Blocks. A VMM such as QEMU connects to the socket and presents the
-/// function to its guest as a real PCI device. The function served today is a
-/// scratch device that exists to exercise the transport; the emulated GPU
-/// replaces it once its model is wired in.
-int run_vfio_server(const std::string &socket_path);
+/// function to its guest as a real PCI device. Which GPU is presented comes from
+/// the config, so a different part is a different config file.
+int run_vfio_server(const std::string &config_path, const std::string &socket_path);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -114,6 +114,30 @@ table KfdDeviceInfo {
   num_sdma_queues_per_engine: uint32;
 }
 
+/// How the GPU presents itself on a PCI bus, for front ends that attach it to a
+/// VMM rather than interposing the KFD ioctls.
+///
+/// Identity fields not repeated here come from KfdDeviceInfo: the vendor, device
+/// and revision a driver reads are the same values KFD reports. What is here is
+/// the bus shape, which nothing else in the simulation describes.
+///
+/// The class code is what a guest driver's PCI table matches on: amdgpu binds
+/// any AMD device presenting 0x120000 (processing accelerator) or a display
+/// class, and then asks the device what it is through IP discovery.
+table PciDeviceInfo {
+  class_code: uint32 = 0x120000;   // 24-bit PCI class, subclass and programming interface.
+  subsystem_vendor_id: uint32 = 0; // 0 = same as the vendor ID.
+  subsystem_id: uint32 = 0;        // 0 = same as the device ID.
+
+  // Aperture sizes. The register aperture must be large enough to reach every
+  // register the driver reads before IP discovery, the furthest of which sits
+  // at byte 0x5a800; a smaller one pushes those reads onto the indirect window.
+  // Every aperture size must be a power of two, as PCI requires of a BAR.
+  vram_aperture_bytes: uint64 = 0; // 0 = an implementation-chosen window, <= 256 MiB.
+  doorbell_aperture_bytes: uint64 = 2097152;
+  register_aperture_bytes: uint64 = 524288;
+}
+
 /// Top-level AMDGPU configuration.
 table AmdgpuConfig {
   num_xcds: uint32;              // Number of Accelerator Complex Dies.
@@ -122,6 +146,10 @@ table AmdgpuConfig {
   memory: GpuMemoryConfig;
   device: KfdDeviceInfo;         // KFD device identity for sysfs topology.
   num_gpus: uint32 = 1;          // Number of simulated GPU instances.
+  // Appended, not inserted: FlatBuffers assigns field IDs by declaration order,
+  // so placing this before num_gpus would renumber it and change how existing
+  // buffers read.
+  pci: PciDeviceInfo;            // Bus shape for PCI-attached front ends.
 }
 
 enum DbtExecutionBackend: byte {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -548,6 +548,7 @@ add_executable(
     data_types_test.cpp
     drm_info_layout_test.cpp
     pci/bar_access_trace_test.cpp
+    pci/gpu_pci_device_test.cpp
     pci/scratch_pci_device_test.cpp
 )
 if(HAS_DEVICE_KERNELS)

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -11,6 +11,7 @@
 #include "rocjitsu/config/checkpoint.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/config/dbt_guest_config.h"
+#include "rocjitsu/config/pci_device_config.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
@@ -108,6 +109,35 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
   EXPECT_EQ(soc->assign_queue_owner_cp(0), soc->xcd(0)->command_processor());
   EXPECT_EQ(soc->assign_queue_owner_cp(1), soc->xcd(1)->command_processor());
   EXPECT_EQ(soc->assign_queue_owner_cp(soc->num_xcds()), soc->xcd(0)->command_processor());
+}
+
+// The VMM reads the bus shape through these two entry points, and nothing else
+// in the suite does: the device tests build a PciDeviceConfig by hand, so a
+// field dropped in the loader, or a wrong default for an omitted section, would
+// leave every test green while a guest saw the wrong device.
+TEST(ConfigLoaderTest, LoadsThePciSectionThroughBothEntryPoints) {
+  const auto identity = config::load_device_identity(CONFIG_DIR_PATH + "/gfx1250_mi455x.json",
+                                                     rocjitsu::kEmbeddedSchema);
+  EXPECT_EQ(identity.pci.vram_aperture_bytes, 268435456u);
+  EXPECT_EQ(identity.device.vendor_id, 0x1002u)
+      << "the identity must come from the same file as the bus shape";
+
+  const auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx1250_mi455x.json", rocjitsu::kEmbeddedSchema);
+  EXPECT_EQ(loaded.pci.vram_aperture_bytes, identity.pci.vram_aperture_bytes)
+      << "the two entry points disagree about the same file";
+}
+
+// A config with no bus section still has to yield a usable one, because most
+// parts do not describe a bus at all.
+TEST(ConfigLoaderTest, DefaultsThePciSectionWhenTheFileOmitsIt) {
+  const auto identity =
+      config::load_device_identity(CONFIG_DIR_PATH + "/gfx1151.json", rocjitsu::kEmbeddedSchema);
+  const config::PciDeviceConfig fallback;
+  EXPECT_EQ(identity.pci.class_code, fallback.class_code);
+  EXPECT_EQ(identity.pci.doorbell_aperture_bytes, fallback.doorbell_aperture_bytes);
+  EXPECT_EQ(identity.pci.register_aperture_bytes, fallback.register_aperture_bytes);
+  EXPECT_EQ(identity.pci.vram_aperture_bytes, fallback.vram_aperture_bytes);
 }
 
 TEST(ConfigLoaderTest, LoadFourGpuMi455xKmdConfig) {

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -1,0 +1,492 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/bar_access_trace.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
+#include "rocjitsu/vm/amdgpu/pci/mmio_registers.h"
+#include "rocjitsu/vm/amdgpu/pci/register_symbols.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+constexpr uint64_t kVramBytes = 16ULL * 1024 * 1024;
+
+/// @brief A configuration equivalent to what a config file would supply.
+rocjitsu::GpuPciDeviceSpec configured_spec() {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.vendor_id = 0x1002;
+  device.device_id = 0x1250;
+  device.pci_revision_id = 0x5a;
+  device.local_mem_size = kVramBytes;
+  return rocjitsu::gpu_pci_spec_from_config(device, {});
+}
+
+class GpuDevice : public ::testing::Test {
+protected:
+  rocjitsu::RegisterSymbols symbols_;
+  rocjitsu::BarAccessTrace trace_{symbols_};
+  rocjitsu::GpuPciDevice device_{"gpu", configured_spec(), &trace_};
+
+  [[nodiscard]] uint32_t read_register(rocjitsu::MmioRegister reg) {
+    std::array<std::byte, 4> raw{};
+    EXPECT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                                 rocjitsu::byte_offset_of(reg), /*write=*/false),
+              4);
+    return std::bit_cast<uint32_t>(raw);
+  }
+
+  [[nodiscard]] const simdojo::BarSpec *bar(int index) {
+    static std::vector<simdojo::BarSpec> bars;
+    bars = device_.bars();
+    const auto found = std::ranges::find(bars, index, &simdojo::BarSpec::index);
+    return found == bars.end() ? nullptr : &*found;
+  }
+};
+
+// The driver's PCI table wildcards the device ID and matches on the class, so
+// this is the field that decides whether amdgpu attaches at all.
+TEST_F(GpuDevice, PresentsTheClassAmdgpuBindsOn) {
+  const simdojo::PciId id = device_.pci_id();
+
+  EXPECT_EQ(id.vendor, 0x1002);
+  EXPECT_EQ(id.cls, 0x12) << "processing accelerator";
+  EXPECT_EQ(id.subcls, 0x00);
+}
+
+TEST_F(GpuDevice, ExposesAMappableVideoMemoryAperture) {
+  ASSERT_TRUE(device_.usable());
+  const simdojo::BarSpec *vram = bar(rocjitsu::GpuPciDevice::kVramBar);
+
+  ASSERT_NE(vram, nullptr);
+  EXPECT_EQ(vram->size, kVramBytes);
+  EXPECT_TRUE(vram->is_64bit);
+  EXPECT_TRUE(vram->prefetch);
+  EXPECT_GE(vram->backing_fd, 0) << "the guest must be able to map video memory";
+  ASSERT_EQ(vram->mmap_areas.size(), 1u);
+  EXPECT_EQ(vram->mmap_areas[0].length, kVramBytes);
+}
+
+// Registers must trap even though memory does not: a read has to be answered by
+// the model rather than served from a page the guest mapped.
+TEST_F(GpuDevice, TrapsEveryRegisterAccess) {
+  const simdojo::BarSpec *registers = bar(rocjitsu::GpuPciDevice::kRegisterBar);
+
+  ASSERT_NE(registers, nullptr);
+  EXPECT_LT(registers->backing_fd, 0);
+  EXPECT_TRUE(registers->mmap_areas.empty());
+}
+
+// The aperture has to reach the furthest register the driver reads before
+// discovery, or that read silently goes through the indirect window instead.
+TEST_F(GpuDevice, SizesTheRegisterApertureToCoverThePreDiscoveryRegisters) {
+  const simdojo::BarSpec *registers = bar(rocjitsu::GpuPciDevice::kRegisterBar);
+
+  ASSERT_NE(registers, nullptr);
+  EXPECT_GT(registers->size, rocjitsu::byte_offset_of(rocjitsu::MmioRegister::Mp0SmnC2pmsg33));
+}
+
+TEST_F(GpuDevice, ReportsItsMemorySizeInMegabytes) {
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::RccConfigMemsize), kVramBytes >> 20);
+}
+
+// Reporting no memory, or all-ones, makes the driver abandon discovery before
+// it starts.
+TEST_F(GpuDevice, NeverReportsAMemorySizeThatAbortsDiscovery) {
+  const uint32_t size = read_register(rocjitsu::MmioRegister::RccConfigMemsize);
+
+  EXPECT_NE(size, 0u);
+  EXPECT_NE(size, 0xffffffffu);
+}
+
+// The driver polls this for up to two seconds waiting for firmware to finish
+// starting. An emulated device has nothing to wait for.
+TEST_F(GpuDevice, ReportsFirmwareInitialisationAlreadyFinished) {
+  EXPECT_NE(read_register(rocjitsu::MmioRegister::Mp0SmnC2pmsg33) & rocjitsu::kFirmwareInitDoneBit,
+            0u);
+}
+
+// Zero tells the driver the discovery table is not published through these
+// registers, sending it to the top of video memory instead.
+TEST_F(GpuDevice, PublishesNoDiscoveryTableThroughTheScratchRegisters) {
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::DriverScratch0), 0u);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::DriverScratch1), 0u);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::DriverScratch2), 0u);
+}
+
+TEST_F(GpuDevice, RecordsARegisterItDoesNotModel) {
+  constexpr uint64_t kUnmodelled = 0x28a04;
+  std::array<std::byte, 4> raw{};
+
+  ASSERT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw, kUnmodelled,
+                               /*write=*/false),
+            4);
+
+  EXPECT_EQ(std::bit_cast<uint32_t>(raw), 0u) << "an unmodelled register reads as absent hardware";
+  EXPECT_NE(trace_.unmodeled_report().find("0x00028a04"), std::string::npos);
+}
+
+TEST_F(GpuDevice, RejectsARegisterAccessNoHardwareWouldAnswer) {
+  std::array<std::byte, 2> narrow{};
+  EXPECT_LT(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, narrow, 0, false), 0);
+
+  std::array<std::byte, 4> unaligned{};
+  EXPECT_LT(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, unaligned, 2, false), 0);
+}
+
+TEST_F(GpuDevice, KeepsDoorbellWritesForTheCommandProcessorToFind) {
+  constexpr uint64_t kDoorbell = 0x1000;
+  auto written = std::bit_cast<std::array<std::byte, 8>>(uint64_t{0x1234});
+
+  ASSERT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kDoorbellBar, written, kDoorbell, true), 8);
+
+  std::array<std::byte, 8> read{};
+  ASSERT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kDoorbellBar, read, kDoorbell, false), 8);
+  EXPECT_EQ(std::bit_cast<uint64_t>(read), 0x1234u);
+}
+
+// Which GPU is presented comes from the config, so a different part is a
+// different config file rather than a different class.
+TEST(GpuDeviceFromConfig, PresentsTheConfiguredIdentityAndApertures) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.vendor_id = 0x1002;
+  device.device_id = 0x74a1;
+  device.pci_revision_id = 0x02;
+  device.local_mem_size = 192ULL * 1024 * 1024 * 1024;
+
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.class_code = 0x030000;
+  pci.subsystem_vendor_id = 0x1028;
+  pci.subsystem_id = 0x0c34;
+  pci.vram_aperture_bytes = 32ULL * 1024 * 1024;
+  pci.doorbell_aperture_bytes = 4ULL * 1024 * 1024;
+  pci.register_aperture_bytes = 1024ULL * 1024;
+
+  rocjitsu::GpuPciDevice configured("configured", rocjitsu::gpu_pci_spec_from_config(device, pci),
+                                    nullptr);
+  ASSERT_TRUE(configured.usable());
+
+  const simdojo::PciId id = configured.pci_id();
+  EXPECT_EQ(id.device, 0x74a1);
+  EXPECT_EQ(id.cls, 0x03) << "the configured class must reach the bus, not a built-in one";
+  EXPECT_EQ(id.subsys_vendor, 0x1028);
+  EXPECT_EQ(id.revision, 0x02);
+
+  const std::vector<simdojo::BarSpec> bars = configured.bars();
+  const auto aperture = [&bars](int index) {
+    return std::ranges::find(bars, index, &simdojo::BarSpec::index)->size;
+  };
+  EXPECT_EQ(aperture(rocjitsu::GpuPciDevice::kVramBar), 32ULL * 1024 * 1024)
+      << "a small window onto large memory is the normal case";
+  EXPECT_EQ(aperture(rocjitsu::GpuPciDevice::kDoorbellBar), 4ULL * 1024 * 1024);
+  EXPECT_EQ(aperture(rocjitsu::GpuPciDevice::kRegisterBar), 1024ULL * 1024);
+}
+
+// An unset subsystem follows the device rather than reading as an unrelated one.
+TEST(GpuDeviceFromConfig, DefaultsTheSubsystemToTheDeviceItself) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.vendor_id = 0x1002;
+  device.device_id = 0x1250;
+  device.local_mem_size = kVramBytes;
+
+  const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});
+
+  EXPECT_EQ(spec.id.subsys_vendor, 0x1002);
+  EXPECT_EQ(spec.id.subsys, 0x1250);
+}
+
+// A register aperture too small to reach the pre-discovery registers would make
+// the driver read them through a window this device does not model, so the
+// device refuses rather than answering wrongly.
+TEST(GpuDeviceFromConfig, RefusesARegisterApertureThatCannotReachThoseRegisters) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = kVramBytes;
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.register_aperture_bytes = 4096;
+
+  const rocjitsu::GpuPciDevice tiny("tiny", rocjitsu::gpu_pci_spec_from_config(device, pci),
+                                    nullptr);
+
+  EXPECT_FALSE(tiny.usable());
+}
+
+// A part whose memory is larger than its window is the normal case, and the
+// discovery table the driver looks for sits at the top of memory, outside it.
+// Reaching that means the indirect window has to work, and has to use the same
+// address encoding the driver does.
+class GpuDeviceIndirectWindow : public ::testing::TestWithParam<uint64_t> {
+public:
+  static constexpr uint64_t kMemoryBytes = 8ULL * 1024 * 1024 * 1024;
+
+protected:
+  rocjitsu::GpuPciDevice gpu_{"gpu", spec(), nullptr};
+
+  static rocjitsu::GpuPciDeviceSpec spec() {
+    rocjitsu::config::KfdDeviceConfig device;
+    device.local_mem_size = kMemoryBytes;
+    rocjitsu::config::PciDeviceConfig pci;
+    pci.vram_aperture_bytes = 1024 * 1024;
+    return rocjitsu::gpu_pci_spec_from_config(device, pci);
+  }
+
+  void write_register(rocjitsu::MmioRegister reg, uint32_t value) {
+    auto raw = std::bit_cast<std::array<std::byte, 4>>(value);
+    ASSERT_EQ(gpu_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                              rocjitsu::byte_offset_of(reg), /*write=*/true),
+              4);
+  }
+
+  uint32_t read_register(rocjitsu::MmioRegister reg) {
+    std::array<std::byte, 4> raw{};
+    EXPECT_EQ(gpu_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                              rocjitsu::byte_offset_of(reg), /*write=*/false),
+              4);
+    return std::bit_cast<uint32_t>(raw);
+  }
+
+  // The sequence amdgpu_device_mm_access uses: the low register carries address
+  // bits 0 to 30 with the memory-select bit set on top, and the high register
+  // starts at address bit 31.
+  void select(uint64_t address) {
+    write_register(rocjitsu::MmioRegister::MmIndex, static_cast<uint32_t>(address) | 0x80000000);
+    write_register(rocjitsu::MmioRegister::MmIndexHi, static_cast<uint32_t>(address >> 31));
+  }
+};
+
+TEST_P(GpuDeviceIndirectWindow, ReachesMemoryTheApertureCannot) {
+  const uint64_t address = GetParam();
+  ASSERT_TRUE(gpu_.usable());
+  constexpr uint32_t kMarker = 0x5a5a1234;
+
+  select(address);
+  write_register(rocjitsu::MmioRegister::MmData, kMarker);
+
+  // Point the window somewhere else first, so a stale address cannot pass.
+  select(0);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0u);
+
+  select(address);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::MmData), kMarker);
+}
+
+// Below, at and above the bit where the address splits between the two index
+// registers, plus the top of memory where the discovery table lives.
+INSTANTIATE_TEST_SUITE_P(AcrossTheIndexRegisterBoundary, GpuDeviceIndirectWindow,
+                         ::testing::Values(0x1000ULL, 0x7ffffffcULL, 0x80000000ULL, 0x80000004ULL,
+                                           0x1'0000'0000ULL,
+                                           GpuDeviceIndirectWindow::kMemoryBytes - 0x10000));
+
+// Bit 31 of MM_INDEX chooses the space the indirect window addresses. Only the
+// memory side is modelled, and answering a register-side request out of the
+// framebuffer would hand the driver bytes from an unrelated address while
+// looking like working hardware.
+TEST(GpuDeviceIndirectWindow, RefusesAnAccessToTheRegisterSpace) {
+  rocjitsu::RegisterSymbols symbols;
+  rocjitsu::BarAccessTrace trace(symbols);
+  rocjitsu::GpuPciDevice gpu("gpu", configured_spec(), &trace);
+  ASSERT_TRUE(gpu.usable());
+
+  const auto write_reg = [&](rocjitsu::MmioRegister reg, uint32_t value) {
+    std::array<std::byte, 4> raw{};
+    std::memcpy(raw.data(), &value, sizeof(value));
+    ASSERT_EQ(gpu.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                             rocjitsu::byte_offset_of(reg), /*write=*/true),
+              4);
+  };
+
+  // Memory select clear: a register-space request this stage does not model.
+  write_reg(rocjitsu::MmioRegister::MmIndexHi, 0);
+  write_reg(rocjitsu::MmioRegister::MmIndex, 0x1000);
+  std::array<std::byte, 4> raw{};
+  EXPECT_LT(gpu.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                           rocjitsu::byte_offset_of(rocjitsu::MmioRegister::MmData),
+                           /*write=*/false),
+            0);
+  EXPECT_TRUE(trace.unmodeled_report().empty())
+      << "a refused access was reported as a register still to be modeled";
+
+  // Memory select set: the modelled path, which answers.
+  write_reg(rocjitsu::MmioRegister::MmIndex, 0x80000000u | 0x1000u);
+  EXPECT_EQ(gpu.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                           rocjitsu::byte_offset_of(rocjitsu::MmioRegister::MmData),
+                           /*write=*/false),
+            4);
+}
+
+// The driver reads the capacity as a count of megabytes, so a finer size rounds
+// down. The device stays usable: what matters is that the reported value is the
+// one it derives everything else from, so the guest is never pointed at an
+// address the device did not use. The remainder is simply unreachable.
+TEST(GpuDeviceFromConfig, ReportsACapacityTheDriverCanReadAndStaysUsable) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = kVramBytes + 512;
+
+  const rocjitsu::GpuPciDevice odd("odd", rocjitsu::gpu_pci_spec_from_config(device, {}), nullptr);
+
+  EXPECT_TRUE(odd.usable())
+      << "an unreportable remainder is not a reason to refuse the whole device";
+}
+
+TEST(GpuDeviceFromConfig, RefusesAnApertureThatIsNotALegalBarSize) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = kVramBytes;
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.doorbell_aperture_bytes = 3 * 1024 * 1024;
+
+  const rocjitsu::GpuPciDevice odd("odd", rocjitsu::gpu_pci_spec_from_config(device, pci), nullptr);
+
+  EXPECT_FALSE(odd.usable()) << "a BAR must be a power of two";
+}
+
+// The smallest accepted register aperture has to reach every register the
+// device claims to answer, and the device has to actually answer them: a
+// constant comparison would still pass if reset_registers() stopped defining
+// one, which is the way this breaks in practice.
+TEST(GpuDeviceFromConfig, AcceptsTheMinimumApertureAndReachesEveryPreDiscoveryRegister) {
+  EXPECT_GT(rocjitsu::GpuPciDevice::kMinRegisterApertureBytes,
+            rocjitsu::byte_offset_of(rocjitsu::MmioRegister::IpDiscoveryVersion));
+  EXPECT_EQ(rocjitsu::GpuPciDevice::kMinRegisterApertureBytes &
+                (rocjitsu::GpuPciDevice::kMinRegisterApertureBytes - 1),
+            0u)
+      << "the advertised minimum must itself be a legal BAR size";
+
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = kVramBytes;
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.register_aperture_bytes = rocjitsu::GpuPciDevice::kMinRegisterApertureBytes;
+
+  rocjitsu::RegisterSymbols symbols;
+  rocjitsu::BarAccessTrace trace(symbols);
+  rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(device, pci), &trace);
+  ASSERT_TRUE(gpu.usable());
+
+  for (const rocjitsu::MmioRegister reg :
+       {rocjitsu::MmioRegister::RccConfigMemsize, rocjitsu::MmioRegister::Mp0SmnC2pmsg33,
+        rocjitsu::MmioRegister::DriverScratch0, rocjitsu::MmioRegister::DriverScratch1,
+        rocjitsu::MmioRegister::DriverScratch2, rocjitsu::MmioRegister::MmIndex,
+        rocjitsu::MmioRegister::MmIndexHi, rocjitsu::MmioRegister::IpDiscoveryVersion}) {
+    std::array<std::byte, 4> raw{};
+    EXPECT_EQ(gpu.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw,
+                             rocjitsu::byte_offset_of(reg), /*write=*/false),
+              4)
+        << "register at " << rocjitsu::byte_offset_of(reg);
+  }
+  EXPECT_TRUE(trace.unmodeled_report().empty())
+      << "a register the device claims to answer before discovery read as absent:\n"
+      << trace.unmodeled_report();
+}
+
+// Most parts report a capacity that is not a power of two and say nothing about
+// the bus, so an omitted section has to yield a BAR that is legal anyway.
+TEST(GpuDeviceFromConfig, DerivesALegalApertureForAConfigWithNoBusSection) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = 192ULL * 1024 * 1024 * 1024;
+
+  const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});
+  const rocjitsu::GpuPciDevice gpu("gpu", spec, nullptr);
+
+  EXPECT_EQ(spec.vram_aperture_bytes, 256ULL * 1024 * 1024);
+  EXPECT_TRUE(gpu.usable()) << "a capacity that is not a power of two must still be presentable";
+}
+
+// A config with no usable device description must not produce a device that
+// claims to be presentable; the transport would reject it moments later.
+TEST(GpuDeviceFromConfig, RefusesAConfigThatDescribesNoMemory) {
+  const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config({}, {});
+
+  EXPECT_EQ(spec.vram_aperture_bytes, 0u) << "no memory has no legal aperture";
+
+  const rocjitsu::GpuPciDevice gpu("gpu", spec, nullptr);
+  EXPECT_FALSE(gpu.usable());
+}
+
+// PCI sets a floor on a memory BAR, and a device that accepts less would be
+// refused by the transport instead, after it had already reported itself fine.
+class GpuDeviceApertureBoundary : public ::testing::TestWithParam<uint64_t> {};
+
+TEST_P(GpuDeviceApertureBoundary, AgreesWithThePciMinimumForAMemoryBar) {
+  const uint64_t aperture = GetParam();
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = 64 * 1024 * 1024;
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.vram_aperture_bytes = aperture;
+
+  const rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(device, pci), nullptr);
+
+  EXPECT_EQ(gpu.usable(), aperture >= rocjitsu::GpuPciDevice::kMinMemoryBarBytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(AroundThePciFloor, GpuDeviceApertureBoundary,
+                         ::testing::Values(1ULL, 8ULL, 16ULL, 32ULL));
+
+// The driver reads memory size as megabytes in a 32-bit register and rejects
+// zero and all-ones, so not every byte capacity can be presented at all.
+struct CapacityCase {
+  uint64_t bytes;
+  bool presentable;
+  const char *why;
+};
+
+class GpuDeviceCapacityBoundary : public ::testing::TestWithParam<CapacityCase> {};
+
+TEST_P(GpuDeviceCapacityBoundary, OnlyAcceptsACapacityTheDriverCanRead) {
+  const CapacityCase &capacity = GetParam();
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = capacity.bytes;
+
+  const rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(device, {}), nullptr);
+
+  EXPECT_EQ(gpu.usable(), capacity.presentable) << capacity.why;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AroundTheMegabyteEncoding, GpuDeviceCapacityBoundary,
+    ::testing::Values(
+        CapacityCase{16, false, "sixteen bytes rounds to zero megabytes"},
+        CapacityCase{(1ULL << 20) - 1, false, "just under a megabyte still rounds to zero"},
+        CapacityCase{1ULL << 20, true, "exactly one megabyte is the smallest sayable size"},
+        CapacityCase{static_cast<uint64_t>(0xffffffffULL) << 20, false,
+                     "all-ones megabytes is how the driver spells no memory"},
+        CapacityCase{static_cast<uint64_t>(0x100000000ULL) << 20, false,
+                     "beyond the register, which would narrow to zero"}));
+
+// A part smaller than the default window gets the largest legal window that
+// fits inside it, rather than one larger than its own memory.
+TEST(GpuDeviceFromConfig, CapsTheDerivedApertureAtTheMemoryItHas) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.local_mem_size = 100ULL * 1024 * 1024;
+
+  const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});
+
+  EXPECT_EQ(spec.vram_aperture_bytes, 64ULL * 1024 * 1024);
+  EXPECT_LE(spec.vram_aperture_bytes, device.local_mem_size);
+}
+
+// Reset returns everything a client could have changed to power-on state.
+TEST_F(GpuDevice, RestoresPowerOnRegisterStateOnReset) {
+  auto changed = std::bit_cast<std::array<std::byte, 4>>(uint32_t{0});
+  ASSERT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, changed,
+                               rocjitsu::byte_offset_of(rocjitsu::MmioRegister::DriverScratch0),
+                               /*write=*/true),
+            4);
+  auto marker = std::bit_cast<std::array<std::byte, 4>>(uint32_t{0xdeadbeef});
+  ASSERT_EQ(device_.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, marker,
+                               rocjitsu::byte_offset_of(rocjitsu::MmioRegister::DriverScratch1),
+                               /*write=*/true),
+            4);
+
+  device_.reset(simdojo::ResetKind::LostConnection);
+
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::DriverScratch1), 0u);
+  EXPECT_NE(read_register(rocjitsu::MmioRegister::Mp0SmnC2pmsg33) & rocjitsu::kFirmwareInitDoneBit,
+            0u);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/vm/amdgpu/pci/bar_access_trace.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
 #include "rocjitsu/vm/amdgpu/pci/register_symbols.h"
 #include "rocjitsu/vm/amdgpu/pci/scratch_pci_device.h"
 #include "rocjitsu/vmm/vfu/vfio_device_host.h"
@@ -223,6 +225,102 @@ TEST(VfioDeviceHost, KeepsCountWhenTheSameWindowIsSharedTwice) {
   EXPECT_EQ(served.device().mapped_regions(), 1u)
       << "one logical window must produce one device mapping";
   ::close(backing);
+}
+
+// A device whose BARs all trap can be served again: nothing of it outlives the
+// connection, so a VMM may be restarted against a running server.
+TEST(VfioDeviceHostLifecycle, ServesAnotherClientWhenNothingWasShared) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+
+  {
+    rocjitsu::test::VfioUserClient first;
+    ASSERT_TRUE(served.attach(first));
+    auto written = std::bit_cast<std::array<std::byte, 4>>(uint32_t{0xa5a5a5a5});
+    ASSERT_TRUE(first.region_write(VFU_PCI_DEV_BAR0_REGION_IDX, 0, written));
+  }
+
+  rocjitsu::test::VfioUserClient second;
+  ASSERT_TRUE(served.attach(second)) << "a trapped-only device must accept a replacement client";
+  std::array<std::byte, 4> read{};
+  EXPECT_TRUE(second.region_read(VFU_PCI_DEV_BAR0_REGION_IDX, 0, read));
+}
+
+// A device that shared video memory by descriptor cannot take that mapping back
+// when the client goes away, so serving ends rather than handing a second
+// client memory the first can still reach.
+TEST(VfioDeviceHostLifecycle, StopsServingAfterASharedMemoryClientDisconnects) {
+  const std::string socket_path =
+      std::format("/tmp/rj-vfu-test-gpu-{}.sock", static_cast<int>(::getpid()));
+  std::filesystem::remove(socket_path);
+
+  rocjitsu::config::KfdDeviceConfig identity;
+  identity.vendor_id = 0x1002;
+  identity.device_id = 0x1250;
+  identity.local_mem_size = 8ULL * 1024 * 1024;
+  rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(identity, {}), nullptr);
+  ASSERT_TRUE(gpu.usable());
+
+  rocjitsu::VfioDeviceHost host(socket_path, gpu);
+  ASSERT_TRUE(host.build());
+
+  std::atomic<bool> finished = false;
+  auto result = rocjitsu::VfioDeviceHost::ServeResult::Failed;
+  std::jthread serving([&](std::stop_token stop) {
+    result = host.run(stop);
+    finished = true;
+  });
+
+  {
+    rocjitsu::test::VfioUserClient client;
+    bool connected = false;
+    for (int attempt = 0; attempt < 200 && !connected; ++attempt) {
+      connected = client.connect(socket_path);
+      if (!connected) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+    ASSERT_TRUE(connected);
+    uint32_t regions = 0;
+    uint32_t irqs = 0;
+    ASSERT_TRUE(client.device_info(regions, irqs));
+  }
+
+  // No stop is requested: the disconnect alone must end serving.
+  for (int attempt = 0; attempt < 500 && !finished.load(); ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_TRUE(finished.load()) << "serving must end on its own once the client is gone";
+  serving.request_stop();
+  serving.join();
+  host.detach();
+  std::filesystem::remove(socket_path);
+
+  EXPECT_EQ(result, rocjitsu::VfioDeviceHost::ServeResult::Stopped)
+      << "ending because the sole client left is orderly, not a failure";
+}
+
+// The device refuses a bus shape the transport would reject; the two must also
+// agree on what is acceptable, or a device reports itself fine and then fails
+// while the transport is being built around it.
+TEST(VfioDeviceHostLifecycle, BuildsTheSmallestBusShapeTheDeviceAccepts) {
+  const std::string socket_path =
+      std::format("/tmp/rj-vfu-test-floor-{}.sock", static_cast<int>(::getpid()));
+  std::filesystem::remove(socket_path);
+
+  rocjitsu::config::KfdDeviceConfig identity;
+  identity.local_mem_size = 64 * 1024 * 1024;
+  rocjitsu::config::PciDeviceConfig pci;
+  pci.vram_aperture_bytes = rocjitsu::GpuPciDevice::kMinMemoryBarBytes;
+  pci.doorbell_aperture_bytes = rocjitsu::GpuPciDevice::kMinMemoryBarBytes;
+
+  rocjitsu::GpuPciDevice gpu("floor", rocjitsu::gpu_pci_spec_from_config(identity, pci), nullptr);
+  ASSERT_TRUE(gpu.usable()) << "the PCI minimum must be acceptable to the device";
+
+  rocjitsu::VfioDeviceHost host(socket_path, gpu);
+  EXPECT_TRUE(host.build()) << "and to the transport, or the two disagree";
+  host.detach();
+  std::filesystem::remove(socket_path);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -10,7 +10,7 @@
 ///   rocjitsu --daemon --config foo.json           (daemon-only: run daemon server)
 ///
 /// Builds configured with ROCJITSU_ENABLE_VFIO additionally support
-///   rocjitsu --vfio-socket <path>                    (serve a PCI device to a VMM)
+///   rocjitsu --config foo.json --vfio-socket <path>  (serve a PCI device to a VMM)
 
 #include "rocjitsu/daemon/rj_daemon.h"
 #if defined(RJ_ENABLE_VFIO_USER)
@@ -387,16 +387,16 @@ void print_usage() {
          "  rocjitsu --daemon --config foo.json -- ./app Daemon mode (fork daemon + launch app)\n"
          "  rocjitsu --daemon --config foo.json          Daemon-only (run server)\n"
          "  rocjitsu --attach --config foo.json -- ./app Attach to running daemon\n"
-         "  rocjitsu --vfio-socket <path>\n"
+         "  rocjitsu --config foo.json --vfio-socket <path>\n"
          "                                               Serve a PCI device to a VMM\n"
          "\n"
          "Options:\n"
          "  --config <path>   Simulation config JSON (required)\n"
          "  --vfio-socket <path>\n"
-         "                    Serve a scratch PCI function to a VMM over the vfio-user\n"
-         "                    protocol on this AF_UNIX socket, for transport bring-up\n"
-         "                    rather than the emulated GPU, instead of launching an\n"
-         "                    application. Requires a build with ROCJITSU_ENABLE_VFIO.\n"
+         "                    Serve the configured GPU as a PCI function to a VMM over\n"
+         "                    the vfio-user protocol on this AF_UNIX socket, instead of\n"
+         "                    launching an application. Requires a build with\n"
+         "                    ROCJITSU_ENABLE_VFIO.\n"
          "                    The VMM must share guest RAM through an mmap-able\n"
          "                    descriptor or the device cannot reach it; with QEMU that\n"
          "                    means -object\n"
@@ -444,32 +444,6 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  // Transport bring-up serves a scratch function that no configuration
-  // describes, so requiring one here would demand a file with no effect on the
-  // run. Dispatched before the config check for that reason; every other mode
-  // simulates the configured machine and still needs one.
-  const bool serving_scratch_over_vfio = vfio_socket != nullptr;
-  if (serving_scratch_over_vfio) {
-    if (daemon_mode || attach_mode || (separator_idx >= 0 && separator_idx + 1 < argc)) {
-      std::cerr << "rocjitsu: --vfio-socket serves a VMM and cannot be combined with "
-                   "--daemon, --attach, or an application\n";
-      return 1;
-    }
-    // Not an error to pass one: later stages serve the configured GPU here, so
-    // rejecting it now would make the option come and go between commits.
-    if (config_path != nullptr) {
-      std::cerr << "rocjitsu: --vfio-socket serves a scratch function for transport "
-                   "bring-up; ignoring --config\n";
-    }
-#if defined(RJ_ENABLE_VFIO_USER)
-    return rocjitsu::run_vfio_server(vfio_socket);
-#else
-    std::cerr << "rocjitsu: this build has no vfio-user support; reconfigure with "
-                 "-DROCJITSU_ENABLE_VFIO=ON\n";
-    return 1;
-#endif
-  }
-
   if (!config_path) {
     std::cerr << "rocjitsu: --config is required\n";
     print_usage();
@@ -480,6 +454,23 @@ int main(int argc, char *argv[]) {
   if (!std::filesystem::exists(abs_config)) {
     std::cerr << std::format("rocjitsu: config file not found: {}\n", abs_config);
     return 1;
+  }
+
+  // Serving a VMM needs the device's identity, not a simulated machine, so this
+  // is dispatched before the parse that builds one.
+  if (vfio_socket != nullptr) {
+    if (daemon_mode || attach_mode || (separator_idx >= 0 && separator_idx + 1 < argc)) {
+      std::cerr << "rocjitsu: --vfio-socket serves a VMM and cannot be combined with "
+                   "--daemon, --attach, or an application\n";
+      return 1;
+    }
+#if defined(RJ_ENABLE_VFIO_USER)
+    return rocjitsu::run_vfio_server(abs_config, vfio_socket);
+#else
+    std::cerr << "rocjitsu: this build has no vfio-user support; reconfigure with "
+                 "-DROCJITSU_ENABLE_VFIO=ON\n";
+    return 1;
+#endif
   }
 
   rocjitsu::config::DbtGuestConfig dbt_guest_config;


### PR DESCRIPTION
The vfio-user front end so far serves a scratch function: enough to prove the transport, but nothing amdgpu would look at twice. Before a real driver can be pointed at rocjitsu it needs a device whose identity it recognizes, apertures it can map, and answers to the handful of registers it reads before it knows what hardware it is talking to.

Add that device, driven entirely by configuration. Identity comes from the section that already describes the GPU to KFD, because the values a guest driver reads and the values KFD reports are the same part and must not be able to disagree; a new section adds only what describes the bus rather than the GPU. The class code carries the most weight there, since the driver's PCI table wildcards the device ID and binds on class alone, then asks the device what it is through IP discovery. Video memory is backed by a descriptor and mapped by the guest directly, since an aperture that trapped every access would be unusable, while the register aperture always traps because a register read has to be answered by the model rather than served from a page. A window smaller than memory is the normal case for a real part, so the index and data registers reach whatever the aperture does not, which is where the driver looks for the discovery table. The registers report a memory size that is neither zero nor all-ones, either of which makes the driver abandon discovery before it starts, firmware initialization already complete since an emulated device has nothing to wait for, and scratch registers left at zero so the driver looks for that table at the top of memory. Configurations that no bus could realize are refused up front rather than part-way through building a transport: apertures must be powers of two above the PCI floor and large enough to reach the registers the device claims to answer, and a capacity must survive being stated in the megabytes the driver reads. A device that shares memory by descriptor serves one client, because the mapping outlives the connection and cannot be reclaimed. Anything unmodelled reads as absent hardware and is counted, which is the list the next stage works through.