### PR TITLE
ci: gate single-arch TheRock CI by label

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -11,6 +11,7 @@ on:
       - synchronize
       - reopened
       - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       projects:
@@ -155,7 +156,11 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:single-arch')) &&
+        needs.setup.outputs.linux_projects != '[]'
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +188,11 @@ jobs:
       id-token: write
     needs: setup
     # Build always runs for all PRs; tests are gated separately by run_mi455_test
-    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:single-arch')) &&
+        needs.setup.outputs.linux_projects != '[]'
+      }}
     uses: ./.github/workflows/therock-build-linux.yml
     with:
       package_version: ${{ needs.setup.outputs.package_version }}
@@ -199,7 +208,11 @@ jobs:
   therock-test-linux-mi455:
     name: Linux MI455 Test
     needs: [setup, therock-build-linux-mi455]
-    if: ${{ needs.setup.outputs.run_mi455_test == 'true' }}
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:single-arch')) &&
+        needs.setup.outputs.run_mi455_test == 'true'
+      }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: "hip-tests, rocrtst"
@@ -211,7 +224,11 @@ jobs:
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
     needs: setup
-    if: ${{ needs.setup.outputs.run_linux_rccl_ci == 'true' }}
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:single-arch')) &&
+        needs.setup.outputs.run_linux_rccl_ci == 'true'
+      }}
     permissions:
       contents: read
       id-token: write
@@ -238,7 +255,11 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:single-arch')) &&
+        needs.setup.outputs.windows_projects != '[]'
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -59,6 +59,22 @@ on:
         type: string
         default: ""
         description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
+      build_python_packages:
+        type: boolean
+        default: false
+        description: "Build ROCm Python packages"
+      build_pytorch:
+        type: boolean
+        default: false
+        description: "Build PyTorch wheels"
+      build_jax:
+        type: boolean
+        default: false
+        description: "Build JAX wheels"
+      build_native_linux:
+        type: boolean
+        default: false
+        description: "Build native Linux packages and run install tests"
 
 permissions:
   contents: read
@@ -124,6 +140,10 @@ jobs:
       # Hard-coding to empty for now.
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      build_python_packages: ${{ inputs.build_python_packages || false }}
+      build_pytorch: ${{ inputs.build_pytorch || false }}
+      build_jax: ${{ inputs.build_jax || false }}
+      build_native_linux: ${{ inputs.build_native_linux || false }}
       # Enable automatic stage reuse - TheRock finds commit-compatible baselines
       # and determines which stages to rebuild based on changed files
       stage_reuse_mode: reuse-stage


### PR DESCRIPTION
## Motivation

Reduce default TheRock CI load while allowing maintainers to request the classic single-arch coverage when needed.

This PR is stacked on https://github.com/ROCm/rocm-systems/pull/10748.

## Technical Details

Gates the expensive single-arch TheRock CI jobs behind the `ci:single-arch` label while leaving the setup and summary portions of the workflow available for required-check configuration.

Also wires the multi-arch CI package toggles included in TheRock commit b45a06045cbb29c85e221748e653ac2521c6e1bf so Python packages, PyTorch, JAX, native Linux packages, and Python package tests are not run by default.

## Issue Tracking

GitHub issue: https://github.com/ROCm/TheRock/issues/3343

## Test Plan

Validated workflow YAML parses successfully and checked the stacked branch with `git diff --check`.

## Test Result

Local YAML and whitespace validation passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
