### PR TITLE
feat(ci): pin TheRock workflows to b45a060

### DIFF
--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -22,7 +22,7 @@ on:
         description: 'ROCm/TheRock git ref for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '2e7c190b99caa226a8644eda6eca720b3db102d5'
+        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -60,7 +60,7 @@ jobs:
       timeout_minutes: 240
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
+      therock_ref: ${{ inputs.therock_ref || '064a78872ba058cbbe13e96f60e05c71538e7610' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
@@ -82,7 +82,7 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      therock_ref: ${{ inputs.therock_ref || '2e7c190b99caa226a8644eda6eca720b3db102d5' }}
+      therock_ref: ${{ inputs.therock_ref || '064a78872ba058cbbe13e96f60e05c71538e7610' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # Gates GIN on build/infra failures only; test failures stay non-gating (red

--- a/.github/workflows/rccl-ci.yml
+++ b/.github/workflows/rccl-ci.yml
@@ -22,7 +22,7 @@ on:
         description: 'ROCm/TheRock git ref for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
+        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -60,7 +60,7 @@ jobs:
       timeout_minutes: 240
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      therock_ref: ${{ inputs.therock_ref || '064a78872ba058cbbe13e96f60e05c71538e7610' }}
+      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # GIN suite (WIP) on Tensorwave. Failures show red with logs on this job.
@@ -82,7 +82,7 @@ jobs:
       non_gating: true
       artifact_group: ${{ inputs.artifact_group || 'gfx950-dcgpu' }}
       artifact_run_id: ${{ inputs.artifact_run_id || '' }}
-      therock_ref: ${{ inputs.therock_ref || '064a78872ba058cbbe13e96f60e05c71538e7610' }}
+      therock_ref: ${{ inputs.therock_ref || 'b45a06045cbb29c85e221748e653ac2521c6e1bf' }}
       amdgpu_targets: ${{ inputs.amdgpu_targets || 'gfx950' }}
 
   # Gates GIN on build/infra failures only; test failures stay non-gating (red

--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -49,7 +49,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
+        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -114,7 +114,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
+        default: 'b45a06045cbb29c85e221748e653ac2521c6e1bf'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string

--- a/.github/workflows/rccl-suite.yml
+++ b/.github/workflows/rccl-suite.yml
@@ -49,7 +49,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '2e7c190b99caa226a8644eda6eca720b3db102d5'
+        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string
@@ -114,7 +114,7 @@ on:
         description: 'ROCm/TheRock git ref to check out for build_tools + setup_test_environment.'
         type: string
         required: false
-        default: '2e7c190b99caa226a8644eda6eca720b3db102d5'
+        default: '064a78872ba058cbbe13e96f60e05c71538e7610'
       amdgpu_targets:
         description: 'GPU arch for rocSHMEM/RCCL/rccl-tests (must match the ROCm family ARCH).'
         type: string

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-build-linux.yml
+++ b/.github/workflows/therock-build-linux.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -28,12 +28,12 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_variant: "asan"
       linux_amdgpu_families: "gfx94X,gfx950,gfx125X"
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   log_therock_ref:
@@ -60,7 +60,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -70,7 +70,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan-nightly.yml
@@ -28,12 +28,12 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_variant: "asan"
       linux_amdgpu_families: "gfx94X,gfx950,gfx125X"
       repository: ROCm/TheRock
-      ref: "main"
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   log_therock_ref:
@@ -60,7 +60,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -70,7 +70,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_variant: "asan"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
@@ -61,7 +61,7 @@ jobs:
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -72,7 +72,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -82,7 +82,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-asan.yml
+++ b/.github/workflows/therock-multi-arch-ci-asan.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_variant: "asan"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950,gfx125X' }}
@@ -61,7 +61,7 @@ jobs:
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       repository: ROCm/TheRock
-      ref: "main"
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -72,7 +72,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -82,7 +82,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-nightly.yml
@@ -10,7 +10,7 @@
 
 name: TheRock Multi-Arch Nightly CI
 
-# TheRock ref: pinned to ROCm/TheRock commit 064a78872ba058cbbe13e96f60e05c71538e7610.
+# TheRock ref: pinned to ROCm/TheRock commit b45a06045cbb29c85e221748e653ac2521c6e1bf.
 
 # =============================================================================
 # TEMPORARY: MI455 (gfx125X) bringup configuration
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_variant: "release"
       # Limit GPU families for nightly CI: gfx94X, gfx950, gfx125X (Linux) and gfx1151 (Windows)
@@ -51,7 +51,7 @@ jobs:
       prebuilt_stages: ''
       baseline_run_id: ''
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       external_repo: >-
@@ -93,7 +93,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -105,7 +105,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -118,7 +118,7 @@ jobs:
         needs.setup.outputs.windows_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -128,7 +128,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci-nightly.yml
+++ b/.github/workflows/therock-multi-arch-ci-nightly.yml
@@ -10,13 +10,7 @@
 
 name: TheRock Multi-Arch Nightly CI
 
-# TheRock ref: the setup job resolves the live tip of ROCm/TheRock@main to one
-# concrete SHA (needs.setup.outputs.ref) and every downstream build/test job
-# consumes that SHA so the whole run is locked to a single TheRock commit. See
-# ROCm/rocm-libraries#9507 (this supersedes the earlier pinned-SHA plan in
-# TheRock#3343). The `uses: ...@main` lines below are the workflow-definition
-# ref (Actions forbids an expression there) and are deliberately separate from
-# the build-source `ref:` inputs.
+# TheRock ref: pinned to ROCm/TheRock commit 064a78872ba058cbbe13e96f60e05c71538e7610.
 
 # =============================================================================
 # TEMPORARY: MI455 (gfx125X) bringup configuration
@@ -32,11 +26,6 @@ on:
   schedule:
     - cron: "0 7 * * *" # Runs nightly at 7 AM UTC
   workflow_dispatch:
-    inputs:
-      therock_ref_override:
-        type: string
-        description: "Optional explicit TheRock ref (branch/tag/SHA) to build against. Empty resolves the live tip of ROCm/TheRock@main."
-        default: ""
 
 permissions:
   contents: read
@@ -51,7 +40,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_variant: "release"
       # Limit GPU families for nightly CI: gfx94X, gfx950, gfx125X (Linux) and gfx1151 (Windows)
@@ -62,10 +51,7 @@ jobs:
       prebuilt_stages: ''
       baseline_run_id: ''
       repository: ROCm/TheRock
-      # Default resolves the live tip of ROCm/TheRock@main; workflow_dispatch can
-      # pin an explicit ref via therock_ref_override. setup resolves this to one
-      # concrete SHA (needs.setup.outputs.ref) for every downstream job.
-      ref: ${{ inputs.therock_ref_override || 'main' }}
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       external_repo: >-
@@ -107,7 +93,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -119,8 +105,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      # Concrete SHA resolved once by setup; do not re-resolve main here.
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -133,7 +118,7 @@ jobs:
         needs.setup.outputs.windows_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -143,8 +128,7 @@ jobs:
       # Empty string triggers full test run in downstream workflow
       changed_projects: ''
       repository: ROCm/TheRock
-      # Concrete SHA resolved once by setup; do not re-resolve main here.
-      ref: ${{ needs.setup.outputs.ref }}
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -162,8 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          # Concrete SHA resolved once by setup; do not re-resolve main here.
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/TheRock
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           path: _therock
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
@@ -110,7 +110,7 @@ jobs:
 
   setup:
     needs: configure
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_variant: "release"
       # Limit GPU families for rocm-systems CI
@@ -128,7 +128,7 @@ jobs:
       # and determines which stages to rebuild based on changed files
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
@@ -156,7 +156,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -168,7 +168,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -182,7 +182,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -192,7 +192,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+      ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
     permissions:
       contents: read
       id-token: write
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -12,7 +12,7 @@
 # - Supports prebuilt stages to skip certain build stages
 # - Better parallelization across GPU architectures
 
-# TheRock ref: using main until full migration, then switch to pinned SHA (TheRock#3343)
+# TheRock ref: pinned to ROCm/TheRock#7636 merge commit for multi-arch package toggles.
 # NOTE: update all `@<ref>` refs and `ref:` inputs together when switching
 
 # =============================================================================
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/TheRock
-          ref: main
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           path: _therock
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
@@ -110,7 +110,7 @@ jobs:
 
   setup:
     needs: configure
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_variant: "release"
       # Limit GPU families for rocm-systems CI
@@ -128,7 +128,7 @@ jobs:
       # and determines which stages to rebuild based on changed files
       stage_reuse_mode: reuse-stage
       repository: ROCm/TheRock
-      ref: main
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
       # TEMPORARY: MI455 bringup - pass family_overrides to configure test runner and limited tests
       # TODO(geomin12): Remove family_overrides once MI455 is in therock-ci-config
       # NOTE: MI455 machine is down - test-runs-on set to "" until back online (was: linux-mi455-gpu-rocm)
@@ -156,7 +156,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
@@ -168,7 +168,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: main
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -182,7 +182,7 @@ jobs:
         needs.setup.outputs.enable_build_jobs == 'true' &&
         needs.configure.outputs.skip_tests != 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
@@ -192,7 +192,7 @@ jobs:
       # Empty string when run_all_tests=true triggers full test run in downstream workflow
       changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
-      ref: main
+      ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
     permissions:
       contents: read
       id-token: write
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: main
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-jax-collective.yml
+++ b/.github/workflows/therock-rccl-test-jax-collective.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d8e27dff1d165462ffa5bd50057a075b943c97c5 # 2026-07-13
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-rocprof.yml
+++ b/.github/workflows/therock-rccl-test-rocprof.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d8e27dff1d165462ffa5bd50057a075b943c97c5 # 2026-07-13
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-test-rocprof.yml
+++ b/.github/workflows/therock-rccl-test-rocprof.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Checkout rocm-systems scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -78,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -68,7 +68,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
+          ref: b45a06045cbb29c85e221748e653ac2521c6e1bf # 2026-08-26
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -68,6 +68,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -80,7 +81,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: b014dba9f285f6d510624cbe1a1d20251c99c0f4 # 2026-08-21
+          ref: 064a78872ba058cbbe13e96f60e05c71538e7610 # 2026-08-25
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Pins all ROCm/TheRock workflow references used by rocm-systems CI to TheRock merge commit b45a06045cbb29c85e221748e653ac2521c6e1bf.

This keeps the reusable workflow definitions and matching TheRock `ref` inputs aligned on the same known-good commit, including the multi-arch CI plumbing for package build toggles and the follow-up fix that suppresses Python package tests when Python package builds are disabled.

ISSUE ID : https://github.com/ROCm/TheRock/issues/3343

Reference Commit: https://github.com/ROCm/TheRock/commit/b45a06045cbb29c85e221748e653ac2521c6e1bf
