### PR TITLE
ci(rocprofiler-systems): adjust clang-tidy settings

### DIFF
--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -116,6 +116,7 @@ Checks: >
   readability-function-cognitive-complexity,
   readability-function-size,
   readability-identifier-length,
+  readability-identifier-naming,
   readability-magic-numbers,
   readability-misleading-indentation,
   readability-redundant-declaration,

--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -171,12 +171,8 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.TypeAliasCase
     value: lower_case
-  - key: readability-identifier-naming.TypeAliasSuffix
-    value: "_t"
   - key: readability-identifier-naming.TypedefCase
     value: lower_case
-  - key: readability-identifier-naming.TypedefSuffix
-    value: "_t"
 
   # --- Abstract/interface classes: require an "_interface" suffix
   - key: readability-identifier-naming.AbstractClassCase

--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -1,5 +1,7 @@
 HeaderFilterRegex: "/rocprofiler-systems/source/"
 
+# Deliberately not enabled:
+#   bugprone-exception-escape: nice to have, but too slow on current tree.
 Checks: >
   -*,
   bugprone-assignment-in-if-condition,
@@ -15,7 +17,6 @@ Checks: >
   bugprone-dynamic-static-initializers,
   bugprone-empty-catch,
   bugprone-exception-copy-constructor-throws,
-  bugprone-exception-escape,
   bugprone-float-loop-counter,
   bugprone-fold-init-type,
   bugprone-implicit-widening-of-multiplication-result,

--- a/projects/rocprofiler-systems/.clang-tidy
+++ b/projects/rocprofiler-systems/.clang-tidy
@@ -297,7 +297,7 @@ CheckOptions:
   - key: readability-identifier-naming.IgnoreMainLikeFunctions
     value: "1"
 
-  # --- identifier lenght
+  # --- identifier length
   - key: readability-identifier-length.MinimumBindingNameLength
     value: "3"
   - key: readability-identifier-length.MinimumExceptionNameLength
@@ -305,6 +305,6 @@ CheckOptions:
   - key: readability-identifier-length.MinimumLoopCounterNameLength
     value: "3"
 
-  # include igrone
+  # include ignore
   - key: misc-include-cleaner.IgnoreHeaders
-    value: "<compare>,<string_view>"
+    value: "compare$;string_view$;concepts$"

--- a/projects/rocprofiler-systems/scripts/clang-tidy-check.py
+++ b/projects/rocprofiler-systems/scripts/clang-tidy-check.py
@@ -32,7 +32,6 @@ _ANSI = {
     "red": "\033[31m",
     "yellow": "\033[33m",
     "green": "\033[32m",
-    "cyan": "\033[36m",
 }
 
 
@@ -244,8 +243,8 @@ def run_clang_tidy(
     return proc.stdout + proc.stderr, True
 
 
-def get_enabled_checks(args: argparse.Namespace) -> list[str]:
-    """Resolve the effective check list clang-tidy will apply."""
+def has_enabled_checks(args: argparse.Namespace) -> bool:
+    """Report whether clang-tidy will apply at least one check."""
     result = _clang_tidy(args, "-list-checks")
 
     if result.returncode != 0:
@@ -254,27 +253,17 @@ def get_enabled_checks(args: argparse.Namespace) -> list[str]:
             _color(f"warning: could not resolve check list: {detail}", "yellow"),
             file=sys.stderr,
         )
-        return []
+        return False
 
-    checks = []
     in_list = False
     for line in result.stdout.splitlines():
         stripped = line.strip()
         if stripped == "Enabled checks:":
             in_list = True
             continue
-        if in_list:
-            if not stripped:
-                break
-            checks.append(stripped)
-    return checks
-
-
-def print_enabled_checks(checks: list[str]) -> None:
-    print(_color(f"Rules to apply ({len(checks)}):", "bold"))
-    for check in checks:
-        print(f"  {_color(check, 'cyan')}")
-    print()
+        if in_list and stripped:
+            return True
+    return False
 
 
 def print_changed_files(changed_files: list[ChangedFile]) -> None:
@@ -392,13 +381,10 @@ def main() -> int:
         print("No relevant changes found.")
         return 0
 
-    enabled_checks = get_enabled_checks(args)
-
-    if not enabled_checks:
+    if not has_enabled_checks(args):
         print("No checks enabled.")
         return 0
 
-    print_enabled_checks(enabled_checks)
     print_changed_files(changed_files)
 
     print(f"Running clang-tidy on {len(changed_files)} files ...")

--- a/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
+++ b/projects/rocprofiler-systems/scripts/test_clang_tidy_check.py
@@ -197,9 +197,9 @@ def test_run_clang_tidy_timeout_returns_false(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# get_enabled_checks
+# has_enabled_checks
 # --------------------------------------------------------------------------- #
-def test_get_enabled_checks_parses_list(monkeypatch):
+def test_has_enabled_checks_true_when_list_populated(monkeypatch):
     out = (
         "Enabled checks:\n"
         "    misc-const-correctness\n"
@@ -210,17 +210,14 @@ def test_get_enabled_checks_parses_list(monkeypatch):
     monkeypatch.setattr(
         ctc, "_clang_tidy", lambda a, *e, timeout=None: _completed(list(e), 0, out, "")
     )
-    assert ctc.get_enabled_checks(_args()) == [
-        "misc-const-correctness",
-        "modernize-use-auto",
-    ]
+    assert ctc.has_enabled_checks(_args()) is True
 
 
-def test_get_enabled_checks_failure_warns_and_returns_empty(monkeypatch, capsys):
+def test_has_enabled_checks_failure_warns_and_returns_false(monkeypatch, capsys):
     monkeypatch.setattr(
         ctc, "_clang_tidy", lambda a, *e, timeout=None: _completed(list(e), 1, "", "boom")
     )
-    assert ctc.get_enabled_checks(_args()) == []
+    assert ctc.has_enabled_checks(_args()) is False
     assert "could not resolve check list" in capsys.readouterr().err
 
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR adjusts some `clang-tidy` checks to avoid timeouts, improve usability and relevance to the project codebase.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- The clang-tidy rule `bugprone-exception-escape` is disabled to avoid timeouts on current tree.
- The `readability-identifier-naming` check is enabled
- For `readability-identifier-naming` check, `TypedefCase` and `TypedefSuffix` are disabled to avoid forcing `_t` suffix on types
- Removed printing enabled checks - they are already listed in `.clang-tidy` file
- `misc-include-cleaner.IgnoreHeaders` changed to "compare$;string_view$;concepts$"

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-496

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

N/A

## Test Result

<!-- Briefly summarize test outcomes. -->

N.A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
