### PR TITLE
[RCCL] QP sharing Unit Testing

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -486,6 +486,7 @@ set(SRC_FILES
   transport/net_ib/p2p_resiliency_recovery.h
   transport/net_ib/reg.cc
   transport/net_ib_cast/net_ib_cast_inspect.h
+  transport/net_ib_cast/net_ib_qp_sharing_inspect.h
   transport/net_ib_cast/net_ib_fault_inject.h
   transport/net_ib/gdaki/gin_host_gdaki.h
   transport/net_telemetry.cc

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -487,6 +487,7 @@ set(SRC_FILES
   transport/net_ib/p2p_resiliency_recovery.h
   transport/net_ib/reg.cc
   transport/net_ib_cast/net_ib_cast_inspect.h
+  transport/net_ib_cast/net_ib_qp_sharing_inspect.h
   transport/net_ib_cast/net_ib_fault_inject.h
   transport/net_ib/gdaki/gin_host_gdaki.h
   transport/net_telemetry.cc

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+    src/transport/net_ib_cast/qp_sharing.h
     src/transport/net_ib_cast/common.cc
     src/transport/net_ib_cast/connect.cc
     src/transport/net_ib_cast/gdr.cc
@@ -23,6 +24,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/reg.cc
     src/transport/net_ib_cast/scheduler.cc
     src/transport/net_ib_cast/gin.cc
+    src/transport/net_ib_cast/qp_sharing.cc
 )
 
 # The cast headers (common_cast.h, p2p_cast.h, etc.) live in this directory.

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(NET_IB_CAST_SOURCES
     src/transport/net_ib_limits.h
     src/transport/net_ib_cast/net_ib_cast_inspect.h
+    src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
     src/transport/net_ib_cast/net_ib_ops_fault.h
     src/transport/net_ib_cast/common_cast.h
     src/transport/net_ib_cast/connect_cast.h

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,6 +23,9 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
+extern int ncclParamIbCastResiliencyPortFailover();
+extern int64_t rcclParamIbCastCommNGroups();
+
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -84,6 +87,17 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
+#if 0
+  if (rcclParamIbCastCommNGroups() > 0) {
+    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
+    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
+    // which is correct for a shared RQ.
+    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
+    }
+    recvComm->prepostReceiveWorkRequests = true;
+  }
+#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -7,6 +7,7 @@
 
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
+#include "qp_sharing.h"
 
 char IbCastIfName[MAX_IF_NAME_SIZE + 1];
 union ncclSocketAddress IbCastIfAddr;
@@ -24,7 +25,6 @@ NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS",
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
 extern int ncclParamIbCastResiliencyPortFailover();
-extern int64_t rcclParamIbCastCommNGroups();
 
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
@@ -87,17 +87,6 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
-#if 0
-  if (rcclParamIbCastCommNGroups() > 0) {
-    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
-    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
-    // which is correct for a shared RQ.
-    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
-    }
-    recvComm->prepostReceiveWorkRequests = true;
-  }
-#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -149,10 +149,17 @@ extern struct ncclIbDev IbCastDevs[MAX_IB_DEVS];
 extern int IbCastRelaxedOrderingEnabled;
 extern bool IbCastUseInline;
 
+#define WR_ID_RX_COMM_ID_MASK  0xffff
+#define WR_ID_RX_COMM_ID_SHIFT 48
 #define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000
 #define WR_IMM_SIZE_MASK 0x007fffff
+// QP sharing BY_ID imm_data layout: reqId in bits[7:0], receiver commId in bits[23:8].
+// reqId fits in 8 bits (NET_IB_MAX_REQUESTS <= 256); commId fits in 16 bits.
+#define WR_IMM_BYID_REQ_ID_MASK   0xff
+#define WR_IMM_BYID_COMM_ID_SHIFT 8
+#define WR_IMM_BYID_COMM_ID_MASK  0xffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool IbCastAinicCtsInlineData;
@@ -525,6 +532,13 @@ struct alignas(32) ncclIbNetCommBase {
   bool faultQpError[NCCL_IB_MAX_QPS];
 #endif
   struct ncclIbResiliency* resiliency;
+
+  // QP Sharing fields
+  uint16_t commId;              // 0 = not shared
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;      // -1 = not shared
+  int      remIbDevIdx;
+  int      sharedPrimaryNqps;
 };
 
 struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -625,6 +639,7 @@ struct ncclIbSendComm {
   // Resolved slot for telChId on this comm's first device (NULL if untracked).
   // Same reasoning as ncclIbQp::telQpStats: avoid re-resolving per completion.
   RcclChannelStats* telChStats;
+  uint16_t remCommId;           // receiver's commId for imm_data encoding (QP sharing)
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -80,7 +80,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
     return BY_ORDER;
   }
 
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     return BY_ID;
   }
 
@@ -814,7 +814,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -908,11 +908,11 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     comm->remCommId = remMeta->commId;
 
     // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
-    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+    if (IbCastCommIsSecondary(&comm->base)) {
       // Just assign remDevIdx from remote metadata
       uint nqps = comm->base.nqps;
       for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -988,6 +988,175 @@ int IbCastGetTrafficClass(void* ctx) {
 void IbCastSetTrafficClass(void* ctx, int trafficClass) {
   ncclNetCommConfig_t* config = (ncclNetCommConfig_t*)ctx;
   if (config) config->trafficClass = trafficClass;
+}
+
+// Determine QP sharing role for sender and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastSenderQpsCreate
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingSenderSetup(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    struct ncclIbConnectionMetadata* meta,
+    const ncclNetVDeviceProps_t* remoteVProps,
+    int depthMult,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || handle->isRMA) {
+    return ncclSuccess;
+  }
+
+  int ngroups = rcclParamIbCastCommNGroups();
+
+  // Allocate commId for this comm
+  comm->base.commId = IbCastAllocCommId(comm, true);
+  if (comm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  IbCastSharedQpKey probeKey;
+  memset(&probeKey, 0, sizeof(probeKey));
+  memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&probeKey.peerAddr);
+
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  //        handle for Fusion/Cast where remoteVProps->ndevs > 1
+  int probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+  int probeRemIbDevIdx = remoteVProps->devs[0];
+
+  // Count existing refs to determine groupIdx
+  int totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+  int groupIdx = totalRefs % ngroups;
+  comm->base.sharedGroupIdx = groupIdx;
+  comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+  probeKey.ibDevN = probeIbDevN;
+  probeKey.remIbDevIdx = probeRemIbDevIdx;
+  probeKey.isSend = true;
+  probeKey.groupIdx = groupIdx;
+  probeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* existingSlot = IbCastFindSharedQp(&probeKey);
+
+  if (existingSlot != NULL) {
+    // SECONDARY: reuse existing QPs from pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+         __func__, comm->base.commId, groupIdx, totalRefs);
+
+    comm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+    comm->base.sharedPrimaryNqps = primaryNqps;
+
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+    key.isSend = true;
+    key.groupIdx = groupIdx;
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQP = q % primaryNqps;
+      key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps->devs[mappedQP % remoteVProps->ndevs];
+      key.qpIdx = mappedQP;
+
+      struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+      if (slot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+        // Fallback: free commId and go non-sharing
+        IbCastFreeCommId(comm->base.commId);
+        comm->base.commId = 0;
+        comm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      // Copy QP info from shared pool to this comm
+      comm->base.qps[q].qp = slot->qp;
+      comm->base.qps[q].devIndex = slot->devIndex;
+      comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+      comm->base.activeQps[q] = &comm->base.qps[q];
+
+      // Populate metadata with shared QP info
+      meta->qpInfo[q].qpn = slot->qp->qp_num;
+      meta->qpInfo[q].devIndex = slot->devIndex;
+
+      slot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+      comm->devs[i].base.cq = existingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = comm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    existingSlot->cqRefcount++;
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY: create QPs with scaled depth, then register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+         __func__, comm->base.commId, groupIdx, depthMult);
+    comm->base.isSharedQpPrimary = true;
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary sender's QPs in the shared pool.
+// Called after IbCastSenderQpsCreate when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingSenderRegisterPrimary(
+    struct ncclIbSendComm* comm,
+    struct ncclIbHandle* handle,
+    const ncclNetVDeviceProps_t* remoteVProps) {
+
+  union ncclSocketAddress peerAddr;
+  memcpy(&peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+  IbCastStripPort(&peerAddr);
+
+  int nqps = comm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    IbCastSharedQpKey key;
+    memset(&key, 0, sizeof(key));
+    key.peerAddr = peerAddr;
+    key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+    key.remIbDevIdx = remoteVProps->devs[q % remoteVProps->ndevs];
+    key.groupIdx = comm->base.sharedGroupIdx;
+    key.isSend = true;
+    key.qpIdx = q;
+
+    int devIdx = q % comm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+        comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+        comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+    entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+  }
+
+  return ncclSuccess;
 }
 
 ncclResult_t IbCastConnectImpl(void* ctx, int dev, void* opaqueHandle, void** sendComm,
@@ -1102,21 +1271,15 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
-  // Initialize QP sharing fields
-  comm->base.commId = 0;
-  comm->base.isSharedQpPrimary = false;
-  comm->base.sharedGroupIdx = -1;
-  comm->base.remIbDevIdx = -1;
-  comm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&comm->base);
   comm->remCommId = 0;
 
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
 
-  // Compute depth multiplier for QP sharing
   int depthMult;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  depthMult = IbCastQpSharingDepthMultiplier();
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1156,194 +1319,48 @@ ib_recv_dev_list:
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
   meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
-  // QP Sharing: sender-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
-    int ngroups = rcclParamIbCastCommNGroups();
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingSenderSetup(comm, handle, &meta, &remoteVProps, depthMult, &sharingRole), ret, fail);
 
-    // Allocate commId for this comm
-    comm->base.commId = IbCastAllocCommId(comm, true);
-    if (comm->base.commId == 0) {
-      // Fallback to non-sharing if pool exhausted
-      goto qp_sharing_skip_sender;
-    }
+  // Set sharedGroupIdx before IbCastSenderQpsCreate which needs it
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-    // Check if primary exists for this group
-    IbCastSharedQpKey probeKey;
-    memset(&probeKey, 0, sizeof(probeKey));
-    // Build probe key from peer address
-    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-    IbCastStripPort(&probeKey.peerAddr);
-
-    // Use first device's ibDevN for the probe
-    int probeIbDevN;
-    int probeRemIbDevIdx;
-    // TODO - QP sharing
-    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
-    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
-    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
-    probeRemIbDevIdx = remoteVProps.devs[0];
-
-    // Count existing refs to determine groupIdx
-    int totalRefs;
-    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
-    int groupIdx;
-    groupIdx = totalRefs % ngroups;
-    comm->base.sharedGroupIdx = groupIdx;
-    comm->base.remIbDevIdx = probeRemIbDevIdx;
-
-    probeKey.ibDevN = probeIbDevN;
-    probeKey.remIbDevIdx = probeRemIbDevIdx;
-    probeKey.isSend = true;
-    probeKey.groupIdx = groupIdx;
-    probeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* existingSlot;
-    existingSlot = IbCastFindSharedQp(&probeKey);
-
-    if (existingSlot != NULL) {
-      // SECONDARY: reuse existing QPs from pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
-           __func__, comm->base.commId, groupIdx, totalRefs);
-
-      comm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
-      comm->base.sharedPrimaryNqps = primaryNqps;
-
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
-      key.isSend = true;
-      key.groupIdx = groupIdx;
-
-      int nqps = comm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-        int mappedQP = q % primaryNqps;
-        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
-        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
-        key.qpIdx = mappedQP;
-
-        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
-        if (slot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
-          // Fallback: free commId and go non-sharing
-          IbCastFreeCommId(comm->base.commId);
-          comm->base.commId = 0;
-          comm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_sender;
-        }
-
-        // Copy QP info from shared pool to this comm
-        comm->base.qps[q].qp = slot->qp;
-        comm->base.qps[q].devIndex = slot->devIndex;
-        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
-        comm->base.activeQps[q] = &comm->base.qps[q];
-
-        // Populate metadata with shared QP info
-        meta.qpInfo[q].qpn = slot->qp->qp_num;
-        meta.qpInfo[q].devIndex = slot->devIndex;
-
-        slot->refcount++;
-      }
-
-      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
+    comm->telChId = channelId;
+    comm->telChStats = NULL;
+  
+    // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
+    // the untracked value the hooks expect.
+    if (rcclTelemetryOn()) {
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
-        comm->devs[i].base.cq = existingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = comm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        int ibDevN = comm->base.vProps.devs[i];
+        int numQpsForDev = 0;
+        for (int q = 0; q < comm->base.nqps; q++)
+          if (comm->base.qps[q].devIndex == i) numQpsForDev++;
+        int numSlots = 0;
+        int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
+        if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
+        int slotOffset = 0;
+        for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
+          if (comm->base.qps[q].devIndex != i) continue;
+          // QPs past the granted slots keep telQpStats == NULL (untracked).
+          int telSlot = startSlot + slotOffset++;
+          rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
+          comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
         }
       }
-      existingSlot->cqRefcount++;
-
-      // Skip QP creation; metadata is already populated
-      goto qp_sharing_done_sender;
-    } else {
-      // PRIMARY: create QPs with scaled depth, then register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
-           __func__, comm->base.commId, groupIdx, depthMult);
-
-      comm->base.isSharedQpPrimary = true;
+      // Request completions are charged to the comm's first device.
+      comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
     }
-  }
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
-qp_sharing_skip_sender:
-  // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
-
-  comm->telChId = channelId;
-  comm->telChStats = NULL;
-
-  // Telemetry-only: skip when off. IbCastQpCreate() left every telQpStats NULL,
-  // the untracked value the hooks expect.
-  if (rcclTelemetryOn()) {
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      int ibDevN = comm->base.vProps.devs[i];
-      int numQpsForDev = 0;
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].devIndex == i) numQpsForDev++;
-      int numSlots = 0;
-      int startSlot = rcclTelemetrySetupChannel(ibDevN, channelId, numQpsForDev, &numSlots);
-      if (!telChannelIdKnown) rcclTelemetryMarkChannelsUnknown(ibDevN);
-      int slotOffset = 0;
-      for (int q = 0; q < comm->base.nqps && slotOffset < numSlots; q++) {
-        if (comm->base.qps[q].devIndex != i) continue;
-        // QPs past the granted slots keep telQpStats == NULL (untracked).
-        int telSlot = startSlot + slotOffset++;
-        rcclTelemetrySetQpRole(ibDevN, channelId, telSlot, comm->base.qps[q].isDataQp);
-        comm->base.qps[q].telQpStats = rcclTelemetryResolveQp(ibDevN, channelId, telSlot);
-      }
-    }
-    // Request completions are charged to the comm's first device.
-    comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
-  }
-
-  // If primary, register QPs in shared pool
-  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
-    union ncclSocketAddress peerAddr;
-    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
-    IbCastStripPort(&peerAddr);
-
-    int nqps = comm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      IbCastSharedQpKey key;
-      memset(&key, 0, sizeof(key));
-      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
-      IbCastStripPort(&key.peerAddr);
-      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
-      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
-      key.groupIdx = comm->base.sharedGroupIdx;
-      key.isSend = true;
-      key.qpIdx = q;
-
-      int devIdx = q % comm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
-          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingSenderRegisterPrimary(comm, handle, &remoteVProps), ret, fail);
     }
   }
 
-qp_sharing_done_sender:
-  // Populate QP sharing metadata
-  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  // Populate remaining QP sharing metadata
   meta.commId = comm->base.commId;
   // TODO - QP sharing
   //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
@@ -1599,7 +1616,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
 
-  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.isQpSharingEnabled = IbCastQpSharingEnabled();
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -1744,10 +1761,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
-      // QP sharing is disabled for flush QP
-      qpCreateAttrs.isQpSharingEnabled = false;
-      qpCreateAttrs.qpSharingGroupIdx = -1;
-      qpCreateAttrs.cqDepthMultiplier = 1;
+      IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1815,6 +1829,221 @@ ncclResult_t IbCastReceiverPrePostReceiveWorkRequests(struct ncclIbRecvComm* rec
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, &recvComm->base.qps[i]));
   }
+  return ncclSuccess;
+}
+
+// Determine QP sharing role for receiver and set up secondary if applicable.
+// On return:
+//   *outRole == QP_SHARING_SECONDARY: QPs assigned from pool, skip IbCastReceiverQpsCreateToRts
+//   *outRole == QP_SHARING_PRIMARY:   proceed with QP creation, then call RegisterPrimary
+//   *outRole == QP_SHARING_NONE:      sharing disabled/fallback, proceed normally
+static ncclResult_t IbCastQpSharingReceiverSetup(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta,
+    struct ncclIbConnectionMetadata* meta,
+    enum IbCastQpSharingRole* outRole) {
+
+  *outRole = QP_SHARING_NONE;
+
+  if (!IbCastQpSharingEnabled() || remMeta->isRMA || remMeta->sharedGroupIdx < 0) {
+    return ncclSuccess;
+  }
+
+  int recvGroupIdx = remMeta->sharedGroupIdx;
+
+  // Allocate commId for this comm
+  rComm->base.commId = IbCastAllocCommId(rComm, false);
+  if (rComm->base.commId == 0) {
+    // Fallback to non-sharing if pool exhausted
+    return ncclSuccess;
+  }
+
+  // Build probe key from peer address
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  rComm->base.sharedGroupIdx = recvGroupIdx;
+  rComm->base.remIbDevIdx = remMeta->senderIbDevIdx;
+  int recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+  IbCastSharedQpKey recvProbeKey;
+  memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+  recvProbeKey.ibDevN = recvProbeIbDevN;
+  recvProbeKey.peerAddr = recvPeerAddr;
+  recvProbeKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvProbeKey.isSend = false;
+  recvProbeKey.groupIdx = recvGroupIdx;
+  recvProbeKey.qpIdx = 0;
+
+  struct IbCastSharedQp* recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+  if (recvExistingSlot != NULL) {
+    // SECONDARY receiver: reuse existing QPs
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+
+    rComm->base.isSharedQpPrimary = false;
+    int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta->senderIbDevIdx, false, remMeta->sharedGroupIdx);
+    rComm->base.sharedPrimaryNqps = primaryNqps;
+    rComm->useCtsOffload = false;
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.isSend = false;
+    recvKey.groupIdx = recvGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      int mappedQ = q % primaryNqps;
+      int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+      recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+      recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      recvKey.qpIdx = mappedQ;
+
+      struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+      if (recvSlot == NULL) {
+        WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+        IbCastFreeCommId(rComm->base.commId);
+        rComm->base.commId = 0;
+        rComm->base.sharedGroupIdx = -1;
+        *outRole = QP_SHARING_NONE;
+        return ncclSuccess;
+      }
+
+      rComm->base.qps[q].qp = recvSlot->qp;
+      rComm->base.qps[q].devIndex = recvSlot->devIndex;
+      rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+      // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+      // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+      rComm->base.qps[q].remDevIdx = remMeta->qpInfo[q].devIndex;
+      rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+      meta->qpInfo[q].qpn = recvSlot->qp->qp_num;
+      meta->qpInfo[q].devIndex = recvSlot->devIndex;
+
+      recvSlot->refcount++;
+    }
+
+    // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+      rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+      // This comm's own PD ref, taken by IbCastInitCommDevBase, is unused: as a
+      // SECONDARY it borrows the primary's QPs and CQ. Release it now so the
+      // group's PD refcount reflects one owner (the PRIMARY), matching the
+      // single release IbCastCleanupGroupCqs performs at the group's last close.
+      int secondaryIbDevN = rComm->base.vProps.devs[i];
+      std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+      if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+        NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+      }
+    }
+    recvExistingSlot->cqRefcount++;
+
+    // Share flush QPs from primary
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = recvGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+        if (flushSlot) {
+          rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+          flushSlot->refcount++;
+          INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+               __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+        } else {
+          WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+               __func__, i, recvGroupIdx, rComm->base.commId);
+        }
+      }
+    }
+
+    *outRole = QP_SHARING_SECONDARY;
+  } else {
+    // PRIMARY receiver: create QPs with scaled depth, register in pool
+    INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d",
+         __func__, rComm->base.commId, recvGroupIdx);
+    rComm->base.isSharedQpPrimary = true;
+    rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    *outRole = QP_SHARING_PRIMARY;
+  }
+
+  return ncclSuccess;
+}
+
+// Register this primary receiver's QPs (and flush QPs) in the shared pool.
+// Called after IbCastReceiverQpsCreateToRts when role == QP_SHARING_PRIMARY.
+static ncclResult_t IbCastQpSharingReceiverRegisterPrimary(
+    struct ncclIbRecvComm* rComm,
+    const struct ncclIbConnectionMetadata* remMeta) {
+
+  union ncclSocketAddress recvPeerAddr;
+  ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+  IbCastStripPort(&recvPeerAddr);
+
+  IbCastSharedQpKey recvKey;
+  memset(&recvKey, 0, sizeof(recvKey));
+  recvKey.peerAddr = recvPeerAddr;
+  recvKey.remIbDevIdx = remMeta->senderIbDevIdx;
+  recvKey.isSend = false;
+  recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+  int nqps = rComm->base.nqps;
+  for (int q = 0; q < nqps; q++) {
+    recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+    recvKey.qpIdx = q;
+
+    int devIdx = q % rComm->base.vProps.ndevs;
+    struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+        rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+        rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
+    if (entry == NULL) {
+      WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+           "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+      return ncclInternalError;
+    }
+    entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+    if (q == 0) {
+      entry->cqRefcount = 1;
+    }
+  }
+
+  // Register flush QPs in shared pool (primary only)
+  if (rComm->flushEnabled) {
+    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+      IbCastSharedQpKey flushKey;
+      memset(&flushKey, 0, sizeof(flushKey));
+      flushKey.ibDevN = rComm->base.vProps.devs[i];
+      flushKey.peerAddr = recvPeerAddr;
+      flushKey.remIbDevIdx = remMeta->senderIbDevIdx;
+      flushKey.isSend = false;
+      flushKey.groupIdx = rComm->base.sharedGroupIdx;
+      flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+      struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+          rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+      if (flushEntry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+             "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+             __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+        continue;
+      }
+      INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+           __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+           rComm->base.sharedGroupIdx, rComm->base.commId);
+    }
+  }
+
   return ncclSuccess;
 }
 
@@ -1953,15 +2182,9 @@ ib_recv:
     }
   }
 
-  // Initialize QP sharing fields on receiver
-  rComm->base.commId = 0;
-  rComm->base.isSharedQpPrimary = false;
-  rComm->base.sharedGroupIdx = -1;
-  rComm->base.remIbDevIdx = -1;
-  rComm->base.sharedPrimaryNqps = 0;
+  IbCastCommInitSharingFields(&rComm->base);
 
   // IB setup
-  // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
   int ibDevN;
   struct ncclIbRecvCommDev* rCommDev;
@@ -1977,9 +2200,8 @@ ib_recv:
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
 
-  // Compute depth multiplier for receiver QP sharing
   int recvDepthMult;
-  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+  recvDepthMult = IbCastQpSharingDepthMultiplier();
 
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
@@ -2056,202 +2278,17 @@ ib_recv:
                           1 :
                           0;
 
-  // QP Sharing: receiver-side primary/secondary determination
-  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
-    int recvGroupIdx = remMeta.sharedGroupIdx;
-    int recvProbeIbDevN;
+  // QP Sharing: determine role and set up secondary if applicable
+  enum IbCastQpSharingRole sharingRole;
+  NCCLCHECKGOTO(IbCastQpSharingReceiverSetup(rComm, &remMeta, &meta, &sharingRole), ret, fail);
 
-    rComm->base.commId = IbCastAllocCommId(rComm, false);
-    if (rComm->base.commId == 0) {
-      goto qp_sharing_skip_recv;
-    }
-    // Build probe key from peer address
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    rComm->base.sharedGroupIdx = recvGroupIdx;
-	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
-
-    IbCastSharedQpKey recvProbeKey;
-    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
-    recvProbeKey.ibDevN = recvProbeIbDevN;
-    recvProbeKey.peerAddr = recvPeerAddr;
-    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvProbeKey.isSend = false;
-    recvProbeKey.groupIdx = recvGroupIdx;
-    recvProbeKey.qpIdx = 0;
-
-    struct IbCastSharedQp* recvExistingSlot;
-    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
-
-    if (recvExistingSlot != NULL) {
-      // SECONDARY receiver: reuse existing QPs
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
-           __func__, rComm->base.commId, recvGroupIdx);
-
-      rComm->base.isSharedQpPrimary = false;
-	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
-
-      rComm->base.sharedPrimaryNqps = primaryNqps;
-      rComm->useCtsOffload = false;
-
-      IbCastSharedQpKey recvKey;
-      memset(&recvKey, 0, sizeof(recvKey));
-      recvKey.peerAddr = recvPeerAddr;
-      recvKey.isSend = false;
-      recvKey.groupIdx = recvGroupIdx;
-
-      int nqps = rComm->base.nqps;
-      for (int q = 0; q < nqps; q++) {
-		int mappedQ = q % primaryNqps;
-		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
-		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
-        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        recvKey.qpIdx = mappedQ;
-
-        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
-        if (recvSlot == NULL) {
-          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
-          IbCastFreeCommId(rComm->base.commId);
-          rComm->base.commId = 0;
-          rComm->base.sharedGroupIdx = -1;
-          goto qp_sharing_skip_recv;
-        }
-
-        rComm->base.qps[q].qp = recvSlot->qp;
-        rComm->base.qps[q].devIndex = recvSlot->devIndex;
-        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
-        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
-        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
-        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
-        rComm->base.activeQps[q] = &rComm->base.qps[q];
-
-        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
-        meta.qpInfo[q].devIndex = recvSlot->devIndex;
-
-        recvSlot->refcount++;
-      }
-
-      // Redirect CQs
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
-        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
-
-        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
-        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
-        // of its own. Release it now so the group's PD refcount reflects one
-        // owner (the PRIMARY), matching the single release
-        // IbCastCleanupGroupCqs performs at the group's last close.
-        int secondaryIbDevN = rComm->base.vProps.devs[i];
-        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
-        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
-          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
-        }
-      }
-      recvExistingSlot->cqRefcount++;
-
-      // Share flush QPs from primary
-      if (rComm->flushEnabled) {
-        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-          IbCastSharedQpKey flushKey;
-          memset(&flushKey, 0, sizeof(flushKey));
-          flushKey.ibDevN = rComm->base.vProps.devs[i];
-          flushKey.peerAddr = recvPeerAddr;
-          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-          flushKey.isSend = false;
-          flushKey.groupIdx = recvGroupIdx;
-          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
-          if (flushSlot) {
-            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
-            flushSlot->refcount++;
-            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
-                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
-          } else {
-            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
-                 __func__, i, recvGroupIdx, rComm->base.commId);
-          }
-        }
-      }
-
-      goto qp_sharing_done_recv;
-    } else {
-      // PRIMARY receiver: create QPs with scaled depth, register in pool
-      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
-           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
-      rComm->base.isSharedQpPrimary = true;
-      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+  if (sharingRole != QP_SHARING_SECONDARY) {
+    NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
+    if (sharingRole == QP_SHARING_PRIMARY) {
+      NCCLCHECKGOTO(IbCastQpSharingReceiverRegisterPrimary(rComm, &remMeta), ret, fail);
     }
   }
 
-qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
-
-  // If primary receiver, register QPs in shared pool
-  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
-    union ncclSocketAddress recvPeerAddr;
-    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
-    IbCastStripPort(&recvPeerAddr);
-
-    IbCastSharedQpKey recvKey;
-    memset(&recvKey, 0, sizeof(recvKey));
-    recvKey.peerAddr = recvPeerAddr;
-    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-    recvKey.isSend = false;
-    recvKey.groupIdx = rComm->base.sharedGroupIdx;
-
-    int nqps = rComm->base.nqps;
-    for (int q = 0; q < nqps; q++) {
-      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
-      recvKey.qpIdx = q;
-
-      int devIdx = q % rComm->base.vProps.ndevs;
-      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
-          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry == NULL) {
-        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
-             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
-        ret = ncclInternalError;
-        goto fail;
-      }
-      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-      if (q == 0) {
-        entry->cqRefcount = 1;
-      }
-    }
-
-    // Register flush QPs in shared pool (primary only)
-    if (rComm->flushEnabled) {
-      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
-        IbCastSharedQpKey flushKey;
-        memset(&flushKey, 0, sizeof(flushKey));
-        flushKey.ibDevN = rComm->base.vProps.devs[i];
-        flushKey.peerAddr = recvPeerAddr;
-        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        flushKey.isSend = false;
-        flushKey.groupIdx = rComm->base.sharedGroupIdx;
-        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
-
-        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
-        if (flushEntry == NULL) {
-          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
-               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
-               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
-          continue;
-        }
-        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
-             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
-             rComm->base.sharedGroupIdx, rComm->base.commId);
-      }
-    }
-  }
-
-qp_sharing_done_recv:
   // Populate QP sharing metadata in response
   meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
   meta.commId = rComm->base.commId;
@@ -2419,20 +2456,37 @@ fail:
   goto exit;
 }
 
+// Per-device MR cleanup for sender comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseSendCommDevResources(struct ncclIbSendComm* comm, int devIndex) {
+  struct ncclIbSendCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (commDev->putSignalScratchpadMr != NULL)
+    NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseSend(void* sendComm) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, true);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2443,53 +2497,33 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
+
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      NCCLCHECK(IbCastCloseSendCommDevResources(comm, i));
+      if (!isSharing) {
+        NCCLCHECK(IbCastDestroyBase(&comm->devs[i].base));
       }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    }
 
-      // Deregister per-comm MRs (not shared)
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
-      }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them, or ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbSendCommDev* commDev = comm->devs + i;
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (commDev->putSignalScratchpadMr != NULL)
-          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-        if (comm->base.resiliency) {
-           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-        }
-        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them, or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
       }
     }
 
@@ -2502,20 +2536,48 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   return ncclSuccess;
 }
 
+// Per-device flush memory cleanup (common between shared/non-shared paths).
+// Releases GPU memory, MRs, and dma-buf FDs. Does NOT destroy the flush QP.
+static ncclResult_t IbCastCloseRecvFlushMem(struct ncclIbRecvCommDev* commDev) {
+  if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+    CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+    commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+    if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+    commDev->gpuFlush.gpuMr = nullptr;
+    if (commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd); }
+  }
+  return ncclSuccess;
+}
+
+// Per-device MR cleanup for receiver comms (shared between shared/non-shared paths)
+static ncclResult_t IbCastCloseRecvCommDevResources(struct ncclIbRecvComm* comm, int devIndex) {
+  struct ncclIbRecvCommDev* commDev = comm->devs + devIndex;
+  if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+  if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+  if (comm->base.resiliency) {
+    NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, devIndex));
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t IbCastCloseRecv(void* recvComm) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm) {
+    bool isSharing = IbCastCommIsSharing(&comm->base);
     if (comm->base.vProps.ndevs > 0)
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
-      // QP sharing teardown: refcount-based
-      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-      struct IbCastSharedQp* slot0 = NULL;
-      for (int q = 0; q < comm->base.nqps; q++) {
-        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
-            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+    // Acquire QP sharing mutex only when this comm participates in sharing
+    std::unique_lock<std::mutex> lock(g_IbCastSharedQpMutex, std::defer_lock);
+    if (isSharing) lock.lock();
+
+    // Data QP teardown: refcount-based for shared, direct destroy for non-shared
+    struct IbCastSharedQp* slot0 = NULL;
+    for (int q = 0; q < comm->base.nqps; q++) {
+      if (comm->base.qps[q].qp == NULL) continue;
+      if (isSharing) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(comm->base.qps[q].qp->qp_num, false);
         if (slot) {
           if (q == 0) slot0 = slot;
           slot->refcount--;
@@ -2526,27 +2588,28 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             slot->qp = NULL;
           }
         }
+      } else {
+        NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
       }
+    }
 
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+    }
 
-      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          // Per-comm flush memory cleanup (always done)
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          // Shared flush QP teardown (refcount-based)
-          if (commDev->gpuFlush.qp.qp != NULL) {
+    if (isSharing) {
+      IbCastFreeCommIdLocked(comm->base.commId);
+    }
+
+    // Per-device resource cleanup: flush QP/memory and MR teardown
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      struct ncclIbRecvCommDev* commDev = comm->devs + i;
+      if (comm->flushEnabled) {
+        // Flush memory is always per-comm
+        NCCLCHECK(IbCastCloseRecvFlushMem(commDev));
+        // Flush QP teardown: refcount-based for shared, direct destroy for non-shared
+        if (commDev->gpuFlush.qp.qp != NULL) {
+          if (isSharing) {
             struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
                 commDev->gpuFlush.qp.qp->qp_num, false);
             if (flushSlot) {
@@ -2556,65 +2619,34 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
+                IbCastUnregisterSharedQpLocked(flushSlot);
               }
             } else {
-              // Not in pool -- e.g. registration hit the pool-exhaustion
-              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
-              // flush QP was never pool-tracked, so just destroy it directly.
+              // Not in pool (pool-exhaustion fallback) — destroy directly
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
-            commDev->gpuFlush.qp.qp = NULL;
+          } else {
+            NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
           }
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+          commDev->gpuFlush.qp.qp = NULL;
         }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
-        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-
-      // Group CQs are torn down last: they must outlive every QP still bound
-      // to them (data QPs above, this comm's own flush QP just above), or
-      // ibv_destroy_cq fails with EBUSY.
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
-    } else {
-      // Non-shared: original teardown
-      for (int q = 0; q < comm->base.nqps; q++)
-        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-      }
-
-      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-        struct ncclIbRecvCommDev* commDev = comm->devs + i;
-        if (comm->flushEnabled) {
-          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-            commDev->gpuFlush.gpuMr = nullptr;
-            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
-          }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
-        }
-        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-        if (comm->base.resiliency) {
-          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-        }
+      NCCLCHECK(IbCastCloseRecvCommDevResources(comm, i));
+      if (!isSharing) {
         NCCLCHECK(IbCastDestroyBase(&commDev->base));
       }
     }
+
+    // Group CQs are torn down last: they must outlive every QP still bound
+    // to them (data QPs and flush QPs above), or ibv_destroy_cq fails with EBUSY.
+    if (isSharing && slot0) {
+      slot0->cqRefcount--;
+      if (slot0->cqRefcount <= 0) {
+        IbCastCleanupGroupCqs(slot0);
+      }
+    }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2100,6 +2100,31 @@ ib_recv:
       }
       recvExistingSlot->cqRefcount++;
 
+      // Share flush QPs from primary
+      if (rComm->flushEnabled) {
+        for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+          IbCastSharedQpKey flushKey;
+          memset(&flushKey, 0, sizeof(flushKey));
+          flushKey.ibDevN = rComm->base.vProps.devs[i];
+          flushKey.peerAddr = recvPeerAddr;
+          flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+          flushKey.isSend = false;
+          flushKey.groupIdx = recvGroupIdx;
+          flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+          struct IbCastSharedQp* flushSlot = IbCastFindSharedQp(&flushKey);
+          if (flushSlot) {
+            rComm->devs[i].gpuFlush.qp.qp = flushSlot->qp;
+            flushSlot->refcount++;
+            INFO(NCCL_NET, "NET/IB: %s: SECONDARY recv sharing flush QP qpn=%u dev=%d group=%d refcount=%d commId=%u",
+                 __func__, flushSlot->qp->qp_num, i, recvGroupIdx, flushSlot->refcount, rComm->base.commId);
+          } else {
+            WARN("NET/IB: %s: SECONDARY recv could not find shared flush QP for dev=%d group=%d commId=%u",
+                 __func__, i, recvGroupIdx, rComm->base.commId);
+          }
+        }
+      }
+
       goto qp_sharing_done_recv;
     } else {
       // PRIMARY receiver: create QPs with scaled depth, register in pool
@@ -2140,6 +2165,26 @@ qp_sharing_skip_recv:
         if (q == 0) {
           entry->cqRefcount = 1;
         }
+      }
+    }
+
+    // Register flush QPs in shared pool (primary only)
+    if (rComm->flushEnabled) {
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        IbCastSharedQpKey flushKey;
+        memset(&flushKey, 0, sizeof(flushKey));
+        flushKey.ibDevN = rComm->base.vProps.devs[i];
+        flushKey.peerAddr = recvPeerAddr;
+        flushKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        flushKey.isSend = false;
+        flushKey.groupIdx = rComm->base.sharedGroupIdx;
+        flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
+
+        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+        INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
+             __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
+             rComm->base.sharedGroupIdx, rComm->base.commId);
       }
     }
   }
@@ -2429,10 +2474,11 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
-      // GPU flush cleanup remains per-comm
+      // GPU flush cleanup — flush QP is shared, memory resources are per-comm
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
+          // Per-comm flush memory cleanup (always done)
           if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
             CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
             commDev->gpuFlush.gpuFlushGpuMem = nullptr;
@@ -2440,7 +2486,25 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
             commDev->gpuFlush.gpuMr = nullptr;
             if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
           }
-          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          // Shared flush QP teardown (refcount-based)
+          if (commDev->gpuFlush.qp.qp != NULL) {
+            struct IbCastSharedQp* flushSlot = IbCastFindSharedQpByQpn(
+                commDev->gpuFlush.qp.qp->qp_num, false);
+            if (flushSlot) {
+              flushSlot->refcount--;
+              if (flushSlot->refcount <= 0 && flushSlot->qp) {
+                INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared flush QP qpn=%u group=%d",
+                     flushSlot->qp->qp_num, flushSlot->key.groupIdx);
+                wrap_ibv_destroy_qp(flushSlot->qp);
+                flushSlot->qp = NULL;
+                flushSlot->used = false;
+              }
+            } else {
+              // Not in pool (shouldn't happen), destroy directly
+              NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+            }
+            commDev->gpuFlush.qp.qp = NULL;
+          }
           if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
         }
         if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -95,7 +95,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int64_t cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -107,12 +107,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
   }
 
   if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
-    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+    WARN("NET/IB: %s: requested CQ size %ld exceeds device %s max_cqe %d, clamping",
          __func__, cqSize, ibDev->devName, ibDev->maxCqe);
     cqSize = ibDev->maxCqe;
   }
 
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, (int)cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -1132,7 +1132,7 @@ ib_recv_dev_list:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, ((int64_t)cqSize * depthMult)), ret, fail);
     if (depthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what depthMult asked for, shrink depthMult to match so QP WR depth
@@ -1995,7 +1995,7 @@ ib_recv:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, ((int64_t)cqSize * recvDepthMult)), ret, fail);
     if (recvDepthMult > 1) {
       // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
       // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
@@ -2236,8 +2236,14 @@ qp_sharing_skip_recv:
         flushKey.groupIdx = rComm->base.sharedGroupIdx;
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
-        IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
+        struct IbCastSharedQp* flushEntry = IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
             rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
+        if (flushEntry == NULL) {
+          WARN("NET/IB: %s: QP sharing PRIMARY recv: shared-QP pool exhausted registering flush QP "
+               "dev=%d group=%d commId=%u, secondaries will not be able to share it",
+               __func__, i, rComm->base.sharedGroupIdx, rComm->base.commId);
+          continue;
+        }
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -106,6 +106,12 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
+  if (ibDev->maxCqe > 0 && cqSize > ibDev->maxCqe) {
+    WARN("NET/IB: %s: requested CQ size %d exceeds device %s max_cqe %d, clamping",
+         __func__, cqSize, ibDev->devName, ibDev->maxCqe);
+    cqSize = ibDev->maxCqe;
+  }
+
   NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
@@ -795,9 +801,13 @@ fail:
 // is updated accordingly. The meta data structure is then expected to be
 // delivered to the remote side (receiver) as part of the connection
 // establishment process.
-static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
+static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId,
+                                          int depthMult) {
   uint nqps = comm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -806,7 +816,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1124,6 +1133,13 @@ ib_recv_dev_list:
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
+    if (depthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what depthMult asked for, shrink depthMult to match so QP WR depth
+      // and this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = comm->devs[i].base.cq->cqe / cqSize;
+      if (achievedMult < depthMult) depthMult = std::max(1, achievedMult);
+    }
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1261,7 +1277,7 @@ ib_recv_dev_list:
 
 qp_sharing_skip_sender:
   // Create QPs on the sender side
-  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId, depthMult), ret, fail);
 
   comm->telChId = channelId;
   comm->telChStats = NULL;
@@ -1564,10 +1580,14 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
+// depthMult is the sizing already applied to this comm's CQs (IbCastInitCommDevBase),
+// clamped to what the device's max_cqe could actually support -- QP send/recv WR
+// depth must scale by that same, possibly-reduced, value or the QP can post more
+// work than its CQ can record completions for.
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
-                                                 struct ncclIbConnectionMetadata* meta, int channelId) {
+                                                 struct ncclIbConnectionMetadata* meta, int channelId,
+                                                 int depthMult) {
   uint nqps = rComm->base.nqps;
-  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1581,7 +1601,6 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
 
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
-  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
   qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
@@ -1977,6 +1996,13 @@ ib_recv:
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
     NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
+    if (recvDepthMult > 1) {
+      // IbCastInitCommDevBase clamps the CQ to the device's max_cqe; if that clamped
+      // us below what recvDepthMult asked for, shrink it to match so QP WR depth and
+      // this group's shared-QP capacityUnits never exceed what the CQ can record.
+      int achievedMult = rCommDev->base.cq->cqe / cqSize;
+      if (achievedMult < recvDepthMult) recvDepthMult = std::max(1, achievedMult);
+    }
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -2162,7 +2188,7 @@ ib_recv:
   }
 
 qp_sharing_skip_recv:
-  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+  NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId, recvDepthMult), ret, fail);
 
   // If primary receiver, register QPs in shared pool
   if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1300,7 +1300,7 @@ qp_sharing_skip_sender:
       int devIdx = q % comm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+          comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -2159,7 +2159,7 @@ qp_sharing_skip_recv:
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+          rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
       if (entry) {
         entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
         if (q == 0) {
@@ -2181,7 +2181,7 @@ qp_sharing_skip_recv:
         flushKey.qpIdx = IBCAST_FLUSH_QP_IDX;
 
         IbCastRegisterSharedQp(&flushKey, rComm->devs[i].gpuFlush.qp.qp,
-            rComm->devs[i].base.cq, &rComm->devs[i].base, i, 1);
+            rComm->devs[i].base.cq, rComm->devs[i].base.ibDevN, i, 1);
         INFO(NCCL_NET, "NET/IB: %s: PRIMARY recv registered flush QP qpn=%u dev=%d group=%d commId=%u",
              __func__, rComm->devs[i].gpuFlush.qp.qp->qp_num, i,
              rComm->base.sharedGroupIdx, rComm->base.commId);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -2382,12 +2382,6 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           }
         }
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
 
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
@@ -2405,6 +2399,15 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them, or ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown
@@ -2466,12 +2469,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      if (slot0) {
-        slot0->cqRefcount--;
-        if (slot0->cqRefcount <= 0) {
-          IbCastCleanupGroupCqs(slot0);
-        }
-      }
       IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // GPU flush cleanup — flush QP is shared, memory resources are per-comm
@@ -2513,6 +2510,16 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           IbCastResiliencyDevDestroy(comm->base.resiliency, i);
         }
         // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+
+      // Group CQs are torn down last: they must outlive every QP still bound
+      // to them (data QPs above, this comm's own flush QP just above), or
+      // ibv_destroy_cq fails with EBUSY.
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
       }
     } else {
       // Non-shared: original teardown

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1077,10 +1077,11 @@ static ncclResult_t IbCastQpSharingSenderSetup(
         return ncclSuccess;
       }
 
-      // Copy QP info from shared pool to this comm
+      // Copy QP info from shared pool to this comm.
+      // ctsQpSlot is not stored in the pool: CTS offload is mutually exclusive
+      // with QP sharing; the non-offload signaling path uses devIndex instead.
       comm->base.qps[q].qp = slot->qp;
       comm->base.qps[q].devIndex = slot->devIndex;
-      comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
       comm->base.activeQps[q] = &comm->base.qps[q];
 
       // Populate metadata with shared QP info
@@ -1153,7 +1154,6 @@ static ncclResult_t IbCastQpSharingSenderRegisterPrimary(
     if (q == 0) {
       entry->cqRefcount = 1;
     }
-    entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
   }
 
   return ncclSuccess;
@@ -1920,9 +1920,10 @@ static ncclResult_t IbCastQpSharingReceiverSetup(
         return ncclSuccess;
       }
 
+      // ctsQpSlot is not stored in the pool: CTS offload is mutually exclusive
+      // with QP sharing; the non-offload signaling path uses devIndex instead.
       rComm->base.qps[q].qp = recvSlot->qp;
       rComm->base.qps[q].devIndex = recvSlot->devIndex;
-      rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
       // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
       // skipped for secondary comms; set it here or CTS rkey selection is wrong.
       rComm->base.qps[q].remDevIdx = remMeta->qpInfo[q].devIndex;
@@ -2020,7 +2021,6 @@ static ncclResult_t IbCastQpSharingReceiverRegisterPrimary(
            "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
       return ncclInternalError;
     }
-    entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
     if (q == 0) {
       entry->cqRefcount = 1;
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1761,7 +1761,15 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
-      IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
+      if (IbCastCommIsPrimary(&rComm->base)) {
+        // Flush QP is shared across comms in the group — enable WR depth
+        // scaling and group-based UDMA pinning so it matches the data QPs.
+        qpCreateAttrs.isQpSharingEnabled = true;
+        qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+        qpCreateAttrs.cqDepthMultiplier = depthMult;
+      } else {
+        IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
+      }
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -10,6 +10,7 @@
 #include "p2p_cast.h"
 #include "p2p_resiliency_cast.h"
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbCastRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
@@ -77,6 +78,10 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
 
   if (useCtsOffload) {
     return BY_ORDER;
+  }
+
+  if (rcclParamIbCastCommNGroups() > 0) {
+    return BY_ID;
   }
 
   if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
@@ -405,6 +410,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   return ncclSuccess;
 }
 
+
 static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs, struct ncclIbQp* qp) {
   struct ibv_qp_init_attr qpInitAttr;
   enum ncclIbChannelType channel_type = (createQpAttrs->isDataQp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
@@ -413,8 +419,14 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
   qpInitAttr.qp_type = createQpAttrs->type;
-  qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
-  qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  // Scale WR depths for QP sharing
+  if (createQpAttrs->isQpSharingEnabled) {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest * createQpAttrs->cqDepthMultiplier;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest * createQpAttrs->cqDepthMultiplier;
+  } else {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  }
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
   if (createQpAttrs->isCtsEnabled) {
@@ -439,17 +451,23 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
 
-  if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
-    bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
-    nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
-      !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
-  }
-  if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+  if (createQpAttrs->isQpSharingEnabled && (createQpAttrs->qpSharingGroupIdx >= 0)) {
+    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
+    uint8_t mask = (createQpAttrs->qpSharingGroupIdx % 2 == 0) ? IONIC_UDMA_MASK_LOW : IONIC_UDMA_MASK_HIGH;
+    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, mask);
   } else {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
+      bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
+      nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
+        !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
+    }
+    if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+    } else {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    }
   }
 
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, createQpAttrs->pd, &qpInitAttr));
@@ -779,12 +797,17 @@ fail:
 // establishment process.
 static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = comm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -876,6 +899,25 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    comm->remCommId = remMeta->commId;
+
+    // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
+    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+      // Just assign remDevIdx from remote metadata
+      uint nqps = comm->base.nqps;
+      for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+        ncclIbQp* localQp = &comm->base.qps[qpIndex];
+        ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
+        localQp->remDevIdx = remQpInfo->devIndex;
+      }
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
+      }
+      return ncclSuccess;
+    }
+  }
+
   uint nqps = comm->base.nqps;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
@@ -904,6 +946,7 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
 
     struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    remDevInfo->mtu = rtrAttr->mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
     rtrAttr->sl = remMeta->sl;
@@ -1050,9 +1093,21 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
+  // Initialize QP sharing fields
+  comm->base.commId = 0;
+  comm->base.isSharedQpPrimary = false;
+  comm->base.sharedGroupIdx = -1;
+  comm->base.remIbDevIdx = -1;
+  comm->base.sharedPrimaryNqps = 0;
+  comm->remCommId = 0;
+
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
+
+  // Compute depth multiplier for QP sharing
+  int depthMult;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1068,7 +1123,7 @@ ib_recv_dev_list:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1079,7 +1134,121 @@ ib_recv_dev_list:
   meta.ndevs = comm->base.vProps.ndevs;
   meta.isP2p = isP2p;
   meta.isRMA = handle->isRMA;
+  meta.sharedGroupIdx = -1;
+  meta.commId = 0;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
+  // QP Sharing: sender-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
+    int ngroups = rcclParamIbCastCommNGroups();
+
+    // Allocate commId for this comm
+    comm->base.commId = IbCastAllocCommId(comm, true);
+    if (comm->base.commId == 0) {
+      // Fallback to non-sharing if pool exhausted
+      goto qp_sharing_skip_sender;
+    }
+
+    // Check if primary exists for this group
+    IbCastSharedQpKey probeKey;
+    memset(&probeKey, 0, sizeof(probeKey));
+    // Build probe key from peer address
+    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+    IbCastStripPort(&probeKey.peerAddr);
+
+    // Use first device's ibDevN for the probe
+    int probeIbDevN;
+    int probeRemIbDevIdx;
+    // TODO - QP sharing
+    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
+    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+    probeRemIbDevIdx = remoteVProps.devs[0];
+
+    // Count existing refs to determine groupIdx
+    int totalRefs;
+    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+    int groupIdx;
+    groupIdx = totalRefs % ngroups;
+    comm->base.sharedGroupIdx = groupIdx;
+    comm->base.remIbDevIdx = probeRemIbDevIdx;
+
+    probeKey.ibDevN = probeIbDevN;
+    probeKey.remIbDevIdx = probeRemIbDevIdx;
+    probeKey.isSend = true;
+    probeKey.groupIdx = groupIdx;
+    probeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* existingSlot;
+    existingSlot = IbCastFindSharedQp(&probeKey);
+
+    if (existingSlot != NULL) {
+      // SECONDARY: reuse existing QPs from pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+           __func__, comm->base.commId, groupIdx, totalRefs);
+
+      comm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+      comm->base.sharedPrimaryNqps = primaryNqps;
+
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+      key.isSend = true;
+      key.groupIdx = groupIdx;
+
+      int nqps = comm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+        int mappedQP = q % primaryNqps;
+        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
+        key.qpIdx = mappedQP;
+
+        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+        if (slot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+          // Fallback: free commId and go non-sharing
+          IbCastFreeCommId(comm->base.commId);
+          comm->base.commId = 0;
+          comm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_sender;
+        }
+
+        // Copy QP info from shared pool to this comm
+        comm->base.qps[q].qp = slot->qp;
+        comm->base.qps[q].devIndex = slot->devIndex;
+        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+        comm->base.activeQps[q] = &comm->base.qps[q];
+
+        // Populate metadata with shared QP info
+        meta.qpInfo[q].qpn = slot->qp->qp_num;
+        meta.qpInfo[q].devIndex = slot->devIndex;
+
+        slot->refcount++;
+      }
+
+      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+        comm->devs[i].base.cq = existingSlot->primaryCq;
+      }
+      existingSlot->cqRefcount++;
+
+      // Skip QP creation; metadata is already populated
+      goto qp_sharing_done_sender;
+    } else {
+      // PRIMARY: create QPs with scaled depth, then register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+           __func__, comm->base.commId, groupIdx, depthMult);
+
+      comm->base.isSharedQpPrimary = true;
+    }
+  }
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+
+qp_sharing_skip_sender:
   // Create QPs on the sender side
   NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
 
@@ -1109,6 +1278,45 @@ ib_recv_dev_list:
     // Request completions are charged to the comm's first device.
     comm->telChStats = rcclTelemetryResolveChannel(comm->base.vProps.devs[0], channelId);
   }
+
+  // If primary, register QPs in shared pool
+  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
+    union ncclSocketAddress peerAddr;
+    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
+    IbCastStripPort(&peerAddr);
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+      IbCastStripPort(&key.peerAddr);
+      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
+      key.groupIdx = comm->base.sharedGroupIdx;
+      key.isSend = true;
+      key.qpIdx = q;
+
+      int devIdx = q % comm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
+      if (entry && q == 0) {
+        entry->cqRefcount = 1;
+      }
+      if (entry) {
+        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+      }
+    }
+  }
+
+qp_sharing_done_sender:
+  // Populate QP sharing metadata
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  meta.commId = comm->base.commId;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
@@ -1344,6 +1552,7 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
                                                  struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = rComm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1354,6 +1563,11 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // When resiliency is enabled, the number of send work requests is as the
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
+
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1408,6 +1622,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
         return ncclInternalError;
       }
     }
+
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
@@ -1495,6 +1710,10 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
+      // QP sharing is disabled for flush QP
+      qpCreateAttrs.isQpSharingEnabled = false;
+      qpCreateAttrs.qpSharingGroupIdx = -1;
+      qpCreateAttrs.cqDepthMultiplier = 1;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1700,6 +1919,13 @@ ib_recv:
     }
   }
 
+  // Initialize QP sharing fields on receiver
+  rComm->base.commId = 0;
+  rComm->base.isSharedQpPrimary = false;
+  rComm->base.sharedGroupIdx = -1;
+  rComm->base.remIbDevIdx = -1;
+  rComm->base.sharedPrimaryNqps = 0;
+
   // IB setup
   // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
@@ -1716,6 +1942,11 @@ ib_recv:
   // Metadata to send back to requestor (sender)
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
+
+  // Compute depth multiplier for receiver QP sharing
+  int recvDepthMult;
+  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
@@ -1730,7 +1961,7 @@ ib_recv:
     if (IbCastDevs[ibDevN].maxCqe > 0) {
       cqSize = std::min(IbCastDevs[ibDevN].maxCqe, cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1784,7 +2015,140 @@ ib_recv:
                           1 :
                           0;
 
+  // QP Sharing: receiver-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
+    int recvGroupIdx = remMeta.sharedGroupIdx;
+    int recvProbeIbDevN;
+
+    rComm->base.commId = IbCastAllocCommId(rComm, false);
+    if (rComm->base.commId == 0) {
+      goto qp_sharing_skip_recv;
+    }
+    // Build probe key from peer address
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    rComm->base.sharedGroupIdx = recvGroupIdx;
+	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+    IbCastSharedQpKey recvProbeKey;
+    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+    recvProbeKey.ibDevN = recvProbeIbDevN;
+    recvProbeKey.peerAddr = recvPeerAddr;
+    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvProbeKey.isSend = false;
+    recvProbeKey.groupIdx = recvGroupIdx;
+    recvProbeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* recvExistingSlot;
+    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+    if (recvExistingSlot != NULL) {
+      // SECONDARY receiver: reuse existing QPs
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+           __func__, rComm->base.commId, recvGroupIdx);
+
+      rComm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
+
+      rComm->base.sharedPrimaryNqps = primaryNqps;
+      rComm->useCtsOffload = false;
+
+      IbCastSharedQpKey recvKey;
+      memset(&recvKey, 0, sizeof(recvKey));
+      recvKey.peerAddr = recvPeerAddr;
+      recvKey.isSend = false;
+      recvKey.groupIdx = recvGroupIdx;
+
+      int nqps = rComm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+		int mappedQ = q % primaryNqps;
+		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        recvKey.qpIdx = mappedQ;
+
+        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+        if (recvSlot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+          IbCastFreeCommId(rComm->base.commId);
+          rComm->base.commId = 0;
+          rComm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_recv;
+        }
+
+        rComm->base.qps[q].qp = recvSlot->qp;
+        rComm->base.qps[q].devIndex = recvSlot->devIndex;
+        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
+        rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
+        meta.qpInfo[q].devIndex = recvSlot->devIndex;
+
+        recvSlot->refcount++;
+      }
+
+      // Redirect CQs
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+      }
+      recvExistingSlot->cqRefcount++;
+
+      goto qp_sharing_done_recv;
+    } else {
+      // PRIMARY receiver: create QPs with scaled depth, register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
+           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
+      rComm->base.isSharedQpPrimary = true;
+      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
+    }
+  }
+
+qp_sharing_skip_recv:
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+
+  // If primary receiver, register QPs in shared pool
+  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvKey.isSend = false;
+    recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+      recvKey.qpIdx = q;
+
+      int devIdx = q % rComm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
+      if (entry) {
+        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+        if (q == 0) {
+          entry->cqRefcount = 1;
+        }
+      }
+    }
+  }
+
+qp_sharing_done_recv:
+  // Populate QP sharing metadata in response
+  meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
+  meta.commId = rComm->base.commId;
+
   if (rComm->prepostReceiveWorkRequests) {
     NCCLCHECKGOTO(IbCastReceiverPrePostReceiveWorkRequests(rComm), ret, fail);
   }
@@ -1955,23 +2319,70 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbSendCommDev* commDev = comm->devs + i;
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared send QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
+          }
+        }
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // Deregister per-comm MRs (not shared)
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
+
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }
@@ -1988,34 +2399,86 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       rcclTelemetryAddCqPolls(comm->base.vProps.devs[0], comm->base.telCqPollCount);
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
-
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbRecvCommDev* commDev = comm->devs + i;
-      if (comm->flushEnabled) {
-        if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-          commDev->gpuFlush.gpuMr = nullptr;
-          if (commDev->gpuFlush.dmabufFd > 0) {
-            close(commDev->gpuFlush.dmabufFd);
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared recv QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
           }
         }
-        if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+
       if (comm->base.resiliency) {
-        IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
+
+      // GPU flush cleanup remains per-comm
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
     }
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1312,12 +1312,16 @@ qp_sharing_skip_sender:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
           comm->devs[devIdx].base.ibDevN, comm->base.qps[q].devIndex, 1);
-      if (entry && q == 0) {
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, comm->base.commId, comm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      if (q == 0) {
         entry->cqRefcount = 1;
       }
-      if (entry) {
-        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
-      }
+      entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
     }
   }
 
@@ -2182,11 +2186,15 @@ qp_sharing_skip_recv:
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
           rComm->devs[devIdx].base.ibDevN, rComm->base.qps[q].devIndex, 1);
-      if (entry) {
-        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
-        if (q == 0) {
-          entry->cqRefcount = 1;
-        }
+      if (entry == NULL) {
+        WARN("NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d: shared-QP pool exhausted "
+             "registering qpIdx=%d/%d", __func__, rComm->base.commId, rComm->base.sharedGroupIdx, q, nqps);
+        ret = ncclInternalError;
+        goto fail;
+      }
+      entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+      if (q == 0) {
+        entry->cqRefcount = 1;
       }
     }
 
@@ -2516,10 +2524,12 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
                      flushSlot->qp->qp_num, flushSlot->key.groupIdx);
                 wrap_ibv_destroy_qp(flushSlot->qp);
                 flushSlot->qp = NULL;
-                flushSlot->used = false;
+                IbCastUnregisterSharedQpLocked(flushSlot);  // caller holds g_IbCastSharedQpMutex
               }
             } else {
-              // Not in pool (shouldn't happen), destroy directly
+              // Not in pool -- e.g. registration hit the pool-exhaustion
+              // fallback (IbCastRegisterSharedQp returned NULL); this comm's
+              // flush QP was never pool-tracked, so just destroy it directly.
               NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
             }
             commDev->gpuFlush.qp.qp = NULL;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1233,6 +1233,17 @@ ib_recv_dev_list:
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
         comm->devs[i].base.cq = existingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = comm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       existingSlot->cqRefcount++;
 
@@ -2097,6 +2108,17 @@ ib_recv:
       for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
         NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
         rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+
+        // This comm's own PD ref, taken by IbCastInitCommDevBase above, is
+        // unused: as a SECONDARY it borrows the primary's QPs and CQ instead
+        // of its own. Release it now so the group's PD refcount reflects one
+        // owner (the PRIMARY), matching the single release
+        // IbCastCleanupGroupCqs performs at the group's last close.
+        int secondaryIbDevN = rComm->base.vProps.devs[i];
+        std::lock_guard<std::mutex> pdLock(IbCastDevs[secondaryIbDevN].mutex);
+        if (0 == --IbCastDevs[secondaryIbDevN].pdRefs) {
+          NCCLCHECK(wrap_ibv_dealloc_pd(IbCastDevs[secondaryIbDevN].pd));
+        }
       }
       recvExistingSlot->cqRefcount++;
 

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -115,6 +115,13 @@ struct ncclIbConnectionMetadata {
   int      senderIbDevIdx;      // sender's IB device index
 };
 
+// Initialize QP sharing fields to defaults (sharing disabled)
+static inline void IbCastQpCreateAttrInitSharing(struct ncclIbQpCreateAttr* attr) {
+  attr->isQpSharingEnabled = false;
+  attr->qpSharingGroupIdx = -1;
+  attr->cqDepthMultiplier = 1;
+}
+
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -57,6 +57,9 @@ struct ncclIbQpCreateAttr {
   int channelId;
   int ibDevN;
   bool useIonic;
+  bool isQpSharingEnabled;
+  int  cqDepthMultiplier;
+  int  qpSharingGroupIdx;
 };
 
 // Per-QP connection metatdata
@@ -105,6 +108,11 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
+
+  // QP Sharing metadata
+  int      sharedGroupIdx;      // QP sharing group index (-1 = not shared)
+  uint16_t commId;              // QP sharing comm ID (0 = not shared)
+  int      senderIbDevIdx;      // sender's IB device index
 };
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -615,6 +615,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, IbCastRelaxedOrderingEnabled ? "[RO]" : "",
          IbCastIfName, ncclSocketToString(&IbCastIfAddr, addrline));
 
+    IbCastQpSharingGlobalEnable = rcclParamIbCastQpSharingEnable() > 0;
     IbCastUseInline = ncclParamIbCastUseInline();
     IbCastGdrFlushDisable = ncclParamIbCastGdrFlushDisable();
 
@@ -658,6 +659,12 @@ exit:
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
+  }
+  if (ret == ncclSuccess && IbCastQpSharingEnabled() && rcclParamIbCastCommNGroups() < 1) {
+    WARN("NET/IB : QP sharing enabled (NCCL_IB_QP_SHARING_ENABLE=1) but NCCL_IB_COMM_NGROUPS=%ld is invalid "
+         "(must be >= 1). Disabling QP sharing.",
+         rcclParamIbCastCommNGroups());
+    IbCastQpSharingGlobalEnable = false;
   }
   if (ret == ncclSuccess && castGlobalQpSchedParms.enable && IbCastQpSharingEnabled()) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -662,7 +662,7 @@ exit:
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastQpSharingEnabled() && rcclParamIbCastCommNGroups() < 1) {
-    WARN("NET/IB : QP sharing enabled (NCCL_IB_QP_SHARING_ENABLE=1) but NCCL_IB_COMM_NGROUPS=%ld is invalid "
+    WARN("NET/IB : QP sharing enabled (RCCL_IB_QP_SHARING_ENABLE=1) but RCCL_IB_COMM_NGROUPS=%ld is invalid "
          "(must be >= 1). Disabling QP sharing.",
          rcclParamIbCastCommNGroups());
     IbCastQpSharingGlobalEnable = false;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -361,8 +361,9 @@ ncclResult_t IbCastFinalizeDevices(void) {
   // the flush is one-shot. atexit(rcclTelemetryFlush) covers the process.
   --netRefCount;
   if (netRefCount == 0) {
-    // debug validation
-    IbCastValidateSharedQpPool();
+    if (rcclParamIbCastQpSharingValidatePool()) {
+      IbCastValidateSharedQpPool();
+    }
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -8,6 +8,7 @@
 #include "common_cast.h"
 #include "p2p_resiliency_recovery_cast.h"
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 extern int64_t ncclParamIbCastQpsPerConn();
 RCCL_PARAM(IbCastQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -633,6 +634,12 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // flag IbCastAinicCtsInlineData is used specifically to identify UseInline for Ainic
       IbCastAinicCtsInlineData = IbCastUseInline;
 
+      // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
+      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+        INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
+        IbCastOffloadEnabled = false;
+      }
+
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: %s; GDR Flush: %s",
@@ -646,6 +653,10 @@ exit:
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
                                "(load balancer integration with resiliency is pending)");
+    castGlobalQpSchedParms.enable = false;
+  }
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -360,6 +360,10 @@ ncclResult_t IbCastFinalizeDevices(void) {
   // No telemetry flush here: netRefCount reaching 0 is not process exit, and
   // the flush is one-shot. atexit(rcclTelemetryFlush) covers the process.
   --netRefCount;
+  if (netRefCount == 0) {
+    // debug validation
+    IbCastValidateSharedQpPool();
+  }
   return ncclSuccess;
 }
 
@@ -635,7 +639,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       IbCastAinicCtsInlineData = IbCastUseInline;
 
       // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
-      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+      if (IbCastOffloadEnabled && IbCastQpSharingEnabled()) {
         INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
         IbCastOffloadEnabled = false;
       }
@@ -655,7 +659,7 @@ exit:
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
   }
-  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && IbCastQpSharingEnabled()) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
     castGlobalQpSchedParms.enable = false;
   }

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_qp_sharing_inspect.h
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_QP_SHARING_INSPECT_H_
+#define RCCL_NET_IB_QP_SHARING_INSPECT_H_
+
+#include <stdint.h>
+#include "net_ib_limits.h"
+
+#ifdef __cplusplus
+#include "nccl.h"  /* ncclResult_t */
+extern "C" {
+#else
+#include "nccl.h"
+#endif
+
+/*
+ * Test-only introspection API for QP sharing (RCCL_IB_COMM_NGROUPS).
+ * Shared between librccl.so and the unit tests so the struct layout
+ * and signatures cannot diverge.
+ */
+
+struct ncclIbQpSharingState {
+  uint16_t commId;             /* 0 = not shared */
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;     /* -1 = not shared */
+  int      refcount;           /* comms sharing this physical QP (0 if not shared) */
+  int      cqRefcount;         /* comms sharing this group's CQ (0 if not shared) */
+  int      nqps;
+  uint32_t qpn[NCCL_IB_MAX_QPS];
+};
+
+/* Copy QP-sharing state out of a connected sendComm or recvComm.
+ * Returns ncclInvalidArgument on null pointers. */
+ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* RCCL_NET_IB_QP_SHARING_INSPECT_H_ */

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -13,6 +13,7 @@
 #include "net_ib_ops_fault.h"
 #endif
 #include "net_telemetry.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
@@ -68,14 +69,14 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   switch (wr->opcode) {
   case IBV_WR_RDMA_WRITE:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
     break;
   case IBV_WR_RDMA_WRITE_WITH_IMM:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
@@ -115,7 +116,12 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : ctsFifoAddr(slots, r);
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    wr->wr_id = wr_id;
+    // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    } else {
+      wr->wr_id = wr_id;
+    }
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif
@@ -132,6 +138,9 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   }
 
   // For ID-based matching scheme, immData carries the request ID.
+  //   If QP sharing is enabled, immData also carries the receiver's commId:
+  //       reqId in bits[7:0],
+  //       remCommId in bits[23:8].
   // For index-based matching scheme, immData layout (BY_INDEX):
   //   bits [31:24] - rxReqIndex: receiver's request slot index (from CTS fifo)
   //   bit  [23]    - WR_IMM_SPLIT_DATA_FLAG: set when sending across >1 QPs
@@ -143,6 +152,10 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
+      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
+                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
       immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
@@ -166,7 +179,14 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     lastWr->imm_data = htobe32(immData);
   }
-  lastWr->wr_id = wr_id;
+  // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
+  // route the send completion to the right comm on a shared QP. The scheduler
+  // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
+  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  } else {
+    lastWr->wr_id = wr_id;
+  }
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
@@ -178,7 +198,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
     TRACE(NCCL_NET,
-          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx) on QP (qp_num=%u, "
           "devIndex=%d, qpIndex=%d)",
           __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
@@ -335,8 +355,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       reqs[r]->send.sentData[qpIndex] = true;
 
       TRACE(NCCL_VERBS,
-            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
-            "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            "Posted send wr_id=0x%lx, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
+            "imm_data=0x%x, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
             comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
             comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid, comm->wrs[r].opcode,
             comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
@@ -345,7 +365,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx)", __func__,
         reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
   if (nowNs) {
     if (comm->base.nextQpTxSchedUpdateNs == 0)
@@ -576,11 +596,15 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
+    // QP Sharing: encode commId in upper bits of CTS wr_id
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -590,7 +614,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   rcclTelemetryQpCtsSent(ctsQp->telQpStats, (wr.send_flags & IBV_SEND_SIGNALED) ? 1 : 0);
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -751,6 +775,9 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
     wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
@@ -759,7 +786,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
@@ -768,7 +795,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
   }
 
@@ -788,6 +815,7 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
+// QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id
 static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
                                                                ncclIbRequest** req) {
   assert(req != NULL);
@@ -797,24 +825,38 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=0x%lx, opcode=%s, imm_data=0x%x, byte_len=%d)",
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+      *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
+    } else {
+      *req = recvComm->recvReqs[immDataHost % NET_IB_MAX_REQUESTS];
+    }
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
-    *req = &base->reqs[((be32toh(wc->imm_data) >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK)];
+    // BY_INDEX (non-sharing CAST default): rxReqIndex is echoed in imm_data[31:24].
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
+    *req = &base->reqs[reqIdx];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
-    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
+    // wr_id[63:48] may carry a commId for completion routing (zero if sharing is
+    // disabled). Strip it to recover the original request index.
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (IbCastStripCommId(wc->wr_id) - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
+    // Non-wr-imm recv (e.g. signalled CTS completion). base is the polling comm.
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[wc->wr_id];
+    *req = recvComm->recvReqs[wc->wr_id & 0xFFFF];
   } else {
+    // Sender completion. targetBase was routed by IbCastTest via commId in wr_id[63:48];
+    // the low byte is the request slot. (BY_ID / BY_ORDER: no scheduler remap.)
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
-      // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
+      // BY_INDEX: wr_id was remapped by the CAST scheduler for RTT timing.
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
@@ -822,13 +864,12 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
-      // BY_ID / other: wr_id is raw slot-encoded value (no remap)
       *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
   TRACE(NCCL_NET,
-        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
-        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, wc.opcode=%s, "
+        "wc.imm_data=0x%x, wc.byte_len=%d, wc.qp_num=%u)",
         __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type],
         wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
@@ -934,21 +975,23 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
     WARN("NET/IB: %s: recvMatchingScheme not supported", __func__);
     return ncclInternalError;
   }
+
   if (commBase->isSend) {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    req = &(commBase->reqs[wc->wr_id & 0xff]);
   }
 
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -959,7 +1002,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -967,7 +1010,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
@@ -997,7 +1040,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1024,8 +1067,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
       req->events[devIndex]--;
       return ncclSuccess;
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1050,7 +1093,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(IbCastRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -1059,7 +1102,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 #ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN + 1];
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -1067,18 +1110,19 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
-    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
+    // QP Sharing: use the target comm from the routed request, not the polling comm
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)req->base;
     struct ncclIbRequest* sendReq = NULL;
     int slot = req->id % NET_IB_MAX_REQUESTS;
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
-      if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
+      if (!req->base->resiliency && (sendReq->events[devIndex] <= 0)) {
         WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
@@ -1100,13 +1144,13 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
-             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=0x%lx, wc.imm_data=0x%x, wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
              ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1132,9 +1176,15 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
+#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
+        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
+        uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
+        commBase->rxPosts[rawWrId]--;
+#else
         commBase->rxPosts[wc->wr_id]--;
+#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
@@ -1166,14 +1216,14 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
-             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             "id=%ld, wc.wr_id=0x%lx, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
              __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
              be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1241,7 +1291,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           // errors happen, so gating this on !resiliency left the counter at 0.
           rcclTelemetryCqError(r->devBases[i]->ibDevN);
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=0x%lx, qp_num=%d)", __func__,
                  i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             IbCastLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
@@ -1249,13 +1299,24 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          TRACE(NCCL_NET,
-                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
-                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
-          if (r->base->recvMatchingScheme != BY_ORDER) {
-            NCCLCHECK(IbCastCompletionEventProcess(r->base, wc, i));
+          struct ncclIbNetCommBase* targetBase = (struct ncclIbNetCommBase*)r->base;
+          // RECV_RDMA_WITH_IMM (data receive) carries commId in imm_data and is
+          // routed in IbCastRequestRetrieveFromCompletion. All other completions
+          // (send, CTS/RDMA_WRITE, flush/RDMA_READ) carry commId in wr_id[63:48]
+          // and are routed here.
+          if (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromWrId(wc->wr_id);
+            if (routed) targetBase = routed;
           } else {
-            NCCLCHECK(IbCastCompletionEventByOrder(r->base, wc, i));
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromImmData((struct ncclIbNetCommBase*)r->base, be32toh(wc->imm_data));
+            if (routed && !routed->isSend && (routed->recvMatchingScheme == BY_ID)) targetBase = routed;
+          }
+
+          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)", __func__, i, targetBase, targetBase->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          if (targetBase->recvMatchingScheme != BY_ORDER) {
+            NCCLCHECK(IbCastCompletionEventProcess(targetBase, wc, i));
+          } else {
+            NCCLCHECK(IbCastCompletionEventByOrder(targetBase, wc, i));
           }
         }
       }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -1181,15 +1181,10 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
-#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
-        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
         uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
         commBase->rxPosts[rawWrId]--;
-#else
-        commBase->rxPosts[wc->wr_id]--;
-#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -770,6 +770,10 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
   req->sock = &comm->base.sock;
   struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[last];
 
+  INFO(NCCL_NET, "NET/IB: %s: flush commId=%u group=%d isPrimary=%d ndevs=%d",
+       __func__, comm->base.commId, comm->base.sharedGroupIdx,
+       comm->base.isSharedQpPrimary, comm->base.vProps.ndevs);
+
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     struct ibv_send_wr wr;
@@ -790,6 +794,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
+    INFO(NCCL_NET, "NET/IB: %s: posting flush dev=%d qpn=%u wr_id=0x%lx",
+         __func__, i, comm->devs[i].gpuFlush.qp.qp->qp_num, wr.wr_id);
     NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
     TIME_STOP(4);
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -117,8 +117,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
     } else {
       wr->wr_id = wr_id;
     }
@@ -152,9 +152,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
-      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
-                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      if (IbCastCommIsSharing(&comm->base) && comm->remCommId != 0) {
+        immData = IbCastEncodeCommIdImmData((uint32_t)reqs[0]->id, comm->remCommId);
       }
     } else {
       uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
@@ -182,8 +181,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
   // route the send completion to the right comm on a shared QP. The scheduler
   // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
-  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+  if (IbCastCommIsSharing(&comm->base)) {
+    lastWr->wr_id = IbCastEncodeCommId(wr_id, comm->base.commId);
   } else {
     lastWr->wr_id = wr_id;
   }
@@ -597,8 +596,8 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
     // QP Sharing: encode commId in upper bits of CTS wr_id
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
@@ -779,8 +778,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    if (IbCastCommIsSharing(&comm->base)) {
+      wr.wr_id = IbCastEncodeCommId(wr.wr_id, comm->base.commId);
     }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
@@ -838,7 +837,7 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     uint32_t immDataHost = be32toh(wc->imm_data);
-    if (rcclParamIbCastCommNGroups() > 0) {
+    if (IbCastQpSharingEnabled()) {
       uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
       *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
     } else {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -17,6 +17,7 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
+extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -275,7 +276,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   bool inFlushRange =
     (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+    WARN("NET/IB: %s: Invalid wr_id (0x%lx). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
          wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
@@ -286,7 +287,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=0x%lx, wc.status=%s(%d)).", __func__,
          resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
@@ -352,7 +353,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
 
   if (request == NULL) {
     WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
-         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         "wc.wr_id=0x%lx, wc.status=%s(%d), wc.opcode=%s(%d)).",
          __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
          ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
@@ -361,7 +362,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = IbCastResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, "
          "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
          __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id,
          ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
@@ -540,7 +541,7 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
 static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
                                                                struct ibv_wc* probeWc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=0x%lx, wc->qp_num=%u)",
        __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
@@ -598,9 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
-         baseComm->isSend ? "send" : "recv", baseComm);
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+    // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
+    // when QP sharing is enabled.
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm,
+         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -810,6 +814,9 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -899,6 +906,9 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"
@@ -1049,7 +1059,7 @@ ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bo
 
 ncclResult_t IbCastResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=0x%lx, "
        "wc->qp_num=%u, wc->byte_len=%d)",
        __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
        wc->qp_num, wc->byte_len);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -9,6 +9,7 @@
 #include "p2p_cast.h" // For replay (IbCastMultiSend() and IbCastPostFifo())
 #include "connect_cast.h" // For IbCastQpCreate()
 #include "p2p_resiliency_recovery_cast.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastResiliencyPortFailover, "IB_RESILIENCY_PORT_FAILOVER", 0);
 NCCL_PARAM(IbCastResiliencyPortFailoverMaxAttempts, "IB_RESILIENCY_PORT_FAILOVER_MAX_ATTEMPTS", 1);
@@ -17,7 +18,6 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
-extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -599,12 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || IbCastQpSharingEnabled()) {
     // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
     // when QP sharing is enabled.
     INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
          baseComm->isSend ? "send" : "recv", baseComm,
-         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
+         IbCastQpSharingEnabled() ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -814,9 +814,7 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -906,9 +904,7 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,9 +313,7 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -387,9 +385,7 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
-  qpCreateAttrs.isQpSharingEnabled = false;
-  qpCreateAttrs.qpSharingGroupIdx = -1;
-  qpCreateAttrs.cqDepthMultiplier = 1;
+  IbCastQpCreateAttrInitSharing(&qpCreateAttrs);
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,6 +313,9 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -384,6 +387,9 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -50,9 +50,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     //        as of now QP sharing disabled during recovery restore.
     //        to analyze and set sharing accordingly for this QP during recovery restore.
     //        identify if it is primary or secondary comm and set sharing attributes accordingly.
-    createAttr.isQpSharingEnabled = false;
-    createAttr.qpSharingGroupIdx = -1;
-    createAttr.cqDepthMultiplier = 1;
+    IbCastQpCreateAttrInitSharing(&createAttr);
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
     localQp->telQpStats = telQpStats;
 
@@ -87,9 +85,7 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.isDataQp = flushQp->isDataQp;
         // TODO - QP sharing:
         //        disabled for flush QP
-        flushCreateAttr.isQpSharingEnabled = false;
-        flushCreateAttr.qpSharingGroupIdx = -1;
-        flushCreateAttr.cqDepthMultiplier = 1;
+        IbCastQpCreateAttrInitSharing(&flushCreateAttr);
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -46,6 +46,13 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     createAttr.isDataQp = localQp->isDataQp;
     // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
     // CTS offload is disabled when resiliency features are enabled (init.cc).
+    // TODO - QP sharing:
+    //        as of now QP sharing disabled during recovery restore.
+    //        to analyze and set sharing accordingly for this QP during recovery restore.
+    //        identify if it is primary or secondary comm and set sharing attributes accordingly.
+    createAttr.isQpSharingEnabled = false;
+    createAttr.qpSharingGroupIdx = -1;
+    createAttr.cqDepthMultiplier = 1;
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
     localQp->telQpStats = telQpStats;
 
@@ -78,6 +85,11 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
+        // TODO - QP sharing:
+        //        disabled for flush QP
+        flushCreateAttr.isQpSharingEnabled = false;
+        flushCreateAttr.qpSharingGroupIdx = -1;
+        flushCreateAttr.cqDepthMultiplier = 1;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -91,7 +91,6 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
     entry->used = true;
-    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -16,6 +16,8 @@ struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+int                         g_IbCastCommIdFreeTop = 0;
 std::mutex                  g_IbCastSharedQpMutex;
 
 void IbCastStripPort(union ncclSocketAddress* addr) {
@@ -109,11 +111,17 @@ int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peer
 
 uint16_t IbCastAllocCommId(void* comm, bool isSend) {
     std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+    uint16_t id;
+    if (g_IbCastCommIdFreeTop > 0) {
+        // Reuse a previously freed commId — O(1)
+        id = g_IbCastCommIdFreeStack[--g_IbCastCommIdFreeTop];
+    } else if (g_IbCastNextCommId < IBCAST_MAX_COMMS) {
+        // Allocate a fresh commId — O(1)
+        id = g_IbCastNextCommId++;
+    } else {
         WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
         return 0;
     }
-    uint16_t id = g_IbCastNextCommId++;
     g_IbCastCommTable[id].comm = comm;
     g_IbCastCommTable[id].isSend = isSend;
     g_IbCastCommTable[id].used = true;
@@ -126,6 +134,7 @@ void IbCastFreeCommIdLocked(uint16_t commId) {
     if (commId > 0 && commId < IBCAST_MAX_COMMS) {
         g_IbCastCommTable[commId].used = false;
         g_IbCastCommTable[commId].comm = NULL;
+        g_IbCastCommIdFreeStack[g_IbCastCommIdFreeTop++] = commId;
     }
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -9,8 +9,13 @@
 #include <cassert>
 
 // QP sharing configuration parameters
-RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
-RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+RCCL_PARAM(IbCastQpSharingEnable, "IB_QP_SHARING_ENABLE", 0);  // master switch: 0=off, 1=on
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 4);            // number of sharing groups (effective only when master switch is on)
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 8); // CQ/WR depth multiplier for shared QPs
+
+// Global runtime enable flag — initialized from master switch param,
+// can be cleared during init if configuration is invalid (e.g. NGROUPS < 1).
+bool IbCastQpSharingGlobalEnable = false;
 
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -12,6 +12,7 @@
 RCCL_PARAM(IbCastQpSharingEnable, "IB_QP_SHARING_ENABLE", 0);  // master switch: 0=off, 1=on
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 4);            // number of sharing groups (effective only when master switch is on)
 RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 8); // CQ/WR depth multiplier for shared QPs
+RCCL_PARAM(IbCastQpSharingValidatePool, "IB_QP_SHARING_VALIDATE_POOL", 0); // 1 = validate pool at shutdown for leaks
 
 // Global runtime enable flag — initialized from master switch param,
 // can be cleared during init if configuration is invalid (e.g. NGROUPS < 1).

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -60,7 +60,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
 
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+    int primaryIbDevN, int devIndex, int initialRefcount) {
 
     if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
@@ -70,7 +70,7 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
-    entry->primaryDevBase = primaryDevBase;
+    entry->primaryIbDevN = primaryIbDevN;
     entry->devIndex = devIndex;
     entry->refcount = initialRefcount;
     entry->cqRefcount = 0;
@@ -197,8 +197,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
                      g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
             }
             destroyedCqs[nDestroyed++] = cq;
-            if (g_IbCastSharedQpPool[i].primaryDevBase) {
-                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+            {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryIbDevN;
                 std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
                 INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
                      ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "qp_sharing.h"
+#include <cassert>
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -163,7 +164,7 @@ struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
 }
 
 struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
-  if (rcclParamIbCastCommNGroups() > 0) {
+  if (IbCastQpSharingEnabled()) {
     uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
     //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
     if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
@@ -190,6 +191,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
 
     for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
         if (!g_IbCastSharedQpPool[i].used) continue;
+        // Skip flush QP slots — they are torn down separately before CQ cleanup
+        if (g_IbCastSharedQpPool[i].key.qpIdx == IBCAST_FLUSH_QP_IDX) continue;
         if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
         if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
         if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
@@ -226,5 +229,42 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
         }
         g_IbCastSharedQpPool[i].used = false;
         g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
+    }
+}
+
+void IbCastValidateSharedQpPool(void) {
+    if (!IbCastQpSharingEnabled()) return;
+
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int leakedSlots = 0;
+    int leakedCommIds = 0;
+
+    // Check QP pool for leaked entries
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        struct IbCastSharedQp* slot = &g_IbCastSharedQpPool[i];
+        if (slot->used) {
+            WARN("IB CAST POOL LEAK: slot=%d qpIdx=%d group=%d isSend=%d refcount=%d cqRefcount=%d qp=%p",
+                 i, slot->key.qpIdx, slot->key.groupIdx, slot->key.isSend,
+                 slot->refcount, slot->cqRefcount, (void*)slot->qp);
+            leakedSlots++;
+        }
+    }
+
+    // Check comm table for leaked commIds
+    for (int i = 1; i < IBCAST_MAX_COMMS; i++) {
+        if (g_IbCastCommTable[i].used) {
+            WARN("IB CAST POOL LEAK: commId=%d isSend=%d comm=%p still in use",
+                 i, g_IbCastCommTable[i].isSend, g_IbCastCommTable[i].comm);
+            leakedCommIds++;
+        }
+    }
+
+    if (leakedSlots == 0 && leakedCommIds == 0) {
+        INFO(NCCL_NET, "IB CAST POOL VALIDATE: clean shutdown — pool=%d/%d slots used, freeStack=%d, nextCommId=%u",
+             0, g_IbCastSharedQpPoolCount, g_IbCastCommIdFreeTop, g_IbCastNextCommId);
+    } else {
+        WARN("IB CAST POOL VALIDATE: UNCLEAN shutdown — %d leaked QP slots, %d leaked commIds", leakedSlots, leakedCommIds);
+        assert(leakedSlots == 0 && "QP sharing pool has leaked QP slots at shutdown");
+        assert(leakedCommIds == 0 && "QP sharing pool has leaked commIds at shutdown");
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -14,6 +14,8 @@ RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
 // Pool and comm table globals
 struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 int                         g_IbCastSharedQpPoolCount = 0;
+int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpFreeTop = 0;
 struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
 uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -62,11 +64,18 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount) {
 
-    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    int idx;
+    if (g_IbCastSharedQpFreeTop > 0) {
+        // Reuse a slot freed by IbCastCleanupGroupCqs -- O(1)
+        idx = g_IbCastSharedQpFreeStack[--g_IbCastSharedQpFreeTop];
+    } else if (g_IbCastSharedQpPoolCount < IBCAST_MAX_SHARED_QPS) {
+        idx = g_IbCastSharedQpPoolCount++;
+    } else {
         WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
         return NULL;
     }
-    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[idx];
     entry->key = *key;
     entry->qp = qp;
     entry->primaryCq = primaryCq;
@@ -77,6 +86,13 @@ struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     entry->used = true;
     entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
     return entry;
+}
+
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry) {
+    if (entry == NULL) return;
+    int idx = (int)(entry - g_IbCastSharedQpPool);
+    entry->used = false;
+    g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = idx;
 }
 
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
@@ -209,5 +225,6 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
             }
         }
         g_IbCastSharedQpPool[i].used = false;
+        g_IbCastSharedQpFreeStack[g_IbCastSharedQpFreeTop++] = i;
     }
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -1,0 +1,204 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing pool management implementation for IB CAST transport layer.
+ ************************************************************************/
+
+#include "qp_sharing.h"
+
+// QP sharing configuration parameters
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+
+// Pool and comm table globals
+struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpPoolCount = 0;
+struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+std::mutex                  g_IbCastSharedQpMutex;
+
+void IbCastStripPort(union ncclSocketAddress* addr) {
+    if (addr->sa.sa_family == AF_INET) {
+        addr->sin.sin_port = 0;
+    } else if (addr->sa.sa_family == AF_INET6) {
+        addr->sin6.sin6_port = 0;
+    }
+}
+
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b) {
+    if (a->ibDevN != b->ibDevN) return false;
+    if (a->isSend != b->isSend) return false;
+    if (a->groupIdx != b->groupIdx) return false;
+    if (a->qpIdx != b->qpIdx) return false;
+    if (a->remIbDevIdx != b->remIbDevIdx) return false;
+    if (memcmp(&a->peerAddr, &b->peerAddr, sizeof(union ncclSocketAddress)) != 0) return false;
+    return true;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && IbCastSharedQpKeyMatch(&g_IbCastSharedQpPool[i].key, key)) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && g_IbCastSharedQpPool[i].qp &&
+            g_IbCastSharedQpPool[i].key.isSend == isSend &&
+            g_IbCastSharedQpPool[i].qp->qp_num == qpn) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+
+    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+        WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
+        return NULL;
+    }
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    entry->key = *key;
+    entry->qp = qp;
+    entry->primaryCq = primaryCq;
+    entry->primaryDevBase = primaryDevBase;
+    entry->devIndex = devIndex;
+    entry->refcount = initialRefcount;
+    entry->cqRefcount = 0;
+    entry->used = true;
+    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
+    return entry;
+}
+
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx) {
+    int count = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend) {
+    int total = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.qpIdx != 0) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            total += g_IbCastSharedQpPool[i].refcount;
+        }
+    }
+    return total;
+}
+
+uint16_t IbCastAllocCommId(void* comm, bool isSend) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+        WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
+        return 0;
+    }
+    uint16_t id = g_IbCastNextCommId++;
+    g_IbCastCommTable[id].comm = comm;
+    g_IbCastCommTable[id].isSend = isSend;
+    g_IbCastCommTable[id].used = true;
+    return id;
+}
+
+// Caller MUST hold g_IbCastSharedQpMutex. Used by the teardown paths, which take
+// the mutex across the whole shared-QP cleanup block.
+void IbCastFreeCommIdLocked(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        g_IbCastCommTable[commId].used = false;
+        g_IbCastCommTable[commId].comm = NULL;
+    }
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
+  uint16_t commId = (wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
+  if (commId == 0 || commId >= IBCAST_MAX_COMMS || !g_IbCastCommTable[commId].used) return NULL;
+  return g_IbCastCommTable[commId].isSend
+    ? &((struct ncclIbSendComm*)g_IbCastCommTable[commId].comm)->base
+    : &((struct ncclIbRecvComm*)g_IbCastCommTable[commId].comm)->base;
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
+    //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+    if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+      return g_IbCastCommTable[immCommId].isSend
+        ? &((struct ncclIbSendComm*)g_IbCastCommTable[immCommId].comm)->base
+        : &((struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm)->base;
+    }
+  }
+  return NULL;
+}
+
+// Self-locking variant for callers that do NOT already hold the mutex
+// (e.g. the connect/accept non-sharing fallback paths).
+void IbCastFreeCommId(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        IbCastFreeCommIdLocked(commId);
+    }
+}
+
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
+    struct ibv_cq* destroyedCqs[NCCL_IB_MAX_DEVS_PER_NIC];
+    int nDestroyed = 0;
+
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, &slot0Entry->key.peerAddr,
+                   sizeof(union ncclSocketAddress)) != 0) continue;
+
+        struct ibv_cq* cq = g_IbCastSharedQpPool[i].primaryCq;
+        bool alreadyDestroyed = false;
+        for (int j = 0; j < nDestroyed; j++) {
+            if (destroyedCqs[j] == cq) { alreadyDestroyed = true; break; }
+        }
+        if (!alreadyDestroyed && cq != NULL) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying CQ %p group=%d ibDevN=%d isSend=%d remIbDev=%d qpIdx=%d refcount=%d",
+                 (void*)cq, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                 g_IbCastSharedQpPool[i].key.isSend, g_IbCastSharedQpPool[i].key.remIbDevIdx,
+                 g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            ncclResult_t cqRet = wrap_ibv_destroy_cq(cq);
+            if (cqRet != ncclSuccess) {
+                WARN("IB CAST TEARDOWN: ibv_destroy_cq FAILED cq=%p errno=%d group=%d ibDevN=%d qpIdx=%d refcount=%d",
+                     (void*)cq, errno, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                     g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            }
+            destroyedCqs[nDestroyed++] = cq;
+            if (g_IbCastSharedQpPool[i].primaryDevBase) {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+                std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
+                INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
+                     ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,
+                     (IbCastDevs[ibDevN2].pdRefs == 1) ? "DEALLOC" : "");
+                if (0 == --IbCastDevs[ibDevN2].pdRefs) {
+                    wrap_ibv_dealloc_pd(IbCastDevs[ibDevN2].pd);
+                }
+            }
+        }
+        g_IbCastSharedQpPool[i].used = false;
+    }
+}

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -7,6 +7,7 @@
 
 #include "qp_sharing.h"
 #include <cassert>
+#include "net_ib_qp_sharing_inspect.h"
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
@@ -267,4 +268,40 @@ void IbCastValidateSharedQpPool(void) {
         assert(leakedSlots == 0 && "QP sharing pool has leaked QP slots at shutdown");
         assert(leakedCommIds == 0 && "QP sharing pool has leaked commIds at shutdown");
     }
+}
+
+// =============================================================================
+// Test introspection API — exposes internal QP-sharing pool state from a
+// sendComm/recvComm handle. Only intended for unit tests; not part of the
+// public net plugin ABI.
+// =============================================================================
+
+// ncclIbCastGetQpSharingState — copy QP-sharing pool state out of a comm.
+extern "C" ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out) {
+    if (!comm || !out) return ncclInvalidArgument;
+    struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+
+    out->commId = base->commId;
+    out->isSharedQpPrimary = base->isSharedQpPrimary;
+    out->sharedGroupIdx = base->sharedGroupIdx;
+    out->nqps = base->nqps;
+    out->refcount = 0;
+    out->cqRefcount = 0;
+
+    int n = (base->nqps < NCCL_IB_MAX_QPS) ? base->nqps : NCCL_IB_MAX_QPS;
+    for (int i = 0; i < n; i++) {
+        struct ncclIbQp* qp = base->activeQps[i];
+        out->qpn[i] = (qp && qp->qp) ? qp->qp->qp_num : 0;
+    }
+
+    if (base->sharedGroupIdx >= 0 && n > 0 && base->activeQps[0] && base->activeQps[0]->qp) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(base->activeQps[0]->qp->qp_num, base->isSend);
+        if (slot) {
+            out->refcount = slot->refcount;
+            out->cqRefcount = slot->cqRefcount;
+        }
+    }
+
+    return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -7,6 +7,7 @@
 
 #include "qp_sharing.h"
 #include <cassert>
+#include "net_ib_qp_sharing_inspect.h"
 
 // QP sharing configuration parameters
 RCCL_PARAM(IbCastQpSharingEnable, "IB_QP_SHARING_ENABLE", 0);  // master switch: 0=off, 1=on
@@ -272,4 +273,40 @@ void IbCastValidateSharedQpPool(void) {
         assert(leakedSlots == 0 && "QP sharing pool has leaked QP slots at shutdown");
         assert(leakedCommIds == 0 && "QP sharing pool has leaked commIds at shutdown");
     }
+}
+
+// =============================================================================
+// Test introspection API — exposes internal QP-sharing pool state from a
+// sendComm/recvComm handle. Only intended for unit tests; not part of the
+// public net plugin ABI.
+// =============================================================================
+
+// ncclIbCastGetQpSharingState — copy QP-sharing pool state out of a comm.
+extern "C" ncclResult_t ncclIbCastGetQpSharingState(void* comm, struct ncclIbQpSharingState* out) {
+    if (!comm || !out) return ncclInvalidArgument;
+    struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+
+    out->commId = base->commId;
+    out->isSharedQpPrimary = base->isSharedQpPrimary;
+    out->sharedGroupIdx = base->sharedGroupIdx;
+    out->nqps = base->nqps;
+    out->refcount = 0;
+    out->cqRefcount = 0;
+
+    int n = (base->nqps < NCCL_IB_MAX_QPS) ? base->nqps : NCCL_IB_MAX_QPS;
+    for (int i = 0; i < n; i++) {
+        struct ncclIbQp* qp = base->activeQps[i];
+        out->qpn[i] = (qp && qp->qp) ? qp->qp->qp_num : 0;
+    }
+
+    if (base->sharedGroupIdx >= 0 && n > 0 && base->activeQps[0] && base->activeQps[0]->qp) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(base->activeQps[0]->qp->qp_num, base->isSend);
+        if (slot) {
+            out->refcount = slot->refcount;
+            out->cqRefcount = slot->cqRefcount;
+        }
+    }
+
+    return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -42,7 +42,10 @@ struct IbCastSharedQp {
     IbCastSharedQpKey key;
     struct ibv_qp*    qp;                  // the physical QP
     struct ibv_cq*    primaryCq;           // CQ for this device in this group
-    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      primaryIbDevN;                // local IB device index of the primary comm's device,
+                                            // captured by value: the primary comm (and its inline
+                                            // devs[]) may be freed while secondaries or this pool
+                                            // entry still reference the group
     int      devIndex;                     // local device index within comm->devs[]
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
@@ -81,7 +84,7 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 // Register a new shared QP in the pool
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
-    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+    int primaryIbDevN, int devIndex, int initialRefcount);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -5,7 +5,9 @@
  * QP Sharing infrastructure for IB CAST transport layer.
  * Allows multiple RCCL communicator channels to share physical IB QPs,
  * reducing QP count and improving scalability.
- * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ * Controlled via NCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
+ * When enabled, NCCL_IB_COMM_NGROUPS (default 4) and
+ * NCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
  ************************************************************************/
 
 #ifndef NET_IB_CAST_QP_SHARING_H_
@@ -16,10 +18,12 @@
 #include <mutex>
 
 // QP sharing configuration parameters
-// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
-// 0 = disabled, >0 = enable QP sharing with N groups
+// Master switch: RCCL_IB_QP_SHARING_ENABLE / NCCL_IB_QP_SHARING_ENABLE
+// 0 = disabled (default), 1 = enabled with sensible defaults
+extern int64_t rcclParamIbCastQpSharingEnable();
+// Number of sharing groups (default 4, effective only when master switch is on)
 extern int64_t rcclParamIbCastCommNGroups();
-// CQ/WR depth scaling for primary QPs
+// CQ/WR depth scaling for primary QPs (default 8, effective only when master switch is on)
 extern int64_t rcclParamIbCastQpDepthMultiplier();
 
 // QP sharing role for a comm during connection setup.
@@ -31,9 +35,13 @@ enum IbCastQpSharingRole {
   QP_SHARING_SECONDARY,  // secondary — QPs already assigned, skip creation
 };
 
-// Returns true when QP sharing is enabled (NCCL_IB_COMM_NGROUPS > 0)
+// Global runtime enable flag — set from master switch param during init,
+// can be cleared if configuration is invalid (e.g. NGROUPS < 1).
+extern bool IbCastQpSharingGlobalEnable;
+
+// Returns true when QP sharing is enabled at runtime.
 static inline bool IbCastQpSharingEnabled(void) {
-  return rcclParamIbCastCommNGroups() > 0;
+  return IbCastQpSharingGlobalEnable;
 }
 
 // Returns true when this comm is actively sharing QPs (sharing enabled AND

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -62,6 +62,8 @@ extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
+extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
+extern int                         g_IbCastCommIdFreeTop;
 extern std::mutex                  g_IbCastSharedQpMutex;
 
 // Strip port from socket address for peer matching

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -167,6 +167,8 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
 
 // Validate that all shared QP pool entries and commIds are cleaned up.
 // Logs leaked entries and asserts on non-zero counts. Call at finalize time.
+// Gated by NCCL_IB_QP_SHARING_VALIDATE_POOL=1.
+extern int64_t rcclParamIbCastQpSharingValidatePool();
 void IbCastValidateSharedQpPool(void);
 
 // Encode commId into wr_id[63:48]. When commId==0 (sharing disabled or

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -5,9 +5,9 @@
  * QP Sharing infrastructure for IB CAST transport layer.
  * Allows multiple RCCL communicator channels to share physical IB QPs,
  * reducing QP count and improving scalability.
- * Controlled via NCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
- * When enabled, NCCL_IB_COMM_NGROUPS (default 4) and
- * NCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
+ * Controlled via RCCL_IB_QP_SHARING_ENABLE (0=disabled, 1=enabled).
+ * When enabled, RCCL_IB_COMM_NGROUPS (default 4) and
+ * RCCL_IB_QP_DEPTH_MULTIPLIER (default 8) tune sharing behavior.
  ************************************************************************/
 
 #ifndef NET_IB_CAST_QP_SHARING_H_
@@ -18,7 +18,7 @@
 #include <mutex>
 
 // QP sharing configuration parameters
-// Master switch: RCCL_IB_QP_SHARING_ENABLE / NCCL_IB_QP_SHARING_ENABLE
+// Master switch: RCCL_IB_QP_SHARING_ENABLE
 // 0 = disabled (default), 1 = enabled with sensible defaults
 extern int64_t rcclParamIbCastQpSharingEnable();
 // Number of sharing groups (default 4, effective only when master switch is on)
@@ -171,7 +171,7 @@ void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
 
 // Validate that all shared QP pool entries and commIds are cleaned up.
 // Logs leaked entries and asserts on non-zero counts. Call at finalize time.
-// Gated by NCCL_IB_QP_SHARING_VALIDATE_POOL=1.
+// Gated by RCCL_IB_QP_SHARING_VALIDATE_POOL=1.
 extern int64_t rcclParamIbCastQpSharingValidatePool();
 void IbCastValidateSharedQpPool(void);
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -77,7 +77,6 @@ static inline int IbCastQpSharingDepthMultiplier(void) {
 
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
-#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
 #define IBCAST_FLUSH_QP_IDX  -1   // sentinel qpIdx for flush QPs in the shared pool
 
 // Pool key -- uniquely identifies a shared QP
@@ -103,7 +102,12 @@ struct IbCastSharedQp {
     int      refcount;                     // number of comms using this QP
     int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
     bool     used;                         // slot in use
-    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+    // Note: ctsQpSlot is NOT tracked in the shared pool.  CTS offload is
+    // mutually exclusive with QP sharing (disabled at init when sharing is on).
+    // In the sharing-enabled, non-offload path, CTS signaling uses
+    // (slot == ctsQp->devIndex) to decide when to set IBV_SEND_SIGNALED,
+    // which relies only on the per-QP devIndex already stored here — no
+    // additional per-pool ctsQpSlot is needed.
 };
 
 // Global comm table for completion routing (commId -> comm pointer)

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -22,6 +22,51 @@ extern int64_t rcclParamIbCastCommNGroups();
 // CQ/WR depth scaling for primary QPs
 extern int64_t rcclParamIbCastQpDepthMultiplier();
 
+// QP sharing role for a comm during connection setup.
+// Returned by IbCastQpSharing{Sender,Receiver}Setup() to tell the caller
+// whether to create QPs, register them, or skip both.
+enum IbCastQpSharingRole {
+  QP_SHARING_NONE,       // sharing disabled or fallback — normal QP creation
+  QP_SHARING_PRIMARY,    // primary — create QPs with scaled depth, then register
+  QP_SHARING_SECONDARY,  // secondary — QPs already assigned, skip creation
+};
+
+// Returns true when QP sharing is enabled (NCCL_IB_COMM_NGROUPS > 0)
+static inline bool IbCastQpSharingEnabled(void) {
+  return rcclParamIbCastCommNGroups() > 0;
+}
+
+// Returns true when this comm is actively sharing QPs (sharing enabled AND
+// commId was successfully allocated; commId==0 means fallback to non-sharing).
+static inline bool IbCastCommIsSharing(const struct ncclIbNetCommBase* base) {
+  return IbCastQpSharingEnabled() && base->commId != 0;
+}
+
+// Returns true when this comm is the primary (owner) of shared QPs in its group.
+static inline bool IbCastCommIsPrimary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && base->isSharedQpPrimary;
+}
+
+// Returns true when this comm is a secondary (reuses QPs owned by a primary).
+static inline bool IbCastCommIsSecondary(const struct ncclIbNetCommBase* base) {
+  return base->commId != 0 && !base->isSharedQpPrimary;
+}
+
+// Initialize QP sharing fields on a comm base to defaults (sharing disabled).
+static inline void IbCastCommInitSharingFields(struct ncclIbNetCommBase* base) {
+  base->commId = 0;
+  base->isSharedQpPrimary = false;
+  base->sharedGroupIdx = -1;
+  base->remIbDevIdx = -1;
+  base->sharedPrimaryNqps = 0;
+}
+
+// Compute CQ/WR depth multiplier for shared QPs.
+// Returns 1 when sharing is disabled.
+static inline int IbCastQpSharingDepthMultiplier(void) {
+  return IbCastQpSharingEnabled() ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+}
+
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
@@ -111,6 +156,23 @@ void IbCastFreeCommIdLocked(uint16_t commId);
 
 // Destroy all CQs for a group when cqRefcount reaches 0
 void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Validate that all shared QP pool entries and commIds are cleaned up.
+// Logs leaked entries and asserts on non-zero counts. Call at finalize time.
+void IbCastValidateSharedQpPool(void);
+
+// Encode commId into wr_id[63:48]. When commId==0 (sharing disabled or
+// fallback) this is a no-op (OR with zero).
+static inline uint64_t IbCastEncodeCommId(uint64_t wr_id, uint16_t commId) {
+  return wr_id | ((uint64_t)commId << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Encode receiver commId into immData for BY_ID matching scheme:
+//   bits[7:0]  = reqId,  bits[23:8] = remCommId.
+static inline uint32_t IbCastEncodeCommIdImmData(uint32_t reqId, uint16_t remCommId) {
+  return (reqId & WR_IMM_BYID_REQ_ID_MASK) |
+         (((uint32_t)remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+}
 
 // Strip the commId from wr_id[63:48], recovering the original index. Safe when
 // sharing is disabled (commId==0, so the mask is a no-op).

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -63,6 +63,8 @@ struct IbCastCommTableEntry {
 // Pool and comm table globals (defined in qp_sharing.cc)
 extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
 extern int                         g_IbCastSharedQpPoolCount;
+extern int                         g_IbCastSharedQpFreeStack[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpFreeTop;
 extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
 extern uint16_t                    g_IbCastNextCommId;
 extern uint16_t                    g_IbCastCommIdFreeStack[IBCAST_MAX_COMMS];
@@ -85,6 +87,10 @@ struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
 struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
     struct ibv_qp* qp, struct ibv_cq* primaryCq,
     int primaryIbDevN, int devIndex, int initialRefcount);
+
+// Undo a registration for a slot whose last user is closing outside of
+// IbCastCleanupGroupCqs (the flush-QP path).
+void IbCastUnregisterSharedQpLocked(struct IbCastSharedQp* entry);
 
 // Count QP slots registered by the primary for a given group
 int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -25,6 +25,7 @@ extern int64_t rcclParamIbCastQpDepthMultiplier();
 #define IBCAST_MAX_SHARED_QPS 1024
 #define IBCAST_MAX_COMMS      4096
 #define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+#define IBCAST_FLUSH_QP_IDX  -1   // sentinel qpIdx for flush QPs in the shared pool
 
 // Pool key -- uniquely identifies a shared QP
 struct IbCastSharedQpKey {

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -1,0 +1,119 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing infrastructure for IB CAST transport layer.
+ * Allows multiple RCCL communicator channels to share physical IB QPs,
+ * reducing QP count and improving scalability.
+ * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ ************************************************************************/
+
+#ifndef NET_IB_CAST_QP_SHARING_H_
+#define NET_IB_CAST_QP_SHARING_H_
+
+#include "common_cast.h"
+#include "param.h"
+#include <mutex>
+
+// QP sharing configuration parameters
+// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
+// 0 = disabled, >0 = enable QP sharing with N groups
+extern int64_t rcclParamIbCastCommNGroups();
+// CQ/WR depth scaling for primary QPs
+extern int64_t rcclParamIbCastQpDepthMultiplier();
+
+#define IBCAST_MAX_SHARED_QPS 1024
+#define IBCAST_MAX_COMMS      4096
+#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+
+// Pool key -- uniquely identifies a shared QP
+struct IbCastSharedQpKey {
+    int             ibDevN;              // local IB device index
+    union ncclSocketAddress peerAddr;    // remote peer address (port stripped)
+    int             remIbDevIdx;         // remote IB device index for disambiguation
+    bool            isSend;              // send vs recv direction
+    int             groupIdx;            // sharing group (0..m-1)
+    int             qpIdx;              // QP slot within the group (0..nqps-1)
+};
+
+// Pool entry -- one per physical shared QP
+struct IbCastSharedQp {
+    IbCastSharedQpKey key;
+    struct ibv_qp*    qp;                  // the physical QP
+    struct ibv_cq*    primaryCq;           // CQ for this device in this group
+    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      devIndex;                     // local device index within comm->devs[]
+    int      refcount;                     // number of comms using this QP
+    int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
+    bool     used;                         // slot in use
+    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+};
+
+// Global comm table for completion routing (commId -> comm pointer)
+struct IbCastCommTableEntry {
+    void*    comm;          // ncclIbSendComm* or ncclIbRecvComm*
+    bool     isSend;
+    bool     used;
+};
+
+// Pool and comm table globals (defined in qp_sharing.cc)
+extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpPoolCount;
+extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+extern uint16_t                    g_IbCastNextCommId;
+extern std::mutex                  g_IbCastSharedQpMutex;
+
+// Strip port from socket address for peer matching
+void IbCastStripPort(union ncclSocketAddress* addr);
+
+// Compare two pool keys
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b);
+
+// Find a shared QP by key
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key);
+
+// Find a shared QP by QP number and direction (for teardown)
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
+
+// Register a new shared QP in the pool
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+
+// Count QP slots registered by the primary for a given group
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx);
+
+// Count total comms connected to a peer (for channelSeq computation)
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend);
+
+// Allocate a commId and register in the global comm table (mutex-protected)
+uint16_t IbCastAllocCommId(void* comm, bool isSend);
+
+// Free a commId (self-locking; for callers NOT holding g_IbCastSharedQpMutex)
+void IbCastFreeCommId(uint16_t commId);
+
+// Free a commId; caller MUST already hold g_IbCastSharedQpMutex (teardown paths)
+void IbCastFreeCommIdLocked(uint16_t commId);
+
+// Destroy all CQs for a group when cqRefcount reaches 0
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Strip the commId from wr_id[63:48], recovering the original index. Safe when
+// sharing is disabled (commId==0, so the mask is a no-op).
+static inline uint64_t IbCastStripCommId(uint64_t wr_id) {
+  return wr_id & ~((uint64_t)WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Look up the target comm from the commId encoded in wr_id[63:48]. Returns NULL
+// if sharing is disabled or the commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id);
+
+// Look up the target comm from the commId encoded in immData.
+// Returns target base based on commId in immData if sharing is enabled or
+// returns NULL if sharing is disabled or commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(
+    struct ncclIbNetCommBase* base, uint32_t immDataHost);
+
+#endif // NET_IB_CAST_QP_SHARING_H_

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -139,7 +139,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/gensrc # for rccl_bfloat16.h
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h, net_ib_qp_sharing_inspect.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h, net_ib/net_ib_flush_fault_inject.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
@@ -691,6 +691,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/OpsFaultUnitTests.cpp
       transport/RmaMPI/RmaMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
+      transport/NetIbMPI/QpSharingTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -152,7 +152,7 @@ if(BUILD_TESTS)
     ${PROJECT_BINARY_DIR}/hipify/gensrc # for rccl_bfloat16.h
     ${PROJECT_BINARY_DIR}/hipify/src # for graph/topo.h
     ${PROJECT_BINARY_DIR}/hipify/src/include/plugin # for recorder tests, nccl_tuner.h
-    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h
+    ${PROJECT_BINARY_DIR}/hipify/src/transport/net_ib_cast # for net_ib_fault_inject.h, net_ib_cast_inspect.h, net_ib_qp_sharing_inspect.h
     ${PROJECT_BINARY_DIR}/hipify/src/transport             # for net_ib_limits.h, net_ib/net_ib_flush_fault_inject.h
     ${ROCM_PATH}/include
     ${ROCM_PATH}
@@ -796,6 +796,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/OpsFaultUnitTests.cpp
       transport/RmaMPI/RmaMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
+      transport/NetIbMPI/QpSharingTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp

--- a/projects/rccl/test/test_categories_mpi.yaml
+++ b/projects/rccl/test/test_categories_mpi.yaml
@@ -194,6 +194,65 @@ test_categories:
       - "NCCL_DEBUG=INFO"
       - "NCCL_LAUNCH_MODE=GROUP"
       - "RCCL_PAT_SHARED_QPS=0"
+  # The QP-sharing functional gate. The same five tests run at three values of
+  # RCCL_IB_COMM_NGROUPS: expectations are derived from ngroups by the reference
+  # model (test/transport/NetIbMPI/QpShareRefModel.hpp), so no test is pinned to
+  # a value and none skips outside one. RCCL_PARAM caches both tunables per
+  # process, which is why ngroups varies across categories rather than within a
+  # test.
+  quick_env_qpshare_ngroups1:
+    description: "QP sharing gate, maximum concentration: NGROUPS=1 puts every connection in group 0, so the whole functional set runs on one shared QP. DEPTH_MULTIPLIER=8 is pinned rather than left at the default so that the shared QP's CQ and work-queue sizing is not close to the queue-depth limit at these connection counts."
+    test_patterns: &qpshare_functional_tests
+      - "NetIbMPITest.QpShareAlgoLayoutSweep:NetIbMPITest.QpShareAlgoChurnLayout:NetIbMPITest.QpShareDataAllConnsTransfer:NetIbMPITest.QpShareDataUnsharedGroups:NetIbMPITest.QpShareDataFlushRouting"
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups2:
+    description: "QP sharing gate, smallest mixed configuration: NGROUPS=2 places a PRIMARY-only group beside a PRIMARY+SECONDARY group — the smallest value at which group-index arithmetic has more than one possible answer. Same five functional tests."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_ngroups16:
+    description: "QP sharing gate, wide configuration: at NGROUPS=16 the connection counts straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. Same five functional tests. The qpshare_heap_poison category below runs the churn test from this set again under glibc heap poisoning, which makes the group teardown path exercise freed memory deterministically rather than by timing."
+    test_patterns: *qpshare_functional_tests
+    exclude_windows: *mpi_exclude_windows
+    labels: *mpi_quick_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+  quick_env_qpshare_depth_ceiling:
+    description: "QP sharing depth-multiplier sizing. The shared CQ is sized 3 × NET_IB_MAX_REQUESTS(256) × NCCL_IB_QPS_PER_CONNECTION × RCCL_IB_QP_DEPTH_MULTIPLIER entries, so the multiplier and the QP count multiply into the same device limit and both are pinned here. 96 with QPS=1 requests a CQ far larger than the default and covers how the transport sizes that CQ against the device's queried max_cqe. QPSHARE_TEST_NCONNS=2 keeps the run to the sizing question rather than connection volume. The usable multiplier is a function of the device's max_cqe and so is hardware-dependent; this value probes the sizing path and is not a portable constant."
+    test_patterns:
+      - "NetIbMPITest.QpShareDataAllConnsTransfer"
+    exclude_windows: *mpi_exclude_windows
+    # Deliberately NOT *mpi_quick_labels: what this configuration can allocate
+    # depends on the device's max_cqe, so it is not a portable smoke/precheck
+    # gate. Selectable and excludable via the qpshare label instead.
+    labels: &qpshare_labels
+      - "rccl"
+      - "mpi"
+      - "qpshare"
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=1"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=96"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+      - "QPSHARE_TEST_NCONNS=2"
   standard:
     description: "MPI regression — all transport / IB / implicit-launch / UBR / graph-capture suites (same patterns as comprehensive; lighter env)."
     test_patterns: &mpi_all_patterns
@@ -382,6 +441,55 @@ test_categories:
       - "RCCL_LL128_FORCE_ENABLE=1"
       - "NCCL_PROTO=LL128"
       - "NCCL_ALGO=Tree"
+  # The stress tests are split across two categories on purpose. The ctest
+  # generator joins a category's test_patterns with ':' into ONE --gtest_filter,
+  # i.e. one process (shared/ctest/parse_test_categories.py, positive_string),
+  # and gtest runs registration order, not filter order. Connection churn is
+  # long-running and is the one test here whose failure mode can take the
+  # process down, so keeping it in its own category is what keeps the batch
+  # result independently reported and lets it carry its own timeout -- do not
+  # merge these back together.
+  qpshare_stress:
+    description: "QP sharing scale and resource lifetime, everything except connection churn: many-connection load, shared-RQ saturation, and batch create/destroy under sharing. NGROUPS=2 with DEPTH_MULTIPLIER=64 and one QP per connection, so the shared QP carries the queue depth the default connection counts require. Scale with QPSHARE_TEST_NCONNS and QPSHARE_TEST_ITERS. RDMA object counts are compared against a pre-batch baseline at each checkpoint."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressManyConns:NetIbMPITest.QpShareStressSharedRqSaturation:NetIbMPITest.QpShareStressBatchCreateDestroy"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  qpshare_stress_churn:
+    description: "QP sharing sequential connection churn, isolated in its own category so it runs in a separate process and its result is reported independently. QPSHARE_TEST_ITERS connect/transfer/close cycles (default 2048) with exactly one connection live at a time, so every cycle is fully torn down before the next begins and each teardown reaches the group-release path. RDMA object counts and the comm's pool state are checkpointed every quarter of the run against a pre-churn baseline. Long-running by design; sharing depth is 1 by construction, so this covers the create/destroy lifecycle of a shared group rather than concurrent occupancy."
+    test_patterns:
+      - "NetIbMPITest.QpShareStressConnectionChurn"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=2"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=64"
+      - "NCCL_IB_QPS_PER_CONNECTION=1"
+  # Same test and tunables as quick_env_qpshare_ngroups16; the only difference
+  # is MALLOC_PERTURB_=165. Since a stale read into freed memory otherwise
+  # usually finds that memory intact, the poison is what makes the group
+  # teardown path exercise it deterministically rather than by timing.
+  qpshare_heap_poison:
+    description: "QP sharing group teardown under glibc heap poisoning. MALLOC_PERTURB_=165 makes glibc overwrite freed heap with 0xa5, so any read through a pointer into a freed comm returns poison rather than whatever the allocator happened to leave behind. Interleaved create/destroy across 16 groups exercises the shared-QP group teardown path against pointers that may outlive the comm they point into. Worth pairing with two controls: the same filter without MALLOC_PERTURB_, and non-sharing NetIb tests with the poison on. MALLOC_PERTURB_ is a glibc feature and is inert on other allocators, so on a non-glibc platform this category is equivalent to quick_env_qpshare_ngroups16."
+    test_patterns:
+      - "NetIbMPITest.QpShareAlgoChurnLayout"
+    exclude_windows: *mpi_exclude_windows
+    labels: *qpshare_labels
+    env_variables:
+      - "NCCL_IB_MERGE_NICS=0"
+      - "NCCL_NET_FORCE_MERGE="
+      - "RCCL_IB_COMM_NGROUPS=16"
+      - "RCCL_IB_QP_DEPTH_MULTIPLIER=8"
+      - "NCCL_GDR_FLUSH_DISABLE=0"
+      - "MALLOC_PERTURB_=165"
 
 execution_settings:
   mpi_launch:
@@ -400,6 +508,10 @@ execution_settings:
     quick_env_netib_xfer_trace: 1200
     quick_env_netib_xfer_log_ranks: 1200
     quick_env_pat_shared_qps_off: 1200
+    quick_env_qpshare_ngroups1: 1200
+    quick_env_qpshare_ngroups2: 1200
+    quick_env_qpshare_ngroups16: 1200
+    quick_env_qpshare_depth_ceiling: 1200
     standard: 1200
     comprehensive: 1200
     comprehensive_disable_env: 1200
@@ -411,3 +523,6 @@ execution_settings:
     full_pow2_tree_ll: 1200
     full_pow2_ring_ll128: 1200
     full_pow2_tree_ll128: 1200
+    qpshare_stress: 3600
+    qpshare_stress_churn: 3600
+    qpshare_heap_poison: 1200

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -97,14 +97,14 @@ using namespace RCCLTestHelpers;
 // scheduler) is enabled alongside it. Must be called from the test body (not
 // a helper), because GTEST_SKIP() only interrupts execution when expanded
 // inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
-// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
-// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+// a_qpshare_* configs in ainic.json (and the matching qpshare_* categories in
+// test_categories_mpi.yaml).
 #define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
     do {                                                                                   \
         const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
         if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
             GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
-                            "Use qpshare_* configs in net_ib_transport.json.";              \
+                            "Use the a_qpshare_* configs in ainic.json.";                   \
         }                                                                                   \
         auto _qpshareIsSetTo1 = [](const char* name) {                                     \
             const char* v = getenv(name);                                                  \
@@ -254,13 +254,6 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
-
-    // ExpectQpShareLayout re-checks every live comm after every create and
-    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
-    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
-    // each TEST_F.
-    static constexpr int kMaxLayoutFailures = 40;
-    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -821,6 +814,71 @@ protected:
         if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
     }
 
+    // One cast connection, from one rank's point of view. Both ranks build the
+    // same sequence; each holds only its own side (rank 0: listen+recv, rank 1:
+    // send), so the unused pointers stay null.
+    struct QpShareConn {
+        void* listen = nullptr;
+        void* send   = nullptr;
+        void* recv   = nullptr;
+        QpShareRefModel::Placement place;
+
+        // This rank's comm: the one the introspection hook can be called on.
+        void* Mine(int rank) const { return rank == 0 ? recv : send; }
+    };
+
+    // Open `n` connections, appending to `cs` and advancing `model` in step.
+    // Stops at the first failure and reports which connection it was and where
+    // the model expected it to land -- diagnosing *why* a connect failed is the
+    // log's job, not the assertion's. Returns the number established.
+    int OpenConns(int n, QpShareRefModel& model,
+                  std::vector<QpShareConn>& cs, const char* what) {
+        int opened = 0;
+        for (int c = 0; c < n; c++) {
+            QpShareConn conn;
+            conn.place = model.AssignOnCreate();
+            if (!TryCastConnection(/*dev=*/0, &conn.listen, &conn.send, &conn.recv)) {
+                model.Release(conn.place);
+                ADD_FAILURE()
+                    << what << ": connection " << c << " of " << n << " failed to establish"
+                    << " (RCCL_IB_COMM_NGROUPS=" << QpShareEnvNGroups()
+                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                    << "); it would have been comm #" << (model.Load(conn.place.group) + 1)
+                    << " in group " << conn.place.group;
+                break;
+            }
+            cs.push_back(conn);
+            opened++;
+        }
+        return opened;
+    }
+
+    // This rank's comms, in order -- the vector ExpectQpShareLayout takes.
+    std::vector<void*> MineOf(const std::vector<QpShareConn>& cs) {
+        const int rank = MPIEnvironment::world_rank;
+        std::vector<void*> mine;
+        mine.reserve(cs.size());
+        for (const QpShareConn& c : cs) mine.push_back(c.Mine(rank));
+        return mine;
+    }
+
+    std::vector<QpShareRefModel::Placement> PlacesOf(const std::vector<QpShareConn>& cs) {
+        std::vector<QpShareRefModel::Placement> p;
+        p.reserve(cs.size());
+        for (const QpShareConn& c : cs) p.push_back(c.place);
+        return p;
+    }
+
+    // Close every connection and empty `cs`. Barriers between closes so the two
+    // ranks tear the same connection down together.
+    void CloseAll(std::vector<QpShareConn>& cs) {
+        for (const QpShareConn& c : cs) {
+            CloseCastConnection(c.listen, c.send, c.recv);
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+        cs.clear();
+    }
+
     // Same MPI_LAND agreement TryCastConnection uses, for any other loop of
     // per-connection setup calls (RegisterMemory, PostRecv, ...) that can fail
     // on one rank but not the other.
@@ -865,95 +923,150 @@ protected:
         fflush(stdout);
     }
 
-    // Compare every live comm's actual sharing state against the reference
-    // model, including cross-comm QP identity: comms in the same group must sit
-    // on one physical QP, comms in different groups must not.
+    // Check that the sharing layout the transport reports is self-consistent.
+    //
+    // Derived entirely from the observed states -- no reference model -- so it
+    // holds whatever assignment policy the transport implements, and keeps
+    // holding after that policy changes. What it pins down is the bookkeeping:
+    //
+    //   * every comm is on the sharing path (commId set, group assigned);
+    //   * a group's refcount equals the number of live comms reporting it, so a
+    //     slot freed on close but still counted, or counted but not freed,
+    //     shows up here;
+    //   * refcount and cqRefcount agree. connect.cc maintains them in lockstep
+    //     over the same set of comms, but cqRefcount alone gates
+    //     IbCastCleanupGroupCqs, i.e. it decides when the group's CQ and PD are
+    //     released. The stress tests see that release only through RDMA object
+    //     counts; a drift caught here says which of the two counters is wrong,
+    //     which an object-count delta cannot;
+    //   * at most one PRIMARY per group -- at most rather than exactly, because
+    //     roles are fixed at connect() time and releasing a group's PRIMARY does
+    //     not promote a SECONDARY, so a live group legitimately has none;
+    //   * comms in one group sit on one physical QP, and no two groups share one.
     //
     // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
-    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
-    // Non-fatal throughout, so a layout divergence is reported for every comm
-    // rather than only the first, and both ranks always reach the next barrier.
-    void ExpectQpShareLayout(const std::vector<void*>& comms,
-                             const std::vector<QpShareRefModel::Placement>& places,
-                             const QpShareRefModel& model,
-                             const char* stage) {
+    // sendComm on rank 1). Non-fatal, so both ranks always reach the next
+    // barrier. Returns false once anything diverges: callers that re-check after
+    // every create and destroy should stop, since a layout that is already wrong
+    // repeats the same failure O(n) more times without adding information.
+    bool ExpectQpShareLayout(const std::vector<void*>& comms, const char* stage) {
+        struct GroupTally {
+            int      live      = 0;
+            int      primaries = 0;
+            uint32_t qpn       = 0;
+        };
+        std::map<int, GroupTally> groups;
+        std::vector<struct ncclIbQpSharingState> states(comms.size());
+        std::vector<bool> live(comms.size(), false);
+        bool ok = true;
+
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            states[i] = GetActualQpSharingState(comms[i]);
+            live[i]   = true;
+
+            if (states[i].commId == 0) {
+                ADD_FAILURE() << stage << ": conn " << i << " has no commId -- it"
+                              << " silently fell back off the sharing path";
+                ok = false;
+            }
+            if (states[i].sharedGroupIdx < 0) {
+                ADD_FAILURE() << stage << ": conn " << i << " has no shared group"
+                              << " while sharing is enabled";
+                ok = false;
+                live[i] = false;   // nothing below is meaningful for it
+                continue;
+            }
+            GroupTally& t = groups[states[i].sharedGroupIdx];
+            t.live++;
+            if (states[i].isSharedQpPrimary) t.primaries++;
+        }
+
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (!live[i]) continue;
+            const struct ncclIbQpSharingState& st = states[i];
+            const int g = st.sharedGroupIdx;
+
+            if (st.refcount != groups[g].live) {
+                ADD_FAILURE() << stage << ": conn " << i << " in group " << g
+                              << " reports refcount=" << st.refcount << " but "
+                              << groups[g].live << " live comms report that group";
+                ok = false;
+            }
+            if (st.cqRefcount != st.refcount) {
+                ADD_FAILURE() << stage << ": conn " << i << " in group " << g
+                              << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                              << st.refcount << ". cqRefcount alone decides when the"
+                              << " group's CQ and PD are released, so a drift here"
+                              << " either frees a CQ that is still in use or never"
+                              << " frees it";
+                ok = false;
+            }
+            if (groups[g].qpn == 0) {
+                groups[g].qpn = st.qpn[0];
+            } else if (st.qpn[0] != groups[g].qpn) {
+                ADD_FAILURE() << stage << ": conn " << i << " is in group " << g
+                              << " but not on that group's physical QP";
+                ok = false;
+            }
+        }
+
+        for (const auto& g : groups) {
+            if (g.second.primaries > 1) {
+                ADD_FAILURE() << stage << ": group " << g.first << " has "
+                              << g.second.primaries << " PRIMARYs; a group has one"
+                              << " physical QP and so at most one owner";
+                ok = false;
+            }
+        }
+        for (auto a = groups.begin(); a != groups.end(); ++a) {
+            auto b = a;
+            for (++b; b != groups.end(); ++b) {
+                if (a->second.qpn != 0 && a->second.qpn == b->second.qpn) {
+                    ADD_FAILURE() << stage << ": groups " << a->first << " and "
+                                  << b->first << " unexpectedly share one physical QP";
+                    ok = false;
+                }
+            }
+        }
+        return ok;
+    }
+
+    // Additionally require the observed placement to match what QpShareRefModel
+    // predicted. This asserts the assignment *policy* -- occupancy-modulo, which
+    // the model transcribes from connect.cc -- rather than the bookkeeping, so a
+    // deliberate policy change fails it and the model has to be updated to match.
+    // Only QpShareAlgoLayoutSweep and QpShareAlgoChurnLayout exist to pin the
+    // policy down; everything else should use ExpectQpShareLayout alone.
+    //
+    // Note that the model counts only the comms the calling test opened, while
+    // the transport counts every live comm to that peer in the process
+    // (IbCastCountPeerTotalRefcount scans the global pool). A comm leaked by an
+    // earlier test in the same binary therefore shifts every prediction here.
+    bool ExpectQpSharePlacement(const std::vector<void*>& comms,
+                                const std::vector<QpShareRefModel::Placement>& places,
+                                const char* stage) {
         EXPECT_EQ(comms.size(), places.size()) << stage;
-        if (comms.size() != places.size()) return;
-        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
-        const int partsOnEntry = CurrentTestFailureParts();
-        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        if (comms.size() != places.size()) return false;
+        bool ok = true;
         for (size_t i = 0; i < comms.size(); i++) {
             if (comms[i] == nullptr) continue;
             struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
-            const int g = places[i].group;
-
-            EXPECT_EQ(st.sharedGroupIdx, g)
-                << stage << ": conn " << i << " group mismatch";
-            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
-                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
-                << " (group " << g << ")";
-            EXPECT_EQ(st.refcount, model.Load(g))
-                << stage << ": conn " << i << " refcount does not match the "
-                << "number of live comms in group " << g;
-            // cqRefcount is a second, independent counter over the same set of
-            // comms: connect.cc increments refcount and cqRefcount together on
-            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
-            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
-            // They must therefore always agree. It is worth asserting
-            // separately because cqRefcount alone gates IbCastCleanupGroupCqs,
-            // i.e. it is the counter that decides when the group's CQ and PD
-            // are released. QpShareStressConnectionChurn and
-            // QpShareStressBatchCreateDestroy observe that release only through
-            // its effect on RDMA object counts; a drift caught here says which
-            // of the two counters is wrong, which an object-count delta cannot.
-            EXPECT_EQ(st.cqRefcount, st.refcount)
-                << stage << ": conn " << i << " in group " << g
-                << " has cqRefcount=" << st.cqRefcount << " but refcount="
-                << st.refcount << ". These count the same comms and are"
-                << " maintained in lockstep; cqRefcount alone decides when the"
-                << " group's CQ and PD are released, so a drift here either"
-                << " frees a CQ that is still in use or never frees it.";
-            EXPECT_NE(st.commId, 0)
-                << stage << ": conn " << i << " has no commId -- it silently fell "
-                << "back off the sharing path";
-
-            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
-            auto it = groupQpn.find(g);
-            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
-            else EXPECT_EQ(st.qpn[0], it->second)
-                << stage << ": conn " << i << " is in group " << g
-                << " but not on that group's physical QP";
-        }
-        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
-            auto b = a;
-            for (++b; b != groupQpn.end(); ++b) {
-                EXPECT_NE(a->second, b->second)
-                    << stage << ": groups " << a->first << " and " << b->first
-                    << " unexpectedly share one physical QP";
+            if (st.sharedGroupIdx != places[i].group) {
+                ADD_FAILURE() << stage << ": conn " << i << " landed in group "
+                              << st.sharedGroupIdx << ", model predicted "
+                              << places[i].group;
+                ok = false;
+            }
+            if (st.isSharedQpPrimary != places[i].primary) {
+                ADD_FAILURE() << stage << ": conn " << i << " is "
+                              << (st.isSharedQpPrimary ? "PRIMARY" : "SECONDARY")
+                              << ", model predicted "
+                              << (places[i].primary ? "PRIMARY" : "SECONDARY");
+                ok = false;
             }
         }
-        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
-        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
-            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
-                   " further per-comm layout checks suppressed for this test."
-                   " The test still fails -- read the FIRST divergence above,"
-                   " not the last: every later one is downstream of it.\n",
-                   kMaxLayoutFailures, stage);
-            fflush(stdout);
-        }
-    }
-
-    // Failure records logged so far by the currently running test. Used as a
-    // cheap delta counter; gtest exposes no "did that block just fail" query.
-    static int CurrentTestFailureParts() {
-        const ::testing::TestInfo* info =
-            ::testing::UnitTest::GetInstance()->current_test_info();
-        if (info == nullptr || info->result() == nullptr) return 0;
-        const ::testing::TestResult* res = info->result();
-        int n = 0;
-        for (int i = 0; i < res->total_part_count(); i++)
-            if (res->GetTestPartResult(i).failed()) n++;
-        return n;
+        return ok;
     }
 
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -11,6 +11,8 @@
 #include <hip/hip_runtime.h>
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "DeviceBufferHelpers.hpp"
@@ -88,6 +90,33 @@ using namespace RCCLTestHelpers;
             GTEST_SKIP() << "Requires RCCL_IB_QP_SCHED_UPDATE_INTERVAL >= "             \
                          << (long long)(min_us) << " us (current: " << _v << ")";        \
         }                                                                                \
+    } while (0)
+
+// Skip a QP-sharing test when RCCL_IB_COMM_NGROUPS is absent/disabled, or when
+// a feature known to be mutually exclusive with sharing (resiliency, CAST
+// scheduler) is enabled alongside it. Must be called from the test body (not
+// a helper), because GTEST_SKIP() only interrupts execution when expanded
+// inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
+// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
+// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+#define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
+    do {                                                                                   \
+        const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
+        if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
+            GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
+                            "Use qpshare_* configs in net_ib_transport.json.";              \
+        }                                                                                   \
+        auto _qpshareIsSetTo1 = [](const char* name) {                                     \
+            const char* v = getenv(name);                                                  \
+            return v && v[0] && strcmp(v, "1") == 0;                                       \
+        };                                                                                  \
+        if (_qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_FAILOVER") ||                        \
+            _qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_RECOVERY")) {                         \
+            GTEST_SKIP() << "QP sharing tests do not support resiliency combos yet.";      \
+        }                                                                                   \
+        if (_qpshareIsSetTo1("RCCL_IB_QP_SCHED_ENABLE")) {                                 \
+            GTEST_SKIP() << "QP sharing tests do not support CAST scheduler combos yet.";  \
+        }                                                                                   \
     } while (0)
 
 // External NET IB plugin
@@ -225,6 +254,13 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
+
+    // ExpectQpShareLayout re-checks every live comm after every create and
+    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
+    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
+    // each TEST_F.
+    static constexpr int kMaxLayoutFailures = 40;
+    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -729,6 +765,197 @@ protected:
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
+    // Non-fatal, rank-agreed variant of SetupCastConnection.
+    //
+    // Returns true only when BOTH ranks established their side (agreed via
+    // MPI_LAND, so the two ranks never disagree about whether the connection
+    // exists). On false, each rank has closed whatever it managed to open and
+    // all three out-params are left null, so the caller can stop cleanly.
+    // It prevents a timeout in the case of a failed connection.
+    bool TryCastConnection(int dev,
+                           void** listenComm, void** sendComm, void** recvComm) {
+        const int rank = MPIEnvironment::world_rank;
+        const int peer = 1 - rank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+        int ok = 1;
+
+        if (rank == 0) {
+            if (CreateListenComm(dev, &handle, listenComm) != ncclSuccess || *listenComm == nullptr)
+                ok = 0;
+            // Sent unconditionally: rank 1 is already blocked in MPI_Recv, and
+            // a zeroed handle makes its connect fail rather than hang.
+            MPI_Send(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *recvComm == nullptr; i++) {
+                if (AcceptConnection(*listenComm, recvComm) != ncclSuccess) ok = 0;
+                else if (*recvComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*recvComm == nullptr) ok = 0;
+        } else {
+            MPI_Recv(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *sendComm == nullptr; i++) {
+                if (ConnectToRemote(dev, &handle, sendComm) != ncclSuccess) ok = 0;
+                else if (*sendComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*sendComm == nullptr) ok = 0;
+        }
+
+        int bothOk = 0;
+        MPI_Allreduce(&ok, &bothOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        if (!bothOk) {
+            if (*recvComm)   { CloseRecvComm(*recvComm);     *recvComm   = nullptr; }
+            if (*listenComm) { CloseListenComm(*listenComm); *listenComm = nullptr; }
+            if (*sendComm)   { CloseSendComm(*sendComm);     *sendComm   = nullptr; }
+        }
+        return bothOk != 0;
+    }
+
+    // Close one cast connection with no memory handle and no barrier. Each rank
+    // holds only its own comms (rank 0: listen+recv, rank 1: send), so the null
+    // checks make this rank-conditional without a rank test. Non-fatal: a close
+    // failure must not strand the peer at the next barrier.
+    void CloseCastConnection(void* listenComm, void* sendComm, void* recvComm) {
+        if (recvComm)   EXPECT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        if (listenComm) EXPECT_EQ(CloseListenComm(listenComm), ncclSuccess);
+        if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+
+    // Same MPI_LAND agreement TryCastConnection uses, for any other loop of
+    // per-connection setup calls (RegisterMemory, PostRecv, ...) that can fail
+    // on one rank but not the other.
+    bool RankAgree(bool localOk) {
+        int ok = localOk ? 1 : 0;
+        int allOk = 0;
+        MPI_Allreduce(&ok, &allOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        return allOk != 0;
+    }
+
+    // Highest refcount across the given comms: the sharing depth this run
+    // actually achieved. 1 means no QP ended up shared.
+    int MaxObservedSharingDepth(const std::vector<void*>& comms) {
+        int m = 0;
+        for (void* c : comms) {
+            if (c == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(c);
+            m = std::max(m, st.refcount);
+        }
+        return m;
+    }
+
+    // Report what a QP-sharing run actually exercised.
+    //
+    // Goes to stdout on rank 0 (visible in mpirun logs) and into the gtest XML.
+    void ReportQpShareCoverage(const char* what, int nconns, int maxCommsPerGroup,
+                               int spread = -1) {
+        const int ng = QpShareEnvNGroups();
+        const int dm = QpShareEnvDepthMultiplier();
+        RecordProperty("qpshare_ngroups", ng);
+        RecordProperty("qpshare_depth_multiplier", dm);
+        RecordProperty("qpshare_nconns", nconns);
+        RecordProperty("qpshare_max_comms_per_group", maxCommsPerGroup);
+        if (spread >= 0) RecordProperty("qpshare_group_spread", spread);
+        if (MPIEnvironment::world_rank != 0) return;
+        printf("[QPSHARE-COV] %s ngroups=%d depth=%d nconns=%d max_comms_per_group=%d",
+               what, ng, dm, nconns, maxCommsPerGroup);
+        if (spread >= 0) printf(" group_spread=%d", spread);
+        if (maxCommsPerGroup <= 1)
+            printf("  (NO QP WAS SHARED -- unshared data path only)");
+        printf("\n");
+        fflush(stdout);
+    }
+
+    // Compare every live comm's actual sharing state against the reference
+    // model, including cross-comm QP identity: comms in the same group must sit
+    // on one physical QP, comms in different groups must not.
+    //
+    // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
+    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
+    // Non-fatal throughout, so a layout divergence is reported for every comm
+    // rather than only the first, and both ranks always reach the next barrier.
+    void ExpectQpShareLayout(const std::vector<void*>& comms,
+                             const std::vector<QpShareRefModel::Placement>& places,
+                             const QpShareRefModel& model,
+                             const char* stage) {
+        EXPECT_EQ(comms.size(), places.size()) << stage;
+        if (comms.size() != places.size()) return;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
+        const int partsOnEntry = CurrentTestFailureParts();
+        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
+            const int g = places[i].group;
+
+            EXPECT_EQ(st.sharedGroupIdx, g)
+                << stage << ": conn " << i << " group mismatch";
+            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
+                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
+                << " (group " << g << ")";
+            EXPECT_EQ(st.refcount, model.Load(g))
+                << stage << ": conn " << i << " refcount does not match the "
+                << "number of live comms in group " << g;
+            // cqRefcount is a second, independent counter over the same set of
+            // comms: connect.cc increments refcount and cqRefcount together on
+            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
+            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
+            // They must therefore always agree. It is worth asserting
+            // separately because cqRefcount alone gates IbCastCleanupGroupCqs,
+            // i.e. it is the counter that decides when the group's CQ and PD
+            // are released. QpShareStressConnectionChurn and
+            // QpShareStressBatchCreateDestroy observe that release only through
+            // its effect on RDMA object counts; a drift caught here says which
+            // of the two counters is wrong, which an object-count delta cannot.
+            EXPECT_EQ(st.cqRefcount, st.refcount)
+                << stage << ": conn " << i << " in group " << g
+                << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                << st.refcount << ". These count the same comms and are"
+                << " maintained in lockstep; cqRefcount alone decides when the"
+                << " group's CQ and PD are released, so a drift here either"
+                << " frees a CQ that is still in use or never frees it.";
+            EXPECT_NE(st.commId, 0)
+                << stage << ": conn " << i << " has no commId -- it silently fell "
+                << "back off the sharing path";
+
+            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
+            auto it = groupQpn.find(g);
+            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
+            else EXPECT_EQ(st.qpn[0], it->second)
+                << stage << ": conn " << i << " is in group " << g
+                << " but not on that group's physical QP";
+        }
+        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
+            auto b = a;
+            for (++b; b != groupQpn.end(); ++b) {
+                EXPECT_NE(a->second, b->second)
+                    << stage << ": groups " << a->first << " and " << b->first
+                    << " unexpectedly share one physical QP";
+            }
+        }
+        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
+            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
+                   " further per-comm layout checks suppressed for this test."
+                   " The test still fails -- read the FIRST divergence above,"
+                   " not the last: every later one is downstream of it.\n",
+                   kMaxLayoutFailures, stage);
+            fflush(stdout);
+        }
+    }
+
+    // Failure records logged so far by the currently running test. Used as a
+    // cheap delta counter; gtest exposes no "did that block just fail" query.
+    static int CurrentTestFailureParts() {
+        const ::testing::TestInfo* info =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        if (info == nullptr || info->result() == nullptr) return 0;
+        const ::testing::TestResult* res = info->result();
+        int n = 0;
+        for (int i = 0; i < res->total_part_count(); i++)
+            if (res->GetTestPartResult(i).failed()) n++;
+        return n;
+    }
+
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.
     // Both ranks call this together. actualNqps is broadcast so rank 0 can coordinate.
     // buf/mhandle must already be registered against the caller's comm.
@@ -745,6 +972,16 @@ protected:
         MPI_Bcast(&nqps, 1, MPI_INT, 1, MPI_COMM_WORLD);
         EXPECT_GT(nqps, 0);
         return nqps;
+    }
+
+    // Read QP-sharing pool state directly from a connected sendComm/recvComm.
+    // Unlike GetActualNqps(), no warmup send/recv is required: PRIMARY/SECONDARY
+    // role, groupIdx, refcount, and QP handles are all fixed at connect()/accept()
+    // time (see connect.cc groupIdx assignment), not populated lazily by traffic.
+    struct ncclIbQpSharingState GetActualQpSharingState(void* comm) {
+        struct ncclIbQpSharingState state = {};
+        EXPECT_EQ(ncclIbCastGetQpSharingState(comm, &state), ncclSuccess);
+        return state;
     }
 
     // Read RCCL_IB_QP_SCHED_SPLIT_DATA_MIN from the environment.

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -12,6 +12,8 @@
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"
 #include "NetIbFaultInject.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "DeviceBufferHelpers.hpp"
@@ -90,6 +92,33 @@ using namespace RCCLTestHelpers;
             GTEST_SKIP() << "Requires RCCL_IB_QP_SCHED_UPDATE_INTERVAL >= "             \
                          << (long long)(min_us) << " us (current: " << _v << ")";        \
         }                                                                                \
+    } while (0)
+
+// Skip a QP-sharing test when RCCL_IB_COMM_NGROUPS is absent/disabled, or when
+// a feature known to be mutually exclusive with sharing (resiliency, CAST
+// scheduler) is enabled alongside it. Must be called from the test body (not
+// a helper), because GTEST_SKIP() only interrupts execution when expanded
+// inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
+// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
+// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+#define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
+    do {                                                                                   \
+        const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
+        if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
+            GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
+                            "Use qpshare_* configs in net_ib_transport.json.";              \
+        }                                                                                   \
+        auto _qpshareIsSetTo1 = [](const char* name) {                                     \
+            const char* v = getenv(name);                                                  \
+            return v && v[0] && strcmp(v, "1") == 0;                                       \
+        };                                                                                  \
+        if (_qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_FAILOVER") ||                        \
+            _qpshareIsSetTo1("NCCL_IB_RESILIENCY_PORT_RECOVERY")) {                         \
+            GTEST_SKIP() << "QP sharing tests do not support resiliency combos yet.";      \
+        }                                                                                   \
+        if (_qpshareIsSetTo1("RCCL_IB_QP_SCHED_ENABLE")) {                                 \
+            GTEST_SKIP() << "QP sharing tests do not support CAST scheduler combos yet.";  \
+        }                                                                                   \
     } while (0)
 
 // External NET IB plugin
@@ -247,6 +276,13 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
+
+    // ExpectQpShareLayout re-checks every live comm after every create and
+    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
+    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
+    // each TEST_F.
+    static constexpr int kMaxLayoutFailures = 40;
+    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -791,6 +827,197 @@ protected:
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
+    // Non-fatal, rank-agreed variant of SetupCastConnection.
+    //
+    // Returns true only when BOTH ranks established their side (agreed via
+    // MPI_LAND, so the two ranks never disagree about whether the connection
+    // exists). On false, each rank has closed whatever it managed to open and
+    // all three out-params are left null, so the caller can stop cleanly.
+    // It prevents a timeout in the case of a failed connection.
+    bool TryCastConnection(int dev,
+                           void** listenComm, void** sendComm, void** recvComm) {
+        const int rank = MPIEnvironment::world_rank;
+        const int peer = 1 - rank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+        int ok = 1;
+
+        if (rank == 0) {
+            if (CreateListenComm(dev, &handle, listenComm) != ncclSuccess || *listenComm == nullptr)
+                ok = 0;
+            // Sent unconditionally: rank 1 is already blocked in MPI_Recv, and
+            // a zeroed handle makes its connect fail rather than hang.
+            MPI_Send(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *recvComm == nullptr; i++) {
+                if (AcceptConnection(*listenComm, recvComm) != ncclSuccess) ok = 0;
+                else if (*recvComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*recvComm == nullptr) ok = 0;
+        } else {
+            MPI_Recv(&handle, sizeof(handle), MPI_BYTE, peer, 0, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            for (int i = 0; ok && i < kMaxRetryAttempts && *sendComm == nullptr; i++) {
+                if (ConnectToRemote(dev, &handle, sendComm) != ncclSuccess) ok = 0;
+                else if (*sendComm == nullptr) usleep(kPollIntervalUs);
+            }
+            if (*sendComm == nullptr) ok = 0;
+        }
+
+        int bothOk = 0;
+        MPI_Allreduce(&ok, &bothOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        if (!bothOk) {
+            if (*recvComm)   { CloseRecvComm(*recvComm);     *recvComm   = nullptr; }
+            if (*listenComm) { CloseListenComm(*listenComm); *listenComm = nullptr; }
+            if (*sendComm)   { CloseSendComm(*sendComm);     *sendComm   = nullptr; }
+        }
+        return bothOk != 0;
+    }
+
+    // Close one cast connection with no memory handle and no barrier. Each rank
+    // holds only its own comms (rank 0: listen+recv, rank 1: send), so the null
+    // checks make this rank-conditional without a rank test. Non-fatal: a close
+    // failure must not strand the peer at the next barrier.
+    void CloseCastConnection(void* listenComm, void* sendComm, void* recvComm) {
+        if (recvComm)   EXPECT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        if (listenComm) EXPECT_EQ(CloseListenComm(listenComm), ncclSuccess);
+        if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+
+    // Same MPI_LAND agreement TryCastConnection uses, for any other loop of
+    // per-connection setup calls (RegisterMemory, PostRecv, ...) that can fail
+    // on one rank but not the other.
+    bool RankAgree(bool localOk) {
+        int ok = localOk ? 1 : 0;
+        int allOk = 0;
+        MPI_Allreduce(&ok, &allOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+        return allOk != 0;
+    }
+
+    // Highest refcount across the given comms: the sharing depth this run
+    // actually achieved. 1 means no QP ended up shared.
+    int MaxObservedSharingDepth(const std::vector<void*>& comms) {
+        int m = 0;
+        for (void* c : comms) {
+            if (c == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(c);
+            m = std::max(m, st.refcount);
+        }
+        return m;
+    }
+
+    // Report what a QP-sharing run actually exercised.
+    //
+    // Goes to stdout on rank 0 (visible in mpirun logs) and into the gtest XML.
+    void ReportQpShareCoverage(const char* what, int nconns, int maxCommsPerGroup,
+                               int spread = -1) {
+        const int ng = QpShareEnvNGroups();
+        const int dm = QpShareEnvDepthMultiplier();
+        RecordProperty("qpshare_ngroups", ng);
+        RecordProperty("qpshare_depth_multiplier", dm);
+        RecordProperty("qpshare_nconns", nconns);
+        RecordProperty("qpshare_max_comms_per_group", maxCommsPerGroup);
+        if (spread >= 0) RecordProperty("qpshare_group_spread", spread);
+        if (MPIEnvironment::world_rank != 0) return;
+        printf("[QPSHARE-COV] %s ngroups=%d depth=%d nconns=%d max_comms_per_group=%d",
+               what, ng, dm, nconns, maxCommsPerGroup);
+        if (spread >= 0) printf(" group_spread=%d", spread);
+        if (maxCommsPerGroup <= 1)
+            printf("  (NO QP WAS SHARED -- unshared data path only)");
+        printf("\n");
+        fflush(stdout);
+    }
+
+    // Compare every live comm's actual sharing state against the reference
+    // model, including cross-comm QP identity: comms in the same group must sit
+    // on one physical QP, comms in different groups must not.
+    //
+    // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
+    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
+    // Non-fatal throughout, so a layout divergence is reported for every comm
+    // rather than only the first, and both ranks always reach the next barrier.
+    void ExpectQpShareLayout(const std::vector<void*>& comms,
+                             const std::vector<QpShareRefModel::Placement>& places,
+                             const QpShareRefModel& model,
+                             const char* stage) {
+        EXPECT_EQ(comms.size(), places.size()) << stage;
+        if (comms.size() != places.size()) return;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
+        const int partsOnEntry = CurrentTestFailureParts();
+        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
+            const int g = places[i].group;
+
+            EXPECT_EQ(st.sharedGroupIdx, g)
+                << stage << ": conn " << i << " group mismatch";
+            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
+                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
+                << " (group " << g << ")";
+            EXPECT_EQ(st.refcount, model.Load(g))
+                << stage << ": conn " << i << " refcount does not match the "
+                << "number of live comms in group " << g;
+            // cqRefcount is a second, independent counter over the same set of
+            // comms: connect.cc increments refcount and cqRefcount together on
+            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
+            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
+            // They must therefore always agree. It is worth asserting
+            // separately because cqRefcount alone gates IbCastCleanupGroupCqs,
+            // i.e. it is the counter that decides when the group's CQ and PD
+            // are released. QpShareStressConnectionChurn and
+            // QpShareStressBatchCreateDestroy observe that release only through
+            // its effect on RDMA object counts; a drift caught here says which
+            // of the two counters is wrong, which an object-count delta cannot.
+            EXPECT_EQ(st.cqRefcount, st.refcount)
+                << stage << ": conn " << i << " in group " << g
+                << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                << st.refcount << ". These count the same comms and are"
+                << " maintained in lockstep; cqRefcount alone decides when the"
+                << " group's CQ and PD are released, so a drift here either"
+                << " frees a CQ that is still in use or never frees it.";
+            EXPECT_NE(st.commId, 0)
+                << stage << ": conn " << i << " has no commId -- it silently fell "
+                << "back off the sharing path";
+
+            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
+            auto it = groupQpn.find(g);
+            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
+            else EXPECT_EQ(st.qpn[0], it->second)
+                << stage << ": conn " << i << " is in group " << g
+                << " but not on that group's physical QP";
+        }
+        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
+            auto b = a;
+            for (++b; b != groupQpn.end(); ++b) {
+                EXPECT_NE(a->second, b->second)
+                    << stage << ": groups " << a->first << " and " << b->first
+                    << " unexpectedly share one physical QP";
+            }
+        }
+        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
+        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
+            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
+                   " further per-comm layout checks suppressed for this test."
+                   " The test still fails -- read the FIRST divergence above,"
+                   " not the last: every later one is downstream of it.\n",
+                   kMaxLayoutFailures, stage);
+            fflush(stdout);
+        }
+    }
+
+    // Failure records logged so far by the currently running test. Used as a
+    // cheap delta counter; gtest exposes no "did that block just fail" query.
+    static int CurrentTestFailureParts() {
+        const ::testing::TestInfo* info =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        if (info == nullptr || info->result() == nullptr) return 0;
+        const ::testing::TestResult* res = info->result();
+        int n = 0;
+        for (int i = 0; i < res->total_part_count(); i++)
+            if (res->GetTestPartResult(i).failed()) n++;
+        return n;
+    }
+
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.
     // Both ranks call this together. actualNqps is broadcast so rank 0 can coordinate.
     // buf/mhandle must already be registered against the caller's comm.
@@ -807,6 +1034,16 @@ protected:
         MPI_Bcast(&nqps, 1, MPI_INT, 1, MPI_COMM_WORLD);
         EXPECT_GT(nqps, 0);
         return nqps;
+    }
+
+    // Read QP-sharing pool state directly from a connected sendComm/recvComm.
+    // Unlike GetActualNqps(), no warmup send/recv is required: PRIMARY/SECONDARY
+    // role, groupIdx, refcount, and QP handles are all fixed at connect()/accept()
+    // time (see connect.cc groupIdx assignment), not populated lazily by traffic.
+    struct ncclIbQpSharingState GetActualQpSharingState(void* comm) {
+        struct ncclIbQpSharingState state = {};
+        EXPECT_EQ(ncclIbCastGetQpSharingState(comm, &state), ncclSuccess);
+        return state;
     }
 
     // Read RCCL_IB_QP_SCHED_SPLIT_DATA_MIN from the environment.

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -99,14 +99,14 @@ using namespace RCCLTestHelpers;
 // scheduler) is enabled alongside it. Must be called from the test body (not
 // a helper), because GTEST_SKIP() only interrupts execution when expanded
 // inline in the test scope. RCCL_IB_COMM_NGROUPS is set per preset by the
-// qpshare_* configs in net_ib_transport.json (and the matching qpshare_*
-// categories in test_categories_mpi.yaml); there is no shared qpshare_base.
+// a_qpshare_* configs in ainic.json (and the matching qpshare_* categories in
+// test_categories_mpi.yaml).
 #define QPSHARE_ENV_CHECK_OR_SKIP()                                                       \
     do {                                                                                   \
         const char* _ng = getenv("RCCL_IB_COMM_NGROUPS");                                  \
         if (!_ng || _ng[0] == '\0' || std::atoll(_ng) <= 0) {                              \
             GTEST_SKIP() << "Requires RCCL_IB_COMM_NGROUPS > 0. "                          \
-                            "Use qpshare_* configs in net_ib_transport.json.";              \
+                            "Use the a_qpshare_* configs in ainic.json.";                   \
         }                                                                                   \
         auto _qpshareIsSetTo1 = [](const char* name) {                                     \
             const char* v = getenv(name);                                                  \
@@ -276,13 +276,6 @@ protected:
     int numDevices_;
     std::vector<int> deviceIds_;
     void* initCtx_;
-
-    // ExpectQpShareLayout re-checks every live comm after every create and
-    // destroy, so a layout that is wrong from connection 0 fails O(n^2) times.
-    // Cap the reporting; see ExpectQpShareLayout. Per-fixture, so it resets for
-    // each TEST_F.
-    static constexpr int kMaxLayoutFailures = 40;
-    int qpShareLayoutFailures_ = 0;
 
     void SetUp() override {
         MPITestBase::SetUp();
@@ -883,6 +876,71 @@ protected:
         if (sendComm)   EXPECT_EQ(CloseSendComm(sendComm), ncclSuccess);
     }
 
+    // One cast connection, from one rank's point of view. Both ranks build the
+    // same sequence; each holds only its own side (rank 0: listen+recv, rank 1:
+    // send), so the unused pointers stay null.
+    struct QpShareConn {
+        void* listen = nullptr;
+        void* send   = nullptr;
+        void* recv   = nullptr;
+        QpShareRefModel::Placement place;
+
+        // This rank's comm: the one the introspection hook can be called on.
+        void* Mine(int rank) const { return rank == 0 ? recv : send; }
+    };
+
+    // Open `n` connections, appending to `cs` and advancing `model` in step.
+    // Stops at the first failure and reports which connection it was and where
+    // the model expected it to land -- diagnosing *why* a connect failed is the
+    // log's job, not the assertion's. Returns the number established.
+    int OpenConns(int n, QpShareRefModel& model,
+                  std::vector<QpShareConn>& cs, const char* what) {
+        int opened = 0;
+        for (int c = 0; c < n; c++) {
+            QpShareConn conn;
+            conn.place = model.AssignOnCreate();
+            if (!TryCastConnection(/*dev=*/0, &conn.listen, &conn.send, &conn.recv)) {
+                model.Release(conn.place);
+                ADD_FAILURE()
+                    << what << ": connection " << c << " of " << n << " failed to establish"
+                    << " (RCCL_IB_COMM_NGROUPS=" << QpShareEnvNGroups()
+                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                    << "); it would have been comm #" << (model.Load(conn.place.group) + 1)
+                    << " in group " << conn.place.group;
+                break;
+            }
+            cs.push_back(conn);
+            opened++;
+        }
+        return opened;
+    }
+
+    // This rank's comms, in order -- the vector ExpectQpShareLayout takes.
+    std::vector<void*> MineOf(const std::vector<QpShareConn>& cs) {
+        const int rank = MPIEnvironment::world_rank;
+        std::vector<void*> mine;
+        mine.reserve(cs.size());
+        for (const QpShareConn& c : cs) mine.push_back(c.Mine(rank));
+        return mine;
+    }
+
+    std::vector<QpShareRefModel::Placement> PlacesOf(const std::vector<QpShareConn>& cs) {
+        std::vector<QpShareRefModel::Placement> p;
+        p.reserve(cs.size());
+        for (const QpShareConn& c : cs) p.push_back(c.place);
+        return p;
+    }
+
+    // Close every connection and empty `cs`. Barriers between closes so the two
+    // ranks tear the same connection down together.
+    void CloseAll(std::vector<QpShareConn>& cs) {
+        for (const QpShareConn& c : cs) {
+            CloseCastConnection(c.listen, c.send, c.recv);
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+        cs.clear();
+    }
+
     // Same MPI_LAND agreement TryCastConnection uses, for any other loop of
     // per-connection setup calls (RegisterMemory, PostRecv, ...) that can fail
     // on one rank but not the other.
@@ -927,95 +985,150 @@ protected:
         fflush(stdout);
     }
 
-    // Compare every live comm's actual sharing state against the reference
-    // model, including cross-comm QP identity: comms in the same group must sit
-    // on one physical QP, comms in different groups must not.
+    // Check that the sharing layout the transport reports is self-consistent.
+    //
+    // Derived entirely from the observed states -- no reference model -- so it
+    // holds whatever assignment policy the transport implements, and keeps
+    // holding after that policy changes. What it pins down is the bookkeeping:
+    //
+    //   * every comm is on the sharing path (commId set, group assigned);
+    //   * a group's refcount equals the number of live comms reporting it, so a
+    //     slot freed on close but still counted, or counted but not freed,
+    //     shows up here;
+    //   * refcount and cqRefcount agree. connect.cc maintains them in lockstep
+    //     over the same set of comms, but cqRefcount alone gates
+    //     IbCastCleanupGroupCqs, i.e. it decides when the group's CQ and PD are
+    //     released. The stress tests see that release only through RDMA object
+    //     counts; a drift caught here says which of the two counters is wrong,
+    //     which an object-count delta cannot;
+    //   * at most one PRIMARY per group -- at most rather than exactly, because
+    //     roles are fixed at connect() time and releasing a group's PRIMARY does
+    //     not promote a SECONDARY, so a live group legitimately has none;
+    //   * comms in one group sit on one physical QP, and no two groups share one.
     //
     // `comms[i]` is this rank's comm for connection i (recvComm on rank 0,
-    // sendComm on rank 1); `places[i]` is what QpShareRefModel predicted for it.
-    // Non-fatal throughout, so a layout divergence is reported for every comm
-    // rather than only the first, and both ranks always reach the next barrier.
-    void ExpectQpShareLayout(const std::vector<void*>& comms,
-                             const std::vector<QpShareRefModel::Placement>& places,
-                             const QpShareRefModel& model,
-                             const char* stage) {
+    // sendComm on rank 1). Non-fatal, so both ranks always reach the next
+    // barrier. Returns false once anything diverges: callers that re-check after
+    // every create and destroy should stop, since a layout that is already wrong
+    // repeats the same failure O(n) more times without adding information.
+    bool ExpectQpShareLayout(const std::vector<void*>& comms, const char* stage) {
+        struct GroupTally {
+            int      live      = 0;
+            int      primaries = 0;
+            uint32_t qpn       = 0;
+        };
+        std::map<int, GroupTally> groups;
+        std::vector<struct ncclIbQpSharingState> states(comms.size());
+        std::vector<bool> live(comms.size(), false);
+        bool ok = true;
+
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (comms[i] == nullptr) continue;
+            states[i] = GetActualQpSharingState(comms[i]);
+            live[i]   = true;
+
+            if (states[i].commId == 0) {
+                ADD_FAILURE() << stage << ": conn " << i << " has no commId -- it"
+                              << " silently fell back off the sharing path";
+                ok = false;
+            }
+            if (states[i].sharedGroupIdx < 0) {
+                ADD_FAILURE() << stage << ": conn " << i << " has no shared group"
+                              << " while sharing is enabled";
+                ok = false;
+                live[i] = false;   // nothing below is meaningful for it
+                continue;
+            }
+            GroupTally& t = groups[states[i].sharedGroupIdx];
+            t.live++;
+            if (states[i].isSharedQpPrimary) t.primaries++;
+        }
+
+        for (size_t i = 0; i < comms.size(); i++) {
+            if (!live[i]) continue;
+            const struct ncclIbQpSharingState& st = states[i];
+            const int g = st.sharedGroupIdx;
+
+            if (st.refcount != groups[g].live) {
+                ADD_FAILURE() << stage << ": conn " << i << " in group " << g
+                              << " reports refcount=" << st.refcount << " but "
+                              << groups[g].live << " live comms report that group";
+                ok = false;
+            }
+            if (st.cqRefcount != st.refcount) {
+                ADD_FAILURE() << stage << ": conn " << i << " in group " << g
+                              << " has cqRefcount=" << st.cqRefcount << " but refcount="
+                              << st.refcount << ". cqRefcount alone decides when the"
+                              << " group's CQ and PD are released, so a drift here"
+                              << " either frees a CQ that is still in use or never"
+                              << " frees it";
+                ok = false;
+            }
+            if (groups[g].qpn == 0) {
+                groups[g].qpn = st.qpn[0];
+            } else if (st.qpn[0] != groups[g].qpn) {
+                ADD_FAILURE() << stage << ": conn " << i << " is in group " << g
+                              << " but not on that group's physical QP";
+                ok = false;
+            }
+        }
+
+        for (const auto& g : groups) {
+            if (g.second.primaries > 1) {
+                ADD_FAILURE() << stage << ": group " << g.first << " has "
+                              << g.second.primaries << " PRIMARYs; a group has one"
+                              << " physical QP and so at most one owner";
+                ok = false;
+            }
+        }
+        for (auto a = groups.begin(); a != groups.end(); ++a) {
+            auto b = a;
+            for (++b; b != groups.end(); ++b) {
+                if (a->second.qpn != 0 && a->second.qpn == b->second.qpn) {
+                    ADD_FAILURE() << stage << ": groups " << a->first << " and "
+                                  << b->first << " unexpectedly share one physical QP";
+                    ok = false;
+                }
+            }
+        }
+        return ok;
+    }
+
+    // Additionally require the observed placement to match what QpShareRefModel
+    // predicted. This asserts the assignment *policy* -- occupancy-modulo, which
+    // the model transcribes from connect.cc -- rather than the bookkeeping, so a
+    // deliberate policy change fails it and the model has to be updated to match.
+    // Only QpShareAlgoLayoutSweep and QpShareAlgoChurnLayout exist to pin the
+    // policy down; everything else should use ExpectQpShareLayout alone.
+    //
+    // Note that the model counts only the comms the calling test opened, while
+    // the transport counts every live comm to that peer in the process
+    // (IbCastCountPeerTotalRefcount scans the global pool). A comm leaked by an
+    // earlier test in the same binary therefore shifts every prediction here.
+    bool ExpectQpSharePlacement(const std::vector<void*>& comms,
+                                const std::vector<QpShareRefModel::Placement>& places,
+                                const char* stage) {
         EXPECT_EQ(comms.size(), places.size()) << stage;
-        if (comms.size() != places.size()) return;
-        if (qpShareLayoutFailures_ > kMaxLayoutFailures) return;
-        const int partsOnEntry = CurrentTestFailureParts();
-        std::map<int, uint32_t> groupQpn;  // group -> qpn of its physical QP
+        if (comms.size() != places.size()) return false;
+        bool ok = true;
         for (size_t i = 0; i < comms.size(); i++) {
             if (comms[i] == nullptr) continue;
             struct ncclIbQpSharingState st = GetActualQpSharingState(comms[i]);
-            const int g = places[i].group;
-
-            EXPECT_EQ(st.sharedGroupIdx, g)
-                << stage << ": conn " << i << " group mismatch";
-            EXPECT_EQ(st.isSharedQpPrimary, places[i].primary)
-                << stage << ": conn " << i << " PRIMARY/SECONDARY role mismatch"
-                << " (group " << g << ")";
-            EXPECT_EQ(st.refcount, model.Load(g))
-                << stage << ": conn " << i << " refcount does not match the "
-                << "number of live comms in group " << g;
-            // cqRefcount is a second, independent counter over the same set of
-            // comms: connect.cc increments refcount and cqRefcount together on
-            // the q==0 slot (:1058/:1066, :1866/:1874) and decrements them
-            // together on close (:2082/:2092, :2160/:2174), both starting at 1.
-            // They must therefore always agree. It is worth asserting
-            // separately because cqRefcount alone gates IbCastCleanupGroupCqs,
-            // i.e. it is the counter that decides when the group's CQ and PD
-            // are released. QpShareStressConnectionChurn and
-            // QpShareStressBatchCreateDestroy observe that release only through
-            // its effect on RDMA object counts; a drift caught here says which
-            // of the two counters is wrong, which an object-count delta cannot.
-            EXPECT_EQ(st.cqRefcount, st.refcount)
-                << stage << ": conn " << i << " in group " << g
-                << " has cqRefcount=" << st.cqRefcount << " but refcount="
-                << st.refcount << ". These count the same comms and are"
-                << " maintained in lockstep; cqRefcount alone decides when the"
-                << " group's CQ and PD are released, so a drift here either"
-                << " frees a CQ that is still in use or never frees it.";
-            EXPECT_NE(st.commId, 0)
-                << stage << ": conn " << i << " has no commId -- it silently fell "
-                << "back off the sharing path";
-
-            if (st.sharedGroupIdx != g) continue;  // QP identity is meaningless if the group is wrong
-            auto it = groupQpn.find(g);
-            if (it == groupQpn.end()) groupQpn[g] = st.qpn[0];
-            else EXPECT_EQ(st.qpn[0], it->second)
-                << stage << ": conn " << i << " is in group " << g
-                << " but not on that group's physical QP";
-        }
-        for (auto a = groupQpn.begin(); a != groupQpn.end(); ++a) {
-            auto b = a;
-            for (++b; b != groupQpn.end(); ++b) {
-                EXPECT_NE(a->second, b->second)
-                    << stage << ": groups " << a->first << " and " << b->first
-                    << " unexpectedly share one physical QP";
+            if (st.sharedGroupIdx != places[i].group) {
+                ADD_FAILURE() << stage << ": conn " << i << " landed in group "
+                              << st.sharedGroupIdx << ", model predicted "
+                              << places[i].group;
+                ok = false;
+            }
+            if (st.isSharedQpPrimary != places[i].primary) {
+                ADD_FAILURE() << stage << ": conn " << i << " is "
+                              << (st.isSharedQpPrimary ? "PRIMARY" : "SECONDARY")
+                              << ", model predicted "
+                              << (places[i].primary ? "PRIMARY" : "SECONDARY");
+                ok = false;
             }
         }
-        qpShareLayoutFailures_ += CurrentTestFailureParts() - partsOnEntry;
-        if (qpShareLayoutFailures_ > kMaxLayoutFailures) {
-            printf("[QPSHARE-COV] layout divergences exceeded %d at \"%s\";"
-                   " further per-comm layout checks suppressed for this test."
-                   " The test still fails -- read the FIRST divergence above,"
-                   " not the last: every later one is downstream of it.\n",
-                   kMaxLayoutFailures, stage);
-            fflush(stdout);
-        }
-    }
-
-    // Failure records logged so far by the currently running test. Used as a
-    // cheap delta counter; gtest exposes no "did that block just fail" query.
-    static int CurrentTestFailureParts() {
-        const ::testing::TestInfo* info =
-            ::testing::UnitTest::GetInstance()->current_test_info();
-        if (info == nullptr || info->result() == nullptr) return 0;
-        const ::testing::TestResult* res = info->result();
-        int n = 0;
-        for (int i = 0; i < res->total_part_count(); i++)
-            if (res->GetTestPartResult(i).failed()) n++;
-        return n;
+        return ok;
     }
 
     // Composite block: Warmup send + read real nqps from sendComm on rank 1.

--- a/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbQpSharingInspect.hpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+#define RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_
+
+#ifdef MPI_TESTS_ENABLED
+
+/*
+ * Re-export the shared struct and function declarations from the library's
+ * internal header.  Using the same header in both the library (qp_sharing.cc)
+ * and the tests guarantees that the ABI can never silently diverge.
+ */
+#include "net_ib_qp_sharing_inspect.h"
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_NET_IB_QP_SHARING_INSPECT_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpShareRefModel.hpp
@@ -1,0 +1,140 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+#define RCCL_TEST_QP_SHARE_REF_MODEL_HPP_
+
+#include <cstdlib>
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+
+#ifdef MPI_TESTS_ENABLED
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Environment readers
+//
+// RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER are plain RCCL_PARAMs
+// (qp_sharing.cc) -- only the RCCL_ prefix is honoured, there is no NCCL_ alias
+// for either despite what the feature commit message says. RCCL_PARAM caches
+// both for the process lifetime, so a test may read them once and assume they
+// hold for its whole run. That also means a sweep over either value needs one
+// process (one mpirun) per point.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static inline int QpShareEnvInt(const char* name, int fallback) {
+    const char* v = getenv(name);
+    if (!v || v[0] == '\0') return fallback;
+    return static_cast<int>(std::atoll(v));
+}
+
+static inline int QpShareEnvNGroups() {
+    return QpShareEnvInt("RCCL_IB_COMM_NGROUPS", 0);
+}
+
+// connect.cc clamps the multiplier to >= 1 before scaling CQ/WR depth, so 0 or
+// a negative value behaves exactly like the default of 1.
+static inline int QpShareEnvDepthMultiplier() {
+    return std::max(1, QpShareEnvInt("RCCL_IB_QP_DEPTH_MULTIPLIER", 1));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// QpShareRefModel -- expected group layout, derived from RCCL_IB_COMM_NGROUPS
+//
+// Encodes the assignment rule the transport implements today (connect.cc):
+//
+//     groupIdx = IbCastCountPeerTotalRefcount(...) % ngroups
+//
+// i.e. occupancy-modulo -- the next comm joins the group selected by the total
+// number of *live* refcounts to that peer, not by a monotonic counter and not
+// by picking the least-loaded group. 
+// ─────────────────────────────────────────────────────────────────────────────
+class QpShareRefModel {
+public:
+    // Where one comm landed. Both fields are fixed at connect()/accept() time,
+    // exactly like ncclIbQpSharingState::sharedGroupIdx / isSharedQpPrimary:
+    // releasing the PRIMARY of a group does not promote a SECONDARY.
+    struct Placement {
+        int  group   = -1;
+        bool primary = false;
+    };
+
+    explicit QpShareRefModel(int ngroups)
+        : ngroups_(ngroups > 0 ? ngroups : 1), loads_(ngroups_, 0) {}
+
+    // Model the next successful connect(). Call this immediately before the
+    // real connection is established, in the same order the test issues them.
+    Placement AssignOnCreate() {
+        Placement p;
+        p.group   = TotalRefs() % ngroups_;
+        p.primary = (loads_[p.group] == 0);
+        loads_[p.group]++;
+        peakLoad_ = std::max(peakLoad_, loads_[p.group]);
+        return p;
+    }
+
+    // Model a comm teardown. Pass the Placement returned by AssignOnCreate().
+    void Release(const Placement& p) {
+        if (p.group < 0 || p.group >= ngroups_) return;
+        if (loads_[p.group] > 0) loads_[p.group]--;
+    }
+
+    int NGroups() const { return ngroups_; }
+
+    // Live comms in `group` -- the expected ncclIbQpSharingState::refcount for
+    // every comm currently in it.
+    int Load(int group) const {
+        if (group < 0 || group >= ngroups_) return -1;
+        return loads_[group];
+    }
+
+    int TotalRefs() const {
+        int sum = 0;
+        for (int l : loads_) sum += l;
+        return sum;
+    }
+
+    // Busiest group -- the achieved sharing depth, and the value
+    // RCCL_IB_QP_DEPTH_MULTIPLIER must currently cover. Simulated rather than
+    // computed as ceil(nconns/ngroups), because occupancy-modulo does not
+    // balance once teardowns are interleaved with creates.
+    int MaxLoad() const {
+        int m = 0;
+        for (int l : loads_) m = std::max(m, l);
+        return m;
+    }
+
+    // Busiest any group ever got, over the whole create/destroy sequence.
+    //
+    // This, not MaxLoad(), is the sharing depth a run achieved. MaxLoad() is
+    // instantaneous: a churn test that stacked three comms on one group and
+    // then released two reports MaxLoad()==1, and the coverage line then prints
+    // "NO QP WAS SHARED" for a run that plainly did share. Measured: churn at
+    // ngroups=2 reported max_comms_per_group=1 beside group_spread=3, which
+    // cannot both be true of the same instant.
+    int PeakLoad() const { return peakLoad_; }
+
+    int MinLoad() const {
+        int m = loads_.empty() ? 0 : loads_[0];
+        for (int l : loads_) m = std::min(m, l);
+        return m;
+    }
+
+    // Imbalance across groups. Reported by the tests, never asserted: how
+    // evenly occupancy-modulo spreads comms is a property worth measuring (it
+    // drives the depth multiplier a given ngroups demands) but not one this
+    // suite is entitled to dictate.
+    int Spread() const { return MaxLoad() - MinLoad(); }
+
+private:
+    int              ngroups_;
+    std::vector<int> loads_;
+    int              peakLoad_ = 0;
+};
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_QP_SHARE_REF_MODEL_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
@@ -9,10 +9,15 @@
 //
 // Three categories:
 //
-//   QpShareAlgo*    group-assignment and PRIMARY/SECONDARY bookkeeping,
-//                   validated against QpShareRefModel. No data phase.
+//   QpShareAlgo*    group-assignment and PRIMARY/SECONDARY bookkeeping. These
+//                   are the only tests that pin the assignment policy itself,
+//                   via QpShareRefModel. No data phase.
 //   QpShareData*    the data path must be correct at every parameter point.
 //   QpShareStress*  scale and churn, with the scale under env control.
+//
+// Everything checks the layout the transport reports for self-consistency
+// (ExpectQpShareLayout); only the Algo tests additionally require it to match
+// the model's prediction (ExpectQpSharePlacement).
 //
 // Every test derives its expectations from RCCL_IB_COMM_NGROUPS rather than
 // pinning one hand-picked value, so all three categories are valid at any
@@ -53,34 +58,6 @@ std::string Stage(const char* what, int i) {
     return std::string(what) + " " + std::to_string(i);
 }
 
-// One rank's view of a set of cast connections, paired with the reference
-// model's prediction for each.
-struct QpShareConns {
-    std::vector<void*> listen;
-    std::vector<void*> send;
-    std::vector<void*> recv;
-    std::vector<void*> mine;   // recvComm on rank 0, sendComm on rank 1
-    std::vector<QpShareRefModel::Placement> place;
-
-    size_t size() const { return mine.size(); }
-
-    void Add(int rank, void* l, void* s, void* r, QpShareRefModel::Placement p) {
-        listen.push_back(l);
-        send.push_back(s);
-        recv.push_back(r);
-        mine.push_back(rank == 0 ? r : s);
-        place.push_back(p);
-    }
-
-    void Erase(size_t i) {
-        listen.erase(listen.begin() + i);
-        send.erase(send.begin() + i);
-        recv.erase(recv.begin() + i);
-        mine.erase(mine.begin() + i);
-        place.erase(place.begin() + i);
-    }
-};
-
 }  // namespace
 
 // =============================================================================
@@ -88,12 +65,15 @@ struct QpShareConns {
 //
 // The group-assignment contract, validated at whatever RCCL_IB_COMM_NGROUPS is
 // configured. Opens connections one at a time up to min(2*ngroups+1, 64), and
-// after every single create re-checks *every* live comm against
-// QpShareRefModel: group index, PRIMARY/SECONDARY role, refcount, commId, and
-// the physical-QP identity relation (same group => same QP, different groups
-// => different QPs). Then tears down in creation order -- which releases each
-// group's PRIMARY while its SECONDARYs are still live -- re-checking after
-// every destroy.
+// after every single create re-checks *every* live comm: the reported layout
+// must be self-consistent (ExpectQpShareLayout) and must match what
+// QpShareRefModel predicted (ExpectQpSharePlacement). Then tears down in
+// creation order -- which releases each group's PRIMARY while its SECONDARYs
+// are still live -- re-checking after every destroy.
+//
+// This and QpShareAlgoChurnLayout are the two tests that pin the assignment
+// policy itself, so they are the two that have to be updated deliberately if
+// the policy ever changes.
 //
 // Subsumes the old QpShareNGroupsOne (ngroups=1), QpSharePrimarySecondaryMix
 // (ngroups=2) and QpShareNGroupsExceedsConns (ngroups > nconns) as three
@@ -117,28 +97,17 @@ TEST_F(NetIbMPITest, QpShareAlgoLayoutSweep) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
+    std::vector<QpShareConn> cs;
 
+    // One at a time, re-checking every live comm after each create. Stops at the
+    // first divergence: the same wrong layout re-reported for every remaining
+    // connection adds nothing.
     for (int c = 0; c < target; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE()
-                << "connection " << c << " of " << target << " failed to establish at "
-                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
-                << QpShareEnvDepthMultiplier() << ". It would have been comm #"
-                << (model.Load(p.group) + 1) << " in group " << p.group
-                << ". This test never approaches the shared-QP pool's capacity (target <= "
-                << kAlgoMaxConns << " connections), so a connect() failure here means either "
-                   "a pool slot leaked by an earlier test in this process (slots are reclaimed "
-                   "on close, so this should not occur under normal operation) or a genuine "
-                   "hard-fail on pool exhaustion -- check NCCL_DEBUG=WARN for \"shared-QP pool "
-                   "exhausted\".";
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after create", c).c_str());
+        if (OpenConns(1, model, cs, "algo sweep") != 1) break;
+        const std::vector<void*> mine = MineOf(cs);
+        const std::string stage = Stage("after create", c);
+        if (!ExpectQpShareLayout(mine, stage.c_str()) ||
+            !ExpectQpSharePlacement(mine, PlacesOf(cs), stage.c_str())) break;
     }
 
     ReportQpShareCoverage("algo_layout_sweep", static_cast<int>(cs.size()),
@@ -146,14 +115,19 @@ TEST_F(NetIbMPITest, QpShareAlgoLayoutSweep) {
 
     // Teardown from the front: releases group PRIMARYs ahead of their
     // SECONDARYs, which is where refcount and pool bookkeeping are most likely
-    // to diverge from the model.
-    for (int c = 0; cs.size() > 0; c++) {
-        model.Release(cs.place[0]);
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
+    // to diverge.
+    for (int c = 0; !cs.empty(); c++) {
+        model.Release(cs.front().place);
+        CloseCastConnection(cs.front().listen, cs.front().send, cs.front().recv);
+        cs.erase(cs.begin());
         MPI_Barrier(MPI_COMM_WORLD);
-        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after destroy", c).c_str());
+        const std::vector<void*> mine = MineOf(cs);
+        const std::string stage = Stage("after destroy", c);
+        if (!ExpectQpShareLayout(mine, stage.c_str()) ||
+            !ExpectQpSharePlacement(mine, PlacesOf(cs), stage.c_str())) break;
     }
+
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -178,7 +152,6 @@ TEST_F(NetIbMPITest, QpShareAlgoChurnLayout) {
         << "Test requires exactly " << kExactTwoProcesses << " processes";
 
     QPSHARE_ENV_CHECK_OR_SKIP();
-    const int rank    = MPIEnvironment::world_rank;
     const int ngroups = QpShareEnvNGroups();
     const int maxLive = Clamp(2 * ngroups, 2, kChurnMaxLive);
     const int steps   = 3 * maxLive + 6;
@@ -187,52 +160,36 @@ TEST_F(NetIbMPITest, QpShareAlgoChurnLayout) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
-    int  observedSpread = 0;
-    bool broke          = false;
+    std::vector<QpShareConn> cs;
+    int observedSpread = 0;
 
     // Deterministic and rank-identical: the decision depends only on `step` and
     // the live count, both of which evolve the same way on both ranks.
-    for (int step = 0; step < steps && !broke; step++) {
-        const bool create = cs.size() == 0 ||
+    for (int step = 0; step < steps; step++) {
+        const bool create = cs.empty() ||
                             (static_cast<int>(cs.size()) < maxLive && (step % 3) != 2);
         if (create) {
-            QpShareRefModel::Placement p = model.AssignOnCreate();
-            void* l = nullptr; void* s = nullptr; void* r = nullptr;
-            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-                model.Release(p);
-                ADD_FAILURE()
-                    << "step " << step << ": connect failed with " << cs.size()
-                    << " live comms at RCCL_IB_COMM_NGROUPS=" << ngroups
-                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
-                    << " (would have been comm #" << (model.Load(p.group) + 1)
-                    << " in group " << p.group << ")";
-                broke = true;
-                break;
-            }
-            cs.Add(rank, l, s, r, p);
+            if (OpenConns(1, model, cs, Stage("churn step", step).c_str()) != 1) break;
         } else {
             // Rotating, non-tail victim: exercises releasing a comm that still
             // has live neighbours in its group.
             const size_t victim = static_cast<size_t>(step / 2) % cs.size();
-            model.Release(cs.place[victim]);
-            CloseCastConnection(cs.listen[victim], cs.send[victim], cs.recv[victim]);
-            cs.Erase(victim);
+            model.Release(cs[victim].place);
+            CloseCastConnection(cs[victim].listen, cs[victim].send, cs[victim].recv);
+            cs.erase(cs.begin() + victim);
             MPI_Barrier(MPI_COMM_WORLD);
         }
         observedSpread = std::max(observedSpread, model.Spread());
-        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("churn step", step).c_str());
+        const std::vector<void*> mine = MineOf(cs);
+        const std::string stage = Stage("churn step", step);
+        if (!ExpectQpShareLayout(mine, stage.c_str()) ||
+            !ExpectQpSharePlacement(mine, PlacesOf(cs), stage.c_str())) break;
     }
 
     ReportQpShareCoverage("algo_churn_layout", static_cast<int>(cs.size()),
                           model.PeakLoad(), observedSpread);
 
-    while (cs.size() > 0) {
-        model.Release(cs.place[0]);
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-        MPI_Barrier(MPI_COMM_WORLD);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -258,36 +215,13 @@ TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
+    std::vector<QpShareConn> cs;
 
-    for (int c = 0; c < nconns; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE()
-                << "connection " << c << " of " << nconns << " failed to establish at "
-                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
-                << QpShareEnvDepthMultiplier() << " -- it would have been comm #"
-                << (model.Load(p.group) + 1) << " in group " << p.group
-                << ", and the shared QP is sized for " << QpShareEnvDepthMultiplier() << "."
-                << (c == 0
-                        ? " This is the FIRST connection, so nothing is shared yet:"
-                          " the depth multiplier itself exceeds what the device can"
-                          " allocate (a known depth-sizing limit, not pool exhaustion)."
-                        : " Pool exhaustion is now a hard connect() failure by design"
-                          " (net_ib_cast no longer falls back to unshared silently), so"
-                          " this is expected only if the shared-QP pool is genuinely"
-                          " full at this scale -- otherwise it indicates a leaked slot.");
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-    }
-
-    const int established = static_cast<int>(cs.size());
-    ExpectQpShareLayout(cs.mine, cs.place, model, "all conns established");
+    const int established = OpenConns(nconns, model, cs, "data all conns");
+    const std::vector<void*> mine = MineOf(cs);
+    ExpectQpShareLayout(mine, "all conns established");
     ReportQpShareCoverage("data_all_conns_transfer", established,
-                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          established > 0 ? MaxObservedSharingDepth(mine) : 0,
                           model.Spread());
 
     if (established > 0) {
@@ -300,7 +234,7 @@ TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
         bool regOk = true;
         for (int c = 0; c < established && regOk; c++) {
             char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
-            if (RegisterMemory(cs.mine[c], regBuf, kMaxSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+            if (RegisterMemory(mine[c], regBuf, kMaxSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed for conn " << c;
                 regOk = false;
             }
@@ -311,7 +245,7 @@ TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
         for (size_t i = 0; i < kSizes.size(); i++) {
             for (int c = 0; c < established; c++) {
                 if (rank == 0) memset(recvBufs[c].data(), 0, kSizes[i]);
-                DoSendRecv(cs.send[c], cs.recv[c],
+                DoSendRecv(cs[c].send, cs[c].recv,
                            sendBufs[c].data(), recvBufs[c].data(),
                            kSizes[i], kTagBase + static_cast<int>(i) * established + c,
                            mhandles[c], mhandles[c],
@@ -320,14 +254,11 @@ TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
         }
 
         for (int c = 0; c < established; c++)
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    while (cs.size() > 0) {
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -353,30 +284,27 @@ TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
+    std::vector<QpShareConn> cs;
 
-    for (int c = 0; c < nconns; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE() << "connection " << c << " of " << nconns
-                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
-                          << " -- nothing is even shared at this connection count";
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-    }
+    const int established = OpenConns(nconns, model, cs, "data unshared groups");
+    const std::vector<void*> mine = MineOf(cs);
+    ExpectQpShareLayout(mine, "unshared groups established");
 
-    const int established = static_cast<int>(cs.size());
-    ExpectQpShareLayout(cs.mine, cs.place, model, "unshared groups established");
+    // The point of this test: at nconns <= ngroups every comm must be alone in
+    // its group and own its QP. Asserted against the observed state, not the
+    // model -- the model predicting solo groups is what makes this the unshared
+    // regime, but it is the transport that has to agree.
     for (int c = 0; c < established; c++) {
-        EXPECT_EQ(model.Load(cs.place[c].group), 1)
-            << "test bug: conn " << c << " was expected to be alone in its group";
-        EXPECT_TRUE(cs.place[c].primary);
+        struct ncclIbQpSharingState st = GetActualQpSharingState(mine[c]);
+        EXPECT_EQ(st.refcount, 1)
+            << "conn " << c << " shares group " << st.sharedGroupIdx
+            << " with " << (st.refcount - 1) << " other comm(s) at nconns="
+            << nconns << " <= ngroups=" << ngroups;
+        EXPECT_TRUE(st.isSharedQpPrimary)
+            << "conn " << c << " is a SECONDARY although it is alone in its group";
     }
     ReportQpShareCoverage("data_unshared_groups", established,
-                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+                          established > 0 ? MaxObservedSharingDepth(mine) : 0);
 
     if (established > 0) {
         constexpr size_t kMsgSz = 64 * 1024;
@@ -386,7 +314,7 @@ TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
         bool regOk = true;
         for (int c = 0; c < established && regOk; c++) {
             char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
-            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+            if (RegisterMemory(mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed for conn " << c;
                 regOk = false;
             }
@@ -394,19 +322,16 @@ TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
         ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
         constexpr int kTagBase = 5100;
         for (int c = 0; c < established; c++) {
-            DoSendRecv(cs.send[c], cs.recv[c], sendBufs[c].data(), recvBufs[c].data(),
+            DoSendRecv(cs[c].send, cs[c].recv, sendBufs[c].data(), recvBufs[c].data(),
                        kMsgSz, kTagBase + c, mhandles[c], mhandles[c],
                        /*patternSeed=*/c + 11);
         }
         for (int c = 0; c < established; c++)
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    while (cs.size() > 0) {
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -439,37 +364,32 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
     const size_t kSz = (nconns <= 8) ? (1024 * 1024) : (64 * 1024);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
-    for (int c = 0; c < nconns; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE() << "connection " << c << " of " << nconns
-                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
-                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-    }
-    const int established = static_cast<int>(cs.size());
-    ExpectQpShareLayout(cs.mine, cs.place, model, "flush conns established");
+    std::vector<QpShareConn> cs;
+    const int established = OpenConns(nconns, model, cs, "data flush routing");
+    const std::vector<void*> mine = MineOf(cs);
+    ExpectQpShareLayout(mine, "flush conns established");
 
-    // Locate a PRIMARY/SECONDARY pair and an unshared baseline from the model.
+    // Locate a PRIMARY/SECONDARY pair and an unshared baseline from what the
+    // transport actually reports, so the flush runs on a genuinely shared CQ
+    // rather than on one the model merely predicted would be shared.
+    std::vector<struct ncclIbQpSharingState> st(established);
+    for (int c = 0; c < established; c++) st[c] = GetActualQpSharingState(mine[c]);
+
     int primaryIdx = -1, secondaryIdx = -1, baselineIdx = -1;
     for (int c = 0; c < established && secondaryIdx < 0; c++) {
-        if (cs.place[c].primary) continue;
+        if (st[c].isSharedQpPrimary) continue;
         secondaryIdx = c;
         for (int q = 0; q < c; q++)
-            if (cs.place[q].group == cs.place[c].group && cs.place[q].primary) primaryIdx = q;
+            if (st[q].sharedGroupIdx == st[c].sharedGroupIdx && st[q].isSharedQpPrimary)
+                primaryIdx = q;
     }
     if (primaryIdx >= 0)
         for (int c = 0; c < established; c++)
-            if (cs.place[c].group != cs.place[primaryIdx].group) { baselineIdx = c; break; }
+            if (st[c].sharedGroupIdx != st[primaryIdx].sharedGroupIdx) { baselineIdx = c; break; }
 
     const bool havePair = (primaryIdx >= 0 && secondaryIdx >= 0);
     ReportQpShareCoverage("data_flush_routing", established,
-                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+                          established > 0 ? MaxObservedSharingDepth(mine) : 0);
     if (!havePair && rank == 0) {
         printf("[QPSHARE-COV] data_flush_routing: no PRIMARY/SECONDARY pair formed at "
                "ngroups=%d with %d conns (cap %d) -- shared-CQ flush routing was NOT "
@@ -491,7 +411,7 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
                 break;
             }
             bufGuards.push_back(makeDeviceBufferAutoGuard(devBufs[c]));
-            if (RegisterMemory(cs.mine[c], devBufs[c], kSz, NCCL_PTR_CUDA, &mhandles[c]) != ncclSuccess) {
+            if (RegisterMemory(mine[c], devBufs[c], kSz, NCCL_PTR_CUDA, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed for conn " << c;
                 setupOk = false;
                 break;
@@ -510,8 +430,8 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
         // Transfer every connection concurrently (post-all, wait-all).
         std::vector<void*> reqs(established, nullptr);
         for (int c = 0; c < established; c++) {
-            if (rank == 0) PostSingleRecv(cs.recv[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
-            else           PostSendWithRetry(cs.send[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+            if (rank == 0) PostSingleRecv(cs[c].recv, devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+            else           PostSendWithRetry(cs[c].send, devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
         }
         MPI_Barrier(MPI_COMM_WORLD);
         for (int c = 0; c < established; c++) {
@@ -524,9 +444,9 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
         if (rank == 0 && havePair) {
             void* fReqP = nullptr; void* fReqS = nullptr;
             int fszP = static_cast<int>(kSz), fszS = static_cast<int>(kSz);
-            EXPECT_EQ(FlushRecv(cs.recv[primaryIdx], 1, &devBufs[primaryIdx], &fszP,
+            EXPECT_EQ(FlushRecv(cs[primaryIdx].recv, 1, &devBufs[primaryIdx], &fszP,
                                 &mhandles[primaryIdx], &fReqP), ncclSuccess);
-            EXPECT_EQ(FlushRecv(cs.recv[secondaryIdx], 1, &devBufs[secondaryIdx], &fszS,
+            EXPECT_EQ(FlushRecv(cs[secondaryIdx].recv, 1, &devBufs[secondaryIdx], &fszS,
                                 &mhandles[secondaryIdx], &fReqS), ncclSuccess);
             EXPECT_NE(fReqP, nullptr);
             EXPECT_NE(fReqS, nullptr);
@@ -553,7 +473,7 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
         if (rank == 0 && soloIdx >= 0) {
             void* fReq = nullptr;
             int fsz = static_cast<int>(kSz);
-            EXPECT_EQ(FlushRecv(cs.recv[soloIdx], 1, &devBufs[soloIdx], &fsz,
+            EXPECT_EQ(FlushRecv(cs[soloIdx].recv, 1, &devBufs[soloIdx], &fsz,
                                 &mhandles[soloIdx], &fReq), ncclSuccess);
             int w = 0;
             EXPECT_EQ(WaitForCompletion(fReq, &w, kLargeTransferTimeoutMs), ncclSuccess)
@@ -564,14 +484,11 @@ TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
 
         MPI_Barrier(MPI_COMM_WORLD);
         for (int c = 0; c < established; c++)
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    while (cs.size() > 0) {
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -597,25 +514,12 @@ TEST_F(NetIbMPITest, QpShareStressManyConns) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
-    for (int c = 0; c < nconns; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE() << "connection " << c << " of " << nconns
-                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
-                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
-                          << " (comm #" << (model.Load(p.group) + 1) << " in group "
-                          << p.group << ")";
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-    }
-    const int established = static_cast<int>(cs.size());
-    ExpectQpShareLayout(cs.mine, cs.place, model, "stress conns established");
+    std::vector<QpShareConn> cs;
+    const int established = OpenConns(nconns, model, cs, "stress many conns");
+    const std::vector<void*> mine = MineOf(cs);
+    ExpectQpShareLayout(mine, "stress conns established");
     ReportQpShareCoverage("stress_many_conns", established,
-                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          established > 0 ? MaxObservedSharingDepth(mine) : 0,
                           model.Spread());
 
     if (established > 0) {
@@ -635,7 +539,7 @@ TEST_F(NetIbMPITest, QpShareStressManyConns) {
         bool regOk = true;
         for (int c = 0; c < established && regOk; c++) {
             char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
-            if (RegisterMemory(cs.mine[c], regBuf, kBufSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+            if (RegisterMemory(mine[c], regBuf, kBufSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed for conn " << c;
                 regOk = false;
             }
@@ -644,7 +548,7 @@ TEST_F(NetIbMPITest, QpShareStressManyConns) {
 
         constexpr int kTagBase = 6000;
         for (int c = 0; c < established; c++) {
-            CastDoBatchSendRecv(rank, cs.send[c], cs.recv[c],
+            CastDoBatchSendRecv(rank, cs[c].send, cs[c].recv,
                                 sendBufs[c].data(), recvBufs[c].data(),
                                 kMsgSz, kNMsgs, kTagBase + c * kNMsgs, mhandles[c]);
         }
@@ -657,14 +561,11 @@ TEST_F(NetIbMPITest, QpShareStressManyConns) {
 
         MPI_Barrier(MPI_COMM_WORLD);
         for (int c = 0; c < established; c++)
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    while (cs.size() > 0) {
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -691,22 +592,11 @@ TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
     AssertInitAndGetDevices(nullptr);
 
     QpShareRefModel model(ngroups);
-    QpShareConns    cs;
-    for (int c = 0; c < nconns; c++) {
-        QpShareRefModel::Placement p = model.AssignOnCreate();
-        void* l = nullptr; void* s = nullptr; void* r = nullptr;
-        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            model.Release(p);
-            ADD_FAILURE() << "connection " << c << " of " << nconns
-                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
-                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
-            break;
-        }
-        cs.Add(rank, l, s, r, p);
-    }
-    const int established = static_cast<int>(cs.size());
+    std::vector<QpShareConn> cs;
+    const int established = OpenConns(nconns, model, cs, "stress rq saturation");
+    const std::vector<void*> mine = MineOf(cs);
     ReportQpShareCoverage("stress_rq_saturation", established,
-                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          established > 0 ? MaxObservedSharingDepth(mine) : 0,
                           model.Spread());
 
     if (established > 0) {
@@ -717,7 +607,7 @@ TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
         bool regOk = true;
         for (int c = 0; c < established && regOk; c++) {
             char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
-            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+            if (RegisterMemory(mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed for conn " << c;
                 regOk = false;
             }
@@ -735,7 +625,7 @@ TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
                     size_t sizes[1]   = {kMsgSz};
                     int    tags[1]    = {tagRoundBase + c};
                     void*  handles[1] = {mhandles[c]};
-                    if (PostRecv(cs.recv[c], 1, bufs, sizes, tags, handles, &reqs[c]) != ncclSuccess
+                    if (PostRecv(cs[c].recv, 1, bufs, sizes, tags, handles, &reqs[c]) != ncclSuccess
                         || reqs[c] == nullptr) {
                         ADD_FAILURE() << "PostRecv failed for round " << round << " conn " << c;
                         postOk = false;
@@ -746,7 +636,7 @@ TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
                 for (int c = 0; c < established; c++) {
                     fillHostBufferWithPattern<uint8_t>(sendBufs[c].data(), kMsgSz,
                                                        makeBytePattern(round * established + c));
-                    PostSendWithRetry(cs.send[c], sendBufs[c].data(), kMsgSz,
+                    PostSendWithRetry(cs[c].send, sendBufs[c].data(), kMsgSz,
                                       tagRoundBase + c, mhandles[c], &reqs[c]);
                 }
             }
@@ -771,14 +661,11 @@ TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
 
         MPI_Barrier(MPI_COMM_WORLD);
         for (int c = 0; c < established; c++)
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    while (cs.size() > 0) {
-        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
-        cs.Erase(0);
-    }
+    CloseAll(cs);
 }
 
 // =============================================================================
@@ -811,13 +698,7 @@ TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
     {
         void* l = nullptr; void* s = nullptr; void* r = nullptr;
         if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            // The shared-QP pool reclaims slots on close (free-stack), so this
-            // should not happen from cross-test accumulation anymore. A failure
-            // here now points at a slot leaked by an earlier test's teardown.
-            ADD_FAILURE() << "warmup connection failed before churn even started "
-                             "(shared-QP pool slot leak from an earlier test in this "
-                             "process? slots are reclaimed on close, so this should "
-                             "not occur under normal operation)";
+            ADD_FAILURE() << "warmup connection failed before churn even started";
             return;
         }
         void* mh = nullptr;
@@ -842,14 +723,8 @@ TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
         if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
             ADD_FAILURE()
                 << "connect failed at churn iteration " << iter << " of " << iters
-                << ". Only one connection is live at a time, so every earlier"
-                   " cycle was fully closed: a resource acquired per cycle was"
-                   " not returned. Check the RDMA-resource checkpoints above and"
-                   " run with NCCL_DEBUG=WARN -- pass -x"
-                   " NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log and read the per-rank"
-                   " files, since a merged mpirun log usually carries rank 0"
-                   " only and the absence of a WARN there is not evidence that"
-                   " none was emitted";
+                << ". Only one connection is live at a time, so every earlier cycle"
+                   " was fully closed; see the RDMA-resource checkpoints above.";
             break;
         }
         void* comm = (rank == 0) ? r : s;
@@ -888,8 +763,7 @@ TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
     // invites the reading that churn says something about sharing depth. It
     // does not. It exercises the create/destroy lifecycle of a shared group
     // whose membership never exceeds one, which is the occupancy that reaches
-    // the group-release path on every single cycle (the same path
-    // QpShareStressBatchCreateDestroy shows leaking a PD).
+    // the group-release path on every single cycle.
     ReportQpShareCoverage("stress_connection_churn", iters, /*maxCommsPerGroup=*/1);
 }
 
@@ -928,13 +802,7 @@ TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
     {
         void* l = nullptr; void* s = nullptr; void* r = nullptr;
         if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-            // The shared-QP pool reclaims slots on close (free-stack), so this
-            // should not happen from cross-test accumulation anymore. A failure
-            // here now points at a slot leaked by an earlier test's teardown.
-            ADD_FAILURE() << "warmup connection failed before batching even started "
-                             "(shared-QP pool slot leak from an earlier test in this "
-                             "process? slots are reclaimed on close, so this should "
-                             "not occur under normal operation)";
+            ADD_FAILURE() << "warmup connection failed before batching even started";
             return;
         }
         void* mh = nullptr;
@@ -955,45 +823,27 @@ TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
     int  peakSpread = 0;
     for (int batch = 0; batch < batches && !broke; batch++) {
         QpShareRefModel model(ngroups);
-        QpShareConns    cs;
-        std::vector<void*> mhandles;
+        std::vector<QpShareConn> cs;
 
-        for (int c = 0; c < perBatch; c++) {
-            QpShareRefModel::Placement p = model.AssignOnCreate();
-            void* l = nullptr; void* s = nullptr; void* r = nullptr;
-            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
-                model.Release(p);
-                ADD_FAILURE()
-                    << "connect failed at batch " << batch << " of " << batches
-                    << ", connection " << c << " of " << perBatch
-                    << " (cumulative connection #" << (batch * perBatch + c)
-                    << "). ngroups=" << ngroups << " depth="
-                    << QpShareEnvDepthMultiplier()
-                    << ". Every previous batch was fully torn down, so a failure "
-                       "here means a per-batch resource was not returned -- check "
-                       "the RDMA-count checkpoints above for which one.";
-                broke = true;
-                break;
-            }
-            cs.Add(rank, l, s, r, p);
-            void* mh = nullptr;
-            bool regOk = (RegisterMemory(cs.mine.back(), buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
-            if (!regOk) {
+        const int live = OpenConns(perBatch, model, cs, Stage("batch", batch).c_str());
+        if (live < perBatch) broke = true;
+        const std::vector<void*> mine = MineOf(cs);
+
+        std::vector<void*> mhandles(live, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < live && regOk; c++) {
+            if (RegisterMemory(mine[c], buf.data(), sz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
                 ADD_FAILURE() << "RegisterMemory failed at batch " << batch
                               << ", connection " << c;
+                regOk = false;
             }
-            if (!RankAgree(regOk)) {
-                broke = true;
-                break;
-            }
-            mhandles.push_back(mh);
         }
+        if (!RankAgree(regOk)) broke = true;
 
-        const int live = static_cast<int>(cs.size());
         peakDepth  = std::max(peakDepth, model.PeakLoad());
         peakSpread = std::max(peakSpread, model.Spread());
-        for (int c = 0; c < live; c++) {
-            DoSendRecv(cs.send[c], cs.recv[c], buf.data(), buf.data(), sz,
+        for (int c = 0; c < live && regOk; c++) {
+            DoSendRecv(cs[c].send, cs[c].recv, buf.data(), buf.data(), sz,
                        /*tag=*/c, mhandles[c], mhandles[c], batch * perBatch + c);
         }
 
@@ -1002,9 +852,8 @@ TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
             // Every batch starts from an empty live set, so the layout must be
             // identical to batch 0's. Drift here means teardown left refcounts
             // behind that IbCastCountPeerTotalRefcount still sees.
-            ExpectQpShareLayout(cs.mine, cs.place, model,
-                                Stage("batch checkpoint", batch).c_str());
-            struct ncclIbQpSharingState st = GetActualQpSharingState(cs.mine[0]);
+            ExpectQpShareLayout(mine, Stage("batch checkpoint", batch).c_str());
+            struct ncclIbQpSharingState st = GetActualQpSharingState(mine[0]);
             EXPECT_GT(st.refcount, 0)
                 << "refcount dropped to 0 at batch " << batch
                 << " -- comms are live but no longer tracked in the shared-QP pool";
@@ -1012,10 +861,9 @@ TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
         }
 
         for (int c = 0; c < live; c++) {
-            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
-            CloseCastConnection(cs.listen[c], cs.send[c], cs.recv[c]);
+            if (mhandles[c]) EXPECT_EQ(DeregisterMemory(mine[c], mhandles[c]), ncclSuccess);
         }
-        MPI_Barrier(MPI_COMM_WORLD);
+        CloseAll(cs);
 
         if (checkpoint && !broke) {
             RdmaResourceCounts now = CaptureRdmaResources();

--- a/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/QpSharingTests.cpp
@@ -1,0 +1,1034 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// MPI test suite for QP sharing (RCCL_IB_COMM_NGROUPS /
+// RCCL_IB_QP_DEPTH_MULTIPLIER).  2-rank, single-IB-device (dev=0).
+//
+// Three categories:
+//
+//   QpShareAlgo*    group-assignment and PRIMARY/SECONDARY bookkeeping,
+//                   validated against QpShareRefModel. No data phase.
+//   QpShareData*    the data path must be correct at every parameter point.
+//   QpShareStress*  scale and churn, with the scale under env control.
+//
+// Every test derives its expectations from RCCL_IB_COMM_NGROUPS rather than
+// pinning one hand-picked value, so all three categories are valid at any
+// (ngroups, depth, nconns). 
+//
+// Both tunables are RCCL_PARAM-backed and therefore cached for the process
+// lifetime (src/include/param.h): a sweep over either needs one mpirun per
+// point. The connection count is *not* cached and can be varied in-process,
+// which is why it is an ordinary env knob (QPSHARE_TEST_NCONNS /
+// QPSHARE_TEST_ITERS).
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbQpSharingInspect.hpp"
+#include "QpShareRefModel.hpp"
+
+#ifdef MPI_TESTS_ENABLED
+
+namespace {
+
+// Connections opened by the algo sweep: enough for every group to hold two
+// comms plus one, so PRIMARY-only, PRIMARY+SECONDARY and (at ngroups=1)
+// deep-stacking layouts all occur in one run. Capped so a large ngroups does
+// not turn a state-only test into a connection-setup benchmark.
+constexpr int kAlgoMaxConns = 64;
+
+// Live connections held by the churn test. Kept at two per group so the test
+// stays about pool bookkeeping rather than about RQ depth.
+constexpr int kChurnMaxLive = 32;
+
+// Connections the flush test may open. It needs ngroups+1 to guarantee one
+// shared pair; past this cap it reports that no pair was formed rather than
+// opening an unbounded number of GDR-registered connections.
+constexpr int kFlushMaxConns = 128;
+
+int Clamp(int v, int lo, int hi) { return std::max(lo, std::min(hi, v)); }
+
+std::string Stage(const char* what, int i) {
+    return std::string(what) + " " + std::to_string(i);
+}
+
+// One rank's view of a set of cast connections, paired with the reference
+// model's prediction for each.
+struct QpShareConns {
+    std::vector<void*> listen;
+    std::vector<void*> send;
+    std::vector<void*> recv;
+    std::vector<void*> mine;   // recvComm on rank 0, sendComm on rank 1
+    std::vector<QpShareRefModel::Placement> place;
+
+    size_t size() const { return mine.size(); }
+
+    void Add(int rank, void* l, void* s, void* r, QpShareRefModel::Placement p) {
+        listen.push_back(l);
+        send.push_back(s);
+        recv.push_back(r);
+        mine.push_back(rank == 0 ? r : s);
+        place.push_back(p);
+    }
+
+    void Erase(size_t i) {
+        listen.erase(listen.begin() + i);
+        send.erase(send.begin() + i);
+        recv.erase(recv.begin() + i);
+        mine.erase(mine.begin() + i);
+        place.erase(place.begin() + i);
+    }
+};
+
+}  // namespace
+
+// =============================================================================
+// Test: QpShareAlgoLayoutSweep  (category: algo)
+//
+// The group-assignment contract, validated at whatever RCCL_IB_COMM_NGROUPS is
+// configured. Opens connections one at a time up to min(2*ngroups+1, 64), and
+// after every single create re-checks *every* live comm against
+// QpShareRefModel: group index, PRIMARY/SECONDARY role, refcount, commId, and
+// the physical-QP identity relation (same group => same QP, different groups
+// => different QPs). Then tears down in creation order -- which releases each
+// group's PRIMARY while its SECONDARYs are still live -- re-checking after
+// every destroy.
+//
+// Subsumes the old QpShareNGroupsOne (ngroups=1), QpSharePrimarySecondaryMix
+// (ngroups=2) and QpShareNGroupsExceedsConns (ngroups > nconns) as three
+// points of the same sweep rather than three hand-computed layouts.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoLayoutSweep) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int target  = std::min(2 * ngroups + 1, kAlgoMaxConns);
+    if (2 * ngroups + 1 > kAlgoMaxConns && rank == 0) {
+        printf("[QPSHARE-COV] algo sweep capped at %d conns (ngroups=%d would need %d "
+               "for two per group)\n", kAlgoMaxConns, ngroups, 2 * ngroups + 1);
+    }
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < target; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << target << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << ". It would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ". This test never approaches the shared-QP pool's capacity (target <= "
+                << kAlgoMaxConns << " connections), so a connect() failure here means either "
+                   "a pool slot leaked by an earlier test in this process (slots are reclaimed "
+                   "on close, so this should not occur under normal operation) or a genuine "
+                   "hard-fail on pool exhaustion -- check NCCL_DEBUG=WARN for \"shared-QP pool "
+                   "exhausted\".";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after create", c).c_str());
+    }
+
+    ReportQpShareCoverage("algo_layout_sweep", static_cast<int>(cs.size()),
+                          model.PeakLoad(), model.Spread());
+
+    // Teardown from the front: releases group PRIMARYs ahead of their
+    // SECONDARYs, which is where refcount and pool bookkeeping are most likely
+    // to diverge from the model.
+    for (int c = 0; cs.size() > 0; c++) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("after destroy", c).c_str());
+    }
+}
+
+// =============================================================================
+// Test: QpShareAlgoChurnLayout  (category: algo)
+//
+// Group assignment under interleaved create/destroy, including releases from
+// the middle of the live set rather than only the tail. This is where
+// occupancy-modulo (groupIdx = live totalRefs % ngroups) stops looking like
+// round-robin: after a non-tail release the next comm can land back in a group
+// that already has members while another sits empty. That behaviour is
+// reproduced by QpShareRefModel and asserted; the resulting imbalance is
+// measured and reported (group_spread) but deliberately not asserted -- how
+// evenly the rule spreads comms is a design question, not this suite's call.
+//
+// Also the sharpest check on pool bookkeeping: a slot freed on close but still
+// counted by IbCastCountPeerTotalRefcount shifts every subsequent assignment
+// and shows up here as a group mismatch.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareAlgoChurnLayout) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int maxLive = Clamp(2 * ngroups, 2, kChurnMaxLive);
+    const int steps   = 3 * maxLive + 6;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    int  observedSpread = 0;
+    bool broke          = false;
+
+    // Deterministic and rank-identical: the decision depends only on `step` and
+    // the live count, both of which evolve the same way on both ranks.
+    for (int step = 0; step < steps && !broke; step++) {
+        const bool create = cs.size() == 0 ||
+                            (static_cast<int>(cs.size()) < maxLive && (step % 3) != 2);
+        if (create) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "step " << step << ": connect failed with " << cs.size()
+                    << " live comms at RCCL_IB_COMM_NGROUPS=" << ngroups
+                    << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                    << " (would have been comm #" << (model.Load(p.group) + 1)
+                    << " in group " << p.group << ")";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+        } else {
+            // Rotating, non-tail victim: exercises releasing a comm that still
+            // has live neighbours in its group.
+            const size_t victim = static_cast<size_t>(step / 2) % cs.size();
+            model.Release(cs.place[victim]);
+            CloseCastConnection(cs.listen[victim], cs.send[victim], cs.recv[victim]);
+            cs.Erase(victim);
+            MPI_Barrier(MPI_COMM_WORLD);
+        }
+        observedSpread = std::max(observedSpread, model.Spread());
+        ExpectQpShareLayout(cs.mine, cs.place, model, Stage("churn step", step).c_str());
+    }
+
+    ReportQpShareCoverage("algo_churn_layout", static_cast<int>(cs.size()),
+                          model.PeakLoad(), observedSpread);
+
+    while (cs.size() > 0) {
+        model.Release(cs.place[0]);
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataAllConnsTransfer  (category: data path)
+//
+// The core data-path gate: at the configured (ngroups, depth), open nconns
+// connections and require every one of them to connect and to move data
+// correctly across a size sweep covering zero-length, single-byte and
+// powers-of-two +/-1 up to 1 MB.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataAllConnsTransfer) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS",
+                                                  Clamp(ngroups + 2, 4, 32)));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE()
+                << "connection " << c << " of " << nconns << " failed to establish at "
+                << "RCCL_IB_COMM_NGROUPS=" << ngroups << " RCCL_IB_QP_DEPTH_MULTIPLIER="
+                << QpShareEnvDepthMultiplier() << " -- it would have been comm #"
+                << (model.Load(p.group) + 1) << " in group " << p.group
+                << ", and the shared QP is sized for " << QpShareEnvDepthMultiplier() << "."
+                << (c == 0
+                        ? " This is the FIRST connection, so nothing is shared yet:"
+                          " the depth multiplier itself exceeds what the device can"
+                          " allocate (a known depth-sizing limit, not pool exhaustion)."
+                        : " Pool exhaustion is now a hard connect() failure by design"
+                          " (net_ib_cast no longer falls back to unshared silently), so"
+                          " this is expected only if the shared-QP pool is genuinely"
+                          " full at this scale -- otherwise it indicates a leaked slot.");
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "all conns established");
+    ReportQpShareCoverage("data_all_conns_transfer", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        const std::vector<size_t> kSizes = {0, 1, 127, 128, 4095, 4096, 65535, 65536, 1 << 20};
+        const size_t kMaxSz = kSizes.back();
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMaxSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMaxSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMaxSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 5300;
+        for (size_t i = 0; i < kSizes.size(); i++) {
+            for (int c = 0; c < established; c++) {
+                if (rank == 0) memset(recvBufs[c].data(), 0, kSizes[i]);
+                DoSendRecv(cs.send[c], cs.recv[c],
+                           sendBufs[c].data(), recvBufs[c].data(),
+                           kSizes[i], kTagBase + static_cast<int>(i) * established + c,
+                           mhandles[c], mhandles[c],
+                           /*patternSeed=*/static_cast<int>(i) * 31 + c);
+            }
+        }
+
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataUnsharedGroups  (category: data path)
+//
+// The nconns <= ngroups regime, where occupancy-modulo gives every connection
+// a group of its own and no QP is shared at all.
+//
+// nconns is derived as min(ngroups, 8) so the test is in the unshared regime
+// whatever ngroups is set to -- there is nothing to skip.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataUnsharedGroups) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = Clamp(ngroups, 1, 8);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " -- nothing is even shared at this connection count";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "unshared groups established");
+    for (int c = 0; c < established; c++) {
+        EXPECT_EQ(model.Load(cs.place[c].group), 1)
+            << "test bug: conn " << c << " was expected to be alone in its group";
+        EXPECT_TRUE(cs.place[c].primary);
+    }
+    ReportQpShareCoverage("data_unshared_groups", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 64 * 1024;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+        constexpr int kTagBase = 5100;
+        for (int c = 0; c < established; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], sendBufs[c].data(), recvBufs[c].data(),
+                       kMsgSz, kTagBase + c, mhandles[c], mhandles[c],
+                       /*patternSeed=*/c + 11);
+        }
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareDataFlushRouting  (category: data path)
+//
+// GDR flush completion routing across a shared CQ. A flush QP is per-comm and
+// is not itself shared, but its completion still lands on the group's shared CQ.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareDataFlushRouting) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::min(ngroups + 1, kFlushMaxConns);
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    ncclNetProperties_t props;
+    ASSERT_EQ(GetDeviceProperties(0, &props), ncclSuccess);
+    if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+        // Hardware capability, not a tunable: without GDR there is no flush to
+        // route. This is the one thing in the suite a parameter cannot fix.
+        GTEST_SKIP() << "GDR not supported on this device, skipping flush routing test";
+    }
+
+    const size_t kSz = (nconns <= 8) ? (1024 * 1024) : (64 * 1024);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "flush conns established");
+
+    // Locate a PRIMARY/SECONDARY pair and an unshared baseline from the model.
+    int primaryIdx = -1, secondaryIdx = -1, baselineIdx = -1;
+    for (int c = 0; c < established && secondaryIdx < 0; c++) {
+        if (cs.place[c].primary) continue;
+        secondaryIdx = c;
+        for (int q = 0; q < c; q++)
+            if (cs.place[q].group == cs.place[c].group && cs.place[q].primary) primaryIdx = q;
+    }
+    if (primaryIdx >= 0)
+        for (int c = 0; c < established; c++)
+            if (cs.place[c].group != cs.place[primaryIdx].group) { baselineIdx = c; break; }
+
+    const bool havePair = (primaryIdx >= 0 && secondaryIdx >= 0);
+    ReportQpShareCoverage("data_flush_routing", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0);
+    if (!havePair && rank == 0) {
+        printf("[QPSHARE-COV] data_flush_routing: no PRIMARY/SECONDARY pair formed at "
+               "ngroups=%d with %d conns (cap %d) -- shared-CQ flush routing was NOT "
+               "exercised; only the unshared flush path was\n",
+               ngroups, established, kFlushMaxConns);
+        fflush(stdout);
+    }
+
+    if (established > 0) {
+        std::vector<void*> devBufs(established, nullptr);
+        std::vector<DeviceBufferAutoGuard> bufGuards;
+        bufGuards.reserve(established);
+        std::vector<void*> mhandles(established, nullptr);
+        bool setupOk = true;
+        for (int c = 0; c < established && setupOk; c++) {
+            if (hipMalloc(&devBufs[c], kSz) != hipSuccess) {
+                ADD_FAILURE() << "hipMalloc failed for conn " << c;
+                setupOk = false;
+                break;
+            }
+            bufGuards.push_back(makeDeviceBufferAutoGuard(devBufs[c]));
+            if (RegisterMemory(cs.mine[c], devBufs[c], kSz, NCCL_PTR_CUDA, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                setupOk = false;
+                break;
+            }
+            if (rank == 1) {
+                if (initializeBufferWithPattern<uint8_t>(devBufs[c], kSz,
+                                                          makeBytePattern(c + 700)) != hipSuccess) {
+                    ADD_FAILURE() << "initializeBufferWithPattern failed for conn " << c;
+                    setupOk = false;
+                    break;
+                }
+            }
+        }
+        ASSERT_TRUE(RankAgree(setupOk)) << "buffer/registration setup failed on one rank only";
+
+        // Transfer every connection concurrently (post-all, wait-all).
+        std::vector<void*> reqs(established, nullptr);
+        for (int c = 0; c < established; c++) {
+            if (rank == 0) PostSingleRecv(cs.recv[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+            else           PostSendWithRetry(cs.send[c], devBufs[c], kSz, 730 + c, mhandles[c], &reqs[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++) {
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kLargeTransferTimeoutMs), ncclSuccess)
+                << "conn " << c << " transfer completion";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0 && havePair) {
+            void* fReqP = nullptr; void* fReqS = nullptr;
+            int fszP = static_cast<int>(kSz), fszS = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[primaryIdx], 1, &devBufs[primaryIdx], &fszP,
+                                &mhandles[primaryIdx], &fReqP), ncclSuccess);
+            EXPECT_EQ(FlushRecv(cs.recv[secondaryIdx], 1, &devBufs[secondaryIdx], &fszS,
+                                &mhandles[secondaryIdx], &fReqS), ncclSuccess);
+            EXPECT_NE(fReqP, nullptr);
+            EXPECT_NE(fReqS, nullptr);
+
+            // Wait SECONDARY first: completions must be routed by commId, not by
+            // the order the requests were posted or polled.
+            int wS = 0, wP = 0;
+            EXPECT_EQ(WaitForCompletion(fReqS, &wS, kLargeTransferTimeoutMs), ncclSuccess)
+                << "SECONDARY (conn " << secondaryIdx << ") flush completion misrouted or lost";
+            EXPECT_EQ(WaitForCompletion(fReqP, &wP, kLargeTransferTimeoutMs), ncclSuccess)
+                << "PRIMARY (conn " << primaryIdx << ") flush completion misrouted or lost";
+
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[primaryIdx], kSz,
+                                                  makeBytePattern(primaryIdx + 700)))
+                << "PRIMARY conn " << primaryIdx << " data wrong after flush -- cross-comm misroute";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[secondaryIdx], kSz,
+                                                  makeBytePattern(secondaryIdx + 700)))
+                << "SECONDARY conn " << secondaryIdx << " data wrong after flush -- cross-comm misroute";
+        }
+
+        // Unshared baseline: flush on a solo group must behave exactly like the
+        // non-sharing path. Falls back to conn 0 when every comm shares a group.
+        const int soloIdx = (baselineIdx >= 0) ? baselineIdx : (havePair ? -1 : 0);
+        if (rank == 0 && soloIdx >= 0) {
+            void* fReq = nullptr;
+            int fsz = static_cast<int>(kSz);
+            EXPECT_EQ(FlushRecv(cs.recv[soloIdx], 1, &devBufs[soloIdx], &fsz,
+                                &mhandles[soloIdx], &fReq), ncclSuccess);
+            int w = 0;
+            EXPECT_EQ(WaitForCompletion(fReq, &w, kLargeTransferTimeoutMs), ncclSuccess)
+                << "unshared baseline conn " << soloIdx << " flush completion";
+            EXPECT_TRUE(verifyBufferData<uint8_t>(devBufs[soloIdx], kSz,
+                                                  makeBytePattern(soloIdx + 700)));
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressManyConns  (category: stress)
+//
+// Flagship regression guard: many connections to one peer under sustained
+// batched concurrent traffic on all of them. At ngroups=2 the default 100
+// connections put ~50 comms on each shared QP.
+//
+// Scale with QPSHARE_TEST_NCONNS.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressManyConns) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 100));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier()
+                          << " (comm #" << (model.Load(p.group) + 1) << " in group "
+                          << p.group << ")";
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ExpectQpShareLayout(cs.mine, cs.place, model, "stress conns established");
+    ReportQpShareCoverage("stress_many_conns", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr int    kNMsgs = 20;
+        constexpr size_t kMsgSz = 4096;
+        constexpr size_t kBufSz = kNMsgs * kMsgSz;
+
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kBufSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kBufSz));
+        for (int c = 0; c < established; c++) {
+            for (size_t i = 0; i < kBufSz; i++)
+                sendBufs[c][i] = static_cast<char>(((i + c) * 5 + 11) & 0xFF);
+            memset(recvBufs[c].data(), 0, kBufSz);
+        }
+
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kBufSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 6000;
+        for (int c = 0; c < established; c++) {
+            CastDoBatchSendRecv(rank, cs.send[c], cs.recv[c],
+                                sendBufs[c].data(), recvBufs[c].data(),
+                                kMsgSz, kNMsgs, kTagBase + c * kNMsgs, mhandles[c]);
+        }
+
+        if (rank == 0) {
+            for (int c = 0; c < established; c++)
+                EXPECT_EQ(memcmp(recvBufs[c].data(), sendBufs[c].data(), kBufSz), 0)
+                    << "data corruption on conn " << c;
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressSharedRqSaturation  (category: stress)
+//
+// Deliberately tries to starve the shared receive queue: one message posted
+// from every connection simultaneously (post-all before any wait), repeated
+// over several rounds.
+//
+// Scale with QPSHARE_TEST_NCONNS (connections) and QPSHARE_TEST_ITERS (rounds).
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressSharedRqSaturation) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank    = MPIEnvironment::world_rank;
+    const int ngroups = QpShareEnvNGroups();
+    const int nconns  = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 50));
+    const int rounds  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    QpShareRefModel model(ngroups);
+    QpShareConns    cs;
+    for (int c = 0; c < nconns; c++) {
+        QpShareRefModel::Placement p = model.AssignOnCreate();
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            model.Release(p);
+            ADD_FAILURE() << "connection " << c << " of " << nconns
+                          << " failed to establish at RCCL_IB_COMM_NGROUPS=" << ngroups
+                          << " RCCL_IB_QP_DEPTH_MULTIPLIER=" << QpShareEnvDepthMultiplier();
+            break;
+        }
+        cs.Add(rank, l, s, r, p);
+    }
+    const int established = static_cast<int>(cs.size());
+    ReportQpShareCoverage("stress_rq_saturation", established,
+                          established > 0 ? MaxObservedSharingDepth(cs.mine) : 0,
+                          model.Spread());
+
+    if (established > 0) {
+        constexpr size_t kMsgSz = 512;
+        std::vector<std::vector<char>> sendBufs(established, std::vector<char>(kMsgSz));
+        std::vector<std::vector<char>> recvBufs(established, std::vector<char>(kMsgSz));
+        std::vector<void*> mhandles(established, nullptr);
+        bool regOk = true;
+        for (int c = 0; c < established && regOk; c++) {
+            char* regBuf = (rank == 0) ? recvBufs[c].data() : sendBufs[c].data();
+            if (RegisterMemory(cs.mine[c], regBuf, kMsgSz, NCCL_PTR_HOST, &mhandles[c]) != ncclSuccess) {
+                ADD_FAILURE() << "RegisterMemory failed for conn " << c;
+                regOk = false;
+            }
+        }
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only";
+
+        constexpr int kTagBase = 7000;
+        for (int round = 0; round < rounds; round++) {
+            std::vector<void*> reqs(established, nullptr);
+            const int tagRoundBase = kTagBase + round * established;
+            bool postOk = true;
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    void*  bufs[1]    = {recvBufs[c].data()};
+                    size_t sizes[1]   = {kMsgSz};
+                    int    tags[1]    = {tagRoundBase + c};
+                    void*  handles[1] = {mhandles[c]};
+                    if (PostRecv(cs.recv[c], 1, bufs, sizes, tags, handles, &reqs[c]) != ncclSuccess
+                        || reqs[c] == nullptr) {
+                        ADD_FAILURE() << "PostRecv failed for round " << round << " conn " << c;
+                        postOk = false;
+                        break;
+                    }
+                }
+            } else {
+                for (int c = 0; c < established; c++) {
+                    fillHostBufferWithPattern<uint8_t>(sendBufs[c].data(), kMsgSz,
+                                                       makeBytePattern(round * established + c));
+                    PostSendWithRetry(cs.send[c], sendBufs[c].data(), kMsgSz,
+                                      tagRoundBase + c, mhandles[c], &reqs[c]);
+                }
+            }
+            ASSERT_TRUE(RankAgree(postOk)) << "PostRecv failed on one rank only (round " << round << ")";
+            for (int c = 0; c < established; c++) {
+                int sz = 0;
+                EXPECT_EQ(WaitForCompletion(reqs[c], &sz, kStressTimeoutMs), ncclSuccess)
+                    << "round " << round << " conn " << c;
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            if (rank == 0) {
+                for (int c = 0; c < established; c++) {
+                    size_t errIdx; uint8_t errExp, errGot;
+                    EXPECT_TRUE(verifyHostBufferData<uint8_t>(
+                        recvBufs[c].data(), kMsgSz, makeBytePattern(round * established + c),
+                        0, 0.0, &errIdx, &errExp, &errGot))
+                        << "round " << round << " conn " << c << " data mismatch at byte " << errIdx;
+                }
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int c = 0; c < established; c++)
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    while (cs.size() > 0) {
+        CloseCastConnection(cs.listen[0], cs.send[0], cs.recv[0]);
+        cs.Erase(0);
+    }
+}
+
+// =============================================================================
+// Test: QpShareStressConnectionChurn  (category: stress)
+//
+// Sequential connect -> transfer -> close cycles, by default 2048 of them.
+// Only one connection is live at a time, so nothing accumulates that the
+// transport is entitled to keep, so every cycle is fully torn down before the
+// next begins. What the checkpoints measure is whether that teardown returns
+// the device resources it took.
+//
+// Iterations are set by QPSHARE_TEST_ITERS;
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressConnectionChurn) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank  = MPIEnvironment::world_rank;
+    const int iters = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 2048));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 1024;
+    std::vector<char> buf(sz);
+
+    // Warmup connect+transfer+close so driver-internal CQs settle before baselining.
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            // The shared-QP pool reclaims slots on close (free-stack), so this
+            // should not happen from cross-test accumulation anymore. A failure
+            // here now points at a slot leaked by an earlier test's teardown.
+            ADD_FAILURE() << "warmup connection failed before churn even started "
+                             "(shared-QP pool slot leak from an earlier test in this "
+                             "process? slots are reclaimed on close, so this should "
+                             "not occur under normal operation)";
+            return;
+        }
+        void* mh = nullptr;
+        bool regOk = (RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed during warmup";
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only during warmup";
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/599, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Checkpoint every quarter, so a failure localises without depending on the
+    // iteration count being the default.
+    const int stride = std::max(1, iters / 4);
+
+    for (int iter = 0; iter < iters; iter++) {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            ADD_FAILURE()
+                << "connect failed at churn iteration " << iter << " of " << iters
+                << ". Only one connection is live at a time, so every earlier"
+                   " cycle was fully closed: a resource acquired per cycle was"
+                   " not returned. Check the RDMA-resource checkpoints above and"
+                   " run with NCCL_DEBUG=WARN -- pass -x"
+                   " NCCL_DEBUG_FILE=<dir>/nccl_%h_%p.log and read the per-rank"
+                   " files, since a merged mpirun log usually carries rank 0"
+                   " only and the absence of a WARN there is not evidence that"
+                   " none was emitted";
+            break;
+        }
+        void* comm = (rank == 0) ? r : s;
+        void* mh   = nullptr;
+        bool regOk = (RegisterMemory(comm, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed at churn iteration " << iter;
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only at iteration " << iter;
+
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/iter % 1000, mh, mh, iter);
+
+        const bool checkpoint = ((iter + 1) % stride == 0) || (iter == iters - 1);
+        if (checkpoint) {
+            struct ncclIbQpSharingState st = GetActualQpSharingState(comm);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at iter " << iter
+                << " -- the comm is live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0)
+                << "commId cleared at iter " << iter
+                << " -- the comm silently fell off the sharing path";
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+
+        if (checkpoint) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("churn@" + std::to_string(iter + 1)).c_str());
+        }
+    }
+
+    // Exactly one comm is live at any instant, so this test never stacks two
+    // comms on one QP -- achieved sharing depth is 1 by construction, not by
+    // accident, and the "NO QP WAS SHARED" banner is the correct label. Report
+    // it rather than leaving the driver's max/grp column blank: a blank column
+    // invites the reading that churn says something about sharing depth. It
+    // does not. It exercises the create/destroy lifecycle of a shared group
+    // whose membership never exceeds one, which is the occupancy that reaches
+    // the group-release path on every single cycle (the same path
+    // QpShareStressBatchCreateDestroy shows leaking a PD).
+    ReportQpShareCoverage("stress_connection_churn", iters, /*maxCommsPerGroup=*/1);
+}
+
+// =============================================================================
+// Test: QpShareStressBatchCreateDestroy  (category: stress)
+//
+// Resource lifetime under a bursty cadence: batches of connections created
+// together, used, and destroyed together. Defaults to 110 batches of 10.
+// RDMA-resource and refcount checkpoints every 25 batches.
+//
+// What this test is positioned to catch is anything that survives a completed
+// batch, which is why the checkpoints compare RDMA object counts against a
+// pre-batch baseline.
+//
+// Batch count from QPSHARE_TEST_ITERS, batch size from QPSHARE_TEST_NCONNS.
+// Unlike the sequential churn test this one holds several comms live at once,
+// so the batch size also has to fit the configured depth multiplier.
+// =============================================================================
+TEST_F(NetIbMPITest, QpShareStressBatchCreateDestroy) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    QPSHARE_ENV_CHECK_OR_SKIP();
+    const int rank     = MPIEnvironment::world_rank;
+    const int ngroups  = QpShareEnvNGroups();
+    const int batches  = std::max(1, QpShareEnvInt("QPSHARE_TEST_ITERS", 110));
+    const int perBatch = std::max(1, QpShareEnvInt("QPSHARE_TEST_NCONNS", 10));
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    const size_t sz = 512;
+    std::vector<char> buf(sz);
+
+    {
+        void* l = nullptr; void* s = nullptr; void* r = nullptr;
+        if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+            // The shared-QP pool reclaims slots on close (free-stack), so this
+            // should not happen from cross-test accumulation anymore. A failure
+            // here now points at a slot leaked by an earlier test's teardown.
+            ADD_FAILURE() << "warmup connection failed before batching even started "
+                             "(shared-QP pool slot leak from an earlier test in this "
+                             "process? slots are reclaimed on close, so this should "
+                             "not occur under normal operation)";
+            return;
+        }
+        void* mh = nullptr;
+        bool regOk = (RegisterMemory((rank == 0) ? r : s, buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+        if (!regOk) ADD_FAILURE() << "RegisterMemory failed during warmup";
+        ASSERT_TRUE(RankAgree(regOk)) << "RegisterMemory failed on one rank only during warmup";
+        DoSendRecv(s, r, buf.data(), buf.data(), sz, /*tag=*/699, mh, mh, /*seed=*/0);
+        MPI_Barrier(MPI_COMM_WORLD);
+        TeardownConnection(r, l, s, mh);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool broke = false;
+    int  peakDepth = 0;   // deepest any group got in any batch
+    int  peakSpread = 0;
+    for (int batch = 0; batch < batches && !broke; batch++) {
+        QpShareRefModel model(ngroups);
+        QpShareConns    cs;
+        std::vector<void*> mhandles;
+
+        for (int c = 0; c < perBatch; c++) {
+            QpShareRefModel::Placement p = model.AssignOnCreate();
+            void* l = nullptr; void* s = nullptr; void* r = nullptr;
+            if (!TryCastConnection(/*dev=*/0, &l, &s, &r)) {
+                model.Release(p);
+                ADD_FAILURE()
+                    << "connect failed at batch " << batch << " of " << batches
+                    << ", connection " << c << " of " << perBatch
+                    << " (cumulative connection #" << (batch * perBatch + c)
+                    << "). ngroups=" << ngroups << " depth="
+                    << QpShareEnvDepthMultiplier()
+                    << ". Every previous batch was fully torn down, so a failure "
+                       "here means a per-batch resource was not returned -- check "
+                       "the RDMA-count checkpoints above for which one.";
+                broke = true;
+                break;
+            }
+            cs.Add(rank, l, s, r, p);
+            void* mh = nullptr;
+            bool regOk = (RegisterMemory(cs.mine.back(), buf.data(), sz, NCCL_PTR_HOST, &mh) == ncclSuccess);
+            if (!regOk) {
+                ADD_FAILURE() << "RegisterMemory failed at batch " << batch
+                              << ", connection " << c;
+            }
+            if (!RankAgree(regOk)) {
+                broke = true;
+                break;
+            }
+            mhandles.push_back(mh);
+        }
+
+        const int live = static_cast<int>(cs.size());
+        peakDepth  = std::max(peakDepth, model.PeakLoad());
+        peakSpread = std::max(peakSpread, model.Spread());
+        for (int c = 0; c < live; c++) {
+            DoSendRecv(cs.send[c], cs.recv[c], buf.data(), buf.data(), sz,
+                       /*tag=*/c, mhandles[c], mhandles[c], batch * perBatch + c);
+        }
+
+        const bool checkpoint = ((batch + 1) % 25 == 0) || (batch == batches - 1);
+        if (checkpoint && live > 0) {
+            // Every batch starts from an empty live set, so the layout must be
+            // identical to batch 0's. Drift here means teardown left refcounts
+            // behind that IbCastCountPeerTotalRefcount still sees.
+            ExpectQpShareLayout(cs.mine, cs.place, model,
+                                Stage("batch checkpoint", batch).c_str());
+            struct ncclIbQpSharingState st = GetActualQpSharingState(cs.mine[0]);
+            EXPECT_GT(st.refcount, 0)
+                << "refcount dropped to 0 at batch " << batch
+                << " -- comms are live but no longer tracked in the shared-QP pool";
+            EXPECT_NE(st.commId, 0) << "commId cleared at batch " << batch;
+        }
+
+        for (int c = 0; c < live; c++) {
+            EXPECT_EQ(DeregisterMemory(cs.mine[c], mhandles[c]), ncclSuccess);
+            CloseCastConnection(cs.listen[c], cs.send[c], cs.recv[c]);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (checkpoint && !broke) {
+            RdmaResourceCounts now = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, now, ("batch@" + std::to_string(batch + 1)).c_str());
+        }
+    }
+
+    // Depth reached inside a batch, which is what sets how often the
+    // group-release path runs: perBatch/ngroups comms per group means only
+    // 1-in-that-many teardowns reaches it. At the default 10 conns / ngroups=2
+    // that is the mild leak rate; at ngroups=10 every group holds one comm and
+    // the rate is the churn test's. Reported so the two are comparable.
+    ReportQpShareCoverage("stress_batch_create_destroy", perBatch, peakDepth, peakSpread);
+}
+
+#endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -239,6 +239,209 @@
       ]
     },
 
+    "qpshare_base": {
+      "extends": "gtest_base",
+      "timeout": 600,
+      "description": "QP-sharing base (RCCL_IB_COMM_NGROUPS). No tests here; children extend and set the tunables. NIC merging is turned off because the suite connects on device 0 and reasons about one physical IB device per rank. The CAST scheduler is deliberately left off: the QP-sharing tests skip themselves when RCCL_IB_QP_SCHED_ENABLE=1, so these configs extend gtest_base rather than cast_base. Both RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER are RCCL_PARAMs and are cached for the process lifetime, which is why each value is a separate config rather than a case inside one run.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0"
+      }
+    },
+
+    "qpshare_ngroups1": {
+      "extends": "qpshare_base",
+      "description": "A17: QP sharing at NGROUPS=1 — every connection is assigned to group 0, so the whole functional set runs on a single shared QP. RCCL_IB_QP_DEPTH_MULTIPLIER=8 scales the shared QP's CQ and work-queue sizing so the configuration is not close to the queue-depth limit at these connection counts.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A17_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Opens connections one at a time up to min(2*NGROUPS+1, 64) and compares every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create — sharedGroupIdx, isSharedQpPrimary, refcount, cqRefcount, commId, and the cross-comm QP-identity relation — then tears down in creation order, releasing each group's PRIMARY while its SECONDARYs are live, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS rather than pinned to one value.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A17_QpShare_AlgoChurnLayout",
+          "description": "Group assignment under interleaved create/destroy with rotating non-tail victims, so a comm is released while it still has live neighbours in its group. Re-validates the full layout against the reference model after every operation, which is where a refcount that survives teardown or a pool slot that is freed but still counted becomes visible. Group spread is measured and reported, never asserted.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A17_QpShare_DataAllConnsTransfer",
+          "description": "Data path at this (NGROUPS, DEPTH_MULTIPLIER) point: opens QPSHARE_TEST_NCONNS connections (default derived from NGROUPS) and moves data on every one of them across a payload sweep of 0, 1, 127, 128, 4095, 4096, 65535, 65536 and 1 MiB bytes, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A17_QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as an explicit case rather than a skip: the connection count is derived as min(NGROUPS, 8) so occupancy-modulo gives every comm a group of its own. Asserts each comm is a solo PRIMARY on a distinct physical QP and exercises the data path on each.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A17_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ. A flush QP is per-comm and is not itself shared, but its completion lands on the group's shared CQ. Locates a PRIMARY/SECONDARY pair from the reference model rather than hardcoded indices, posts iflush() on both, and waits the SECONDARY first so completions are exercised against commId routing rather than post order. An unshared comm supplies the baseline. Requires GDR-capable hardware and skips otherwise.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups2": {
+      "extends": "qpshare_base",
+      "description": "A18: QP sharing at NGROUPS=2 — the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, so group-index arithmetic has more than one possible answer. Same five functional tests as A17.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A18_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout at NGROUPS=2, state only. See A17 for what the sweep checks; the connection count and every expectation are re-derived from NGROUPS.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A18_QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims at NGROUPS=2, layout re-validated against the reference model after every operation.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A18_QpShare_DataAllConnsTransfer",
+          "description": "Payload sweep from 0 to 1 MiB on every connection at NGROUPS=2, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A18_QpShare_DataUnsharedGroups",
+          "description": "Unshared regime at NGROUPS=2: two connections, one solo PRIMARY per group, each on its own physical QP.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A18_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ at NGROUPS=2, with an unshared comm as baseline. Skips on hardware without GDR.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups16": {
+      "extends": "qpshare_base",
+      "description": "A19: QP sharing at NGROUPS=16 — the wide point. The connection counts the tests derive straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. Same five functional tests as A17.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A19_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout across 16 groups, state only: 33 connections created and torn down one at a time, full layout re-checked after every operation.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A19_QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims across 16 groups — the widest point at which occupancy-modulo assignment is exercised against the reference model.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A19_QpShare_DataAllConnsTransfer",
+          "description": "Payload sweep from 0 to 1 MiB on every connection at NGROUPS=16, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A19_QpShare_DataUnsharedGroups",
+          "description": "Unshared regime at NGROUPS=16: the connection count is capped at 8, so every comm is a solo PRIMARY on its own physical QP.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A19_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ at NGROUPS=16, with an unshared comm as baseline. Skips on hardware without GDR.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_depth_ceiling": {
+      "extends": "qpshare_base",
+      "timeout": 300,
+      "description": "A20: shared-QP depth-multiplier sizing. RCCL_IB_QP_DEPTH_MULTIPLIER scales the shared CQ, which is sized 3 x NET_IB_MAX_REQUESTS(256) x NCCL_IB_QPS_PER_CONNECTION x multiplier entries, so the multiplier and the QP count multiply into the same device limit and both are pinned here. 96 with QPS=1 requests a CQ far larger than the default and covers how the transport sizes that CQ against the device's queried max_cqe. QPSHARE_TEST_NCONNS=2 keeps the run to the sizing question rather than connection volume. The usable multiplier is hardware-dependent (a function of the device's max_cqe), so this value is a probe of the sizing path, not a portable constant.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "96",
+        "NCCL_IB_QPS_PER_CONNECTION": "1",
+        "QPSHARE_TEST_NCONNS": "2"
+      },
+      "tests": [
+        {
+          "name": "A20_QpShare_DataAllConnsTransfer_DepthCeiling",
+          "description": "Two connections in one group at a depth multiplier of 96, exercising shared-CQ sizing and the data path at that setting.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        }
+      ]
+    },
+
+    "qpshare_stress": {
+      "extends": "qpshare_base",
+      "timeout": 900,
+      "description": "A21: QP-sharing scale and resource lifetime. NGROUPS=2 with DEPTH_MULTIPLIER=64 and one QP per connection, so the shared QP carries the queue depth the default connection counts require. Scale with QPSHARE_TEST_NCONNS and QPSHARE_TEST_ITERS. Connection churn is intentionally not in this config — it runs separately as A22.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "A21_QpShare_StressManyConns",
+          "description": "Sustained batched traffic over QPSHARE_TEST_NCONNS connections to one peer (default 100, so roughly 50 comms per shared QP at NGROUPS=2). Each connection sends 20 messages of 4 KiB and the received data is compared byte-for-byte.",
+          "test_filter": "NetIbMPITest.QpShareStressManyConns"
+        },
+        {
+          "name": "A21_QpShare_StressSharedRqSaturation",
+          "description": "Loads the shared receive queue: one message posted from every connection before any completion is waited on, repeated for QPSHARE_TEST_ITERS rounds (default 10) over QPSHARE_TEST_NCONNS connections (default 50), with per-round pattern verification.",
+          "test_filter": "NetIbMPITest.QpShareStressSharedRqSaturation"
+        },
+        {
+          "name": "A21_QpShare_StressBatchCreateDestroy",
+          "description": "Bursty lifecycle: QPSHARE_TEST_ITERS batches (default 110) of QPSHARE_TEST_NCONNS connections (default 10) created together, used, and destroyed together. Every batch starts from an empty live set, so at each checkpoint the layout is re-derived from a fresh reference model and RDMA object counts are compared against a pre-batch baseline. Because several comms are live at once, the batch size has to fit the configured depth multiplier.",
+          "test_filter": "NetIbMPITest.QpShareStressBatchCreateDestroy"
+        }
+      ]
+    },
+
+    "qpshare_stress_churn": {
+      "extends": "qpshare_base",
+      "timeout": 1800,
+      "description": "A22: sequential connection churn under QP sharing, isolated in its own config so it runs in a separate process from A21 and its result is reported independently. Long-running by design — the default 2048 connect/transfer/close cycles are minutes of wall time, hence the 1800s timeout.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "A22_QpShare_StressConnectionChurn",
+          "description": "QPSHARE_TEST_ITERS connect/transfer/close cycles (default 2048) with exactly one connection live at a time, so every cycle is fully torn down before the next begins and each teardown reaches the group-release path. RDMA object counts and the comm's pool state are checkpointed every quarter of the run against a pre-churn baseline. Sharing depth is 1 by construction here: the test covers the create/destroy lifecycle of a shared group, not concurrent occupancy.",
+          "test_filter": "NetIbMPITest.QpShareStressConnectionChurn"
+        }
+      ]
+    },
+
+    "qpshare_heap_poison": {
+      "extends": "qpshare_base",
+      "description": "A23: QP-sharing group teardown under glibc heap poisoning. Same test and tunables as A19; the addition is MALLOC_PERTURB_=165, which makes glibc overwrite freed heap with 0xa5, so any read through a pointer into a freed comm returns poison instead of whatever the allocator happened to leave behind. MALLOC_PERTURB_ is a glibc feature and is inert on other allocators, so on a non-glibc platform this config is equivalent to A19.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0",
+        "MALLOC_PERTURB_": "165"
+      },
+      "tests": [
+        {
+          "name": "A23_QpShare_AlgoChurnLayout_HeapPoison",
+          "description": "Interleaved create/destroy across 16 groups with freed heap poisoned, exercising the shared-QP group teardown path against pointers that may outlive the comm they point into.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        }
+      ]
+    },
+
     "rccl_tests_base": {
       "is_gtest": false,
       "test_binary_dir": "${PERF_BIN_DIR:-/it-share/rccl-ci/rccl-tests-2.30.4/bin}",
@@ -458,6 +661,14 @@
     { "config": "rocmib_no_cts_offload", "enabled": true, "smoke": true },
     { "config": "cts_force_override",    "enabled": true, "smoke": true },
     { "config": "alltoall_fullrange_guard", "enabled": true, "smoke": true },
+
+    { "config": "qpshare_ngroups1",       "enabled": true, "smoke": true },
+    { "config": "qpshare_ngroups2",       "enabled": true, "smoke": true },
+    { "config": "qpshare_ngroups16",      "enabled": true, "smoke": true },
+    { "config": "qpshare_depth_ceiling",  "enabled": true },
+    { "config": "qpshare_stress",         "enabled": true },
+    { "config": "qpshare_stress_churn",   "enabled": true },
+    { "config": "qpshare_heap_poison",    "enabled": true },
 
     { "config": "ionic_counters",        "enabled": true }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json
@@ -262,6 +262,210 @@
       ]
     },
 
+    "qpshare_base": {
+      "extends": "gtest_base",
+      "timeout": 600,
+      "description": "QP-sharing base (RCCL_IB_QP_SHARING_ENABLE master switch + RCCL_IB_COMM_NGROUPS). No tests here; children extend and set the tunables. NIC merging is turned off because the suite connects on device 0 and reasons about one physical IB device per rank. The CAST scheduler is deliberately left off: the QP-sharing tests skip themselves when RCCL_IB_QP_SCHED_ENABLE=1, so these configs extend gtest_base rather than cast_base. RCCL_IB_QP_SHARING_ENABLE, RCCL_IB_COMM_NGROUPS and RCCL_IB_QP_DEPTH_MULTIPLIER are all RCCL_PARAMs and are cached for the process lifetime, which is why each value is a separate config rather than a case inside one run.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0",
+        "RCCL_IB_QP_SHARING_ENABLE": "1"
+      }
+    },
+
+    "qpshare_ngroups1": {
+      "extends": "qpshare_base",
+      "description": "A17: QP sharing at NGROUPS=1 — every connection is assigned to group 0, so the whole functional set runs on a single shared QP. RCCL_IB_QP_DEPTH_MULTIPLIER=8 scales the shared QP's CQ and work-queue sizing so the configuration is not close to the queue-depth limit at these connection counts.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A17_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout, state only, no data phase. Opens connections one at a time up to min(2*NGROUPS+1, 64) and compares every live comm against the reference model (test/transport/NetIbMPI/QpShareRefModel.hpp) after each create — sharedGroupIdx, isSharedQpPrimary, refcount, cqRefcount, commId, and the cross-comm QP-identity relation — then tears down in creation order, releasing each group's PRIMARY while its SECONDARYs are live, re-checking after each destroy. Expectations are derived from RCCL_IB_COMM_NGROUPS rather than pinned to one value.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A17_QpShare_AlgoChurnLayout",
+          "description": "Group assignment under interleaved create/destroy with rotating non-tail victims, so a comm is released while it still has live neighbours in its group. Re-validates the full layout against the reference model after every operation, which is where a refcount that survives teardown or a pool slot that is freed but still counted becomes visible. Group spread is measured and reported, never asserted.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A17_QpShare_DataAllConnsTransfer",
+          "description": "Data path at this (NGROUPS, DEPTH_MULTIPLIER) point: opens QPSHARE_TEST_NCONNS connections (default derived from NGROUPS) and moves data on every one of them across a payload sweep of 0, 1, 127, 128, 4095, 4096, 65535, 65536 and 1 MiB bytes, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A17_QpShare_DataUnsharedGroups",
+          "description": "The unshared regime as an explicit case rather than a skip: the connection count is derived as min(NGROUPS, 8) so occupancy-modulo gives every comm a group of its own. Asserts each comm is a solo PRIMARY on a distinct physical QP and exercises the data path on each.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A17_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ. A flush QP is per-comm and is not itself shared, but its completion lands on the group's shared CQ. Locates a PRIMARY/SECONDARY pair from the reference model rather than hardcoded indices, posts iflush() on both, and waits the SECONDARY first so completions are exercised against commId routing rather than post order. An unshared comm supplies the baseline. Requires GDR-capable hardware and skips otherwise.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups2": {
+      "extends": "qpshare_base",
+      "description": "A18: QP sharing at NGROUPS=2 — the smallest value that mixes a PRIMARY-only group with a PRIMARY+SECONDARY group, so group-index arithmetic has more than one possible answer. Same five functional tests as A17.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A18_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout at NGROUPS=2, state only. See A17 for what the sweep checks; the connection count and every expectation are re-derived from NGROUPS.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A18_QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims at NGROUPS=2, layout re-validated against the reference model after every operation.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A18_QpShare_DataAllConnsTransfer",
+          "description": "Payload sweep from 0 to 1 MiB on every connection at NGROUPS=2, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A18_QpShare_DataUnsharedGroups",
+          "description": "Unshared regime at NGROUPS=2: two connections, one solo PRIMARY per group, each on its own physical QP.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A18_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ at NGROUPS=2, with an unshared comm as baseline. Skips on hardware without GDR.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_ngroups16": {
+      "extends": "qpshare_base",
+      "description": "A19: QP sharing at NGROUPS=16 — the wide point. The connection counts the tests derive straddle the shared and unshared regimes within one run, and the layout sweep reaches 33 connections across 16 groups. Same five functional tests as A17.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "A19_QpShare_AlgoLayoutSweep",
+          "description": "Group-assignment layout across 16 groups, state only: 33 connections created and torn down one at a time, full layout re-checked after every operation.",
+          "test_filter": "NetIbMPITest.QpShareAlgoLayoutSweep"
+        },
+        {
+          "name": "A19_QpShare_AlgoChurnLayout",
+          "description": "Interleaved create/destroy with rotating non-tail victims across 16 groups — the widest point at which occupancy-modulo assignment is exercised against the reference model.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        },
+        {
+          "name": "A19_QpShare_DataAllConnsTransfer",
+          "description": "Payload sweep from 0 to 1 MiB on every connection at NGROUPS=16, pattern-verified per connection.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        },
+        {
+          "name": "A19_QpShare_DataUnsharedGroups",
+          "description": "Unshared regime at NGROUPS=16: the connection count is capped at 8, so every comm is a solo PRIMARY on its own physical QP.",
+          "test_filter": "NetIbMPITest.QpShareDataUnsharedGroups"
+        },
+        {
+          "name": "A19_QpShare_DataFlushRouting",
+          "description": "GDR flush completion routing over a shared CQ at NGROUPS=16, with an unshared comm as baseline. Skips on hardware without GDR.",
+          "test_filter": "NetIbMPITest.QpShareDataFlushRouting"
+        }
+      ]
+    },
+
+    "qpshare_depth_ceiling": {
+      "extends": "qpshare_base",
+      "timeout": 300,
+      "description": "A20: shared-QP depth-multiplier sizing. RCCL_IB_QP_DEPTH_MULTIPLIER scales the shared CQ, which is sized 3 x NET_IB_MAX_REQUESTS(256) x NCCL_IB_QPS_PER_CONNECTION x multiplier entries, so the multiplier and the QP count multiply into the same device limit and both are pinned here. 96 with QPS=1 requests a CQ far larger than the default and covers how the transport sizes that CQ against the device's queried max_cqe. QPSHARE_TEST_NCONNS=2 keeps the run to the sizing question rather than connection volume. The usable multiplier is hardware-dependent (a function of the device's max_cqe), so this value is a probe of the sizing path, not a portable constant.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "1",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "96",
+        "NCCL_IB_QPS_PER_CONNECTION": "1",
+        "QPSHARE_TEST_NCONNS": "2"
+      },
+      "tests": [
+        {
+          "name": "A20_QpShare_DataAllConnsTransfer_DepthCeiling",
+          "description": "Two connections in one group at a depth multiplier of 96, exercising shared-CQ sizing and the data path at that setting.",
+          "test_filter": "NetIbMPITest.QpShareDataAllConnsTransfer"
+        }
+      ]
+    },
+
+    "qpshare_stress": {
+      "extends": "qpshare_base",
+      "timeout": 900,
+      "description": "A21: QP-sharing scale and resource lifetime. NGROUPS=2 with DEPTH_MULTIPLIER=64 and one QP per connection, so the shared QP carries the queue depth the default connection counts require. Scale with QPSHARE_TEST_NCONNS and QPSHARE_TEST_ITERS. Connection churn is intentionally not in this config — it runs separately as A22.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "A21_QpShare_StressManyConns",
+          "description": "Sustained batched traffic over QPSHARE_TEST_NCONNS connections to one peer (default 100, so roughly 50 comms per shared QP at NGROUPS=2). Each connection sends 20 messages of 4 KiB and the received data is compared byte-for-byte.",
+          "test_filter": "NetIbMPITest.QpShareStressManyConns"
+        },
+        {
+          "name": "A21_QpShare_StressSharedRqSaturation",
+          "description": "Loads the shared receive queue: one message posted from every connection before any completion is waited on, repeated for QPSHARE_TEST_ITERS rounds (default 10) over QPSHARE_TEST_NCONNS connections (default 50), with per-round pattern verification.",
+          "test_filter": "NetIbMPITest.QpShareStressSharedRqSaturation"
+        },
+        {
+          "name": "A21_QpShare_StressBatchCreateDestroy",
+          "description": "Bursty lifecycle: QPSHARE_TEST_ITERS batches (default 110) of QPSHARE_TEST_NCONNS connections (default 10) created together, used, and destroyed together. Every batch starts from an empty live set, so at each checkpoint the layout is re-derived from a fresh reference model and RDMA object counts are compared against a pre-batch baseline. Because several comms are live at once, the batch size has to fit the configured depth multiplier.",
+          "test_filter": "NetIbMPITest.QpShareStressBatchCreateDestroy"
+        }
+      ]
+    },
+
+    "qpshare_stress_churn": {
+      "extends": "qpshare_base",
+      "timeout": 1800,
+      "description": "A22: sequential connection churn under QP sharing, isolated in its own config so it runs in a separate process from A21 and its result is reported independently. Long-running by design — the default 2048 connect/transfer/close cycles are minutes of wall time, hence the 1800s timeout.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "2",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "64",
+        "NCCL_IB_QPS_PER_CONNECTION": "1"
+      },
+      "tests": [
+        {
+          "name": "A22_QpShare_StressConnectionChurn",
+          "description": "QPSHARE_TEST_ITERS connect/transfer/close cycles (default 2048) with exactly one connection live at a time, so every cycle is fully torn down before the next begins and each teardown reaches the group-release path. RDMA object counts and the comm's pool state are checkpointed every quarter of the run against a pre-churn baseline. Sharing depth is 1 by construction here: the test covers the create/destroy lifecycle of a shared group, not concurrent occupancy.",
+          "test_filter": "NetIbMPITest.QpShareStressConnectionChurn"
+        }
+      ]
+    },
+
+    "qpshare_heap_poison": {
+      "extends": "qpshare_base",
+      "description": "A23: QP-sharing group teardown under glibc heap poisoning. Same test and tunables as A19; the addition is MALLOC_PERTURB_=165, which makes glibc overwrite freed heap with 0xa5, so any read through a pointer into a freed comm returns poison instead of whatever the allocator happened to leave behind. MALLOC_PERTURB_ is a glibc feature and is inert on other allocators, so on a non-glibc platform this config is equivalent to A19.",
+      "env_variables": {
+        "RCCL_IB_COMM_NGROUPS": "16",
+        "RCCL_IB_QP_DEPTH_MULTIPLIER": "8",
+        "NCCL_GDR_FLUSH_DISABLE": "0",
+        "MALLOC_PERTURB_": "165"
+      },
+      "tests": [
+        {
+          "name": "A23_QpShare_AlgoChurnLayout_HeapPoison",
+          "description": "Interleaved create/destroy across 16 groups with freed heap poisoned, exercising the shared-QP group teardown path against pointers that may outlive the comm they point into.",
+          "test_filter": "NetIbMPITest.QpShareAlgoChurnLayout"
+        }
+      ]
+    },
+
     "rccl_tests_base": {
       "is_gtest": false,
       "test_binary_dir": "${PERF_BIN_DIR:-/it-share/rccl-ci/rccl-tests-2.30.4/bin}",
@@ -482,6 +686,14 @@
     { "config": "rocmib_no_cts_offload", "enabled": true, "smoke": true },
     { "config": "cts_force_override",    "enabled": true, "smoke": true },
     { "config": "alltoall_fullrange_guard", "enabled": true, "smoke": true },
+
+    { "config": "qpshare_ngroups1",       "enabled": true, "smoke": true },
+    { "config": "qpshare_ngroups2",       "enabled": true, "smoke": true },
+    { "config": "qpshare_ngroups16",      "enabled": true, "smoke": true },
+    { "config": "qpshare_depth_ceiling",  "enabled": true },
+    { "config": "qpshare_stress",         "enabled": true },
+    { "config": "qpshare_stress_churn",   "enabled": true },
+    { "config": "qpshare_heap_poison",    "enabled": true },
 
     { "config": "ionic_counters",        "enabled": true }
   ]


### PR DESCRIPTION
## Motivation

This PR adds Unit tests for QP sharing feature.

## Technical Details

This pull request introduces QP (Queue Pair) sharing support into the `net_ib_cast` transport, along with related code changes and debugging improvements. The core changes add new data structures, APIs, and logic for QP sharing, update work request encoding to support shared QPs, and improve trace/debug output for better visibility. Several build and source files are updated to include the new QP sharing implementation and introspection API.

**QP Sharing Implementation and Introspection:**

* Added new files `qp_sharing.h`, `qp_sharing.cc`, and `net_ib_qp_sharing_inspect.h` to implement and expose QP sharing logic and a test-only introspection API for QP sharing state. These are included in the build and source lists. [[1]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR15) [[2]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR28) [[3]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR489) [[4]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44)

* Extended key data structures (`ncclIbNetCommBase`, `ncclIbSendComm`, `ncclIbQpCreateAttr`, `ncclIbConnectionMetadata`, etc.) with QP sharing fields such as `commId`, `isSharedQpPrimary`, and `sharedGroupIdx`. Added helper functions and macros for QP sharing state and encoding. [[1]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R535-R541) [[2]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R642) [[3]](diffhunk://#diff-4d17df7cca81bd31e60f651caee9743b3d88e9f426a0fc64d05f3aceb84f3b08R60-R62) [[4]](diffhunk://#diff-4d17df7cca81bd31e60f651caee9743b3d88e9f426a0fc64d05f3aceb84f3b08R111-R124)

**Work Request and Completion Handling:**

* Updated work request (`wr_id` and `imm_data`) encoding to include `commId` for QP sharing, enabling correct routing of completions and requests in shared environments. This affects send and CTS operations. [[1]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR119-R124) [[2]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR141-R143) [[3]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR155-R157) [[4]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR181-R188) [[5]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR598-R606)

* Improved debug and trace output to print `wr_id` and `imm_data` in hexadecimal format, aiding troubleshooting of QP sharing and request matching. [[1]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL71-R79) [[2]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL181-R200) [[3]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL338-R358) [[4]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL348-R367) [[5]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL593-R616)

**Initialization and Feature Interactions:**

* Modified device initialization to disable features incompatible with QP sharing (CTS offload, QP scheduler), with informative log messages. Added a validation call for the shared QP pool at finalization. [[1]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R363-R366) [[2]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R641-R646) [[3]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R662-R665)

**Codebase Integration:**

* Included the new QP sharing headers in all relevant source files to ensure the new logic is accessible throughout the transport layer. [[1]](diffhunk://#diff-c005ab1e30ba8ec58f4f3d003553ca72f36e89037fd254e51dee538d664d0405R10) [[2]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R11) [[3]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR16)

These changes collectively enable QP sharing in the IB transport, improve visibility for debugging and testing, and ensure safe interaction with other features.

**References:**  
[[1]](diffhunk://#diff-80d037920bc0eee8f7f90a3c45f1b4ad34d72a23c319ceaa5991d1338659b1cbR489) [[2]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR5) [[3]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR15) [[4]](diffhunk://#diff-8ed092dfa73f33cdae2d35e41481690c355b65aa9823ecc324c72dd87206946aR28) [[5]](diffhunk://#diff-c005ab1e30ba8ec58f4f3d003553ca72f36e89037fd254e51dee538d664d0405R10) [[6]](diffhunk://#diff-c005ab1e30ba8ec58f4f3d003553ca72f36e89037fd254e51dee538d664d0405R27-R28) [[7]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R152-R162) [[8]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R535-R541) [[9]](diffhunk://#diff-7d5dd730edc944ad8f3fd53433ee7e0641345155d533947488562f047b290b10R642) [[10]](diffhunk://#diff-4d17df7cca81bd31e60f651caee9743b3d88e9f426a0fc64d05f3aceb84f3b08R60-R62) [[11]](diffhunk://#diff-4d17df7cca81bd31e60f651caee9743b3d88e9f426a0fc64d05f3aceb84f3b08R111-R124) [[12]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R11) [[13]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R363-R366) [[14]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R641-R646) [[15]](diffhunk://#diff-db6e760ac7bc9b5208df2c521a9dc2dad492d38c58297f37153d45f084ca0c00R662-R665) [[16]](diffhunk://#diff-3818a7bb73a7f279d6af73ea7609738548afdaf428b452480b51c4808826b98bR1-R44) [[17]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR16) [[18]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL71-R79) [[19]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR119-R124) [[20]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR141-R143) [[21]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR155-R157) [[22]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR181-R188) [[23]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL181-R200) [[24]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL338-R358) [[25]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL348-R367) [[26]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cR598-R606) [[27]](diffhunk://#diff-9ae32920140dccfb6f544d080e545b2834a8f09b9dcac0168862d254ce1ee71cL593-R616)

## Issue Tracking

AICOMNET-352

## Test Plan

Run tests through CI.
Manual tests run on mi355 cluster

## Test Result

```
RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile MPI_PATH=~/openmpi-5.0.9/install python3 tools/scripts/test_runner/test_runner.py     -c tools/scripts/test_runner/configs/mi355x_ainic_tw_roce.json     --suite-name "qpshare*"     --system ainic --no-build --build-dir ~/rccl_qp-sharing-08-26-with-tests/rccl/build/debug/
...
Detailed Results:
------------------------------------------------------------------------------------------------------------------------
Test Suite                               Test Name                                Result     Duration
------------------------------------------------------------------------------------------------------------------------
qpshare_ngroups1                         A17_QpShare_AlgoLayoutSweep              PASSED     1.667 seconds
qpshare_ngroups1                         A17_QpShare_AlgoChurnLayout              PASSED     1.717 seconds
qpshare_ngroups1                         A17_QpShare_DataAllConnsTransfer         PASSED     2.268 seconds
qpshare_ngroups1                         A17_QpShare_DataUnsharedGroups           PASSED     1.517 seconds
qpshare_ngroups1                         A17_QpShare_DataFlushRouting             PASSED     1.667 seconds
qpshare_ngroups2                         A18_QpShare_AlgoLayoutSweep              PASSED     1.667 seconds
qpshare_ngroups2                         A18_QpShare_AlgoChurnLayout              PASSED     2.218 seconds
qpshare_ngroups2                         A18_QpShare_DataAllConnsTransfer         PASSED     2.368 seconds
qpshare_ngroups2                         A18_QpShare_DataUnsharedGroups           PASSED     1.567 seconds
qpshare_ngroups2                         A18_QpShare_DataFlushRouting             PASSED     1.917 seconds
qpshare_ngroups16                        A19_QpShare_AlgoLayoutSweep              PASSED     4.021 seconds
qpshare_ngroups16                        A19_QpShare_AlgoChurnLayout              PASSED     6.877 seconds
qpshare_ngroups16                        A19_QpShare_DataAllConnsTransfer         PASSED     6.175 seconds
qpshare_ngroups16                        A19_QpShare_DataUnsharedGroups           PASSED     2.368 seconds
qpshare_ngroups16                        A19_QpShare_DataFlushRouting             PASSED     3.470 seconds
qpshare_depth_ceiling                    A20_QpShare_DataAllConnsTransfer_DepthCeiling PASSED     1.617 seconds
qpshare_stress                           A21_QpShare_StressManyConns              PASSED     9.331 seconds
qpshare_stress                           A21_QpShare_StressSharedRqSaturation     PASSED     4.522 seconds
qpshare_stress                           A21_QpShare_StressBatchCreateDestroy     PASSED     102.946 seconds
qpshare_stress_churn                     A22_QpShare_StressConnectionChurn        PASSED     207.533 seconds
qpshare_heap_poison                      A23_QpShare_AlgoChurnLayout_HeapPoison   PASSED     6.726 seconds
------------------------------------------------------------------------------------------------------------------------
Total Tests:   21
Passed:        21
Failed:        0
Skipped:       0
Timeout:       0
Total Time:    6 min 14.16 sec
========================================================================================================================
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
