### PR TITLE
rccl: split TDM copy cache policy into local and remote legs

### DIFF
--- a/projects/rccl/src/device/tdm/asyncCopy.h
+++ b/projects/rccl/src/device/tdm/asyncCopy.h
@@ -370,7 +370,10 @@ __device__ static void setTransferSize(gfx1250_TDM_GROUP1& group1, int numElemen
 // Warp-level tile copier built on top of the async-to/from-LDS builtins.  Exposes the same interface as
 // TileMover so the two can be used interchangeably as the TileMoverType of a copy kernel.  An entire warp
 // makes each call, and the shmem/global pointers must be uniform across the warp (no per-lane offsets).
-template <typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
+// The two policies are named for the calls they govern: loadCp applies to loadTile()'s read of global
+// memory and storeCp to storeTile()'s write. Each leg is driven separately here, so which one faces a
+// peer is the caller's business.
+template <typename T, CachePolicy loadCp = DEFAULT_CACHE_POLICY, CachePolicy storeCp = DEFAULT_CACHE_POLICY>
 struct AsyncDataCopier {
   size_t sizeInBytes_{0};
   T* shmemPtr_{nullptr};
@@ -383,14 +386,14 @@ struct AsyncDataCopier {
   __device__ void loadTile(T* shmemPtr, const T* srcPtr, int numElementsToProcess) {
     sizeInBytes_ = static_cast<size_t>(numElementsToProcess) * sizeof(T);
     shmemPtr_ = shmemPtr;
-    asyncLoadToLDS<SyncPolicy::Async, cp>(reinterpret_cast<const uint8_t*>(srcPtr),
-                                          reinterpret_cast<uint8_t*>(shmemPtr), sizeInBytes_);
+    asyncLoadToLDS<SyncPolicy::Async, loadCp>(reinterpret_cast<const uint8_t*>(srcPtr),
+                                              reinterpret_cast<uint8_t*>(shmemPtr), sizeInBytes_);
   }
 
   // An entire warp makes this call.  The dstPtr should be the same across all lanes in the warp.
   __device__ void storeTile(T* dstPtr) {
-    asyncStoreFromLDS<SyncPolicy::Async, cp>(reinterpret_cast<const uint8_t*>(shmemPtr_),
-                                             reinterpret_cast<uint8_t*>(dstPtr), sizeInBytes_);
+    asyncStoreFromLDS<SyncPolicy::Async, storeCp>(reinterpret_cast<const uint8_t*>(shmemPtr_),
+                                                  reinterpret_cast<uint8_t*>(dstPtr), sizeInBytes_);
   }
 
   template <int WAIT_CNT = 0>
@@ -407,8 +410,9 @@ struct AsyncDataCopier {
 
 #if TDM_TOOLCHAIN_AVAILABLE
 // Warp-level data copier.  Moves whole 1D tiles in between global memory and LDS using the TDM.  Both pointers ideally should be a multiple of 128-byte aligned
-// for maximum performance.
-template <typename T, CachePolicy cp = DEFAULT_CACHE_POLICY>
+// for maximum performance.  loadCp governs loadTile()'s read of global memory, storeCp storeTile()'s write to it
+// (same naming as AsyncDataCopier, so the two stay interchangeable).
+template <typename T, CachePolicy loadCp = DEFAULT_CACHE_POLICY, CachePolicy storeCp = DEFAULT_CACHE_POLICY>
 struct TileMover {
   gfx1250_TDM_GROUP0 group0;
   gfx1250_TDM_GROUP1 group1;
@@ -432,14 +436,14 @@ struct TileMover {
     group0.globalAddr((uintptr_t)srcPtr);
     setTransferSize(group1, numElementsToProcess);
     __builtin_amdgcn_tensor_load_to_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{},
-                                        __rccl_int32x8{}, cp);
+                                        __rccl_int32x8{}, loadCp);
   }
 
   // An entire warp makes this call.  The dstPtr should be the same across all lanes in the warp.  Do not pass in per-lane offsets for addresses.
   __device__ void storeTile(T* dstPtr) {
     group0.globalAddr((uintptr_t)dstPtr);
     __builtin_amdgcn_tensor_store_from_lds(group0.m_bitfield, group1.m_bitfield, __rccl_int32x4{}, __rccl_int32x4{},
-                                           __rccl_int32x8{}, cp);
+                                           __rccl_int32x8{}, storeCp);
   }
 
   template <
@@ -503,13 +507,15 @@ __device__ inline void warpGlobalCopy(const uint8_t* s, uint8_t* d, size_t n, ui
 // caller and templated in here rather than branched per iteration. The Sync policy waits after the load
 // (RAW: the store must see the filled LDS) and after the store (WAR: the next load must not overwrite LDS
 // that is still draining).
-template <CachePolicy cp, bool LoadAligned, bool StoreAligned>
+//
+// Each leg carries its own cache policy: localCp on the read of `s`, remoteCp on the write to `d`.
+template <CachePolicy localCp, CachePolicy remoteCp, bool LoadAligned, bool StoreAligned>
 __device__ inline void stageLoop(const uint8_t* s, uint8_t* d, uint8_t* myLds, size_t myStart, size_t myBytes,
                                  uint32_t window) {
   for (size_t o = 0; o < myBytes; o += window) {
     const size_t chunk = (myBytes - o < window) ? (myBytes - o) : window;
-    asyncLoadToLDS<SyncPolicy::Sync, cp, LoadAligned>(s + myStart + o, myLds, chunk);
-    asyncStoreFromLDS<SyncPolicy::Sync, cp, StoreAligned>(myLds, d + myStart + o, chunk);
+    asyncLoadToLDS<SyncPolicy::Sync, localCp, LoadAligned>(s + myStart + o, myLds, chunk);
+    asyncStoreFromLDS<SyncPolicy::Sync, remoteCp, StoreAligned>(myLds, d + myStart + o, chunk);
   }
 }
 
@@ -520,7 +526,7 @@ __device__ inline void stageLoop(const uint8_t* s, uint8_t* d, uint8_t* myLds, s
 // tile already drains its own load/store (RAW/WAR) inside the loop, so nothing
 // is left in flight on return; async::tdmWait() below is therefore a no-op guard
 // kept for API parity with tdm::tdmWait().
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes,
                              uint32_t startWarpId, uint32_t stopWarpId) {
   const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
@@ -549,7 +555,7 @@ __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void*
 
   // --- tiny-LDS fallback: not enough LDS for a single window ---------------
   if (ldsBytes < WINDOW_GRAIN) {
-    if (rank == 0) warpGlobalCopy<cp>(s, d, sizeBytes, warpThread, warpThreads);
+    if (rank == 0) warpGlobalCopy<localCp>(s, d, sizeBytes, warpThread, warpThreads);
     return;
   }
 
@@ -587,10 +593,10 @@ __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void*
   const bool loadAligned = ldsAligned && (((uintptr_t)(s + myStart) & mask) == 0);
   const bool storeAligned = ldsAligned && (((uintptr_t)(d + myStart) & mask) == 0);
 
-  if (loadAligned && storeAligned) stageLoop<cp, true, true>(s, d, myLds, myStart, myBytes, window);
-  else if (loadAligned) stageLoop<cp, true, false>(s, d, myLds, myStart, myBytes, window);
-  else if (storeAligned) stageLoop<cp, false, true>(s, d, myLds, myStart, myBytes, window);
-  else stageLoop<cp, false, false>(s, d, myLds, myStart, myBytes, window);
+  if (loadAligned && storeAligned) stageLoop<localCp, remoteCp, true, true>(s, d, myLds, myStart, myBytes, window);
+  else if (loadAligned) stageLoop<localCp, remoteCp, true, false>(s, d, myLds, myStart, myBytes, window);
+  else if (storeAligned) stageLoop<localCp, remoteCp, false, true>(s, d, myLds, myStart, myBytes, window);
+  else stageLoop<localCp, remoteCp, false, false>(s, d, myLds, myStart, myBytes, window);
 }
 
 } // namespace detail
@@ -603,26 +609,26 @@ __device__ ASYNC_API void tdmWait() ASYNC_DELETED;
 
 /// \brief Non-blocking block-collective copy: issue and return.
 /// \see tdm::tdmCopyAsync.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ ASYNC_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                        size_t ldsBufferBytes) ASYNC_DELETED;
 
 /// \brief Blocking block-collective copy of [0, sizeBytes): dst <- src.
-/// \see tdm::tdmCopy.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+/// \see tdm::tdmCopy, including the localCp (read leg) / remoteCp (write leg) split.
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ ASYNC_API void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                   size_t ldsBufferBytes) ASYNC_DELETED;
 
 /// \brief Non-blocking WARP-SPECIALIZED copy by one contiguous warp team.
 /// \see tdm::tdmCopyAsyncByTeam.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ ASYNC_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                              size_t ldsBufferBytes, uint32_t startWarpId,
                                              uint32_t stopWarpId) ASYNC_DELETED;
 
 /// \brief Blocking WARP-SPECIALIZED copy by one contiguous warp team.
 /// \see tdm::tdmCopyByTeam.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ ASYNC_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                         size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) ASYNC_DELETED;
 
@@ -632,28 +638,28 @@ __device__ inline void tdmWait() {
   asyncWait<0>();
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                     size_t ldsBufferBytes) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
   tdmWait();
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                           size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                      size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
   tdmWait(); // no-op on any warp that issued nothing / is off-team
 }
 

--- a/projects/rccl/src/device/tdm/cachePolicy.h
+++ b/projects/rccl/src/device/tdm/cachePolicy.h
@@ -27,6 +27,14 @@ THE SOFTWARE.
 /// implementation (asyncCopy.h) accept the same compile-time cache policy so their
 /// public APIs stay identical.  A CachePolicy packs a temporal hint together with a
 /// memory scope into the integer immediate the memory instructions expect.
+///
+/// A round-trip copy (global -> LDS -> global) touches two different global buffers,
+/// which in a collective are typically not equally distant: the source is usually
+/// local HBM while the destination is a peer's memory reached over the interconnect.
+/// The copy entry points therefore take TWO policies -- localCp for the read leg and
+/// remoteCp for the write leg -- so the near side can use a cheaper scope than the
+/// far side.  The one-way global<->LDS primitives touch a single global buffer and
+/// keep a single policy for it.
 
 #ifndef __TDM_CACHE_POLICY_H
 #define __TDM_CACHE_POLICY_H
@@ -50,14 +58,17 @@ enum struct MemScope : uint32_t {
   SYS, // System scope
 };
 
+// Near cache is L1 data cache, far cache is L2.  The first four values apply the same temporality to both caches.  
+// The last four values have different policies for the near cache and far cache.
 enum struct TemporalHint : uint32_t {
   RT = 0, // Regular temporal (nothing special)
   NT, // Not temporal
   HT, // High temporal
   LU, // Last use
-  NT_RT,
-  RT_NT,
-  NT_HT,
+  NT_RT, // Not temporal near cache, regular temporal far cache
+  RT_NT, // Regular temporal near cache, not temporal far cache
+  NT_HT, // Not temporal near cache, high temporal far cache
+  NT_WB, // Non temporal near cache, writeback far cache, only valid for stores, not loads
 };
 
 __host__ __device__ constexpr CachePolicy createCachePolicy(TemporalHint temporal, MemScope scope) noexcept {

--- a/projects/rccl/src/device/tdm/tdmCopy.h
+++ b/projects/rccl/src/device/tdm/tdmCopy.h
@@ -177,17 +177,23 @@ __host__ __device__ inline bool IsTdmCopySupported(int deviceId = 0) {
 /// \param ldsBuffer      Per-block LDS staging area (shared memory).
 /// \param ldsBufferBytes Size of \p ldsBuffer in bytes; subdivided among warps.
 ///
-/// \tparam cp Compile-time cache policy (temporal hint + memory scope) baked into
-///            the tensor load/store as their immediate cpol operand. Build one
-///            with createCachePolicy(); see cachePolicy.h. Must be a constant
-///            because the hardware instruction takes an immediate.
+/// \tparam localCp  Compile-time cache policy (temporal hint + memory scope) for the
+///                  READ leg, i.e. the tensor load that pulls \p src into LDS. Named
+///                  for the common case where the source is local HBM.
+/// \tparam remoteCp Same, for the WRITE leg: the tensor store that pushes LDS out to
+///                  \p dst, typically a peer's memory across the interconnect.
+///
+/// Each policy becomes the immediate cpol operand of its own instruction, so both
+/// must be constants. Build them with createCachePolicy(); see cachePolicy.h. The
+/// unaligned head (and the LDS-too-small fallback) is an ordinary vector copy and
+/// carries neither policy.
 ///
 /// \note For BLOCK-wide visibility, follow with __syncthreads() (and see the
 ///       visibility notes at the bottom of the file).
 /// \warning \p src and \p dst must be GLOBAL (HBM) pointers. Passing a shared /
 ///          LDS pointer compiles (it decays to void*) but is undefined at run
 ///          time -- the address is programmed into the descriptor's global field.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ TDM_API void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                 size_t ldsBufferBytes) TDM_DELETED;
 
@@ -197,9 +203,9 @@ __device__ TDM_API void tdmCopy(void* dst, const void* src, size_t sizeBytes, vo
 /// few TDM ops (bounded by the per-wave queue depth) stay in flight so they
 /// overlap with whatever the calling warp does next. Pair with tdmWait().
 ///
-/// \see tdmCopy for parameter meanings (including the \p cp cache policy).
+/// \see tdmCopy for parameter meanings (including the two cache policies).
 /// \see tdmWait to complete the copy.
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ TDM_API void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                      size_t ldsBufferBytes) TDM_DELETED;
 
@@ -234,14 +240,14 @@ __device__ TDM_API void tdmCopyAsync(void* dst, const void* src, size_t sizeByte
 ///       /* compute -- use LDS past the team's window */;
 ///   __syncthreads();
 /// \endcode
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ TDM_API void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                       size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) TDM_DELETED;
 
 /// \brief Non-blocking variant of tdmCopyByTeam(): issue and return.
-/// \see tdmCopyByTeam for parameter meanings and team semantics (incl. \p cp).
+/// \see tdmCopyByTeam for parameter meanings and team semantics (incl. the cache policies).
 /// \see tdmWait to complete the copy (called by each participating warp).
-template <CachePolicy cp = DEFAULT_CACHE_POLICY>
+template <CachePolicy localCp = DEFAULT_CACHE_POLICY, CachePolicy remoteCp = DEFAULT_CACHE_POLICY>
 __device__ TDM_API void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                            size_t ldsBufferBytes, uint32_t startWarpId,
                                            uint32_t stopWarpId) TDM_DELETED;
@@ -285,7 +291,10 @@ __device__ TDM_API void tdmWait() TDM_DELETED;
 ///                 leaves the transfer in flight to overlap with the caller's
 ///                 next work, to be completed with tdmWait().
 /// \tparam cp      Compile-time cache policy baked into the tensor load as its
-///                 immediate cpol operand; see cachePolicy.h.
+///                 immediate cpol operand; see cachePolicy.h. One leg touches one
+///                 global buffer, so there is a single policy here -- the caller
+///                 passes whichever of its local/remote policies applies (the
+///                 round-trip copies above take both).
 /// \tparam Aligned Pass true only when \p globalSrc and \p ldsDst are both known
 ///                 to be 128-byte aligned; this compiles out the head peel.
 ///
@@ -381,7 +390,9 @@ using u32x8 = __attribute__((ext_vector_type(8))) uint32_t;   // D1, D4
 
 // The cache policy is baked into the instruction as its immediate cpol operand,
 // so it must be a compile-time constant -- hence a template parameter (mirroring
-// how asyncCopy.h passes its cache policy to the async builtins).
+// how asyncCopy.h passes its cache policy to the async builtins). Each instruction
+// carries one cpol, which is what lets a round trip give its read and write legs
+// different policies (see issueRows()).
 template <CachePolicy cp>
 __device__ inline void load(const gfx1250_TDM_GROUP0& g0, const gfx1250_TDM_GROUP1& g1) {
   __builtin_amdgcn_tensor_load_to_lds(g0.m_bitfield,               // D0  addresses
@@ -419,7 +430,10 @@ __device__ inline void warpVecCopy(const uint8_t* s, uint8_t* d, size_t n, uint3
 //   * load -> wait: the store reads the LDS the load just wrote (RAW hazard).
 //   * store -> wait: the caller reuses this same window next iteration; the next
 //     load must not overwrite LDS the store is still draining (WAR hazard).
-template <CachePolicy cp>
+//
+// The load reads `src` (the near side, localCp) and the store writes `dst` (the far
+// side, remoteCp); the LDS window in between is untouched by either policy.
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void issueRows(uint64_t src, uint32_t lds, uint64_t dst, uint32_t rows) {
   gfx1250_TDM_GROUP1 g1;
   g1.dataSize(DS4);
@@ -432,16 +446,16 @@ __device__ inline void issueRows(uint64_t src, uint32_t lds, uint64_t dst, uint3
     // Higher dims (D2/D3/D4) are unused for this 2D tile -> passed as zero inside
     // load()/store(), matching known-good example usage.
   gfx1250_TDM_GROUP0 g0l(lds, src);
-  load<cp>(g0l, g1);
+  load<localCp>(g0l, g1);
   waitTensor0();       // RAW: fill LDS before store reads it
   gfx1250_TDM_GROUP0 g0s(lds, dst);
-  store<cp>(g0s, g1);
+  store<remoteCp>(g0s, g1);
   waitTensor0();       // WAR: drain store before window reuse
 }
 
 // ---- issue a sub-row tail (<256B) as a 1-D tile at BYTE granularity. ---------
 // Same single-buffered LDS window and the same required RAW/WAR waits as above.
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void issueRow1d(uint64_t src, uint32_t lds, uint64_t dst, uint32_t nbytes) {
   gfx1250_TDM_GROUP1 g1;
   g1.dataSize(DS1);                        // 1-byte elements: exact length
@@ -452,10 +466,10 @@ __device__ inline void issueRow1d(uint64_t src, uint32_t lds, uint64_t dst, uint
   g1.tensorDim0Stride(nbytes);
 
   gfx1250_TDM_GROUP0 g0l(lds, src);        // unused higher dims -> zero (see load())
-  load<cp>(g0l, g1);
+  load<localCp>(g0l, g1);
   waitTensor0();       // RAW: fill LDS before store reads it
   gfx1250_TDM_GROUP0 g0s(lds, dst);
-  store<cp>(g0s, g1);
+  store<remoteCp>(g0s, g1);
   waitTensor0();       // WAR: drain store before window reuse
 }
 
@@ -549,7 +563,7 @@ __device__ inline void warpLdsCopy(uint64_t global, uint32_t lds, size_t sizeInB
 // NO final wait. Work + LDS partition by rank within the team (warpId - start),
 // so each team indexes its own `ldsBuffer` from zero. Safe to call collectively
 // (warps outside the range return immediately) or only from the team's warps.
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes,
                              uint32_t startWarpId, uint32_t stopWarpId) {
   const uint8_t* s = reinterpret_cast<const uint8_t*>(src);
@@ -587,7 +601,8 @@ __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void*
   if (rank == 0 && head) warpVecCopy(s, d, head, warpThread, warpThreads);
   if (rank == 0 && tail) {
     if (ldsBytes >= tail) // stage tail in rank 0's window
-      issueRow1d<cp>(reinterpret_cast<uint64_t>(s + tailOff), ldsBase, reinterpret_cast<uint64_t>(d + tailOff), tail);
+      issueRow1d<localCp, remoteCp>(reinterpret_cast<uint64_t>(s + tailOff), ldsBase,
+                                    reinterpret_cast<uint64_t>(d + tailOff), tail);
     else warpVecCopy(s + tailOff, d + tailOff, tail, warpThread, warpThreads);
   }
 
@@ -618,7 +633,7 @@ __device__ inline void issue(void* dst, const void* src, size_t sizeBytes, void*
   for (size_t r = 0; r < myRows; r += rowsPerChunk) {
     uint32_t chunkRows = (myRows - r < rowsPerChunk) ? static_cast<uint32_t>(myRows - r) : rowsPerChunk;
     uint64_t off = (uint64_t)r * WIDTH;
-    issueRows<cp>(sBase + off, myLds, dBase + off, chunkRows);
+    issueRows<localCp, remoteCp>(sBase + off, myLds, dBase + off, chunkRows);
   }
 }
 
@@ -630,28 +645,28 @@ __device__ inline void tdmWait() {
   detail::waitTensor0();
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyAsync(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                     size_t ldsBufferBytes) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopy(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer, size_t ldsBufferBytes) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, /*start=*/0, /*stop=*/~0u);
   tdmWait();
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyAsyncByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                           size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
 }
 
-template <CachePolicy cp>
+template <CachePolicy localCp, CachePolicy remoteCp>
 __device__ inline void tdmCopyByTeam(void* dst, const void* src, size_t sizeBytes, void* ldsBuffer,
                                      size_t ldsBufferBytes, uint32_t startWarpId, uint32_t stopWarpId) {
-  detail::issue<cp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
+  detail::issue<localCp, remoteCp>(dst, src, sizeBytes, ldsBuffer, ldsBufferBytes, startWarpId, stopWarpId);
   tdmWait(); // no-op on any warp that issued nothing / is off-team
 }
 

--- a/projects/rccl/test/device/TestAsyncCopy.cpp
+++ b/projects/rccl/test/device/TestAsyncCopy.cpp
@@ -17,9 +17,10 @@
 //   * async::tdmCopyByTeam()       - blocking, warp-specialized (a contiguous team)
 //   * async::tdmCopyAsyncByTeam()  - non-blocking, warp-specialized
 //
-// It additionally checks that a non-default compile-time cache policy still
-// produces a correct copy (the policy is baked into the async instructions as
-// their immediate cpol operand).
+// It additionally checks that non-default compile-time cache policies still produce
+// a correct copy, varying the read leg's (local) and write leg's (remote) policy
+// independently. Each is baked into its async instructions as their immediate cpol
+// operand.
 
 #include "DeviceTestBase.hpp"
 
@@ -49,33 +50,34 @@ constexpr CachePolicy kAltCachePolicy = createCachePolicy(TemporalHint::NT, MemS
 // ---------------------------------------------------------------------------
 
 // Whole-block copy of [0, n): dst <- src. Every thread calls with identical args.
-template<bool ASYNC, CachePolicy CP = DEFAULT_CACHE_POLICY>
+// LOCAL_CP applies to the read leg (src), REMOTE_CP to the write leg (dst).
+template<bool ASYNC, CachePolicy LOCAL_CP = DEFAULT_CACHE_POLICY, CachePolicy REMOTE_CP = DEFAULT_CACHE_POLICY>
 __global__ void kAsyncBlockCopy([[maybe_unused]] uint8_t* dst, [[maybe_unused]] const uint8_t* src,
                                 [[maybe_unused]] size_t n, [[maybe_unused]] size_t ldsBytes) {
 #if ASYNC_COPY_SUPPORTED
   extern __shared__ __align__(128) uint8_t lds[];
   if constexpr (ASYNC) {
-    async::tdmCopyAsync<CP>(dst, src, n, lds, ldsBytes);
+    async::tdmCopyAsync<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes);
     async::tdmWait();
   } else {
-    async::tdmCopy<CP>(dst, src, n, lds, ldsBytes);
+    async::tdmCopy<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes);
   }
   __syncthreads();
 #endif
 }
 
 // Warp-specialized copy: only warps in [start, stop) participate.
-template<bool ASYNC, CachePolicy CP = DEFAULT_CACHE_POLICY>
+template<bool ASYNC, CachePolicy LOCAL_CP = DEFAULT_CACHE_POLICY, CachePolicy REMOTE_CP = DEFAULT_CACHE_POLICY>
 __global__ void kAsyncTeamCopy([[maybe_unused]] uint8_t* dst, [[maybe_unused]] const uint8_t* src,
                                [[maybe_unused]] size_t n, [[maybe_unused]] size_t ldsBytes,
                                [[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t stop) {
 #if ASYNC_COPY_SUPPORTED
   extern __shared__ __align__(128) uint8_t lds[];
   if constexpr (ASYNC) {
-    async::tdmCopyAsyncByTeam<CP>(dst, src, n, lds, ldsBytes, start, stop);
+    async::tdmCopyAsyncByTeam<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes, start, stop);
     async::tdmWait();   // no-op on warps that issued nothing
   } else {
-    async::tdmCopyByTeam<CP>(dst, src, n, lds, ldsBytes, start, stop);
+    async::tdmCopyByTeam<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes, start, stop);
   }
   __syncthreads();
 #endif
@@ -350,9 +352,15 @@ TEST_F(AsyncTwoTeamTest, Async)    { run<true>(8192, 2048, 256);  }
 //  Non-default cache policy still copies correctly.
 // ===========================================================================
 
+// The near/far pair, matching TestTdmCopy.cpp so the two implementations are
+// exercised with the same local/remote split.
+constexpr CachePolicy kAsyncLocalCachePolicy  = createCachePolicy(TemporalHint::NT, MemScope::DEV);
+constexpr CachePolicy kAsyncRemoteCachePolicy = createCachePolicy(TemporalHint::HT, MemScope::SYS);
+
 class AsyncCachePolicyTest : public AsyncCopyTest {
 protected:
-  void run(size_t n, size_t lds, int off, int block) {
+  template<CachePolicy LOCAL_CP, CachePolicy REMOTE_CP>
+  void run(size_t n, size_t lds, int off, int block, const std::string& tag) {
     if (!supported_) GTEST_SKIP() << "async copy not supported on this device";
 
     const size_t srcTotal  = static_cast<size_t>(off) + n;
@@ -367,15 +375,25 @@ protected:
     DeviceBuffer<uint8_t> d_dst(dstTotal);
     d_dst.copyFrom(h_dstInit);
 
-    kAsyncBlockCopy<false, kAltCachePolicy><<<1, block, lds>>>(
+    kAsyncBlockCopy<false, LOCAL_CP, REMOTE_CP><<<1, block, lds>>>(
         d_dst.ptr + copyStart, d_src.ptr + off, n, lds);
     syncAndCheck();
 
     auto h_out = d_dst.copyTo();
-    checkCopy(h_out, h_src, static_cast<size_t>(off), copyStart, n, "alt_cache_policy");
+    checkCopy(h_out, h_src, static_cast<size_t>(off), copyStart, n, tag);
   }
 };
 
-TEST_F(AsyncCachePolicyTest, NonDefaultPolicy) { run(6000, 2048, 64, 256); }
+TEST_F(AsyncCachePolicyTest, NonDefaultRemotePolicy) {
+  run<DEFAULT_CACHE_POLICY, kAltCachePolicy>(6000, 2048, 64, 256, "alt_remote_policy");
+}
+
+TEST_F(AsyncCachePolicyTest, NonDefaultLocalPolicy) {
+  run<kAltCachePolicy, DEFAULT_CACHE_POLICY>(6000, 2048, 64, 256, "alt_local_policy");
+}
+
+TEST_F(AsyncCachePolicyTest, DistinctLocalAndRemotePolicies) {
+  run<kAsyncLocalCachePolicy, kAsyncRemoteCachePolicy>(6000, 2048, 64, 256, "distinct_policies");
+}
 
 }  // namespace RcclUnitTesting

--- a/projects/rccl/test/device/TestTdmCopy.cpp
+++ b/projects/rccl/test/device/TestTdmCopy.cpp
@@ -59,34 +59,35 @@ constexpr uint32_t kTeamToEnd = ~0u;
 // non-TDM device pass) while emitting the real copy for the gfx1250 device pass.
 
 // Whole-block copy of [0, n): dst <- src. Every thread calls with identical args.
-// CP is the compile-time cache policy threaded into the tensor load/store.
-template<bool ASYNC, CachePolicy CP = DEFAULT_CACHE_POLICY>
+// LOCAL_CP is the cache policy for the read leg (src), REMOTE_CP for the write leg
+// (dst); each becomes the cpol immediate of its own tensor instruction.
+template<bool ASYNC, CachePolicy LOCAL_CP = DEFAULT_CACHE_POLICY, CachePolicy REMOTE_CP = DEFAULT_CACHE_POLICY>
 __global__ void kTdmBlockCopy([[maybe_unused]] uint8_t* dst, [[maybe_unused]] const uint8_t* src,
                               [[maybe_unused]] size_t n, [[maybe_unused]] size_t ldsBytes) {
 #if TDM_SUPPORTED
   extern __shared__ __align__(128) uint8_t lds[];
   if constexpr (ASYNC) {
-    tdm::tdmCopyAsync<CP>(dst, src, n, lds, ldsBytes);
+    tdm::tdmCopyAsync<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes);
     tdm::tdmWait();
   } else {
-    tdm::tdmCopy<CP>(dst, src, n, lds, ldsBytes);
+    tdm::tdmCopy<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes);
   }
   __syncthreads();
 #endif
 }
 
 // Warp-specialized copy: only warps in [start, stop) participate.
-template<bool ASYNC>
+template<bool ASYNC, CachePolicy LOCAL_CP = DEFAULT_CACHE_POLICY, CachePolicy REMOTE_CP = DEFAULT_CACHE_POLICY>
 __global__ void kTdmTeamCopy([[maybe_unused]] uint8_t* dst, [[maybe_unused]] const uint8_t* src,
                              [[maybe_unused]] size_t n, [[maybe_unused]] size_t ldsBytes,
                              [[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t stop) {
 #if TDM_SUPPORTED
   extern __shared__ __align__(128) uint8_t lds[];
   if constexpr (ASYNC) {
-    tdm::tdmCopyAsyncByTeam(dst, src, n, lds, ldsBytes, start, stop);
+    tdm::tdmCopyAsyncByTeam<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes, start, stop);
     tdm::tdmWait();   // no-op on warps that issued nothing
   } else {
-    tdm::tdmCopyByTeam(dst, src, n, lds, ldsBytes, start, stop);
+    tdm::tdmCopyByTeam<LOCAL_CP, REMOTE_CP>(dst, src, n, lds, ldsBytes, start, stop);
   }
   __syncthreads();
 #endif
@@ -374,16 +375,24 @@ TEST_F(TdmTwoTeamTest, Blocking) { run<false>(8192, 2048, 256); }
 TEST_F(TdmTwoTeamTest, Async)    { run<true>(8192, 2048, 256);  }
 
 // ===========================================================================
-//  Non-default cache policy still copies correctly.
+//  Non-default cache policies still copy correctly.
 // ===========================================================================
 
-// A non-default cache policy proves the cp template argument threads all the way
-// through the tensor load/store as their immediate cpol operand.
+// A non-default cache policy proves a policy template argument threads all the way
+// through to a tensor instruction's immediate cpol operand.
 constexpr CachePolicy kTdmAltCachePolicy = createCachePolicy(TemporalHint::NT, MemScope::DEV);
+
+// The pair the two-policy API exists for: the read leg stays at device scope (the
+// source is local HBM) while the write leg goes out to system scope (the
+// destination is a peer's memory). Distinct values, so a swapped or shared policy
+// shows up as a different cpol immediate in the generated ISA.
+constexpr CachePolicy kTdmLocalCachePolicy  = createCachePolicy(TemporalHint::NT, MemScope::DEV);
+constexpr CachePolicy kTdmRemoteCachePolicy = createCachePolicy(TemporalHint::HT, MemScope::SYS);
 
 class TdmCachePolicyTest : public TdmCopyTest {
 protected:
-  void run(size_t n, size_t lds, int off, int block) {
+  template<CachePolicy LOCAL_CP, CachePolicy REMOTE_CP>
+  void run(size_t n, size_t lds, int off, int block, const std::string& tag) {
     if (!supported_) GTEST_SKIP() << "TDM not supported on this device";
 
     const size_t srcTotal  = static_cast<size_t>(off) + n;
@@ -398,15 +407,60 @@ protected:
     DeviceBuffer<uint8_t> d_dst(dstTotal);
     d_dst.copyFrom(h_dstInit);
 
-    kTdmBlockCopy<false, kTdmAltCachePolicy><<<1, block, lds>>>(
+    kTdmBlockCopy<false, LOCAL_CP, REMOTE_CP><<<1, block, lds>>>(
         d_dst.ptr + copyStart, d_src.ptr + off, n, lds);
     syncAndCheck();
 
     auto h_out = d_dst.copyTo();
-    checkCopy(h_out, h_src, static_cast<size_t>(off), copyStart, n, "alt_cache_policy");
+    checkCopy(h_out, h_src, static_cast<size_t>(off), copyStart, n, tag);
+  }
+
+  // Same, driven through the warp-specialized entry points.
+  template<CachePolicy LOCAL_CP, CachePolicy REMOTE_CP>
+  void runByTeam(size_t n, size_t lds, int off, int block, uint32_t start, uint32_t stop,
+                 const std::string& tag) {
+    if (!supported_) GTEST_SKIP() << "TDM not supported on this device";
+
+    const size_t srcTotal  = static_cast<size_t>(off) + n;
+    const size_t dstTotal  = static_cast<size_t>(kGuard) + off + n + kGuard;
+    const size_t copyStart = static_cast<size_t>(kGuard) + off;
+
+    auto h_src = makePattern(srcTotal, 0xB0A7u);
+    DeviceBuffer<uint8_t> d_src(srcTotal);
+    d_src.copyFrom(h_src);
+
+    std::vector<uint8_t> h_dstInit(dstTotal, kSentinel);
+    DeviceBuffer<uint8_t> d_dst(dstTotal);
+    d_dst.copyFrom(h_dstInit);
+
+    kTdmTeamCopy<false, LOCAL_CP, REMOTE_CP><<<1, block, lds>>>(
+        d_dst.ptr + copyStart, d_src.ptr + off, n, lds, start, stop);
+    syncAndCheck();
+
+    auto h_out = d_dst.copyTo();
+    checkCopy(h_out, h_src, static_cast<size_t>(off), copyStart, n, tag);
   }
 };
 
-TEST_F(TdmCachePolicyTest, NonDefaultPolicy) { run(6000, 2048, 64, 256); }
+// Each policy is varied on its own, so a mix-up that dropped one of the two (or
+// applied the other's value to both legs) still has to copy correctly here.
+TEST_F(TdmCachePolicyTest, NonDefaultRemotePolicy) {
+  run<DEFAULT_CACHE_POLICY, kTdmAltCachePolicy>(6000, 2048, 64, 256, "alt_remote_policy");
+}
+
+TEST_F(TdmCachePolicyTest, NonDefaultLocalPolicy) {
+  run<kTdmAltCachePolicy, DEFAULT_CACHE_POLICY>(6000, 2048, 64, 256, "alt_local_policy");
+}
+
+TEST_F(TdmCachePolicyTest, DistinctLocalAndRemotePolicies) {
+  run<kTdmLocalCachePolicy, kTdmRemoteCachePolicy>(6000, 2048, 64, 256, "distinct_policies");
+}
+
+// The head/tail edges and the 1-D tail tile are issued by the team's first warp, so
+// a small odd size on a sub-team covers those paths with distinct policies too.
+TEST_F(TdmCachePolicyTest, DistinctPoliciesByTeam) {
+  runByTeam<kTdmLocalCachePolicy, kTdmRemoteCachePolicy>(6000, 2048, 64, 128, 1, kTeamToEnd,
+                                                        "distinct_policies_team");
+}
 
 }  // namespace RcclUnitTesting


### PR DESCRIPTION
## Summary
- Round-trip TDM and async copies now take two compile-time cache policies: `localCp` on the source/read (tensor/async load) and `remoteCp` on the destination/write (tensor/async store), so a local HBM load can use a cheaper scope than a peer write.
- `TileMover` and `AsyncDataCopier` use matching `loadCp`/`storeCp` template arguments on `loadTile()`/`storeTile()`. Existing single-policy call sites keep compiling because both arguments default to `DEFAULT_CACHE_POLICY`.
- Tests independently vary the local and remote policies (including a distinct-policy team copy) so a swapped or shared policy still has to copy correctly.

## Test plan
- [x] Build fixtures: `ONLY_FUNCS=AllGather ./install.sh -l -t -d` (or `--amdgpu_targets gfx1250 -t -d` if `-l` cannot see `/dev/kfd`)
- [x] Source the emulator env (`~/.profile` and `ffmlite_env.sh`) and run `rccl-UnitTestsFixtures` with the TDM/async filter:
      `TdmCopyTest.*:TdmBlockCopyTest.*:TdmTeamCopyTest.*:TdmTwoTeamTest.*:TdmCachePolicyTest.*:AsyncCopyTest.*:AsyncBlockCopyTest.*:AsyncTeamCopyTest.*:AsyncTwoTeamTest.*:AsyncCachePolicyTest.*:*TdmLds*:*AsyncLds*:MixedLdsTransferTest.*:LdsSupportTest.*:TestNaiveTDM.*:TestTileApiTDM.*:TestAsyncDataCopierTileApi.*`
- [ ] Confirm `TdmCachePolicyTest.DistinctLocalAndRemotePolicies` and `AsyncCachePolicyTest.DistinctLocalAndRemotePolicies` pass on gfx1250


Made with [Cursor](https://cursor.com)