### PR TITLE
fix(rccl): copy DDA headers into topo_expl hipify staging

### DIFF
--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -117,6 +117,7 @@ hipify:
 	# Also copy to rccl/rccl.h for files that use #include <rccl/rccl.h>
 	cp -a ../../src/nccl.h.in include/rccl/rccl.h
 	cp -a ../../src/include/ hipify_rccl/
+	cp -a ../../src/algorithms/ hipify_rccl/include/algorithms/
 	cp -a ../../src/graph/ hipify_rccl/
 	cp -a ../../src/device/*.h hipify_rccl/src/device/include
 	cp -a ../../src/device/network/unpack/*.h hipify_rccl/include/network/unpack


### PR DESCRIPTION
## Motivation

After PR #10072 moved DDA sources to src/algorithms/dda/, topo_expl could not find algorithms/dda/dda_init_detail.h included from comm.h.

## Technical Details

The hipify staging step in `tools/topo_expl/Makefile` was missing the new `src/algorithms/` directory. Added a copy step to include it at `hipify_rccl/include/algorithms/`.

## Issue Tracking

JIRA ID: AICOMRCCL-2167

## Test Plan

- Run `make hipify && make` in `tools/topo_expl/` directory
- Verify build completes without missing header errors

## Test Result

topo_expl builds successfully with DDA headers resolved.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.