### PR TITLE
fix(roprofiler-sdk): aqlprofile overloaded-virtual shadow

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
@@ -45,6 +45,11 @@ private:
 public:
     Gfx10CmdBuilder(const reg_base_offset_table* _table)
     : CmdBuilder(_table){};
+
+    // The uint32_t override below hides the base's other BuildCopyRegDataPacket
+    // overloads, re-expose them (-Woverloaded-virtual).
+    using CmdBuilder::BuildCopyRegDataPacket;
+
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)
     {
         return ((addr >= CONFIG_SPACE_START) && (addr <= CONFIG_SPACE_END));

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
@@ -47,7 +47,7 @@ public:
     : CmdBuilder(_table){};
 
     // The uint32_t override below hides the base's other BuildCopyRegDataPacket
-    // overloads, re-expose them (-Woverloaded-virtual).
+    // overloads, re-expose them
     using CmdBuilder::BuildCopyRegDataPacket;
 
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
@@ -53,7 +53,7 @@ public:
     : CmdBuilder(_table){};
 
     // The uint32_t override below hides the base's other BuildCopyRegDataPacket
-    // overloads, re-expose them (-Woverloaded-virtual).
+    // overloads, re-expose them
     using CmdBuilder::BuildCopyRegDataPacket;
 
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
@@ -51,6 +51,11 @@ private:
 public:
     Gfx11CmdBuilder(const reg_base_offset_table* _table)
     : CmdBuilder(_table){};
+
+    // The uint32_t override below hides the base's other BuildCopyRegDataPacket
+    // overloads, re-expose them (-Woverloaded-virtual).
+    using CmdBuilder::BuildCopyRegDataPacket;
+
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)
     {
         return ((addr >= CONFIG_SPACE_START) && (addr <= CONFIG_SPACE_END));

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
@@ -314,6 +314,10 @@ public:
     Gfx12CmdBuilder(const reg_base_offset_table* _table)
     : CmdBuilder(_table){};
 
+    // The uint32_t override below hides the base's other BuildCopyRegDataPacket
+    // overloads, re-expose them (-Woverloaded-virtual).
+    using CmdBuilder::BuildCopyRegDataPacket;
+
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)
     {
         return ((addr >= CONFIG_SPACE_START) && (addr <= CONFIG_SPACE_END));

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
@@ -315,7 +315,7 @@ public:
     : CmdBuilder(_table){};
 
     // The uint32_t override below hides the base's other BuildCopyRegDataPacket
-    // overloads, re-expose them (-Woverloaded-virtual).
+    // overloads, re-expose them
     using CmdBuilder::BuildCopyRegDataPacket;
 
     static constexpr bool IsPrivilegedConfigReg(uint32_t addr)


### PR DESCRIPTION
## Motivation

Fix build warnings-as-errors with GCC 15.2, for `-Werror=overloaded-virtual=`, because of the `uint64_t` variant for `src_reg_addr` in aqlprofile. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
