### PR TITLE
rocjitsu: Advertise an interrupt so a guest driver keeps the device

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -95,6 +95,38 @@ public:
 
   [[nodiscard]] std::vector<simdojo::BarSpec> bars() const override;
 
+  /// @brief Advertise a single legacy interrupt pin.
+  ///
+  /// @details The driver asks the bus for one vector of any kind at all and
+  /// refuses the device outright when it cannot have one, so a function with no
+  /// interrupt capability whatsoever does not merely lose interrupts: its
+  /// interrupt-handling block fails to initialize and the probe ends there. A
+  /// pin is the smallest capability that satisfies that, and the only one this
+  /// transport can currently advertise.
+  ///
+  /// Nothing built against it is wasted when this becomes MSI-X, because the
+  /// driver decides how to program the interrupt ring from a module parameter
+  /// rather than from what the bus actually gave it, and so programs the ring
+  /// identically either way.
+  ///
+  /// **A pin must not be what finally raises an interrupt, though.** A client
+  /// disables every mmap of every BAR while a legacy interrupt is pending, and
+  /// restores them only after a quiet period; this device's largest BAR is the
+  /// memory aperture the guest maps to avoid trapping. Raising pins at the rate
+  /// an interrupt ring produces them would therefore cost the guest its direct
+  /// view of memory for as long as they keep arriving, and would present as a
+  /// collapse of the memory path rather than as anything to do with interrupts.
+  ///
+  /// @returns A single legacy pin. The vectors field is NOT APPLICABLE here
+  ///          rather than meaningful: it counts message-signalled vectors, so
+  ///          the zero reported alongside IntxPin is not a count of anything
+  ///          this device declines to raise. What is advertised is a capability
+  ///          the guest driver checks for before it will keep the device; this
+  ///          device raises nothing through it yet.
+  [[nodiscard]] simdojo::InterruptSpec interrupts() const override {
+    return {.kind = simdojo::InterruptKind::IntxPin, .vectors = 0};
+  }
+
   [[nodiscard]] int64_t bar_access(int bar, std::span<std::byte> buf, uint64_t offset,
                                    bool write) override;
   void dma_map(const simdojo::DmaRegion &region) override;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.h
@@ -47,8 +47,14 @@ struct InterruptPlan {
 /// @returns The plan; @ref InterruptPlan::supported is false for capabilities
 ///          this transport does not implement, which the caller must refuse
 ///          rather than quietly substitute something else for.
-/// @details A device that raises nothing is advertised with nothing: telling a
-/// guest about a pin the device never asserts invites a driver to wait on it.
+/// @details A device that raises nothing is normally advertised with nothing:
+/// telling a guest about a pin the device never asserts invites a driver to
+/// wait on it. The exception belongs to the DEVICE, not to this function: a
+/// device facing a driver that refuses a function with no interrupt capability
+/// at all should itself request IntxPin, because there the choice is not
+/// between a pin and silence but between a pin nobody asserts yet and no
+/// device. This function never substitutes a capability the device did not
+/// ask for; an unsupported one comes back with supported false.
 [[nodiscard]] InterruptPlan plan_interrupts(const simdojo::InterruptSpec &spec);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -150,6 +150,24 @@ TEST_F(GpuDevice, AcceptsTheHdpFlushTheDriverIssues) {
       << "the flush hole is not modelled, so the write was dropped";
 }
 
+// The driver asks the bus for one vector of any kind and treats not getting one
+// as fatal rather than as doing without: `pci_alloc_irq_vectors` returning
+// negative fails the interrupt block's initialization, which fails the probe.
+// So a function advertising no interrupt capability at all is refused before it
+// has raised, or failed to raise, anything.
+TEST_F(GpuDevice, AdvertisesAnInterruptTheDriverCanAllocate) {
+  const simdojo::InterruptSpec interrupts = device_.interrupts();
+
+  EXPECT_NE(interrupts.kind, simdojo::InterruptKind::None)
+      << "a device with no interrupt capability fails the driver's probe";
+  // The kind is deliberately not asserted: this stage advertises a pin and a
+  // later one advertises MSI-X, and freezing the kind here would only record
+  // which stage this is. That the transport can actually advertise whichever
+  // kind is asked for is checked next to the transport, in bus_plan_test: this
+  // device is modelled whether or not the vfio-user backend is built, so a test
+  // here that called into it would leave the whole suite unlinkable without it.
+}
+
 // The driver's PCI table wildcards the device ID and matches on the class, so
 // this is the field that decides whether amdgpu attaches at all.
 TEST_F(GpuDevice, PresentsTheClassAmdgpuBindsOn) {

--- a/emulation/rocjitsu/tests/vmm/bus_plan_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/bus_plan_test.cpp
@@ -3,7 +3,12 @@
 
 #include "rocjitsu/vmm/vfu/bus_plan.h"
 
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device.h"
+#include "rocjitsu/vm/amdgpu/pci/gpu_pci_device_spec.h"
+
 #include <gtest/gtest.h>
+
+#include <cstdint>
 
 namespace {
 
@@ -93,6 +98,22 @@ TEST(InterruptPlan, AdvertisesOnePinWhenAsked) {
 
   ASSERT_TRUE(plan.supported);
   EXPECT_EQ(plan.intx_count, 1u);
+}
+
+// The device asking and the transport advertising are written apart, so nothing
+// else pairs them. Asking for a kind this transport cannot advertise is worse
+// than asking for none: the function is refused before it is served at all, so
+// the guest sees no device rather than a device without interrupts.
+TEST(InterruptPlan, AdvertisesWhatTheModelledGpuAsksFor) {
+  rocjitsu::config::KfdDeviceConfig configured;
+  configured.gfx_target_version = 120500;
+  configured.vendor_id = 0x1002;
+  configured.device_id = 0x1250;
+  configured.local_mem_size = 16ULL * 1024 * 1024;
+  rocjitsu::GpuPciDevice device("gpu", rocjitsu::gpu_pci_spec_from_config(configured, {}), nullptr);
+
+  EXPECT_TRUE(rocjitsu::plan_interrupts(device.interrupts()).supported)
+      << "the transport cannot advertise the capability this device asks for";
 }
 
 TEST(InterruptPlan, RefusesMsiXUntilItIsImplemented) {

--- a/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
@@ -287,6 +287,16 @@ TEST(VfioDeviceHostLifecycle, StopsServingAfterASharedMemoryClientDisconnects) {
     uint32_t regions = 0;
     uint32_t irqs = 0;
     ASSERT_TRUE(client.device_info(regions, irqs));
+
+    // What the guest actually sees, rather than what the device asked for. The
+    // capability only reaches it if vfu_setup_device_nr_irqs() ran for the kind
+    // the plan chose, and nothing else covers that path: the device-side tests
+    // stop at interrupts() and plan_interrupts().
+    uint32_t intx_vectors = 0;
+    ASSERT_TRUE(client.irq_info(VFIO_PCI_INTX_IRQ_INDEX, intx_vectors));
+    EXPECT_EQ(intx_vectors, 1u)
+        << "the guest is offered no legacy pin, so its driver's pci_alloc_irq_vectors() fails "
+           "and the probe fails with it";
   }
 
   // No stop is requested: the disconnect alone must end serving.

--- a/emulation/rocjitsu/tests/vmm/vfio_user_client.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_user_client.cpp
@@ -217,6 +217,23 @@ bool VfioUserClient::device_info(uint32_t &region_count, uint32_t &irq_count) {
   return true;
 }
 
+bool VfioUserClient::irq_info(uint32_t index, uint32_t &count) {
+  vfio_irq_info request_body{};
+  request_body.argsz = sizeof(request_body);
+  request_body.index = index;
+
+  std::vector<std::byte> reply;
+  if (!request(VFIO_USER_DEVICE_GET_IRQ_INFO,
+               {reinterpret_cast<const std::byte *>(&request_body), sizeof(request_body)}, -1,
+               reply) ||
+      reply.size() < sizeof(vfio_irq_info)) {
+    return false;
+  }
+
+  count = reinterpret_cast<const vfio_irq_info *>(reply.data())->count;
+  return true;
+}
+
 bool VfioUserClient::region_info(uint32_t region, uint64_t &size, uint32_t &flags) {
   vfio_region_info request_body{};
   request_body.argsz = sizeof(request_body);

--- a/emulation/rocjitsu/tests/vmm/vfio_user_client.h
+++ b/emulation/rocjitsu/tests/vmm/vfio_user_client.h
@@ -42,6 +42,12 @@ public:
   /// @param[out] irq_count Interrupt types reported.
   [[nodiscard]] bool device_info(uint32_t &region_count, uint32_t &irq_count);
 
+  /// @brief Ask how many vectors an interrupt index offers.
+  /// @param[in] index VFIO interrupt index, e.g. VFIO_PCI_INTX_IRQ_INDEX.
+  /// @param[out] count Vectors the server reports for it.
+  /// @retval false The server refused the request.
+  [[nodiscard]] bool irq_info(uint32_t index, uint32_t &count);
+
   /// @brief Read the size and flags of one region.
   /// @param[in] region Region index.
   /// @param[out] size Region size in bytes.


### PR DESCRIPTION
A driver asks the bus for one interrupt vector of any kind before it will initialize the block that handles them, and treats not getting one as fatal rather than as cause to do without. A function that advertises no interrupt capability at all therefore does not merely lose interrupts: the block fails to initialize, device initialization fails with it, and the probe ends before the device has been asked to raise anything.

Advertise a single legacy pin. It is the smallest capability that satisfies the request and the only one this transport can already advertise. Real parts prefer MSI-X, which needs room for a vector table in a BAR and a capability in configuration space -- the table itself being the client's to emulate -- and none of that can be exercised until the device has something to raise an interrupt about.