### PR TITLE
fix(rocprofiler-systems): Reintroduce closeSymtab

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -149,9 +149,7 @@ rocprofsys_get_is_executable(const std::string& _cmd, bool _default_v)
         if(Dyninst::SymtabAPI::Symtab::openFile(_symtab, _cmd.data()))
         {
             _is_executable = _symtab->isExecutable() && _symtab->isExec();
-            // Workaround introduced in ROCm/rocm-systems#10171
-            // Tracking with JIRA AIPROFSYST-730
-            // Dyninst::SymtabAPI::Symtab::closeSymtab(_symtab);
+            Dyninst::SymtabAPI::Symtab::closeSymtab(_symtab);
         }
     }
     return _is_executable;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Reverts the workaround introduced in #10171 by updating dyninst submodule to the commit that contains the fix (https://github.com/ROCm/dyninst/pull/29).

See both PRs for details.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Reverts #10171 
 - Bump dyninst submodule to d5adcef5fb64965beee445d16ce2a6f2c08c2496

## Issue Tracking

<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

JIRA ID: AIPROFSYST-730

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows (ASan must pass)

## Test Result

<!-- Briefly summarize test outcomes. -->

See workflows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
