### PR TITLE
rocjitsu: Deliver interrupts by message rather than by pin

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
@@ -249,6 +249,7 @@ GpuPciDevice::GpuPciDevice(std::string name, const GpuPciDeviceSpec &spec, BarAc
     return;
   }
   doorbells_.resize(spec_.doorbell_aperture_bytes);
+  msix_table_.resize(kMsixBarBytes);
 
   // One entry per dword of the aperture.
   const auto register_count = static_cast<uint32_t>(spec_.register_aperture_bytes / 4);
@@ -371,7 +372,21 @@ std::vector<simdojo::BarSpec> GpuPciDevice::bars() const {
   registers.size = spec_.register_aperture_bytes;
   registers.mem = true;
 
-  return {vram, doorbell, registers};
+  // Trapped rather than mapped, so every access is seen. What this stage does
+  // with what it sees is nothing beyond storing it: the table and the pending
+  // bits are one undifferentiated buffer, the device is told nothing about
+  // which vectors the guest has masked, and it sets no pending bit of its own.
+  // That is enough for a client that emulates the table itself, which is what
+  // this transport's clients do. Modelling ownership properly -- the device
+  // setting pending bits for a masked vector and learning mask changes through
+  // a state callback -- needs an interface this device does not have yet, and
+  // trapping is the precondition for adding it without changing the bus shape.
+  simdojo::BarSpec msix;
+  msix.index = kMsixBar;
+  msix.size = kMsixBarBytes;
+  msix.mem = true;
+
+  return {vram, doorbell, registers, msix};
 }
 
 void GpuPciDevice::reset_registers() {
@@ -624,6 +639,8 @@ int64_t GpuPciDevice::bar_access(int bar, std::span<std::byte> buf, uint64_t off
     return access_registers(buf, offset, write);
   case kDoorbellBar:
     return access_memory(buf, offset, write, doorbells_);
+  case kMsixBar:
+    return access_memory(buf, offset, write, msix_table_);
   case kVramBar:
     // Reached only for a guest that did not map the aperture; a mapped one
     // never traps here.
@@ -651,6 +668,7 @@ void GpuPciDevice::reset(simdojo::ResetKind kind) {
   // memory is not cleared here: a mapping already handed out cannot be taken
   // back, which is why a device that exports one is served to a single client.
   std::ranges::fill(doorbells_, std::byte{0});
+  std::ranges::fill(msix_table_, std::byte{0});
   reset_registers();
   // The table is restored rather than assumed intact. On real hardware it lives
   // in memory the security processor reserves and the driver cannot write; here

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -60,6 +60,38 @@ public:
   /// @brief BAR carrying the register aperture.
   static constexpr int kRegisterBar = 5;
 
+  /// @brief BAR carrying the message-signalled interrupt table.
+  ///
+  /// @details Its own BAR rather than a corner of the register aperture, so
+  /// that a table entry can never be mistaken for a register or land on one.
+  /// BARs 1 and 3 are the upper halves of the two 64-bit apertures, which
+  /// leaves this as the only free index.
+  static constexpr int kMsixBar = 4;
+
+  /// @brief Size of that BAR.
+  ///
+  /// @details The table and the pending bits get a 4 KiB page each. Nothing
+  /// requires it -- they may share a page with each other, and a client asks
+  /// only that they be eight-byte aligned and not overlap -- but a page apiece
+  /// means neither can ever share one with anything else, which is what the
+  /// specification does care about, and it costs 8 KiB of a BAR that holds
+  /// nothing else.
+  static constexpr uint64_t kMsixBarBytes = 8 * 1024;
+
+  /// @brief Where the table starts within that BAR.
+  static constexpr uint64_t kMsixTableOffset = 0;
+
+  /// @brief Where the pending bits start, one page after it.
+  static constexpr uint64_t kMsixPendingOffset = 4 * 1024;
+
+  /// @brief Message vectors advertised.
+  ///
+  /// @details One, because the driver asks the bus for exactly one and this
+  /// device has exactly one thing to report: that its interrupt ring has
+  /// something in it. Advertising more would be describing hardware that is
+  /// not there.
+  static constexpr uint32_t kMsixVectors = 1;
+
   /// @brief Smallest memory BAR the PCI specification allows.
   ///
   /// @details Checked here so a device reports its own configuration unusable
@@ -95,36 +127,37 @@ public:
 
   [[nodiscard]] std::vector<simdojo::BarSpec> bars() const override;
 
-  /// @brief Advertise a single legacy interrupt pin.
+  /// @brief Advertise message-signalled interrupts.
   ///
   /// @details The driver asks the bus for one vector of any kind at all and
   /// refuses the device outright when it cannot have one, so a function with no
   /// interrupt capability whatsoever does not merely lose interrupts: its
-  /// interrupt-handling block fails to initialize and the probe ends there. A
-  /// pin is the smallest capability that satisfies that, and the only one this
-  /// transport can currently advertise.
+  /// interrupt-handling block fails to initialize and the probe ends there.
   ///
-  /// Nothing built against it is wasted when this becomes MSI-X, because the
-  /// driver decides how to program the interrupt ring from a module parameter
-  /// rather than from what the bus actually gave it, and so programs the ring
-  /// identically either way.
+  /// A legacy pin would satisfy that too, and is cheaper, but it cannot be what
+  /// raises the interrupt: a client disables every mmap of every BAR while a
+  /// legacy interrupt is pending and restores them only after a quiet period,
+  /// and this device's largest BAR is the memory aperture the guest maps to
+  /// avoid trapping. Raising pins at the rate an interrupt ring produces them
+  /// would cost the guest its direct view of memory for as long as they kept
+  /// arriving, and would present as a collapse of the memory path rather than
+  /// as anything to do with interrupts. Messages carry no such penalty, and
+  /// they are what the parts being modelled use.
   ///
-  /// **A pin must not be what finally raises an interrupt, though.** A client
-  /// disables every mmap of every BAR while a legacy interrupt is pending, and
-  /// restores them only after a quiet period; this device's largest BAR is the
-  /// memory aperture the guest maps to avoid trapping. Raising pins at the rate
-  /// an interrupt ring produces them would therefore cost the guest its direct
-  /// view of memory for as long as they keep arriving, and would present as a
-  /// collapse of the memory path rather than as anything to do with interrupts.
+  /// The cost of offering no pin at all is that a driver *forced* to legacy
+  /// interrupts -- by the module parameter that turns messages off -- asks the
+  /// bus for a pin, is refused, and fails the same probe this capability
+  /// exists to get through. That is a debugging option rather than a
+  /// configuration anyone runs, and restoring the pin would reintroduce the
+  /// mapping penalty above the moment anything raised one.
   ///
-  /// @returns A single legacy pin. The vectors field is NOT APPLICABLE here
-  ///          rather than meaningful: it counts message-signalled vectors, so
-  ///          the zero reported alongside IntxPin is not a count of anything
-  ///          this device declines to raise. What is advertised is a capability
-  ///          the guest driver checks for before it will keep the device; this
-  ///          device raises nothing through it yet.
+  /// @returns One vector, and where its table lives.
   [[nodiscard]] simdojo::InterruptSpec interrupts() const override {
-    return {.kind = simdojo::InterruptKind::IntxPin, .vectors = 0};
+    return {.kind = simdojo::InterruptKind::MsiX,
+            .vectors = kMsixVectors,
+            .table_bar = kMsixBar,
+            .table_offset = kMsixTableOffset,
+            .pending_offset = kMsixPendingOffset};
   }
 
   [[nodiscard]] int64_t bar_access(int bar, std::span<std::byte> buf, uint64_t offset,
@@ -240,6 +273,13 @@ private:
   std::byte *vram_ = nullptr;
 
   std::vector<std::byte> doorbells_;
+
+  /// @brief Backing for the message table and its pending bits.
+  ///
+  /// @details Plain storage. A client of this transport emulates the table's
+  /// meaning itself and delivers the message, so what the device has to do is
+  /// hold the bytes and not lose them.
+  std::vector<std::byte> msix_table_;
   bool usable_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.cpp
@@ -4,6 +4,23 @@
 #include "rocjitsu/vmm/vfu/bus_plan.h"
 
 namespace rocjitsu {
+namespace {
+
+/// @brief Highest BAR index a PCI function has.
+constexpr int kMaxBarIndex = 5;
+
+/// @brief Vectors a message-interrupt capability can describe, its table-size
+/// field being eleven bits holding one less than the count.
+constexpr uint32_t kMaxMsixVectors = 2048;
+
+/// @brief Units the table and pending-bit offsets are recorded in, the low
+/// three bits of each field carrying the BAR index instead.
+constexpr uint64_t kMsixOffsetUnit = 8;
+
+/// @brief Largest offset those fields can express, twenty-nine bits of units.
+constexpr uint64_t kMaxMsixOffset = (uint64_t{1} << 32) - kMsixOffsetUnit;
+
+} // namespace
 
 BarRegionPlan plan_bar_region(const simdojo::BarSpec &bar) {
   BarRegionPlan plan;
@@ -43,8 +60,28 @@ InterruptPlan plan_interrupts(const simdojo::InterruptSpec &spec) {
     plan.intx_count = 1;
     break;
   case simdojo::InterruptKind::MsiX:
-    // MSI-X needs a vector table inside a BAR, which arrives with the first
-    // device that raises per-vector completions.
+    // A table of no vectors is not a capability: a guest would allocate from
+    // it and get nothing back, which is worse than not offering it.
+    if (spec.vectors == 0) {
+      break;
+    }
+    // What a capability can say about itself, and therefore what a device is
+    // allowed to declare: a table size one less than the count in eleven bits,
+    // a BAR index in three, and two offsets in units of eight bytes in
+    // twenty-nine. A declaration that does not fit would not be refused
+    // anywhere downstream -- it would be published rounded down or wrapped
+    // around, naming bytes the device does not treat as a table.
+    if (spec.vectors > kMaxMsixVectors || spec.table_bar < 0 || spec.table_bar > kMaxBarIndex ||
+        (spec.table_offset % kMsixOffsetUnit) != 0 ||
+        (spec.pending_offset % kMsixOffsetUnit) != 0 || spec.table_offset > kMaxMsixOffset ||
+        spec.pending_offset > kMaxMsixOffset) {
+      break;
+    }
+    plan.supported = true;
+    plan.msix_count = spec.vectors;
+    plan.table_bar = spec.table_bar;
+    plan.table_offset = spec.table_offset;
+    plan.pending_offset = spec.pending_offset;
     break;
   }
   return plan;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/bus_plan.h
@@ -38,15 +38,24 @@ struct BarRegionPlan {
 
 /// @brief How a device's interrupt declaration should be registered.
 struct InterruptPlan {
-  bool supported = false;  ///< False if the transport cannot advertise this kind yet.
-  uint32_t intx_count = 0; ///< Legacy interrupt pins to advertise; zero for none.
+  /// @brief False when the declaration cannot be advertised as it stands.
+  ///
+  /// @details Either a kind this transport does not implement, or one it does
+  /// that the device described in terms a capability cannot express.
+  bool supported = false;
+  uint32_t intx_count = 0;     ///< Legacy interrupt pins to advertise; zero for none.
+  uint32_t msix_count = 0;     ///< Message vectors to advertise; zero for none.
+  int table_bar = 0;           ///< BAR holding the message table, when there is one.
+  uint64_t table_offset = 0;   ///< Byte offset of the table within that BAR.
+  uint64_t pending_offset = 0; ///< Byte offset of the pending-bit array, likewise.
 };
 
 /// @brief Decide how @p spec should be advertised.
 /// @param[in] spec The interrupt capability the device declared.
-/// @returns The plan; @ref InterruptPlan::supported is false for capabilities
-///          this transport does not implement, which the caller must refuse
-///          rather than quietly substitute something else for.
+/// @returns The plan; @ref InterruptPlan::supported is false both for
+///          capabilities this transport does not implement and for ones it does
+///          that @p spec describes inexpressibly. The caller must refuse either
+///          rather than quietly substitute something else.
 /// @details A device that raises nothing is normally advertised with nothing:
 /// telling a guest about a pin the device never asserts invites a driver to
 /// wait on it. The exception belongs to the DEVICE, not to this function: a

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
@@ -25,6 +25,7 @@
 
 extern "C" {
 #include <libvfio-user.h>
+#include <pci_caps/msix.h>
 }
 
 #include <poll.h>
@@ -44,6 +45,14 @@ namespace {
 /// @brief Longest a serving thread waits for socket activity before rechecking
 /// its stop token. Nothing observes this delay except shutdown latency.
 constexpr int kPollTimeoutMs = 100;
+
+/// @brief Bytes one message-table entry occupies: two address words, a data
+/// word and a vector-control word.
+constexpr uint64_t kMsixEntryBytes = 16;
+
+/// @brief Bytes one word of the pending-bit array occupies; the array is words
+/// of 64 bits rather than a byte per vector.
+constexpr uint64_t kMsixPendingWordBytes = 8;
 
 /// @brief Most scatter-gather entries one guest memory transfer may span.
 /// @brief Scatter-gather entries a transfer is attempted with before the
@@ -219,6 +228,7 @@ bool VfioDeviceHost::build() {
   // library, so the byte is written directly or the guest sees revision zero.
   vfu_pci_get_config_space(ctx_)->hdr.rid = id.revision;
 
+  std::array<uint64_t, 6> bar_sizes{};
   for (const simdojo::BarSpec &bar : device_.bars()) {
     const BarRegionPlan plan = plan_bar_region(bar);
     single_client_ = single_client_ || !plan.mmap_areas.empty();
@@ -255,19 +265,69 @@ bool VfioDeviceHost::build() {
           std::format("vfu: cannot set up BAR{}: {}", bar.index, std::strerror(errno)));
       return false;
     }
+    bar_sizes[static_cast<std::size_t>(bar.index)] = bar.size;
   }
 
   const InterruptPlan interrupts = plan_interrupts(device_.interrupts());
   if (!interrupts.supported) {
-    util::Logger::warn(std::format(
-        "vfu: device {} asked for an interrupt kind this transport does not implement yet",
-        device_.name()));
+    util::Logger::warn(
+        std::format("vfu: device {} declared interrupts this transport cannot advertise, either a "
+                    "kind it does not implement or one described in terms a capability cannot "
+                    "express",
+                    device_.name()));
     return false;
   }
+  // Both of these must happen before the device is realized: the interrupt
+  // count decides whether a pin is published in configuration space, and a
+  // capability added afterwards is not published at all. Neither call reports
+  // being too late, so the ordering is the only thing enforcing it.
   if (interrupts.intx_count != 0 &&
       vfu_setup_device_nr_irqs(ctx_, VFU_DEV_INTX_IRQ, interrupts.intx_count) < 0) {
     util::Logger::warn(std::format("vfu: cannot set up interrupts: {}", std::strerror(errno)));
     return false;
+  }
+  if (interrupts.msix_count != 0) {
+    // The capability names a BAR and two offsets, and nothing downstream
+    // checks that they describe somewhere the device actually answers. A
+    // client refuses a table that runs past its BAR or that overlaps the
+    // pending bits, but it does so at the guest's realization and in terms of
+    // the guest's own layout, naming none of the offsets involved.
+    //
+    // plan_interrupts has already bounded the index, so this indexes safely.
+    const auto table_bar = static_cast<std::size_t>(interrupts.table_bar);
+    const uint64_t table_end = interrupts.table_offset + interrupts.msix_count * kMsixEntryBytes;
+    // The pending bits are an array of 64-bit words, not a byte per vector.
+    const uint64_t pending_end =
+        interrupts.pending_offset + ((interrupts.msix_count + 63) / 64) * kMsixPendingWordBytes;
+    const bool overlap =
+        interrupts.table_offset < pending_end && interrupts.pending_offset < table_end;
+    if (table_end > bar_sizes[table_bar] || pending_end > bar_sizes[table_bar] || overlap) {
+      util::Logger::warn(std::format(
+          "vfu: device {} puts its message table at {:#x}..{:#x} and its pending bits at "
+          "{:#x}..{:#x} of BAR{}, which is {} bytes",
+          device_.name(), interrupts.table_offset, table_end, interrupts.pending_offset,
+          pending_end, interrupts.table_bar, bar_sizes[table_bar]));
+      return false;
+    }
+    if (vfu_setup_device_nr_irqs(ctx_, VFU_DEV_MSIX_IRQ, interrupts.msix_count) < 0) {
+      util::Logger::warn(
+          std::format("vfu: cannot set up message interrupts: {}", std::strerror(errno)));
+      return false;
+    }
+    // The table and pending-bit offsets are recorded in units of eight bytes,
+    // and the low three bits of each field carry the BAR index instead.
+    msixcap msix{};
+    msix.hdr.id = PCI_CAP_ID_MSIX;
+    msix.mxc.ts = static_cast<uint16_t>(interrupts.msix_count - 1);
+    msix.mtab.tbir = static_cast<uint32_t>(interrupts.table_bar);
+    msix.mtab.to = static_cast<uint32_t>(interrupts.table_offset >> 3);
+    msix.mpba.pbir = static_cast<uint32_t>(interrupts.table_bar);
+    msix.mpba.pbao = static_cast<uint32_t>(interrupts.pending_offset >> 3);
+    if (vfu_pci_add_capability(ctx_, 0, 0, &msix) < 0) {
+      util::Logger::warn(
+          std::format("vfu: cannot publish the message table: {}", std::strerror(errno)));
+      return false;
+    }
   }
 
   if (vfu_setup_device_dma(ctx_, LIBVFIO_USER_MAX_DMA_REGIONS, &dma_register_trampoline,

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/pci_device.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/pci_device.h
@@ -159,6 +159,15 @@ enum class InterruptKind {
 struct InterruptSpec {
   InterruptKind kind = InterruptKind::None; ///< What to advertise.
   uint32_t vectors = 0;                     ///< Vector count, for @ref InterruptKind::MsiX.
+  /// @brief BAR holding the message table and its pending-bit array.
+  ///
+  /// @details Message-signalled interrupts are configured through a table in
+  /// the device's own memory rather than through configuration space, so the
+  /// device decides where that table lives and the transport only reports the
+  /// decision. Meaningful only for @ref InterruptKind::MsiX.
+  int table_bar = 0;
+  uint64_t table_offset = 0;   ///< Byte offset of the table within that BAR.
+  uint64_t pending_offset = 0; ///< Byte offset of the pending-bit array, likewise.
 };
 
 /// @brief Sink through which a device raises interrupts toward the guest.

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -168,6 +168,43 @@ TEST_F(GpuDevice, AdvertisesAnInterruptTheDriverCanAllocate) {
   // here that called into it would leave the whole suite unlinkable without it.
 }
 
+// The message table is memory the guest writes to say where an interrupt should
+// be delivered, so it needs a BAR of its own that traps. Putting it in a corner
+// of the register aperture would let a table entry and a register land on the
+// same address, and the two are read by entirely different machinery.
+TEST_F(GpuDevice, CarriesTheMessageTableInATrappedBarOfItsOwn) {
+  ASSERT_TRUE(device_.usable());
+  const simdojo::InterruptSpec interrupts = device_.interrupts();
+  ASSERT_EQ(interrupts.kind, simdojo::InterruptKind::MsiX);
+
+  const simdojo::BarSpec *table = bar(interrupts.table_bar);
+  ASSERT_NE(table, nullptr) << "the table is advertised in a BAR that does not exist";
+  EXPECT_LT(table->backing_fd, 0) << "a mapped table would let the guest change it unobserved";
+  EXPECT_TRUE(table->mmap_areas.empty());
+  EXPECT_NE(interrupts.table_bar, rocjitsu::GpuPciDevice::kRegisterBar);
+
+  // Both structures have to fit, and the pending bits must not start inside the
+  // table: one vector's entry is 16 bytes and its pending bit is in the first 8.
+  const uint64_t table_bytes = interrupts.vectors * 16;
+  EXPECT_LE(interrupts.table_offset + table_bytes, interrupts.pending_offset);
+  EXPECT_LE(interrupts.pending_offset + 8, table->size);
+}
+
+// The table is plain storage, but it has to be storage: a write the device
+// dropped would leave the guest believing it had programmed a destination.
+TEST_F(GpuDevice, RemembersWhatTheGuestWritesIntoTheMessageTable) {
+  ASSERT_TRUE(device_.usable());
+  const simdojo::InterruptSpec interrupts = device_.interrupts();
+  const int table_bar = interrupts.table_bar;
+  auto raw = std::bit_cast<std::array<std::byte, 4>>(uint32_t{0xfeedface});
+
+  ASSERT_EQ(device_.bar_access(table_bar, raw, interrupts.table_offset, /*write=*/true), 4);
+
+  std::array<std::byte, 4> read_back{};
+  ASSERT_EQ(device_.bar_access(table_bar, read_back, interrupts.table_offset, /*write=*/false), 4);
+  EXPECT_EQ(std::bit_cast<uint32_t>(read_back), 0xfeedfaceu);
+}
+
 // The driver's PCI table wildcards the device ID and matches on the class, so
 // this is the field that decides whether amdgpu attaches at all.
 TEST_F(GpuDevice, PresentsTheClassAmdgpuBindsOn) {

--- a/emulation/rocjitsu/tests/vmm/bus_plan_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/bus_plan_test.cpp
@@ -116,11 +116,65 @@ TEST(InterruptPlan, AdvertisesWhatTheModelledGpuAsksFor) {
       << "the transport cannot advertise the capability this device asks for";
 }
 
-TEST(InterruptPlan, RefusesMsiXUntilItIsImplemented) {
+// Where the table lives is the device's decision, and the transport carries it
+// through unchanged: the guest is told to look at this BAR and these offsets,
+// and it looks exactly there. A transport that adjusted them would point the
+// guest at bytes the device does not treat as a table.
+TEST(InterruptPlan, CarriesTheMessageTableThroughUntouched) {
+  const rocjitsu::InterruptPlan plan = rocjitsu::plan_interrupts({
+      .kind = simdojo::InterruptKind::MsiX,
+      .vectors = 4,
+      .table_bar = 4,
+      .table_offset = 0,
+      .pending_offset = 4096,
+  });
+
+  ASSERT_TRUE(plan.supported);
+  EXPECT_EQ(plan.msix_count, 4u);
+  EXPECT_EQ(plan.table_bar, 4);
+  EXPECT_EQ(plan.table_offset, 0u);
+  EXPECT_EQ(plan.pending_offset, 4096u);
+  EXPECT_EQ(plan.intx_count, 0u) << "a pin as well would be two capabilities for one interrupt";
+}
+
+// A capability offering nothing to allocate is worse than none at all: the
+// driver asks for a vector, gets nothing, and fails the same probe it would
+// have failed anyway -- but now with a published table to explain away.
+TEST(InterruptPlan, RefusesMessageInterruptsWithNoVectors) {
   const rocjitsu::InterruptPlan plan =
-      rocjitsu::plan_interrupts({.kind = simdojo::InterruptKind::MsiX, .vectors = 4});
+      rocjitsu::plan_interrupts({.kind = simdojo::InterruptKind::MsiX, .vectors = 0});
 
   EXPECT_FALSE(plan.supported);
+}
+
+// Every field of the capability is packed -- eleven bits of count, three of BAR
+// index, twenty-nine of offset in units of eight bytes -- and nothing
+// downstream refuses a declaration that does not fit. It would be published
+// rounded down or wrapped around, naming bytes the device does not treat as a
+// table. These are the boundaries, because a wrong bound would sit on one.
+TEST(InterruptPlan, AcceptsTheLargestDeclarationACapabilityCanExpress) {
+  constexpr uint64_t kMaxOffset = 0xfffffff8;
+  const auto accepted = [](uint32_t vectors, int bar, uint64_t table, uint64_t pending) {
+    return rocjitsu::plan_interrupts({.kind = simdojo::InterruptKind::MsiX,
+                                      .vectors = vectors,
+                                      .table_bar = bar,
+                                      .table_offset = table,
+                                      .pending_offset = pending})
+        .supported;
+  };
+
+  EXPECT_TRUE(accepted(2048, 5, kMaxOffset, kMaxOffset)) << "every field at its ceiling";
+  EXPECT_TRUE(accepted(1, 0, 8, 16));
+
+  EXPECT_FALSE(accepted(2049, 0, 0, 8)) << "one more vector than eleven bits can say";
+  EXPECT_FALSE(accepted(1, 6, 0, 8)) << "a BAR index past the six a function has";
+  EXPECT_FALSE(accepted(1, -1, 0, 8)) << "a negative BAR index would wrap into another BAR";
+  EXPECT_FALSE(accepted(1, 0, 4, 8)) << "an offset that is not a whole number of units";
+  EXPECT_FALSE(accepted(1, 0, 0, 12)) << "likewise for the pending bits";
+  EXPECT_FALSE(accepted(1, 0, kMaxOffset + 8, 8)) << "one unit past what the field holds";
+  // Both ceilings, not just the table's: the two are separate disjuncts, and a
+  // slip duplicating one of them would leave the other unchecked.
+  EXPECT_FALSE(accepted(1, 0, 8, kMaxOffset + 8)) << "likewise for the pending bits";
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
@@ -30,15 +30,20 @@
 extern "C" {
 #include <libvfio-user.h>
 }
+
+#include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <bit>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -291,12 +296,18 @@ TEST(VfioDeviceHostLifecycle, StopsServingAfterASharedMemoryClientDisconnects) {
     // What the guest actually sees, rather than what the device asked for. The
     // capability only reaches it if vfu_setup_device_nr_irqs() ran for the kind
     // the plan chose, and nothing else covers that path: the device-side tests
-    // stop at interrupts() and plan_interrupts().
+    // stop at interrupts() and plan_interrupts(). The device advertises
+    // messages now, so the pin it used to offer must be gone as well -- a guest
+    // that finds both would be free to choose the one this device cannot raise.
+    uint32_t msix_vectors = 0;
+    ASSERT_TRUE(client.irq_info(VFIO_PCI_MSIX_IRQ_INDEX, msix_vectors));
+    EXPECT_EQ(msix_vectors, 1u)
+        << "the guest is offered no message vector, so its driver's pci_alloc_irq_vectors() "
+           "fails and the probe fails with it";
+
     uint32_t intx_vectors = 0;
     ASSERT_TRUE(client.irq_info(VFIO_PCI_INTX_IRQ_INDEX, intx_vectors));
-    EXPECT_EQ(intx_vectors, 1u)
-        << "the guest is offered no legacy pin, so its driver's pci_alloc_irq_vectors() fails "
-           "and the probe fails with it";
+    EXPECT_EQ(intx_vectors, 0u) << "the legacy pin outlived the switch to messages";
   }
 
   // No stop is requested: the disconnect alone must end serving.
@@ -333,6 +344,192 @@ TEST(VfioDeviceHostLifecycle, BuildsTheSmallestBusShapeTheDeviceAccepts) {
 
   rocjitsu::VfioDeviceHost host(socket_path, gpu);
   EXPECT_TRUE(host.build()) << "and to the transport, or the two disagree";
+  host.detach();
+  std::filesystem::remove(socket_path);
+}
+
+/// @brief A minimal MSI-X device that raises on demand.
+///
+/// @details The GPU device has nothing that triggers an interrupt yet -- that
+/// is a later commit -- so the delivery path is exercised through a device
+/// whose only job is to raise one. It advertises the same capability the GPU
+/// does, so the transport sets up the same way.
+class RaisingDevice : public simdojo::PciDevice {
+public:
+  RaisingDevice() : simdojo::PciDevice("raiser", kTestId) {}
+
+  [[nodiscard]] std::vector<simdojo::BarSpec> bars() const override {
+    simdojo::BarSpec msix;
+    msix.index = 0;
+    msix.size = 8 * 1024;
+    msix.mem = true;
+    return {msix};
+  }
+
+  [[nodiscard]] simdojo::InterruptSpec interrupts() const override {
+    return {.kind = simdojo::InterruptKind::MsiX,
+            .vectors = 1,
+            .table_bar = 0,
+            .table_offset = 0,
+            .pending_offset = 4 * 1024};
+  }
+
+  [[nodiscard]] int64_t bar_access(int, std::span<std::byte> buf, uint64_t, bool write) override {
+    if (!write) {
+      std::ranges::fill(buf, std::byte{0});
+    }
+    return static_cast<int64_t>(buf.size());
+  }
+
+  void dma_map(const simdojo::DmaRegion &) override {}
+  void dma_unmap(const simdojo::DmaRegion &) override {}
+  void reset(simdojo::ResetKind) override {}
+
+  /// @brief Raise vector zero, as an interrupt source eventually will.
+  [[nodiscard]] bool raise() { return irq_ != nullptr && irq_->trigger(0); }
+};
+
+// The capability bytes only say the device *can* be signalled. This checks that
+// it actually is: the client arms a vector with an eventfd, the device raises,
+// and the descriptor the client handed over is what moves. Without it the test
+// above still passes if vfu_setup_device_nr_irqs() and VfioDeviceHost::trigger()
+// stop being connected to each other.
+TEST(VfioDeviceHostLifecycle, DeliversAMessageToTheVectorTheClientArmed) {
+  const std::string socket_path =
+      std::format("/tmp/rj-vfu-test-raise-{}.sock", static_cast<int>(::getpid()));
+  std::filesystem::remove(socket_path);
+
+  RaisingDevice device;
+  rocjitsu::VfioDeviceHost host(socket_path, device);
+  ASSERT_TRUE(host.build());
+  std::jthread serving([&host](std::stop_token stop) { (void)host.run(stop); });
+
+  rocjitsu::test::VfioUserClient client;
+  bool attached = false;
+  for (int attempt = 0; attempt < 200 && !attached; ++attempt) {
+    attached = client.connect(socket_path);
+    if (!attached) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+  ASSERT_TRUE(attached);
+
+  const int signalled = ::eventfd(0, EFD_NONBLOCK);
+  ASSERT_GE(signalled, 0);
+  ASSERT_TRUE(client.arm_irq(VFIO_PCI_MSIX_IRQ_INDEX, signalled))
+      << "the server refused to arm the vector, so nothing could be delivered";
+
+  ASSERT_TRUE(device.raise());
+
+  uint64_t count = 0;
+  bool delivered = false;
+  for (int attempt = 0; attempt < 200 && !delivered; ++attempt) {
+    delivered = ::read(signalled, &count, sizeof(count)) == sizeof(count);
+    if (!delivered) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+  EXPECT_TRUE(delivered) << "the device raised and the client's eventfd never moved";
+  EXPECT_EQ(count, 1u);
+
+  ::close(signalled);
+  serving.request_stop();
+  serving.join();
+  host.detach();
+  std::filesystem::remove(socket_path);
+}
+
+// The message capability is three little-endian dwords and every field in it is
+// packed: the vector count is stored one less than it is, and the two offsets
+// are stored in units of eight bytes with the BAR index tucked into the three
+// bits below them. Nothing downstream rejects a bad packing -- a guest simply
+// looks for its table at whatever address comes out -- so the encoding is
+// checked here rather than by booting one and reading dmesg.
+TEST(VfioDeviceHostLifecycle, EncodesTheMessageCapabilityAGuestCanFollow) {
+  const std::string socket_path =
+      std::format("/tmp/rj-vfu-test-msix-{}.sock", static_cast<int>(::getpid()));
+  std::filesystem::remove(socket_path);
+
+  rocjitsu::config::KfdDeviceConfig identity;
+  identity.gfx_target_version = 120500;
+  identity.local_mem_size = 64 * 1024 * 1024;
+  rocjitsu::GpuPciDevice gpu("msix", rocjitsu::gpu_pci_spec_from_config(identity, {}), nullptr);
+  ASSERT_TRUE(gpu.usable());
+
+  rocjitsu::VfioDeviceHost host(socket_path, gpu);
+  ASSERT_TRUE(host.build());
+  std::jthread serving([&host](std::stop_token stop) { (void)host.run(stop); });
+  rocjitsu::test::VfioUserClient client;
+  bool attached = false;
+  for (int attempt = 0; attempt < 200 && !attached; ++attempt) {
+    attached = client.connect(socket_path);
+    if (!attached) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+  ASSERT_TRUE(attached);
+
+  // A failed read throws rather than recording a non-fatal expectation: these
+  // return a value, so ASSERT_ is unavailable here, and continuing would walk
+  // the capability list through zeros and report a wrong pointer rather than
+  // the read that never happened.
+  const auto read_byte = [&client](uint64_t at) {
+    std::array<std::byte, 1> one{};
+    if (!client.region_read(VFU_PCI_DEV_CFG_REGION_IDX, at, one)) {
+      throw std::runtime_error(std::format("cannot read config byte at {:#x}", at));
+    }
+    return std::to_integer<uint8_t>(one[0]);
+  };
+  const auto read_dword = [&client](uint64_t at) {
+    std::array<std::byte, 4> four{};
+    if (!client.region_read(VFU_PCI_DEV_CFG_REGION_IDX, at, four)) {
+      throw std::runtime_error(std::format("cannot read config dword at {:#x}", at));
+    }
+    return std::bit_cast<uint32_t>(four);
+  };
+
+  // A capability added after the device is realized still writes itself and
+  // still writes the pointer at 0x34; the one thing left clear is this bit, and
+  // a guest reads it before it reads the pointer. So this, rather than finding
+  // the capability, is what says the ordering in build() held.
+  std::array<std::byte, 2> status{};
+  ASSERT_TRUE(client.region_read(VFU_PCI_DEV_CFG_REGION_IDX, 0x06, status));
+  ASSERT_NE(std::bit_cast<uint16_t>(status) & 0x10u, 0u)
+      << "the capability list is not advertised, so a guest never walks it";
+
+  // The point of the whole capability is to avoid a pin, whose delivery costs
+  // the guest every BAR mapping it holds. Nothing else asserts what actually
+  // reaches configuration space.
+  EXPECT_EQ(read_byte(0x3d), 0u)
+      << "a pin as well would put the client's mmap-disabling path back in reach";
+
+  // Walk the capability list the way a guest does, from the pointer at 0x34.
+  uint64_t at = read_byte(0x34);
+  uint64_t found = 0;
+  for (int hop = 0; hop < 48 && at >= 0x40; ++hop) {
+    if (read_byte(at) == PCI_CAP_ID_MSIX) {
+      found = at;
+      break;
+    }
+    at = read_byte(at + 1);
+  }
+  ASSERT_NE(found, 0u) << "no message capability is published for a guest to find";
+
+  const auto control = static_cast<uint16_t>(read_dword(found) >> 16);
+  const uint32_t table = read_dword(found + 4);
+  const uint32_t pending = read_dword(found + 8);
+
+  EXPECT_EQ((control & 0x7ffu) + 1, rocjitsu::GpuPciDevice::kMsixVectors)
+      << "the table size is stored one less than the count";
+  EXPECT_EQ(table & 0x7u, static_cast<uint32_t>(rocjitsu::GpuPciDevice::kMsixBar));
+  EXPECT_EQ(table & ~0x7u, rocjitsu::GpuPciDevice::kMsixTableOffset);
+  EXPECT_EQ(pending & 0x7u, static_cast<uint32_t>(rocjitsu::GpuPciDevice::kMsixBar));
+  EXPECT_EQ(pending & ~0x7u, rocjitsu::GpuPciDevice::kMsixPendingOffset);
+
+  serving.request_stop();
+  if (serving.joinable()) {
+    serving.join();
+  }
   host.detach();
   std::filesystem::remove(socket_path);
 }

--- a/emulation/rocjitsu/tests/vmm/vfio_user_client.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_user_client.cpp
@@ -234,6 +234,22 @@ bool VfioUserClient::irq_info(uint32_t index, uint32_t &count) {
   return true;
 }
 
+bool VfioUserClient::arm_irq(uint32_t index, int fd) {
+  // The wire struct ends in a flexible array, which C++ will not let us nest or
+  // instantiate, so the payload is built as bytes. One vector needs one
+  // descriptor, and it rides in the message's control data rather than here.
+  std::vector<std::byte> payload(sizeof(vfio_irq_set));
+  auto *set = reinterpret_cast<vfio_irq_set *>(payload.data());
+  set->argsz = static_cast<uint32_t>(payload.size());
+  set->flags = VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER;
+  set->index = index;
+  set->start = 0;
+  set->count = 1;
+
+  std::vector<std::byte> reply;
+  return request(VFIO_USER_DEVICE_SET_IRQS, payload, fd, reply);
+}
+
 bool VfioUserClient::region_info(uint32_t region, uint64_t &size, uint32_t &flags) {
   vfio_region_info request_body{};
   request_body.argsz = sizeof(request_body);

--- a/emulation/rocjitsu/tests/vmm/vfio_user_client.h
+++ b/emulation/rocjitsu/tests/vmm/vfio_user_client.h
@@ -48,6 +48,14 @@ public:
   /// @retval false The server refused the request.
   [[nodiscard]] bool irq_info(uint32_t index, uint32_t &count);
 
+  /// @brief Arm one vector of @p index to signal @p fd.
+  /// @details The descriptor travels with the message, which is the only way
+  /// the server can signal a client it shares no memory with.
+  /// @param[in] index VFIO interrupt index, e.g. VFIO_PCI_MSIX_IRQ_INDEX.
+  /// @param[in] fd Eventfd the server should write to when it triggers.
+  /// @retval false The server refused the request.
+  [[nodiscard]] bool arm_irq(uint32_t index, int fd);
+
   /// @brief Read the size and flags of one region.
   /// @param[in] region Region index.
   /// @param[out] size Region size in bytes.


### PR DESCRIPTION
A legacy pin is enough to get a driver to keep the device, but it cannot be what finally raises an interrupt. A client of this transport disables every mmap of every BAR while a legacy interrupt is pending and restores them only after a quiet period, and this device's largest BAR is the memory aperture the guest maps precisely to avoid trapping. Raising pins at the rate an interrupt ring produces them would cost the guest its direct view of memory for as long as they kept arriving, and would look like the memory path collapsing rather than like anything to do with interrupts.

Advertise message-signalled interrupts instead. These are configured through a table in the device's own memory, so the device chooses where that table lives and the transport reports the choice; it gets a trapped BAR of its own, because a client reads the pending bits back out of the device even though it services the table itself. Every field of the capability is packed -- a count stored one less than it is, offsets in units of eight bytes with the BAR index below them -- and nothing downstream rejects a bad packing, so what a device may declare is checked where it can be tested rather than discovered by booting a guest.