### PR TITLE
rocjitsu: Publish the table a guest driver reads to learn what the GPU is

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -415,6 +415,7 @@ add_dependencies(rocjitsu_shared flatbuffers_schemas)
 
 # Developer and test workflow tools.
 add_subdirectory(tools)
+add_subdirectory(tools/rj-ip-discovery)
 add_subdirectory(fuzz/decode)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/CMakeLists.txt
@@ -9,6 +9,8 @@ set(RJ_PCI_SOURCES
     bar_access_trace.cpp
     scratch_pci_device.cpp
     gpu_pci_device_spec.cpp
+    ip_discovery.cpp
+    ip_discovery_profile.cpp
 )
 
 # The GPU model shares its video memory with a guest through a file descriptor,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
 
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h"
 #include "rocjitsu/vm/amdgpu/pci/mmio_registers.h"
 #include "util/log.h"
 
@@ -11,9 +13,11 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstring>
 #include <format>
 #include <limits>
+#include <span>
 #include <utility>
 
 namespace rocjitsu {
@@ -36,6 +40,37 @@ constexpr uint32_t kIndirectMemorySelect = 0x80000000;
 
 /// @brief Address bit at which the high index register begins.
 constexpr unsigned kIndirectHighShift = 31;
+
+/// @brief Write a whole buffer at an offset, resuming after a short write.
+///
+/// @details A single pwrite is permitted to transfer fewer bytes than asked
+/// for, and a discovery table is large enough that a partial store would leave
+/// the driver reading a truncated table rather than none at all: the signature
+/// at the front would be intact, so the failure would surface as a malformed
+/// record rather than as an absent table.
+/// @param[in] fd File to write to.
+/// @param[in] bytes Buffer to store.
+/// @param[in] at Byte offset within @p fd.
+/// @retval true The whole buffer was stored.
+/// @retval false The write failed or the file would take no more.
+[[nodiscard]] bool write_all_at(int fd, std::span<const std::byte> bytes, uint64_t at) {
+  std::size_t done = 0;
+  while (done < bytes.size()) {
+    const ssize_t wrote =
+        ::pwrite(fd, bytes.data() + done, bytes.size() - done, static_cast<off_t>(at + done));
+    if (wrote < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (wrote == 0) {
+      return false;
+    }
+    done += static_cast<std::size_t>(wrote);
+  }
+  return true;
+}
 
 } // namespace
 
@@ -137,7 +172,75 @@ GpuPciDevice::GpuPciDevice(std::string name, const GpuPciDeviceSpec &spec, BarAc
   registers_.assign(register_count, 0);
   modelled_.assign(register_count, false);
   reset_registers();
+
+  // A device that answers every pre-discovery register and then has nothing at
+  // the address those answers point to is worse than one that fails to
+  // construct: the driver would read a zero signature and reject it, with the
+  // registers all looking correct.
+  if (!publish_discovery_table()) {
+    return;
+  }
   usable_ = true;
+}
+
+bool GpuPciDevice::publish_discovery_table() {
+  // Guarded rather than left to pwrite returning EBADF, because this is now
+  // reachable from the public reset() as well as from a device whose memory
+  // never came up, and because reading and writing memory guard the same way.
+  if (vram_fd_ < 0) {
+    util::Logger::warn(
+        std::format("{}: no video memory to publish a discovery table into", name()));
+    return false;
+  }
+  if (spec_.discovery.blocks.empty()) {
+    util::Logger::warn(std::format("{}: no discovery profile for this configuration, so a guest "
+                                   "driver would find nothing to attach to",
+                                   name()));
+    return false;
+  }
+  const IpDiscoveryBuild built = build_ip_discovery_table(spec_.discovery);
+  if (!built.ok()) {
+    util::Logger::warn(
+        std::format("{}: cannot build a discovery table: {}", name(), built.problem));
+    return false;
+  }
+  const IpDiscoveryValidation checked = validate_ip_discovery_table(built.table);
+  if (!checked.valid) {
+    util::Logger::warn(std::format("{}: would publish a discovery table the driver refuses: {}",
+                                   name(), checked.problem));
+    return false;
+  }
+  if (built.table.size() > kDiscoveryTableBytes) {
+    util::Logger::warn(std::format("{}: the discovery table is {} bytes, more than the {} the "
+                                   "driver reads",
+                                   name(), built.table.size(), kDiscoveryTableBytes));
+    return false;
+  }
+  // The driver never learns the byte count. It reads the megabyte count out of
+  // RCC_CONFIG_MEMSIZE and computes the address itself, as
+  // `(vram_size << 20) - DISCOVERY_TMR_OFFSET` (amdgpu_discovery.c:1996-1997).
+  // Publishing at a top-of-memory derived from the unrounded byte count would
+  // therefore miss by the remainder for any capacity that is not a whole number
+  // of megabytes, and the driver would read zeros and reject the signature with
+  // no hint that the address was the problem. Deriving the address from the
+  // value the device already committed to in reset_registers() is what keeps
+  // the two from drifting; configs/gfx1151.json is one of the capacities that
+  // would otherwise miss, by 446464 bytes.
+  const uint64_t reported_bytes = static_cast<uint64_t>(vram_megabytes_) << 20;
+  if (reported_bytes < kDiscoveryOffsetFromTopOfVram) {
+    util::Logger::warn(std::format("{}: {} bytes of video memory has no room for a discovery "
+                                   "table {} from the top",
+                                   name(), reported_bytes, kDiscoveryOffsetFromTopOfVram));
+    return false;
+  }
+
+  const uint64_t at = reported_bytes - kDiscoveryOffsetFromTopOfVram;
+  if (!write_all_at(vram_fd_, built.table, at)) {
+    util::Logger::warn(std::format("{}: cannot store the {}-byte discovery table at {:#x}: {}",
+                                   name(), built.table.size(), at, std::strerror(errno)));
+    return false;
+  }
+  return true;
 }
 
 GpuPciDevice::~GpuPciDevice() {
@@ -183,6 +286,11 @@ void GpuPciDevice::reset_registers() {
   // Reporting no memory, or all-ones, makes it give up before it starts.
   define_register(byte_offset_of(MmioRegister::RccConfigMemsize), vram_megabytes_);
   define_register(byte_offset_of(MmioRegister::Mp0SmnC2pmsg33), kFirmwareInitDoneBit);
+  // Zero says this is a physical function with virtualization disabled, which is
+  // what lets the driver treat the device as passed through to it whole. The
+  // alternative would be to model the SR-IOV mailbox a virtual function reaches
+  // its host through, which this device does not have.
+  define_register(byte_offset_of(MmioRegister::RccIovFuncIdentifier), 0);
   // Zero here tells the driver the discovery table is not published through
   // these registers, so it looks for it at the top of video memory instead.
   define_register(byte_offset_of(MmioRegister::DriverScratch0), 0);
@@ -341,6 +449,15 @@ void GpuPciDevice::reset(simdojo::ResetKind kind) {
   // back, which is why a device that exports one is served to a single client.
   std::ranges::fill(doorbells_, std::byte{0});
   reset_registers();
+  // The table is restored rather than assumed intact. On real hardware it lives
+  // in memory the security processor reserves and the driver cannot write; here
+  // it is ordinary video memory, reachable through MM_DATA, so a guest that
+  // scribbles over it once would otherwise make every later bind fail.
+  if (!publish_discovery_table()) {
+    util::Logger::warn(std::format("{}: the discovery table could not be restored, so a driver "
+                                   "binding after this reset will refuse the device",
+                                   name()));
+  }
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "rocjitsu/vm/amdgpu/pci/bar_access_trace.h"
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
 #include "simdojo/components/pci_device.h"
 #include "simdojo/components/register_file.h"
 
@@ -35,6 +36,15 @@ struct GpuPciDeviceSpec {
   uint64_t vram_aperture_bytes = 0;
   uint64_t doorbell_aperture_bytes = 0; ///< Doorbell aperture size.
   uint64_t register_aperture_bytes = 0; ///< Register aperture size.
+  /// @brief The blocks this device publishes to a guest driver.
+  ///
+  /// @details Carried in the spec rather than chosen inside the device, because
+  /// the identity in @ref id and the hardware described here have to be the
+  /// same GPU. A device that picked its own table could present one part's PCI
+  /// IDs alongside another part's blocks, and the guest would instantiate
+  /// drivers for hardware the identity says is not there. Derive it with
+  /// @ref gpu_pci_spec_from_config, which reads both from one config.
+  IpDiscoverySpec discovery;
 };
 
 /// @brief PCI function presenting a simulated GPU to a guest driver.
@@ -64,6 +74,15 @@ public:
   /// through the indirect window, but a device that advertises an aperture too
   /// small to answer its own registers is refused rather than quietly broken.
   static constexpr uint64_t kMinRegisterApertureBytes = 512 * 1024;
+
+  /// @brief Where the discovery table sits, measured back from the top of
+  /// memory.
+  ///
+  /// @details The driver computes this itself, from the capacity the device
+  /// reports, whenever the scratch registers do not name somewhere else. So the
+  /// device does not get to choose the address: it either writes the table here
+  /// or the driver reads whatever happens to be here instead.
+  static constexpr uint64_t kDiscoveryOffsetFromTopOfVram = 64 * 1024;
 
   /// @brief Construct the function.
   /// @param[in] name Component name, used in diagnostics.
@@ -102,6 +121,10 @@ private:
   [[nodiscard]] uint64_t indirect_address() const;
   [[nodiscard]] bool read_vram(uint64_t offset, uint32_t &value) const;
   bool write_vram(uint64_t offset, uint32_t value);
+
+  /// @brief Write the discovery table where the driver will look for it.
+  /// @returns Whether the table was built, accepted and stored.
+  [[nodiscard]] bool publish_discovery_table();
 
   GpuPciDeviceSpec spec_;
   BarAccessTrace *trace_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.cpp
@@ -3,7 +3,11 @@
 
 #include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
 
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h"
+#include "util/log.h"
+
 #include <algorithm>
+#include <format>
 
 namespace rocjitsu {
 namespace {
@@ -30,6 +34,30 @@ uint64_t largest_power_of_two_within(uint64_t limit) {
 /// so exposing all of one as a BAR is neither legal nor necessary: the indirect
 /// window reaches whatever the aperture does not.
 constexpr uint64_t kDefaultVramApertureBytes = 256 * 1024 * 1024;
+
+/// @brief KFD target version of the one part a discovery profile exists for.
+constexpr uint32_t kGfx1250TargetVersion = 120500;
+
+/// @brief Choose the IP blocks to describe for @p device.
+///
+/// @details gfx1250 is the only part modelled well enough to publish. Any other
+/// target, including one left unset, gets no blocks: publishing gfx1250's table
+/// for a configuration that models a different part would have the guest driver
+/// bind support for hardware the rest of the simulation is not, which fails
+/// later and further away than refusing here. An empty profile makes the device
+/// refuse to become usable, and says why.
+/// @param[in] device The configured device.
+/// @returns The blocks to describe, empty if this part has no profile.
+[[nodiscard]] IpDiscoverySpec discovery_spec_for(const config::KfdDeviceConfig &device) {
+  if (device.gfx_target_version != kGfx1250TargetVersion) {
+    util::Logger::warn(std::format(
+        "gfx target {} has no IP discovery profile, so this device cannot describe itself to a "
+        "guest driver; only gfx{} is modelled",
+        device.gfx_target_version, kGfx1250TargetVersion));
+    return {};
+  }
+  return gfx1250_discovery_spec();
+}
 
 } // namespace
 
@@ -59,6 +87,9 @@ GpuPciDeviceSpec gpu_pci_spec_from_config(const config::KfdDeviceConfig &device,
           : largest_power_of_two_within(std::min(device.local_mem_size, kDefaultVramApertureBytes));
   spec.doorbell_aperture_bytes = pci.doorbell_aperture_bytes;
   spec.register_aperture_bytes = pci.register_aperture_bytes;
+  // The blocks are chosen here, next to the identity, so the two describe one
+  // GPU.
+  spec.discovery = discovery_spec_for(device);
   return spec;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery.cpp
@@ -1,0 +1,413 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
+
+#include <algorithm>
+#include <cstring>
+#include <format>
+#include <numeric>
+#include <optional>
+#include <span>
+
+namespace rocjitsu {
+namespace {
+
+/// @brief Marks the start of a discovery binary.
+constexpr uint32_t kBinarySignature = 0x28211407;
+
+/// @brief Marks the start of the table listing the device's blocks.
+constexpr uint32_t kTableSignature = 0x53445049;
+
+/// @brief Tables the binary header can point at.
+constexpr std::size_t kTableCount = 6;
+
+/// @brief Index of the block list within the table list.
+constexpr std::size_t kIpDiscoveryTableIndex = 0;
+
+/// @brief Index of the table saying which blocks are disabled in this part.
+constexpr std::size_t kHarvestTableIndex = 2;
+
+/// @brief Marks the start of the harvest table.
+constexpr uint32_t kHarvestSignature = 0x56524148;
+
+/// @brief Entries the harvest table always carries, used or not.
+constexpr std::size_t kHarvestEntries = 32;
+
+/// @brief Size of the harvest table: a signature, a version, and the entries.
+constexpr std::size_t kHarvestTableSize = 8 + kHarvestEntries * 4;
+
+/// @brief Table version that says base addresses are 64 bits wide.
+constexpr uint16_t kIpDiscoveryVersion = 4;
+
+/// @brief Dies the header can describe. The field is fixed size whether or not
+/// they are used.
+constexpr std::size_t kMaxDies = 16;
+
+/// @brief Instances per block the driver has room for, its HWIP_MAX_INSTANCE.
+constexpr uint16_t kMaxInstances = 48;
+
+/// @brief One past the largest hardware id the driver keeps, its HW_ID_MAX.
+constexpr uint16_t kMaxHardwareId = 300;
+
+/// @brief Offsets within the binary header, which the driver reads as a packed
+/// structure. Spelled out rather than mirrored as a C++ struct, because the
+/// generator's job is to produce exactly these bytes.
+constexpr std::size_t kBinaryChecksumOffset = 8;
+constexpr std::size_t kBinarySizeOffset = 10;
+constexpr std::size_t kTableListOffset = 12;
+constexpr std::size_t kTableInfoSize = 8;
+constexpr std::size_t kBinaryHeaderSize = kTableListOffset + kTableCount * kTableInfoSize;
+
+/// @brief Offsets within the table that lists the blocks.
+constexpr std::size_t kTableSizeOffset = 6;
+constexpr std::size_t kTableNumDiesOffset = 12;
+constexpr std::size_t kTableDieInfoOffset = 14;
+constexpr std::size_t kTableHeaderSize = kTableDieInfoOffset + kMaxDies * 4 + 2;
+
+void put16(std::vector<std::byte> &into, std::size_t at, uint16_t value) {
+  into[at] = static_cast<std::byte>(value & 0xff);
+  into[at + 1] = static_cast<std::byte>((value >> 8) & 0xff);
+}
+
+void put32(std::vector<std::byte> &into, std::size_t at, uint32_t value) {
+  put16(into, at, static_cast<uint16_t>(value & 0xffff));
+  put16(into, at + 2, static_cast<uint16_t>((value >> 16) & 0xffff));
+}
+
+/// @brief The driver's checksum: a plain sum of bytes, truncated to 16 bits.
+uint16_t byte_sum(std::span<const std::byte> bytes) {
+  return std::accumulate(bytes.begin(), bytes.end(), uint16_t{0},
+                         [](uint16_t total, std::byte value) {
+                           return static_cast<uint16_t>(total + std::to_integer<uint8_t>(value));
+                         });
+}
+
+/// @brief Little-endian reads that refuse to run off the end of the input.
+///
+/// @details A table under validation may be arbitrary bytes, and every length
+/// written inside it is exactly what we are trying to check, so nothing inside
+/// the table is trusted to bound a read of the table.
+class Reader {
+public:
+  explicit Reader(std::span<const std::byte> bytes) : bytes_(bytes) {}
+
+  /// @returns Whether @p length bytes at @p at lie inside the input.
+  [[nodiscard]] bool covers(std::size_t at, std::size_t length) const {
+    return at <= bytes_.size() && length <= bytes_.size() - at;
+  }
+
+  [[nodiscard]] std::optional<uint8_t> u8(std::size_t at) const {
+    if (!covers(at, 1)) {
+      return std::nullopt;
+    }
+    return std::to_integer<uint8_t>(bytes_[at]);
+  }
+
+  [[nodiscard]] std::optional<uint16_t> u16(std::size_t at) const {
+    if (!covers(at, 2)) {
+      return std::nullopt;
+    }
+    return static_cast<uint16_t>(std::to_integer<uint8_t>(bytes_[at]) |
+                                 (std::to_integer<uint8_t>(bytes_[at + 1]) << 8));
+  }
+
+  [[nodiscard]] std::optional<uint32_t> u32(std::size_t at) const {
+    const std::optional<uint16_t> low = u16(at);
+    const std::optional<uint16_t> high = u16(at + 2);
+    if (!low || !high) {
+      return std::nullopt;
+    }
+    return static_cast<uint32_t>(*low) | (static_cast<uint32_t>(*high) << 16);
+  }
+
+  /// @returns The byte sum of a range, or nothing if it is not all present.
+  [[nodiscard]] std::optional<uint16_t> checksum(std::size_t at, std::size_t length) const {
+    if (!covers(at, length)) {
+      return std::nullopt;
+    }
+    return byte_sum(bytes_.subspan(at, length));
+  }
+
+private:
+  std::span<const std::byte> bytes_;
+};
+
+/// @brief Largest value each narrow field of the format can carry.
+constexpr std::size_t kMaxBasesPerBlock = 0xff;
+constexpr std::size_t kMaxBlocksPerDie = 0xffff;
+constexpr std::size_t kMaxTableBytes = 0xffff;
+
+} // namespace
+
+IpDiscoveryBuild build_ip_discovery_table(const IpDiscoverySpec &spec) {
+  if (spec.blocks.size() > kMaxBlocksPerDie) {
+    return {.table = {},
+            .problem = std::format("{} blocks, more than the {} a die can list", spec.blocks.size(),
+                                   kMaxBlocksPerDie)};
+  }
+  for (const IpBlock &block : spec.blocks) {
+    if (block.register_bases.size() > kMaxBasesPerBlock) {
+      return {.table = {},
+              .problem = std::format("a block declares {} register bases, more than the {} its "
+                                     "count field can express",
+                                     block.register_bases.size(), kMaxBasesPerBlock)};
+    }
+  }
+
+  // One die carrying every block. Real parts spread blocks across dies, but the
+  // driver reads instance numbers rather than dies to tell copies apart, and a
+  // single die keeps the generated table's shape obvious.
+  std::vector<std::byte> ip_table(kTableHeaderSize + 4, std::byte{0});
+  put32(ip_table, 0, kTableSignature);
+  put16(ip_table, 4, kIpDiscoveryVersion);
+  put32(ip_table, 8, 0);
+  put16(ip_table, kTableNumDiesOffset, 1);
+  put16(ip_table, kTableDieInfoOffset, 0); // die id
+  // A die's offset is measured from the start of the binary, not from the table
+  // that holds it, even though that table's own offset is what led the driver
+  // here. Getting this wrong points the driver at the binary header, where it
+  // reads a die of zero blocks and rejects the device with no diagnostic.
+  put16(ip_table, kTableDieInfoOffset + 2,
+        static_cast<uint16_t>(kBinaryHeaderSize + kTableHeaderSize));
+  // Base addresses are 64 bits wide, which the flag immediately after the die
+  // list declares.
+  ip_table[kTableHeaderSize - 2] = std::byte{1};
+
+  put16(ip_table, kTableHeaderSize, 0); // die id
+  put16(ip_table, kTableHeaderSize + 2, static_cast<uint16_t>(spec.blocks.size()));
+
+  for (const IpBlock &block : spec.blocks) {
+    const std::size_t at = ip_table.size();
+    ip_table.resize(at + 8 + block.register_bases.size() * sizeof(uint64_t), std::byte{0});
+    put16(ip_table, at, static_cast<uint16_t>(block.hardware_id));
+    ip_table[at + 2] = static_cast<std::byte>(block.instance);
+    ip_table[at + 3] = static_cast<std::byte>(block.register_bases.size());
+    ip_table[at + 4] = static_cast<std::byte>(block.major);
+    ip_table[at + 5] = static_cast<std::byte>(block.minor);
+    ip_table[at + 6] = static_cast<std::byte>(block.revision);
+    ip_table[at + 7] = std::byte{0}; // sub-revision and variant
+    for (std::size_t i = 0; i < block.register_bases.size(); ++i) {
+      const uint64_t base = block.register_bases[i];
+      put32(ip_table, at + 8 + i * sizeof(uint64_t), static_cast<uint32_t>(base));
+      put32(ip_table, at + 12 + i * sizeof(uint64_t), static_cast<uint32_t>(base >> 32));
+    }
+  }
+  if (ip_table.size() > kMaxTableBytes) {
+    return {.table = {},
+            .problem = std::format("the block list is {} bytes, more than the {} its "
+                                   "size field can express",
+                                   ip_table.size(), kMaxTableBytes)};
+  }
+  put16(ip_table, kTableSizeOffset, static_cast<uint16_t>(ip_table.size()));
+
+  std::vector<std::byte> binary(kBinaryHeaderSize, std::byte{0});
+  put32(binary, 0, kBinarySignature);
+  put16(binary, 4, 1); // version major
+  put16(binary, 6, 0); // version minor
+
+  // Which parts of the device are fused off. Everything present is described as
+  // working. Omitting the table would not be fatal — the driver logs "invalid
+  // harvest table offset" and continues with no harvest counts — but every real
+  // part publishes one, and the log line reads like a defect.
+  std::vector<std::byte> harvest_table(kHarvestTableSize, std::byte{0});
+  put32(harvest_table, 0, kHarvestSignature);
+  put32(harvest_table, 4, 0);
+
+  const auto describe_table = [&binary](std::size_t index, std::size_t offset,
+                                        std::span<const std::byte> contents) {
+    const std::size_t at = kTableListOffset + index * kTableInfoSize;
+    put16(binary, at, static_cast<uint16_t>(offset));
+    put16(binary, at + 2, byte_sum(contents));
+    put16(binary, at + 4, static_cast<uint16_t>(contents.size()));
+  };
+
+  describe_table(kIpDiscoveryTableIndex, kBinaryHeaderSize, ip_table);
+  describe_table(kHarvestTableIndex, kBinaryHeaderSize + ip_table.size(), harvest_table);
+
+  binary.insert(binary.end(), ip_table.begin(), ip_table.end());
+  binary.insert(binary.end(), harvest_table.begin(), harvest_table.end());
+  if (binary.size() > kMaxTableBytes) {
+    return {.table = {},
+            .problem = std::format("the binary is {} bytes, more than the {} its size "
+                                   "field can express",
+                                   binary.size(), kMaxTableBytes)};
+  }
+  put16(binary, kBinarySizeOffset, static_cast<uint16_t>(binary.size()));
+
+  // The binary's own checksum covers everything after the checksum field.
+  const std::span<const std::byte> after_checksum(binary.data() + kBinaryChecksumOffset + 2,
+                                                  binary.size() - kBinaryChecksumOffset - 2);
+  put16(binary, kBinaryChecksumOffset, byte_sum(after_checksum));
+  return {.table = std::move(binary), .problem = {}};
+}
+
+IpDiscoveryValidation validate_ip_discovery_table(std::span<const std::byte> table) {
+  const auto reject = [](std::string problem) {
+    return IpDiscoveryValidation{.valid = false, .problem = std::move(problem)};
+  };
+  const Reader in(table);
+
+  const std::optional<uint32_t> signature = in.u32(0);
+  if (!signature) {
+    return reject("shorter than a binary header");
+  }
+  if (*signature != kBinarySignature) {
+    return reject(
+        std::format("binary signature is {:#x}, expected {:#x}", *signature, kBinarySignature));
+  }
+  if (!in.covers(0, kBinaryHeaderSize)) {
+    return reject("shorter than a binary header");
+  }
+
+  // amdgpu_discovery_get_table_info accepts 0, 1 and 2, but its `case 2` reads
+  // a binary_header_v2, whose table list sits somewhere else entirely. Versions
+  // 0 and 1 share the one layout this reader assumes, so both are accepted and
+  // only 2 is refused.
+  const uint16_t version_major = in.u16(4).value();
+  if (version_major > 1) {
+    return reject(std::format("binary version {} puts its table list somewhere this reader does "
+                              "not look; only 0 and 1 share the layout it assumes",
+                              version_major));
+  }
+
+  const uint16_t declared_size = in.u16(kBinarySizeOffset).value();
+  if (declared_size != table.size()) {
+    return reject(std::format("declares {} bytes but is {}", declared_size, table.size()));
+  }
+
+  const uint16_t declared_checksum = in.u16(kBinaryChecksumOffset).value();
+  const uint16_t actual_checksum =
+      in.checksum(kBinaryChecksumOffset + 2, table.size() - kBinaryChecksumOffset - 2).value();
+  if (declared_checksum != actual_checksum) {
+    return reject(std::format("binary checksum is {:#x}, computed {:#x}", declared_checksum,
+                              actual_checksum));
+  }
+
+  // Each table_info is offset, checksum, size. The driver checksums the harvest
+  // table over its own fixed size rather than the size recorded here, so that is
+  // the length checked. A zero offset is *not* rejected: the driver guards both
+  // consumers on it (`check_table && offset` at amdgpu_discovery.c:641, and an
+  // early return at :836-840 that logs "invalid harvest table offset" and
+  // carries on with no harvest counts). Rejecting it here would refuse a table
+  // the driver accepts, which is the one thing this function must not do.
+  const std::size_t harvest_info = kTableListOffset + kHarvestTableIndex * kTableInfoSize;
+  const uint16_t harvest_offset = in.u16(harvest_info).value();
+  const uint16_t harvest_checksum = in.u16(harvest_info + 2).value();
+  if (harvest_offset != 0) {
+    if (!in.covers(harvest_offset, kHarvestTableSize)) {
+      return reject("the harvest table runs past the end of the binary");
+    }
+    if (in.u32(harvest_offset).value() != kHarvestSignature) {
+      return reject("the harvest table has the wrong signature");
+    }
+    if (in.checksum(harvest_offset, kHarvestTableSize).value() != harvest_checksum) {
+      return reject("the harvest table checksum does not match");
+    }
+  }
+
+  const std::size_t ip_info = kTableListOffset + kIpDiscoveryTableIndex * kTableInfoSize;
+  const uint16_t ip_offset = in.u16(ip_info).value();
+  const uint16_t ip_checksum = in.u16(ip_info + 2).value();
+  const uint16_t ip_size = in.u16(ip_info + 4).value();
+  if (ip_offset == 0 || ip_size == 0) {
+    return reject("describes no block list");
+  }
+  if (!in.covers(ip_offset, kTableHeaderSize)) {
+    return reject("the block list is too short to hold its own header");
+  }
+  if (in.u32(ip_offset).value() != kTableSignature) {
+    return reject("the block list has the wrong signature");
+  }
+
+  // The size recorded in the table list and the one inside the block list are
+  // both used: the driver checksums against the embedded one and bounds nothing
+  // against the outer one, so a disagreement means one of the two consumers is
+  // reading a different table than the other.
+  const uint16_t embedded_size = in.u16(ip_offset + kTableSizeOffset).value();
+  if (embedded_size != ip_size) {
+    return reject(std::format("the block list says it is {} bytes but the table list says {}",
+                              embedded_size, ip_size));
+  }
+  if (!in.covers(ip_offset, embedded_size)) {
+    return reject("the block list runs past the end of the binary");
+  }
+  if (in.checksum(ip_offset, embedded_size).value() != ip_checksum) {
+    return reject("the block list checksum does not match");
+  }
+
+  const uint16_t dies = in.u16(ip_offset + kTableNumDiesOffset).value();
+  if (dies == 0) {
+    return reject("describes no dies");
+  }
+  if (dies > kMaxDies) {
+    return reject(
+        std::format("describes {} dies, more than the {} the header has room for", dies, kMaxDies));
+  }
+  const bool bases_are_64_bit = (in.u8(ip_offset + kTableHeaderSize - 2).value() & 1) != 0;
+  const std::size_t base_width = bases_are_64_bit ? sizeof(uint64_t) : sizeof(uint32_t);
+
+  // Walk every record the way the driver does, from the start of the binary. A
+  // die offset measured from the wrong place still lands inside the table, so
+  // this checks by reading what it points at rather than by arithmetic.
+  bool has_graphics = false;
+  for (uint16_t die = 0; die < dies; ++die) {
+    const uint16_t die_offset = in.u16(ip_offset + kTableDieInfoOffset + die * 4 + 2).value();
+    if (!in.covers(die_offset, 4)) {
+      return reject(std::format("die {} sits past the end of the binary", die));
+    }
+    const uint16_t die_id = in.u16(die_offset).value();
+    if (die_id != die) {
+      return reject(std::format("die {} identifies itself as {}, which means its offset points at "
+                                "the wrong place",
+                                die, die_id));
+    }
+    const uint16_t blocks = in.u16(die_offset + 2).value();
+    if (blocks == 0) {
+      return reject(std::format("die {} lists no blocks", die));
+    }
+
+    std::size_t at = static_cast<std::size_t>(die_offset) + 4;
+    for (uint16_t block = 0; block < blocks; ++block) {
+      if (!in.covers(at, 8)) {
+        return reject(std::format("die {} block {} runs past the end of the binary", die, block));
+      }
+      const uint16_t hardware_id = in.u16(at).value();
+      const uint8_t instance = in.u8(at + 2).value();
+      const uint8_t bases = in.u8(at + 3).value();
+      // The driver drops these records rather than refusing the table
+      // (amdgpu_discovery_validate_ip, then `goto next_ip`), so a table
+      // containing them parses into a guest quietly missing blocks. Refusing
+      // here is the difference between a named fault and a silent one.
+      if (instance >= kMaxInstances) {
+        return reject(std::format("die {} block {} is instance {}, past the {} the driver keeps",
+                                  die, block, instance, kMaxInstances));
+      }
+      if (hardware_id >= kMaxHardwareId) {
+        return reject(std::format("die {} block {} has hardware id {}, past the {} the driver "
+                                  "keeps",
+                                  die, block, hardware_id, kMaxHardwareId));
+      }
+      if (!in.covers(at + 8, bases * base_width)) {
+        return reject(std::format("die {} block {} declares {} register bases that run past the "
+                                  "end of the binary",
+                                  die, block, bases));
+      }
+      if (hardware_id == static_cast<uint16_t>(IpHardwareId::Gc)) {
+        has_graphics = true;
+      }
+      at += 8 + bases * base_width;
+    }
+  }
+
+  // A table listing no graphics block leaves the driver with no recognized GC
+  // version, and it refuses the device in a switch whose default returns
+  // -EINVAL without printing anything.
+  if (!has_graphics) {
+    return reject("lists no graphics block, which the driver refuses with no diagnostic");
+  }
+
+  return {.valid = true, .problem = {}};
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file ip_discovery.h
+/// @brief Builds the table a guest driver reads to learn what the GPU contains.
+///
+/// @details An AMD GPU does not tell the driver what it is through its PCI IDs.
+/// The driver binds on the class code and then reads a table out of the device
+/// that lists every IP block present, its version, and where its registers live.
+/// Almost nothing else can happen first: the table is what decides which drivers
+/// for which blocks are even instantiated.
+///
+/// So an emulated GPU has to publish one. Its contents are a design decision
+/// rather than a transcription, because omitting a block is the cleanest way to
+/// say "this device does not have one" and keeps the driver from initialising
+/// something the model cannot answer.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief How much of the table the driver will read, its DISCOVERY_TMR_SIZE.
+///
+/// @details Both paths that deliver a table are bounded by this: the device
+/// stores only this much at the top of memory, and the driver refuses a larger
+/// file outright ("ip discovery firmware too large"). It belongs to the format
+/// rather than to either consumer, so both check against the same number.
+constexpr std::size_t kDiscoveryTableBytes = 10 * 1024;
+
+/// @brief Hardware identifiers, as the driver's tables spell them.
+///
+/// @details Values come from the driver's own soc15_hw_ip.h. Only the blocks a
+/// generated table can currently describe are listed.
+enum class IpHardwareId : uint16_t {
+  Mp1 = 1,     ///< System management, which owns power and clocks.
+  Gc = 11,     ///< Graphics and compute; its instance count is the XCC mask.
+  MmHub = 34,  ///< Memory hub.
+  AtHub = 35,  ///< Address translation hub.
+  OssSys = 40, ///< Interrupt handling, among other system blocks.
+  Hdp = 41,    ///< Host data path.
+  Sdma0 = 42,  ///< System DMA.
+  Nbif = 108,  ///< North bridge interface, the bus side of the device.
+  Mp0 = 255    ///< Security processor, which the driver requires to be present.
+};
+
+/// @brief One IP block as the table describes it.
+struct IpBlock {
+  IpHardwareId hardware_id = IpHardwareId::Gc; ///< Which block this is.
+  uint8_t instance = 0;                        ///< Which copy of it.
+  uint8_t major = 0;                           ///< Version, as IP_VERSION spells it.
+  uint8_t minor = 0;
+  uint8_t revision = 0;
+  std::vector<uint64_t> register_bases; ///< Where its registers start.
+};
+
+/// @brief Everything a generated table describes.
+struct IpDiscoverySpec {
+  std::vector<IpBlock> blocks; ///< The device's blocks, in any order.
+};
+
+/// @brief A serialized table, or the reason there is not one.
+///
+/// @details Building can fail, because the format's fields are narrower than
+/// the spec's: a block count, a table size, or a base-address count that does
+/// not fit would truncate into a table the driver misparses rather than
+/// rejects. Saying so is better than emitting bytes that mean something else.
+struct IpDiscoveryBuild {
+  std::vector<std::byte> table; ///< The table, when it could be built.
+  std::string problem;          ///< Why it could not be, when it could not.
+
+  /// @returns Whether a table was produced.
+  [[nodiscard]] bool ok() const { return problem.empty(); }
+};
+
+/// @brief Serialize @p spec into the binary the driver parses.
+/// @param[in] spec The blocks to describe.
+/// @returns The table, or why the spec cannot be expressed in the format.
+[[nodiscard]] IpDiscoveryBuild build_ip_discovery_table(const IpDiscoverySpec &spec);
+
+/// @brief Why a table would be rejected, if it would be.
+///
+/// @details Mirrors the checks the driver performs before it will read a table,
+/// so a generated one can be validated here rather than by booting a guest and
+/// reading a failure out of dmesg.
+struct IpDiscoveryValidation {
+  bool valid = false;  ///< Whether the driver would accept the table.
+  std::string problem; ///< What is wrong with it, when it would not.
+};
+
+/// @brief Check that the driver would accept a table *and use every record in it*.
+///
+/// @details Covers what `amdgpu_discovery_init` verifies before it will use a
+/// table — signatures and checksums for the binary, the block list, and the
+/// harvest table — and then walks the structures the way
+/// `amdgpu_discovery_reg_base_init` walks them. That second half is the part
+/// that matters: a table can satisfy every checksum and still describe a device
+/// the driver refuses, and it refuses with a bare `-EINVAL` and no diagnostic.
+/// A die pointed at the wrong place, a block count that disagrees with the
+/// records behind it, and a missing graphics block all fail that way.
+///
+/// It is deliberately stricter than the driver in one direction: records the
+/// driver would silently *drop* rather than refuse — an instance or hardware id
+/// past the range it keeps — are reported here as problems. A table full of
+/// dropped records parses into a guest quietly missing blocks, which is worse
+/// to debug than a refusal. So a rejection means "the driver would not use this
+/// table as written", not always "the driver would fail to parse it". Callers
+/// that gate device construction on this are choosing that stricter contract.
+///
+/// Every read is bounds-checked against @p table rather than trusting the
+/// lengths written inside it, because the input may be arbitrary bytes.
+///
+/// @param[in] table The serialized table.
+/// @returns Whether the driver would accept it, and why not if it would not.
+[[nodiscard]] IpDiscoveryValidation validate_ip_discovery_table(std::span<const std::byte> table);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery_profile.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery_profile.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h"
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// Register bases are per-block *segments*, not one number. Every register the
+// driver touches carries a `_BASE_IDX` naming the segment it lives in, and
+// `SOC15_REG_OFFSET` resolves it as `reg_offset[ip][inst][BASE_IDX] + reg`. A
+// block that publishes a single base therefore answers only for its
+// `_BASE_IDX 0` registers; the rest resolve against whatever follows that base
+// in the blob, which for a 64-bit base is its zero high dword. The access then
+// lands at a raw offset with nothing reporting an error, so it reads as a
+// broken register model rather than as a short table. gc_12_1_0_offset.h puts
+// 3576 registers at index 1 against 2441 at index 0, so this is the common case
+// and not a corner: gfx_v12_1 alone uses 58 of them, and gfxhub_v12_1 reads
+// regGCMC_VM_FB_OFFSET during the GMC init this device has to survive.
+//
+// These lists are transcribed from a **shipping GFX12 part** reporting GC
+// 12.0.1, read out of the table the driver publishes for any bound GPU at
+// /sys/class/drm/card*/device/ip_discovery/die/0/<ip>/<inst>/base_addr. Reading
+// them off a part that answers beats deriving them: the values are what the
+// driver itself resolved, so misreading the format shows up as a mismatch
+// rather than as a plausible wrong number. MMHUB and ATHUB match that part's
+// versions exactly (4.1.0), so they are transcriptions rather than inferences;
+// the others are the same family at a different revision, so treat their higher
+// segments as unconfirmed until a table for this part can be read the same way.
+
+/// @brief GC's four segments, which SDMA shares verbatim on this family.
+constexpr uint64_t kGcBases[] = {0x00001260, 0x0000A000, 0x0001C000, 0x02402C00};
+
+/// @brief The security and management processors, which publish one list between them.
+constexpr uint64_t kMpBases[] = {0x00016000, 0x00016200, 0x0001CE00, 0x00DC0000, 0x00E00000,
+                                 0x00E40000, 0x00E80000, 0x00EC0000, 0x00F00000, 0x02400400,
+                                 0x0243FC00, 0x0244D400, 0x03200000, 0x03240000, 0x03280000};
+
+constexpr uint64_t kOssSysBases[] = {0x000010A0, 0x0240A000};
+constexpr uint64_t kNbifBases[] = {0x00000000, 0x00000014, 0x00000D20,
+                                   0x00010400, 0x0241B000, 0x04040000};
+constexpr uint64_t kHdpBases[] = {0x00000F20, 0x0240A400};
+constexpr uint64_t kMmHubBases[] = {0x0001A000, 0x02408800};
+constexpr uint64_t kAtHubBases[] = {0x00000C00, 0x02408C00};
+
+template <std::size_t N> std::vector<uint64_t> bases(const uint64_t (&list)[N]) {
+  return std::vector<uint64_t>(std::begin(list), std::end(list));
+}
+
+} // namespace
+
+IpDiscoverySpec gfx1250_discovery_spec(const GpuDiscoveryTopology &topology) {
+  IpDiscoverySpec spec;
+
+  // Graphics and compute. Its instance count is what the driver turns into the
+  // XCC mask, and a table with no graphics block at all is refused outright.
+  for (uint8_t instance = 0; instance < topology.graphics_instances; ++instance) {
+    spec.blocks.push_back({.hardware_id = IpHardwareId::Gc,
+                           .instance = instance,
+                           .major = 12,
+                           .minor = 1,
+                           .revision = 0,
+                           .register_bases = bases(kGcBases)});
+  }
+
+  // The security processor. The driver has no arm for a device without one and
+  // fails to add any PSP block, so it must be named whether or not it is used.
+  spec.blocks.push_back({.hardware_id = IpHardwareId::Mp0,
+                         .instance = 0,
+                         .major = 15,
+                         .minor = 0,
+                         .revision = 8,
+                         .register_bases = bases(kMpBases)});
+  spec.blocks.push_back({.hardware_id = IpHardwareId::Mp1,
+                         .instance = 0,
+                         .major = 15,
+                         .minor = 0,
+                         .revision = 8,
+                         .register_bases = bases(kMpBases)});
+  spec.blocks.push_back({.hardware_id = IpHardwareId::OssSys,
+                         .instance = 0,
+                         .major = 7,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = bases(kOssSysBases)});
+  spec.blocks.push_back({.hardware_id = IpHardwareId::Nbif,
+                         .instance = 0,
+                         .major = 7,
+                         .minor = 11,
+                         .revision = 0,
+                         .register_bases = bases(kNbifBases)});
+  // 7.0.0 rather than 7.1.0, deliberately. The driver's HDP switch has an arm
+  // only for 7.0.0; 7.1.0 falls through its default and leaves `hdp.funcs`
+  // null, so there is no HDP block driver at all and the flush path quietly
+  // does nothing. No hdp_v7_1 exists anywhere in the tree, and 7.0.0 is what
+  // the real part these bases came from reports, so nothing is given up.
+  spec.blocks.push_back({.hardware_id = IpHardwareId::Hdp,
+                         .instance = 0,
+                         .major = 7,
+                         .minor = 0,
+                         .revision = 0,
+                         .register_bases = bases(kHdpBases)});
+  spec.blocks.push_back({.hardware_id = IpHardwareId::MmHub,
+                         .instance = 0,
+                         .major = 4,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = bases(kMmHubBases)});
+  spec.blocks.push_back({.hardware_id = IpHardwareId::AtHub,
+                         .instance = 0,
+                         .major = 4,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = bases(kAtHubBases)});
+  // One engine, named so the driver instantiates an SDMA block at all; a second
+  // instance would be a second record here, and this device models none. The
+  // segments are GC's, which this family shares between the two.
+  spec.blocks.push_back({.hardware_id = IpHardwareId::Sdma0,
+                         .instance = 0,
+                         .major = 7,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = bases(kGcBases)});
+  return spec;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file ip_discovery_profile.h
+/// @brief The blocks a simulated gfx1250 reports to a guest driver.
+///
+/// @details One place decides what the device says it contains, because two
+/// places would eventually disagree: the device publishes this table into its
+/// own memory, and the offline tool writes the same bytes to a file for a guest
+/// booted with `amdgpu.discovery=2`. A guest that sees different hardware
+/// depending on which path delivered the table would be worse than either.
+
+#pragma once
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
+
+#include <cstdint>
+
+namespace rocjitsu {
+
+/// @brief How much of the part the discovery table advertises.
+///
+/// @details Instance counts in the table are not decoration: the driver derives
+/// its XCC mask from the number of graphics instances, and on this family it
+/// then derives the SDMA mask from that (`soc_v1_0_init_soc_config` recomputes
+/// `sdma_mask` as two engines per XCC, discarding whatever the SDMA records
+/// said). So the graphics instance count is the one knob that decides the shape
+/// of the machine the guest believes it has.
+struct GpuDiscoveryTopology {
+  /// @brief Graphics instances, which become the guest's XCC mask.
+  ///
+  /// @details Deliberately one during bring-up, which is **narrower than the
+  /// eight XCDs the part's own config describes**. Advertising all eight would
+  /// give the guest sixteen SDMA engines and two AIDs, pulling in XCP partition
+  /// management and exhausting the MMHUB invalidation-engine budget, none of
+  /// which the device can answer yet. Raise this when the blocks that consume
+  /// it are modelled, and not before.
+  uint8_t graphics_instances = 1;
+};
+
+/// @brief The blocks a simulated gfx1250 reports.
+///
+/// @details A short list on purpose. Naming a block is what makes the driver
+/// instantiate a driver for it, so leaving one out is how the device says it
+/// does not have that hardware yet.
+///
+/// @param[in] topology How much of the part to advertise.
+/// @returns The spec to serialize with @ref build_ip_discovery_table.
+[[nodiscard]] IpDiscoverySpec gfx1250_discovery_spec(const GpuDiscoveryTopology &topology = {});
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/mmio_registers.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/mmio_registers.h
@@ -22,15 +22,16 @@ namespace rocjitsu {
 
 /// @brief Register index, in dwords, as the driver's accessors take it.
 enum class MmioRegister : uint32_t {
-  MmIndex = 0x0,               ///< Selects a register for the indirect window.
-  MmData = 0x1,                ///< Reads or writes the register selected above.
-  MmIndexHi = 0x6,             ///< High half of the indirect window selector.
-  DriverScratch0 = 0x94,       ///< Low half of a discovery table offset, when nonzero.
-  DriverScratch1 = 0x95,       ///< High half of that offset.
-  DriverScratch2 = 0x96,       ///< Discovery table size; zero means it is not published here.
-  RccConfigMemsize = 0xde3,    ///< Video memory size in megabytes.
-  Mp0SmnC2pmsg33 = 0x16061,    ///< Firmware init status; bit 31 means initialization finished.
-  IpDiscoveryVersion = 0x16a00 ///< Version of the discovery table format.
+  MmIndex = 0x0,                ///< Selects a register for the indirect window.
+  MmData = 0x1,                 ///< Reads or writes the register selected above.
+  MmIndexHi = 0x6,              ///< High half of the indirect window selector.
+  DriverScratch0 = 0x94,        ///< Low half of a discovery table offset, when nonzero.
+  DriverScratch1 = 0x95,        ///< High half of that offset.
+  DriverScratch2 = 0x96,        ///< Discovery table size; zero means it is not published here.
+  RccConfigMemsize = 0xde3,     ///< Video memory size in megabytes.
+  RccIovFuncIdentifier = 0xde5, ///< Whether this function is virtualized.
+  Mp0SmnC2pmsg33 = 0x16061,     ///< Firmware init status; bit 31 means initialization finished.
+  IpDiscoveryVersion = 0x16a00  ///< Version of the discovery table format.
 };
 
 /// @brief Byte offset of a register within the aperture.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/register_symbols.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/register_symbols.cpp
@@ -41,6 +41,7 @@ void add_pre_discovery_symbols(RegisterSymbols &symbols, int bar) {
   name_register(MmioRegister::DriverScratch1, "DRIVER_SCRATCH_1");
   name_register(MmioRegister::DriverScratch2, "DRIVER_SCRATCH_2");
   name_register(MmioRegister::RccConfigMemsize, "RCC_CONFIG_MEMSIZE");
+  name_register(MmioRegister::RccIovFuncIdentifier, "RCC_IOV_FUNC_IDENTIFIER");
   name_register(MmioRegister::Mp0SmnC2pmsg33, "MP0_SMN_C2PMSG_33");
   name_register(MmioRegister::IpDiscoveryVersion, "IP_DISCOVERY_VERSION");
 }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -550,6 +550,7 @@ add_executable(
     pci/bar_access_trace_test.cpp
     pci/gpu_pci_device_test.cpp
     pci/scratch_pci_device_test.cpp
+    pci/ip_discovery_test.cpp
 )
 if(HAS_DEVICE_KERNELS)
     target_sources(

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -19,9 +19,16 @@ namespace {
 
 constexpr uint64_t kVramBytes = 16ULL * 1024 * 1024;
 
+/// @brief The only part with an IP discovery profile.
+/// @details Every device built here is meant to be that part: a configuration
+/// naming anything else deliberately has no profile and cannot become usable,
+/// which two tests below cover on purpose.
+constexpr uint32_t kModelledTarget = 120500;
+
 /// @brief A configuration equivalent to what a config file would supply.
 rocjitsu::GpuPciDeviceSpec configured_spec() {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.vendor_id = 0x1002;
   device.device_id = 0x1250;
   device.pci_revision_id = 0x5a;
@@ -156,6 +163,7 @@ TEST_F(GpuDevice, KeepsDoorbellWritesForTheCommandProcessorToFind) {
 // different config file rather than a different class.
 TEST(GpuDeviceFromConfig, PresentsTheConfiguredIdentityAndApertures) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.vendor_id = 0x1002;
   device.device_id = 0x74a1;
   device.pci_revision_id = 0x02;
@@ -192,6 +200,7 @@ TEST(GpuDeviceFromConfig, PresentsTheConfiguredIdentityAndApertures) {
 // An unset subsystem follows the device rather than reading as an unrelated one.
 TEST(GpuDeviceFromConfig, DefaultsTheSubsystemToTheDeviceItself) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.vendor_id = 0x1002;
   device.device_id = 0x1250;
   device.local_mem_size = kVramBytes;
@@ -207,6 +216,7 @@ TEST(GpuDeviceFromConfig, DefaultsTheSubsystemToTheDeviceItself) {
 // device refuses rather than answering wrongly.
 TEST(GpuDeviceFromConfig, RefusesARegisterApertureThatCannotReachThoseRegisters) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = kVramBytes;
   rocjitsu::config::PciDeviceConfig pci;
   pci.register_aperture_bytes = 4096;
@@ -221,16 +231,20 @@ TEST(GpuDeviceFromConfig, RefusesARegisterApertureThatCannotReachThoseRegisters)
 // discovery table the driver looks for sits at the top of memory, outside it.
 // Reaching that means the indirect window has to work, and has to use the same
 // address encoding the driver does.
-class GpuDeviceIndirectWindow : public ::testing::TestWithParam<uint64_t> {
+class GpuDeviceWindow : public ::testing::Test {
 public:
   static constexpr uint64_t kMemoryBytes = 8ULL * 1024 * 1024 * 1024;
 
 protected:
-  rocjitsu::GpuPciDevice gpu_{"gpu", spec(), nullptr};
+  explicit GpuDeviceWindow(uint64_t capacity = kMemoryBytes)
+      : gpu_{"gpu", spec(capacity), nullptr} {}
 
-  static rocjitsu::GpuPciDeviceSpec spec() {
+  rocjitsu::GpuPciDevice gpu_;
+
+  static rocjitsu::GpuPciDeviceSpec spec(uint64_t capacity) {
     rocjitsu::config::KfdDeviceConfig device;
-    device.local_mem_size = kMemoryBytes;
+    device.gfx_target_version = kModelledTarget;
+    device.local_mem_size = capacity;
     rocjitsu::config::PciDeviceConfig pci;
     pci.vram_aperture_bytes = 1024 * 1024;
     return rocjitsu::gpu_pci_spec_from_config(device, pci);
@@ -260,6 +274,80 @@ protected:
   }
 };
 
+// The scratch registers all read zero, which tells the driver the table is at
+// the top of memory rather than somewhere the device names. Nothing else checks
+// that anything is actually there: a device that answers every register
+// correctly and leaves that address empty looks healthy right up until the
+// driver reads a zero signature and refuses it.
+TEST_F(GpuDeviceWindow, PublishesADiscoveryTableWhereTheRegistersPromiseOne) {
+  ASSERT_TRUE(gpu_.usable());
+  ASSERT_EQ(read_register(rocjitsu::MmioRegister::DriverScratch2), 0u)
+      << "the device names its own discovery address, so it is not at the top of memory";
+
+  select(kMemoryBytes - rocjitsu::GpuPciDevice::kDiscoveryOffsetFromTopOfVram);
+
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0x28211407u);
+}
+
+// The driver never learns the byte count. It reads a count of megabytes out of
+// RCC_CONFIG_MEMSIZE and computes the address itself, so a capacity that is not
+// a whole number of megabytes has two candidate addresses and only the rounded
+// one is ever read. Publishing at the true top instead misses by the remainder,
+// and the driver then reports a bad signature rather than a bad address. Some
+// of the shipped configs have exactly such a capacity.
+class GpuDeviceUnroundedMemory : public GpuDeviceWindow {
+protected:
+  /// @brief A capacity whose last megabyte is incomplete, by half of one.
+  static constexpr uint64_t kUnroundedBytes = kMemoryBytes + 512 * 1024;
+
+  GpuDeviceUnroundedMemory() : GpuDeviceWindow(kUnroundedBytes) {}
+};
+
+// A reset republishes the table. Without that, a guest that resets the device
+// and re-reads the signature finds whatever the previous guest left there, and
+// the failure surfaces as a driver that will not attach for no visible reason.
+TEST_F(GpuDeviceWindow, RestoresTheDiscoveryTableOnReset) {
+  const uint64_t table_at =
+      (static_cast<uint64_t>(read_register(rocjitsu::MmioRegister::RccConfigMemsize)) << 20) -
+      rocjitsu::GpuPciDevice::kDiscoveryOffsetFromTopOfVram;
+
+  select(table_at);
+  ASSERT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0x28211407u);
+
+  // Corrupt it the only way a guest can: through the indirect window.
+  select(table_at);
+  write_register(rocjitsu::MmioRegister::MmData, 0xdeadbeefu);
+  select(table_at);
+  ASSERT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0xdeadbeefu)
+      << "the signature was not actually overwritten, so this proves nothing";
+
+  gpu_.reset(simdojo::ResetKind::FunctionLevel);
+
+  select(table_at);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0x28211407u)
+      << "reset left the previous guest's bytes where the driver looks for the table";
+}
+
+TEST_F(GpuDeviceUnroundedMemory, PublishesWhereTheReportedCapacityPointsNotAtTheRealTop) {
+  ASSERT_TRUE(gpu_.usable());
+
+  const uint64_t reported_top =
+      static_cast<uint64_t>(read_register(rocjitsu::MmioRegister::RccConfigMemsize)) << 20;
+  ASSERT_LT(reported_top, kUnroundedBytes) << "this capacity does not round down, so it proves "
+                                              "nothing about which address is used";
+
+  select(reported_top - rocjitsu::GpuPciDevice::kDiscoveryOffsetFromTopOfVram);
+  EXPECT_EQ(read_register(rocjitsu::MmioRegister::MmData), 0x28211407u)
+      << "nothing is where the driver computes the address from the capacity it was given";
+
+  select(kUnroundedBytes - rocjitsu::GpuPciDevice::kDiscoveryOffsetFromTopOfVram);
+  EXPECT_NE(read_register(rocjitsu::MmioRegister::MmData), 0x28211407u)
+      << "the table is at the true top of memory, which the driver never reads";
+}
+
+class GpuDeviceIndirectWindow : public GpuDeviceWindow,
+                                public ::testing::WithParamInterface<uint64_t> {};
+
 TEST_P(GpuDeviceIndirectWindow, ReachesMemoryTheApertureCannot) {
   const uint64_t address = GetParam();
   ASSERT_TRUE(gpu_.usable());
@@ -277,11 +365,13 @@ TEST_P(GpuDeviceIndirectWindow, ReachesMemoryTheApertureCannot) {
 }
 
 // Below, at and above the bit where the address splits between the two index
-// registers, plus the top of memory where the discovery table lives.
+// registers, plus high memory the aperture cannot reach. The last address stays
+// clear of the discovery table at the very top, which this test would otherwise
+// overwrite.
 INSTANTIATE_TEST_SUITE_P(AcrossTheIndexRegisterBoundary, GpuDeviceIndirectWindow,
                          ::testing::Values(0x1000ULL, 0x7ffffffcULL, 0x80000000ULL, 0x80000004ULL,
                                            0x1'0000'0000ULL,
-                                           GpuDeviceIndirectWindow::kMemoryBytes - 0x10000));
+                                           GpuDeviceIndirectWindow::kMemoryBytes - 0x20000));
 
 // Bit 31 of MM_INDEX chooses the space the indirect window addresses. Only the
 // memory side is modelled, and answering a register-side request out of the
@@ -326,6 +416,7 @@ TEST(GpuDeviceIndirectWindow, RefusesAnAccessToTheRegisterSpace) {
 // address the device did not use. The remainder is simply unreachable.
 TEST(GpuDeviceFromConfig, ReportsACapacityTheDriverCanReadAndStaysUsable) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = kVramBytes + 512;
 
   const rocjitsu::GpuPciDevice odd("odd", rocjitsu::gpu_pci_spec_from_config(device, {}), nullptr);
@@ -336,6 +427,7 @@ TEST(GpuDeviceFromConfig, ReportsACapacityTheDriverCanReadAndStaysUsable) {
 
 TEST(GpuDeviceFromConfig, RefusesAnApertureThatIsNotALegalBarSize) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = kVramBytes;
   rocjitsu::config::PciDeviceConfig pci;
   pci.doorbell_aperture_bytes = 3 * 1024 * 1024;
@@ -358,6 +450,7 @@ TEST(GpuDeviceFromConfig, AcceptsTheMinimumApertureAndReachesEveryPreDiscoveryRe
       << "the advertised minimum must itself be a legal BAR size";
 
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = kVramBytes;
   rocjitsu::config::PciDeviceConfig pci;
   pci.register_aperture_bytes = rocjitsu::GpuPciDevice::kMinRegisterApertureBytes;
@@ -387,6 +480,7 @@ TEST(GpuDeviceFromConfig, AcceptsTheMinimumApertureAndReachesEveryPreDiscoveryRe
 // the bus, so an omitted section has to yield a BAR that is legal anyway.
 TEST(GpuDeviceFromConfig, DerivesALegalApertureForAConfigWithNoBusSection) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = 192ULL * 1024 * 1024 * 1024;
 
   const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});
@@ -414,6 +508,7 @@ class GpuDeviceApertureBoundary : public ::testing::TestWithParam<uint64_t> {};
 TEST_P(GpuDeviceApertureBoundary, AgreesWithThePciMinimumForAMemoryBar) {
   const uint64_t aperture = GetParam();
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = 64 * 1024 * 1024;
   rocjitsu::config::PciDeviceConfig pci;
   pci.vram_aperture_bytes = aperture;
@@ -439,6 +534,7 @@ class GpuDeviceCapacityBoundary : public ::testing::TestWithParam<CapacityCase> 
 TEST_P(GpuDeviceCapacityBoundary, OnlyAcceptsACapacityTheDriverCanRead) {
   const CapacityCase &capacity = GetParam();
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = capacity.bytes;
 
   const rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(device, {}), nullptr);
@@ -461,6 +557,7 @@ INSTANTIATE_TEST_SUITE_P(
 // fits inside it, rather than one larger than its own memory.
 TEST(GpuDeviceFromConfig, CapsTheDerivedApertureAtTheMemoryItHas) {
   rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
   device.local_mem_size = 100ULL * 1024 * 1024;
 
   const rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});

--- a/emulation/rocjitsu/tests/pci/ip_discovery_test.cpp
+++ b/emulation/rocjitsu/tests/pci/ip_discovery_test.cpp
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+/// @brief A device with the blocks a driver needs before it will go further.
+rocjitsu::IpDiscoverySpec gfx1250_spec() { return rocjitsu::gfx1250_discovery_spec(); }
+
+/// @brief Build a table, insisting it could be built at all.
+///
+/// @details Failure throws rather than recording a non-fatal expectation,
+/// because every caller reads the returned table by offset: a build that failed
+/// would return an empty one and the test would index past its end rather than
+/// stop at the real problem. ASSERT_ is unavailable here, since this returns a
+/// value.
+std::vector<std::byte> build(const rocjitsu::IpDiscoverySpec &spec) {
+  const rocjitsu::IpDiscoveryBuild built = rocjitsu::build_ip_discovery_table(spec);
+  if (!built.ok()) {
+    throw std::runtime_error("cannot build a discovery table: " + built.problem);
+  }
+  return built.table;
+}
+
+uint16_t read16(const std::vector<std::byte> &table, std::size_t at) {
+  return static_cast<uint16_t>(std::to_integer<uint8_t>(table[at]) |
+                               (std::to_integer<uint8_t>(table[at + 1]) << 8));
+}
+
+void write16(std::vector<std::byte> &table, std::size_t at, uint16_t value) {
+  table[at] = static_cast<std::byte>(value & 0xff);
+  table[at + 1] = static_cast<std::byte>((value >> 8) & 0xff);
+}
+
+/// @brief Offset of the block list, as the table list records it.
+std::size_t ip_table_offset(const std::vector<std::byte> &table) { return read16(table, 12); }
+
+uint16_t byte_sum(const std::vector<std::byte> &table, std::size_t at, std::size_t length) {
+  uint16_t sum = 0;
+  for (std::size_t i = at; i < at + length; ++i) {
+    sum = static_cast<uint16_t>(sum + std::to_integer<uint8_t>(table[i]));
+  }
+  return sum;
+}
+
+/// @brief Restore the block list's checksum after tampering with its contents.
+///
+/// @details Without this a test that corrupts something structural inside the
+/// block list is rejected for a failed checksum instead, which looks like a
+/// pass and proves nothing about the check it meant to exercise.
+void reseal_block_list(std::vector<std::byte> &table) {
+  const std::size_t ip_table = ip_table_offset(table);
+  write16(table, 12 + 2, byte_sum(table, ip_table, read16(table, ip_table + 6)));
+}
+
+/// @brief Restore the binary checksum, which covers everything after it.
+void reseal_binary(std::vector<std::byte> &table) {
+  write16(table, 8, byte_sum(table, 10, table.size() - 10));
+}
+
+TEST(IpDiscoveryTable, BuildsATableTheDriverWouldAccept) {
+  const std::vector<std::byte> table = build(gfx1250_spec());
+
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+  EXPECT_TRUE(checked.valid) << checked.problem;
+}
+
+// Register bases are segments, and the driver picks between them with each
+// register's `_BASE_IDX` (`SOC15_REG_OFFSET` indexes this very list). A block
+// publishing one base therefore answers only for its index-0 registers, and
+// gfx1250 puts more registers at index 1 than at index 0. Nothing reports the
+// mismatch: the access resolves against the base's zero high dword and lands at
+// a raw offset, which reads as a broken register model rather than a short
+// table. This is what left GMC initializing against a memory size of zero.
+TEST(IpDiscoveryProfile, PublishesEverySegmentTheDriverIndexesInto) {
+  // Exact counts, not a floor: these are what a real GFX12 part publishes, and
+  // the failure that matters is a list losing its *tail*. NBIO reaches
+  // _BASE_IDX 5, so a truncation to two entries would break it while sailing
+  // past any lower bound.
+  const std::map<rocjitsu::IpHardwareId, std::size_t> expected = {
+      {rocjitsu::IpHardwareId::Gc, 4},    {rocjitsu::IpHardwareId::Mp0, 15},
+      {rocjitsu::IpHardwareId::Mp1, 15},  {rocjitsu::IpHardwareId::OssSys, 2},
+      {rocjitsu::IpHardwareId::Nbif, 6},  {rocjitsu::IpHardwareId::Hdp, 2},
+      {rocjitsu::IpHardwareId::MmHub, 2}, {rocjitsu::IpHardwareId::AtHub, 2},
+      {rocjitsu::IpHardwareId::Sdma0, 4},
+  };
+
+  const std::vector<rocjitsu::IpBlock> &blocks = gfx1250_spec().blocks;
+
+  // The whole contract, not a property of whatever happens to be present. A
+  // per-present-block loop still passes if a block disappears, is duplicated,
+  // or changes version -- exactly the edits that silently change which driver
+  // support the guest binds and where it resolves that block's registers.
+  //
+  // Every base below is what a real GPU of this family published through
+  // /sys/.../ip_discovery/die/0/<ip>/<inst>/base_addr. NBIF segment 0 really is
+  // zero: its registers start at raw offset 0.
+  struct Expected {
+    rocjitsu::IpHardwareId id;
+    uint16_t major;
+    uint16_t minor;
+    uint16_t revision;
+    std::vector<uint64_t> bases;
+  };
+  const std::vector<Expected> contract = {
+      {rocjitsu::IpHardwareId::Gc, 12, 1, 0, {0x00001260, 0x0000A000, 0x0001C000, 0x02402C00}},
+      {rocjitsu::IpHardwareId::Mp0,
+       15,
+       0,
+       8,
+       {0x00016000, 0x00016200, 0x0001CE00, 0x00DC0000, 0x00E00000, 0x00E40000, 0x00E80000,
+        0x00EC0000, 0x00F00000, 0x02400400, 0x0243FC00, 0x0244D400, 0x03200000, 0x03240000,
+        0x03280000}},
+      {rocjitsu::IpHardwareId::Mp1,
+       15,
+       0,
+       8,
+       {0x00016000, 0x00016200, 0x0001CE00, 0x00DC0000, 0x00E00000, 0x00E40000, 0x00E80000,
+        0x00EC0000, 0x00F00000, 0x02400400, 0x0243FC00, 0x0244D400, 0x03200000, 0x03240000,
+        0x03280000}},
+      {rocjitsu::IpHardwareId::OssSys, 7, 1, 0, {0x000010A0, 0x0240A000}},
+      {rocjitsu::IpHardwareId::Nbif,
+       7,
+       11,
+       0,
+       {0x00000000, 0x00000014, 0x00000D20, 0x00010400, 0x0241B000, 0x04040000}},
+      // 7.0.0 deliberately: the driver's HDP switch has no arm for 7.1.0, which
+      // would leave hdp.funcs null and the flush path silently doing nothing.
+      {rocjitsu::IpHardwareId::Hdp, 7, 0, 0, {0x00000F20, 0x0240A400}},
+      {rocjitsu::IpHardwareId::MmHub, 4, 1, 0, {0x0001A000, 0x02408800}},
+      {rocjitsu::IpHardwareId::AtHub, 4, 1, 0, {0x00000C00, 0x02408C00}},
+      // GC's segments, which this family shares between the two.
+      {rocjitsu::IpHardwareId::Sdma0, 7, 1, 0, {0x00001260, 0x0000A000, 0x0001C000, 0x02402C00}},
+  };
+
+  ASSERT_EQ(blocks.size(), contract.size())
+      << "the profile publishes a different set of blocks than this contract names";
+  for (std::size_t i = 0; i < contract.size(); ++i) {
+    const rocjitsu::IpBlock &block = blocks[i];
+    const Expected &want = contract[i];
+    EXPECT_EQ(block.hardware_id, want.id) << "block " << i;
+    EXPECT_EQ(block.instance, 0u) << "block " << i << ": one instance of each is modelled";
+    EXPECT_EQ(block.major, want.major) << "block " << i;
+    EXPECT_EQ(block.minor, want.minor) << "block " << i;
+    EXPECT_EQ(block.revision, want.revision) << "block " << i;
+    EXPECT_EQ(block.register_bases, want.bases)
+        << "block " << i << ": a changed base resolves this block's registers elsewhere";
+  }
+}
+
+TEST(IpDiscoveryTable, StartsWithTheSignatureTheDriverLooksFor) {
+  const std::vector<std::byte> table = build(gfx1250_spec());
+
+  ASSERT_GE(table.size(), 4u);
+  const auto byte_at = [&table](std::size_t index) {
+    return std::to_integer<unsigned>(table[index]);
+  };
+  // 0x28211407, little endian, which the driver reports as an invalid signature
+  // when it is absent.
+  EXPECT_EQ(byte_at(0), 0x07u);
+  EXPECT_EQ(byte_at(1), 0x14u);
+  EXPECT_EQ(byte_at(2), 0x21u);
+  EXPECT_EQ(byte_at(3), 0x28u);
+}
+
+// The driver checksums the binary and the block list separately, so a table
+// corrupted anywhere has to be caught here rather than in a guest's dmesg.
+TEST(IpDiscoveryTable, RejectsACorruptedBlockList) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  ASSERT_TRUE(rocjitsu::validate_ip_discovery_table(table).valid);
+
+  table[table.size() - 1] = static_cast<std::byte>(std::to_integer<uint8_t>(table.back()) ^ 0xff);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+TEST(IpDiscoveryTable, RejectsATableWithTheWrongSignature) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  table[0] = std::byte{0};
+
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+
+  EXPECT_FALSE(checked.valid);
+  EXPECT_NE(checked.problem.find("signature"), std::string::npos);
+}
+
+TEST(IpDiscoveryTable, RejectsATruncatedTable) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  table.resize(table.size() - 8);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+// Every length inside the table is the thing under test, so none of them may
+// bound a read of it. Each of these once walked off the end of the buffer.
+TEST(IpDiscoveryTable, RejectsInputTooShortToHoldAHeader) {
+  for (std::size_t size = 0; size < 60; ++size) {
+    const std::vector<std::byte> table(size, std::byte{0});
+    EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid) << "at " << size << " bytes";
+  }
+}
+
+TEST(IpDiscoveryTable, RejectsABlockListShorterThanItsOwnHeader) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  // Point the block list one byte before the end, so the range check on its
+  // recorded size passes while its fixed header does not fit.
+  write16(table, 12, static_cast<uint16_t>(table.size() - 1));
+  write16(table, 12 + 4, 1);
+  reseal_binary(table);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+TEST(IpDiscoveryTable, RejectsMoreDiesThanTheHeaderHasRoomFor) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  write16(table, ip_table_offset(table) + 12, 17);
+  reseal_block_list(table);
+  reseal_binary(table);
+
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+  EXPECT_FALSE(checked.valid);
+  EXPECT_NE(checked.problem.find("dies"), std::string::npos);
+}
+
+TEST(IpDiscoveryTable, RejectsADiePointedPastTheEnd) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  write16(table, ip_table_offset(table) + 14 + 2, static_cast<uint16_t>(table.size() - 2));
+  reseal_block_list(table);
+  reseal_binary(table);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+// The bug that shipped: a die offset measured from the table rather than from
+// the binary still lands inside the table, so only reading what it points at
+// catches it.
+TEST(IpDiscoveryTable, RejectsADieOffsetMeasuredFromTheWrongPlace) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  const std::size_t ip_table = ip_table_offset(table);
+  const uint16_t correct = read16(table, ip_table + 14 + 2);
+  write16(table, ip_table + 14 + 2, static_cast<uint16_t>(correct - ip_table));
+  reseal_block_list(table);
+  reseal_binary(table);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+TEST(IpDiscoveryTable, RejectsDisagreeingEmbeddedAndOuterSizes) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  const std::size_t ip_table = ip_table_offset(table);
+  write16(table, ip_table + 6, static_cast<uint16_t>(read16(table, ip_table + 6) - 8));
+  reseal_binary(table);
+
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+  EXPECT_FALSE(checked.valid);
+  EXPECT_NE(checked.problem.find("bytes"), std::string::npos);
+}
+
+TEST(IpDiscoveryTable, RejectsBlockRecordsThatRunPastTheEnd) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  const std::size_t ip_table = ip_table_offset(table);
+  const uint16_t die = read16(table, ip_table + 14 + 2);
+  // Claim far more blocks than the records behind the die can supply.
+  write16(table, die + 2, 4096);
+  reseal_block_list(table);
+  reseal_binary(table);
+
+  EXPECT_FALSE(rocjitsu::validate_ip_discovery_table(table).valid);
+}
+
+TEST(IpDiscoveryTable, RejectsATableWithNoGraphicsBlock) {
+  rocjitsu::IpDiscoverySpec spec;
+  spec.blocks.push_back({.hardware_id = rocjitsu::IpHardwareId::Mp0,
+                         .instance = 0,
+                         .major = 15,
+                         .minor = 0,
+                         .revision = 8,
+                         .register_bases = {0x00016000}});
+
+  const rocjitsu::IpDiscoveryValidation checked =
+      rocjitsu::validate_ip_discovery_table(build(spec));
+
+  EXPECT_FALSE(checked.valid);
+  EXPECT_NE(checked.problem.find("graphics"), std::string::npos);
+}
+
+TEST(IpDiscoveryTable, RejectsACorruptedHarvestTable) {
+  std::vector<std::byte> table = build(gfx1250_spec());
+  const uint16_t harvest = read16(table, 12 + 2 * 8);
+  ASSERT_NE(harvest, 0u);
+  table[harvest] = static_cast<std::byte>(std::to_integer<uint8_t>(table[harvest]) ^ 0xff);
+  reseal_binary(table);
+
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+  EXPECT_FALSE(checked.valid);
+  EXPECT_NE(checked.problem.find("harvest"), std::string::npos);
+}
+
+// Walks to the block count the way the driver does, from the start of the
+// binary rather than from the table holding the die list. Written out here
+// instead of asking the validator, because a table whose die offsets are
+// measured from the wrong place still validates against any checker that makes
+// the same mistake — which is how this shipped as "9 blocks" to a driver that
+// read zero of them and refused the device with no diagnostic.
+TEST(IpDiscoveryTable, PutsItsDieWhereTheDriverLooksForIt) {
+  const rocjitsu::IpDiscoverySpec spec = gfx1250_spec();
+  const std::vector<std::byte> table = build(spec);
+
+  const unsigned ip_table = read16(table, 12);           // table_list[0].offset
+  const unsigned die = read16(table, ip_table + 14 + 2); // die_info[0].die_offset
+
+  ASSERT_LT(die + 4u, table.size());
+  EXPECT_EQ(read16(table, die), 0u) << "die 0 does not identify itself as die 0";
+  EXPECT_EQ(read16(table, die + 2), spec.blocks.size());
+}
+
+TEST(IpDiscoveryTable, DescribesEveryBlockItWasGiven) {
+  rocjitsu::IpDiscoverySpec spec = gfx1250_spec();
+  const std::vector<std::byte> smaller = build(spec);
+
+  spec.blocks.push_back({.hardware_id = rocjitsu::IpHardwareId::Sdma0,
+                         .instance = 1,
+                         .major = 7,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = {0x00001260}});
+  const std::vector<std::byte> larger = build(spec);
+
+  EXPECT_GT(larger.size(), smaller.size());
+  EXPECT_TRUE(rocjitsu::validate_ip_discovery_table(larger).valid);
+}
+
+// The format records a base count in one byte, so a block with more bases than
+// that would serialize a count meaning something else entirely.
+TEST(IpDiscoveryTable, RefusesToBuildABlockWithMoreBasesThanTheFormatHolds) {
+  rocjitsu::IpDiscoverySpec spec = gfx1250_spec();
+  spec.blocks.push_back({.hardware_id = rocjitsu::IpHardwareId::Hdp,
+                         .instance = 1,
+                         .major = 7,
+                         .minor = 1,
+                         .revision = 0,
+                         .register_bases = std::vector<uint64_t>(256, 0x1000)});
+
+  const rocjitsu::IpDiscoveryBuild built = rocjitsu::build_ip_discovery_table(spec);
+
+  EXPECT_FALSE(built.ok());
+  EXPECT_TRUE(built.table.empty());
+}
+
+// The advertised graphics instance count becomes the guest's XCC mask, so it is
+// a deliberate choice rather than an incidental one.
+TEST(IpDiscoveryProfile, AdvertisesTheRequestedGraphicsInstances) {
+  const rocjitsu::IpDiscoverySpec spec =
+      rocjitsu::gfx1250_discovery_spec({.graphics_instances = 4});
+
+  int graphics = 0;
+  for (const rocjitsu::IpBlock &block : spec.blocks) {
+    if (block.hardware_id == rocjitsu::IpHardwareId::Gc) {
+      ++graphics;
+    }
+  }
+
+  EXPECT_EQ(graphics, 4);
+  EXPECT_TRUE(rocjitsu::validate_ip_discovery_table(build(spec)).valid);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
@@ -257,6 +257,9 @@ TEST(VfioDeviceHostLifecycle, StopsServingAfterASharedMemoryClientDisconnects) {
   rocjitsu::config::KfdDeviceConfig identity;
   identity.vendor_id = 0x1002;
   identity.device_id = 0x1250;
+  // Only this target has an IP discovery profile, and a device without one
+  // refuses to become usable rather than describing itself as another part.
+  identity.gfx_target_version = 120500;
   identity.local_mem_size = 8ULL * 1024 * 1024;
   rocjitsu::GpuPciDevice gpu("gpu", rocjitsu::gpu_pci_spec_from_config(identity, {}), nullptr);
   ASSERT_TRUE(gpu.usable());
@@ -310,6 +313,7 @@ TEST(VfioDeviceHostLifecycle, BuildsTheSmallestBusShapeTheDeviceAccepts) {
 
   rocjitsu::config::KfdDeviceConfig identity;
   identity.local_mem_size = 64 * 1024 * 1024;
+  identity.gfx_target_version = 120500;
   rocjitsu::config::PciDeviceConfig pci;
   pci.vram_aperture_bytes = rocjitsu::GpuPciDevice::kMinMemoryBarBytes;
   pci.doorbell_aperture_bytes = rocjitsu::GpuPciDevice::kMinMemoryBarBytes;

--- a/emulation/rocjitsu/tools/rj-ip-discovery/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rj-ip-discovery/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include(rj_configure_target)
+
+add_executable(rj_ip_discovery main.cpp)
+target_link_libraries(rj_ip_discovery PRIVATE rocjitsu_pci simdojo util)
+set_target_properties(rj_ip_discovery PROPERTIES OUTPUT_NAME rj-ip-discovery)
+rj_configure_target(rj_ip_discovery TOOL)

--- a/emulation/rocjitsu/tools/rj-ip-discovery/main.cpp
+++ b/emulation/rocjitsu/tools/rj-ip-discovery/main.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file main.cpp
+/// @brief Writes the IP discovery table a guest driver reads from a device.
+///
+/// @details The driver can be told to load this table from a file instead of
+/// from the device, which is how a generated one is tried without first teaching
+/// the device to publish it. Drop the output at
+/// `/lib/firmware/amdgpu/ip_discovery.bin` in a guest and boot with
+/// `amdgpu.discovery=2`.
+
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery.h"
+#include "rocjitsu/vm/amdgpu/pci/ip_discovery_profile.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: rj-ip-discovery <output-path>\n";
+    return EXIT_FAILURE;
+  }
+
+  const rocjitsu::IpDiscoveryBuild built =
+      rocjitsu::build_ip_discovery_table(rocjitsu::gfx1250_discovery_spec());
+  if (!built.ok()) {
+    std::cerr << "rj-ip-discovery: cannot build a table: " << built.problem << "\n";
+    return EXIT_FAILURE;
+  }
+  const std::vector<std::byte> &table = built.table;
+  const rocjitsu::IpDiscoveryValidation checked = rocjitsu::validate_ip_discovery_table(table);
+  if (!checked.valid) {
+    std::cerr << "rj-ip-discovery: refusing to write an unusable table: " << checked.problem
+              << "\n";
+    return EXIT_FAILURE;
+  }
+  // The format permits a larger table than the driver will load from a file, so
+  // a well-formed one can still be unusable by the path this tool writes for.
+  if (table.size() > rocjitsu::kDiscoveryTableBytes) {
+    std::cerr << "rj-ip-discovery: refusing to write " << table.size() << " bytes, more than the "
+              << rocjitsu::kDiscoveryTableBytes << " the driver loads\n";
+    return EXIT_FAILURE;
+  }
+
+  std::ofstream out(argv[1], std::ios::binary);
+  out.write(reinterpret_cast<const char *>(table.data()),
+            static_cast<std::streamsize>(table.size()));
+  if (!out) {
+    std::cerr << "rj-ip-discovery: cannot write " << argv[1] << "\n";
+    return EXIT_FAILURE;
+  }
+
+  std::cerr << "rj-ip-discovery: wrote " << table.size() << " bytes to " << argv[1] << "\n";
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
An AMD GPU does not tell the driver what it is through its PCI IDs. The driver binds on class, then reads a table out of the device listing every IP block, its version, and where its registers live; without one it cannot decide which block drivers to instantiate, and it refuses the device.

Generate that table and write it where the driver looks, 64 KiB below the top of the megabyte-rounded capacity the device reports, since the driver computes that address from what it read rather than being told and never learns the true byte count. Each block names its registers as the list of segments the driver indexes by _BASE_IDX rather than as one address, so publishing a single base leaves most of a block resolving against nothing. Validate all of it here rather than by reading a guest's dmesg: the validator walks the structures the way the driver walks them, from the start of the binary rather than from the table holding them, because an offset measured from the wrong place still lands inside the table and the driver rejects it with a bare -EINVAL.