### PR TITLE
rocjitsu: Learn where the driver put its interrupt ring

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
@@ -146,6 +146,65 @@ constexpr HubInvalidationLayout kHubInvalidationLayouts[] = {
     {IpHardwareId::MmHub, 4, 1, 0x0575, 0x0587, 0x0599},
 };
 
+/// @brief The interrupt ring's registers within OSSSYS, in dwords.
+///
+/// @details `regIH_RB_{CNTL,RPTR,WPTR,BASE,BASE_HI,WPTR_ADDR_HI,WPTR_ADDR_LO}`
+/// and `regIH_DOORBELL_RPTR` of `osssys_7_1_0_offset.h`, all `_BASE_IDX 0`.
+/// The last matters more than it looks: the ring is created with doorbells
+/// unconditionally on, so the driver acknowledges entries by writing a doorbell
+/// rather than the read-pointer register. The driver programs them in
+/// `ih_v7_0_enable_ring` and reads the pointers back on every interrupt, so
+/// they are ordinary storage rather than answers fixed at reset.
+constexpr uint32_t kIhRingControl = 0x0080;
+constexpr uint32_t kIhRingReadPointer = 0x0081;
+constexpr uint32_t kIhRingWritePointer = 0x0082;
+constexpr uint32_t kIhRingBase = 0x0083;
+constexpr uint32_t kIhRingBaseHigh = 0x0084;
+constexpr uint32_t kIhRingWritePointerAddressHigh = 0x0085;
+constexpr uint32_t kIhRingWritePointerAddressLow = 0x0086;
+constexpr uint32_t kIhRingDoorbell = 0x0087;
+
+/// @brief Bits the driver shifts the ring's address down by before writing it.
+///
+/// @details The base register holds bits 39:8, so the low eight are implied
+/// zero and the ring is at least 256-byte aligned. The address itself does not
+/// stop at 39: the high register below continues it from bit 40, and the two
+/// together carry 48 bits.
+constexpr unsigned kIhRingBaseShift = 8;
+
+/// @brief Address bit at which the high half of the base register continues.
+constexpr unsigned kIhRingBaseHighShift = 40;
+
+/// @brief Bits of the write-pointer address carried by its high register.
+constexpr uint64_t kIhWritePointerAddressHighMask = 0xffff;
+
+/// @brief Bit selecting the ring within the control register.
+constexpr uint32_t kIhRingEnableMask = 1U << 0;
+
+/// @brief Bit asking for an interrupt per entry.
+constexpr uint32_t kIhRingInterruptEnableMask = 1U << 17;
+
+/// @brief Where the size field sits within the control register.
+///
+/// @details The driver stores the base-two logarithm of the ring's size in
+/// dwords, so a size of `4 << field` bytes.
+constexpr unsigned kIhRingSizeShift = 1;
+
+/// @brief Its width, once shifted down: the field mask is `0x3e`.
+constexpr uint32_t kIhRingSizeMask = 0x1f;
+
+/// @brief Where the address-space field sits within the control register.
+constexpr unsigned kIhRingSpaceShift = 28;
+
+/// @brief Its width, once shifted down: the field mask is `0x70000000`.
+constexpr uint32_t kIhRingSpaceMask = 0x7;
+
+/// @brief Bits of the ring's base carried by its high register.
+///
+/// @details Narrower than the register's own field, which is seventeen bits,
+/// because the driver only ever writes eight of them.
+constexpr uint64_t kIhRingBaseHighMask = 0xff;
+
 /// @brief Acknowledge value reporting every VMID's flush already complete.
 ///
 /// @details The driver polls for `1 << vmid` and this device has no translation
@@ -459,6 +518,33 @@ void GpuPciDevice::reset_registers() {
       flushes_answerable_ = false;
     }
   }
+
+  // The interrupt ring's registers answer as plain storage: the driver writes
+  // where it put the ring and reads its own pointers back, so anything the
+  // device invented here would be a fact the driver did not state.
+  ih_control_offset_.reset();
+  if (const IpBlock *osssys = published_block(IpHardwareId::OssSys);
+      osssys != nullptr && segment_within_aperture(osssys->register_bases.front())) {
+    const uint64_t segment = osssys->register_bases.front();
+    for (const uint32_t reg :
+         {kIhRingControl, kIhRingReadPointer, kIhRingWritePointer, kIhRingBase, kIhRingBaseHigh,
+          kIhRingWritePointerAddressHigh, kIhRingWritePointerAddressLow, kIhRingDoorbell}) {
+      const uint64_t at = (segment + reg) * 4;
+      if (at + 4 <= spec_.register_aperture_bytes) {
+        define_register(at, 0);
+      }
+    }
+    // Recorded only when the dword it names was actually modelled. Recording it
+    // for a control register that fell outside the aperture would have every
+    // later read of it answer out of an index this device never defined.
+    const uint64_t control_at = (segment + kIhRingControl) * 4;
+    if (control_at + 4 <= spec_.register_aperture_bytes) {
+      ih_control_offset_ = control_at;
+    }
+    // Cleared with the registers it describes: a reset discards what the driver
+    // said, so the next programming has to be reported as freshly as the first.
+    announced_interrupt_ring_ = false;
+  }
 }
 
 const IpBlock *GpuPciDevice::published_block(IpHardwareId id) const {
@@ -468,6 +554,98 @@ const IpBlock *GpuPciDevice::published_block(IpHardwareId id) const {
     }
   }
   return nullptr;
+}
+
+bool GpuPciDevice::segment_within_aperture(uint64_t segment) const {
+  // Checked at the one place a segment becomes an address rather than by each
+  // caller: every one turns it into `(segment + register) * 4`, and a large
+  // enough segment wraps that multiply into a small address that passes an
+  // aperture bounds test and lands on an unrelated register.
+  //
+  // A segment equal to the aperture's dword count already names the dword one
+  // past the end, so this is not a `>`.
+  if (segment >= spec_.register_aperture_bytes / 4) {
+    util::Logger::warn(
+        std::format("{}: the block at segment {:#x} is not within a {}-byte register aperture, "
+                    "so its registers cannot be answered",
+                    name(), segment, spec_.register_aperture_bytes));
+    return false;
+  }
+  return true;
+}
+
+std::string GpuPciDevice::describe(const InterruptRing &ring) {
+  // Initialised to the fallback and switched without a default: a fourth space
+  // added later is a compiler warning here, while a value cast in from outside
+  // the enumerators still renders as something rather than as a null pointer.
+  const char *space = "an unstated address space";
+  switch (ring.space) {
+  case InterruptRingSpace::BusAddress:
+    space = "a bus address";
+    break;
+  case InterruptRingSpace::GpuVirtual:
+    space = "a translated address";
+    break;
+  case InterruptRingSpace::Unset:
+    space = "an unstated address space";
+    break;
+  }
+  // Whether it was switched on is part of the state, not a detail: a sized and
+  // addressed ring that the driver never enabled is a different situation from
+  // a running one, and reading the two the same way sends whoever is
+  // diagnosing a silent guest looking in the wrong place.
+  return std::format("its interrupt ring at {:#x}, {} bytes, {}, publishing its write pointer to "
+                     "{:#x}; it {} an interrupt per entry, and it is {}",
+                     ring.base, ring.bytes, space, ring.wptr_address,
+                     ring.raises_messages ? "asks for" : "does not ask for",
+                     ring.enabled ? "enabled" : "not yet enabled");
+}
+
+GpuPciDevice::InterruptRing GpuPciDevice::interrupt_ring() const {
+  InterruptRing ring;
+  const IpBlock *osssys = published_block(IpHardwareId::OssSys);
+  if (osssys == nullptr || !segment_within_aperture(osssys->register_bases.front())) {
+    return ring;
+  }
+  const auto value = [this, base = osssys->register_bases.front()](uint32_t reg) -> uint32_t {
+    const uint64_t at = (base + reg) * 4;
+    if (at + 4 > spec_.register_aperture_bytes) {
+      return 0;
+    }
+    return registers_[static_cast<uint32_t>(at / 4)];
+  };
+
+  ring.base =
+      (static_cast<uint64_t>(value(kIhRingBase)) << kIhRingBaseShift) |
+      (static_cast<uint64_t>(value(kIhRingBaseHigh) & kIhRingBaseHighMask) << kIhRingBaseHighShift);
+  ring.wptr_address = static_cast<uint64_t>(value(kIhRingWritePointerAddressLow)) |
+                      ((static_cast<uint64_t>(value(kIhRingWritePointerAddressHigh)) &
+                        kIhWritePointerAddressHighMask)
+                       << 32);
+
+  const uint32_t control = value(kIhRingControl);
+  ring.enabled = (control & kIhRingEnableMask) != 0;
+  ring.raises_messages = (control & kIhRingInterruptEnableMask) != 0;
+  // The field beside them saying what the addresses above are addresses in.
+  // Anything the driver has not written yet reads as zero, which is neither of
+  // the two values it uses and is reported as such rather than guessed at.
+  switch ((control >> kIhRingSpaceShift) & kIhRingSpaceMask) {
+  case static_cast<uint32_t>(InterruptRingSpace::BusAddress):
+    ring.space = InterruptRingSpace::BusAddress;
+    break;
+  case static_cast<uint32_t>(InterruptRingSpace::GpuVirtual):
+    ring.space = InterruptRingSpace::GpuVirtual;
+    break;
+  default:
+    ring.space = InterruptRingSpace::Unset;
+    break;
+  }
+  // The field is the logarithm of the size in dwords, so the size is four bytes
+  // shifted up by it. A ring the driver has not sized yet reads as zero rather
+  // than as the four bytes that shift would otherwise imply.
+  const uint32_t size_log = (control >> kIhRingSizeShift) & kIhRingSizeMask;
+  ring.bytes = size_log == 0 ? 0 : uint64_t{4} << size_log;
+  return ring;
 }
 
 bool GpuPciDevice::define_invalidation_engines(uint64_t segment,
@@ -481,16 +659,6 @@ bool GpuPciDevice::define_invalidation_engines(uint64_t segment,
         std::format("{}: {} invalidation engines do not fit between the semaphore, request and "
                     "acknowledge blocks of the hub at register segment {:#x} (byte {:#x})",
                     name(), kInvalidationEngines, segment, segment * 4));
-    return false;
-  }
-  // The segment comes from a published table, so it is checked rather than
-  // trusted: a large enough one would wrap the byte address and land the
-  // register somewhere unrelated inside the aperture.
-  if (segment > spec_.register_aperture_bytes / 4) {
-    util::Logger::warn(
-        std::format("{}: the hub at register segment {:#x} (byte {:#x}) is not within a {}-byte "
-                    "register aperture",
-                    name(), segment, segment * 4, spec_.register_aperture_bytes));
     return false;
   }
 
@@ -601,6 +769,28 @@ int64_t GpuPciDevice::access_registers(std::span<std::byte> buf, uint64_t offset
       uint32_t value = 0;
       std::memcpy(&value, buf.data(), sizeof(value));
       registers_[index] = value;
+      // Switching the interrupt ring on is the moment the device learns where
+      // to deliver, and it is worth saying once rather than being read back
+      // later: a reset clears these registers, so anything asked afterwards
+      // finds a device that was never told.
+      if (ih_control_offset_ && offset == *ih_control_offset_ && (value & kIhRingEnableMask) != 0 &&
+          !announced_interrupt_ring_) {
+        announced_interrupt_ring_ = true;
+        const InterruptRing ring = interrupt_ring();
+        util::Logger::warn(std::format("{}: the driver enabled {}", name(), describe(ring)));
+        // An address the device cannot translate is worth saying plainly now
+        // rather than leaving for whoever wonders why no interrupt arrived.
+        if (ring.space == InterruptRingSpace::GpuVirtual) {
+          util::Logger::warn(
+              std::format("{}: that ring is behind translation tables this device does not walk, "
+                          "so it cannot be reached; the driver places it there whenever firmware "
+                          "is loaded through the security processor",
+                          name()));
+        } else if (ring.space != InterruptRingSpace::BusAddress) {
+          util::Logger::warn(std::format(
+              "{}: that ring names no address space, so where it is cannot be acted on", name()));
+        }
+      }
     }
     return 4;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -166,6 +166,75 @@ public:
   void dma_unmap(const simdojo::DmaRegion &region) override;
   void reset(simdojo::ResetKind kind) override;
 
+  /// @brief Which address space an interrupt ring's addresses are in.
+  ///
+  /// @details The driver puts this in the same register as the ring's size and
+  /// its enable bit, and it decides what the addresses beside it *mean*. It
+  /// follows how firmware is loaded: a driver loading firmware through the
+  /// security processor allocates the ring through the translation tables and
+  /// programs virtual addresses, and every other way of loading gets a bus
+  /// address. So identical register values denote different memory depending on
+  /// a module parameter, and an address used in the wrong space does not fail --
+  /// it points somewhere real and wrong.
+  enum class InterruptRingSpace : uint8_t {
+    /// @brief Not one of the two values the driver writes; in practice, a ring
+    /// it has not programmed yet.
+    Unset = 0,
+    BusAddress = 2, ///< Guest physical, reachable through a shared window.
+    GpuVirtual = 4  ///< Behind translation tables this device does not walk.
+  };
+
+  /// @brief The interrupt ring as the driver has programmed it so far.
+  ///
+  /// @details The ring is the device's side of the interrupt path: the device
+  /// writes an entry into it, publishes a write pointer, and raises a message.
+  /// All of that needs to know where the driver put the ring, which the driver
+  /// says only by writing these registers -- so this is read back out of them
+  /// rather than tracked as they are written, because the driver writes them in
+  /// its own order and rewrites them on reset.
+  struct InterruptRing {
+    /// @brief Address of the ring in @ref space, or zero if it is not set.
+    uint64_t base = 0;
+    uint64_t bytes = 0;        ///< Its size, decoded from the size field.
+    uint64_t wptr_address = 0; ///< Where the device publishes the write pointer.
+    /// @brief What @ref base and @ref wptr_address are addresses in.
+    InterruptRingSpace space = InterruptRingSpace::Unset;
+    bool enabled = false;         ///< Whether the driver has switched the ring on.
+    bool raises_messages = false; ///< Whether it wants an interrupt per entry.
+
+    /// @brief Whether the driver has said anything at all about the ring.
+    ///
+    /// @details Every field, rather than the address and the enable bit alone:
+    /// a driver that sized a ring and named a write-pointer address but had not
+    /// switched it on yet has said a great deal, and reporting that as nothing
+    /// programmed would hide exactly the partial state worth seeing. These read
+    /// back as their defaults only while the registers are untouched.
+    /// @retval false Every field still holds what a reset left.
+    [[nodiscard]] bool programmed() const {
+      return base != 0 || bytes != 0 || wptr_address != 0 || space != InterruptRingSpace::Unset ||
+             enabled || raises_messages;
+    }
+  };
+
+  /// @brief Read the interrupt ring out of the registers the driver wrote.
+  ///
+  /// @details Reads register state without a lock of its own, so it must be
+  /// called either from the thread servicing register access or after that
+  /// thread has been joined.
+  ///
+  /// @returns What the driver has said about the ring so far.
+  [[nodiscard]] InterruptRing interrupt_ring() const;
+
+  /// @brief Render a ring for a diagnostic.
+  ///
+  /// @details A sentence fragment beginning "its interrupt ring at ...", meant
+  /// to follow a subject and verb naming who did what -- "the driver enabled",
+  /// "the driver left". Logged on its own it reads as though it lost a word.
+  ///
+  /// @param[in] ring The ring to describe.
+  /// @returns Where it is, how big, and in which address space.
+  [[nodiscard]] static std::string describe(const InterruptRing &ring);
+
   /// @brief Whether the device is usable.
   /// @retval false The configuration was rejected or its memory could not be
   ///               backed; the reason has been logged and it must not be served.
@@ -213,6 +282,13 @@ private:
   /// @details Returns instance 0. The version matters as much as the segment:
   /// register offsets within a block move between versions of it.
   [[nodiscard]] const IpBlock *published_block(IpHardwareId id) const;
+
+  /// @brief Whether a published segment can be turned into a byte address.
+  /// @details One place rather than each caller: every caller computes
+  /// `(segment + register) * 4`, which a large enough segment wraps into a
+  /// small address that would pass a bounds test and land on an unrelated
+  /// register.
+  [[nodiscard]] bool segment_within_aperture(uint64_t segment) const;
 
   /// @brief Whether every named hub's flush handshakes can be answered.
   bool flushes_answerable_ = false;
@@ -269,6 +345,14 @@ private:
 
   /// @brief Which of the modelled registers ignore writes.
   std::vector<bool> read_only_;
+
+  /// @brief Byte offset of the interrupt ring's control register, or nothing
+  /// when the published table names no block that has one. Not zero for that:
+  /// byte zero is the indirect window's own index register.
+  std::optional<uint64_t> ih_control_offset_;
+
+  /// @brief Whether the ring being switched on has already been reported.
+  bool announced_interrupt_ring_ = false;
   int vram_fd_ = -1;
   std::byte *vram_ = nullptr;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
@@ -118,6 +118,19 @@ int run_vfio_server(const std::string &config_path, const std::string &socket_pa
   }
   pthread_sigmask(SIG_SETMASK, &previous_signals, nullptr);
 
+  // What the driver said about its interrupt ring. Reported next to the
+  // unmodelled registers because it answers the same question -- how far the
+  // driver got before it stopped telling us anything -- and because the ring is
+  // the one thing the device now knows that it cannot yet act on.
+  const GpuPciDevice::InterruptRing ring = device.interrupt_ring();
+  // Only when there is something to say. A reset or a disconnect clears these
+  // registers, so a guest that detached cleanly has already taken the ring with
+  // it, and warning about its absence would make an ordinary shutdown look like
+  // a fault. What the driver said while attached is reported when it says it.
+  if (ring.programmed()) {
+    util::Logger::warn(std::format("vfu: the driver left {}", GpuPciDevice::describe(ring)));
+  }
+
   const std::string report = trace.unmodeled_report();
   if (!report.empty()) {
     util::Logger::warn(report);

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -14,6 +14,7 @@
 #include <bit>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 
 namespace {
 
@@ -133,6 +134,124 @@ TEST_F(GpuDevice, KeepsGrantingTheInvalidationSemaphoreAfterItIsReleased) {
 
   EXPECT_EQ(read_register_at(kMmHubSemaphore17) & 0x1u, 0x1u)
       << "releasing the semaphore latched it low, so the next flush would stall";
+}
+
+// The driver says where it put the interrupt ring only by writing these
+// registers, and it says it in pieces: the address arrives shifted down by
+// eight across two registers, the size as the logarithm of a dword count, and
+// the write-pointer address split across two more. Reading that back wrongly
+// would point the device at the wrong guest memory, which is indistinguishable
+// from the driver never being interrupted.
+//   OSSSYS segment 0x10a0, all _BASE_IDX 0, so byte offset (0x10a0 + reg) * 4:
+//     IH_RB_CNTL 0x0080 -> 0x4480      IH_RB_BASE 0x0083 -> 0x448c
+//     IH_RB_BASE_HI 0x0084 -> 0x4490   WPTR_ADDR_HI 0x0085 -> 0x4494
+//     WPTR_ADDR_LO 0x0086 -> 0x4498
+TEST_F(GpuDevice, ReadsBackTheInterruptRingTheDriverProgrammed) {
+  ASSERT_TRUE(device_.usable());
+  EXPECT_EQ(device_.interrupt_ring().base, 0u) << "nothing has been programmed yet";
+  EXPECT_FALSE(device_.interrupt_ring().enabled);
+
+  // A ring at 0x1234_5678_9A00 of 256 KiB, its write pointer at 0xABCD_1000,
+  // switched on and asking for an interrupt per entry. 256 KiB is 65536 dwords,
+  // so the size field is 16.
+  constexpr uint64_t kRingBase = 0x123456789a00;
+  // Above four gigabytes on purpose: a guest with that much memory routinely
+  // puts the write pointer there, and a 32-bit value would leave the high half
+  // of the decode unproven -- deleting it entirely would still pass.
+  constexpr uint64_t kWptrAddress = 0x5abcd1000;
+  write_register_at(0x448c, static_cast<uint32_t>(kRingBase >> 8));
+  write_register_at(0x4490, static_cast<uint32_t>(kRingBase >> 40) & 0xff);
+  write_register_at(0x4498, static_cast<uint32_t>(kWptrAddress));
+  write_register_at(0x4494, static_cast<uint32_t>(kWptrAddress >> 32) & 0xffff);
+  // Size 16, enabled, interrupt per entry, and the address-space field saying
+  // these are bus addresses (2 at bit 28).
+  write_register_at(0x4480, (16u << 1) | (1u << 0) | (1u << 17) | (2u << 28));
+
+  const rocjitsu::GpuPciDevice::InterruptRing ring = device_.interrupt_ring();
+  EXPECT_EQ(ring.base, kRingBase);
+  EXPECT_EQ(ring.wptr_address, kWptrAddress);
+  EXPECT_EQ(ring.bytes, 256u * 1024) << "the size field is a logarithm of a dword count";
+  EXPECT_TRUE(ring.enabled);
+  EXPECT_TRUE(ring.raises_messages);
+  EXPECT_EQ(ring.space, rocjitsu::GpuPciDevice::InterruptRingSpace::BusAddress);
+
+  // The same registers with the space the driver uses when it loads firmware
+  // through the security processor: the addresses are then translated, and
+  // acting on them as if they were bus addresses would write somewhere real
+  // and wrong.
+  write_register_at(0x4480, (16u << 1) | (1u << 0) | (1u << 17) | (4u << 28));
+  EXPECT_EQ(device_.interrupt_ring().space, rocjitsu::GpuPciDevice::InterruptRingSpace::GpuVirtual);
+}
+
+// programmed() is what decides whether the shutdown diagnostic says anything,
+// so the states it must recognise are the partial ones: a driver that sized a
+// ring, or named a write-pointer address, and then stopped has said a great
+// deal, and reporting that as nothing programmed hides exactly the state worth
+// seeing. The test above jumps from reset defaults straight to a fully enabled
+// ring and would not notice any of these being dropped.
+TEST_F(GpuDevice, ReportsAPartiallyProgrammedInterruptRingAsProgrammed) {
+  ASSERT_TRUE(device_.usable());
+  ASSERT_FALSE(device_.interrupt_ring().programmed()) << "a reset ring has said nothing";
+
+  // Each of these on its own, from reset, with the base and the enable bit
+  // still clear -- the two fields a narrower predicate would have keyed on.
+  struct Case {
+    const char *what;
+    uint64_t reg;
+    uint32_t value;
+  };
+  for (const Case &partial :
+       {Case{"a size alone", 0x4480, 16u << 1}, Case{"an address space alone", 0x4480, 2u << 28},
+        Case{"a request for messages alone", 0x4480, 1u << 17},
+        Case{"a write-pointer address alone", 0x4498, 0xabcd1000u}}) {
+    device_.reset(simdojo::ResetKind::FunctionLevel);
+    ASSERT_FALSE(device_.interrupt_ring().programmed()) << "reset did not clear the ring";
+
+    write_register_at(partial.reg, partial.value);
+    const rocjitsu::GpuPciDevice::InterruptRing ring = device_.interrupt_ring();
+    EXPECT_TRUE(ring.programmed()) << partial.what << " was reported as nothing programmed";
+    EXPECT_EQ(ring.base, 0u) << partial.what;
+    EXPECT_FALSE(ring.enabled) << partial.what;
+  }
+
+  // And back to nothing, so the diagnostic does not keep reporting a ring the
+  // guest has already taken away.
+  device_.reset(simdojo::ResetKind::FunctionLevel);
+  EXPECT_FALSE(device_.interrupt_ring().programmed());
+}
+
+// A segment that wraps when turned into a byte address would otherwise pass an
+// aperture bounds test and land on an unrelated register -- the ring's control
+// dword resolving on top of something the driver depends on.
+TEST(GpuDeviceFlushes, RefusesASegmentThatWrapsIntoTheAperture) {
+  rocjitsu::config::KfdDeviceConfig device;
+  device.gfx_target_version = kModelledTarget;
+  device.local_mem_size = 8ULL * 1024 * 1024 * 1024;
+
+  rocjitsu::GpuPciDeviceSpec spec = rocjitsu::gpu_pci_spec_from_config(device, {});
+  for (rocjitsu::IpBlock &block : spec.discovery.blocks) {
+    if (block.hardware_id == rocjitsu::IpHardwareId::OssSys) {
+      block.register_bases.front() = std::numeric_limits<uint64_t>::max() - 0x7f;
+    }
+  }
+
+  rocjitsu::RegisterSymbols symbols;
+  rocjitsu::BarAccessTrace trace(symbols);
+  rocjitsu::GpuPciDevice wrapped("wrapped", spec, &trace);
+  ASSERT_TRUE(wrapped.usable()) << "the hubs are untouched, so the device still comes up";
+
+  // This segment puts the ring's control dword at byte zero: the control
+  // register sits 0x80 dwords into the block, and 0x80 past this base is
+  // exactly 2^64. Unchecked, the multiply lands it inside the aperture and the
+  // device both defines it there and reads the ring back out of it.
+  std::array<std::byte, 4> raw{};
+  const auto enabled = std::bit_cast<std::array<std::byte, 4>>(uint32_t{1});
+  ASSERT_EQ(wrapped.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw, 0, /*write=*/false), 4);
+  raw = enabled;
+  (void)wrapped.bar_access(rocjitsu::GpuPciDevice::kRegisterBar, raw, 0, /*write=*/true);
+
+  EXPECT_FALSE(wrapped.interrupt_ring().programmed())
+      << "a wrapped segment resolved the ring's control register onto byte zero";
 }
 
 // The HDP flush is a write to a hole the bus reserves rather than to any block's


### PR DESCRIPTION
The device cannot deliver an interrupt until it knows where to deliver it, and the driver says that only by writing registers: the ring's address arrives shifted down by eight and split across two of them, its size as the logarithm of a count of dwords, and the address the write pointer is published to across two more. None of that was modelled, so every word of it was dropped and the device had nothing to act on.

Answer those registers as plain storage and read the ring back out of them, rather than tracking it as they are written, because the driver writes them in its own order and rewrites them after a reset. Read the address-space field beside them too, since it decides what the addresses mean: a driver loading firmware through the security processor places the ring behind its translation tables, and acting on such an address as though it were a bus address would not fail but would write somewhere real and wrong. Say once, when the ring is switched on, what was learned -- at that moment rather than later, because a reset clears the registers and anything asked afterwards would find a device that was never told. A guest now reports a 256 KiB ring at a bus address, which is the size and the space the driver asks for.