### PR TITLE
fix: emit completion signal for packet-less leaf graph segments

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -593,7 +593,12 @@ void GraphExecSegmented::BuildSyncPlan() {
     const bool completion_signal_needed = (hw_slot >= 0);
 
     auto& lastBatch = segBatch.packet_batches.back();
-    if (last_node_uncaptured && completion_signal_needed) {
+    // A segment whose trailing nodes emit no packets at all (e.g. a leaf segment
+    // holding only an empty node) has nothing to carry the signal, so it needs a
+    // standalone barrier just like an uncaptured trailing node. Without this the
+    // slot allocated in PASS 1 is never signalled and the leaf sync in
+    // EnqueueSegmentedGraph waits on it forever.
+    if (completion_signal_needed && (last_node_uncaptured || lastBatch.dispatchPackets.empty())) {
       uint8_t* completion_barrier = device->CreateBarrierPacket();
       sync_plan_.barrier_packets.push_back(completion_barrier);
 
@@ -604,7 +609,7 @@ void GraphExecSegmented::BuildSyncPlan() {
       sync_plan_.patch_list.push_back(
           {completion_barrier, nullptr, hw_slot,
            amd::Device::HwEventPatch::kCompletionSignal, segment.id});
-    } else if (!lastBatch.dispatchPackets.empty() && completion_signal_needed) {
+    } else if (completion_signal_needed) {
       // Safe to patch the last kernel dispatch directly
       uint8_t* last_pkt = lastBatch.dispatchPackets.back();
       sync_plan_.patch_list.push_back(

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -9,6 +9,9 @@ graph:
   Unit_hipGraphAddEmptyNode_BarrierFunc:
     <<: *level_2
     tags: [node]
+  Unit_hipGraphAddEmptyNode_IndependentLeafNode:
+    <<: *level_2
+    tags: [node]
   Unit_hipGraph_ConcurrentCreate_GraphIDRace:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEmptyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEmptyNode.cc
@@ -14,6 +14,8 @@ Testcase Scenarios :
     add another empty node with dependencies on the 3 kernel nodes and
     add 3 independent memcpy_d2h nodes with dependencies on previous empty
     node. Execute the graph and validate the results.
+ 4) Launch a graph in which an independent empty node is the sole node of a
+    leaf segment and verify the launch completes.
 */
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
@@ -225,5 +227,36 @@ HIP_TEST_CASE(Unit_hipGraphAddEmptyNode_BarrierFunc) {
                            false);
   HipTest::freeArrays<int>(inputVec_d3, outputVec_d3, nullptr, inputVec_h3, outputVec_h3, nullptr,
                            false);
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/**
+ * An empty node emits no packets, so when it is the only node of a leaf segment
+ * there is nothing to carry that segment's completion signal. The event nodes
+ * split the graph into more than one segment, which is what enables the leaf
+ * synchronization that waits on those signals.
+ */
+HIP_TEST_CASE(Unit_hipGraphAddEmptyNode_IndependentLeafNode) {
+  hipGraph_t graph{};
+  hipStream_t stream{};
+  hipEvent_t event{};
+  hipGraphExec_t graphExec{nullptr};
+  hipGraphNode_t emptyNode{}, eventRecordNode{}, eventWaitNode{};
+
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipEventCreate(&event));
+
+  HIP_CHECK(hipGraphAddEventRecordNode(&eventRecordNode, graph, nullptr, 0, event));
+  HIP_CHECK(hipGraphAddEventWaitNode(&eventWaitNode, graph, nullptr, 0, event));
+  HIP_CHECK(hipGraphAddEmptyNode(&emptyNode, graph, nullptr, 0));
+
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipGraphDestroy(graph));
 }


### PR DESCRIPTION
A leaf segment whose trailing nodes emit no dispatch packets - an empty node is captured as a zero-length node range - was allocated a hardware event slot by BuildSyncPlan PASS 1 but never had a completion signal attached, because neither emission branch applied: the trailing node is captured and the batch has no packet to patch. EnqueueSegmentedGraph still added that slot as a leaf dependency, so hipStreamSynchronize waited on a signal that was never set and the launch hung.

Emit a standalone barrier whenever the signal is needed and no packet can carry it.

Reproduces on gfx1151 with a graph holding an event record node, an event wait node and an independent empty node; the event nodes split the graph so the empty node ends up alone in a leaf segment. This is the hang behind Unit_hipGraphDebugDotPrint_Functional timing out with no output on gfx1151/gfx110x/gfx120x. The default stream assignment collapses such graphs to a single stream, which is why the test only hangs on runners that keep the multi-stream path.

Resolves #10627.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
