### PR TITLE
rocjitsu: Deliver an interrupt the guest driver receives

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.cpp
@@ -13,6 +13,9 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <bit>
 #include <cerrno>
 #include <cstring>
 #include <format>
@@ -204,6 +207,40 @@ constexpr uint32_t kIhRingSpaceMask = 0x7;
 /// @details Narrower than the register's own field, which is seventeen bits,
 /// because the driver only ever writes eight of them.
 constexpr uint64_t kIhRingBaseHighMask = 0xff;
+
+/// @brief Dwords one interrupt entry occupies, and the bytes that comes to.
+///
+/// @details The driver advances its read pointer by this much per entry and
+/// decodes exactly this many dwords, so an entry of any other size would put
+/// every later entry at an offset it does not look at.
+constexpr uint32_t kInterruptEntryDwords = 8;
+constexpr uint32_t kInterruptEntryBytes = kInterruptEntryDwords * 4;
+
+/// @brief Bits of the write-pointer register that carry the offset.
+///
+/// @details `IH_RB_WPTR__OFFSET_MASK`. The offset occupies bits 17:2; bits 1:0
+/// are the overflow flag, so the register does not carry the low two bits of an
+/// address at all. Anything above the field is not part of one either.
+constexpr uint32_t kIhWritePointerOffsetMask = 0x0003fffc;
+
+/// @brief Largest ring whose every entry the write-pointer register can name.
+///
+/// @details The offset field is sixteen bits wide, so it addresses exactly one
+/// 256 KiB ring. A larger one would have entries the device could never point
+/// at, and worse, the device would wrap at the field width while the driver
+/// wrapped at the ring size -- the two would disagree about which entry a
+/// pointer names, and the driver would decode the never-written remainder as
+/// entries. The size field is five bits and guest-writable, so it can ask for
+/// far more than this.
+constexpr uint64_t kLargestAddressableRingBytes =
+    (uint64_t{kIhWritePointerOffsetMask} & ~uint64_t{kInterruptEntryBytes - 1}) +
+    kInterruptEntryBytes;
+
+/// @brief The message vector an entry is announced on.
+///
+/// @details The device advertises one, so this is it. A second would need the
+/// capability to advertise it before anything could be delivered on it.
+constexpr uint32_t kInterruptVector = 0;
 
 /// @brief Acknowledge value reporting every VMID's flush already complete.
 ///
@@ -572,6 +609,101 @@ bool GpuPciDevice::segment_within_aperture(uint64_t segment) const {
     return false;
   }
   return true;
+}
+
+bool GpuPciDevice::deliver_interrupt(const InterruptEntry &entry) {
+  const IpBlock *osssys = published_block(IpHardwareId::OssSys);
+  if (osssys == nullptr || !segment_within_aperture(osssys->register_bases.front())) {
+    return false;
+  }
+  const uint64_t wptr_register = (osssys->register_bases.front() + kIhRingWritePointer) * 4;
+  if (wptr_register + 4 > spec_.register_aperture_bytes) {
+    return false;
+  }
+
+  const InterruptRing ring = interrupt_ring();
+  if (!ring.enabled || ring.bytes < kInterruptEntryBytes ||
+      ring.bytes > kLargestAddressableRingBytes) {
+    return false;
+  }
+  // An address in a space this device cannot resolve would be written to
+  // whatever guest page happens to sit at that number. That is worse than
+  // declining: the driver would carry on waiting while memory it owns was
+  // quietly changed underneath it.
+  if (ring.space != InterruptRingSpace::BusAddress) {
+    return false;
+  }
+  if (dma_ == nullptr || irq_ == nullptr) {
+    return false;
+  }
+
+  // Publishing to nowhere is not publishing: the driver reads the pointer from
+  // memory, so a ring switched on before that address was given has no way to
+  // be told anything, and guest-physical zero is a real page to write over.
+  //
+  // The ring's own base is the same question and the same answer. A driver may
+  // set the enable bit before it has written the base -- the registers are
+  // separate and it writes them in its own order -- and zero there means unset,
+  // not "the ring is at address zero". Writing entries into guest-physical zero
+  // would corrupt whatever the guest keeps in its first page.
+  if (ring.base == 0 || ring.wptr_address == 0) {
+    return false;
+  }
+
+  // The pointers are byte offsets into the ring and wrap with it. Taking the
+  // current one from the register rather than from a member keeps the device's
+  // idea of it and the driver's the same object rather than two that drift --
+  // every driver-side re-init writes this register back to zero.
+  //
+  // It is a *guest-writable* register, though, and this is where its value
+  // becomes an address. So it is put through the field mask the hardware
+  // defines and then aligned down to an entry, because the driver's own write-
+  // and read-pointer shadows sit immediately after the ring: an entry placed
+  // at an unaligned offset would run off the end and overwrite exactly the two
+  // words the interrupt protocol depends on.
+  const uint64_t stated =
+      registers_[static_cast<uint32_t>(wptr_register / 4)] & kIhWritePointerOffsetMask;
+  const auto at =
+      static_cast<uint32_t>((stated & ~uint64_t{kInterruptEntryBytes - 1}) % ring.bytes);
+
+  std::array<uint32_t, kInterruptEntryDwords> words = {};
+  words[0] = static_cast<uint32_t>(entry.client_id) | (static_cast<uint32_t>(entry.source_id) << 8);
+  words[4] = entry.data[0];
+  words[5] = entry.data[1];
+  words[6] = entry.data[2];
+  words[7] = entry.data[3];
+
+  std::array<std::byte, kInterruptEntryBytes> raw = {};
+  std::memcpy(raw.data(), words.data(), raw.size());
+  if (!dma_->write(ring.base + at, raw)) {
+    return false;
+  }
+
+  // Only now is there something to point at. Publishing the pointer first would
+  // invite the driver to read an entry that is not yet there -- the driver orders
+  // its read of the ring against its read of this pointer with a barrier, so the
+  // device owes it the matching store order.
+  //
+  // That order is DmaEngine::write()'s to keep, not this function's: it returns
+  // only once the bytes are guest-visible, and writes become visible in the order
+  // they return. A fence here would not have been enough anyway, since it cannot
+  // order stores an implementation has only queued.
+  const auto next = static_cast<uint32_t>((uint64_t{at} + kInterruptEntryBytes) % ring.bytes);
+  const auto published = std::bit_cast<std::array<std::byte, sizeof(uint32_t)>>(next);
+  if (!dma_->write(ring.wptr_address, published)) {
+    return false;
+  }
+  define_register(wptr_register, next);
+
+  // The ring can be switched on while messages for it are switched off, in
+  // which case entries accumulate and the driver finds them when it next looks.
+  // The driver moves the two bits together, so this is a state it never asks
+  // for -- but the field is decoded, and decoding a field and then ignoring it
+  // is how a model starts disagreeing with itself.
+  if (!ring.raises_messages) {
+    return true;
+  }
+  return irq_->trigger(kInterruptVector);
 }
 
 std::string GpuPciDevice::describe(const InterruptRing &ring) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/pci/gpu_pci_device.h
@@ -19,6 +19,7 @@
 #include "simdojo/components/pci_device.h"
 #include "simdojo/components/register_file.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -224,6 +225,47 @@ public:
   ///
   /// @returns What the driver has said about the ring so far.
   [[nodiscard]] InterruptRing interrupt_ring() const;
+
+  /// @brief One interrupt, as the ring carries it.
+  ///
+  /// @details The driver looks up a handler by the pair of identifiers and
+  /// passes the rest to it. Everything else an entry can carry -- timestamps,
+  /// process and node identifiers -- describes work this device does not run,
+  /// so it is left zero rather than invented.
+  struct InterruptEntry {
+    uint8_t client_id = 0;             ///< Which block is reporting.
+    uint8_t source_id = 0;             ///< What it is reporting.
+    std::array<uint32_t, 4> data = {}; ///< Whatever that source attaches.
+  };
+
+  /// @brief Put one entry in the interrupt ring and raise the message for it.
+  ///
+  /// @details The whole delivery, because the parts are only meaningful
+  /// together: an entry the driver never sees, a write pointer naming an entry
+  /// that is not there, or a message with nothing behind it are each worse than
+  /// doing nothing. The write pointer is published into guest memory as well as
+  /// into its register, because the driver reads it from memory; it reads the
+  /// register only when the pointer it read says an overflow happened.
+  ///
+  /// **Nothing tracks how much of the ring the driver has consumed.** The
+  /// driver acknowledges entries by writing a doorbell, which this device
+  /// records and does not read, so a ring filled faster than it is drained
+  /// overwrites entries the driver has not seen, and reports no overflow. That
+  /// is survivable only while deliveries are occasional; anything raising
+  /// interrupts at a rate needs the read pointer followed first.
+  ///
+  /// Must be called from the thread servicing register access, or with that
+  /// thread stopped: it reads registers and reaches guest memory through the
+  /// transport, neither of which it locks.
+  ///
+  /// @param[in] entry What to report.
+  /// @retval false Nothing was delivered, or not all of it was. A ring that is
+  ///               unusable is declined before anything is written; a failure
+  ///               to publish the pointer leaves an entry nobody is pointed at,
+  ///               which the next delivery overwrites; a message the transport
+  ///               would not take leaves the entry and the pointer in place,
+  ///               for the next delivery's message to cover.
+  [[nodiscard]] bool deliver_interrupt(const InterruptEntry &entry);
 
   /// @brief Render a ring for a diagnostic.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.cpp
@@ -33,9 +33,11 @@ extern "C" {
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cerrno>
 #include <cstring>
 #include <format>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -43,7 +45,12 @@ namespace rocjitsu {
 namespace {
 
 /// @brief Longest a serving thread waits for socket activity before rechecking
-/// its stop token. Nothing observes this delay except shutdown latency.
+/// its stop token.
+///
+/// @details Two things wait on it, not one: shutdown, and any work handed over
+/// by ask_serving_thread(), which the serving thread only picks up when this
+/// poll returns. Raising it lengthens both, so a request that looks instant
+/// from the caller can sit here for the whole interval.
 constexpr int kPollTimeoutMs = 100;
 
 /// @brief Bytes one message-table entry occupies: two address words, a data
@@ -54,7 +61,6 @@ constexpr uint64_t kMsixEntryBytes = 16;
 /// of 64 bits rather than a byte per vector.
 constexpr uint64_t kMsixPendingWordBytes = 8;
 
-/// @brief Most scatter-gather entries one guest memory transfer may span.
 /// @brief Scatter-gather entries a transfer is attempted with before the
 /// library is asked how many it actually needs.
 constexpr std::size_t kInitialSgEntries = 8;
@@ -201,6 +207,30 @@ VfioDeviceHost::~VfioDeviceHost() {
 void VfioDeviceHost::detach() {
   device_.set_irq_sink(nullptr);
   device_.set_dma_engine(nullptr);
+}
+
+bool VfioDeviceHost::ask_serving_thread(std::function<void()> work) {
+  // Refused here rather than thrown there. An empty target reaches the serving
+  // thread as a bad_function_call, which is reported as work that failed --
+  // indistinguishable from work that ran and could not be done -- and it
+  // occupies the single slot while doing nothing at all.
+  if (!work) {
+    return false;
+  }
+  const std::lock_guard lock(asked_mutex_);
+  // One slot, and a refusal rather than a drop. The serving thread can be parked
+  // reading from a stalled client while requests keep arriving, so something has
+  // to give; telling the caller lets it decide, where silently discarding the
+  // 65th of a backlog only looked like it had a policy.
+  // Outstanding means accepted but not yet FINISHED, not merely not yet picked
+  // up. Freeing the slot the moment the serving thread takes the work would let
+  // a second request be accepted while the first is still running, which is not
+  // the one-at-a-time contract this promises.
+  if (asked_.has_value() || asked_running_) {
+    return false;
+  }
+  asked_ = std::move(work);
+  return true;
 }
 
 bool VfioDeviceHost::build() {
@@ -367,6 +397,33 @@ VfioDeviceHost::ServeResult VfioDeviceHost::run(std::stop_token stop_token) {
       return ServeResult::Failed;
     }
 
+    // Anything another thread handed over runs here, on the serving thread and
+    // between protocol messages, so it sees the device the way a callback does.
+    // Drained before the wait rather than after it, which bounds the delay at
+    // one poll timeout rather than leaving a request until the next message.
+    std::optional<std::function<void()>> asked;
+    {
+      const std::lock_guard asked_lock(asked_mutex_);
+      asked.swap(asked_);
+      asked_running_ = asked.has_value();
+    }
+    if (asked.has_value()) {
+      const std::lock_guard lock(vfu_mutex_);
+      // The request runs on this thread, so an exception escaping it would take
+      // the process down rather than the request. Report and carry on serving:
+      // a faulty request is not a reason to drop the guest's device.
+      try {
+        (*asked)();
+      } catch (const std::exception &error) {
+        util::Logger::warn(
+            std::format("vfu: a request for the serving thread failed: {}", error.what()));
+      } catch (...) {
+        util::Logger::warn("vfu: a request for the serving thread failed");
+      }
+      const std::lock_guard asked_lock(asked_mutex_);
+      asked_running_ = false;
+    }
+
     pollfd wait = {.fd = poll_fd, .events = POLLIN, .revents = 0};
     const int ready = poll(&wait, 1, kPollTimeoutMs);
     if (ready < 0 && errno != EINTR) {
@@ -522,8 +579,17 @@ bool VfioDeviceHost::read(uint64_t guest_phys, std::span<std::byte> dst) {
 
 bool VfioDeviceHost::write(uint64_t guest_phys, std::span<const std::byte> src) {
   // vfu_sgl_write does not modify the source, but takes it as void*.
-  return copy_guest_memory(guest_phys, const_cast<std::byte *>(src.data()), src.size(),
-                           /*to_guest=*/true);
+  if (!copy_guest_memory(guest_phys, const_cast<std::byte *>(src.data()), src.size(),
+                         /*to_guest=*/true)) {
+    return false;
+  }
+  // DmaEngine::write() promises the bytes are guest-visible on return, and that
+  // writes become visible in the order they return. The copy above lands in
+  // memory the guest has mapped, so completeness is already met; this is what
+  // makes the ORDER hold, and it belongs here because this is the code that owns
+  // the transfer -- a caller cannot order stores on its behalf.
+  std::atomic_thread_fence(std::memory_order_release);
+  return true;
 }
 
 bool VfioDeviceHost::copy_guest_memory(uint64_t guest_phys, void *data, std::size_t length,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_device_host.h
@@ -56,10 +56,13 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <stop_token>
 #include <string>
+#include <vector>
 
 struct vfu_ctx;
 struct dma_sg;
@@ -111,6 +114,40 @@ public:
   /// @brief Device this host serves, for the protocol callbacks to dispatch to.
   [[nodiscard]] simdojo::PciDevice &device() { return device_; }
 
+  /// @brief Ask for @p work to run on the serving thread, one request at a time.
+  ///
+  /// @details The device is otherwise touched only by protocol callbacks, which
+  /// all arrive on the serving thread. A thread that wants to make the device
+  /// act on its own -- to raise an interrupt for something the guest did not
+  /// ask for -- hands the work here rather than reaching into the device, so
+  /// that invariant holds rather than being widened to a second thread.
+  ///
+  /// Deliberately not "run it under the transport's lock". That lock is held
+  /// across protocol dispatch, which can block reading from a stalled client,
+  /// so waiting for it would let one guest make the caller unresponsive -- and
+  /// the caller here is the thread that handles shutdown signals.
+  ///
+  /// This is deliberately NOT a general work queue, and should not become one
+  /// without the semantics a producer of completions or faults would need. What
+  /// it promises is only what the one-shot request it exists for needs:
+  /// - **At most one request is outstanding**, where outstanding means accepted
+  ///   but not yet finished -- not merely not yet picked up. A second while one
+  ///   is outstanding is REFUSED, so a caller is told rather than having its work
+  ///   silently dropped.
+  /// - **Latency is bounded by one transport poll**, because the serving thread
+  ///   drains before it waits. It is not immediate, and there is no wake-up: a
+  ///   caller needing promptness needs a different mechanism.
+  /// - **@p work must not throw.** It runs on the serving thread, so an escaping
+  ///   exception would terminate the process; this catches and reports instead,
+  ///   which keeps a faulty request from taking the device down but does NOT
+  ///   make throwing a supported way to report failure.
+  /// - **It may never run.** If serving stops first the request is discarded.
+  ///
+  /// @param[in] work What the serving thread should do.
+  /// @retval true The request was accepted and will run, unless serving stops.
+  /// @retval false A request is already outstanding; @p work was not taken.
+  [[nodiscard]] bool ask_serving_thread(std::function<void()> work);
+
   /// @brief Record a guest memory window the client registered.
   /// @param[in] region The window, as the transport reported it.
   /// @retval true The window was not already known, so the device should be told.
@@ -149,6 +186,16 @@ private:
   simdojo::PciDevice &device_;
 
   std::recursive_mutex vfu_mutex_;
+
+  /// @brief The single outstanding request, and the lock guarding it.
+  ///
+  /// @details Its own lock rather than @ref vfu_mutex_, so handing work over
+  /// never waits on protocol dispatch. One slot rather than a queue: see
+  /// ask_serving_thread() for why this is not a general work queue.
+  std::mutex asked_mutex_;
+  std::optional<std::function<void()>> asked_;
+  /// @brief Set while the serving thread is running a request it already took.
+  bool asked_running_ = false;
   vfu_ctx *ctx_ = nullptr;
   bool attached_ = false;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.cpp
@@ -25,10 +25,53 @@
 namespace rocjitsu {
 namespace {
 
-/// @brief How often the waiting thread rechecks for a shutdown signal.
+/// @brief Consume any pending handled signal, then put the old mask back.
+///
+/// @details Restoring the mask with one of these still queued kills the
+/// process: terminating is the default disposition for the request signal as
+/// well as the shutdown ones. Every path that unmasks has to drain first, which
+/// is why this is a function rather than a sequence written out at each of
+/// them.
+/// @param[in] handled The signals this server blocked.
+/// @param[in] previous The mask to restore.
+void drain_and_restore(const sigset_t &handled, const sigset_t &previous) {
+  while (true) {
+    const timespec no_wait{.tv_sec = 0, .tv_nsec = 0};
+    if (sigtimedwait(&handled, nullptr, &no_wait) < 0) {
+      break;
+    }
+  }
+  pthread_sigmask(SIG_SETMASK, &previous, nullptr);
+}
+
+/// @brief How often the waiting thread rechecks for a signal.
 constexpr long kSignalPollNanoseconds = 100'000'000;
 
+/// @brief What a requested interrupt reports itself as.
+///
+/// @details This device runs no work, so it has nothing of its own to report
+/// and no block it could honestly attribute an interrupt to. What is wanted is
+/// an identifier the driver accepts as well formed and then finds no handler
+/// for, so the entry exercises its dispatch rather than its malformed-entry
+/// path while naming no hardware that did anything. Anything at or above the
+/// client count is rejected as invalid, and of the values below it this is one
+/// that no block registers a source for -- not because the architecture
+/// reserves it on this generation, but because nothing here claims it. It will
+/// stop being inert the day something does.
+constexpr uint8_t kRequestedInterruptClient = 0x1a;
+constexpr uint8_t kRequestedInterruptSource = 0x00;
+
 } // namespace
+
+ServerSignalAction action_for_signal(int signal) {
+  if (signal == SIGINT || signal == SIGTERM) {
+    return ServerSignalAction::Stop;
+  }
+  if (signal == SIGUSR1) {
+    return ServerSignalAction::DeliverInterrupt;
+  }
+  return ServerSignalAction::KeepServing;
+}
 
 int run_vfio_server(const std::string &config_path, const std::string &socket_path) {
   config::DeviceIdentityConfig identity;
@@ -52,13 +95,24 @@ int run_vfio_server(const std::string &config_path, const std::string &socket_pa
   // Shutdown signals are blocked and then consumed synchronously, the way the
   // daemon does it. Almost nothing is safe to touch from a signal handler, least
   // of all the synchronization a stop request runs through.
-  sigset_t shutdown_signals;
-  sigemptyset(&shutdown_signals);
-  sigaddset(&shutdown_signals, SIGINT);
-  sigaddset(&shutdown_signals, SIGTERM);
+  //
+  // POSIX rather than std, deliberately and not for want of looking: C++ offers
+  // no per-thread signal mask and no synchronous signal wait. std::signal gives
+  // only an async handler, which is the thing being avoided here, and sigprocmask
+  // is unspecified in a process with threads -- which this one has, since serving
+  // runs on its own. pthread_sigmask is the correct call, and <csignal> declares
+  // it; it does not need <pthread.h>.
+  sigset_t handled_signals;
+  sigemptyset(&handled_signals);
+  sigaddset(&handled_signals, SIGINT);
+  sigaddset(&handled_signals, SIGTERM);
+  // Delivering an interrupt on request is a bring-up affordance, not a model of
+  // anything: the device has no event source yet, so the only way to show that
+  // the interrupt path works end to end is for something outside to ask.
+  sigaddset(&handled_signals, SIGUSR1);
   sigset_t previous_signals;
-  if (pthread_sigmask(SIG_BLOCK, &shutdown_signals, &previous_signals) != 0) {
-    util::Logger::warn("vfu: cannot block shutdown signals");
+  if (pthread_sigmask(SIG_BLOCK, &handled_signals, &previous_signals) != 0) {
+    util::Logger::warn("vfu: cannot block the signals this server waits on");
     return 1;
   }
 
@@ -66,7 +120,10 @@ int run_vfio_server(const std::string &config_path, const std::string &socket_pa
   {
     VfioDeviceHost host(socket_path, device);
     if (!host.build()) {
-      pthread_sigmask(SIG_SETMASK, &previous_signals, nullptr);
+      // Drained on this path too: a request signal queued while the mask was on
+      // is still pending, and unmasking with one outstanding kills the process
+      // on the way out of a failure it has already reported.
+      drain_and_restore(handled_signals, previous_signals);
       return 1;
     }
 
@@ -86,9 +143,37 @@ int run_vfio_server(const std::string &config_path, const std::string &socket_pa
     // healthy process in front of a dead socket.
     while (!serving_finished.load()) {
       const timespec timeout{.tv_sec = 0, .tv_nsec = kSignalPollNanoseconds};
-      const int signal = sigtimedwait(&shutdown_signals, nullptr, &timeout);
-      if (signal == SIGINT || signal == SIGTERM) {
+      const int signal = sigtimedwait(&handled_signals, nullptr, &timeout);
+      const ServerSignalAction action = action_for_signal(signal);
+      if (action == ServerSignalAction::Stop) {
         break;
+      }
+      if (action == ServerSignalAction::DeliverInterrupt) {
+        // Handed to the serving thread rather than done here: that thread is
+        // otherwise the only one that touches the device, and waiting on its
+        // lock would let a stalled client make this loop miss a shutdown.
+        // Refused when one is still outstanding: the serving thread has not run
+        // the previous request yet, so a second would only queue behind work that
+        // is itself waiting on a client. Say so rather than appearing to comply.
+        const bool accepted = host.ask_serving_thread([&device] {
+          if (device.deliver_interrupt({.client_id = kRequestedInterruptClient,
+                                        .source_id = kRequestedInterruptSource})) {
+            // The entry is in the ring either way; whether a message went with
+            // it is the driver's choice, and saying otherwise would misreport a
+            // silent ring as a delivered interrupt.
+            util::Logger::warn(device.interrupt_ring().raises_messages
+                                   ? "vfu: delivered an interrupt on request"
+                                   : "vfu: put an entry in the ring on request, with messages "
+                                     "switched off by the driver");
+          } else {
+            util::Logger::warn(std::format("vfu: cannot deliver an interrupt: {}",
+                                           GpuPciDevice::describe(device.interrupt_ring())));
+          }
+        });
+        if (!accepted) {
+          util::Logger::warn("vfu: an interrupt request is already pending; ignoring this one");
+        }
+        continue;
       }
       if (signal < 0 && errno != EAGAIN && errno != EINTR) {
         util::Logger::warn("vfu: failed while waiting for a shutdown signal");
@@ -107,16 +192,7 @@ int run_vfio_server(const std::string &config_path, const std::string &socket_pa
     }
   }
 
-  // Drain anything that arrived while shutting down. Restoring the previous mask
-  // with a shutdown signal still pending would kill the process on the way out
-  // of an otherwise orderly stop.
-  while (true) {
-    const timespec no_wait{.tv_sec = 0, .tv_nsec = 0};
-    if (sigtimedwait(&shutdown_signals, nullptr, &no_wait) < 0) {
-      break;
-    }
-  }
-  pthread_sigmask(SIG_SETMASK, &previous_signals, nullptr);
+  drain_and_restore(handled_signals, previous_signals);
 
   // What the driver said about its interrupt ring. Reported next to the
   // unmodelled registers because it answers the same question -- how far the

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vmm/vfu/vfio_server.h
@@ -14,6 +14,22 @@
 
 namespace rocjitsu {
 
+/// @brief What the serving loop does about a signal it woke on.
+enum class ServerSignalAction {
+  KeepServing,      ///< Nothing arrived, or nothing this server acts on.
+  Stop,             ///< Shut down and exit.
+  DeliverInterrupt, ///< Ask the device to put an entry in its interrupt ring.
+};
+
+/// @brief Map a signal the server waits on to what it should do about it.
+/// @details Exposed because the loop that consumes it needs a process, a socket
+/// and a connected client before it runs a single line, so nothing that tests
+/// the loop tests only this. A signal routed to the wrong arm, or an arm
+/// deleted, is otherwise invisible.
+/// @param[in] signal Signal number, or negative when the wait timed out.
+/// @returns What the loop should do next.
+[[nodiscard]] ServerSignalAction action_for_signal(int signal);
+
 /// @brief Serve a PCI function on @p socket_path until the process is signalled.
 /// @param[in] config_path Simulation config describing the GPU to present.
 /// @param[in] socket_path Filesystem path of the AF_UNIX socket to listen on.

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/pci_device.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/pci_device.h
@@ -206,8 +206,19 @@ public:
   /// @brief Write @p src to guest memory at @p guest_phys.
   /// @param[in] guest_phys Guest-physical destination address.
   /// @param[in] src Source bytes; their size is the transfer length.
-  /// @retval true The full range was written.
+  /// @retval true The full range was written AND is visible to the guest.
   /// @retval false The access failed or fell outside a mapped window.
+  /// @details Writes are ORDERED AND COMPLETE on return. A true result means the
+  /// bytes are guest-visible, not merely accepted for later transfer, and two
+  /// writes that return in order become visible to the guest in that order.
+  ///
+  /// This is part of the contract rather than something a caller can arrange,
+  /// because a caller cannot: publishing a ring entry and then its write pointer
+  /// is only safe if the entry is already visible when the pointer write starts,
+  /// and no fence a caller issues can order stores an implementation has merely
+  /// queued. A driver reads the pointer and the entry with a barrier between
+  /// them, so an implementation that buffers has to flush here to hold up its
+  /// side -- an implementation that cannot must fail rather than return true.
   [[nodiscard]] virtual bool write(uint64_t guest_phys, std::span<const std::byte> src) = 0;
 };
 

--- a/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
+++ b/emulation/rocjitsu/tests/pci/gpu_pci_device_test.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 
 namespace {
 
@@ -252,6 +253,272 @@ TEST(GpuDeviceFlushes, RefusesASegmentThatWrapsIntoTheAperture) {
 
   EXPECT_FALSE(wrapped.interrupt_ring().programmed())
       << "a wrapped segment resolved the ring's control register onto byte zero";
+}
+
+/// @brief Guest memory and an interrupt line, recorded rather than delivered.
+class RecordingTransport : public simdojo::DmaEngine, public simdojo::IrqSink {
+public:
+  [[nodiscard]] bool read(uint64_t guest_phys, std::span<std::byte> dst) override {
+    for (std::size_t i = 0; i < dst.size(); ++i) {
+      const auto found = memory.find(guest_phys + i);
+      dst[i] = found == memory.end() ? std::byte{0} : found->second;
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool write(uint64_t guest_phys, std::span<const std::byte> src) override {
+    if (refuse_writes || writes_before_refusing == 0) {
+      return false;
+    }
+    if (writes_before_refusing > 0) {
+      --writes_before_refusing;
+    }
+    writes.emplace_back(guest_phys, src.size());
+    for (std::size_t i = 0; i < src.size(); ++i) {
+      memory[guest_phys + i] = src[i];
+    }
+    return true;
+  }
+
+  [[nodiscard]] bool trigger(uint32_t vector) override {
+    triggered.push_back(vector);
+    return !refuse_trigger;
+  }
+
+  [[nodiscard]] uint32_t dword_at(uint64_t guest_phys) {
+    std::array<std::byte, 4> raw{};
+    (void)read(guest_phys, raw);
+    return std::bit_cast<uint32_t>(raw);
+  }
+
+  std::map<uint64_t, std::byte> memory;
+  /// @brief Every write, as address and length, so a transfer that overran can
+  /// be told apart from a legitimate one to the address it overran into.
+  std::vector<std::pair<uint64_t, std::size_t>> writes;
+  std::vector<uint32_t> triggered;
+  bool refuse_writes = false;
+  bool refuse_trigger = false;
+  /// @brief Writes to accept before refusing, or negative for no limit.
+  int writes_before_refusing = -1;
+};
+
+// Delivering an interrupt is three things that mean nothing apart: the entry
+// goes into the ring, the write pointer is published so the driver knows it is
+// there, and the message is raised so the driver looks. The driver reads that
+// pointer out of *guest memory* rather than out of the register, so publishing
+// it only to the register would leave the driver waiting forever.
+class GpuDeviceDelivery : public GpuDevice {
+protected:
+  static constexpr uint64_t kRingBase = 0x900000000;
+  static constexpr uint64_t kWptrAddress = 0x900001000;
+  static constexpr uint64_t kRingBytes = 4096;
+  static constexpr uint64_t kInterruptEntryBytes = 32;
+
+  RecordingTransport transport_;
+
+  void SetUp() override {
+    ASSERT_TRUE(device_.usable());
+    device_.set_dma_engine(&transport_);
+    device_.set_irq_sink(&transport_);
+    // A 4 KiB ring above the 32-bit boundary, its write pointer published just
+    // past it, switched on and at a bus address. 4 KiB is 1024 dwords, so the
+    // size field is 10.
+    write_register_at(0x448c, static_cast<uint32_t>(kRingBase >> 8));
+    write_register_at(0x4490, static_cast<uint32_t>(kRingBase >> 40) & 0xff);
+    write_register_at(0x4498, static_cast<uint32_t>(kWptrAddress));
+    write_register_at(0x4494, static_cast<uint32_t>(kWptrAddress >> 32) & 0xffff);
+    write_register_at(0x4480, (10u << 1) | (1u << 0) | (1u << 17) | (2u << 28));
+  }
+
+  void TearDown() override {
+    device_.set_dma_engine(nullptr);
+    device_.set_irq_sink(nullptr);
+  }
+};
+
+TEST_F(GpuDeviceDelivery, PutsTheEntryInTheRingThenPointsAtItThenRaises) {
+  ASSERT_TRUE(device_.deliver_interrupt({.client_id = 0x12, .source_id = 0x34, .data = {0xaaaa}}));
+
+  // The two identifiers the driver looks a handler up by share the first dword.
+  EXPECT_EQ(transport_.dword_at(kRingBase) & 0xffff, 0x3412u);
+  EXPECT_EQ(transport_.dword_at(kRingBase + 16), 0xaaaau) << "the source's own data";
+  // Everything describing work this device does not run stays zero.
+  EXPECT_EQ(transport_.dword_at(kRingBase + 4), 0u) << "timestamp";
+  EXPECT_EQ(transport_.dword_at(kRingBase + 12), 0u) << "process and node";
+
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 32u)
+      << "the driver reads the write pointer from memory, not from the register";
+  ASSERT_EQ(transport_.triggered.size(), 1u);
+  EXPECT_EQ(transport_.triggered[0], 0u) << "the one vector the device advertises";
+}
+
+// The write pointer says where the next entry goes, so an entry must land at
+// it. A device that always wrote to the start of the ring would pass every
+// other test here.
+TEST_F(GpuDeviceDelivery, PlacesEachEntryAtTheCurrentWritePointer) {
+  ASSERT_TRUE(device_.deliver_interrupt({.client_id = 1, .source_id = 1}));
+  ASSERT_TRUE(device_.deliver_interrupt({.client_id = 2, .source_id = 2}));
+
+  EXPECT_EQ(transport_.dword_at(kRingBase) & 0xffff, 0x0101u) << "the first entry stays put";
+  EXPECT_EQ(transport_.dword_at(kRingBase + 32) & 0xffff, 0x0202u)
+      << "the second follows it rather than overwriting it";
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 64u);
+  EXPECT_EQ(read_register_at(0x4488), 64u) << "the register shadows the published pointer";
+}
+
+// The write pointer is a register the guest can write, and this is where its
+// value becomes an address. The driver's own pointer shadows sit immediately
+// after the ring, so an entry placed at an unaligned offset would run off the
+// end and overwrite exactly the words the interrupt protocol depends on.
+TEST_F(GpuDeviceDelivery, NeverWritesPastTheRingHoweverTheGuestSetsThePointer) {
+  for (const uint32_t hostile : {static_cast<uint32_t>(kRingBytes - 1),
+                                 static_cast<uint32_t>(kRingBytes - 4), 0xffffffffu, 0x7u}) {
+    // All three, so a failure names the pointer that actually caused it rather
+    // than re-reporting an earlier iteration's write against this one's value.
+    transport_.memory.clear();
+    transport_.writes.clear();
+    transport_.triggered.clear();
+    write_register_at(0x4488, hostile);
+
+    ASSERT_TRUE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}))
+        << "pointer " << hostile;
+
+    // Checked per write rather than by highest address touched: the driver puts
+    // its pointer shadows immediately after the ring, so an entry that overran
+    // would land on exactly the address the pointer is legitimately published
+    // to, and the two are indistinguishable by address alone.
+    for (const auto &[address, length] : transport_.writes) {
+      if (length != kInterruptEntryBytes) {
+        continue;
+      }
+      EXPECT_LE(address + length, kRingBase + kRingBytes)
+          << "an entry written at " << std::hex << address << " with the pointer set to " << hostile
+          << " runs past the ring, onto the driver's own pointer shadows";
+    }
+  }
+}
+
+TEST_F(GpuDeviceDelivery, WrapsTheWritePointerAtTheEndOfTheRing) {
+  constexpr std::size_t kEntries = kRingBytes / 32;
+  for (std::size_t i = 0; i < kEntries; ++i) {
+    ASSERT_TRUE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+  }
+
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 0u) << "a filled ring wraps to its start";
+  EXPECT_EQ(transport_.triggered.size(), kEntries);
+}
+
+// Nothing partial: a delivery that cannot finish must not leave a pointer
+// naming an entry that was never written, which the driver would decode out of
+// whatever the ring happened to contain.
+// The registers are separate and the driver writes them in whatever order it
+// likes, so a ring can be switched on before its base has been given. Zero
+// there means unset, not "the ring is at address zero" -- delivering anyway
+// would write entries over whatever the guest keeps in its first page.
+TEST_F(GpuDeviceDelivery, DeclinesARingEnabledBeforeItsBaseWasProgrammed) {
+  write_register_at(0x448c, 0);
+  write_register_at(0x4490, 0);
+  ASSERT_EQ(device_.interrupt_ring().base, 0u) << "the base must be unset for this to prove it";
+  ASSERT_TRUE(device_.interrupt_ring().enabled) << "and the ring still switched on";
+
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 0x12, .source_id = 0x34, .data = {0xaaaa}}));
+  EXPECT_TRUE(transport_.writes.empty()) << "an entry was written into guest-physical zero";
+  EXPECT_TRUE(transport_.triggered.empty()) << "a message was raised for an entry never written";
+}
+
+TEST_F(GpuDeviceDelivery, PublishesNothingWhenGuestMemoryCannotBeReached) {
+  transport_.refuse_writes = true;
+
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  EXPECT_TRUE(transport_.triggered.empty()) << "a message with nothing behind it";
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 0u);
+}
+
+// Publishing the pointer is the second of two writes. If it fails, the entry is
+// already in the ring -- harmless, since nothing points at it -- but the message
+// must not go out, or the driver would read a pointer that never moved.
+TEST_F(GpuDeviceDelivery, RaisesNothingWhenThePointerCannotBePublished) {
+  transport_.writes_before_refusing = 1;
+
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  EXPECT_TRUE(transport_.triggered.empty());
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 0u) << "the pointer never moved";
+  EXPECT_NE(transport_.dword_at(kRingBase), 0u)
+      << "the entry stays in the ring with nothing pointing at it, to be overwritten";
+}
+
+// The third outcome the contract describes: everything is published and only
+// the message fails. The entry and the pointer must stay, so the next message
+// covers them -- rolling them back would lose an entry the driver may already
+// have seen.
+TEST_F(GpuDeviceDelivery, LeavesTheEntryPublishedWhenTheMessageIsRefused) {
+  transport_.refuse_trigger = true;
+
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 32u) << "the pointer stays advanced";
+  EXPECT_NE(transport_.dword_at(kRingBase), 0u) << "and the entry stays in the ring";
+}
+
+// A ring may be switched on with messages switched off, in which case entries
+// accumulate for the driver to find when it next looks. The device decodes that
+// field, so it has to act on it.
+TEST_F(GpuDeviceDelivery, FillsTheRingWithoutRaisingWhenMessagesAreOff) {
+  write_register_at(0x4480, (10u << 1) | (1u << 0) | (2u << 28));
+
+  EXPECT_TRUE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  EXPECT_NE(transport_.dword_at(kRingBase), 0u) << "the entry is written";
+  EXPECT_EQ(transport_.dword_at(kWptrAddress), 32u) << "and pointed at";
+  EXPECT_TRUE(transport_.triggered.empty()) << "but no message goes out";
+}
+
+// A ring the driver has not switched on, one whose addresses are in a space
+// this device cannot resolve, one too small to hold an entry, or one with
+// nowhere to publish its pointer, is declined rather than written to: such an
+// address still names a real guest page and would quietly corrupt it.
+TEST_F(GpuDeviceDelivery, DeclinesARingItCannotSafelyWriteTo) {
+  write_register_at(0x4480, (10u << 1) | (1u << 17) | (2u << 28));
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2})) << "not enabled";
+
+  write_register_at(0x4480, (10u << 1) | (1u << 0) | (1u << 17) | (4u << 28));
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2})) << "translated";
+
+  write_register_at(0x4480, (2u << 1) | (1u << 0) | (1u << 17) | (2u << 28));
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}))
+      << "a ring too small to hold one entry";
+
+  // The size field is five bits, so a guest can ask for a ring far larger than
+  // the sixteen-bit write-pointer field can name. Accepting one would have the
+  // device wrap at the field width while the driver wrapped at the ring size,
+  // and the driver would decode the never-written remainder as entries.
+  write_register_at(0x4480, (17u << 1) | (1u << 0) | (1u << 17) | (2u << 28));
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}))
+      << "a ring with entries the write pointer could never name";
+
+  write_register_at(0x4480, (10u << 1) | (1u << 0) | (1u << 17) | (2u << 28));
+  write_register_at(0x4498, 0);
+  write_register_at(0x4494, 0);
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}))
+      << "nowhere to publish the pointer";
+
+  EXPECT_TRUE(transport_.triggered.empty());
+  EXPECT_TRUE(transport_.memory.empty()) << "nothing was written anywhere";
+}
+
+// Without a transport there is no guest to reach and no line to raise, which is
+// the state between construction and being served.
+TEST_F(GpuDeviceDelivery, DeclinesWithNoTransportAttached) {
+  device_.set_dma_engine(nullptr);
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  device_.set_dma_engine(&transport_);
+  device_.set_irq_sink(nullptr);
+  EXPECT_FALSE(device_.deliver_interrupt({.client_id = 1, .source_id = 2}));
+
+  EXPECT_TRUE(transport_.memory.empty());
 }
 
 // The HDP flush is a write to a hole the bus reserves rather than to any block's

--- a/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
+++ b/emulation/rocjitsu/tests/vmm/vfio_device_host_test.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/vm/amdgpu/pci/register_symbols.h"
 #include "rocjitsu/vm/amdgpu/pci/scratch_pci_device.h"
 #include "rocjitsu/vmm/vfu/vfio_device_host.h"
+#include "rocjitsu/vmm/vfu/vfio_server.h"
 #include "vfio_user_client.h"
 
 #include <gtest/gtest.h>
@@ -40,9 +41,11 @@ extern "C" {
 #include <atomic>
 #include <bit>
 #include <chrono>
+#include <csignal>
 #include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <future>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -97,6 +100,19 @@ public:
   }
 
   rocjitsu::ScratchPciDevice &device() { return device_; }
+
+  rocjitsu::VfioDeviceHost &host() { return host_; }
+
+  /// @brief Identify the serving thread, so work can assert it ran there.
+  [[nodiscard]] std::thread::id serving_thread_id() const { return serving_.get_id(); }
+
+  /// @brief Stop serving and join, without waiting for the destructor.
+  void stop_serving() {
+    serving_.request_stop();
+    if (serving_.joinable()) {
+      serving_.join();
+    }
+  }
 
 private:
   static inline std::atomic<int> instance_counter_ = 0;
@@ -535,3 +551,129 @@ TEST(VfioDeviceHostLifecycle, EncodesTheMessageCapabilityAGuestCanFollow) {
 }
 
 } // namespace
+
+// The handoff the request signal depends on. Nothing else links an outside
+// request to the device: the delivery tests call deliver_interrupt() directly,
+// so without this the only untested part is the step that actually gets that
+// call onto the thread allowed to make it.
+// The serving loop needs a process, a socket and a connected client before it
+// runs a line, so nothing that exercises it exercises only this mapping -- and
+// the mapping is what silently breaks. A signal routed to the wrong arm, or the
+// request arm deleted, leaves every other test passing.
+TEST(VfioServerSignals, MapsEachHandledSignalToItsAction) {
+  EXPECT_EQ(rocjitsu::action_for_signal(SIGINT), rocjitsu::ServerSignalAction::Stop);
+  EXPECT_EQ(rocjitsu::action_for_signal(SIGTERM), rocjitsu::ServerSignalAction::Stop);
+  EXPECT_EQ(rocjitsu::action_for_signal(SIGUSR1), rocjitsu::ServerSignalAction::DeliverInterrupt)
+      << "the interrupt request is the one arm with no other coverage at all";
+
+  // A timed-out wait returns negative, and anything else is not this server's.
+  EXPECT_EQ(rocjitsu::action_for_signal(-1), rocjitsu::ServerSignalAction::KeepServing);
+  EXPECT_EQ(rocjitsu::action_for_signal(SIGUSR2), rocjitsu::ServerSignalAction::KeepServing)
+      << "a signal this server does not handle must not stop it or fire an interrupt";
+}
+
+// An empty target is a caller's mistake, and the serving thread is the wrong
+// place to discover it: invoking one throws bad_function_call there, which is
+// reported as work that ran and failed -- indistinguishable from work that
+// could not be done -- while the single slot is spent on nothing.
+TEST(VfioDeviceHost, RefusesEmptyWorkRatherThanThrowingOnTheServingThread) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+
+  EXPECT_FALSE(served.host().ask_serving_thread({})) << "an empty target was accepted";
+
+  // And the slot is still free, so a real request is not lost behind it.
+  std::atomic<bool> ran = false;
+  EXPECT_TRUE(served.host().ask_serving_thread([&ran] { ran = true; }))
+      << "the refused request consumed the one outstanding slot";
+}
+
+TEST(VfioDeviceHost, RunsAskedWorkOnTheServingThread) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+
+  std::promise<std::thread::id> ran_on;
+  std::future<std::thread::id> where = ran_on.get_future();
+  ASSERT_TRUE(served.host().ask_serving_thread(
+      [&ran_on] { ran_on.set_value(std::this_thread::get_id()); }));
+
+  // Bounded by one transport poll, per the documented contract; the generous
+  // wait here is for a loaded machine, not for the contract.
+  ASSERT_EQ(where.wait_for(std::chrono::seconds(10)), std::future_status::ready)
+      << "asked work never ran";
+  EXPECT_EQ(where.get(), served.serving_thread_id())
+      << "asked work must run on the serving thread, not the caller's";
+}
+
+// One outstanding request, refused rather than dropped. The earlier version kept
+// a 64-deep queue and discarded silently past that, which gave a caller no way to
+// tell that its request had been thrown away.
+TEST(VfioDeviceHost, RefusesASecondRequestWhileOneIsOutstanding) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+
+  // Block the first request inside the serving thread so it stays outstanding
+  // while the second is offered.
+  std::promise<void> running;
+  std::future<void> is_running = running.get_future();
+  std::promise<void> release;
+  std::future<void> may_finish = release.get_future();
+  ASSERT_TRUE(served.host().ask_serving_thread([&running, &may_finish] {
+    running.set_value();
+    (void)may_finish.wait_for(std::chrono::seconds(10));
+  }));
+  ASSERT_EQ(is_running.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+  bool second_ran = false;
+  EXPECT_FALSE(served.host().ask_serving_thread([&second_ran] { second_ran = true; }))
+      << "a second request must be refused while one is outstanding";
+  release.set_value();
+  EXPECT_FALSE(second_ran) << "a refused request must not run";
+}
+
+// A request that throws must not take the process with it: it runs on the serving
+// thread, where an escaping exception would terminate rather than propagate.
+TEST(VfioDeviceHost, SurvivesAThrowingRequest) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+
+  std::promise<void> threw;
+  std::future<void> did_throw = threw.get_future();
+  ASSERT_TRUE(served.host().ask_serving_thread([&threw] {
+    threw.set_value();
+    throw std::runtime_error("request failed");
+  }));
+  ASSERT_EQ(did_throw.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+  // Still serving afterwards, which is the point: the request failed, the device
+  // did not. Retried because the throwing request signalled before it threw, so
+  // it is legitimately still outstanding -- and therefore still refusing -- for
+  // the moment it takes the serving thread to unwind and clear it.
+  std::promise<void> ran_after;
+  std::future<void> after = ran_after.get_future();
+  bool accepted = false;
+  for (int attempt = 0; attempt < 200 && !accepted; ++attempt) {
+    accepted = served.host().ask_serving_thread([&ran_after] { ran_after.set_value(); });
+    if (!accepted) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+  ASSERT_TRUE(accepted) << "the host never accepted a request again after one threw";
+  EXPECT_EQ(after.wait_for(std::chrono::seconds(10)), std::future_status::ready)
+      << "serving stopped after a request threw";
+}
+
+// Documented: a request may never run. Accepting one after serving has stopped
+// must not leave a caller waiting for work that has nothing left to run it.
+TEST(VfioDeviceHost, DiscardsAskedWorkWhenServingHasStopped) {
+  ServedDevice served;
+  ASSERT_TRUE(served.built());
+  served.stop_serving();
+
+  bool ran = false;
+  // Accepted or refused is not the contract here; running is. Nothing is left to
+  // drain the request, so it must simply never execute.
+  (void)served.host().ask_serving_thread([&ran] { ran = true; });
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  EXPECT_FALSE(ran) << "work ran with no serving thread to run it";
+}


### PR DESCRIPTION
The device knew where the interrupt ring was and had a message vector the guest had allocated, but nothing joined them: it could not tell the driver anything had happened. That is the last thing standing between this stack and a driver that takes an interrupt from us.

Deliver the whole thing at once, because the parts mean nothing apart. The entry goes into the ring at the write pointer; the pointer is then advanced and published into *guest memory*, which is where the driver reads it from, after a release that matches the barrier the driver orders its own reads with; and only then is the message raised. This is also the first place a guest-writable register becomes an address this device writes to, so the pointer is put through the field mask the hardware defines and aligned to an entry before it is used: the driver keeps its own pointer shadows immediately after the ring, and an unaligned entry would run off the end onto exactly the words the protocol depends on. A ring that is switched off, too small, without anywhere to publish its pointer, or whose addresses are in a space this device cannot resolve, is declined rather than written to.

Nothing yet has anything to report, so what asks for a delivery is a signal to the server rather than an event inside the device, and the work is handed to the serving thread rather than done on the signal thread -- that thread must stay free to notice a shutdown, and the device is otherwise touched from one thread only. A guest now counts the interrupt on its message vector and decodes the entry that caused it.