### PR TITLE
test(rccl): Fix failing Transport and Rcclwrap tests

### DIFF
--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -556,9 +556,9 @@ TEST(Rcclwrap, RcclSetPipelining_Invalid_DType)
     // Pipeline should not be set for non-bf16 datatypes, unless
     // rcclParamPipelineAllDTypes() returns true
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", 8);
     comm->nNodes = 2; // Multi node
 
     ncclTaskColl info = {};
@@ -585,9 +585,9 @@ TEST(Rcclwrap, RcclSetPipelining_GFX950_SingleNode_Disable)
 
     // For single-node, pipeline remains 0
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", 8);
     comm->nNodes = 1; // Single node
 
     ncclTaskColl info = {};
@@ -617,9 +617,9 @@ TEST(Rcclwrap, RcclSetPipelining_GFX942_SingleNode_AllReduce_Enable)
 
     // For single-node, pipeline is set to 1 for AllReduce with bf16
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", 8);
     comm->nNodes = 1; // Single node
 
     ncclTaskColl info = {};
@@ -648,9 +648,9 @@ TEST(Rcclwrap, RcclSetPipelining_GFX942_MultiNode_AllReduce_Enable)
     // nBytes <= 512MB * 2^(log2(nNodes)-1)
     // Testing with nNodes = 4  => threshold = 512MB * 2^(2-1) = 1GB
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", 8);
     comm->nNodes = 4;
 
     ncclTaskColl info = {};
@@ -677,9 +677,9 @@ TEST(Rcclwrap, RcclSetPipelining_GFX942_MultiNode_AllReduce_Disable)
 
     // When nBytes is just above the threshold, pipelining should be disabled
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", 8);
     comm->nNodes = 4;
 
     ncclTaskColl info = {};
@@ -707,9 +707,9 @@ TEST(Rcclwrap, RcclSetPipelining_GFX942_Enable)
 
     // ReduceScatter & Reduce should enable pipelining regardless of no. of nodes
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", 8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", 8);
     comm->nNodes = 8;
 
     ncclTaskColl info = {};
@@ -1109,9 +1109,9 @@ TEST(Rcclwrap, AllrcclSetP2pNetChunkSizeTests)
                 [tc]()
                 {
                     ncclComm_t            mockComm = nullptr;
-                    struct ncclTopoSystem mockTopo;
+                    auto                  mockTopo = std::make_unique<ncclTopoSystem>();
                     struct ncclTopoNode   mockGpuNode;
-                    CreateMockComm(mockComm, mockTopo, mockGpuNode, tc.arch.c_str(), tc.ranks);
+                    CreateMockComm(mockComm, *mockTopo, mockGpuNode, tc.arch.c_str(), tc.ranks);
 
                     int chunkSize = RCCL_VALUE_UNSET;
                     rcclSetP2pNetChunkSize(mockComm, chunkSize);
@@ -1231,9 +1231,9 @@ TEST(Rcclwrap, AllPxnTests)
                     );
 
                     ncclComm_t            mockComm = nullptr;
-                    struct ncclTopoSystem mockTopo;
+                    auto                  mockTopo = std::make_unique<ncclTopoSystem>();
                     struct ncclTopoNode   mockGpuNode;
-                    CreateMockComm(mockComm, mockTopo, mockGpuNode, tc.arch.c_str(), tc.ranks);
+                    CreateMockComm(mockComm, *mockTopo, mockGpuNode, tc.arch.c_str(), tc.ranks);
 
                     int pxnDisable = RCCL_VALUE_UNSET;
                     rcclSetPxn(mockComm, pxnDisable);
@@ -1377,9 +1377,9 @@ TEST(Rcclwrap, RcclUseAllGatherDirectNodeCountTests)
                     }
 
                     ncclComm_t            mockComm = nullptr;
-                    struct ncclTopoSystem mockTopo;
+                    auto                  mockTopo = std::make_unique<ncclTopoSystem>();
                     struct ncclTopoNode   mockGpuNode;
-                    CreateMockComm(mockComm, mockTopo, mockGpuNode, tc.arch.c_str(), tc.nRanks);
+                    CreateMockComm(mockComm, *mockTopo, mockGpuNode, tc.arch.c_str(), tc.nRanks);
                     mockComm->nNodes = tc.nNodes;
 
                     // Use a message size that passes the threshold check so only
@@ -1474,10 +1474,10 @@ TEST(Rcclwrap, RcclUseHierarchicalAllGatherTests)
                 [tc]()
                 {
                     ncclComm_t            mockComm = nullptr;
-                    struct ncclTopoSystem mockTopo;
+                    auto                  mockTopo = std::make_unique<ncclTopoSystem>();
                     struct ncclTopoNode   mockGpu;
                     CreateMockComm(mockComm,
-                                   mockTopo,
+                                   *mockTopo,
                                    mockGpu,
                                    "gfx942",
                                    /*nRanks=*/8 * tc.nNodes);
@@ -1571,10 +1571,10 @@ TEST(Rcclwrap, RcclUseHierarchicalReduceScatterTests)
                 [tc]()
                 {
                     ncclComm_t            mockComm = nullptr;
-                    struct ncclTopoSystem mockTopo;
+                    auto                  mockTopo = std::make_unique<ncclTopoSystem>();
                     struct ncclTopoNode   mockGpu;
                     CreateMockComm(mockComm,
-                                   mockTopo,
+                                   *mockTopo,
                                    mockGpu,
                                    "gfx942",
                                    /*nRanks=*/8 * tc.nNodes);
@@ -2007,9 +2007,9 @@ TEST(Rcclwrap, CanUseWarpSpeedAuto_Gfx950SingleNode_True)
     }
 
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->cuCount = 256; // SPX mode (256 CU on gfx950); auto mode requires cuCount > 128
 
     EXPECT_TRUE(rcclCanUseWarpSpeedAuto(comm, /*nNodes=*/1));
@@ -2025,9 +2025,9 @@ TEST(Rcclwrap, CanUseWarpSpeedAuto_Gfx950SingleNode_True)
 TEST(Rcclwrap, CanUseWarpSpeedAuto_NonGfx950_False)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", /*nRanks=*/8);
 
     EXPECT_FALSE(rcclCanUseWarpSpeedAuto(comm, /*nNodes=*/1));
 
@@ -2038,9 +2038,9 @@ TEST(Rcclwrap, CanUseWarpSpeedAuto_NonGfx950_False)
 TEST(Rcclwrap, CanUseWarpSpeedAuto_MultiNode_False)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/16);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/16);
 
     EXPECT_FALSE(rcclCanUseWarpSpeedAuto(comm, /*nNodes=*/2));
 
@@ -2056,9 +2056,9 @@ TEST(Rcclwrap, CanUseWarpSpeedAuto_AutoModeDisabled_False)
         []()
         {
             ncclComm_t            comm = nullptr;
-            struct ncclTopoSystem topo;
+            auto                  topo = std::make_unique<ncclTopoSystem>();
             struct ncclTopoNode   gpu;
-            CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+            CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
             comm->cuCount = 256; // ensure only RCCL_WARP_SPEED_AUTO=0 makes this ineligible
 
             EXPECT_FALSE(rcclCanUseWarpSpeedAuto(comm, /*nNodes=*/1));
@@ -2073,9 +2073,9 @@ TEST(Rcclwrap, CanUseWarpSpeedAuto_AutoModeDisabled_False)
 TEST(Rcclwrap, GetMaxWarpsPerBlock_SingleNode)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->nNodes   = 1;
     comm->WarpSize = 64;
 
@@ -2088,9 +2088,9 @@ TEST(Rcclwrap, GetMaxWarpsPerBlock_SingleNode)
 TEST(Rcclwrap, GetMaxWarpsPerBlock_MultiNodeGfx950)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/16);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/16);
     comm->nNodes   = 2;
     comm->WarpSize = 64;
 
@@ -2103,9 +2103,9 @@ TEST(Rcclwrap, GetMaxWarpsPerBlock_MultiNodeGfx950)
 TEST(Rcclwrap, GetMaxWarpsPerBlock_MultiNodeOtherArch)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", /*nRanks=*/16);
+    CreateMockComm(comm, *topo, gpu, "gfx942", /*nRanks=*/16);
     comm->nNodes   = 2;
     comm->WarpSize = 64;
 
@@ -2123,9 +2123,9 @@ TEST(Rcclwrap, GetMaxWarpsPerBlock_MultiNodeOtherArch)
 TEST(Rcclwrap, GetMaxWarpsPerBlock_BranchesCurrentlyEquivalent)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->WarpSize = 64;
 
     comm->nNodes    = 1;
@@ -2145,9 +2145,9 @@ TEST(Rcclwrap, GetMaxWarpsPerBlock_BranchesCurrentlyEquivalent)
 TEST(Rcclwrap, ComputeNChannels_SingleNode_Gfx950_8Ranks_Halved)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->nNodes    = 1;
     comm->nChannels = 2;
 
@@ -2165,9 +2165,9 @@ TEST(Rcclwrap, ComputeNChannels_SingleNode_Gfx950_8Ranks_Halved)
 TEST(Rcclwrap, ComputeNChannels_SingleNode_4Ranks_NoHalving)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/4);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/4);
     comm->nNodes    = 1;
     comm->nChannels = 2;
 
@@ -2184,9 +2184,9 @@ TEST(Rcclwrap, ComputeNChannels_SingleNode_4Ranks_NoHalving)
 TEST(Rcclwrap, ComputeNChannels_MultiNode_CappedByMaxChannels)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->nNodes    = 2;
     comm->nChannels = 2;
 
@@ -2204,9 +2204,9 @@ TEST(Rcclwrap, ComputeNChannels_MultiNode_CappedByMaxChannels)
 TEST(Rcclwrap, ComputeNChannels_UserOverride_NoClamp)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->nNodes    = 1;
     comm->nChannels = 2;
 
@@ -2223,9 +2223,9 @@ TEST(Rcclwrap, ComputeNChannels_UserOverride_NoClamp)
 TEST(Rcclwrap, ComputeNChannels_UserOverride_ClampedToMaxChannels)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->nNodes    = 1;
     comm->nChannels = 2;
 
@@ -2242,9 +2242,9 @@ TEST(Rcclwrap, ComputeNChannels_UserOverride_ClampedToMaxChannels)
 TEST(Rcclwrap, AdjustChannels_Disabled_NoChange)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
     comm->topo->warpSpeedEnabled     = false;
     comm->warpSpeedChannelMultiplier = 4;
 
@@ -2261,9 +2261,9 @@ TEST(Rcclwrap, AdjustChannels_Disabled_NoChange)
 TEST(Rcclwrap, AdjustChannels_Enabled_DividesByMultiplier)
 {
     ncclComm_t            comm = nullptr;
-    struct ncclTopoSystem topo;
+    auto                  topo = std::make_unique<ncclTopoSystem>();
     struct ncclTopoNode   gpu;
-    CreateMockComm(comm, topo, gpu, "gfx942", /*nRanks=*/8);
+    CreateMockComm(comm, *topo, gpu, "gfx942", /*nRanks=*/8);
     comm->topo->warpSpeedEnabled     = true;
     comm->warpSpeedChannelMultiplier = 4;
 
@@ -2286,9 +2286,9 @@ TEST(Rcclwrap, AdjustChannels_Gfx950SingleNode8Ranks_NonMainColl_Doubles)
         []()
         {
             ncclComm_t            comm = nullptr;
-            struct ncclTopoSystem topo;
+            auto                  topo = std::make_unique<ncclTopoSystem>();
             struct ncclTopoNode   gpu;
-            CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+            CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
             comm->nNodes                     = 1;
             comm->topo->warpSpeedEnabled     = true;
             comm->warpSpeedChannelMultiplier = 4;
@@ -2313,9 +2313,9 @@ TEST(Rcclwrap, AdjustChannels_Gfx950SingleNode8Ranks_MainColl_NoDouble)
         []()
         {
             ncclComm_t            comm = nullptr;
-            struct ncclTopoSystem topo;
+            auto                  topo = std::make_unique<ncclTopoSystem>();
             struct ncclTopoNode   gpu;
-            CreateMockComm(comm, topo, gpu, "gfx950", /*nRanks=*/8);
+            CreateMockComm(comm, *topo, gpu, "gfx950", /*nRanks=*/8);
             comm->nNodes                     = 1;
             comm->topo->warpSpeedEnabled     = true;
             comm->warpSpeedChannelMultiplier = 4;
@@ -2362,9 +2362,9 @@ TEST(Rcclwrap, RcclUseCeAllReduce_BiasBuffer)
             []()
             {
                 ncclComm_t            comm = nullptr;
-                struct ncclTopoSystem topo;
+                auto                  topo = std::make_unique<ncclTopoSystem>();
                 struct ncclTopoNode   gpu;
-                CreateCeAllReduceEligibleComm(comm, topo, gpu, /*nRanks=*/8);
+                CreateCeAllReduceEligibleComm(comm, *topo, gpu, /*nRanks=*/8);
 
                 int biasBuffer = 0;
                 EXPECT_FALSE(rcclUseCeAllReduce(comm,
@@ -2386,9 +2386,9 @@ TEST(Rcclwrap, RcclUseCeAllReduce_BiasBuffer)
             []()
             {
                 ncclComm_t            comm = nullptr;
-                struct ncclTopoSystem topo;
+                auto                  topo = std::make_unique<ncclTopoSystem>();
                 struct ncclTopoNode   gpu;
-                CreateCeAllReduceEligibleComm(comm, topo, gpu, /*nRanks=*/8);
+                CreateCeAllReduceEligibleComm(comm, *topo, gpu, /*nRanks=*/8);
 
                 EXPECT_TRUE(rcclUseCeAllReduce(comm,
                                                kCeAllReduceCount,

--- a/projects/rccl/test/TransportTests.cpp
+++ b/projects/rccl/test/TransportTests.cpp
@@ -25,6 +25,12 @@ TEST(TransportTest, CollNetRecvSetup) {
   ncclPeerInfo peerInfo[3] = {};
   comm.peerInfo = peerInfo;
 
+  // --- Setup bootstrap ---
+  // bootstrapAllGather reads rank/nranks from this state and is a no-op at nranks==1
+  ncclComm_t bootstrapComm = nullptr;
+  ASSERT_EQ(ncclCommInitAll(&bootstrapComm, 1, nullptr), ncclSuccess);
+  comm.bootstrap = bootstrapComm->bootstrap;
+
   // --- Setup channel ---
   ncclChannel channel = {};
   static ncclChannelPeer peerArray[3];
@@ -77,6 +83,7 @@ TEST(TransportTest, CollNetRecvSetup) {
   // --- Cleanup ---
   ASSERT_EQ(hipFree(devPeerArrayDevice), hipSuccess);
   ASSERT_EQ(hipFree(devPeerPtrsDevice), hipSuccess);
+  ncclCommDestroy(bootstrapComm);
 }
 
 TEST(TransportTest, CollNetSendSetup) {


### PR DESCRIPTION
## Motivation

Resolve TransportTest and Rcclwrap gtest failures, both of which segfaulted and took down the rest of their suite.

## Technical Details

- `TransportTests`: `CollNetRecvSetup` passed a null `comm.bootstrap` into the `collNetRecv` path, where `bootstrapAllGather` dereferences it immediately, so borrow a real bootstrap from a single-rank communicator where the ring exchange is a no-op.

- `RcclWrapTests`: `ncclTopoSystem` is ~13 MB and was declared on the 8 MB stack in 30 tests, so switch those to `std::make_unique` matching the idiom already used elsewhere in the file.

## Issue Tracking

JIRA ID: AICOMRCCL-2135, AICOMRCCL-2130

## Test Plan

Run these tests on the CI

## Test Result

All Transport and Rcclwrap tests pass as expected in the code coverage CI:
```
Detailed Results:
------------------------------------------------------------------------------------------------------------------------
Test Suite                               Test Name                                Result     Duration
------------------------------------------------------------------------------------------------------------------------
Unit Tests - Fixtures (Debug)            Rcclwrap                                 PASSED     16.116 seconds
Unit Tests - Fixtures (Debug)            TransportTest                            PASSED     5.238 seconds
------------------------------------------------------------------------------------------------------------------------
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
