### PR TITLE
fix(rccl): keep AMD CPX PCI functions out of MLOPart bus-id encoding

### DIFF
--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -628,10 +628,10 @@ static ncclResult_t ncclTopoAddGpuSub(struct ncclXmlNode* xmlPci, struct ncclXml
                                       int64_t busId, float bw) {
   int mloPart = 0, sm = 0;
   int64_t devBusId = busId;
-  NCCLCHECK(ncclTopoCheckMloPartBusId(busId));
   NCCLCHECK(xmlGetAttrIntDefault(xmlGpu, "mlopart", &mloPart, NCCL_TOPO_UNDEF));
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "sm", &sm));
   if (mloPart != NCCL_TOPO_UNDEF && ncclParamTopoSplitMlopart()) {
+    NCCLCHECK(ncclTopoCheckMloPartBusId(busId));
     if (mloPart >= NCCL_TOPO_MLOPART_DEV_MAX) {
       WARN("MLOPart index %d out of range (max %d)", mloPart, NCCL_TOPO_MLOPART_DEV_MAX - 1);
       return ncclInternalError;
@@ -655,14 +655,17 @@ static ncclResult_t ncclTopoAddGpuSub(struct ncclXmlNode* xmlPci, struct ncclXml
     NCCLCHECK(xmlGetAttrInt(xmlGpu, "gdr", &gpudeviceNode->dev.gdrSupport));
     NCCLCHECK(ncclTopoConnectNodes(gpudeviceNode, parent, LINK_PCI, bw));
     NCCLCHECK(ncclTopoConnectNodes(parent, gpudeviceNode, LINK_PCI, bw));
-    // add the local link with the existing uGPUs.
-    struct ncclTopoNode* sibDevs[NCCL_TOPO_MLOPART_DEV_MAX];
-    int nSibDevs = 0;
-    NCCLCHECK(ncclTopoGetDevNodes(system, gpudeviceNode->id, sibDevs, &nSibDevs));
-    for (int s = 0; s < nSibDevs; s++) {
-      if (sibDevs[s] == gpudeviceNode) continue;
-      NCCLCHECK(ncclTopoConnectNodes(gpudeviceNode, sibDevs[s], LINK_LOC, MLOPART_LOC_BW));
-      NCCLCHECK(ncclTopoConnectNodes(sibDevs[s], gpudeviceNode, LINK_LOC, MLOPART_LOC_BW));
+    if (mloPart != NCCL_TOPO_UNDEF && ncclParamTopoSplitMlopart()) {
+      // Add the local link with the existing MLOPart uGPUs. Physical PCI
+      // functions, such as AMD CPX partitions, remain distinct DEV nodes.
+      struct ncclTopoNode* sibDevs[NCCL_TOPO_MLOPART_DEV_MAX];
+      int nSibDevs = 0;
+      NCCLCHECK(ncclTopoGetDevNodes(system, gpudeviceNode->id, sibDevs, &nSibDevs));
+      for (int s = 0; s < nSibDevs; s++) {
+        if (sibDevs[s] == gpudeviceNode) continue;
+        NCCLCHECK(ncclTopoConnectNodes(gpudeviceNode, sibDevs[s], LINK_LOC, MLOPART_LOC_BW));
+        NCCLCHECK(ncclTopoConnectNodes(sibDevs[s], gpudeviceNode, LINK_LOC, MLOPART_LOC_BW));
+      }
     }
   }
 
@@ -846,11 +849,13 @@ static ncclResult_t ncclTopoGetGpuDevNode(struct ncclXmlNode* xmlGpu, const char
   int mloPart, sm;
   int64_t rawBusId;
   NCCLCHECK(busIdToInt64(busId, &rawBusId));
-  NCCLCHECK(ncclTopoCheckMloPartBusId(rawBusId));
   NCCLCHECK(xmlGetAttrIntDefault(xmlGpu, "mlopart", &mloPart, NCCL_TOPO_UNDEF));
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "sm", &sm));
-  int64_t devBusId =
-    (mloPart != NCCL_TOPO_UNDEF && ncclParamTopoSplitMlopart()) ? NCCL_TOPO_MLOPART_BUSID(rawBusId, mloPart) : rawBusId;
+  int64_t devBusId = rawBusId;
+  if (mloPart != NCCL_TOPO_UNDEF && ncclParamTopoSplitMlopart()) {
+    NCCLCHECK(ncclTopoCheckMloPartBusId(rawBusId));
+    devBusId = NCCL_TOPO_MLOPART_BUSID(rawBusId, mloPart);
+  }
   NCCLCHECK(ncclTopoGetNode(system, devNode, DEV, NCCL_TOPO_ID(systemId, devBusId)));
   return ncclSuccess;
 }
@@ -903,17 +908,20 @@ ncclResult_t ncclTopoAddXGMI(struct ncclXmlNode* node, struct ncclTopoSystem* sy
     int targetType;
     NCCLCHECK(kvConvertToInt(targetClass, &targetType, kvDictPciClass));
     struct ncclTopoNode* remote = NULL;
-    if (targetType == GPU) {
-      // XGMI P2P connection to another GPU (between physical DEV nodes)
-      const char* target;
-      NCCLCHECK(xmlGetAttrStr(node, "target", &target));
-      int64_t busId;
-      NCCLCHECK(busIdToInt64(target, &busId));
-      NCCLCHECK(ncclTopoGetNode(system, &remote, DEV, NCCL_TOPO_ID(systemId, busId)));
+    const char* target;
+    NCCLCHECK(xmlGetAttrStr(node, "target", &target));
+    int64_t busId;
+    NCCLCHECK(busIdToInt64(target, &busId));
+    // CPX functions can report an NVS class for an XGMI target even though
+    // the target BDF belongs to another GPU DEV node. Prefer the topology's
+    // known DEV identity over the reported target class.
+    NCCLCHECK(ncclTopoGetNode(system, &remote, DEV, NCCL_TOPO_ID(systemId, busId)));
+    if (remote != NULL) {
+      targetType = GPU;
     } else if (targetType == CPU) {
       // XGMI connection to the local CPU
       NCCLCHECK(findLocalCpu(devNode, &remote, NULL));
-    } else {
+    } else if (targetType != GPU) {
       if (system->nodes[NVS].count == 0) {
         NCCLCHECK(ncclTopoCreateNode(system, &remote, NVS, 0));
       } else {

--- a/projects/rccl/test/graph/TopoTests.cpp
+++ b/projects/rccl/test/graph/TopoTests.cpp
@@ -98,11 +98,11 @@ protected:
 
   // GPU-to-GPU link entry (tclass 0x03 -> GPU) connecting to a peer GPU.
   void addGpuLink(struct ncclXmlNode* holder, const char* targetBusId,
-                  int count) {
+                  int count, const char* targetClass = "0x03") {
     struct ncclXmlNode* link = nullptr;
     EXPECT_EQ(xmlAddNode(xml, holder, "xgmi", &link), ncclSuccess);
     EXPECT_EQ(xmlSetAttr(link, "target", targetBusId), ncclSuccess);
-    EXPECT_EQ(xmlSetAttr(link, "tclass", "0x03"), ncclSuccess);
+    EXPECT_EQ(xmlSetAttr(link, "tclass", targetClass), ncclSuccess);
     EXPECT_EQ(xmlSetAttrInt(link, "count", count), ncclSuccess);
   }
 
@@ -353,6 +353,61 @@ TEST_F(TopoTest, GetSystemFromXml_SingleSystem_BuildsLinks) {
   EXPECT_FLOAT_EQ(l10->bw, 8 * ncclTopoXGMISpeed("gfx942"));
 
   ncclTopoFree(built);
+}
+
+// Regression: AMD CPX exposes compute partitions as distinct PCI functions
+// (.0-.3). Those function bits are part of the real BDF and must not be
+// rejected or reused as synthetic MLOPart bits when mlopart is undefined.
+TEST_F(TopoTest, GetSystemFromXml_CpxFunctionsRemainDistinct) {
+  const uint64_t host = 0x29358;
+
+  struct ncclXmlNode* cpu = addSystemCpu(host);
+  struct ncclXmlNode* pci0 = addGpuPci(cpu, "0000:03:00.0", "gfx950", 0, 0);
+  struct ncclXmlNode* pci1 = addGpuPci(cpu, "0000:03:00.1", "gfx950", 1, 1);
+  struct ncclXmlNode* pci2 = addGpuPci(cpu, "0000:03:00.2", "gfx950", 2, 2);
+  struct ncclXmlNode* pci3 = addGpuPci(cpu, "0000:03:00.3", "gfx950", 3, 3);
+  // Match MI350P CPX discovery: links targeting non-zero functions may carry
+  // the generic NVS class even when the target BDF is a known GPU partition.
+  addGpuLink(pci0, "0000:03:00.1", 8, "0x068000");
+  addGpuLink(pci1, "0000:03:00.0", 8, "0x120000");
+  addGpuLink(pci2, "0000:03:00.3", 8, "0x068000");
+  addGpuLink(pci3, "0000:03:00.2", 8, "0x068000");
+
+  struct ncclTopoSystem* built = nullptr;
+  ASSERT_EQ(ncclTopoGetSystemFromXml(xml, &built, host), ncclSuccess);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(built->nodes[DEV].count, 4);
+  ASSERT_EQ(built->nodes[GPU].count, 4);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+
+  for (int function = 0; function < 4; function++) {
+    char busId[32];
+    snprintf(busId, sizeof(busId), "0000:03:00.%d", function);
+    int64_t bus = 0;
+    ASSERT_EQ(busIdToInt64(busId, &bus), ncclSuccess);
+    struct ncclTopoNode* devNode = nullptr;
+    ASSERT_EQ(ncclTopoGetNode(built, &devNode, DEV, NCCL_TOPO_ID(0, bus)),
+              ncclSuccess);
+    EXPECT_NE(devNode, nullptr) << "missing CPX function " << function;
+  }
+
+  ncclTopoFree(built);
+}
+
+// The CPX exception must not weaken genuine MLOPart collision detection:
+// synthetic MLOPart IDs still require the reserved low bus-id bits to be free.
+TEST_F(TopoTest, GetSystemFromXml_MloPartBusIdCollisionStillFails) {
+  const uint64_t host = 0x29359;
+
+  struct ncclXmlNode* cpu = addSystemCpu(host);
+  struct ncclXmlNode* pci =
+      addGpuPci(cpu, "0000:03:00.1", "gfx950", 0, 0);
+  ASSERT_EQ(pci->nSubs, 1);
+  ASSERT_EQ(xmlSetAttrInt(pci->subs[0], "mlopart", 0), ncclSuccess);
+
+  struct ncclTopoSystem* built = nullptr;
+  EXPECT_EQ(ncclTopoGetSystemFromXml(xml, &built, host), ncclInternalError);
+  if (built != nullptr) ncclTopoFree(built);
 }
 
 // Under the 2.30 DEV model a direct XGMI GPU->GPU path is the 3-hop


### PR DESCRIPTION
MLOPart reserved the low PCI function bits for synthetic partition IDs and applied that check to every GPU. AMD CPX already uses functions .1-.3, so communicator init failed on MI350P. Gate the encoding to real MLOPart devices and resolve XGMI targets by known DEV BDF.

## Motivation

CPX init fails with:
`Reducing maxBytes to 11451848021 due to memory limitation
Test NCCL failure ... 'internal error - please report this issue to the NCCL developers'`

Reducing `maxBytes` is only rccl-tests shrinking 16G because each CPX slice has less VRAM. The abort is RCCL topology, not the test harness or the VRAM-drain wait.

SPX only uses `….00.0`, so it never hit the check. CPX uses` ….00.0–.3`, so init always failed. Without this, MI350/MI300 CPX collectives cannot start.

## Technical Details

NCCL v2.30 MLOPart encodes two virtual partitions that share function .0 by OR-ing into the packed bus id:
`#define NCCL_TOPO_MLOPART_MASK (0x3) // bit0=enabled, bit1=partition index`
Packed PCI id is `domain|bus|device|function`; function is the low nibble. AMD CPX already uses those bits:

BDF | Packed id | id & 0x3 | Before this patch
-- | -- | -- | --
0000:03:00.0 | 0x3000 | 0 | OK (SPX / CPX rank 0)
0000:03:00.1 | 0x3001 | 1 | ncclInternalError
0000:03:00.2 | 0x3002 | 2 | fail
0000:03:00.3 | 0x3003 | 3 | fail


HIP names are AMD Instinct MI350P, not MLOPart N, so `peerInfo.mloPart == -1`. The check still ran unconditionally in `ncclTopoAddGpuSub() / ncclTopoGetGpuDevNode()`.

Sibling grouping via ncclTopoGetDevNodes() also masked & ~0x3 and capped at 2 DEVs per GPU. Four CPX functions then hit `too many DEV nodes for busId`.

After those gates, path search required a reverse XGMI edge. CPX XML often tags targets as` tclass=0x068000` (NVS) because `ncclOsGetPciDeviceClassByBusId()` cannot classify function .1–.3. That created a fake NVSwitch instead of a DEV↔DEV link `(Failed to find reverse path from remNode 8/3000 … to node 8/3001)`.

## Code changes (projects/rccl/src/graph/topo.cc)

- Run ncclTopoCheckMloPartBusId and NCCL_TOPO_MLOPART_BUSID only if mlopart != UNDEF && TOPO_SPLIT_MLOPART.

- Wire MLOPart LINK_LOC siblings only on that same path; CPX functions stay distinct DEVs.

- In ncclTopoAddXGMI(), look up the target BDF as a DEV first; treat NVS class as fallback only if no GPU DEV exists.

NVIDIA MLOPart on function .0 is unchanged: collision check still fires if those bits are already set.
## Issue Tracking


JIRA ID: ROCM-29538

## Test Plan



## Test Result

Validated on the MI350:

- ./rccl-UnitTestsFixturesDebug --gtest_filter='TopoTest.*' → 11/11

- CPX, 8 HIP devices, 10 collectives × 3 dtypes, -np 8 -b 1 -e 1 → 30/30

- CPX -np 8 all_reduce -e 16G → pass (size still reduced to ~11.4 GiB)

- SPX, 2 HIP devices, same 30-case matrix -np 2 → 30/30

- SPX -np 2 all_reduce -e 16G → pass (full 16G)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
