### PR TITLE
fix(rocprofiler-systems): pin OpenMP 5.0 for the Fortran host example

### DIFF
--- a/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
@@ -87,7 +87,8 @@ enable_language(Fortran)
 # ---------------------------------------------------------------------------------------#
 
 set(HOST_EXAMPLE_NAME "openmp-fortran-host")
-set(HOST_EXAMPLE_FLAGS "-fopenmp")
+# host.f90 requires OpenMP 5.0 for task detach.
+set(HOST_EXAMPLE_FLAGS "-fopenmp" "-fopenmp-version=50")
 
 add_executable(${HOST_EXAMPLE_NAME})
 # TODO: Once SDK issue is fixed (early_fulfill arriving after task_complete causes failure),


### PR DESCRIPTION
host.f90 uses task detach, omp_event_handle_kind and omp_fulfill_event, all of which require OpenMP 5.0, but the example only passed -fopenmp and so inherited whatever version the flang in use defaults to. Upstream flang sets that default to 3.1 and rejects the detach clause:

  host.f90:65:24: error: DETACH clause is not allowed on directive TASK
  in OpenMP v3.1, try -fopenmp-version=50

AMD's flang defaults to 5.2, which is why this is not seen in builds using it. Pin -fopenmp-version=50, the minimum the source needs. offload.f90 shares these flags and is unaffected; its target teams distribute construct already compiles under the 3.1 default.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
