### PR TITLE
fix(libhsakmt): correct independent DXG state and metadata bugs

### DIFF
--- a/projects/rocr-runtime/libhsakmt/librocdxg.pc.in
+++ b/projects/rocr-runtime/libhsakmt/librocdxg.pc.in
@@ -1,4 +1,4 @@
-prefix=${pcfiledir}/../../..
+prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@

--- a/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
@@ -703,8 +703,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFD(void) {
   return result;
 dxcore_loader_failed:
 #if defined(__linux__)
-  close(fd);
+  if (dxg_runtime->dxg_fd >= 0) close(dxg_runtime->dxg_fd);
 #endif
+  dxg_runtime->dxg_fd = -1;
 open_failed:
 
   return result;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -760,12 +760,26 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   props.WaveFrontSize = device->WavefrontSize();
   props.NumShaderBanks = device->NumShaderEngine();
   props.NumArrays = device->ShaderArrayPerShaderEngine();
-  if (props.NumArrays == 0) {
-    pr_warn("NumArrays is 0 for node %u, forcing NumCUPerArray to 0\n",
-            node_id);
-    props.NumCUPerArray = 0;
-  } else {
-    props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  /* NumArrays counts shader arrays per shader engine, so the number of arrays
+   * on the whole GPU is NumShaderBanks * NumArrays.
+   */
+  {
+    const uint32_t total_arrays = props.NumShaderBanks * props.NumArrays;
+    if (total_arrays == 0) {
+      pr_warn(
+          "NumShaderBanks(%u)*NumArrays(%u) is 0 for node %u, forcing "
+          "NumCUPerArray to 0\n",
+          props.NumShaderBanks, props.NumArrays, node_id);
+      props.NumCUPerArray = 0;
+    } else {
+      const uint32_t cu_count = device->ComputeUnitCount();
+      if (cu_count % total_arrays != 0)
+        pr_warn(
+            "ComputeUnitCount(%u) is not a multiple of the %u shader "
+            "arrays on node %u; NumCUPerArray is truncated\n",
+            cu_count, total_arrays, node_id);
+      props.NumCUPerArray = cu_count / total_arrays;
+    }
   }
   props.NumSIMDPerCU = simd_per_cu;
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
@@ -809,7 +823,10 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   props.Domain = device->Domain();
   props.UniqueID = device->Uuid();
   props.NumXcc = device->NumXcc();
-  props.KFDGpuID = device->DeviceId();  // TODO
+  /* KFDGpuID is a nonzero snapshot-local key, not the PCI device ID. The node
+   * ordinal is unique by construction even when two GPUs have the same model.
+   */
+  props.KFDGpuID = node_id + 1;
   props.FamilyID = device->GfxFamily();
   props.LuidLowPart = device->GetLuid().LowPart;
   props.LuidHighPart = device->GetLuid().HighPart;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -823,8 +823,14 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   props.Domain = device->Domain();
   props.UniqueID = device->Uuid();
   props.NumXcc = device->NumXcc();
-  /* KFDGpuID is a nonzero snapshot-local key, not the PCI device ID. The node
-   * ordinal is unique by construction even when two GPUs have the same model.
+  /*
+   * KFDGpuID is a nonzero snapshot-local key: not the PCI device ID, and not a
+   * kernel gpu_id, which only the native sysfs path supplies. Uniqueness and
+   * nonzeroness are all the DXG consumers require: a "node is a GPU" predicate
+   * and the gpuid<->nodeid lookups in this file. It becomes externally visible
+   * only through amd_core_dump.cpp, which writes it as the core dump's gpu_id,
+   * so a debugger correlating that field against kernel state will not match
+   * on WSL.
    */
   props.KFDGpuID = node_id + 1;
   props.FamilyID = device->GfxFamily();


### PR DESCRIPTION
## Motivation

These are four independent DXG issues discovered while validating the WSL
topology path. None of them is required for topology access, so they have been
split out of
[#10034](https://github.com/ROCm/rocm-systems/pull/10034) to keep that PR
focused on the multi-consumer topology prerequisite and make both changes
easier to review.

Two of the issues produce incorrect results rather than representing only
latent risks: `NumCUPerArray` is over-reported on devices with more than one
shader engine, and `KFDGpuID` collides across identical GPUs, causing reverse
lookups for both devices to resolve to the first node.

## Technical Details

### `NumCUPerArray` used the wrong shader-array count

`src/dxg/topology.cpp`

`NumArrays` is `ShaderArrayPerShaderEngine()`, so the total number of shader
arrays across the GPU is:

`NumShaderBanks * NumArrays`

The previous calculation divided `ComputeUnitCount()` by `NumArrays` alone,
which over-reported `NumCUPerArray` by the shader-engine count. It produced the
correct result only when `NumShaderBanks == 1`, which is why single-shader-engine
devices were unaffected.

The divisor now uses the total number of shader arrays. The zero-divisor guard
has been updated accordingly, and a warning is emitted if the CU count is not
evenly divisible by the array count because the integer division would
otherwise truncate the result.

### `KFDGpuID` was not unique across identical GPUs

`src/dxg/topology.cpp`

`KFDGpuID` was populated with the PCI device ID. The field is used both as the
predicate indicating that a node is a GPU and as the key inverted by
`gpuid_to_nodeid()` and `get_device_id_by_gpu_id()`.

A PCI device ID is neither unique across identical GPUs nor guaranteed to be
nonzero. As a result, identical GPUs could receive the same `KFDGpuID`, causing
both reverse lookups to resolve to the first matching node.

`KFDGpuID` is now assigned as `node_id + 1`, making it unique within the
topology snapshot and nonzero for every node.

### Failed DXG open left a stale file descriptor

`src/dxg/openclose.cpp`

On the `dxcore_loader_failed` path, the local `fd` was closed while
`dxg_runtime->dxg_fd` still retained the closed descriptor value.

A subsequent `hsaKmtOpenKFD()` could therefore observe a non-negative
`dxg_runtime->dxg_fd`, skip reopening `/dev/dxg`, and return a stale file
descriptor.

The failure path now closes the stored descriptor and resets
`dxg_runtime->dxg_fd` to `-1`.

### `librocdxg.pc` resolved the install prefix one directory too high

`librocdxg.pc.in`

The pkg-config file is installed under `${CMAKE_INSTALL_LIBDIR}/pkgconfig`,
which is two directory levels below the install prefix. Using
`${pcfiledir}/../../..` therefore resolved one level above the actual prefix and
made the derived `libdir` and `includedir` paths incorrect.

The prefix is now derived from `${pcfiledir}/../..`, matching the existing
layout used by `libhsakmt.pc.in`.

## Issue Tracking

JIRA ID: ROCM-23912
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
