### PR TITLE
feat(rocDecode): Windows support stage 1: Cross-platform portability fixes for parsers and commons.

### DIFF
--- a/projects/rocdecode/src/bit_stream_reader/es_reader.h
+++ b/projects/rocdecode/src/bit_stream_reader/es_reader.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #define BS_RING_SIZE (16 * 1024 * 1024)
 #define INIT_PIC_DATA_SIZE (2 * 1024 * 1024)
 
-enum {
+enum StreamFileType {
     kStreamTypeUnsupported = -1,
     kStreamTypeAvcElementary = 0,
     kStreamTypeHevcElementary,
@@ -39,7 +39,7 @@ enum {
     kStreamTypeAv1Ivf,
     kStreamTypeVp9Ivf,
     kStreamTypeNumSupported
-} StreamFileType;
+};
 
 #define STREAM_PROBE_SIZE 2 * 1024
 #define STREAM_TYPE_SCORE_THRESHOLD 50

--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -66,10 +66,12 @@ enum RocDecLogLevel {
 
 #ifdef _WIN32
 #define GET_TIME_NS() ([]() -> uint64_t { \
-    static LARGE_INTEGER freq = {}; \
-    if (freq.QuadPart == 0) QueryPerformanceFrequency(&freq); \
-    LARGE_INTEGER cnt; QueryPerformanceCounter(&cnt); \
-    return static_cast<uint64_t>(cnt.QuadPart * 1000000000ULL / freq.QuadPart); }())
+    static const LARGE_INTEGER freq = []() { LARGE_INTEGER f{}; QueryPerformanceFrequency(&f); return f; }(); \
+    LARGE_INTEGER cnt{}; QueryPerformanceCounter(&cnt); \
+    if (freq.QuadPart <= 0) return 0ULL; \
+    const uint64_t sec = static_cast<uint64_t>(cnt.QuadPart / freq.QuadPart); \
+    const uint64_t rem = static_cast<uint64_t>(cnt.QuadPart % freq.QuadPart); \
+    return sec * 1000000000ULL + (rem * 1000000000ULL) / static_cast<uint64_t>(freq.QuadPart); }())
 #define FILENAME_ONLY (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__))
 #define GET_THREAD_ID() (static_cast<uint32_t>(GetCurrentThreadId()))
 #define GET_PID() (_getpid())

--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -30,12 +30,17 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <ctime>
 #include <time.h>
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#else
 #include <unistd.h>
+#include <sys/syscall.h>
+#endif
 #include <stdint.h>
 #include <thread>
 #include <sstream>
 #include <iomanip>
-#include <sys/syscall.h>
 
 #define MSG(X) std::clog << X << std::endl;
 #define MSG_NO_NEWLINE(X) std::clog << X;
@@ -53,11 +58,23 @@ enum RocDecLogLevel {
     kRocDecLogLevelMax       = 4
 };
 
+#ifdef _WIN32
+#define GET_TIME_NS() ([]() -> uint64_t { \
+    static LARGE_INTEGER freq = {}; \
+    if (freq.QuadPart == 0) QueryPerformanceFrequency(&freq); \
+    LARGE_INTEGER cnt; QueryPerformanceCounter(&cnt); \
+    return static_cast<uint64_t>(cnt.QuadPart * 1000000000ULL / freq.QuadPart); }())
+#define FILENAME_ONLY (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__))
+#define GET_THREAD_ID() (static_cast<uint32_t>(GetCurrentThreadId()))
+#define GET_PID() (_getpid())
+#else
 #define GET_TIME_NS() ([]() -> uint64_t { struct timespec ts_; clock_gettime(CLOCK_MONOTONIC, &ts_); return static_cast<uint64_t>(ts_.tv_sec) * 1000000000LL + ts_.tv_nsec; }())
 #define FILENAME_ONLY (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define GET_HASHED_THREAD_ID() ([]() -> std::string { std::ostringstream oss; oss << "0x" << std::hex << std::setw(5) << std::setfill('0') << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); return oss.str(); }())
 #define GET_THREAD_ID() (static_cast<pid_t>(syscall(SYS_gettid)))
-#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") + ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
+#define GET_PID() (getpid())
+#endif
+#define GET_HASHED_THREAD_ID() ([]() -> std::string { std::ostringstream oss; oss << "0x" << std::hex << std::setw(5) << std::setfill('0') << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); return oss.str(); }())
+#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(GET_PID()) + ROCDEC_STR(" tid:") + ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
 
 #define OutputMsg(msg) std::cout << msg << std::endl
 #define OutputErrMsg(msg) std::cerr << msg << std::endl
@@ -102,7 +119,7 @@ public:
         if (logger_.GetLogLevel() >= kRocDecLogInfo) {
             start_time_ = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
+                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(GET_PID()) + ROCDEC_STR(" tid:") +
                       ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) +
                       "( " + args_ + " ): entry ...");
         }
@@ -111,7 +128,7 @@ public:
         if (start_time_ != 0 && logger_.GetLogLevel() >= kRocDecLogInfo) {
             uint64_t end_time = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
+                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(GET_PID()) + ROCDEC_STR(" tid:") +
                       ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) +
                       "( " + args_ + " ): exit (" + ROCDEC_TOSTR(end_time - start_time_) + " us) ...");
         }

--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <ctime>
 #include <time.h>
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <process.h>
 #include <windows.h>
 #else

--- a/projects/rocdecode/src/parser/av1_parser.cpp
+++ b/projects/rocdecode/src/parser/av1_parser.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
+#include <numeric>
 #include "av1_parser.h"
 
 Av1VideoParser::Av1VideoParser() {
@@ -258,7 +259,7 @@ ParserResult Av1VideoParser::NotifyNewSequence(Av1SequenceHeader *p_seq_header, 
     // Display aspect ratio
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left);
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top);
-    int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor
+    int gcd = std::gcd(disp_width, disp_height); // greatest common divisor
     if (gcd) {
         video_format_params_.display_aspect_ratio.x = disp_width / gcd;
         video_format_params_.display_aspect_ratio.y = disp_height / gcd;

--- a/projects/rocdecode/src/parser/avc_parser.cpp
+++ b/projects/rocdecode/src/parser/avc_parser.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
+#include <numeric>
 #include "avc_parser.h"
 
 AvcVideoParser::AvcVideoParser() {
@@ -497,7 +498,7 @@ ParserResult AvcVideoParser::NotifyNewSps(AvcSeqParameterSet *p_sps) {
     }
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left) * sar.numerator;
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top) * sar.denominator;
-    int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor
+    int gcd = std::gcd(disp_width, disp_height); // greatest common divisor
     if (gcd) {
         video_format_params_.display_aspect_ratio.x = disp_width / gcd;
         video_format_params_.display_aspect_ratio.y = disp_height / gcd;

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <numeric>
 #include "hevc_parser.h"
 
 HevcVideoParser::HevcVideoParser() {
@@ -207,7 +208,7 @@ int HevcVideoParser::FillSeqCallbackFn(HevcSeqParamSet* sps_data) {
     }
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left) * sar.numerator;
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top) * sar.denominator;
-    int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor
+    int gcd = std::gcd(disp_width, disp_height); // greatest common divisor
     if (gcd) {
         video_format_params_.display_aspect_ratio.x = disp_width / gcd;
         video_format_params_.display_aspect_ratio.y = disp_height / gcd;

--- a/projects/rocdecode/src/parser/roc_video_parser.h
+++ b/projects/rocdecode/src/parser/roc_video_parser.h
@@ -108,13 +108,13 @@ typedef struct {
     } \
 }
 
-enum {
+enum FrameBufUseStatus {
     kNotUsed = 0,
     kTopFieldUsedForDecode = 1,
     kBottomFieldUsedForDecode = 1 << 1,
     kFrameUsedForDecode = kTopFieldUsedForDecode | kBottomFieldUsedForDecode,
     kFrameUsedForDisplay = 1 << 2
-} FrameBufUseStatus;
+};
 
 /**
  * @brief Base class for video parsing

--- a/projects/rocdecode/src/parser/vp9_parser.cpp
+++ b/projects/rocdecode/src/parser/vp9_parser.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
+#include <numeric>
 #include "vp9_parser.h"
 
 Vp9VideoParser::Vp9VideoParser() {
@@ -239,7 +240,7 @@ ParserResult Vp9VideoParser::NotifyNewSequence(Vp9UncompressedHeader *p_uncomp_h
     // Display aspect ratio
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left);
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top);
-    int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor
+    int gcd = std::gcd(disp_width, disp_height); // greatest common divisor
     if (gcd) {
         video_format_params_.display_aspect_ratio.x = disp_width / gcd;
         video_format_params_.display_aspect_ratio.y = disp_height / gcd;


### PR DESCRIPTION
## Motivation

rocDecode's parser and logging code used several GCC-specific constructs that are not portable to MSVC/Windows: the non-standard `std::__gcd` extension, anonymous enums with trailing variable names (which silently declare globals on GCC but error on MSVC), and POSIX-only system calls (`clock_gettime`, `syscall(SYS_gettid)`, `getpid`) in the logging macros. This PR replaces them with C++17 standard or platform-abstracted equivalents as a prerequisite for the Windows VA-API backend bring-up. All changes are backward-compatible on Linux; existing behavior is unchanged.

## Technical Details

  Named enums — the previous `enum { ... } Name;` pattern declared an anonymous enum plus
  a global variable with that name. GCC/Clang accepted it; MSVC rejects it. Converted to
  proper named enum declarations:
  - `src/bit_stream_reader/es_reader.h` — `enum StreamFileType { ... };`
  - `src/parser/roc_video_parser.h` — `enum FrameBufUseStatus { ... };`

  `std::__gcd` → `std::gcd` — replaced the GCC internal with the C++17 standard
  `std::gcd` and added `#include <numeric>` in all four codec parsers:
  - `src/parser/av1_parser.cpp`
  - `src/parser/avc_parser.cpp`
  - `src/parser/hevc_parser.cpp`
  - `src/parser/vp9_parser.cpp`

  `src/commons.h` — platform-branched logging primitives behind `#ifdef _WIN32`:
  - `GET_TIME_NS()` — `QueryPerformanceCounter` on Windows, `clock_gettime` on Linux.
  - `GET_THREAD_ID()` — `GetCurrentThreadId()` on Windows, `syscall(SYS_gettid)` on Linux.
  - `GET_PID()` — `_getpid()` on Windows, `getpid()` on Linux.
  - `FILENAME_ONLY` — handles both `\` and `/` separators on Windows.
  - `MakeMsg` macro and `InfoLogger` class updated to use the new platform-neutral wrappers.

  No library, API, or build-system changes — source portability only.

## Issue Tracking

AICV-281

## Test Plan

Run CTests, conformance and performance regression tests.

## Test Result

CTests, conformance tests pass. No performance regression observed.

Validation pipeline complete — everything passed.

  Validation Summary

  ┌──────────────────────────────┬──────────┐
  │            Stage             │  Result  │
  ├──────────────────────────────┼──────────┤
  │ Build + install core library │ ✓        │
  ├──────────────────────────────┼──────────┤
  │ Build all 10 samples         │ ✓        │
  ├──────────────────────────────┼──────────┤
  │ CTest (15 tests)             │ ✓ PASSED │
  ├──────────────────────────────┼──────────┤
  │ Conformance AVC              │ ✓ PASSED │
  ├──────────────────────────────┼──────────┤
  │ Conformance AV1              │ ✓ PASSED │
  ├──────────────────────────────┼──────────┤
  │ Conformance HEVC             │ ✓ PASSED │
  ├──────────────────────────────┼──────────┤
  │ Conformance VP9              │ ✓ PASSED │
  ├──────────────────────────────┼──────────┤
  │ Overall                      │ ✓ PASSED │
  └──────────────────────────────┴──────────┘

 Quick perf check complete — no regressions.

  Performance Regression Summary (quick)

  GPU: Navi31 (AMD Radeon RX 7900 XTX) · baseline column Navi31 VCN4.0 · tolerance 5%

  ┌──────────────────┬──────────┐
  │      Codec       │  Result  │
  ├──────────────────┼──────────┤
  │ AVC (2 streams)  │ ✓ PASSED │
  ├──────────────────┼──────────┤
  │ HEVC (3 streams) │ ✓ PASSED │
  ├──────────────────┼──────────┤
  │ AV1 (2 streams)  │ ✓ PASSED │
  ├──────────────────┼──────────┤
  │ VP9 (2 streams)  │ ✓ PASSED │
  ├──────────────────┼──────────┤
  │ Overall          │ ✓ PASSED │
  └──────────────────┴──────────┘

Full perf sweep complete — no regressions across all 81 streams.

  Performance Regression Summary (full)

  GPU: Navi31 (AMD Radeon RX 7900 XTX) · baseline column Navi31 VCN4.0 · tolerance 5%

  ┌───────────────────┬──────────┐
  │       Codec       │  Result  │
  ├───────────────────┼──────────┤
  │ AVC (13 streams)  │ ✓ PASSED │
  ├───────────────────┼──────────┤
  │ HEVC (23 streams) │ ✓ PASSED │
  ├───────────────────┼──────────┤
  │ AV1 (20 streams)  │ ✓ PASSED │
  ├───────────────────┼──────────┤
  │ VP9 (25 streams)  │ ✓ PASSED │
  ├───────────────────┼──────────┤
  │ Overall           │ ✓ PASSED │
  └───────────────────┴──────────┘
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
