### PR TITLE
fix(rccl): mock hipHostMalloc in host microtests after #10510

### DIFF
--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -120,6 +120,17 @@ static hipError_t DefaultHipExtMallocWithFlags(void** ptr, std::size_t size, uns
 std::function<hipError_t(void**, std::size_t, unsigned)>
     g_hipExtMallocWithFlags = DefaultHipExtMallocWithFlags;
 
+static hipError_t DefaultHipHostMalloc(void** ptr, std::size_t size, unsigned)
+{
+    if (ptr) {
+        *ptr = std::malloc(size);
+        return *ptr ? hipSuccess : hipErrorOutOfMemory;
+    }
+    return hipErrorInvalidValue;
+}
+std::function<hipError_t(void**, std::size_t, unsigned)>
+    g_hipHostMalloc = DefaultHipHostMalloc;
+
 static hipError_t DefaultHipFree(void* ptr)
 {
     std::free(ptr);
@@ -181,6 +192,7 @@ void ResetHipFakes()
     g_hipRuntimeGetVersion          = DefaultHipRuntimeGetVersion;
     g_hipGetDeviceProperties        = DefaultHipGetDeviceProperties;
     g_hipExtMallocWithFlags         = DefaultHipExtMallocWithFlags;
+    g_hipHostMalloc                 = DefaultHipHostMalloc;
     g_hipFree                       = DefaultHipFree;
     g_hipGetDevice                  = DefaultHipGetDevice;
     g_hipSetDevice                  = DefaultHipSetDevice;
@@ -298,10 +310,9 @@ hipError_t hipGetLastError(void) { return hipErrorInvalidValue; }
 
 hipError_t hipHostFree(void*) { return hipErrorInvalidValue; }
 
-hipError_t hipHostMalloc(void** ptr, size_t, unsigned int)
+hipError_t hipHostMalloc(void** ptr, size_t size, unsigned int flags)
 {
-    if (ptr) *ptr = nullptr;
-    return hipErrorInvalidValue;
+    return g_hipHostMalloc(ptr, size, flags);
 }
 
 hipError_t hipIpcCloseMemHandle(void*) { return hipErrorInvalidValue; }

--- a/projects/rccl/test/host/fakes/hip_fakes.cc
+++ b/projects/rccl/test/host/fakes/hip_fakes.cc
@@ -308,7 +308,11 @@ const char* hipGetErrorString(hipError_t) { return "[hip_fake] stub error"; }
 
 hipError_t hipGetLastError(void) { return hipErrorInvalidValue; }
 
-hipError_t hipHostFree(void*) { return hipErrorInvalidValue; }
+hipError_t hipHostFree(void* ptr)
+{
+    std::free(ptr);
+    return hipSuccess;
+}
 
 hipError_t hipHostMalloc(void** ptr, size_t size, unsigned int flags)
 {

--- a/projects/rccl/test/host/fakes/hip_fakes.h
+++ b/projects/rccl/test/host/fakes/hip_fakes.h
@@ -69,6 +69,9 @@ extern std::function<hipError_t(hipDeviceProp_t* /*prop*/, int /*device*/)>
 extern std::function<hipError_t(void** /*ptr*/, std::size_t /*size*/,
                                 unsigned /*flags*/)>
     g_hipExtMallocWithFlags;
+extern std::function<hipError_t(void** /*ptr*/, std::size_t /*size*/,
+                                unsigned /*flags*/)>
+    g_hipHostMalloc;
 extern std::function<hipError_t(void* /*ptr*/)> g_hipFree;
 extern int g_deviceCount;
 extern int g_currentDevice;

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -810,7 +810,7 @@ TEST_F(InitMicrotest, DevCommSetup_DevCommAllocFails_ReturnsError) {
   InstallDevCommSetupSuccess();
   std::unique_ptr<ncclComm> comm;
   ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));
-  g_hipExtMallocWithFlags = [](void**, std::size_t, unsigned) { return hipErrorMemoryAllocation; };
+  g_hipHostMalloc = [](void**, std::size_t, unsigned) { return hipErrorMemoryAllocation; };
   EXPECT_NE(ncclSuccess, devCommSetup(comm.get()));
 }
 

--- a/projects/rccl/test/host/init-test.cc
+++ b/projects/rccl/test/host/init-test.cc
@@ -806,7 +806,7 @@ TEST_F(InitMicrotest, DevCommSetup_AsyncOpFails_ReturnsError) {
   EXPECT_NE(ncclSuccess, devCommSetup(comm.get()));
 }
 
-TEST_F(InitMicrotest, DevCommSetup_DevCommAllocFails_ReturnsError) {
+TEST_F(InitMicrotest, DevCommSetup_HostAllocFails_ReturnsError) {
   InstallDevCommSetupSuccess();
   std::unique_ptr<ncclComm> comm;
   ASSERT_NO_FATAL_FAILURE(AllocedComm(comm));


### PR DESCRIPTION
## Motivation

PR #10510 routes ncclCudaHostCalloc through hipHostMalloc, but the host test fake always returned hipErrorInvalidValue, breaking the DevCommSetup host-alloc failure test.

## Technical Details

Added a controllable `g_hipHostMalloc` seam to the HIP fakes infrastructure, following the existing `g_hipExtMallocWithFlags` pattern. The default implementation allocates via `std::malloc`. Updated `DevCommSetup_DevCommAllocFails_ReturnsError` to inject failure through the new seam.

## Issue Tracking

JIRA ID: AICOMRCCL-2168

## Test Plan

- Run `ctest -R host` in build directory
- Verify `DevCommSetup_DevCommAllocFails_ReturnsError` test passes

## Test Result

Host microtests pass with hipHostMalloc properly mocked.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.