### PR TITLE
fix(rocprofiler-sdk): KFD dispatch-log signal-less review fixes (F1-F29)

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/api-reference/tool_library_environment.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/tool_library_environment.rst
@@ -140,8 +140,9 @@ Kernel dispatch timestamp source
         ``4194303``. Defaults to 10 MiB. A non-integer, empty, zero, or
         out-of-range value is ignored with a warning and the default is used. If
         the firmware laps the reader the SDK logs an overrun warning and the
-        affected dispatches fall back to the HSA timestamps; raising this value
-        gives the reader more headroom.
+        affected signal-less dispatches emit no record (their firmware records were
+        overwritten before the reader copied them); raising this value gives the
+        reader more headroom.
 
         The driver only accepts ring sizes of ``80 * 2^k`` bytes (80 KiB, 160 KiB,
         320 KiB, ... up to the 640 MiB maximum), so the requested size is rounded

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
@@ -1270,15 +1270,13 @@ shutdown(hsa_executable_t executable)
 
     auto _unloaded = code_object::get_unloaded_code_objects(executable);
 
-    // Code-object unload callbacks often invalidate tool-side kernel symbol metadata. Drain inline
-    // queue-interposition completion records first so pending dispatch records are delivered while
-    // that metadata is still valid.
-    // Hub-aware sync: joining already-enqueued tasks is not enough once a
-    // firmware record can still be sitting in the ring or parked in the retry
-    // owner. This additionally fences registration/publication, the reader's
-    // drain, and the ready-task handoff, so no completion can run against symbol
-    // metadata this unload is about to invalidate. No-op with signal-less off.
-    ::rocprofiler::kfd::signal_less_fence_completions();
+    // No signal-less-specific hook at code-object unload: a late signal-less completion
+    // is memory-safe (the payload carries copies, no code-object-owned pointer is
+    // dereferenced), so the only residual is a tool-semantic/buffered-tracing
+    // inconsistency, which is explicitly acceptable per the success criterion.
+
+    // Unloading invalidates tool-side kernel symbol metadata, so drain in-flight
+    // queue-interposition completions first while that metadata is still valid.
     ::rocprofiler::hsa::queue_interposition::interposition_sync();
 
     constexpr auto CODE_OBJECT_KIND = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
@@ -1270,16 +1270,10 @@ shutdown(hsa_executable_t executable)
 
     auto _unloaded = code_object::get_unloaded_code_objects(executable);
 
-    // Code-object unload callbacks often invalidate tool-side kernel symbol metadata. Drain inline
-    // queue-interposition completion records first so pending dispatch records are delivered while
-    // that metadata is still valid.
-    // Hub-aware sync: joining already-enqueued tasks is not enough once a
-    // firmware record can still be sitting in the ring or parked in the retry
-    // owner. This additionally fences registration/publication, the reader's
-    // drain, and the ready-task handoff, so no completion can run against symbol
-    // metadata this unload is about to invalidate. No-op with signal-less off.
-    ::rocprofiler::kfd::signal_less_fence_completions();
-    ::rocprofiler::hsa::queue_interposition::interposition_sync();
+    // No signal-less-specific hook at code-object unload: a late signal-less completion
+    // is memory-safe (the payload carries copies, no code-object-owned pointer is
+    // dereferenced), so the only residual is a tool-semantic/buffered-tracing
+    // inconsistency, which is explicitly acceptable per the success criterion.
 
     constexpr auto CODE_OBJECT_KIND = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
     constexpr auto CODE_OBJECT_LOAD = ROCPROFILER_CODE_OBJECT_LOAD;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.cpp
@@ -31,6 +31,7 @@
 #include "lib/rocprofiler-sdk/hsa/pc_sampling.hpp"
 #include "lib/rocprofiler-sdk/hsa/scratch_memory.hpp"
 #include "lib/rocprofiler-sdk/hsa/utils.hpp"
+#include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 #include "lib/rocprofiler-sdk/tracing/tracing.hpp"
@@ -574,6 +575,11 @@ hsa_shut_down_refcnt_impl()
             // thread-trace producer/consumer threads *before* ROCR tears down
             // SDMA engines and signal pools in Runtime::Unload().
             thread_trace::flush_and_stop();
+            // F24 terminal fail-closed fence: after real hsa_shut_down the runtime
+            // frees SDMA/signal state, so no callback-capable signal-less completion
+            // may survive. On timeout abandon+disable process-wide. No-op with the
+            // feature off.
+            ::rocprofiler::kfd::signal_less_fence_completions();
         }
         return get_core_table()->hsa_shut_down_fn();
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -41,9 +41,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <optional>
-#include <set>
 
 namespace rocprofiler
 {
@@ -442,60 +440,44 @@ QueueController::add_queue(hsa_queue_t*           id,
     // dispatches still owns its slot); the clock is read once, before the map lock.
     if(is_compute && kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
     {
-        if(const auto* _q = get_queue(*id))
+        if(const auto* _q = get_queue(*id);
+           _q && kfd::gpu_supports_dispatch_log(
+                     static_cast<uint32_t>(_q->get_agent().get_rocp_agent()->gpu_id)))
         {
-            // T-CLK per-SKU gate (section 5.9): open owner windows only on a SKU whose
-            // clock domain passed the T-CLK Tier-1 screen. On any other SKU the
-            // firmware<->KFD clock offset is unscreened, so a record could be
-            // mis-windowed -- open no window (and do not register), so every dispatch
-            // there takes the signal path. Do NOT disable process-wide: another agent
-            // may be a validated SKU.
-            const auto* _rocp = _q->get_agent().get_rocp_agent();
-            if(kfd::tclk_validated_sku(_rocp->gfx_target_version))
+            // T-CLK: gate all window/registry bookkeeping on this GPU's dispatch-log
+            // capability FIRST. A compute queue on an unsupported/attached GPU is not a
+            // dispatch-log participant, so it must not open windows, register ownership,
+            // or trip signal_less_disable_permanently() process-wide.
+            // Open the owner window on any dispatch_log_stream_format-capable compute
+            // agent: the record tick and gpu_tick_now are the same free-running GPU
+            // clock counter, so the capability probe already covers the clock domain.
+            const auto* _rocp    = _q->get_agent().get_rocp_agent();
+            const auto  _gpu     = static_cast<uint32_t>(_rocp->gpu_id);
+            auto        _slot    = std::optional<uint32_t>{};
+            bool        _poison  = false;
+            bool        _disable = is_attach;  // an adopted queue's history is unseen
+            if(auto _db = capture_doorbell_key(_q->intercept_queue()))
             {
-                const auto _gpu     = static_cast<uint32_t>(_rocp->gpu_id);
-                auto       _slot    = std::optional<uint32_t>{};
-                bool       _poison  = false;
-                bool       _disable = is_attach;  // an adopted queue's history is unseen
-                if(auto _db = capture_doorbell_key(_q->intercept_queue()))
+                _slot = *_db;  // a live owner, always registered with its real slot
+                if(!is_attach)
                 {
-                    _slot = *_db;  // a live owner, always registered with its real slot
-                    if(!is_attach)
-                    {
-                        const uint64_t _tick =
-                            gpu_tick_now(get_core_table(), _q->get_agent().get_hsa_agent());
-                        if(_tick == 0)
-                            _poison = true;  // clock failure: slot-scoped poison
-                        else
-                            _poison = kfd::doorbell_map()
-                                          .open_window(_gpu, _q->get_id(), *_slot, _tick)
-                                          .overlapped;  // two live owners
-                    }
+                    const uint64_t _tick =
+                        gpu_tick_now(get_core_table(), _q->get_agent().get_hsa_agent());
+                    if(_tick == 0)
+                        _poison = true;  // clock failure: slot-scoped poison
+                    else
+                        _poison = kfd::doorbell_map()
+                                      .open_window(_gpu, _q->get_id(), *_slot, _tick)
+                                      .overlapped;  // two live owners
                 }
-                else
-                {
-                    _disable = true;  // capture failed: an unwindowed owner exists
-                }
-                kfd::add_live_queue(_q->get_id().handle, _gpu, _slot);
-                if(_poison && _slot) kfd::poison_slot(_gpu, *_slot);
-                if(_disable) kfd::signal_less_disable_permanently();
             }
             else
             {
-                // Record the arch once per distinct SKU so an operator sees why
-                // signal-less is inactive on this GPU. Interposition still proceeds
-                // below, so signal-based tracing is unaffected.
-                static auto _warned_mu   = std::mutex{};
-                static auto _warned_arch = std::set<uint32_t>{};
-                auto        _lk          = std::lock_guard<std::mutex>{_warned_mu};
-                if(_warned_arch.insert(_rocp->gfx_target_version).second)
-                    ROCP_WARNING << fmt::format(
-                        "KFD dispatch-log: signal-less gated off on {} (gfx_target_version {}): "
-                        "not "
-                        "a T-CLK-validated SKU; its dispatches use the signal path (design 5.9).",
-                        _rocp->name != nullptr ? _rocp->name : "?",
-                        _rocp->gfx_target_version);
+                _disable = true;  // capture failed: an unwindowed owner exists
             }
+            kfd::add_live_queue(_q->get_id().handle, _gpu, _slot);
+            if(_poison && _slot) kfd::poison_slot(_gpu, *_slot);
+            if(_disable) kfd::signal_less_disable_permanently();
         }
     }
 
@@ -524,11 +506,20 @@ QueueController::destroy_queue(hsa_queue_t* id)
     // at any instant, so no lock cycle exists. Never blocks on the reader.
     if(kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
     {
+        // F1: hold drain_mu across the whole close/drain/close-window sequence, so
+        // finalization's concurrent drain either wins the mutex (and blocks us before
+        // the runtime queue is freed) or observes rdid_valid==false and skips. The
+        // state shared_ptr keeps QueueState (and drain_mu) alive across the erase.
+        auto _state    = queue_interposition::lookup_queue_state(id, /*create_if_missing=*/false);
+        auto _drain_lk = _state ? std::unique_lock<std::mutex>{_state->drain_mu}
+                                : std::unique_lock<std::mutex>{};
+
         // Step 0: latch admission AND snapshot next_submit_pos in ONE gate_lock
         // section. The latch precedes the snapshot; both are ordered
         // against every publishing critical section by that lock, so no separate
         // fence is needed and every already-registered packet is <= P.
-        const uint64_t _P = queue_interposition::close_admission_and_snapshot(id);
+        const uint64_t _P =
+            _state ? queue_interposition::close_admission_and_snapshot_locked(*_state) : 0;
 
         // Step 0b: derive (gpu, slot) BEFORE step 6 destroys the mapping; skip the
         // window work entirely when this queue never resolved a slot.
@@ -541,7 +532,9 @@ QueueController::destroy_queue(hsa_queue_t* id)
             // unanchored t_close could misattribute. Bounded by the
             // per-close budget; the aggregate pool is deleted.
             const uint64_t _deadline = kfd::steady_now_ns() + kfd::close_drain_budget_ns();
-            const bool     _drained = queue_interposition::wait_queue_hw_drained(id, _P, _deadline);
+            const bool     _drained =
+                _state ? queue_interposition::wait_queue_hw_drained_locked(*_state, _P, _deadline)
+                           : true;
             // Step 3: read t_close AFTER the drain, before any lock, from this
             // queue's agent.
             const uint64_t _tick =
@@ -556,6 +549,16 @@ QueueController::destroy_queue(hsa_queue_t* id)
 
         // Step 6: drop ownership so a surviving co-owner becomes injective again.
         kfd::remove_live_queue(_queue_token);
+
+        // Last action under drain_mu: invalidate the interlock BEFORE releasing it,
+        // so finalization can never load a real_rdid the runtime is about to free.
+        if(_state)
+        {
+            _state->rdid_valid = false;
+            _state->real_rdid  = nullptr;
+        }
+        // Release drain_mu here (end of the `if` scope) -- BEFORE destroy_queue_state/
+        // sync/erase, i.e. before anything can free amd_queue_t.
     }
 
     queue_interposition::destroy_queue_state(id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -41,9 +41,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <optional>
-#include <set>
 
 namespace rocprofiler
 {
@@ -442,60 +440,44 @@ QueueController::add_queue(hsa_queue_t*           id,
     // dispatches still owns its slot); the clock is read once, before the map lock.
     if(is_compute && kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
     {
-        if(const auto* _q = get_queue(*id))
+        if(const auto* _q = get_queue(*id); _q &&
+           kfd::gpu_supports_dispatch_log(
+               static_cast<uint32_t>(_q->get_agent().get_rocp_agent()->gpu_id)))
         {
-            // T-CLK per-SKU gate (section 5.9): open owner windows only on a SKU whose
-            // clock domain passed the T-CLK Tier-1 screen. On any other SKU the
-            // firmware<->KFD clock offset is unscreened, so a record could be
-            // mis-windowed -- open no window (and do not register), so every dispatch
-            // there takes the signal path. Do NOT disable process-wide: another agent
-            // may be a validated SKU.
-            const auto* _rocp = _q->get_agent().get_rocp_agent();
-            if(kfd::tclk_validated_sku(_rocp->gfx_target_version))
+            // T-CLK: gate all window/registry bookkeeping on this GPU's dispatch-log
+            // capability FIRST. A compute queue on an unsupported/attached GPU is not a
+            // dispatch-log participant, so it must not open windows, register ownership,
+            // or trip signal_less_disable_permanently() process-wide.
+            // Open the owner window on any dispatch_log_stream_format-capable compute
+            // agent: the record tick and gpu_tick_now are the same free-running GPU
+            // clock counter, so the capability probe already covers the clock domain.
+            const auto* _rocp    = _q->get_agent().get_rocp_agent();
+            const auto  _gpu     = static_cast<uint32_t>(_rocp->gpu_id);
+            auto        _slot    = std::optional<uint32_t>{};
+            bool        _poison  = false;
+            bool        _disable = is_attach;  // an adopted queue's history is unseen
+            if(auto _db = capture_doorbell_key(_q->intercept_queue()))
             {
-                const auto _gpu     = static_cast<uint32_t>(_rocp->gpu_id);
-                auto       _slot    = std::optional<uint32_t>{};
-                bool       _poison  = false;
-                bool       _disable = is_attach;  // an adopted queue's history is unseen
-                if(auto _db = capture_doorbell_key(_q->intercept_queue()))
+                _slot = *_db;  // a live owner, always registered with its real slot
+                if(!is_attach)
                 {
-                    _slot = *_db;  // a live owner, always registered with its real slot
-                    if(!is_attach)
-                    {
-                        const uint64_t _tick =
-                            gpu_tick_now(get_core_table(), _q->get_agent().get_hsa_agent());
-                        if(_tick == 0)
-                            _poison = true;  // clock failure: slot-scoped poison
-                        else
-                            _poison = kfd::doorbell_map()
-                                          .open_window(_gpu, _q->get_id(), *_slot, _tick)
-                                          .overlapped;  // two live owners
-                    }
+                    const uint64_t _tick =
+                        gpu_tick_now(get_core_table(), _q->get_agent().get_hsa_agent());
+                    if(_tick == 0)
+                        _poison = true;  // clock failure: slot-scoped poison
+                    else
+                        _poison = kfd::doorbell_map()
+                                      .open_window(_gpu, _q->get_id(), *_slot, _tick)
+                                      .overlapped;  // two live owners
                 }
-                else
-                {
-                    _disable = true;  // capture failed: an unwindowed owner exists
-                }
-                kfd::add_live_queue(_q->get_id().handle, _gpu, _slot);
-                if(_poison && _slot) kfd::poison_slot(_gpu, *_slot);
-                if(_disable) kfd::signal_less_disable_permanently();
             }
             else
             {
-                // Record the arch once per distinct SKU so an operator sees why
-                // signal-less is inactive on this GPU. Interposition still proceeds
-                // below, so signal-based tracing is unaffected.
-                static auto _warned_mu   = std::mutex{};
-                static auto _warned_arch = std::set<uint32_t>{};
-                auto        _lk          = std::lock_guard<std::mutex>{_warned_mu};
-                if(_warned_arch.insert(_rocp->gfx_target_version).second)
-                    ROCP_WARNING << fmt::format(
-                        "KFD dispatch-log: signal-less gated off on {} (gfx_target_version {}): "
-                        "not "
-                        "a T-CLK-validated SKU; its dispatches use the signal path (design 5.9).",
-                        _rocp->name != nullptr ? _rocp->name : "?",
-                        _rocp->gfx_target_version);
+                _disable = true;  // capture failed: an unwindowed owner exists
             }
+            kfd::add_live_queue(_q->get_id().handle, _gpu, _slot);
+            if(_poison && _slot) kfd::poison_slot(_gpu, *_slot);
+            if(_disable) kfd::signal_less_disable_permanently();
         }
     }
 
@@ -524,11 +506,20 @@ QueueController::destroy_queue(hsa_queue_t* id)
     // at any instant, so no lock cycle exists. Never blocks on the reader.
     if(kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
     {
+        // F1: hold drain_mu across the whole close/drain/close-window sequence, so
+        // finalization's concurrent drain either wins the mutex (and blocks us before
+        // the runtime queue is freed) or observes rdid_valid==false and skips. The
+        // state shared_ptr keeps QueueState (and drain_mu) alive across the erase.
+        auto _state = queue_interposition::lookup_queue_state(id, /*create_if_missing=*/false);
+        auto _drain_lk =
+            _state ? std::unique_lock<std::mutex>{_state->drain_mu} : std::unique_lock<std::mutex>{};
+
         // Step 0: latch admission AND snapshot next_submit_pos in ONE gate_lock
         // section. The latch precedes the snapshot; both are ordered
         // against every publishing critical section by that lock, so no separate
         // fence is needed and every already-registered packet is <= P.
-        const uint64_t _P = queue_interposition::close_admission_and_snapshot(id);
+        const uint64_t _P =
+            _state ? queue_interposition::close_admission_and_snapshot_locked(*_state) : 0;
 
         // Step 0b: derive (gpu, slot) BEFORE step 6 destroys the mapping; skip the
         // window work entirely when this queue never resolved a slot.
@@ -541,7 +532,9 @@ QueueController::destroy_queue(hsa_queue_t* id)
             // unanchored t_close could misattribute. Bounded by the
             // per-close budget; the aggregate pool is deleted.
             const uint64_t _deadline = kfd::steady_now_ns() + kfd::close_drain_budget_ns();
-            const bool     _drained = queue_interposition::wait_queue_hw_drained(id, _P, _deadline);
+            const bool     _drained =
+                _state ? queue_interposition::wait_queue_hw_drained_locked(*_state, _P, _deadline)
+                       : true;
             // Step 3: read t_close AFTER the drain, before any lock, from this
             // queue's agent.
             const uint64_t _tick =
@@ -556,6 +549,16 @@ QueueController::destroy_queue(hsa_queue_t* id)
 
         // Step 6: drop ownership so a surviving co-owner becomes injective again.
         kfd::remove_live_queue(_queue_token);
+
+        // Last action under drain_mu: invalidate the interlock BEFORE releasing it,
+        // so finalization can never load a real_rdid the runtime is about to free.
+        if(_state)
+        {
+            _state->rdid_valid = false;
+            _state->real_rdid  = nullptr;
+        }
+        // Release drain_mu here (end of the `if` scope) -- BEFORE destroy_queue_state/
+        // sync/erase, i.e. before anything can free amd_queue_t.
     }
 
     queue_interposition::destroy_queue_state(id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1713,6 +1713,16 @@ interposition_fini()
     // disable active interception
     s_intercept_active.store(false, std::memory_order_release);
 
+    // A fork child that never exec'd still runs this at exit, and everything below
+    // it is unsafe there: the registry wlock and the signal pool's lock may have
+    // been held by a thread that did not survive the fork, so acquiring them hangs
+    // the child, and destroying inherited HSA signals reaches into a runtime the
+    // child does not own. The child abandoned all of this state (D6) and is on its
+    // way out, so skip it -- the same treatment interposition_sync() and
+    // submit_inline_async() already give the fork generation. The atomic stores
+    // above are kept: they are safe and make the child's interception inert.
+    if(internal_threading::fork_stale()) return;
+
     // wait for any in-flight signal handlers to complete and clean up the signal pool
     interposition_sync();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -63,6 +63,9 @@
 #include <array>
 #include <atomic>
 #include <cstring>
+#include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -75,6 +78,18 @@ namespace queue_interposition
 namespace
 {
 auto s_active_queue_interposition_consumers = std::atomic<uint32_t>{0};
+
+// Makes the inline pool's construct-and-submit region mutually exclusive with
+// interposition_sync()'s join. Submitters hold it SHARED; the sync takes it
+// EXCLUSIVE, so a submitter mid-construction cannot slip a task past a sync that
+// already read "not constructed". A leaf lock: it nests inside g_submit_gate
+// (shared) on the hand_off_proven() path, never the reverse.
+std::shared_mutex g_handler_gate;
+
+// Set with release right after the inline pool's static initializer completes, so
+// interposition_sync() can tell "constructed, must join" from "never constructed"
+// without itself constructing the pool. Acquire-loaded by the exists-check.
+std::atomic<bool> g_async_handler_constructed{false};
 
 // NOTE:
 //  - "installed" is for checking whether HSA functions have been passed
@@ -137,7 +152,14 @@ lookup_queue_state(const hsa_queue_t* queue, bool create_if_missing)
     // if create_if_missing is true, create a new state. this is for dynamic discovery of queues.
     if(!_state && create_if_missing)
     {
-        return create_queue_state(queue, true);
+        auto _created = create_queue_state(queue, true);
+        // F29: a queue discovered dynamically (never seen at hsa_queue_create) was
+        // never windowed, so first_owner can no longer be trusted anywhere -- the
+        // documented "owner we never windowed" invariant. Disable signal-less
+        // process-wide. Called with no hub/registry lock held (create returned).
+        if(_created && kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
+            kfd::signal_less_disable_permanently();
+        return _created;
     }
 
     return _state;
@@ -307,10 +329,13 @@ ring_buffer_writer(const void* pkts, uint64_t pkt_count)
     }
 }
 
-auto
+bool
 async_signal_handler_exists()
 {
-    return common::static_object<internal_threading::task_group_t>::get();
+    // Acquire pairs with the release store in get_async_signal_handler(): a true
+    // read means the pool is fully constructed. Never reads the raw m_object
+    // pointer, which a concurrent constructor may be publishing (TSan race).
+    return g_async_handler_constructed.load(std::memory_order_acquire);
 }
 }  // namespace
 
@@ -354,7 +379,36 @@ get_async_signal_handler()
             static_cast<create_task_group_fn_t>(&internal_threading::create_task_group),
             get_async_signal_handler_thread_count());
 
+    // Release-store unconditionally on every call, AFTER the static initializer:
+    // the constructing thread's store is ordered after the constructor, and any
+    // other thread reached here only by acquiring the same static guard, so it
+    // carries the construction in its happens-before chain too. Must NOT go in
+    // construct_via_function's call_once, which runs before the object exists.
+    g_async_handler_constructed.store(true, std::memory_order_release);
+
     return _v;
+}
+
+// The ONLY caller of get_async_signal_handler()->async(). Makes the
+// construct-and-submit region mutually exclusive with interposition_sync() so a
+// task can never be queued on a pool the sync already decided not to join.
+// Consumes `task` only on the path that returns true: every false return happens
+// before the std::move, so a rejected task is destroyed intact by the caller.
+bool
+submit_inline_async(std::function<void()>&& task, bool refuse_during_fini)
+{
+    // 1. FIRST, before any lock: a child forked while a vanished parent thread
+    // held g_handler_gate can never acquire it, so testing staleness after taking
+    // the gate would deadlock the child instead of letting it defer/skip.
+    if(internal_threading::fork_stale()) return false;
+    // 2. construct+submit region, shared so concurrent submitters proceed together.
+    auto _g = std::shared_lock<std::shared_mutex>{g_handler_gate};
+    // 3. Inside the region: a submitter that read fini==0 then blocked on the gate
+    // must still be refused, or it would submit after the exclusive sync section.
+    if(refuse_during_fini && registration::get_fini_status() != 0) return false;
+    // 4. Constructs the pool on first real use (correct for signal-less work).
+    get_async_signal_handler()->async(std::move(task));
+    return true;
 }
 
 bool
@@ -536,7 +590,7 @@ complete_signal_less_dispatch(kfd::signal_less_hub_t::proven&& proven)
             "KFD dispatch-log: no timing for dispatch (reason={}, gpu={} slot={} idx={})",
             kfd::finalize_reason_name(_detail.reason),
             proven.key.gpu_id,
-            proven.key.doorbell_off,
+            proven.key.doorbell_slot,
             proven.key.dispatch_idx_low32);
     }
 }
@@ -544,13 +598,18 @@ complete_signal_less_dispatch(kfd::signal_less_hub_t::proven&& proven)
 bool
 submit_to_task_group(kfd::signal_less_hub_t::proven& proven)
 {
-    auto* _tg = get_async_signal_handler();
-    if(!_tg || registration::get_fini_status() != 0) return false;
-
-    // task_group_t::async takes a std::function, which must be copy-constructible;
-    // the payload is move-only, so it travels in a shared_ptr.
+    // task_group_t::async takes a copy-constructible std::function but the payload
+    // is move-only, so it travels in a shared_ptr the wrapper keeps. On refusal
+    // (fork-stale or fini) the primitive returns before consuming the task, so the
+    // payload is restored intact and the caller defers it -- packaging it after a
+    // refusable call would strand a moved-from payload and never retire its id.
     auto _held = std::make_shared<kfd::signal_less_hub_t::proven>(std::move(proven));
-    _tg->async([_held]() { complete_signal_less_dispatch(std::move(*_held)); });
+    if(!submit_inline_async([_held]() { complete_signal_less_dispatch(std::move(*_held)); },
+                            /*refuse_during_fini=*/true))
+    {
+        proven = std::move(*_held);
+        return false;
+    }
     return true;
 }
 
@@ -767,13 +826,58 @@ write_interceptor(Queue*                                queue,
         // packets in a batch share one queue, hence one owner_window.
         auto            _signal_less_keys   = std::vector<std::optional<kfd::correlation_key>>{};
         kfd::window_ptr _signal_less_window = {};
-        const bool      _signal_less_batch  = signal_less_batch_eligible(queue,
-                                                                   _packets,
-                                                                   _num_packets,
-                                                                   _base_pkt_index,
-                                                                   &_signal_less_keys,
-                                                                   &_signal_less_window);
-        auto            _signal_less_regs   = std::vector<kfd::signal_less_hub_t::registration>{};
+        // Non-const: D7 clears it on the register_batch refusal path so the post-loop
+        // signal-path block runs and builds the async waiter for the fallback.
+        bool _signal_less_batch = signal_less_batch_eligible(queue,
+                                                             _packets,
+                                                             _num_packets,
+                                                             _base_pkt_index,
+                                                             &_signal_less_keys,
+                                                             &_signal_less_window);
+        auto _signal_less_regs  = std::vector<kfd::signal_less_hub_t::registration>{};
+
+        // Parallel to _info_session.packet_data: for each dispatch packet, the index
+        // in transformed_packets of its SUBMITTED packet plus whether it is the ext
+        // form. transformed_packets also holds pass-through and barrier/interrupt
+        // packets, so packet_data[k] != transformed_packets[k]; the D7 fallback needs
+        // both to write the replayed signal into the right submitted packet field.
+        struct dispatch_pkt_ref
+        {
+            size_t transformed_index = 0;
+            bool   is_ext            = false;
+        };
+        auto _dispatch_pkt_index = std::vector<dispatch_pkt_ref>{};
+
+        auto create_signal = [](auto* signal) -> common::container::pool_object<signal_t>* {
+            if(auto* pool = get_signal_pool(); pool && signal->handle == 0)
+            {
+                auto& _signal = pool->acquire(construct_hsa_signal, 0, 0, nullptr, 0);
+                ROCP_FATAL_IF(!_signal.in_use()) << "Acquired signal from pool that is not in use";
+                ROCP_FATAL_IF(_signal.get().value == null_signal)
+                    << "Acquired signal from pool that has invalid handle";
+                *CHECK_NOTNULL(signal) = _signal.get().value;
+                return &_signal;
+            }
+            return nullptr;
+        };
+
+        // The three signal-path steps, factored so the normal !_signal_less_batch
+        // branch and the D7 refusal fallback cannot drift: borrow a pooled signal if
+        // the app supplied none, bump its value by 1, and record it on the packet.
+        // Returns the completion signal written into pd.kernel_packet.
+        auto apply_signal_path = [&create_signal](packet_data_t& pd, bool is_ext) -> hsa_signal_t {
+            (void) is_ext;
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+            auto& _cs = is_ext ? pd.kernel_packet.ext_kernel_dispatch.completion_signal
+                               : pd.kernel_packet.kernel_dispatch.completion_signal;
+#else
+            auto& _cs = pd.kernel_packet.kernel_dispatch.completion_signal;
+#endif
+            if(_cs == null_signal) pd.pooled_signal = create_signal(&_cs);
+            get_core_table()->hsa_signal_add_scacq_screl_fn(_cs, 1);
+            pd.completion_signal = _cs;
+            return _cs;
+        };
 
         // Searching across all the packets given during this write
         for(size_t i = 0; i < _num_packets; ++i)
@@ -860,49 +964,18 @@ write_interceptor(Queue*                                queue,
                 }
             };
 
-            const auto     pkt_info = extract_packet_info(_packets[i], is_ext_kernel_dispatch);
-            const auto     original_completion_signal = pkt_info.completion_signal;
+            const auto     pkt_info  = extract_packet_info(_packets[i], is_ext_kernel_dispatch);
             const uint64_t kernel_id = code_object::get_kernel_id(pkt_info.kernel_object);
-            const auto     existing_completion_signal = (original_completion_signal != null_signal);
 
             // Copy kernel pkt, copy is to allow for signal to be modified
             _packet_data.kernel_packet = _packets[i];
             // create a reference for short hand access
             auto& kernel_packet = _packet_data.kernel_packet;
 
-#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
-            auto& completion_signal =
-                is_ext_kernel_dispatch
-                    ? _packet_data.kernel_packet.ext_kernel_dispatch.completion_signal
-                    : _packet_data.kernel_packet.kernel_dispatch.completion_signal;
-#else
-            auto& completion_signal = _packet_data.kernel_packet.kernel_dispatch.completion_signal;
-#endif
-
-            auto create_signal = [](auto* signal) -> common::container::pool_object<signal_t>* {
-                if(auto* pool = get_signal_pool(); pool && signal->handle == 0)
-                {
-                    auto& _signal = pool->acquire(construct_hsa_signal, 0, 0, nullptr, 0);
-                    ROCP_FATAL_IF(!_signal.in_use())
-                        << "Acquired signal from pool that is not in use";
-                    ROCP_FATAL_IF(_signal.get().value == null_signal)
-                        << "Acquired signal from pool that has invalid handle";
-                    *CHECK_NOTNULL(signal) = _signal.get().value;
-                    return &_signal;
-                }
-                return nullptr;
-            };
-
             if(!_signal_less_batch)
             {
-                // No barrier packet: borrow a pooled signal if needed, then bump value by 1.
-                if(!existing_completion_signal)
-                    _packet_data.pooled_signal = create_signal(&completion_signal);
-
-                get_core_table()->hsa_signal_add_scacq_screl_fn(completion_signal, 1);
-
-                // set the completion signal to the kernel packet
-                _packet_data.completion_signal = completion_signal;
+                // No barrier packet: borrow a pooled signal if needed, bump by 1, record it.
+                apply_signal_path(_packet_data, is_ext_kernel_dispatch);
             }
 
             // computes the "size" based on the offset of reserved_padding field
@@ -973,7 +1046,10 @@ write_interceptor(Queue*                                queue,
             // along with an ID of the client we got the packet from (this will be returned via
             // completed_cb_t)
 
-            // emplace the kernel packet
+            // emplace the kernel packet; record its submitted index (and ext-ness) so
+            // the D7 fallback can write a replayed signal into the right submitted slot.
+            _dispatch_pkt_index.push_back(
+                dispatch_pkt_ref{transformed_packets.size(), is_ext_kernel_dispatch});
             transformed_packets.emplace_back(kernel_packet);
 
             ROCP_FATAL_IF(!is_kernel_dispatch && !is_ext_kernel_dispatch)
@@ -998,30 +1074,59 @@ write_interceptor(Queue*                                queue,
 
         // Register the whole batch BEFORE the writer publishes any packet, so a
         // firmware record can never arrive for a dispatch the hub has not seen.
+        // Cap-evicted closed-window entries leave via _evicted, released here AFTER
+        // m_mu is dropped (the hub's no-destroy-under-lock contract).
         const auto _signal_less_count = _signal_less_regs.size();
+        auto       _evicted           = std::vector<kfd::signal_less_hub_t::leaked>{};
         if(_signal_less_batch &&
-           !kfd::signal_less_hub().register_batch(std::move(_signal_less_regs)))
+           !kfd::signal_less_hub().register_batch(std::move(_signal_less_regs), _evicted))
         {
-            // Reachable only if another queue's collision quarantined this slot between
-            // eligibility and here. The packets already skipped their signals, so nothing
-            // else will retire these ids.
+            // D7: reachable on a slot quarantined between eligibility and here, or the
+            // per-GPU cap exceeded with no eligible victim (D9). The batch skipped its
+            // signal instrumentation, so replay exactly the !_signal_less_batch signal
+            // path per dispatch and fall through to the normal signal-path completion.
+            // No id retirement here: register_batch did not consume _signal_less_regs on
+            // refusal, its payload correlation_id* is non-owning, and the signal path's
+            // completion handler performs the matching releases -- retiring here would
+            // double-release. Telemetry only.
             kfd::note_signal_less(kfd::signal_less_counter::register_refused, _signal_less_count);
-            // Safe to iterate after the std::move above: register_batch() validates the
-            // whole batch under its lock and returns false BEFORE moving any element, so
-            // on this refusal path _signal_less_regs is intact.
-            for(auto& _reg : _signal_less_regs)
+            for(size_t k = 0; k < _info_session.packet_data.size(); ++k)
             {
-                auto* _corr_id = _reg.payload.correlation_id;
-                if(_corr_id == nullptr) continue;
-                _corr_id->sub_kern_count();
-                _corr_id->sub_ref_count();
+                auto&      _pd  = _info_session.packet_data[k];
+                const auto _sig = apply_signal_path(_pd, _dispatch_pkt_index[k].is_ext);
+                // Mirror the replayed signal into the SUBMITTED packet, whose index in
+                // transformed_packets differs from k (pass-through/barrier packets).
+                auto& _tp = transformed_packets[_dispatch_pkt_index[k].transformed_index];
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+                if(_dispatch_pkt_index[k].is_ext)
+                    _tp.ext_kernel_dispatch.completion_signal = _sig;
+                else
+                    _tp.kernel_dispatch.completion_signal = _sig;
+#else
+                _tp.kernel_dispatch.completion_signal = _sig;
+#endif
             }
-            ROCP_WARNING << "KFD dispatch-log: signal-less batch registration refused; these "
-                            "dispatches will not be timed";
+            // Clear BEFORE the post-loop block so it builds the async waiter unchanged.
+            _signal_less_batch = false;
+            ROCP_WARNING << "KFD dispatch-log: signal-less batch registration refused; falling "
+                            "back to the signal path for these dispatches";
         }
         else if(_signal_less_batch)
         {
             kfd::note_signal_less(kfd::signal_less_counter::entry_registered, _signal_less_count);
+        }
+
+        // Cap eviction is loud accepted coverage loss: count it, warn (rate-limited by
+        // the census cadence), and latch losses (INV-L1) before any finalize can see
+        // the ledgered ids. Off-lock; _evicted's payloads release at scope end.
+        if(!_evicted.empty())
+        {
+            kfd::note_signal_less(kfd::signal_less_counter::cap_evicted, _evicted.size());
+            kfd::note_signal_less_losses();
+            ROCP_WARNING << fmt::format(
+                "KFD dispatch-log: per-GPU hub cap evicted {} closed-window entry(ies); those "
+                "dispatches emit no record",
+                _evicted.size());
         }
 
         // A signal-less batch has no completion signal to wait on.
@@ -1058,7 +1163,10 @@ write_interceptor(Queue*                                queue,
             if(deferred_async_tasks)
                 deferred_async_tasks->emplace_back(std::move(_task));
             else
-                get_async_signal_handler()->async(std::move(_task));
+                // Signal path: refuse_during_fini=false. This task owns the
+                // queue_info_session and performs its correlation-id releases, so
+                // refusing during fini would strand those ids -- behaviour unchanged.
+                submit_inline_async(std::move(_task), /*refuse_during_fini=*/false);
         }
     };
 
@@ -1072,23 +1180,24 @@ write_interceptor(Queue*                                queue,
 }
 }  // namespace
 
+// Precondition (F1): caller holds state.drain_mu. gate_lock still orders the
+// admission_closed store against the publishing critical sections.
 uint64_t
-close_admission_and_snapshot(const hsa_queue_t* queue)
+close_admission_and_snapshot_locked(QueueState& state)
 {
-    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
-    if(!state) return 0;
-    auto lk                 = std::lock_guard<std::mutex>{state->gate_lock};
-    state->admission_closed = true;  // SW-2: no later batch can register
-    return state->next_submit_pos;   // snapshot, ordered by this same lock
+    auto lk                = std::lock_guard<std::mutex>{state.gate_lock};
+    state.admission_closed = true;  // SW-2: no later batch can register
+    return state.next_submit_pos;   // snapshot, ordered by this same lock
 }
 
+// Precondition (F1): caller holds state.drain_mu, so real_rdid (which points into
+// the runtime's amd_queue_t) cannot be freed by a concurrent destroy under the load.
 bool
-wait_queue_hw_drained(const hsa_queue_t* queue, uint64_t submit_pos, uint64_t deadline_ns)
+wait_queue_hw_drained_locked(QueueState& state, uint64_t submit_pos, uint64_t deadline_ns)
 {
-    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
-    if(!state || !state->real_rdid) return true;
+    if(!state.real_rdid) return true;
 
-    while(!hw_queue_drained(__atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE), submit_pos))
+    while(!hw_queue_drained(__atomic_load_n(state.real_rdid, __ATOMIC_ACQUIRE), submit_pos))
     {
         if(kfd::steady_now_ns() >= deadline_ns) return false;
         std::this_thread::sleep_for(std::chrono::microseconds{200});
@@ -1111,6 +1220,29 @@ fence_all_queue_gates()
     for(const auto& _state : _states)
     {
         auto lk = std::lock_guard<std::mutex>{_state->gate_lock};
+    }
+}
+
+void
+drain_all_queues_hw(uint64_t deadline_ns)
+{
+    // F1 teardown drain, race-free against concurrent hsa_queue_destroy. Snapshot
+    // the states under the registry lock, release it, then per state take drain_mu
+    // and skip any queue destroy already invalidated (rdid_valid==false) -- that
+    // queue ran its own drain. Lock order: registry lock -> (released) -> drain_mu.
+    auto _states = std::vector<queue_state_ptr_t>{};
+    get_queue_registry().rlock([&_states](const auto& map) {
+        _states.reserve(map.size());
+        for(const auto& itr : map)
+            if(itr.second) _states.emplace_back(itr.second);
+    });
+
+    for(const auto& _state : _states)
+    {
+        auto _lk = std::unique_lock<std::mutex>{_state->drain_mu};
+        if(!_state->rdid_valid) continue;  // destroyed under the same lock; skip
+        const uint64_t _P = close_admission_and_snapshot_locked(*_state);
+        wait_queue_hw_drained_locked(*_state, _P, deadline_ns);
     }
 }
 
@@ -1260,7 +1392,7 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     lock.unlock();
 
     for(auto& itr : deferred_async_tasks)
-        get_async_signal_handler()->async(std::move(itr));
+        submit_inline_async(std::move(itr), /*refuse_during_fini=*/false);
 }
 
 std::shared_ptr<QueueState>
@@ -1298,8 +1430,19 @@ create_queue_state(const hsa_queue_t* queue, bool overwrite)
     state->virtual_wptr.store(current_wdid, std::memory_order_relaxed);
     state->next_scan_pos   = current_wdid;
     state->next_submit_pos = current_wdid;
+    // Close the interlock's init end: set AFTER real_rdid, BEFORE publication, so no
+    // observer reaches a state with rdid_valid true but real_rdid null. The wlock
+    // release below orders this plain-bool write for every reader.
+    state->rdid_valid = true;
 
+    // Get-or-create UNDER the final wlock: the pre-check above is a separate rlock, so
+    // two concurrent dynamic-discovery lookups of the same queue could both miss and
+    // both publish, splitting D8's drain_mu across two live states (real_rdid UAF).
+    // Re-checking here keeps exactly one live QueueState per queue; a loser discards
+    // its just-built state harmlessly (refcount drops).
     return get_queue_registry().wlock([&](auto& map) {
+        auto it = map.find(queue);
+        if(it != map.end() && it->second) return it->second;
         map[queue] = state;
         return state;
     });
@@ -1486,14 +1629,27 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
 void
 interposition_sync()
 {
-    if(async_signal_handler_exists())  // query without constructing
+    // FIRST, before the gate: an inherited g_handler_gate held by a vanished parent
+    // thread is unacquirable, so a staleness check placed after it never runs. A
+    // fork child owns no inline workers, so there is nothing to join.
+    if(internal_threading::fork_stale()) return;
+
+    // Take the gate EXCLUSIVE to wait out every submitter already inside
+    // submit_inline_async(), then read the constructed flag: it is now either true
+    // with a fully constructed pool or false with provably no submitter in flight,
+    // closing the flag-alone ordering gap. Release BEFORE join(): joining under the
+    // exclusive lock would block every submitter for the join, which runs tasks
+    // that may re-enter. Precondition: callers have already closed their submission
+    // source (fini latch / D5 neutralization) or a later submitter escapes this.
+    bool _constructed = false;
     {
-        constexpr auto async_only = true;
-        if(auto* tg = get_async_signal_handler(); tg)
-        {
-            tg->join(async_only);
-        }
+        auto _g      = std::unique_lock<std::shared_mutex>{g_handler_gate};
+        _constructed = async_signal_handler_exists();
     }
+    if(!_constructed) return;
+
+    constexpr auto async_only = true;
+    if(auto* tg = get_async_signal_handler(); tg) tg->join(async_only);
 }
 
 void
@@ -1589,6 +1745,12 @@ void
 drain_signal_less_interceptor()
 {
     hsa::queue_interposition::fence_all_queue_gates();
+}
+
+void
+drain_signal_less_queues_hw(uint64_t deadline_ns)
+{
+    hsa::queue_interposition::drain_all_queues_hw(deadline_ns);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -63,6 +63,9 @@
 #include <array>
 #include <atomic>
 #include <cstring>
+#include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -75,6 +78,18 @@ namespace queue_interposition
 namespace
 {
 auto s_active_queue_interposition_consumers = std::atomic<uint32_t>{0};
+
+// Makes the inline pool's construct-and-submit region mutually exclusive with
+// interposition_sync()'s join. Submitters hold it SHARED; the sync takes it
+// EXCLUSIVE, so a submitter mid-construction cannot slip a task past a sync that
+// already read "not constructed". A leaf lock: it nests inside g_submit_gate
+// (shared) on the hand_off_proven() path, never the reverse.
+std::shared_mutex g_handler_gate;
+
+// Set with release right after the inline pool's static initializer completes, so
+// interposition_sync() can tell "constructed, must join" from "never constructed"
+// without itself constructing the pool. Acquire-loaded by the exists-check.
+std::atomic<bool> g_async_handler_constructed{false};
 
 // NOTE:
 //  - "installed" is for checking whether HSA functions have been passed
@@ -137,7 +152,14 @@ lookup_queue_state(const hsa_queue_t* queue, bool create_if_missing)
     // if create_if_missing is true, create a new state. this is for dynamic discovery of queues.
     if(!_state && create_if_missing)
     {
-        return create_queue_state(queue, true);
+        auto _created = create_queue_state(queue, true);
+        // F29: a queue discovered dynamically (never seen at hsa_queue_create) was
+        // never windowed, so first_owner can no longer be trusted anywhere -- the
+        // documented "owner we never windowed" invariant. Disable signal-less
+        // process-wide. Called with no hub/registry lock held (create returned).
+        if(_created && kfd::signal_less_feature_enabled() && !kfd::signal_less_child_stale())
+            kfd::signal_less_disable_permanently();
+        return _created;
     }
 
     return _state;
@@ -307,10 +329,13 @@ ring_buffer_writer(const void* pkts, uint64_t pkt_count)
     }
 }
 
-auto
+bool
 async_signal_handler_exists()
 {
-    return common::static_object<internal_threading::task_group_t>::get();
+    // Acquire pairs with the release store in get_async_signal_handler(): a true
+    // read means the pool is fully constructed. Never reads the raw m_object
+    // pointer, which a concurrent constructor may be publishing (TSan race).
+    return g_async_handler_constructed.load(std::memory_order_acquire);
 }
 }  // namespace
 
@@ -354,7 +379,36 @@ get_async_signal_handler()
             static_cast<create_task_group_fn_t>(&internal_threading::create_task_group),
             get_async_signal_handler_thread_count());
 
+    // Release-store unconditionally on every call, AFTER the static initializer:
+    // the constructing thread's store is ordered after the constructor, and any
+    // other thread reached here only by acquiring the same static guard, so it
+    // carries the construction in its happens-before chain too. Must NOT go in
+    // construct_via_function's call_once, which runs before the object exists.
+    g_async_handler_constructed.store(true, std::memory_order_release);
+
     return _v;
+}
+
+// The ONLY caller of get_async_signal_handler()->async(). Makes the
+// construct-and-submit region mutually exclusive with interposition_sync() so a
+// task can never be queued on a pool the sync already decided not to join.
+// Consumes `task` only on the path that returns true: every false return happens
+// before the std::move, so a rejected task is destroyed intact by the caller.
+bool
+submit_inline_async(std::function<void()>&& task, bool refuse_during_fini)
+{
+    // 1. FIRST, before any lock: a child forked while a vanished parent thread
+    // held g_handler_gate can never acquire it, so testing staleness after taking
+    // the gate would deadlock the child instead of letting it defer/skip.
+    if(internal_threading::fork_stale()) return false;
+    // 2. construct+submit region, shared so concurrent submitters proceed together.
+    auto _g = std::shared_lock<std::shared_mutex>{g_handler_gate};
+    // 3. Inside the region: a submitter that read fini==0 then blocked on the gate
+    // must still be refused, or it would submit after the exclusive sync section.
+    if(refuse_during_fini && registration::get_fini_status() != 0) return false;
+    // 4. Constructs the pool on first real use (correct for signal-less work).
+    get_async_signal_handler()->async(std::move(task));
+    return true;
 }
 
 bool
@@ -536,7 +590,7 @@ complete_signal_less_dispatch(kfd::signal_less_hub_t::proven&& proven)
             "KFD dispatch-log: no timing for dispatch (reason={}, gpu={} slot={} idx={})",
             kfd::finalize_reason_name(_detail.reason),
             proven.key.gpu_id,
-            proven.key.doorbell_off,
+            proven.key.doorbell_slot,
             proven.key.dispatch_idx_low32);
     }
 }
@@ -544,13 +598,18 @@ complete_signal_less_dispatch(kfd::signal_less_hub_t::proven&& proven)
 bool
 submit_to_task_group(kfd::signal_less_hub_t::proven& proven)
 {
-    auto* _tg = get_async_signal_handler();
-    if(!_tg || registration::get_fini_status() != 0) return false;
-
-    // task_group_t::async takes a std::function, which must be copy-constructible;
-    // the payload is move-only, so it travels in a shared_ptr.
+    // task_group_t::async takes a copy-constructible std::function but the payload
+    // is move-only, so it travels in a shared_ptr the wrapper keeps. On refusal
+    // (fork-stale or fini) the primitive returns before consuming the task, so the
+    // payload is restored intact and the caller defers it -- packaging it after a
+    // refusable call would strand a moved-from payload and never retire its id.
     auto _held = std::make_shared<kfd::signal_less_hub_t::proven>(std::move(proven));
-    _tg->async([_held]() { complete_signal_less_dispatch(std::move(*_held)); });
+    if(!submit_inline_async([_held]() { complete_signal_less_dispatch(std::move(*_held)); },
+                            /*refuse_during_fini=*/true))
+    {
+        proven = std::move(*_held);
+        return false;
+    }
     return true;
 }
 
@@ -767,13 +826,58 @@ write_interceptor(Queue*                                queue,
         // packets in a batch share one queue, hence one owner_window.
         auto            _signal_less_keys   = std::vector<std::optional<kfd::correlation_key>>{};
         kfd::window_ptr _signal_less_window = {};
-        const bool      _signal_less_batch  = signal_less_batch_eligible(queue,
-                                                                   _packets,
-                                                                   _num_packets,
-                                                                   _base_pkt_index,
-                                                                   &_signal_less_keys,
-                                                                   &_signal_less_window);
+        // Non-const: D7 clears it on the register_batch refusal path so the post-loop
+        // signal-path block runs and builds the async waiter for the fallback.
+        bool            _signal_less_batch  = signal_less_batch_eligible(queue,
+                                                                  _packets,
+                                                                  _num_packets,
+                                                                  _base_pkt_index,
+                                                                  &_signal_less_keys,
+                                                                  &_signal_less_window);
         auto            _signal_less_regs   = std::vector<kfd::signal_less_hub_t::registration>{};
+
+        // Parallel to _info_session.packet_data: for each dispatch packet, the index
+        // in transformed_packets of its SUBMITTED packet plus whether it is the ext
+        // form. transformed_packets also holds pass-through and barrier/interrupt
+        // packets, so packet_data[k] != transformed_packets[k]; the D7 fallback needs
+        // both to write the replayed signal into the right submitted packet field.
+        struct dispatch_pkt_ref
+        {
+            size_t transformed_index = 0;
+            bool   is_ext            = false;
+        };
+        auto            _dispatch_pkt_index = std::vector<dispatch_pkt_ref>{};
+
+        auto create_signal = [](auto* signal) -> common::container::pool_object<signal_t>* {
+            if(auto* pool = get_signal_pool(); pool && signal->handle == 0)
+            {
+                auto& _signal = pool->acquire(construct_hsa_signal, 0, 0, nullptr, 0);
+                ROCP_FATAL_IF(!_signal.in_use()) << "Acquired signal from pool that is not in use";
+                ROCP_FATAL_IF(_signal.get().value == null_signal)
+                    << "Acquired signal from pool that has invalid handle";
+                *CHECK_NOTNULL(signal) = _signal.get().value;
+                return &_signal;
+            }
+            return nullptr;
+        };
+
+        // The three signal-path steps, factored so the normal !_signal_less_batch
+        // branch and the D7 refusal fallback cannot drift: borrow a pooled signal if
+        // the app supplied none, bump its value by 1, and record it on the packet.
+        // Returns the completion signal written into pd.kernel_packet.
+        auto apply_signal_path = [&create_signal](packet_data_t& pd, bool is_ext) -> hsa_signal_t {
+            (void) is_ext;
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+            auto& _cs = is_ext ? pd.kernel_packet.ext_kernel_dispatch.completion_signal
+                               : pd.kernel_packet.kernel_dispatch.completion_signal;
+#else
+            auto& _cs = pd.kernel_packet.kernel_dispatch.completion_signal;
+#endif
+            if(_cs == null_signal) pd.pooled_signal = create_signal(&_cs);
+            get_core_table()->hsa_signal_add_scacq_screl_fn(_cs, 1);
+            pd.completion_signal = _cs;
+            return _cs;
+        };
 
         // Searching across all the packets given during this write
         for(size_t i = 0; i < _num_packets; ++i)
@@ -861,48 +965,17 @@ write_interceptor(Queue*                                queue,
             };
 
             const auto     pkt_info = extract_packet_info(_packets[i], is_ext_kernel_dispatch);
-            const auto     original_completion_signal = pkt_info.completion_signal;
             const uint64_t kernel_id = code_object::get_kernel_id(pkt_info.kernel_object);
-            const auto     existing_completion_signal = (original_completion_signal != null_signal);
 
             // Copy kernel pkt, copy is to allow for signal to be modified
             _packet_data.kernel_packet = _packets[i];
             // create a reference for short hand access
             auto& kernel_packet = _packet_data.kernel_packet;
 
-#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
-            auto& completion_signal =
-                is_ext_kernel_dispatch
-                    ? _packet_data.kernel_packet.ext_kernel_dispatch.completion_signal
-                    : _packet_data.kernel_packet.kernel_dispatch.completion_signal;
-#else
-            auto& completion_signal = _packet_data.kernel_packet.kernel_dispatch.completion_signal;
-#endif
-
-            auto create_signal = [](auto* signal) -> common::container::pool_object<signal_t>* {
-                if(auto* pool = get_signal_pool(); pool && signal->handle == 0)
-                {
-                    auto& _signal = pool->acquire(construct_hsa_signal, 0, 0, nullptr, 0);
-                    ROCP_FATAL_IF(!_signal.in_use())
-                        << "Acquired signal from pool that is not in use";
-                    ROCP_FATAL_IF(_signal.get().value == null_signal)
-                        << "Acquired signal from pool that has invalid handle";
-                    *CHECK_NOTNULL(signal) = _signal.get().value;
-                    return &_signal;
-                }
-                return nullptr;
-            };
-
             if(!_signal_less_batch)
             {
-                // No barrier packet: borrow a pooled signal if needed, then bump value by 1.
-                if(!existing_completion_signal)
-                    _packet_data.pooled_signal = create_signal(&completion_signal);
-
-                get_core_table()->hsa_signal_add_scacq_screl_fn(completion_signal, 1);
-
-                // set the completion signal to the kernel packet
-                _packet_data.completion_signal = completion_signal;
+                // No barrier packet: borrow a pooled signal if needed, bump by 1, record it.
+                apply_signal_path(_packet_data, is_ext_kernel_dispatch);
             }
 
             // computes the "size" based on the offset of reserved_padding field
@@ -973,7 +1046,10 @@ write_interceptor(Queue*                                queue,
             // along with an ID of the client we got the packet from (this will be returned via
             // completed_cb_t)
 
-            // emplace the kernel packet
+            // emplace the kernel packet; record its submitted index (and ext-ness) so
+            // the D7 fallback can write a replayed signal into the right submitted slot.
+            _dispatch_pkt_index.push_back(
+                dispatch_pkt_ref{transformed_packets.size(), is_ext_kernel_dispatch});
             transformed_packets.emplace_back(kernel_packet);
 
             ROCP_FATAL_IF(!is_kernel_dispatch && !is_ext_kernel_dispatch)
@@ -998,30 +1074,59 @@ write_interceptor(Queue*                                queue,
 
         // Register the whole batch BEFORE the writer publishes any packet, so a
         // firmware record can never arrive for a dispatch the hub has not seen.
+        // Cap-evicted closed-window entries leave via _evicted, released here AFTER
+        // m_mu is dropped (the hub's no-destroy-under-lock contract).
         const auto _signal_less_count = _signal_less_regs.size();
+        auto       _evicted           = std::vector<kfd::signal_less_hub_t::leaked>{};
         if(_signal_less_batch &&
-           !kfd::signal_less_hub().register_batch(std::move(_signal_less_regs)))
+           !kfd::signal_less_hub().register_batch(std::move(_signal_less_regs), _evicted))
         {
-            // Reachable only if another queue's collision quarantined this slot between
-            // eligibility and here. The packets already skipped their signals, so nothing
-            // else will retire these ids.
+            // D7: reachable on a slot quarantined between eligibility and here, or the
+            // per-GPU cap exceeded with no eligible victim (D9). The batch skipped its
+            // signal instrumentation, so replay exactly the !_signal_less_batch signal
+            // path per dispatch and fall through to the normal signal-path completion.
+            // No id retirement here: register_batch did not consume _signal_less_regs on
+            // refusal, its payload correlation_id* is non-owning, and the signal path's
+            // completion handler performs the matching releases -- retiring here would
+            // double-release. Telemetry only.
             kfd::note_signal_less(kfd::signal_less_counter::register_refused, _signal_less_count);
-            // Safe to iterate after the std::move above: register_batch() validates the
-            // whole batch under its lock and returns false BEFORE moving any element, so
-            // on this refusal path _signal_less_regs is intact.
-            for(auto& _reg : _signal_less_regs)
+            for(size_t k = 0; k < _info_session.packet_data.size(); ++k)
             {
-                auto* _corr_id = _reg.payload.correlation_id;
-                if(_corr_id == nullptr) continue;
-                _corr_id->sub_kern_count();
-                _corr_id->sub_ref_count();
+                auto&      _pd  = _info_session.packet_data[k];
+                const auto _sig = apply_signal_path(_pd, _dispatch_pkt_index[k].is_ext);
+                // Mirror the replayed signal into the SUBMITTED packet, whose index in
+                // transformed_packets differs from k (pass-through/barrier packets).
+                auto& _tp = transformed_packets[_dispatch_pkt_index[k].transformed_index];
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+                if(_dispatch_pkt_index[k].is_ext)
+                    _tp.ext_kernel_dispatch.completion_signal = _sig;
+                else
+                    _tp.kernel_dispatch.completion_signal = _sig;
+#else
+                _tp.kernel_dispatch.completion_signal = _sig;
+#endif
             }
-            ROCP_WARNING << "KFD dispatch-log: signal-less batch registration refused; these "
-                            "dispatches will not be timed";
+            // Clear BEFORE the post-loop block so it builds the async waiter unchanged.
+            _signal_less_batch = false;
+            ROCP_WARNING << "KFD dispatch-log: signal-less batch registration refused; falling "
+                            "back to the signal path for these dispatches";
         }
         else if(_signal_less_batch)
         {
             kfd::note_signal_less(kfd::signal_less_counter::entry_registered, _signal_less_count);
+        }
+
+        // Cap eviction is loud accepted coverage loss: count it, warn (rate-limited by
+        // the census cadence), and latch losses (INV-L1) before any finalize can see
+        // the ledgered ids. Off-lock; _evicted's payloads release at scope end.
+        if(!_evicted.empty())
+        {
+            kfd::note_signal_less(kfd::signal_less_counter::cap_evicted, _evicted.size());
+            kfd::note_signal_less_losses();
+            ROCP_WARNING << fmt::format(
+                "KFD dispatch-log: per-GPU hub cap evicted {} closed-window entry(ies); those "
+                "dispatches emit no record",
+                _evicted.size());
         }
 
         // A signal-less batch has no completion signal to wait on.
@@ -1058,7 +1163,10 @@ write_interceptor(Queue*                                queue,
             if(deferred_async_tasks)
                 deferred_async_tasks->emplace_back(std::move(_task));
             else
-                get_async_signal_handler()->async(std::move(_task));
+                // Signal path: refuse_during_fini=false. This task owns the
+                // queue_info_session and performs its correlation-id releases, so
+                // refusing during fini would strand those ids -- behaviour unchanged.
+                submit_inline_async(std::move(_task), /*refuse_during_fini=*/false);
         }
     };
 
@@ -1072,23 +1180,24 @@ write_interceptor(Queue*                                queue,
 }
 }  // namespace
 
+// Precondition (F1): caller holds state.drain_mu. gate_lock still orders the
+// admission_closed store against the publishing critical sections.
 uint64_t
-close_admission_and_snapshot(const hsa_queue_t* queue)
+close_admission_and_snapshot_locked(QueueState& state)
 {
-    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
-    if(!state) return 0;
-    auto lk                 = std::lock_guard<std::mutex>{state->gate_lock};
-    state->admission_closed = true;  // SW-2: no later batch can register
-    return state->next_submit_pos;   // snapshot, ordered by this same lock
+    auto lk                = std::lock_guard<std::mutex>{state.gate_lock};
+    state.admission_closed = true;   // SW-2: no later batch can register
+    return state.next_submit_pos;    // snapshot, ordered by this same lock
 }
 
+// Precondition (F1): caller holds state.drain_mu, so real_rdid (which points into
+// the runtime's amd_queue_t) cannot be freed by a concurrent destroy under the load.
 bool
-wait_queue_hw_drained(const hsa_queue_t* queue, uint64_t submit_pos, uint64_t deadline_ns)
+wait_queue_hw_drained_locked(QueueState& state, uint64_t submit_pos, uint64_t deadline_ns)
 {
-    auto state = lookup_queue_state(queue, /*create_if_missing=*/false);
-    if(!state || !state->real_rdid) return true;
+    if(!state.real_rdid) return true;
 
-    while(!hw_queue_drained(__atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE), submit_pos))
+    while(!hw_queue_drained(__atomic_load_n(state.real_rdid, __ATOMIC_ACQUIRE), submit_pos))
     {
         if(kfd::steady_now_ns() >= deadline_ns) return false;
         std::this_thread::sleep_for(std::chrono::microseconds{200});
@@ -1111,6 +1220,29 @@ fence_all_queue_gates()
     for(const auto& _state : _states)
     {
         auto lk = std::lock_guard<std::mutex>{_state->gate_lock};
+    }
+}
+
+void
+drain_all_queues_hw(uint64_t deadline_ns)
+{
+    // F1 teardown drain, race-free against concurrent hsa_queue_destroy. Snapshot
+    // the states under the registry lock, release it, then per state take drain_mu
+    // and skip any queue destroy already invalidated (rdid_valid==false) -- that
+    // queue ran its own drain. Lock order: registry lock -> (released) -> drain_mu.
+    auto _states = std::vector<queue_state_ptr_t>{};
+    get_queue_registry().rlock([&_states](const auto& map) {
+        _states.reserve(map.size());
+        for(const auto& itr : map)
+            if(itr.second) _states.emplace_back(itr.second);
+    });
+
+    for(const auto& _state : _states)
+    {
+        auto _lk = std::unique_lock<std::mutex>{_state->drain_mu};
+        if(!_state->rdid_valid) continue;  // destroyed under the same lock; skip
+        const uint64_t _P = close_admission_and_snapshot_locked(*_state);
+        wait_queue_hw_drained_locked(*_state, _P, deadline_ns);
     }
 }
 
@@ -1260,7 +1392,7 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     lock.unlock();
 
     for(auto& itr : deferred_async_tasks)
-        get_async_signal_handler()->async(std::move(itr));
+        submit_inline_async(std::move(itr), /*refuse_during_fini=*/false);
 }
 
 std::shared_ptr<QueueState>
@@ -1298,8 +1430,19 @@ create_queue_state(const hsa_queue_t* queue, bool overwrite)
     state->virtual_wptr.store(current_wdid, std::memory_order_relaxed);
     state->next_scan_pos   = current_wdid;
     state->next_submit_pos = current_wdid;
+    // Close the interlock's init end: set AFTER real_rdid, BEFORE publication, so no
+    // observer reaches a state with rdid_valid true but real_rdid null. The wlock
+    // release below orders this plain-bool write for every reader.
+    state->rdid_valid = true;
 
+    // Get-or-create UNDER the final wlock: the pre-check above is a separate rlock, so
+    // two concurrent dynamic-discovery lookups of the same queue could both miss and
+    // both publish, splitting D8's drain_mu across two live states (real_rdid UAF).
+    // Re-checking here keeps exactly one live QueueState per queue; a loser discards
+    // its just-built state harmlessly (refcount drops).
     return get_queue_registry().wlock([&](auto& map) {
+        auto it = map.find(queue);
+        if(it != map.end() && it->second) return it->second;
         map[queue] = state;
         return state;
     });
@@ -1486,14 +1629,27 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
 void
 interposition_sync()
 {
-    if(async_signal_handler_exists())  // query without constructing
+    // FIRST, before the gate: an inherited g_handler_gate held by a vanished parent
+    // thread is unacquirable, so a staleness check placed after it never runs. A
+    // fork child owns no inline workers, so there is nothing to join.
+    if(internal_threading::fork_stale()) return;
+
+    // Take the gate EXCLUSIVE to wait out every submitter already inside
+    // submit_inline_async(), then read the constructed flag: it is now either true
+    // with a fully constructed pool or false with provably no submitter in flight,
+    // closing the flag-alone ordering gap. Release BEFORE join(): joining under the
+    // exclusive lock would block every submitter for the join, which runs tasks
+    // that may re-enter. Precondition: callers have already closed their submission
+    // source (fini latch / D5 neutralization) or a later submitter escapes this.
+    bool _constructed = false;
     {
-        constexpr auto async_only = true;
-        if(auto* tg = get_async_signal_handler(); tg)
-        {
-            tg->join(async_only);
-        }
+        auto _g      = std::unique_lock<std::shared_mutex>{g_handler_gate};
+        _constructed = async_signal_handler_exists();
     }
+    if(!_constructed) return;
+
+    constexpr auto async_only = true;
+    if(auto* tg = get_async_signal_handler(); tg) tg->join(async_only);
 }
 
 void
@@ -1589,6 +1745,12 @@ void
 drain_signal_less_interceptor()
 {
     hsa::queue_interposition::fence_all_queue_gates();
+}
+
+void
+drain_signal_less_queues_hw(uint64_t deadline_ns)
+{
+    hsa::queue_interposition::drain_all_queues_hw(deadline_ns);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -71,10 +71,19 @@ struct QueueState
     std::mutex         gate_lock       = {};       ///< Lock for packet submission gating
 
     /// Signal-less admission latch (§1.5.4). Plain bool, guarded by gate_lock: set
-    /// by the destroy path's close_admission_and_snapshot() so no later batch can
+    /// by the destroy path's close_admission_and_snapshot_locked() so no later batch can
     /// register against this queue's window, read in signal_less_batch_eligible()
     /// which already holds gate_lock. Never an atomic -- one lock orders both.
     bool admission_closed = false;
+
+    /// F1 lifetime interlock. drain_mu is held by whoever dereferences real_rdid for
+    /// a bounded HW drain; destroy_queue() holds it across its whole sequence and
+    /// clears rdid_valid+real_rdid under it BEFORE the runtime queue can be freed, so
+    /// finalization's "skip if it disappeared" test (rdid_valid) is race-free. Leaf:
+    /// acquired only at the TOP of the two drain sequences, never under gate_lock /
+    /// doorbell map / hub / owner registry / the queue registry lock.
+    std::mutex drain_mu   = {};
+    bool       rdid_valid = false;  // guarded by drain_mu; set true at publication
 };
 
 using queue_state_ptr_t = std::shared_ptr<QueueState>;
@@ -223,6 +232,12 @@ destroy_queue_state(const hsa_queue_t* queue);
 void
 fence_all_queue_gates();
 
+// F1 teardown HW drain across every live queue, race-free against a concurrent
+// hsa_queue_destroy (the drain_mu/rdid_valid interlock). One shared absolute
+// deadline. Caller holds no hub, registry, gate, or drain lock.
+void
+drain_all_queues_hw(uint64_t deadline_ns);
+
 /// The hardware queue has consumed every packet we submitted. The inline path's
 /// analogue of `_active_kernels == 0`, which only the legacy path maintains.
 inline bool
@@ -236,18 +251,22 @@ hw_queue_drained(uint64_t real_rdid, uint64_t next_submit_pos)
 // register against this queue's window) AND read next_submit_pos, ordered by the
 // same lock that serialises every publishing critical section. Returns that
 // snapshot P. No separate fence and no atomic are needed.
+//
+// _locked: the caller holds state.drain_mu (F1). State-based, not pointer-based, so
+// no relookup races the queue's destruction. The pointer-taking overloads are gone.
 uint64_t
-close_admission_and_snapshot(const hsa_queue_t* queue);
+close_admission_and_snapshot_locked(QueueState& state);
 
 /// Wait, bounded by an absolute kfd::steady_now_ns() deadline, until this queue's
 /// hardware read index has caught up with the sampled submit position `P`, so
 /// every packet in that snapshot -- hence every registered START -- has been
 /// consumed by the CP before the caller decides anything was lost (§1.3 Path 4).
 ///
-/// False on deadline; true immediately with no state or when P is already drained.
-/// Takes no lock: P was snapshotted under gate_lock by close_admission_and_snapshot.
+/// False on deadline; true immediately when real_rdid is null or P is already
+/// drained. _locked: the caller holds state.drain_mu, so real_rdid cannot be freed
+/// under the load (F1). State-based; the pointer-taking overload is gone.
 bool
-wait_queue_hw_drained(const hsa_queue_t* queue, uint64_t submit_pos, uint64_t deadline_ns);
+wait_queue_hw_drained_locked(QueueState& state, uint64_t submit_pos, uint64_t deadline_ns);
 
 /**
  * @brief Check if queue interposition has been installed

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
@@ -48,6 +48,20 @@ namespace rocprofiler
 {
 namespace internal_threading
 {
+// Constant-initialised so no lazy init hides behind the atfork child handler,
+// which must be async-signal-safe (one atomic RMW, no lock/alloc/join).
+std::atomic<uint64_t> g_fork_generation{0};
+static_assert(std::atomic<uint64_t>::is_always_lock_free,
+              "g_fork_generation must be lock-free for async-signal-safe atfork bump");
+
+bool
+fork_stale()
+{
+    // Acquire pairs with the atfork child handler's release bump, so a stale
+    // stamp comparison and any post-fork inline-pool state are seen consistently.
+    return g_fork_generation.load(std::memory_order_acquire) != 0;
+}
+
 namespace
 {
 using task_group_vec_t     = common::container::stable_vector<task_group_t*>;
@@ -79,10 +93,15 @@ get_thread_pool_config(size_t pool_size = 1)
 TaskGroup::TaskGroup(size_t pool_size)
 : parent_type{new thread_pool_t{get_thread_pool_config(pool_size)}, false}
 , m_pool{parent_type::thread_pool()}
+, m_fork_generation{g_fork_generation.load(std::memory_order_acquire)}
 {}
 
 TaskGroup::~TaskGroup()
 {
+    // A pool stamped in an earlier generation was inherited across a fork: its
+    // worker threads do not exist in this child, so destroy_threadpool() would
+    // join threads that never ran. Leak m_pool deliberately rather than hang.
+    if(m_fork_generation != g_fork_generation.load(std::memory_order_acquire)) return;
     m_pool->destroy_threadpool();
     delete m_pool;
 }
@@ -251,6 +270,12 @@ get_task_groups()
 void
 create_forked_callback_threads()
 {
+    // Bump BEFORE any replacement TaskGroup is constructed, so child-created pools
+    // carry the new generation and destroy normally while inherited pools stay
+    // stale. First statement so no third atfork registration can reorder ahead of
+    // it. Release pairs with fork_stale()/the destructor guard's acquire.
+    g_fork_generation.fetch_add(1, std::memory_order_release);
+
     if(get_task_groups())
     {
         for(auto& itr : *get_task_groups())

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.hpp
@@ -31,6 +31,7 @@
 #include <PTL/TaskManager.hh>
 #include <PTL/ThreadPool.hh>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -69,9 +70,18 @@ private:
     std::deque<std::shared_ptr<task_type>> m_tasks           = {};
     std::deque<std::shared_ptr<task_type>> m_completed_tasks = {};
     std::atomic<bool>                      m_async_only      = true;
+    // Fork generation the pool was constructed in. ~TaskGroup() leaks m_pool
+    // rather than joining vanished workers when this is stale (see fork_stale).
+    uint64_t m_fork_generation = 0;
 };
 
 using task_group_t = TaskGroup;
+
+// True in a fork child: g_fork_generation != 0. The inline interposition pool
+// and its gate are never legitimately recreated in a child, so a nonzero
+// generation is conclusive (see D4/D6).
+bool
+fork_stale();
 
 void notify_pre_internal_thread_create(rocprofiler_runtime_library_t);
 void notify_post_internal_thread_create(rocprofiler_runtime_library_t);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/CMakeLists.txt
@@ -13,6 +13,7 @@ set(ROCPROFILER_LIB_KFD_EVENT_HEADERS
     stream_geometry.hpp
     correlation_types.hpp
     doorbell_map.hpp
+    env_parse.hpp
     kfd_correlation.hpp
     poll_reader.hpp
     kfd_profiler.hpp

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
@@ -56,7 +56,7 @@ steady_now_ns()
 // now representable (the hub's multimap) and resolved by window containment.
 struct correlation_key
 {
-    uint32_t doorbell_off       = 0;
+    uint32_t doorbell_slot      = 0;
     uint32_t dispatch_idx_low32 = 0;
     // Doorbell slots and dispatch indices are per-GPU and both restart from low
     // values, so without this a record from one GPU can match a dispatch on
@@ -65,7 +65,7 @@ struct correlation_key
 
     bool operator==(const correlation_key& rhs) const
     {
-        return doorbell_off == rhs.doorbell_off && dispatch_idx_low32 == rhs.dispatch_idx_low32 &&
+        return doorbell_slot == rhs.doorbell_slot && dispatch_idx_low32 == rhs.dispatch_idx_low32 &&
                gpu_id == rhs.gpu_id;
     }
 
@@ -98,7 +98,7 @@ struct correlation_key_hash
         auto mix = [](size_t seed, uint32_t value) {
             return seed ^ (std::hash<uint32_t>{}(value) + 0x9e3779b9UL + (seed << 6) + (seed >> 2));
         };
-        size_t seed = std::hash<uint32_t>{}(key.doorbell_off);
+        size_t seed = std::hash<uint32_t>{}(key.doorbell_slot);
         seed        = mix(seed, key.dispatch_idx_low32);
         seed        = mix(seed, key.gpu_id);
         return seed;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/correlation_types.hpp
@@ -56,7 +56,7 @@ steady_now_ns()
 // now representable (the hub's multimap) and resolved by window containment.
 struct correlation_key
 {
-    uint32_t doorbell_off       = 0;
+    uint32_t doorbell_slot      = 0;
     uint32_t dispatch_idx_low32 = 0;
     // Doorbell slots and dispatch indices are per-GPU and both restart from low
     // values, so without this a record from one GPU can match a dispatch on
@@ -65,8 +65,8 @@ struct correlation_key
 
     bool operator==(const correlation_key& rhs) const
     {
-        return doorbell_off == rhs.doorbell_off && dispatch_idx_low32 == rhs.dispatch_idx_low32 &&
-               gpu_id == rhs.gpu_id;
+        return doorbell_slot == rhs.doorbell_slot &&
+               dispatch_idx_low32 == rhs.dispatch_idx_low32 && gpu_id == rhs.gpu_id;
     }
 
     bool operator!=(const correlation_key& rhs) const { return !(*this == rhs); }
@@ -98,7 +98,7 @@ struct correlation_key_hash
         auto mix = [](size_t seed, uint32_t value) {
             return seed ^ (std::hash<uint32_t>{}(value) + 0x9e3779b9UL + (seed << 6) + (seed >> 2));
         };
-        size_t seed = std::hash<uint32_t>{}(key.doorbell_off);
+        size_t seed = std::hash<uint32_t>{}(key.doorbell_slot);
         seed        = mix(seed, key.dispatch_idx_low32);
         seed        = mix(seed, key.gpu_id);
         return seed;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
@@ -272,7 +272,9 @@ public:
     // (containment applied even for a sole candidate -- a stale pending entry could
     // be the sole candidate while the record's true owner is an unregistered later
     // dispatch on a colliding low-32 id). With no START (shape ii), accept only a
-    // sole candidate on a first_owner, non-superseded window. Otherwise drop.
+    // sole candidate on a first_owner, non-superseded window whose t_open the EOP
+    // postdates. Otherwise drop. EVERY acceptance test runs before the entry is
+    // taken, so a rejected record never consumes or retires anything.
     //
     // NO session-mode gate: an EOP arriving during the teardown drain still proves
     // its kernel finished. A key with no live entry is REJECTED, never cached.
@@ -318,6 +320,20 @@ public:
         const auto& w = first->second.window;
         if(!w || !w->first_owner) return std::nullopt;
         if(w->superseded.load(std::memory_order_acquire)) return std::nullopt;
+        // Terminal-time sanity, applied BEFORE take(): a kernel registered in this
+        // window cannot have ended at or before the window opened, so such an EOP
+        // belongs to an earlier dispatch on this raw key whose START was lost.
+        // Taking it would consume and retire a NEWER dispatch's entry against a
+        // foreign record -- the finalizer's staleness bound runs too late to undo
+        // that. Rejected here the entry stays PENDING for its own EOP. Same clock
+        // domain as the containment test above: raw agent GPU ticks, so no
+        // conversion and no host clock is involved. There is deliberately no upper
+        // bound: t_close bounds STARTs, not ends -- a kernel legitimately outlives
+        // its window -- and the hub holds no tick-domain `now` to bound the future
+        // with, so an implausibly-future EOP is still taken here and rejected by
+        // the finalizer's kMaxFutureNs test (a no-timing record, not a misattributed
+        // one).
+        if(end_ticks <= w->t_open) return std::nullopt;
         return take(first);
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
@@ -24,8 +24,11 @@
 
 #include "lib/rocprofiler-sdk/kfd/correlation_types.hpp"
 #include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <mutex>
@@ -82,6 +85,52 @@ struct loss_stats
     uint64_t correlation_ids = 0;
 };
 
+// Sole bound on hub growth for entries whose window never closes (gc_closed_windows
+// only reaps closed windows; F3's start_max_age_ns ages pending_starts, not the hub
+// -- the two are unrelated). Env ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU,
+// default 2000000, accepted range [1, 4194304], read once (F3 pattern). Reject-and-
+// default via D8's parse contract; the upper limit keeps cap far below SIZE_MAX so
+// the register_batch comparisons cannot be defeated by an absurd value.
+//
+// Sizing (empirically validated, not the original ~100 B "few MB" estimate): a
+// graph-launch burst workload (hipGraphLaunch, e.g. 1024-node graph x 1000 iters)
+// legitimately keeps hundreds of thousands of dispatches in flight relative to the
+// reader/processor retirement rate -- an order of magnitude above the old 65536
+// default, which refused 16-41% of dispatches and forced the slower signal path,
+// erasing most of the signal-less speedup. At ~100 B/entry the 2M default costs
+// ~190-200 MB per GPU at worst. Why not a "medium" cap: collect_cap_victims_locked
+// is an O(live-entries-for-that-GPU) scan+sort under the single hub mutex, so a cap
+// a realistic workload still exceeds is WORSE than a small cap (cheap scans) or a
+// large one (scans essentially never fire) -- a mid cap that trips constantly cost
+// +408% in the benchmark. Residual (accepted, not re-engineered here): a workload
+// whose genuine peak concurrency exceeds 2M, or a real EOP-loss leak growing
+// unboundedly toward the cap, still pays that eviction-scan cost; a proper fix needs
+// a per-GPU secondary index for eligible-victim lookup, out of scope for this fix.
+inline size_t
+hub_max_pending_per_gpu()
+{
+    static const size_t _v = []() -> size_t {
+        constexpr long _dflt = 2'000'000;
+        auto           _parsed =
+            env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU", 1, 4'194'304);
+        return static_cast<size_t>(_parsed.value_or(_dflt));
+    }();
+    return _v;
+}
+
+// Exact per-GPU cap shortfall: how many entries must be evicted for `batch` new
+// entries to fit under `cap` given `live` already present, or 0 if none. All
+// three are size_t; the checked branches never form `live + batch` (overflows) or
+// subtract into a wrap on a healthy GPU (the underflow the review flagged). Pure
+// and header-exposed so the D9 arithmetic is a deterministic unit seam.
+inline size_t
+hub_cap_need(size_t live, size_t batch, size_t cap)
+{
+    if(live > cap) return (live - cap) + batch;          // live-cap guarded by live>cap
+    if(batch > cap - live) return batch - (cap - live);  // cap-live safe: live <= cap
+    return 0;                                            // fits: no shortfall
+}
+
 template <typename PayloadT>
 class DispatchHub
 {
@@ -131,7 +180,11 @@ public:
     // signal path on false. Not mode-gated: eligibility already committed this
     // batch, so refusing here would leave dispatches that skipped their signals
     // with nothing to complete them.
-    bool register_batch(std::vector<registration>&& batch)
+    //
+    // Cap-evicted payloads leave via evicted_out for the caller to release AFTER
+    // it drops m_mu (the hub's standing no-destroy-under-lock contract). On false
+    // the map is UNMUTATED across every GPU and evicted_out is empty.
+    bool register_batch(std::vector<registration>&& batch, std::vector<leaked>& evicted_out)
     {
         if(m_abandoned.load(std::memory_order_acquire)) return false;
 
@@ -150,13 +203,45 @@ public:
                 if(batch[j].key == batch[i].key) return false;
         }
 
+        // Per-GPU cap, evaluated for the WHOLE batch in this one critical section
+        // so two batches cannot each observe headroom only one has. Eligibility uses
+        // the same clock domain (steady_now_ns) as gc_deadline_ns / gc_closed_windows.
+        const size_t   cap          = hub_max_pending_per_gpu();
+        const uint64_t now_ns       = steady_now_ns();
+        auto           batch_by_gpu = std::unordered_map<uint32_t, size_t>{};
+        for(const auto& reg : batch)
+            ++batch_by_gpu[reg.key.gpu_id];
+
+        // Read-only victim selection across ALL GPUs first; evict only once every
+        // GPU's shortfall is satisfied, so a shortfall on a later GPU leaves the
+        // map unmutated. Checked comparisons only -- never live+batch-cap, which
+        // overflows the add and underflows a healthy GPU into a huge `need`.
+        auto victims = std::vector<typename pending_entry_map::iterator>{};
+        for(const auto& [gpu, bcount] : batch_by_gpu)
+        {
+            const size_t live = pending_count_for_gpu_locked(gpu);
+            const size_t need = hub_cap_need(live, bcount, cap);
+            if(need == 0) continue;  // fits: no shortfall for this GPU
+
+            if(!collect_cap_victims_locked(gpu, need, now_ns, victims))
+                return false;  // insufficient eligible victims -> refuse, map unmutated
+        }
+
+        for(auto it : victims)
+        {
+            evicted_out.emplace_back(leak_locked(it));
+            erase_entry_locked(it);
+        }
+
         for(auto& reg : batch)
         {
             auto e           = entry{};
             e.correlation_id = reg.correlation_id;
             e.window         = std::move(reg.window);
             e.payload        = std::move(reg.payload);
+            e.seq            = m_next_seq++;
             m_entries.emplace(reg.key, std::move(e));
+            ++m_pending_by_gpu[reg.key.gpu_id];
         }
         return true;
     }
@@ -209,7 +294,7 @@ public:
             out.start_ticks    = start_ticks_opt;
             out.end_ticks      = end_ticks;
             out.payload        = std::move(it->second.payload);
-            m_entries.erase(it);
+            erase_entry_locked(it);
             return out;
         };
 
@@ -249,10 +334,10 @@ public:
         auto out = std::vector<leaked>{};
         for(auto it = m_entries.begin(); it != m_entries.end();)
         {
-            if(it->first.gpu_id == gpu_id && it->first.doorbell_off == doorbell_slot)
+            if(it->first.gpu_id == gpu_id && it->first.doorbell_slot == doorbell_slot)
             {
                 out.emplace_back(leak_locked(it));
-                it = m_entries.erase(it);
+                it = erase_entry_locked(it);
             }
             else
             {
@@ -281,7 +366,7 @@ public:
             {
                 ids.insert(it->second.correlation_id);
                 out.emplace_back(leak_locked(it));
-                it = m_entries.erase(it);
+                it = erase_entry_locked(it);
             }
             else
             {
@@ -340,6 +425,14 @@ public:
         return m_entries.size();
     }
 
+    // Next insertion seq to be assigned. D9 cap eviction orders victims by it. Under m_mu.
+    uint64_t current_seq() const
+    {
+        if(m_abandoned.load(std::memory_order_acquire)) return 0;
+        auto lk = std::lock_guard<std::mutex>{m_mu};
+        return m_next_seq;
+    }
+
     session_mode mode() const
     {
         if(m_abandoned.load(std::memory_order_acquire)) return session_mode::child_stale;
@@ -368,6 +461,9 @@ private:
         uint64_t   correlation_id = 0;
         window_ptr window         = {};
         PayloadT   payload        = {};
+        // Monotonic insertion order, assigned under m_mu. Ages the cap's eviction
+        // selection (oldest-first).
+        uint64_t seq = 0;
     };
 
     // A doorbell slot is only unique per GPU, so every slot-keyed container is
@@ -389,13 +485,49 @@ private:
     // admitted. Session mode gates eligibility, not registration.
     bool key_admissible_locked(const correlation_key& key) const
     {
-        if(m_quarantined.count({key.gpu_id, key.doorbell_off}) != 0) return false;
+        if(m_quarantined.count({key.gpu_id, key.doorbell_slot}) != 0) return false;
         auto [first, last] = m_entries.equal_range(key);
         for(auto it = first; it != last; ++it)
         {
             const auto& w = it->second.window;
             if(w && w->t_close.load(std::memory_order_acquire) == kWindowOpen) return false;
         }
+        return true;
+    }
+
+    // Caller holds m_mu. Live PENDING entries on one GPU (0 if none).
+    size_t pending_count_for_gpu_locked(uint32_t gpu_id) const
+    {
+        auto it = m_pending_by_gpu.find(gpu_id);
+        return it == m_pending_by_gpu.end() ? 0 : it->second;
+    }
+
+    // Caller holds m_mu. Collect up to `need` oldest-by-seq ELIGIBLE victims on one
+    // GPU into `out` (appended). Eligible == gc_closed_windows()'s own predicate:
+    // window closed AND now_ns >= gc_deadline_ns -- never open-window, never in-grace,
+    // so no admission guard is lost and no still-running kernel is ledgered. Returns
+    // false (collecting nothing usable for the caller to act on) if fewer than `need`
+    // eligible entries exist; the caller then refuses and leaves the map unmutated.
+    bool collect_cap_victims_locked(uint32_t                                           gpu_id,
+                                    size_t                                             need,
+                                    uint64_t                                           now_ns,
+                                    std::vector<typename pending_entry_map::iterator>& out)
+    {
+        auto eligible = std::vector<typename pending_entry_map::iterator>{};
+        for(auto it = m_entries.begin(); it != m_entries.end(); ++it)
+        {
+            if(it->first.gpu_id != gpu_id) continue;
+            const auto& w = it->second.window;
+            if(w && w->t_close.load(std::memory_order_acquire) != kWindowOpen &&
+               now_ns >= w->gc_deadline_ns)
+                eligible.push_back(it);
+        }
+        if(eligible.size() < need) return false;
+        std::sort(eligible.begin(), eligible.end(), [](const auto& a, const auto& b) {
+            return a->second.seq < b->second.seq;  // oldest first
+        });
+        out.insert(
+            out.end(), eligible.begin(), eligible.begin() + static_cast<std::ptrdiff_t>(need));
         return true;
     }
 
@@ -429,6 +561,7 @@ private:
             out.emplace_back(leak_locked(it));
         }
         m_entries.clear();
+        m_pending_by_gpu.clear();
         auto stats            = loss_stats{};
         stats.dispatches      = out.size();
         stats.correlation_ids = ids.size();
@@ -446,6 +579,23 @@ private:
     bool               m_ledger_saturated = false;
     // A single GPU's queue destroy must not quarantine another GPU's live slot.
     slot_set m_quarantined = {};
+    // Next insertion seq, and live PENDING count per gpu_id (the cap is per-GPU).
+    // Incremented at insert, decremented on every erase path via erase_entry_locked.
+    uint64_t                             m_next_seq       = 0;
+    std::unordered_map<uint32_t, size_t> m_pending_by_gpu = {};
+
+    // Caller holds m_mu. Erase an entry and keep m_pending_by_gpu in step; the
+    // single removal point every path funnels through so the per-GPU count cannot
+    // drift. Returns the iterator following the erased element.
+    typename pending_entry_map::iterator erase_entry_locked(typename pending_entry_map::iterator it)
+    {
+        auto _g = m_pending_by_gpu.find(it->first.gpu_id);
+        if(_g != m_pending_by_gpu.end() && _g->second > 0)
+        {
+            if(--_g->second == 0) m_pending_by_gpu.erase(_g);
+        }
+        return m_entries.erase(it);
+    }
 };
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
@@ -24,8 +24,11 @@
 
 #include "lib/rocprofiler-sdk/kfd/correlation_types.hpp"
 #include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <mutex>
@@ -82,6 +85,51 @@ struct loss_stats
     uint64_t correlation_ids = 0;
 };
 
+// Sole bound on hub growth for entries whose window never closes (gc_closed_windows
+// only reaps closed windows; F3's start_max_age_ns ages pending_starts, not the hub
+// -- the two are unrelated). Env ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU,
+// default 2000000, accepted range [1, 4194304], read once (F3 pattern). Reject-and-
+// default via D8's parse contract; the upper limit keeps cap far below SIZE_MAX so
+// the register_batch comparisons cannot be defeated by an absurd value.
+//
+// Sizing (empirically validated, not the original ~100 B "few MB" estimate): a
+// graph-launch burst workload (hipGraphLaunch, e.g. 1024-node graph x 1000 iters)
+// legitimately keeps hundreds of thousands of dispatches in flight relative to the
+// reader/processor retirement rate -- an order of magnitude above the old 65536
+// default, which refused 16-41% of dispatches and forced the slower signal path,
+// erasing most of the signal-less speedup. At ~100 B/entry the 2M default costs
+// ~190-200 MB per GPU at worst. Why not a "medium" cap: collect_cap_victims_locked
+// is an O(live-entries-for-that-GPU) scan+sort under the single hub mutex, so a cap
+// a realistic workload still exceeds is WORSE than a small cap (cheap scans) or a
+// large one (scans essentially never fire) -- a mid cap that trips constantly cost
+// +408% in the benchmark. Residual (accepted, not re-engineered here): a workload
+// whose genuine peak concurrency exceeds 2M, or a real EOP-loss leak growing
+// unboundedly toward the cap, still pays that eviction-scan cost; a proper fix needs
+// a per-GPU secondary index for eligible-victim lookup, out of scope for this fix.
+inline size_t
+hub_max_pending_per_gpu()
+{
+    static const size_t _v = []() -> size_t {
+        constexpr long _dflt = 2'000'000;
+        auto _v = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU", 1, 4'194'304);
+        return static_cast<size_t>(_v.value_or(_dflt));
+    }();
+    return _v;
+}
+
+// Exact per-GPU cap shortfall: how many entries must be evicted for `batch` new
+// entries to fit under `cap` given `live` already present, or 0 if none. All
+// three are size_t; the checked branches never form `live + batch` (overflows) or
+// subtract into a wrap on a healthy GPU (the underflow the review flagged). Pure
+// and header-exposed so the D9 arithmetic is a deterministic unit seam.
+inline size_t
+hub_cap_need(size_t live, size_t batch, size_t cap)
+{
+    if(live > cap) return (live - cap) + batch;   // live-cap guarded by live>cap
+    if(batch > cap - live) return batch - (cap - live);  // cap-live safe: live <= cap
+    return 0;                                      // fits: no shortfall
+}
+
 template <typename PayloadT>
 class DispatchHub
 {
@@ -131,7 +179,11 @@ public:
     // signal path on false. Not mode-gated: eligibility already committed this
     // batch, so refusing here would leave dispatches that skipped their signals
     // with nothing to complete them.
-    bool register_batch(std::vector<registration>&& batch)
+    //
+    // Cap-evicted payloads leave via evicted_out for the caller to release AFTER
+    // it drops m_mu (the hub's standing no-destroy-under-lock contract). On false
+    // the map is UNMUTATED across every GPU and evicted_out is empty.
+    bool register_batch(std::vector<registration>&& batch, std::vector<leaked>& evicted_out)
     {
         if(m_abandoned.load(std::memory_order_acquire)) return false;
 
@@ -150,13 +202,45 @@ public:
                 if(batch[j].key == batch[i].key) return false;
         }
 
+        // Per-GPU cap, evaluated for the WHOLE batch in this one critical section
+        // so two batches cannot each observe headroom only one has. Eligibility uses
+        // the same clock domain (steady_now_ns) as gc_deadline_ns / gc_closed_windows.
+        const size_t   cap    = hub_max_pending_per_gpu();
+        const uint64_t now_ns = steady_now_ns();
+        auto batch_by_gpu     = std::unordered_map<uint32_t, size_t>{};
+        for(const auto& reg : batch)
+            ++batch_by_gpu[reg.key.gpu_id];
+
+        // Read-only victim selection across ALL GPUs first; evict only once every
+        // GPU's shortfall is satisfied, so a shortfall on a later GPU leaves the
+        // map unmutated. Checked comparisons only -- never live+batch-cap, which
+        // overflows the add and underflows a healthy GPU into a huge `need`.
+        auto victims = std::vector<typename pending_entry_map::iterator>{};
+        for(const auto& [gpu, bcount] : batch_by_gpu)
+        {
+            const size_t live = pending_count_for_gpu_locked(gpu);
+            const size_t need = hub_cap_need(live, bcount, cap);
+            if(need == 0) continue;  // fits: no shortfall for this GPU
+
+            if(!collect_cap_victims_locked(gpu, need, now_ns, victims))
+                return false;  // insufficient eligible victims -> refuse, map unmutated
+        }
+
+        for(auto it : victims)
+        {
+            evicted_out.emplace_back(leak_locked(it));
+            erase_entry_locked(it);
+        }
+
         for(auto& reg : batch)
         {
             auto e           = entry{};
             e.correlation_id = reg.correlation_id;
             e.window         = std::move(reg.window);
             e.payload        = std::move(reg.payload);
+            e.seq            = m_next_seq++;
             m_entries.emplace(reg.key, std::move(e));
+            ++m_pending_by_gpu[reg.key.gpu_id];
         }
         return true;
     }
@@ -209,7 +293,7 @@ public:
             out.start_ticks    = start_ticks_opt;
             out.end_ticks      = end_ticks;
             out.payload        = std::move(it->second.payload);
-            m_entries.erase(it);
+            erase_entry_locked(it);
             return out;
         };
 
@@ -249,10 +333,10 @@ public:
         auto out = std::vector<leaked>{};
         for(auto it = m_entries.begin(); it != m_entries.end();)
         {
-            if(it->first.gpu_id == gpu_id && it->first.doorbell_off == doorbell_slot)
+            if(it->first.gpu_id == gpu_id && it->first.doorbell_slot == doorbell_slot)
             {
                 out.emplace_back(leak_locked(it));
-                it = m_entries.erase(it);
+                it = erase_entry_locked(it);
             }
             else
             {
@@ -281,7 +365,7 @@ public:
             {
                 ids.insert(it->second.correlation_id);
                 out.emplace_back(leak_locked(it));
-                it = m_entries.erase(it);
+                it = erase_entry_locked(it);
             }
             else
             {
@@ -340,6 +424,14 @@ public:
         return m_entries.size();
     }
 
+    // Next insertion seq to be assigned. D9 cap eviction orders victims by it. Under m_mu.
+    uint64_t current_seq() const
+    {
+        if(m_abandoned.load(std::memory_order_acquire)) return 0;
+        auto lk = std::lock_guard<std::mutex>{m_mu};
+        return m_next_seq;
+    }
+
     session_mode mode() const
     {
         if(m_abandoned.load(std::memory_order_acquire)) return session_mode::child_stale;
@@ -368,6 +460,9 @@ private:
         uint64_t   correlation_id = 0;
         window_ptr window         = {};
         PayloadT   payload        = {};
+        // Monotonic insertion order, assigned under m_mu. Ages the cap's eviction
+        // selection (oldest-first).
+        uint64_t seq = 0;
     };
 
     // A doorbell slot is only unique per GPU, so every slot-keyed container is
@@ -389,13 +484,48 @@ private:
     // admitted. Session mode gates eligibility, not registration.
     bool key_admissible_locked(const correlation_key& key) const
     {
-        if(m_quarantined.count({key.gpu_id, key.doorbell_off}) != 0) return false;
+        if(m_quarantined.count({key.gpu_id, key.doorbell_slot}) != 0) return false;
         auto [first, last] = m_entries.equal_range(key);
         for(auto it = first; it != last; ++it)
         {
             const auto& w = it->second.window;
             if(w && w->t_close.load(std::memory_order_acquire) == kWindowOpen) return false;
         }
+        return true;
+    }
+
+    // Caller holds m_mu. Live PENDING entries on one GPU (0 if none).
+    size_t pending_count_for_gpu_locked(uint32_t gpu_id) const
+    {
+        auto it = m_pending_by_gpu.find(gpu_id);
+        return it == m_pending_by_gpu.end() ? 0 : it->second;
+    }
+
+    // Caller holds m_mu. Collect up to `need` oldest-by-seq ELIGIBLE victims on one
+    // GPU into `out` (appended). Eligible == gc_closed_windows()'s own predicate:
+    // window closed AND now_ns >= gc_deadline_ns -- never open-window, never in-grace,
+    // so no admission guard is lost and no still-running kernel is ledgered. Returns
+    // false (collecting nothing usable for the caller to act on) if fewer than `need`
+    // eligible entries exist; the caller then refuses and leaves the map unmutated.
+    bool collect_cap_victims_locked(uint32_t                                            gpu_id,
+                                    size_t                                              need,
+                                    uint64_t                                            now_ns,
+                                    std::vector<typename pending_entry_map::iterator>& out)
+    {
+        auto eligible = std::vector<typename pending_entry_map::iterator>{};
+        for(auto it = m_entries.begin(); it != m_entries.end(); ++it)
+        {
+            if(it->first.gpu_id != gpu_id) continue;
+            const auto& w = it->second.window;
+            if(w && w->t_close.load(std::memory_order_acquire) != kWindowOpen &&
+               now_ns >= w->gc_deadline_ns)
+                eligible.push_back(it);
+        }
+        if(eligible.size() < need) return false;
+        std::sort(eligible.begin(), eligible.end(), [](const auto& a, const auto& b) {
+            return a->second.seq < b->second.seq;  // oldest first
+        });
+        out.insert(out.end(), eligible.begin(), eligible.begin() + static_cast<std::ptrdiff_t>(need));
         return true;
     }
 
@@ -429,6 +559,7 @@ private:
             out.emplace_back(leak_locked(it));
         }
         m_entries.clear();
+        m_pending_by_gpu.clear();
         auto stats            = loss_stats{};
         stats.dispatches      = out.size();
         stats.correlation_ids = ids.size();
@@ -446,6 +577,23 @@ private:
     bool               m_ledger_saturated = false;
     // A single GPU's queue destroy must not quarantine another GPU's live slot.
     slot_set m_quarantined = {};
+    // Next insertion seq, and live PENDING count per gpu_id (the cap is per-GPU).
+    // Incremented at insert, decremented on every erase path via erase_entry_locked.
+    uint64_t                          m_next_seq       = 0;
+    std::unordered_map<uint32_t, size_t> m_pending_by_gpu = {};
+
+    // Caller holds m_mu. Erase an entry and keep m_pending_by_gpu in step; the
+    // single removal point every path funnels through so the per-GPU count cannot
+    // drift. Returns the iterator following the erased element.
+    typename pending_entry_map::iterator erase_entry_locked(typename pending_entry_map::iterator it)
+    {
+        auto _g = m_pending_by_gpu.find(it->first.gpu_id);
+        if(_g != m_pending_by_gpu.end() && _g->second > 0)
+        {
+            if(--_g->second == 0) m_pending_by_gpu.erase(_g);
+        }
+        return m_entries.erase(it);
+    }
 };
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -202,6 +202,35 @@ struct pair_state
     uint64_t equal_tick_drops   = 0;  // EOP tick == retained START tick (fail-closed)
     uint64_t stale_eop_drops    = 0;  // EOP tick < retained START tick (belongs earlier)
     uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
+    uint64_t starts_cap_evicted = 0;  // retained STARTs dropped by the hard size cap
+
+    // Hard bound on pending_starts, mirroring D9's per-GPU hub cap (this map is
+    // per-GPU too, and a START is of the same order in size). evict_stale is only
+    // an AGE backstop -- at the 30-min default a sustained EOP loss exhausts memory
+    // long before it fires -- and D9's cap does not cover this map, because
+    // firmware emits records for signal-fallback dispatches the hub never saw.
+    // Overridden from ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS by the
+    // reader; the default stands for a unit test that never sets it.
+    size_t max_pending_starts = 2'000'000;
+
+    // Drop the single oldest retained START, counting its outstanding STARTs as
+    // lost (each is a dispatch that will now complete start-unknown -- coverage
+    // loss, not a wrong record). RESIDUAL, accepted: this is an O(live) scan, paid
+    // on every insert while the map sits AT the cap. Reaching the cap already means
+    // EOPs are being lost at a rate no sane workload produces, and the alternative
+    // there is memory exhaustion; a cheap victim lookup would need a second index
+    // ordered by seen_at_ns, the same secondary-index work D9 deferred.
+    void evict_oldest_start()
+    {
+        auto _oldest = pending_starts.end();
+        for(auto it = pending_starts.begin(); it != pending_starts.end(); ++it)
+            if(_oldest == pending_starts.end() ||
+               it->second.seen_at_ns < _oldest->second.seen_at_ns)
+                _oldest = it;
+        if(_oldest == pending_starts.end()) return;
+        starts_cap_evicted += _oldest->second.outstanding;
+        pending_starts.erase(_oldest);
+    }
 
     // Stream-driven eviction watermark: the copy timestamp of the last batch that
     // triggered an evict for this GPU. Compared against batch.now_ns,
@@ -424,6 +453,13 @@ pair_records(const copied_record* records,
         if(rec.record_type == kRecStart)
         {
             ++state.starts_seen;
+            // Hard size cap. Only an insert that GROWS the map can breach it, so a
+            // recurring key is exempt -- evicting there could pick the very key
+            // about to be touched and silently reset its `ambiguous` latch. The
+            // size test short-circuits, so the normal path pays no extra lookup.
+            if(state.pending_starts.size() >= state.max_pending_starts &&
+               state.pending_starts.find(key) == state.pending_starts.end())
+                state.evict_oldest_start();
             // dispatch_id is only low-32, so a raw key can recur. A second
             // outstanding START on one key makes it AMBIGUOUS: keep the first
             // START's ticks and age unchanged (so an unpairable key still ages out

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -30,6 +30,8 @@
 // `region_record_count` slots (a power of two). Multiple queues can multiplex
 // into one region; records carry their own (doorbell_off, dispatch_id).
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <string_view>
@@ -137,7 +139,7 @@ struct copied_record
 struct ring_cursors
 {
     uint64_t rptr[kMaxRegions] = {};     // consumer read pos per region
-    bool     rptr_init         = false;  // sync rptr to wptr on first drain
+    bool     rptr_init         = false;  // zero rptr[] on first drain (both local and shared)
 
     // Overrun telemetry. Exclusive-end contract: the producer has LAPPED us only
     // once `w - rptr` EXCEEDS region_slots (== region_slots is merely exactly full).
@@ -197,6 +199,8 @@ struct pair_state
     uint64_t eops_seen          = 0;
     uint64_t starts_overwritten = 0;  // a second START arrived on a retained key
     uint64_t ambiguous_pairs    = 0;  // EOPs dropped because their raw key was ambiguous
+    uint64_t equal_tick_drops   = 0;  // EOP tick == retained START tick (fail-closed)
+    uint64_t stale_eop_drops    = 0;  // EOP tick < retained START tick (belongs earlier)
     uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
 
     // Stream-driven eviction watermark: the copy timestamp of the last batch that
@@ -213,8 +217,11 @@ struct pair_state
         {
             if(now_ns > it->second.seen_at_ns && now_ns - it->second.seen_at_ns > max_age_ns)
             {
+                // A single key can hold more than one outstanding START (a recycled
+                // doorbell latched it ambiguous); each is a stranded START, so the
+                // telemetry counts outstanding, not one per key.
+                removed += it->second.outstanding;
                 it = pending_starts.erase(it);
-                ++removed;
             }
             else
             {
@@ -243,7 +250,10 @@ copy_pipes(const uint8_t*           records_base,
            // NOLINTNEXTLINE(readability-non-const-parameter)
            volatile uint64_t* rptr_arr,
            ring_cursors&      cursors,
-           OutT&              out)
+           OutT&              out,
+           // Reserved per region before the first memcpy so a record is counted
+           // from the instant it leaves the ring into `out`. nullptr in tests.
+           std::atomic<uint64_t>* inflight = nullptr)
 {
     if(num_regions == 0 || num_regions > kMaxRegions) return 0;
 
@@ -267,10 +277,18 @@ copy_pipes(const uint8_t*           records_base,
         uint64_t       scan = cursors.rptr[p];
         if(w < scan)
         {
-            // wptr moved backwards: the stream was reset underneath us. Readiness
-            // uses wptr != rptr, so leaving rptr ahead would report ready forever
-            // while the w > scan drain below never runs. Snap rptr back to wptr in
-            // both the local cursor and the shared rptr[] so the predicates agree.
+            // wptr < rptr. Per the driver contract (kfd_dlog_stream.c): wptr is
+            // monotonic within a stream's lifetime -- it is zeroed only once at
+            // setup, before firmware arms, and a GPU reset sets the fatal latch
+            // (EPOLLERR) WITHOUT regressing wptr. So a live stream cannot legitimately
+            // move wptr backwards; observing it here means a torn/corrupt read of the
+            // volatile mapping (F5/F12), not a reset generation. The safe response is
+            // to drop this region's un-drained span rather than trust a rewound
+            // window that could mis-publish stale slots as fresh: snap rptr up to the
+            // observed wptr (in both the local cursor and the shared rptr[] so
+            // wptr!=rptr readiness agrees) and skip it. No new-generation drain is
+            // attempted because that mid-stream reset-with-wptr-rewind state cannot
+            // occur under the driver contract.
             ++cursors.wptr_regressions;
             cursors.rptr[p] = w;
             __atomic_store_n(&rptr_arr[p], w, __ATOMIC_RELEASE);
@@ -283,6 +301,12 @@ copy_pipes(const uint8_t*           records_base,
         // (NOT w - slots + 1, which skipped one valid record).
         cursors.note_overrun(w - scan, region_slots);
         if(w - scan > region_slots) scan = w - region_slots;
+
+        // Reserve BEFORE the first memcpy: from that instant these records live in
+        // `out` and will be processed while the pipe still reads empty. `w - scan`
+        // is exact here (post-clamp) and is exactly what the batch's publish
+        // fetch_sub removes. Release pairs with the GC gate's acquire load.
+        if(inflight != nullptr) inflight->fetch_add(w - scan, std::memory_order_release);
 
         // Every copied record starts loss_free = true; the region-wide
         // verdict is gone. The untrusted back-patch below is per-record.
@@ -303,6 +327,16 @@ copy_pipes(const uint8_t*           records_base,
         // aliases is untrusted. w is exclusive, so index w2 aliases w2 - slots
         // (power-of-two mask); the boundary the drain sits on when it just keeps up
         // is exactly the one an acquire load of w2 cannot certify -- hence `<=`.
+        //
+        // Acquire fence pairing the plain payload memcpy above with the w2 acquire
+        // load below: the memcpy reads are non-atomic, and an acquire load only
+        // orders operations that follow it, not ones that precede it. Without this
+        // fence a weak-memory CPU (aarch64) could satisfy a payload read AFTER
+        // observing w2, so the untrusted back-patch would test a stale w2 against a
+        // read that actually raced the producer's overwrite. The fence keeps every
+        // memcpy read sequenced before the w2 observation, so the `idx <=
+        // untrusted_upto` test certifies exactly the slots that were read clean.
+        std::atomic_thread_fence(std::memory_order_acquire);
         const uint64_t w2 = __atomic_load_n(&wptr_arr[p], __ATOMIC_ACQUIRE);
         if(w2 >= region_slots)
         {
@@ -337,90 +371,127 @@ pair_records(const copied_record* records,
              OnRecord&&           on_record)
 {
     uint64_t seen = 0;
-    // Two passes over the batch: bind every START first, then match every EOP. A
-    // batch is one drain sweep of all regions in index order, and the HWS can
-    // remap a queue onto a lower-numbered MEC pipe between its START and its EOP,
-    // which puts the EOP in an earlier region than the START -- so in copy order
-    // the EOP can precede its own START within this one batch. Firmware always
-    // writes START before EOP and the sweep reads region k before region k+1, so
-    // a copied EOP's START is either in an earlier batch (already consumed) or
-    // later in THIS batch; binding all of this batch's STARTs before any EOP is
-    // therefore exact, not a heuristic, and removes the spurious start-unknown
-    // that the old single pass produced for a same-batch region reorder.
-    for(int pass = 0; pass < 2; ++pass)
-        for(size_t i = 0; i < count; ++i)
+
+    // Pair in TICK order, not batch/region position. Each record carries its own
+    // per-agent GPU-clock tick (the stream is per-GPU, so all ticks in a batch are
+    // comparable), so tick order == temporal order regardless of which region an
+    // HWS remap copied a record from. Only THIS batch's records are ordered; the
+    // retained cross-batch pending_starts map is the state the pass runs against
+    // and is never re-fed into the work list (re-appending it would push a second
+    // START transition on every retained key and latch ambiguous spuriously).
+    struct work_item
+    {
+        uint64_t tick;         // start_ticks for a START, end_ticks for an EOP
+        uint32_t kind;         // 0 = EOP, 1 = START: equal ticks run all EOPs first
+        uint32_t arrival_seq;  // region-ordered merge index; ordering only, never a pairing input
+        size_t   idx;          // record index in `records`
+    };
+    std::vector<work_item> work;
+    work.reserve(count);
+    for(size_t i = 0; i < count; ++i)
+    {
+        const auto& rec = records[i].rec;
+        if(rec.record_type == kRecPadding || rec.doorbell_off == 0) continue;
+        // a torn record's doorbell_off/dispatch_id are as suspect as its tick, so
+        // it must never bind a START or claim an EOP. A torn START is thus never
+        // retained; its later intact EOP arrives start-unknown.
+        if(!records[i].loss_free) continue;
+        if(rec.record_type != kRecStart && rec.record_type != kRecEop) continue;
+
+        const uint64_t ts =
+            static_cast<uint64_t>(rec.ts_lo) | (static_cast<uint64_t>(rec.ts_hi) << 32);
+        work.push_back(work_item{
+            ts, rec.record_type == kRecStart ? 1u : 0u, static_cast<uint32_t>(work.size()), i});
+    }
+
+    // EOP-before-START at equal ticks (the `kind` term) is what makes ties
+    // order-independent AND keeps ordinary doorbell reuse intact: {E_A(t),S_B(t)}
+    // pairs E_A with the outstanding S_A, then installs S_B cleanly. arrival_seq
+    // only completes the strict weak ordering; it never decides a pairing.
+    std::sort(work.begin(), work.end(), [](const work_item& a, const work_item& b) {
+        if(a.tick != b.tick) return a.tick < b.tick;
+        if(a.kind != b.kind) return a.kind < b.kind;
+        return a.arrival_seq < b.arrival_seq;
+    });
+
+    for(const auto& w : work)
+    {
+        const auto&    rec = records[w.idx].rec;
+        const uint64_t ts  = w.tick;
+        const uint64_t key = (static_cast<uint64_t>(rec.doorbell_off) << 32) |
+                             static_cast<uint64_t>(rec.dispatch_id);
+
+        if(rec.record_type == kRecStart)
         {
-            const auto& rec = records[i].rec;
-            if(rec.record_type == kRecPadding || rec.doorbell_off == 0) continue;
-            // a torn record's doorbell_off/dispatch_id are as suspect as
-            // its tick, so it must never bind a START or claim an EOP. A torn START
-            // is thus never retained; its later intact EOP arrives start-unknown.
-            if(!records[i].loss_free) continue;
-            if(pass == 0 && rec.record_type != kRecStart) continue;
-            if(pass == 1 && rec.record_type == kRecStart) continue;
-
-            const uint64_t ts =
-                static_cast<uint64_t>(rec.ts_lo) | (static_cast<uint64_t>(rec.ts_hi) << 32);
-            const uint64_t key = (static_cast<uint64_t>(rec.doorbell_off) << 32) |
-                                 static_cast<uint64_t>(rec.dispatch_id);
-
-            if(rec.record_type == kRecStart)
+            ++state.starts_seen;
+            // dispatch_id is only low-32, so a raw key can recur. A second
+            // outstanding START on one key makes it AMBIGUOUS: keep the first
+            // START's ticks and age unchanged (so an unpairable key still ages out
+            // -- refreshing seen_at_ns would make it permanent) and count another
+            // outstanding. try_emplace, not [], so the first START's fields survive.
+            auto [it, ins] = state.pending_starts.try_emplace(
+                key, pair_state::pending_start{ts, now_ns, 1, false});
+            if(!ins)
             {
-                ++state.starts_seen;
-                // dispatch_id is only low-32, so a raw key can recur. A second
-                // outstanding START on one key makes it AMBIGUOUS: keep the first
-                // START's ticks and age unchanged (so an unpairable key still
-                // ages out -- refreshing seen_at_ns would make it permanent) and
-                // count another outstanding. try_emplace, not [], so the first
-                // START's fields survive the duplicate.
-                auto [it, ins] = state.pending_starts.try_emplace(
-                    key, pair_state::pending_start{ts, now_ns, 1, false});
-                if(!ins)
-                {
-                    ++state.starts_overwritten;
-                    it->second.ambiguous = true;
-                    ++it->second.outstanding;
-                }
-                continue;
+                ++state.starts_overwritten;
+                it->second.ambiguous = true;
+                ++it->second.outstanding;
             }
-            if(rec.record_type != kRecEop) continue;
-            ++state.eops_seen;
-
-            auto it = state.pending_starts.find(key);
-            if(it == state.pending_starts.end())
-            {
-                // The START was lost (shape ii): the EOP still proves the kernel
-                // finished, it just carries no interval.
-                ++state.unmatched_eops;
-                auto out         = drained_record{};
-                out.doorbell_off = rec.doorbell_off;
-                out.dispatch_id  = rec.dispatch_id;
-                out.end_ticks    = ts;
-                out.start_known  = false;
-                on_record(out);
-            }
-            else if(it->second.ambiguous)
-            {
-                // Cannot say which dispatch this EOP belongs to. Drop it HERE --
-                // forwarding it start-unknown would let the hub complete the
-                // wrong dispatch (the same-window low-32-wrap shape). The key
-                // stays unpairable until every outstanding START is consumed.
-                ++state.ambiguous_pairs;
-                if(--it->second.outstanding == 0) state.pending_starts.erase(it);
-            }
-            else
-            {
-                auto out         = drained_record{};
-                out.doorbell_off = rec.doorbell_off;
-                out.dispatch_id  = rec.dispatch_id;
-                out.end_ticks    = ts;
-                out.start_ticks  = it->second.start_ticks;
-                out.start_known  = true;
-                state.pending_starts.erase(it);
-                ++seen;
-                on_record(out);
-            }
+            continue;
         }
+
+        ++state.eops_seen;
+        auto it = state.pending_starts.find(key);
+        if(it == state.pending_starts.end())
+        {
+            // (1) no entry -- the START was lost: the EOP still proves the kernel
+            // finished, it just carries no interval.
+            ++state.unmatched_eops;
+            auto out         = drained_record{};
+            out.doorbell_off = rec.doorbell_off;
+            out.dispatch_id  = rec.dispatch_id;
+            out.end_ticks    = ts;
+            out.start_known  = false;
+            on_record(out);
+        }
+        else if(it->second.ambiguous)
+        {
+            // (2) ambiguous -- cannot say which dispatch this EOP belongs to.
+            // Drop HERE: forwarding it start-unknown would let the hub complete the
+            // wrong dispatch. The key stays unpairable until every outstanding
+            // START is consumed.
+            ++state.ambiguous_pairs;
+            if(--it->second.outstanding == 0) state.pending_starts.erase(it);
+        }
+        else if(ts == it->second.start_ticks)
+        {
+            // (3) equal tick -- no HW contract that start_ticks < end_ticks for a
+            // real pair, so fail closed: drop rather than form a zero/ambiguous pair.
+            ++state.equal_tick_drops;
+            if(--it->second.outstanding == 0) state.pending_starts.erase(it);
+        }
+        else if(ts < it->second.start_ticks)
+        {
+            // (4) stale EOP -- it predates the outstanding START, so it belongs to
+            // an earlier dispatch whose START was lost. Drop the EOP and leave the
+            // retained START untouched; consuming it would strand the EOP that
+            // really belongs to it.
+            ++state.stale_eop_drops;
+        }
+        else
+        {
+            // (5) outstanding==1, !ambiguous, t > start_ticks -- pair and erase.
+            auto out         = drained_record{};
+            out.doorbell_off = rec.doorbell_off;
+            out.dispatch_id  = rec.dispatch_id;
+            out.end_ticks    = ts;
+            out.start_ticks  = it->second.start_ticks;
+            out.start_known  = true;
+            state.pending_starts.erase(it);
+            ++seen;
+            on_record(out);
+        }
+    }
     return seen;
 }
 }  // namespace kfd

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -30,6 +30,8 @@
 // `region_record_count` slots (a power of two). Multiple queues can multiplex
 // into one region; records carry their own (doorbell_off, dispatch_id).
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <string_view>
@@ -137,7 +139,7 @@ struct copied_record
 struct ring_cursors
 {
     uint64_t rptr[kMaxRegions] = {};     // consumer read pos per region
-    bool     rptr_init         = false;  // sync rptr to wptr on first drain
+    bool     rptr_init         = false;  // zero rptr[] on first drain (both local and shared)
 
     // Overrun telemetry. Exclusive-end contract: the producer has LAPPED us only
     // once `w - rptr` EXCEEDS region_slots (== region_slots is merely exactly full).
@@ -197,6 +199,8 @@ struct pair_state
     uint64_t eops_seen          = 0;
     uint64_t starts_overwritten = 0;  // a second START arrived on a retained key
     uint64_t ambiguous_pairs    = 0;  // EOPs dropped because their raw key was ambiguous
+    uint64_t equal_tick_drops   = 0;  // EOP tick == retained START tick (fail-closed)
+    uint64_t stale_eop_drops    = 0;  // EOP tick < retained START tick (belongs earlier)
     uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
 
     // Stream-driven eviction watermark: the copy timestamp of the last batch that
@@ -213,8 +217,11 @@ struct pair_state
         {
             if(now_ns > it->second.seen_at_ns && now_ns - it->second.seen_at_ns > max_age_ns)
             {
+                // A single key can hold more than one outstanding START (a recycled
+                // doorbell latched it ambiguous); each is a stranded START, so the
+                // telemetry counts outstanding, not one per key.
+                removed += it->second.outstanding;
                 it = pending_starts.erase(it);
-                ++removed;
             }
             else
             {
@@ -243,7 +250,10 @@ copy_pipes(const uint8_t*           records_base,
            // NOLINTNEXTLINE(readability-non-const-parameter)
            volatile uint64_t* rptr_arr,
            ring_cursors&      cursors,
-           OutT&              out)
+           OutT&              out,
+           // Reserved per region before the first memcpy so a record is counted
+           // from the instant it leaves the ring into `out`. nullptr in tests.
+           std::atomic<uint64_t>* inflight = nullptr)
 {
     if(num_regions == 0 || num_regions > kMaxRegions) return 0;
 
@@ -267,10 +277,18 @@ copy_pipes(const uint8_t*           records_base,
         uint64_t       scan = cursors.rptr[p];
         if(w < scan)
         {
-            // wptr moved backwards: the stream was reset underneath us. Readiness
-            // uses wptr != rptr, so leaving rptr ahead would report ready forever
-            // while the w > scan drain below never runs. Snap rptr back to wptr in
-            // both the local cursor and the shared rptr[] so the predicates agree.
+            // wptr < rptr. Per the driver contract (kfd_dlog_stream.c): wptr is
+            // monotonic within a stream's lifetime -- it is zeroed only once at
+            // setup, before firmware arms, and a GPU reset sets the fatal latch
+            // (EPOLLERR) WITHOUT regressing wptr. So a live stream cannot legitimately
+            // move wptr backwards; observing it here means a torn/corrupt read of the
+            // volatile mapping (F5/F12), not a reset generation. The safe response is
+            // to drop this region's un-drained span rather than trust a rewound
+            // window that could mis-publish stale slots as fresh: snap rptr up to the
+            // observed wptr (in both the local cursor and the shared rptr[] so
+            // wptr!=rptr readiness agrees) and skip it. No new-generation drain is
+            // attempted because that mid-stream reset-with-wptr-rewind state cannot
+            // occur under the driver contract.
             ++cursors.wptr_regressions;
             cursors.rptr[p] = w;
             __atomic_store_n(&rptr_arr[p], w, __ATOMIC_RELEASE);
@@ -283,6 +301,12 @@ copy_pipes(const uint8_t*           records_base,
         // (NOT w - slots + 1, which skipped one valid record).
         cursors.note_overrun(w - scan, region_slots);
         if(w - scan > region_slots) scan = w - region_slots;
+
+        // Reserve BEFORE the first memcpy: from that instant these records live in
+        // `out` and will be processed while the pipe still reads empty. `w - scan`
+        // is exact here (post-clamp) and is exactly what the batch's publish
+        // fetch_sub removes. Release pairs with the GC gate's acquire load.
+        if(inflight != nullptr) inflight->fetch_add(w - scan, std::memory_order_release);
 
         // Every copied record starts loss_free = true; the region-wide
         // verdict is gone. The untrusted back-patch below is per-record.
@@ -303,6 +327,16 @@ copy_pipes(const uint8_t*           records_base,
         // aliases is untrusted. w is exclusive, so index w2 aliases w2 - slots
         // (power-of-two mask); the boundary the drain sits on when it just keeps up
         // is exactly the one an acquire load of w2 cannot certify -- hence `<=`.
+        //
+        // Acquire fence pairing the plain payload memcpy above with the w2 acquire
+        // load below: the memcpy reads are non-atomic, and an acquire load only
+        // orders operations that follow it, not ones that precede it. Without this
+        // fence a weak-memory CPU (aarch64) could satisfy a payload read AFTER
+        // observing w2, so the untrusted back-patch would test a stale w2 against a
+        // read that actually raced the producer's overwrite. The fence keeps every
+        // memcpy read sequenced before the w2 observation, so the `idx <=
+        // untrusted_upto` test certifies exactly the slots that were read clean.
+        std::atomic_thread_fence(std::memory_order_acquire);
         const uint64_t w2 = __atomic_load_n(&wptr_arr[p], __ATOMIC_ACQUIRE);
         if(w2 >= region_slots)
         {
@@ -337,90 +371,129 @@ pair_records(const copied_record* records,
              OnRecord&&           on_record)
 {
     uint64_t seen = 0;
-    // Two passes over the batch: bind every START first, then match every EOP. A
-    // batch is one drain sweep of all regions in index order, and the HWS can
-    // remap a queue onto a lower-numbered MEC pipe between its START and its EOP,
-    // which puts the EOP in an earlier region than the START -- so in copy order
-    // the EOP can precede its own START within this one batch. Firmware always
-    // writes START before EOP and the sweep reads region k before region k+1, so
-    // a copied EOP's START is either in an earlier batch (already consumed) or
-    // later in THIS batch; binding all of this batch's STARTs before any EOP is
-    // therefore exact, not a heuristic, and removes the spurious start-unknown
-    // that the old single pass produced for a same-batch region reorder.
-    for(int pass = 0; pass < 2; ++pass)
-        for(size_t i = 0; i < count; ++i)
+
+    // Pair in TICK order, not batch/region position. Each record carries its own
+    // per-agent GPU-clock tick (the stream is per-GPU, so all ticks in a batch are
+    // comparable), so tick order == temporal order regardless of which region an
+    // HWS remap copied a record from. Only THIS batch's records are ordered; the
+    // retained cross-batch pending_starts map is the state the pass runs against
+    // and is never re-fed into the work list (re-appending it would push a second
+    // START transition on every retained key and latch ambiguous spuriously).
+    struct work_item
+    {
+        uint64_t tick;         // start_ticks for a START, end_ticks for an EOP
+        uint32_t kind;         // 0 = EOP, 1 = START: equal ticks run all EOPs first
+        uint32_t arrival_seq;  // region-ordered merge index; ordering only, never a pairing input
+        size_t   idx;          // record index in `records`
+    };
+    std::vector<work_item> work;
+    work.reserve(count);
+    for(size_t i = 0; i < count; ++i)
+    {
+        const auto& rec = records[i].rec;
+        if(rec.record_type == kRecPadding || rec.doorbell_off == 0) continue;
+        // a torn record's doorbell_off/dispatch_id are as suspect as its tick, so
+        // it must never bind a START or claim an EOP. A torn START is thus never
+        // retained; its later intact EOP arrives start-unknown.
+        if(!records[i].loss_free) continue;
+        if(rec.record_type != kRecStart && rec.record_type != kRecEop) continue;
+
+        const uint64_t ts =
+            static_cast<uint64_t>(rec.ts_lo) | (static_cast<uint64_t>(rec.ts_hi) << 32);
+        work.push_back(work_item{ts,
+                                 rec.record_type == kRecStart ? 1u : 0u,
+                                 static_cast<uint32_t>(work.size()),
+                                 i});
+    }
+
+    // EOP-before-START at equal ticks (the `kind` term) is what makes ties
+    // order-independent AND keeps ordinary doorbell reuse intact: {E_A(t),S_B(t)}
+    // pairs E_A with the outstanding S_A, then installs S_B cleanly. arrival_seq
+    // only completes the strict weak ordering; it never decides a pairing.
+    std::sort(work.begin(), work.end(), [](const work_item& a, const work_item& b) {
+        if(a.tick != b.tick) return a.tick < b.tick;
+        if(a.kind != b.kind) return a.kind < b.kind;
+        return a.arrival_seq < b.arrival_seq;
+    });
+
+    for(const auto& w : work)
+    {
+        const auto&    rec = records[w.idx].rec;
+        const uint64_t ts  = w.tick;
+        const uint64_t key = (static_cast<uint64_t>(rec.doorbell_off) << 32) |
+                             static_cast<uint64_t>(rec.dispatch_id);
+
+        if(rec.record_type == kRecStart)
         {
-            const auto& rec = records[i].rec;
-            if(rec.record_type == kRecPadding || rec.doorbell_off == 0) continue;
-            // a torn record's doorbell_off/dispatch_id are as suspect as
-            // its tick, so it must never bind a START or claim an EOP. A torn START
-            // is thus never retained; its later intact EOP arrives start-unknown.
-            if(!records[i].loss_free) continue;
-            if(pass == 0 && rec.record_type != kRecStart) continue;
-            if(pass == 1 && rec.record_type == kRecStart) continue;
-
-            const uint64_t ts =
-                static_cast<uint64_t>(rec.ts_lo) | (static_cast<uint64_t>(rec.ts_hi) << 32);
-            const uint64_t key = (static_cast<uint64_t>(rec.doorbell_off) << 32) |
-                                 static_cast<uint64_t>(rec.dispatch_id);
-
-            if(rec.record_type == kRecStart)
+            ++state.starts_seen;
+            // dispatch_id is only low-32, so a raw key can recur. A second
+            // outstanding START on one key makes it AMBIGUOUS: keep the first
+            // START's ticks and age unchanged (so an unpairable key still ages out
+            // -- refreshing seen_at_ns would make it permanent) and count another
+            // outstanding. try_emplace, not [], so the first START's fields survive.
+            auto [it, ins] = state.pending_starts.try_emplace(
+                key, pair_state::pending_start{ts, now_ns, 1, false});
+            if(!ins)
             {
-                ++state.starts_seen;
-                // dispatch_id is only low-32, so a raw key can recur. A second
-                // outstanding START on one key makes it AMBIGUOUS: keep the first
-                // START's ticks and age unchanged (so an unpairable key still
-                // ages out -- refreshing seen_at_ns would make it permanent) and
-                // count another outstanding. try_emplace, not [], so the first
-                // START's fields survive the duplicate.
-                auto [it, ins] = state.pending_starts.try_emplace(
-                    key, pair_state::pending_start{ts, now_ns, 1, false});
-                if(!ins)
-                {
-                    ++state.starts_overwritten;
-                    it->second.ambiguous = true;
-                    ++it->second.outstanding;
-                }
-                continue;
+                ++state.starts_overwritten;
+                it->second.ambiguous = true;
+                ++it->second.outstanding;
             }
-            if(rec.record_type != kRecEop) continue;
-            ++state.eops_seen;
-
-            auto it = state.pending_starts.find(key);
-            if(it == state.pending_starts.end())
-            {
-                // The START was lost (shape ii): the EOP still proves the kernel
-                // finished, it just carries no interval.
-                ++state.unmatched_eops;
-                auto out         = drained_record{};
-                out.doorbell_off = rec.doorbell_off;
-                out.dispatch_id  = rec.dispatch_id;
-                out.end_ticks    = ts;
-                out.start_known  = false;
-                on_record(out);
-            }
-            else if(it->second.ambiguous)
-            {
-                // Cannot say which dispatch this EOP belongs to. Drop it HERE --
-                // forwarding it start-unknown would let the hub complete the
-                // wrong dispatch (the same-window low-32-wrap shape). The key
-                // stays unpairable until every outstanding START is consumed.
-                ++state.ambiguous_pairs;
-                if(--it->second.outstanding == 0) state.pending_starts.erase(it);
-            }
-            else
-            {
-                auto out         = drained_record{};
-                out.doorbell_off = rec.doorbell_off;
-                out.dispatch_id  = rec.dispatch_id;
-                out.end_ticks    = ts;
-                out.start_ticks  = it->second.start_ticks;
-                out.start_known  = true;
-                state.pending_starts.erase(it);
-                ++seen;
-                on_record(out);
-            }
+            continue;
         }
+
+        ++state.eops_seen;
+        auto it = state.pending_starts.find(key);
+        if(it == state.pending_starts.end())
+        {
+            // (1) no entry -- the START was lost: the EOP still proves the kernel
+            // finished, it just carries no interval.
+            ++state.unmatched_eops;
+            auto out         = drained_record{};
+            out.doorbell_off = rec.doorbell_off;
+            out.dispatch_id  = rec.dispatch_id;
+            out.end_ticks    = ts;
+            out.start_known  = false;
+            on_record(out);
+        }
+        else if(it->second.ambiguous)
+        {
+            // (2) ambiguous -- cannot say which dispatch this EOP belongs to.
+            // Drop HERE: forwarding it start-unknown would let the hub complete the
+            // wrong dispatch. The key stays unpairable until every outstanding
+            // START is consumed.
+            ++state.ambiguous_pairs;
+            if(--it->second.outstanding == 0) state.pending_starts.erase(it);
+        }
+        else if(ts == it->second.start_ticks)
+        {
+            // (3) equal tick -- no HW contract that start_ticks < end_ticks for a
+            // real pair, so fail closed: drop rather than form a zero/ambiguous pair.
+            ++state.equal_tick_drops;
+            if(--it->second.outstanding == 0) state.pending_starts.erase(it);
+        }
+        else if(ts < it->second.start_ticks)
+        {
+            // (4) stale EOP -- it predates the outstanding START, so it belongs to
+            // an earlier dispatch whose START was lost. Drop the EOP and leave the
+            // retained START untouched; consuming it would strand the EOP that
+            // really belongs to it.
+            ++state.stale_eop_drops;
+        }
+        else
+        {
+            // (5) outstanding==1, !ambiguous, t > start_ticks -- pair and erase.
+            auto out         = drained_record{};
+            out.doorbell_off = rec.doorbell_off;
+            out.dispatch_id  = rec.dispatch_id;
+            out.end_ticks    = ts;
+            out.start_ticks  = it->second.start_ticks;
+            out.start_known  = true;
+            state.pending_starts.erase(it);
+            ++seen;
+            on_record(out);
+        }
+    }
     return seen;
 }
 }  // namespace kfd

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
@@ -67,5 +67,30 @@ env_long_in_range(std::string_view name, long lo, long hi)
     }
     return _val;
 }
+
+// Same reject-and-default policy for a STRICT OPT-IN switch: only an explicit
+// true value turns the feature on. Unset, empty, a recognized false value, or
+// anything unrecognized all yield false -- the unrecognized case with exactly one
+// warning naming the variable and the value.
+//
+// common::get_env<bool> cannot serve here: it maps an unrecognized word ("flase")
+// to TRUE, fatals on empty, and throws on an out-of-range number. For an
+// LD_PRELOAD switch that changes completion semantics, every one of those is the
+// wrong direction -- a typo must never silently enable it and a bad value must
+// never throw out of a static initializer.
+inline bool
+env_bool_opt_in(std::string_view name)
+{
+    auto _raw = common::get_env_optional(name);
+    if(!_raw) return false;  // unset: off, no warning
+
+    const std::string& _s = *_raw;
+    if(_s == "1" || _s == "true" || _s == "yes" || _s == "on") return true;
+    if(_s == "0" || _s == "false" || _s == "no" || _s == "off" || _s.empty()) return false;
+
+    ROCP_WARNING << "KFD dispatch-log: " << name << "='" << _s
+                 << "' is not one of 1/true/yes/on or 0/false/no/off; treating as DISABLED";
+    return false;
+}
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
@@ -1,0 +1,71 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/environment.hpp"
+#include "lib/common/logging.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+// Shared env-parse contract for every dispatch-log knob (D8's quiesce, D5's two
+// budgets, D9's cap). common::get_env<int> cannot implement reject-and-warn --
+// std::stol silently accepts trailing junk and a narrowing cast hides overflow --
+// so accessors build on common::get_env_optional plus this helper instead.
+//
+// Policy, identical everywhere: reject-and-default, NEVER clamp. A value that is
+// SET but malformed or out of range yields nullopt (the caller substitutes its
+// default) and emits exactly one warning naming the variable and the value.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// nullopt = unset OR rejected. long is the parse type, so representability is
+// decided by strtol + ERANGE and the explicit [lo, hi] range, never a cast.
+inline std::optional<long>
+env_long_in_range(std::string_view name, long lo, long hi)
+{
+    auto _raw = common::get_env_optional(name);
+    if(!_raw) return std::nullopt;  // unset: caller's default, no warning
+
+    const std::string& _s = *_raw;
+    errno                 = 0;
+    char*      _end       = nullptr;
+    const long _val       = std::strtol(_s.c_str(), &_end, 10);
+    const bool _no_digit  = (_end == _s.c_str());
+    const bool _trailing  = (*_end != '\0');  // any trailing char, incl whitespace
+    const bool _range     = (errno == ERANGE) || (_val < lo) || (_val > hi);
+    if(_no_digit || _trailing || _range)
+    {
+        ROCP_WARNING << "KFD dispatch-log: " << name << "='" << _s << "' is not an integer in ["
+                     << lo << ", " << hi << "]; using default";
+        return std::nullopt;
+    }
+    return _val;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
@@ -1,0 +1,71 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/environment.hpp"
+#include "lib/common/logging.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+// Shared env-parse contract for every dispatch-log knob (D8's quiesce, D5's two
+// budgets, D9's cap). common::get_env<int> cannot implement reject-and-warn --
+// std::stol silently accepts trailing junk and a narrowing cast hides overflow --
+// so accessors build on common::get_env_optional plus this helper instead.
+//
+// Policy, identical everywhere: reject-and-default, NEVER clamp. A value that is
+// SET but malformed or out of range yields nullopt (the caller substitutes its
+// default) and emits exactly one warning naming the variable and the value.
+
+namespace rocprofiler
+{
+namespace kfd
+{
+// nullopt = unset OR rejected. long is the parse type, so representability is
+// decided by strtol + ERANGE and the explicit [lo, hi] range, never a cast.
+inline std::optional<long>
+env_long_in_range(std::string_view name, long lo, long hi)
+{
+    auto _raw = common::get_env_optional(name);
+    if(!_raw) return std::nullopt;  // unset: caller's default, no warning
+
+    const std::string& _s   = *_raw;
+    errno                    = 0;
+    char*      _end          = nullptr;
+    const long _val          = std::strtol(_s.c_str(), &_end, 10);
+    const bool _no_digit     = (_end == _s.c_str());
+    const bool _trailing     = (*_end != '\0');  // any trailing char, incl whitespace
+    const bool _range        = (errno == ERANGE) || (_val < lo) || (_val > hi);
+    if(_no_digit || _trailing || _range)
+    {
+        ROCP_WARNING << "KFD dispatch-log: " << name << "='" << _s << "' is not an integer in ["
+                     << lo << ", " << hi << "]; using default";
+        return std::nullopt;
+    }
+    return _val;
+}
+}  // namespace kfd
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
@@ -24,6 +24,7 @@
 
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
 #include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
@@ -149,6 +150,17 @@ discover_stream_dispatch_log_gpus(const char* nodes_path)
     return gpu_ids;
 }
 
+// F15: is any registered context actually tracing kernel dispatch? Same predicate
+// as the interposition arm (buffer OR callback kernel-dispatch tracing).
+bool
+kernel_dispatch_context_registered()
+{
+    return !context::get_registered_contexts([](const context::context* ctx) {
+                return ctx->is_tracing_one_of(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                              ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH);
+            }).empty();
+}
+
 void
 init_kfd_profiler()
 {
@@ -204,10 +216,12 @@ init_kfd_profiler()
     // a tool that starts its kernel-dispatch context in tool_init calls
     // start_context BEFORE HSA loads, so the arm there is a guaranteed no-op and
     // the ring is armed only lazily on the first dispatch -- losing the earliest
-    // ones. This runs at HSA-table install, gated by the feature and reached only
-    // because a kernel-dispatch context enabled interception, so arm now that
-    // probe_ok is set. Idempotent (establish_session early-outs).
-    if(signal_less_feature_enabled()) arm_dispatch_log_sessions();
+    // ones. This runs at HSA-table install, so arm eagerly ONLY when a
+    // kernel-dispatch context is actually registered (F15); the start_context arm
+    // and the lazy first-dispatch fallback still cover a context started later.
+    // Idempotent (establish_session early-outs).
+    if(signal_less_feature_enabled() && kernel_dispatch_context_registered())
+        arm_dispatch_log_sessions();
 
     // Neither the reader thread nor the ring is created here: installing the HSA
     // table says nothing about whether anyone wants kernel traces, and the SDK

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.cpp
@@ -24,6 +24,7 @@
 
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
 #include "lib/rocprofiler-sdk/kfd/signal_less_gate.hpp"
 
@@ -149,6 +150,18 @@ discover_stream_dispatch_log_gpus(const char* nodes_path)
     return gpu_ids;
 }
 
+// F15: is any registered context actually tracing kernel dispatch? Same predicate
+// as the interposition arm (buffer OR callback kernel-dispatch tracing).
+bool
+kernel_dispatch_context_registered()
+{
+    return !context::get_registered_contexts([](const context::context* ctx) {
+                return ctx->is_tracing_one_of(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                              ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH);
+            })
+                .empty();
+}
+
 void
 init_kfd_profiler()
 {
@@ -204,10 +217,12 @@ init_kfd_profiler()
     // a tool that starts its kernel-dispatch context in tool_init calls
     // start_context BEFORE HSA loads, so the arm there is a guaranteed no-op and
     // the ring is armed only lazily on the first dispatch -- losing the earliest
-    // ones. This runs at HSA-table install, gated by the feature and reached only
-    // because a kernel-dispatch context enabled interception, so arm now that
-    // probe_ok is set. Idempotent (establish_session early-outs).
-    if(signal_less_feature_enabled()) arm_dispatch_log_sessions();
+    // ones. This runs at HSA-table install, so arm eagerly ONLY when a
+    // kernel-dispatch context is actually registered (F15); the start_context arm
+    // and the lazy first-dispatch fallback still cover a context started later.
+    // Idempotent (establish_session early-outs).
+    if(signal_less_feature_enabled() && kernel_dispatch_context_registered())
+        arm_dispatch_log_sessions();
 
     // Neither the reader thread nor the ring is created here: installing the HSA
     // table says nothing about whether anyone wants kernel traces, and the SDK

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_profiler.hpp
@@ -43,9 +43,10 @@ std::unordered_set<uint32_t>
 discover_stream_dispatch_log_gpus(const char* nodes_path);
 
 // Env opt-out, open /dev/kfd, profiler VERSION ioctl, ABI check, GPU discovery.
-// Idempotent, never throws. Probe only: it starts no thread and arms no ring, so
-// a process with no consumer of kernel-dispatch data gains no SDK-internal
-// thread. Outcome published via kfd_dispatch_log_supported().
+// Idempotent, never throws. Starts no reader thread; it arms the ring eagerly only
+// when a kernel-dispatch context is already registered (F15), otherwise a process
+// with no consumer of kernel-dispatch data gains no SDK-internal thread and the
+// ring is armed lazily on first dispatch. Outcome via kfd_dispatch_log_supported().
 void
 init_kfd_profiler();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -29,6 +29,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
 #include "lib/rocprofiler-sdk/kfd/poll_reader.hpp"
@@ -125,6 +126,25 @@ start_max_age_ns()
     return _cached;
 }
 
+// Hard size cap on a GPU's retained-START map. start_max_age_ns() above is only
+// the slow age backstop, so this is the bound that actually holds under a
+// sustained EOP loss -- exactly the role D9's cap plays for the hub, sized the
+// same way and for the same reason (the map is per-GPU, and a workload's genuine
+// in-flight peak is hundreds of thousands of dispatches). The [1, 4194304] range
+// and the reject-and-default parse are D8/D9's shared contract; read once, forced
+// at reader start so no worker thread races a concurrent setenv.
+size_t
+pending_starts_cap()
+{
+    static const size_t _cached = []() -> size_t {
+        constexpr long _dflt = 2'000'000;
+        auto           _v =
+            env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
+        return static_cast<size_t>(_v.value_or(_dflt));
+    }();
+    return _cached;
+}
+
 // Overflow depth at which the processor is clearly not keeping up. Not a cap:
 // dropping here would lose records the ring already gave us.
 constexpr size_t kOverflowWarnDepth = 256;
@@ -157,7 +177,12 @@ struct processor_state
 {
     std::unordered_map<uint32_t, pair_state> by_gpu = {};
 
-    pair_state& for_gpu(uint32_t gpu_id) { return by_gpu[gpu_id]; }
+    pair_state& for_gpu(uint32_t gpu_id)
+    {
+        auto [it, ins] = by_gpu.try_emplace(gpu_id);
+        if(ins) it->second.max_pending_starts = pending_starts_cap();
+        return it->second;
+    }
 };
 
 // Validated before any sizing math uses it.
@@ -858,9 +883,14 @@ processor_loop()
         // reader's release so the following pipe.empty() is guaranteed to see it.
         // Covers only copied-but-unpublished EOPs (F4); an EOP still in the ring is
         // the accepted R10 residual and is not gated here.
-        const uint64_t _gc_now = common::timestamp_ns();
-        if(gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
-                        st.pipe.empty()) &&
+        // Sequenced into named locals rather than passed inline: the order of
+        // evaluation of function arguments is UNSPECIFIED, so the required
+        // "in-flight load, THEN pipe.empty()" ordering cannot be expressed by
+        // argument position.
+        const uint64_t _gc_now      = common::timestamp_ns();
+        const uint64_t _unpublished = st.reader_copied_unpublished.load(std::memory_order_acquire);
+        const bool     _pipe_empty  = st.pipe.empty();
+        if(gc_gate_open(_unpublished, _pipe_empty) &&
            _gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
         {
             last_gc_ns = _gc_now;
@@ -910,7 +940,8 @@ processor_loop()
             "KFD dispatch-log pairing census (gpu_id={}): {} START record(s) drained, {} EOP "
             "record(s) drained, {} EOP(s) unmatched, {} START(s) overwritten on a live key, {} "
             "ambiguous EOP(s) dropped, {} equal-tick EOP(s) dropped, {} stale EOP(s) dropped, {} "
-            "START(s) evicted stale, {} START(s) still retained at exit",
+            "START(s) evicted stale, {} START(s) evicted by the size cap, {} START(s) still "
+            "retained at exit",
             _gpu_itr.first,
             _p.starts_seen,
             _p.eops_seen,
@@ -920,6 +951,7 @@ processor_loop()
             _p.equal_tick_drops,
             _p.stale_eop_drops,
             _p.starts_evicted,
+            _p.starts_cap_evicted,
             _p.pending_starts.size());
     }
 }
@@ -1126,6 +1158,64 @@ reader_loop()
             auto&                 _s   = st.sessions[slot_of[k - kFirstStreamPollSlot]];
             if(_s.quarantined) continue;
 
+            // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
+            // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal are
+            // independent latches in the driver) after which the stream never produces
+            // again ("no live consumer, do not arm"). Read STREAM_OP_STATUS to tell
+            // them apart; FATAL is terminal.
+            //
+            // Also probed with NO revents at all while the empty-wake backstop is
+            // tripped: the backstop polls only the control fd and zeroes the stream
+            // revents, so classify_terminal_revents() reports `none` forever and a
+            // stream that went fatal underneath it would never be re-examined -- the
+            // session would stay `ready`, handing out correlation keys nothing can
+            // ever deliver. Restricted to the backstop's poll TIMEOUT so the extra
+            // ioctl runs at the poll-timeout cadence, not per wake.
+            const bool _probe_fatal =
+                (_act == terminal_action::keep_live) || (_backstop && rc == 0);
+            if(_probe_fatal && (read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
+            {
+                // Drain-first: defer while records remain (the top-of-loop drain
+                // already ran this pass; firmware produces nothing more after
+                // FATAL, so this converges) so no already-published record is lost.
+                if(session_has_pending(_s) || !_s.overflow.empty()) continue;
+                log_stream_status(_s);
+                ROCP_WARNING << fmt::format(
+                    "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
+                    "draining, quarantining, and disabling signal-less process-wide",
+                    _s.gpu_id,
+                    static_cast<unsigned>(fds[k].revents));
+                // Clear ready before quarantine so find_session()/establish_session()
+                // stop handing out keys for a stream that can never deliver them.
+                _s.ready.store(false, std::memory_order_release);
+                _s.quarantined   = true;
+                _quarantined_any = true;
+                // Smallest safe containment: the reset invalidated the clock domain
+                // this stream's windows were opened against, so drop the whole
+                // signal-less path process-wide (hub disable latch drains+ledgers
+                // live entries) rather than risk mis-windowing against a reset clock.
+                //
+                // Ring and overflow are dry above, but the batches already PUBLISHED
+                // into the pipe are not: this session's final EOP, and the EOPs of
+                // every healthy GPU queued behind it, are still waiting on the
+                // processor. Draining the hub first would ledger their entries and
+                // leave those records unmatched. So latch admission closed, let the
+                // processor consume what is published (the same gate the closed-window
+                // GC uses -- copied-unpublished first, then pipe.empty), and only then
+                // ledger the residual. Bounded by the close budget so one wedged
+                // processor cannot stall the ring for the other GPUs; on timeout the
+                // disable proceeds exactly as it did before.
+                signal_less_disable_latch().store(true, std::memory_order_release);
+                const uint64_t _pipe_deadline = common::timestamp_ns() + close_drain_budget_ns();
+                while(!gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
+                                    st.pipe.empty()) &&
+                      common::timestamp_ns() < _pipe_deadline &&
+                      !st.stop.load(std::memory_order_acquire))
+                    std::this_thread::sleep_for(std::chrono::microseconds{200});
+                signal_less_disable_permanently();
+                continue;
+            }
+
             if(_act == terminal_action::none)
             {
                 // A real poll of this stream showing no error clears the edge trigger
@@ -1137,36 +1227,6 @@ reader_loop()
 
             if(_act == terminal_action::keep_live)
             {
-                // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
-                // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal
-                // are independent latches in the driver) after which the stream never
-                // produces again ("no live consumer, do not arm"). Read STREAM_OP_STATUS
-                // to tell them apart; FATAL is terminal.
-                if((read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
-                {
-                    // Drain-first: defer while records remain (the top-of-loop drain
-                    // already ran this pass; firmware produces nothing more after
-                    // FATAL, so this converges) so no already-published record is lost.
-                    if(session_has_pending(_s) || !_s.overflow.empty()) continue;
-                    log_stream_status(_s);
-                    ROCP_WARNING << fmt::format(
-                        "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
-                        "draining, quarantining, and disabling signal-less process-wide",
-                        _s.gpu_id,
-                        static_cast<unsigned>(fds[k].revents));
-                    // Clear ready before quarantine so find_session()/establish_session()
-                    // stop handing out keys for a stream that can never deliver them.
-                    _s.ready.store(false, std::memory_order_release);
-                    _s.quarantined   = true;
-                    _quarantined_any = true;
-                    // Smallest safe containment: the reset invalidated the clock domain
-                    // this stream's windows were opened against, so drop the whole
-                    // signal-less path process-wide (hub disable latch drains+ledgers
-                    // live entries) rather than risk mis-windowing against a reset clock.
-                    signal_less_disable_permanently();
-                    continue;
-                }
-
                 // Recoverable reset: describe it ONCE per episode -- POLLERR is
                 // returned by poll() every pass, so an unlatched warning would spin
                 // the log -- then keep the stream live. The wake already fed the
@@ -1364,6 +1424,15 @@ start_kfd_reader()
     // a proven completion are constructed lazily, but they run off the pipe, not
     // the ring, so a first-use allocation there cannot cause an overrun.)
     overrun_reported();
+
+    // Same reasoning for the env-backed knobs: each caches its read in a
+    // function-local static on first use, and common::get_env* scans `environ`,
+    // which races a concurrent setenv. Populate them all HERE, on the one
+    // serialized start path under setup_mu with no worker thread yet in existence,
+    // instead of letting a processor/producer/teardown thread do it lazily.
+    start_max_age_ns();
+    pending_starts_cap();
+    signal_less_prime_env();
 
     // Processor first: it must be ready to consume before the reader can publish,
     // otherwise the first batches are dropped for no reason.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -92,7 +92,38 @@ constexpr size_t kMaxSessions = 64;
 // unmatched start belongs to a dispatch whose eop never arrived.
 constexpr uint64_t kLoggingIntervalNs        = 1'000'000'000ull;  // 1 s
 constexpr uint64_t kProcessorEvictIntervalNs = 1'000'000'000ull;  // 1 s
-constexpr uint64_t kStartMaxAgeNs            = 5'000'000'000ull;  // 5 s
+
+// F3: a retained START may belong to a still-running long kernel, so the eviction
+// age MUST exceed the longest real dispatch or a live kernel's START is aged out
+// before its EOP arrives (emitting it start-unknown). The old 5 s bound aged out
+// ordinary multi-second kernels; default to 30 min and let it be tuned in seconds
+// via ROCPROFILER_KFD_DISPATCH_LOG_START_MAX_AGE_SEC. Eviction still bounds
+// pending_starts growth for genuinely orphaned STARTs (queue died mid-dispatch),
+// now paired with the F7 per-GPU hub cap for the fast-churn case. Coordinated with
+// F7: the age is the slow backstop, the hub cap the hard bound.
+constexpr uint64_t kStartMaxAgeSecDefault = 1800;  // 30 min
+
+uint64_t
+start_max_age_ns()
+{
+    // Read the env once: this runs every processor batch and common::get_env
+    // scans environ, which is not thread-safe against concurrent env mutation.
+    static const uint64_t _cached = []() {
+        const uint64_t _sec = common::get_env<uint64_t>(
+            "ROCPROFILER_KFD_DISPATCH_LOG_START_MAX_AGE_SEC", uint64_t{kStartMaxAgeSecDefault});
+        // Clamp: 0 (or an unparsed 0) would evict everything immediately; an absurd
+        // value could overflow the ns multiply. Bound to [1 s, 7 days].
+        constexpr uint64_t _min_sec = 1;
+        constexpr uint64_t _max_sec = 7ull * 24 * 3600;
+        uint64_t           _use     = _sec;
+        if(_sec < _min_sec)
+            _use = kStartMaxAgeSecDefault;
+        else if(_sec > _max_sec)
+            _use = _max_sec;
+        return _use * 1'000'000'000ull;
+    }();
+    return _cached;
+}
 
 // Overflow depth at which the processor is clearly not keeping up. Not a cap:
 // dropping here would lose records the ring already gave us.
@@ -209,6 +240,13 @@ struct reader_state
     // `stop` only asks it to wind down; the reader still publishes a final batch
     // afterwards, so the processor must key its exit off this instead.
     std::atomic<bool> reader_done = {false};
+    // Records copied out of the ring but not yet visible in the pipe: reserved
+    // per region inside copy_pipes() before the first memcpy, discharged per batch
+    // at publish(). The processor's closed-window GC reads this (acquire) before
+    // pipe.empty() so it never expires a window whose EOP is already in the
+    // reader's hand but not yet published. Reader is the sole writer. Covers only
+    // COPIED EOPs (F4); EOPs still in the ring remain the accepted R10 residual.
+    std::atomic<uint64_t> reader_copied_unpublished = {0};
     // Read by nudge_reader() (from wait_for_reader_quiesce, ~500 Hz) while
     // stop_reader() writes them; atomic so those overlap without a data race and a
     // nudge never writes into a recycled fd.
@@ -500,18 +538,28 @@ copy_records(reader_state& st)
                                         wptr_arr,
                                         rptr_arr,
                                         _s.cursors,
-                                        _batch->records);
+                                        _batch->records,
+                                        &st.reader_copied_unpublished);
 
         if(_direct)
         {
             // Release-store inside publish() orders the copy above before the
-            // processor can observe the batch.
-            if(_copied > 0) st.pipe.publish();
+            // processor can observe the batch. Discharge the reservation this
+            // batch made (_copied == _batch->records.size() on the direct path)
+            // right after publish, so a copied EOP is counted continuously from
+            // copy_pipes' reserve until the processor can see it.
+            if(_copied > 0)
+            {
+                st.pipe.publish();
+                st.reader_copied_unpublished.fetch_sub(_copied, std::memory_order_release);
+            }
         }
         else
         {
             if(_copied == 0) _s.overflow.pop_back();
-            spill_overflow_to_pipe(st.pipe, _s.overflow);
+            // Records parked in overflow stay reserved until their spill publishes
+            // them, so window (1) is covered by the same counter.
+            spill_overflow_to_pipe(st.pipe, _s.overflow, &st.reader_copied_unpublished);
             note_overflow_depth(st, _s);
         }
         _total += _copied;
@@ -561,7 +609,7 @@ process_batch(processor_state& proc, const record_batch& batch)
     // backlogged processor ages nothing. starts_evicted is an R1 source counter.
     if(batch.now_ns - _pairing.last_evict_ns >= kProcessorEvictIntervalNs)
     {
-        _pairing.starts_evicted += _pairing.evict_stale(batch.now_ns, kStartMaxAgeNs);
+        _pairing.starts_evicted += _pairing.evict_stale(batch.now_ns, start_max_age_ns());
         _pairing.last_evict_ns = batch.now_ns;
     }
 
@@ -646,21 +694,50 @@ log_stream_status(const dlog_session& s)
                              args.status.target_exit_count);
 }
 
+// Read the STREAM_OP_STATUS flags word (F11 FATAL detection). Returns 0 on a dead
+// fd or a failed ioctl: 0 has no bits set, so the FATAL test fails and the caller
+// falls back to the recoverable-reset handling -- safe, because a genuinely fatal
+// stream also stops producing and will re-assert POLLERR (or HUP) on the next pass.
+// Unlike log_stream_status this returns the word so a data decision can be made:
+// FATAL is the one status bit that gates handling, per the driver contract.
+uint64_t
+read_stream_status_flags(const dlog_session& s)
+{
+    if(s.stream_fd < 0) return 0;
+    auto args = kfd_dlog_stream_args{};
+    args.op   = KFD_DLOG_STREAM_OP_STATUS;
+    if(ioctl(s.stream_fd, KFD_DLOG_STREAM_IOC, &args) != 0) return 0;
+    return args.status.status;
+}
+
 void
 stop_reader()
 {
     auto& st = state();
-    if(!st.running.load(std::memory_order_acquire)) return;
+
+    // setup_mu is taken BEFORE reading running: reading it first (as before) is a
+    // no-op that misses a concurrent establish_session() mid-arm before it publishes
+    // running=true, which would then create reader threads and publish a session
+    // after teardown. establish_session() re-checks get_fini_status() and
+    // reader_unavailable UNDER this same lock, so latching reader_unavailable here
+    // makes the in-flight arm refuse. The whole terminating sequence runs in this one
+    // critical section; setup_mu is a leaf (no worker thread acquires it), so holding
+    // it across the joins cannot deadlock. stop+wake precede the joins so the join is
+    // bounded rather than hanging while holding setup_mu.
+    auto _lk = std::lock_guard<std::mutex>{st.setup_mu};
+    if(!st.running.load(std::memory_order_relaxed)) return;
 
     // Latch unavailable before the join so no dispatch can acquire a correlation
-    // key against a reader that is on its way out (cleared again below).
+    // key against a reader that is on its way out (cleared again below only on a
+    // non-finalize stop).
     st.reader_unavailable.store(true, std::memory_order_release);
     st.stop.store(true, std::memory_order_release);
     const int _wake = st.wake_fd.load(std::memory_order_acquire);
     if(_wake >= 0)
     {
         uint64_t one = 1;
-        // Best-effort wake; a failed write only costs one poll interval.
+        // Best-effort wake BEFORE any join, so the reader observes stop and exits
+        // rather than the join hanging while setup_mu is held.
         [[maybe_unused]] auto _rc = ::write(_wake, &one, sizeof(one));
     }
     if(st.thread.joinable()) st.thread.join();
@@ -668,17 +745,6 @@ stop_reader()
     // only shrink. The processor then drains what is left and exits.
     if(st.processor_thread.joinable()) st.processor_thread.join();
 
-    // Teardown runs without taking setup_mu on purpose: it is only safe because the
-    // caller (registration::finalize) tears down queue interception
-    // (queue_controller_fini) BEFORE kfd::finalize(), so no interceptor thread can
-    // still be inside ensure_reader_session()/setup_session() by the time we get
-    // here, and finalize itself is std::call_once (single-threaded). If that ordering
-    // ever changes, this teardown must take st.setup_mu to serialize against a
-    // concurrent setup_session(). The reader thread is already stopped+joined above.
-    // Belt-and-suspenders against a late dispatch in the teardown window:
-    // establish_session() additionally refuses when registration::get_fini_status()
-    // != 0, so once finalization has started a dispatch can no longer re-arm the
-    // reader even if it slips past the reader_unavailable latch this function set.
     const size_t _n = st.session_count.load(std::memory_order_acquire);
     for(size_t i = 0; i < _n; ++i)
     {
@@ -687,7 +753,13 @@ stop_reader()
     }
     st.session_count.store(0, std::memory_order_release);
     st.any_session_ready.store(false, std::memory_order_release);
-    st.reader_unavailable.store(false, std::memory_order_release);
+    // Finalize-path stop: leave reader_unavailable LATCHED so a dispatch that
+    // slipped past establish_session()'s pre-lock checks cannot re-arm the reader
+    // under setup_mu after us. A non-finalize stop (a client detach that may
+    // re-attach) clears it so a later establish_session() can restart the reader.
+    if(registration::get_fini_status() == 0)
+        st.reader_unavailable.store(false, std::memory_order_release);
+
     if(st.kfd_fd >= 0)
     {
         ::close(st.kfd_fd);
@@ -701,7 +773,16 @@ stop_reader()
     ROCP_INFO << "KFD dispatch-log reader: stopped";
 }
 
-reader_state::~reader_state() { stop_reader(); }
+reader_state::~reader_state()
+{
+    // F13 part 2: in a fork child (D6's unconditional fork generation) the reader
+    // thread does not exist and setup_mu / the session containers may be mid-mutation
+    // by a vanished thread. Skip stop_reader()'s join+teardown -- the same treatment
+    // D6 gives TaskGroup (skip the dangerous thread work; the child abandoned this
+    // state via disable_reader_in_child). Value members destruct as they do there.
+    if(internal_threading::fork_stale()) return;
+    stop_reader();
+}
 
 // pthread_atfork child handler. Only the forking thread survives, so this does
 // atomic stores and fd/mapping drops only -- no lock, no allocation, no join.
@@ -723,18 +804,23 @@ disable_reader_in_child()
     // Not detach(): that would leave the handle believing a thread exists.
     new(&st.thread) std::thread{};
     new(&st.processor_thread) std::thread{};
-    // Drop the reference WITHOUT closing (§3.8): the persistent wake eventfd is
-    // owned by the parent; closing it here would corrupt the parent's descriptor. A
-    // child that later starts a reader creates its own (wake_fd < 0).
+    // Drop the reference WITHOUT closing (§3.8): the persistent wake eventfd's number
+    // must never be recycled under the parent's nudge_reader; the child sets it -1 so
+    // its own nudge is inert and a later child reader creates a fresh one.
     st.wake_fd.store(-1, std::memory_order_relaxed);
-    st.kfd_fd = -1;
-    // Dropping ownership without freeing: the parent still owns them, and a free
-    // here would corrupt its state.
+    // F13: close the inherited fds/maps. After fork the child has its own fd table,
+    // so close()/munmap() here release the child's copies WITHOUT touching the
+    // parent's descriptors (the old "corrupts the parent" comment was wrong). Both
+    // are async-signal-safe, which the atfork child handler requires.
+    if(st.kfd_fd >= 0) ::close(st.kfd_fd);
+    st.kfd_fd       = -1;
     const size_t _n = st.session_count.load(std::memory_order_relaxed);
     for(size_t i = 0; i < _n && i < kMaxSessions; ++i)
     {
         st.sessions[i].ready.store(false, std::memory_order_relaxed);
-        st.sessions[i].smap      = MAP_FAILED;
+        if(st.sessions[i].smap != MAP_FAILED) munmap(st.sessions[i].smap, st.sessions[i].smap_len);
+        st.sessions[i].smap = MAP_FAILED;
+        if(st.sessions[i].stream_fd >= 0) ::close(st.sessions[i].stream_fd);
         st.sessions[i].stream_fd = -1;
         // Same reuse hazard as teardown_session(): session_count is zeroed here, so
         // any later re-arm in the child reuses these slots. Reset the drain cursors
@@ -755,13 +841,27 @@ processor_loop()
 
     while(true)
     {
-        // GC closed-window entries on the periodic tick, ABOVE the
-        // pipe-empty continue -- an idle GPU (a queue destroyed after its work
-        // finished, the dominant case) never delivers another batch, so a GC placed
-        // after process_batch would never run and the close_grace_ns bound would be
-        // vacuous. Leaked payloads are ledgered; dropping them here is off the lock.
+        // GC closed-window entries on the periodic tick, but ONLY when the pipe is
+        // empty: an EOP that would resolve a closed window may be sitting in a
+        // backlog behind us, and GC'ing its window first would expire it as a leak
+        // and then drop the EOP as start-unknown. Gating on an empty pipe means we
+        // only expire windows once no queued batch can still close them. The idle
+        // GPU (a queue destroyed after its work finished, the dominant case) still
+        // GCs promptly -- its pipe drains to empty and stays there, so the
+        // close_grace_ns bound is honored. Residual: a GPU whose pipe never empties
+        // (a continuous backlog) defers GC indefinitely, but a continuous backlog
+        // means the processor is actively resolving windows, so nothing is leaking.
+        // Leaked payloads are ledgered; dropping them here is off the lock.
+        // In-flight load FIRST, then pipe.empty(): reversing them is unsound. A
+        // zero read here (acquire) means every record the reader took out of the
+        // ring was published BEFORE this load, and the acquire pairs with the
+        // reader's release so the following pipe.empty() is guaranteed to see it.
+        // Covers only copied-but-unpublished EOPs (F4); an EOP still in the ring is
+        // the accepted R10 residual and is not gated here.
         const uint64_t _gc_now = common::timestamp_ns();
-        if(_gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
+        if(gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
+                        st.pipe.empty()) &&
+           _gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
         {
             last_gc_ns = _gc_now;
             auto _gc   = signal_less_hub().gc_closed_windows(steady_now_ns());
@@ -809,14 +909,16 @@ processor_loop()
         ROCP_WARNING << fmt::format(
             "KFD dispatch-log pairing census (gpu_id={}): {} START record(s) drained, {} EOP "
             "record(s) drained, {} EOP(s) unmatched, {} START(s) overwritten on a live key, {} "
-            "ambiguous EOP(s) dropped, {} START(s) evicted stale, {} START(s) still retained at "
-            "exit",
+            "ambiguous EOP(s) dropped, {} equal-tick EOP(s) dropped, {} stale EOP(s) dropped, {} "
+            "START(s) evicted stale, {} START(s) still retained at exit",
             _gpu_itr.first,
             _p.starts_seen,
             _p.eops_seen,
             _p.unmatched_eops,
             _p.starts_overwritten,
             _p.ambiguous_pairs,
+            _p.equal_tick_drops,
+            _p.stale_eop_drops,
             _p.starts_evicted,
             _p.pending_starts.size());
     }
@@ -998,6 +1100,16 @@ reader_loop()
                 backstop_warned = true;
             }
         }
+        else if(all_live_overflow_empty(st))
+        {
+            // No session is armed, so the ready-set is trivially drained: advance
+            // drain_epoch every pass so a fence blocked on drain progress is not made
+            // to burn its whole timeout waiting for a +2 that drain_sessions_bounded
+            // (only reached when a session IS ready) would otherwise never post. The
+            // overflow guard still holds: a copied-but-unpublished batch must reach
+            // the pipe before the epoch may advance.
+            st.drain_epoch.fetch_add(1, std::memory_order_release);
+        }
 
         // Terminal streams. POLLHUP/POLLNVAL are terminal: the stream will never
         // produce again, so it is drained first (above), then -- only once it is
@@ -1025,6 +1137,36 @@ reader_loop()
 
             if(_act == terminal_action::keep_live)
             {
+                // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
+                // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal
+                // are independent latches in the driver) after which the stream never
+                // produces again ("no live consumer, do not arm"). Read STREAM_OP_STATUS
+                // to tell them apart; FATAL is terminal.
+                if((read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
+                {
+                    // Drain-first: defer while records remain (the top-of-loop drain
+                    // already ran this pass; firmware produces nothing more after
+                    // FATAL, so this converges) so no already-published record is lost.
+                    if(session_has_pending(_s) || !_s.overflow.empty()) continue;
+                    log_stream_status(_s);
+                    ROCP_WARNING << fmt::format(
+                        "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
+                        "draining, quarantining, and disabling signal-less process-wide",
+                        _s.gpu_id,
+                        static_cast<unsigned>(fds[k].revents));
+                    // Clear ready before quarantine so find_session()/establish_session()
+                    // stop handing out keys for a stream that can never deliver them.
+                    _s.ready.store(false, std::memory_order_release);
+                    _s.quarantined   = true;
+                    _quarantined_any = true;
+                    // Smallest safe containment: the reset invalidated the clock domain
+                    // this stream's windows were opened against, so drop the whole
+                    // signal-less path process-wide (hub disable latch drains+ledgers
+                    // live entries) rather than risk mis-windowing against a reset clock.
+                    signal_less_disable_permanently();
+                    continue;
+                }
+
                 // Recoverable reset: describe it ONCE per episode -- POLLERR is
                 // returned by poll() every pass, so an unlatched warning would spin
                 // the log -- then keep the stream live. The wake already fed the
@@ -1043,8 +1185,12 @@ reader_loop()
             }
 
             // Drain-first-then-quarantine: defer while records remain so terminal
-            // records are not discarded at the bounded-pass cap.
-            if(session_has_pending(_s)) continue;
+            // records are not discarded at the bounded-pass cap. session_has_pending
+            // only inspects the ring; a batch already copied into this session's
+            // reader-owned overflow deque but not yet spilled to the pipe would be
+            // stranded by quarantine (copy_records skips !ready sessions), so defer
+            // while overflow is non-empty too.
+            if(session_has_pending(_s) || !_s.overflow.empty()) continue;
 
             log_stream_status(_s);
             ROCP_INFO << fmt::format(
@@ -1099,7 +1245,9 @@ reader_loop()
             _pending = false;
             for(size_t i = 0; i < _n; ++i)
             {
-                if(spill_overflow_to_pipe(st.pipe, st.sessions[i].overflow)) continue;
+                if(spill_overflow_to_pipe(
+                       st.pipe, st.sessions[i].overflow, &st.reader_copied_unpublished))
+                    continue;
                 _pending = true;
             }
             if(_pending) std::this_thread::sleep_for(std::chrono::microseconds{200});
@@ -1201,6 +1349,10 @@ start_kfd_reader()
 
     st.stop.store(false, std::memory_order_release);
     st.reader_done.store(false, std::memory_order_release);
+    // Reset before any worker thread exists: teardown_session() drops a prior
+    // reader's unspilled overflow batches whose reservations never published, so a
+    // stale residual here would keep the GC gate closed for this whole instance.
+    st.reader_copied_unpublished.store(0, std::memory_order_release);
 
     // Force-construct the singletons the reader/processor hot paths touch here,
     // BEFORE the worker threads exist, so a first-use allocation cannot stall the
@@ -1266,6 +1418,15 @@ kfd_reader_state_constructed()
 {
     // Non-constructing peek (::get(), not state()'s ::construct()).
     return common::static_object<reader_state>::get() != nullptr;
+}
+
+bool
+reader_unavailable()
+{
+    // Non-constructing: an unconstructed reader was never armed, so it is not
+    // "unavailable" in the sense N1 cares about (nothing to quiesce).
+    auto* _st = common::static_object<reader_state>::get();
+    return _st != nullptr && _st->reader_unavailable.load(std::memory_order_acquire);
 }
 
 bool
@@ -1383,6 +1544,12 @@ establish_session(uint32_t gpu_id, bool latch_retryable)
         return _existing->ready.load(std::memory_order_acquire);
 
     auto lk = std::lock_guard<std::mutex>{st.setup_mu};
+    // Re-check finalization UNDER setup_mu: the pre-lock get_fini_status() check
+    // above can pass and finalization then begin before we take the lock. stop_reader()
+    // sets reader_unavailable and tears down sessions while holding this same lock, so
+    // re-checking both here closes the window where we would setup_session() into an
+    // array stop_reader() is concurrently clearing.
+    if(registration::get_fini_status() != 0) return false;
     // Re-check under the lock: another thread may have armed this GPU meanwhile.
     if(auto* _existing = find_session(st, gpu_id))
         return _existing->ready.load(std::memory_order_relaxed);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -92,7 +92,36 @@ constexpr size_t kMaxSessions = 64;
 // unmatched start belongs to a dispatch whose eop never arrived.
 constexpr uint64_t kLoggingIntervalNs        = 1'000'000'000ull;  // 1 s
 constexpr uint64_t kProcessorEvictIntervalNs = 1'000'000'000ull;  // 1 s
-constexpr uint64_t kStartMaxAgeNs            = 5'000'000'000ull;  // 5 s
+
+// F3: a retained START may belong to a still-running long kernel, so the eviction
+// age MUST exceed the longest real dispatch or a live kernel's START is aged out
+// before its EOP arrives (emitting it start-unknown). The old 5 s bound aged out
+// ordinary multi-second kernels; default to 30 min and let it be tuned in seconds
+// via ROCPROFILER_KFD_DISPATCH_LOG_START_MAX_AGE_SEC. Eviction still bounds
+// pending_starts growth for genuinely orphaned STARTs (queue died mid-dispatch),
+// now paired with the F7 per-GPU hub cap for the fast-churn case. Coordinated with
+// F7: the age is the slow backstop, the hub cap the hard bound.
+constexpr uint64_t kStartMaxAgeSecDefault = 1800;  // 30 min
+
+uint64_t
+start_max_age_ns()
+{
+    // Read the env once: this runs every processor batch and common::get_env
+    // scans environ, which is not thread-safe against concurrent env mutation.
+    static const uint64_t _cached = []() {
+        const uint64_t _sec = common::get_env<uint64_t>(
+            "ROCPROFILER_KFD_DISPATCH_LOG_START_MAX_AGE_SEC", uint64_t{kStartMaxAgeSecDefault});
+        // Clamp: 0 (or an unparsed 0) would evict everything immediately; an absurd
+        // value could overflow the ns multiply. Bound to [1 s, 7 days].
+        constexpr uint64_t _min_sec = 1;
+        constexpr uint64_t _max_sec = 7ull * 24 * 3600;
+        const uint64_t     _use     = _sec < _min_sec   ? kStartMaxAgeSecDefault
+                                      : _sec > _max_sec ? _max_sec
+                                                        : _sec;
+        return _use * 1'000'000'000ull;
+    }();
+    return _cached;
+}
 
 // Overflow depth at which the processor is clearly not keeping up. Not a cap:
 // dropping here would lose records the ring already gave us.
@@ -209,6 +238,13 @@ struct reader_state
     // `stop` only asks it to wind down; the reader still publishes a final batch
     // afterwards, so the processor must key its exit off this instead.
     std::atomic<bool> reader_done = {false};
+    // Records copied out of the ring but not yet visible in the pipe: reserved
+    // per region inside copy_pipes() before the first memcpy, discharged per batch
+    // at publish(). The processor's closed-window GC reads this (acquire) before
+    // pipe.empty() so it never expires a window whose EOP is already in the
+    // reader's hand but not yet published. Reader is the sole writer. Covers only
+    // COPIED EOPs (F4); EOPs still in the ring remain the accepted R10 residual.
+    std::atomic<uint64_t> reader_copied_unpublished = {0};
     // Read by nudge_reader() (from wait_for_reader_quiesce, ~500 Hz) while
     // stop_reader() writes them; atomic so those overlap without a data race and a
     // nudge never writes into a recycled fd.
@@ -500,18 +536,28 @@ copy_records(reader_state& st)
                                         wptr_arr,
                                         rptr_arr,
                                         _s.cursors,
-                                        _batch->records);
+                                        _batch->records,
+                                        &st.reader_copied_unpublished);
 
         if(_direct)
         {
             // Release-store inside publish() orders the copy above before the
-            // processor can observe the batch.
-            if(_copied > 0) st.pipe.publish();
+            // processor can observe the batch. Discharge the reservation this
+            // batch made (_copied == _batch->records.size() on the direct path)
+            // right after publish, so a copied EOP is counted continuously from
+            // copy_pipes' reserve until the processor can see it.
+            if(_copied > 0)
+            {
+                st.pipe.publish();
+                st.reader_copied_unpublished.fetch_sub(_copied, std::memory_order_release);
+            }
         }
         else
         {
             if(_copied == 0) _s.overflow.pop_back();
-            spill_overflow_to_pipe(st.pipe, _s.overflow);
+            // Records parked in overflow stay reserved until their spill publishes
+            // them, so window (1) is covered by the same counter.
+            spill_overflow_to_pipe(st.pipe, _s.overflow, &st.reader_copied_unpublished);
             note_overflow_depth(st, _s);
         }
         _total += _copied;
@@ -561,7 +607,7 @@ process_batch(processor_state& proc, const record_batch& batch)
     // backlogged processor ages nothing. starts_evicted is an R1 source counter.
     if(batch.now_ns - _pairing.last_evict_ns >= kProcessorEvictIntervalNs)
     {
-        _pairing.starts_evicted += _pairing.evict_stale(batch.now_ns, kStartMaxAgeNs);
+        _pairing.starts_evicted += _pairing.evict_stale(batch.now_ns, start_max_age_ns());
         _pairing.last_evict_ns = batch.now_ns;
     }
 
@@ -646,21 +692,50 @@ log_stream_status(const dlog_session& s)
                              args.status.target_exit_count);
 }
 
+// Read the STREAM_OP_STATUS flags word (F11 FATAL detection). Returns 0 on a dead
+// fd or a failed ioctl: 0 has no bits set, so the FATAL test fails and the caller
+// falls back to the recoverable-reset handling -- safe, because a genuinely fatal
+// stream also stops producing and will re-assert POLLERR (or HUP) on the next pass.
+// Unlike log_stream_status this returns the word so a data decision can be made:
+// FATAL is the one status bit that gates handling, per the driver contract.
+uint64_t
+read_stream_status_flags(const dlog_session& s)
+{
+    if(s.stream_fd < 0) return 0;
+    auto args = kfd_dlog_stream_args{};
+    args.op   = KFD_DLOG_STREAM_OP_STATUS;
+    if(ioctl(s.stream_fd, KFD_DLOG_STREAM_IOC, &args) != 0) return 0;
+    return args.status.status;
+}
+
 void
 stop_reader()
 {
     auto& st = state();
-    if(!st.running.load(std::memory_order_acquire)) return;
+
+    // setup_mu is taken BEFORE reading running: reading it first (as before) is a
+    // no-op that misses a concurrent establish_session() mid-arm before it publishes
+    // running=true, which would then create reader threads and publish a session
+    // after teardown. establish_session() re-checks get_fini_status() and
+    // reader_unavailable UNDER this same lock, so latching reader_unavailable here
+    // makes the in-flight arm refuse. The whole terminating sequence runs in this one
+    // critical section; setup_mu is a leaf (no worker thread acquires it), so holding
+    // it across the joins cannot deadlock. stop+wake precede the joins so the join is
+    // bounded rather than hanging while holding setup_mu.
+    auto _lk = std::lock_guard<std::mutex>{st.setup_mu};
+    if(!st.running.load(std::memory_order_relaxed)) return;
 
     // Latch unavailable before the join so no dispatch can acquire a correlation
-    // key against a reader that is on its way out (cleared again below).
+    // key against a reader that is on its way out (cleared again below only on a
+    // non-finalize stop).
     st.reader_unavailable.store(true, std::memory_order_release);
     st.stop.store(true, std::memory_order_release);
     const int _wake = st.wake_fd.load(std::memory_order_acquire);
     if(_wake >= 0)
     {
         uint64_t one = 1;
-        // Best-effort wake; a failed write only costs one poll interval.
+        // Best-effort wake BEFORE any join, so the reader observes stop and exits
+        // rather than the join hanging while setup_mu is held.
         [[maybe_unused]] auto _rc = ::write(_wake, &one, sizeof(one));
     }
     if(st.thread.joinable()) st.thread.join();
@@ -668,17 +743,6 @@ stop_reader()
     // only shrink. The processor then drains what is left and exits.
     if(st.processor_thread.joinable()) st.processor_thread.join();
 
-    // Teardown runs without taking setup_mu on purpose: it is only safe because the
-    // caller (registration::finalize) tears down queue interception
-    // (queue_controller_fini) BEFORE kfd::finalize(), so no interceptor thread can
-    // still be inside ensure_reader_session()/setup_session() by the time we get
-    // here, and finalize itself is std::call_once (single-threaded). If that ordering
-    // ever changes, this teardown must take st.setup_mu to serialize against a
-    // concurrent setup_session(). The reader thread is already stopped+joined above.
-    // Belt-and-suspenders against a late dispatch in the teardown window:
-    // establish_session() additionally refuses when registration::get_fini_status()
-    // != 0, so once finalization has started a dispatch can no longer re-arm the
-    // reader even if it slips past the reader_unavailable latch this function set.
     const size_t _n = st.session_count.load(std::memory_order_acquire);
     for(size_t i = 0; i < _n; ++i)
     {
@@ -687,7 +751,13 @@ stop_reader()
     }
     st.session_count.store(0, std::memory_order_release);
     st.any_session_ready.store(false, std::memory_order_release);
-    st.reader_unavailable.store(false, std::memory_order_release);
+    // Finalize-path stop: leave reader_unavailable LATCHED so a dispatch that
+    // slipped past establish_session()'s pre-lock checks cannot re-arm the reader
+    // under setup_mu after us. A non-finalize stop (a client detach that may
+    // re-attach) clears it so a later establish_session() can restart the reader.
+    if(registration::get_fini_status() == 0)
+        st.reader_unavailable.store(false, std::memory_order_release);
+
     if(st.kfd_fd >= 0)
     {
         ::close(st.kfd_fd);
@@ -701,7 +771,16 @@ stop_reader()
     ROCP_INFO << "KFD dispatch-log reader: stopped";
 }
 
-reader_state::~reader_state() { stop_reader(); }
+reader_state::~reader_state()
+{
+    // F13 part 2: in a fork child (D6's unconditional fork generation) the reader
+    // thread does not exist and setup_mu / the session containers may be mid-mutation
+    // by a vanished thread. Skip stop_reader()'s join+teardown -- the same treatment
+    // D6 gives TaskGroup (skip the dangerous thread work; the child abandoned this
+    // state via disable_reader_in_child). Value members destruct as they do there.
+    if(internal_threading::fork_stale()) return;
+    stop_reader();
+}
 
 // pthread_atfork child handler. Only the forking thread survives, so this does
 // atomic stores and fd/mapping drops only -- no lock, no allocation, no join.
@@ -723,18 +802,23 @@ disable_reader_in_child()
     // Not detach(): that would leave the handle believing a thread exists.
     new(&st.thread) std::thread{};
     new(&st.processor_thread) std::thread{};
-    // Drop the reference WITHOUT closing (§3.8): the persistent wake eventfd is
-    // owned by the parent; closing it here would corrupt the parent's descriptor. A
-    // child that later starts a reader creates its own (wake_fd < 0).
+    // Drop the reference WITHOUT closing (§3.8): the persistent wake eventfd's number
+    // must never be recycled under the parent's nudge_reader; the child sets it -1 so
+    // its own nudge is inert and a later child reader creates a fresh one.
     st.wake_fd.store(-1, std::memory_order_relaxed);
+    // F13: close the inherited fds/maps. After fork the child has its own fd table,
+    // so close()/munmap() here release the child's copies WITHOUT touching the
+    // parent's descriptors (the old "corrupts the parent" comment was wrong). Both
+    // are async-signal-safe, which the atfork child handler requires.
+    if(st.kfd_fd >= 0) ::close(st.kfd_fd);
     st.kfd_fd = -1;
-    // Dropping ownership without freeing: the parent still owns them, and a free
-    // here would corrupt its state.
     const size_t _n = st.session_count.load(std::memory_order_relaxed);
     for(size_t i = 0; i < _n && i < kMaxSessions; ++i)
     {
         st.sessions[i].ready.store(false, std::memory_order_relaxed);
-        st.sessions[i].smap      = MAP_FAILED;
+        if(st.sessions[i].smap != MAP_FAILED) munmap(st.sessions[i].smap, st.sessions[i].smap_len);
+        st.sessions[i].smap = MAP_FAILED;
+        if(st.sessions[i].stream_fd >= 0) ::close(st.sessions[i].stream_fd);
         st.sessions[i].stream_fd = -1;
         // Same reuse hazard as teardown_session(): session_count is zeroed here, so
         // any later re-arm in the child reuses these slots. Reset the drain cursors
@@ -755,13 +839,27 @@ processor_loop()
 
     while(true)
     {
-        // GC closed-window entries on the periodic tick, ABOVE the
-        // pipe-empty continue -- an idle GPU (a queue destroyed after its work
-        // finished, the dominant case) never delivers another batch, so a GC placed
-        // after process_batch would never run and the close_grace_ns bound would be
-        // vacuous. Leaked payloads are ledgered; dropping them here is off the lock.
+        // GC closed-window entries on the periodic tick, but ONLY when the pipe is
+        // empty: an EOP that would resolve a closed window may be sitting in a
+        // backlog behind us, and GC'ing its window first would expire it as a leak
+        // and then drop the EOP as start-unknown. Gating on an empty pipe means we
+        // only expire windows once no queued batch can still close them. The idle
+        // GPU (a queue destroyed after its work finished, the dominant case) still
+        // GCs promptly -- its pipe drains to empty and stays there, so the
+        // close_grace_ns bound is honored. Residual: a GPU whose pipe never empties
+        // (a continuous backlog) defers GC indefinitely, but a continuous backlog
+        // means the processor is actively resolving windows, so nothing is leaking.
+        // Leaked payloads are ledgered; dropping them here is off the lock.
+        // In-flight load FIRST, then pipe.empty(): reversing them is unsound. A
+        // zero read here (acquire) means every record the reader took out of the
+        // ring was published BEFORE this load, and the acquire pairs with the
+        // reader's release so the following pipe.empty() is guaranteed to see it.
+        // Covers only copied-but-unpublished EOPs (F4); an EOP still in the ring is
+        // the accepted R10 residual and is not gated here.
         const uint64_t _gc_now = common::timestamp_ns();
-        if(_gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
+        if(gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
+                        st.pipe.empty()) &&
+           _gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
         {
             last_gc_ns = _gc_now;
             auto _gc   = signal_less_hub().gc_closed_windows(steady_now_ns());
@@ -809,14 +907,16 @@ processor_loop()
         ROCP_WARNING << fmt::format(
             "KFD dispatch-log pairing census (gpu_id={}): {} START record(s) drained, {} EOP "
             "record(s) drained, {} EOP(s) unmatched, {} START(s) overwritten on a live key, {} "
-            "ambiguous EOP(s) dropped, {} START(s) evicted stale, {} START(s) still retained at "
-            "exit",
+            "ambiguous EOP(s) dropped, {} equal-tick EOP(s) dropped, {} stale EOP(s) dropped, {} "
+            "START(s) evicted stale, {} START(s) still retained at exit",
             _gpu_itr.first,
             _p.starts_seen,
             _p.eops_seen,
             _p.unmatched_eops,
             _p.starts_overwritten,
             _p.ambiguous_pairs,
+            _p.equal_tick_drops,
+            _p.stale_eop_drops,
             _p.starts_evicted,
             _p.pending_starts.size());
     }
@@ -998,6 +1098,16 @@ reader_loop()
                 backstop_warned = true;
             }
         }
+        else if(all_live_overflow_empty(st))
+        {
+            // No session is armed, so the ready-set is trivially drained: advance
+            // drain_epoch every pass so a fence blocked on drain progress is not made
+            // to burn its whole timeout waiting for a +2 that drain_sessions_bounded
+            // (only reached when a session IS ready) would otherwise never post. The
+            // overflow guard still holds: a copied-but-unpublished batch must reach
+            // the pipe before the epoch may advance.
+            st.drain_epoch.fetch_add(1, std::memory_order_release);
+        }
 
         // Terminal streams. POLLHUP/POLLNVAL are terminal: the stream will never
         // produce again, so it is drained first (above), then -- only once it is
@@ -1025,6 +1135,36 @@ reader_loop()
 
             if(_act == terminal_action::keep_live)
             {
+                // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
+                // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal
+                // are independent latches in the driver) after which the stream never
+                // produces again ("no live consumer, do not arm"). Read STREAM_OP_STATUS
+                // to tell them apart; FATAL is terminal.
+                if((read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
+                {
+                    // Drain-first: defer while records remain (the top-of-loop drain
+                    // already ran this pass; firmware produces nothing more after
+                    // FATAL, so this converges) so no already-published record is lost.
+                    if(session_has_pending(_s) || !_s.overflow.empty()) continue;
+                    log_stream_status(_s);
+                    ROCP_WARNING << fmt::format(
+                        "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
+                        "draining, quarantining, and disabling signal-less process-wide",
+                        _s.gpu_id,
+                        static_cast<unsigned>(fds[k].revents));
+                    // Clear ready before quarantine so find_session()/establish_session()
+                    // stop handing out keys for a stream that can never deliver them.
+                    _s.ready.store(false, std::memory_order_release);
+                    _s.quarantined   = true;
+                    _quarantined_any = true;
+                    // Smallest safe containment: the reset invalidated the clock domain
+                    // this stream's windows were opened against, so drop the whole
+                    // signal-less path process-wide (hub disable latch drains+ledgers
+                    // live entries) rather than risk mis-windowing against a reset clock.
+                    signal_less_disable_permanently();
+                    continue;
+                }
+
                 // Recoverable reset: describe it ONCE per episode -- POLLERR is
                 // returned by poll() every pass, so an unlatched warning would spin
                 // the log -- then keep the stream live. The wake already fed the
@@ -1043,8 +1183,12 @@ reader_loop()
             }
 
             // Drain-first-then-quarantine: defer while records remain so terminal
-            // records are not discarded at the bounded-pass cap.
-            if(session_has_pending(_s)) continue;
+            // records are not discarded at the bounded-pass cap. session_has_pending
+            // only inspects the ring; a batch already copied into this session's
+            // reader-owned overflow deque but not yet spilled to the pipe would be
+            // stranded by quarantine (copy_records skips !ready sessions), so defer
+            // while overflow is non-empty too.
+            if(session_has_pending(_s) || !_s.overflow.empty()) continue;
 
             log_stream_status(_s);
             ROCP_INFO << fmt::format(
@@ -1099,7 +1243,9 @@ reader_loop()
             _pending = false;
             for(size_t i = 0; i < _n; ++i)
             {
-                if(spill_overflow_to_pipe(st.pipe, st.sessions[i].overflow)) continue;
+                if(spill_overflow_to_pipe(
+                       st.pipe, st.sessions[i].overflow, &st.reader_copied_unpublished))
+                    continue;
                 _pending = true;
             }
             if(_pending) std::this_thread::sleep_for(std::chrono::microseconds{200});
@@ -1201,6 +1347,10 @@ start_kfd_reader()
 
     st.stop.store(false, std::memory_order_release);
     st.reader_done.store(false, std::memory_order_release);
+    // Reset before any worker thread exists: teardown_session() drops a prior
+    // reader's unspilled overflow batches whose reservations never published, so a
+    // stale residual here would keep the GC gate closed for this whole instance.
+    st.reader_copied_unpublished.store(0, std::memory_order_release);
 
     // Force-construct the singletons the reader/processor hot paths touch here,
     // BEFORE the worker threads exist, so a first-use allocation cannot stall the
@@ -1266,6 +1416,15 @@ kfd_reader_state_constructed()
 {
     // Non-constructing peek (::get(), not state()'s ::construct()).
     return common::static_object<reader_state>::get() != nullptr;
+}
+
+bool
+reader_unavailable()
+{
+    // Non-constructing: an unconstructed reader was never armed, so it is not
+    // "unavailable" in the sense N1 cares about (nothing to quiesce).
+    auto* _st = common::static_object<reader_state>::get();
+    return _st != nullptr && _st->reader_unavailable.load(std::memory_order_acquire);
 }
 
 bool
@@ -1383,6 +1542,12 @@ establish_session(uint32_t gpu_id, bool latch_retryable)
         return _existing->ready.load(std::memory_order_acquire);
 
     auto lk = std::lock_guard<std::mutex>{st.setup_mu};
+    // Re-check finalization UNDER setup_mu: the pre-lock get_fini_status() check
+    // above can pass and finalization then begin before we take the lock. stop_reader()
+    // sets reader_unavailable and tears down sessions while holding this same lock, so
+    // re-checking both here closes the window where we would setup_session() into an
+    // array stop_reader() is concurrently clearing.
+    if(registration::get_fini_status() != 0) return false;
     // Re-check under the lock: another thread may have armed this GPU meanwhile.
     if(auto* _existing = find_session(st, gpu_id))
         return _existing->ready.load(std::memory_order_relaxed);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.hpp
@@ -26,7 +26,7 @@
 // data ring. It sets up the KFD session, then poll()s one control eventfd plus
 // every live stream fd (with a 10 ms timeout as the sparse-tail / lost-interrupt
 // watchdog), drains firmware records, pairs dispatch_start + eop, and deposits
-// paired timings into the ResultsMap. wptr != rptr is the sole drain authority;
+// paired timings into the DispatchHub. wptr != rptr is the sole drain authority;
 // poll wakes are only hints. Finalization uses nudge_reader() +
 // wait_for_reader_quiesce() so the poll timeout never delays teardown.
 //
@@ -59,6 +59,12 @@ stop_kfd_reader();
 // this process. Used to verify flag-off inertness. Never constructs it.
 bool
 kfd_reader_state_constructed();
+
+// True when the reader can never serve a session (dead/stopping), as opposed to a
+// single GPU failing to arm. N1's fence short-circuits to abandon on this: a
+// reader that is gone will not quiesce within the budget. Non-constructing.
+bool
+reader_unavailable();
 
 // Ensure a dispatch-log session exists for the given gpu_id. Returns true only
 // when a live session belongs to THIS gpu_id; callers must otherwise leave the

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
@@ -140,17 +140,35 @@ private:
 // dropped when the pipe was full at stop.
 template <size_t Capacity>
 bool
-spill_overflow_to_pipe(record_pipe<Capacity>& pipe, std::deque<record_batch>& overflow)
+spill_overflow_to_pipe(record_pipe<Capacity>&    pipe,
+                       std::deque<record_batch>& overflow,
+                       std::atomic<uint64_t>*    inflight = nullptr)
 {
     while(!overflow.empty())
     {
         auto* _slot = pipe.acquire();
         if(_slot == nullptr) return false;
-        *_slot = std::move(overflow.front());
+        // Count captured BEFORE the move: std::move empties the source vector, so
+        // reading its size after would read 0 and under-discharge the reservation.
+        const auto _count = overflow.front().records.size();
+        *_slot            = std::move(overflow.front());
         overflow.pop_front();
         pipe.publish();
+        // Discharge after publish; release pairs with the GC gate's acquire load.
+        if(inflight != nullptr) inflight->fetch_sub(_count, std::memory_order_release);
     }
     return true;
+}
+
+// D2 gate predicate: closed-window GC may run only when nothing copied is still
+// invisible to the processor -- no reader-reserved-but-unpublished record AND an
+// empty pipe. Pure and header-exposed so a unit test can drive all four
+// combinations directly; the acquire load feeding `inflight` and its ordering
+// ahead of pipe.empty() live at the call site in kfd_reader.cpp.
+inline bool
+gc_gate_open(uint64_t inflight, bool pipe_empty)
+{
+    return inflight == 0 && pipe_empty;
 }
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/record_pipe.hpp
@@ -140,17 +140,36 @@ private:
 // dropped when the pipe was full at stop.
 template <size_t Capacity>
 bool
-spill_overflow_to_pipe(record_pipe<Capacity>& pipe, std::deque<record_batch>& overflow)
+spill_overflow_to_pipe(record_pipe<Capacity>&    pipe,
+                       std::deque<record_batch>& overflow,
+                       std::atomic<uint64_t>*    inflight = nullptr)
 {
     while(!overflow.empty())
     {
         auto* _slot = pipe.acquire();
         if(_slot == nullptr) return false;
-        *_slot = std::move(overflow.front());
+        // Count captured BEFORE the move: std::move empties the source vector, so
+        // reading its size after would read 0 and under-discharge the reservation.
+        const auto _count = overflow.front().records.size();
+        *_slot            = std::move(overflow.front());
         overflow.pop_front();
         pipe.publish();
+        // Discharge after publish; release pairs with the GC gate's acquire load.
+        if(inflight != nullptr)
+            inflight->fetch_sub(_count, std::memory_order_release);
     }
     return true;
+}
+
+// D2 gate predicate: closed-window GC may run only when nothing copied is still
+// invisible to the processor -- no reader-reserved-but-unpublished record AND an
+// empty pipe. Pure and header-exposed so a unit test can drive all four
+// combinations directly; the acquire load feeding `inflight` and its ordering
+// ahead of pipe.empty() live at the call site in kfd_reader.cpp.
+inline bool
+gc_gate_open(uint64_t inflight, bool pipe_empty)
+{
+    return inflight == 0 && pipe_empty;
 }
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -69,7 +69,9 @@ signal_less_feature_enabled()
     // Read once: the answer must not change under a running process, and the
     // enqueue path cannot afford an env lookup per batch.
     static const bool _enabled = []() {
-        if(!common::get_env("ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS", false)) return false;
+        // Strict opt-in, fail-closed: only an explicit true value activates a
+        // feature that changes completion semantics process-wide.
+        if(!env_bool_opt_in("ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS")) return false;
         // register the fork-child abandon handler HERE, where the feature
         // is decided -- every path that creates signal-less state passes this gate
         // first, so "state exists => a handler is registered" is a property of the
@@ -326,6 +328,22 @@ quiesce_budget_ns()
 }
 
 void
+signal_less_prime_env()
+{
+    // Every knob below caches its env read in a function-local static on FIRST USE,
+    // and common::get_env* scans `environ`, which is not safe against a concurrent
+    // setenv. Left lazy, that first use lands on whichever worker, producer or
+    // teardown thread happens to reach it first. Calling them here -- from the one
+    // serialized reader-start path, before any worker thread exists and before the
+    // application is dispatching -- makes the cached value deterministic and takes
+    // the environ scan off every concurrent thread.
+    signal_less_feature_enabled();
+    hub_max_pending_per_gpu();
+    close_drain_budget_ns();
+    quiesce_budget_ns();
+}
+
+void
 signal_less_disable_permanently()
 {
     if(g_child_stale.load(std::memory_order_acquire)) return;
@@ -369,6 +387,48 @@ signal_less_id_is_leaked(uint64_t correlation_id)
     return signal_less_hub().is_ledgered(correlation_id);
 }
 
+namespace
+{
+// The one TERMINAL transition, fail-closed: latch no-new-eligibility, stop and
+// JOIN the reader+processor so no further completion can ever be produced, then
+// ledger everything still PENDING. Returns the loss stats.
+//
+// IDEMPOTENT BY CONSTRUCTION, deliberately with no run-once latch: every step
+// already no-ops when it has nothing to do (stop_kfd_reader() returns on
+// !running, drain_for_teardown() on an empty hub, the latch store is a repeat).
+// A latch would be actively worse twice over -- a second caller would return
+// BEFORE the first one's stop completed, which is exactly the guarantee a
+// terminal fence owes; and a reader legitimately restarted after an earlier
+// fence would then never be stopped at all.
+//
+// NOT DEADLOCK-PRONE BY CONSTRUCTION, two ways:
+//  - it never joins the task group. A signal-less completion runs as a TaskGroup
+//    task and may synchronously call a client callback that finalizes, reaching
+//    here on a task-group worker; TaskGroup::join spins on a task count that very
+//    task still holds, so joining there would wait for itself forever. Callers
+//    that must also wait out already-submitted completions do that themselves,
+//    after this returns.
+//  - it holds NO lock across the join. The processor takes g_submit_gate SHARED
+//    on its handoff path, so latching that gate exclusively around
+//    stop_kfd_reader() would deadlock against the very thread being joined. The
+//    threads joined here (reader, processor) never run client code and never
+//    submit-and-wait, so joining them from any other thread terminates.
+loss_stats
+signal_less_terminal_stop()
+{
+    // Latched BEFORE the stop so a batch that already passed eligibility cannot
+    // register into the hub after the drain below empties it: register_batch tests
+    // this latch under m_mu, which orders it against drain_for_teardown().
+    signal_less_disable_latch().store(true, std::memory_order_release);
+    // The sole producer of PENDING->EOP_PROVEN. Once joined, no record_kernel_end
+    // and therefore no hand_off_proven can run again.
+    stop_kfd_reader();
+    auto _loss = signal_less_hub().drain_for_teardown();
+    if(_loss.second.dispatches > 0) note_signal_less_losses();
+    return _loss.second;
+}
+}  // namespace
+
 void
 signal_less_teardown()
 {
@@ -386,8 +446,10 @@ signal_less_teardown()
     //   2. quiesce   -> fences in-flight registration/publication
     //   3. join      -> only the reader creates PENDING->EOP_PROVEN, so after this
     //                   nothing can be added to the retry owner
-    //   4. flush     -> therefore final; leftovers finalize in place on THIS thread
-    //   5. leak      -> whatever never got an EOP is ledgered, so finalize skips it
+    //   4. leak      -> whatever never got an EOP is ledgered, so finalize skips it
+    //   5. flush     -> therefore final; leftovers finalize in place on THIS thread.
+    //                   Order against step 4 is free: a deferred completion left the
+    //                   hub at record_kernel_end, so the two touch disjoint sets
     //   6. join tasks-> safe only now: no producer can submit another task
     signal_less_hub().set_mode(session_mode::stopping);
     drain_signal_less_interceptor();
@@ -403,20 +465,21 @@ signal_less_teardown()
     // below is stronger than the fence's abandon, and drain_for_teardown() ledgers
     // whatever is left.
     wait_for_reader_quiesce();
-    stop_kfd_reader();
+    // Steps 3 and 5 in the primitive shared with the F23/F24 fence; step 4 (the
+    // flush) stays here, outside it, so it runs on EVERY call -- the fence may
+    // already have stopped an earlier reader, and a reader restarted since then can
+    // still have deferred completions this thread must finalize.
+    const auto   _loss    = signal_less_terminal_stop();
     const size_t _flushed = flush_deferred_completions();
-
-    auto         _loss   = signal_less_hub().drain_for_teardown();
-    const size_t _leaked = _loss.second.dispatches;
+    const size_t _leaked  = _loss.dispatches;
     if(_leaked > 0)
     {
-        note_signal_less_losses();
         ROCP_WARNING << fmt::format(
             "KFD dispatch-log: {} signal-less dispatch(es) across {} correlation id(s) were still "
             "in flight at finalization; they emit no record and their correlation ids are not "
             "retired.",
-            _loss.second.dispatches,
-            _loss.second.correlation_ids);
+            _loss.dispatches,
+            _loss.correlation_ids);
     }
 
     join_signal_less_tasks();
@@ -487,9 +550,25 @@ signal_less_fence_completions()
             _loss.second.dispatches,
             _loss.second.correlation_ids);
     }
-    // (c) nothing is left deferred waiting to be finalized, and (d) every submitted
-    // completion has finished executing -- both before returning, because closing
-    // the gate stops further submissions but not already-queued ones.
+    // (c) BOTH fence sites are TERMINAL, so quiescing is not enough: F23 frees the
+    // client's callback/buffer machinery and F24 lets the HSA runtime unload, both
+    // immediately after we return. A dispatch still PENDING here would otherwise
+    // complete afterwards and deref a freed context* out of the copied
+    // tracing_data, or convert ticks against a dead runtime. Make the transition
+    // terminal instead: stop+join the reader/processor so no completion can be
+    // produced at all, and ledger whatever never got an EOP. Fail-closed --
+    // signal-less stays off for the rest of the process, the accepted cost of a
+    // detach or an HSA shutdown. Idempotent, so a second fence call is harmless.
+    const auto _loss = signal_less_terminal_stop();
+    ROCP_WARNING_IF(_loss.dispatches > 0) << fmt::format(
+        "KFD dispatch-log fence: signal-less stopped terminally (client detach or HSA shutdown); "
+        "{} dispatch(es) across {} correlation id(s) were still in flight and are ledgered.",
+        _loss.dispatches,
+        _loss.correlation_ids);
+    // (d) nothing is left deferred waiting to be finalized, and (e) every submitted
+    // completion has finished executing -- both before returning. The flush is safe
+    // here and not on a worker: the reader and processor are joined, so this thread
+    // is the only one that can still touch a deferred completion.
     flush_deferred_completions();
     join_signal_less_tasks();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -25,8 +25,10 @@
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
 
 #include <fmt/core.h>
 
@@ -172,6 +174,7 @@ signal_less_counter_name(signal_less_counter which)
         case signal_less_counter::finalizer_emitted: return "emitted";
         case signal_less_counter::finalizer_no_timing: return "no-timing";
         case signal_less_counter::register_refused: return "register-refused";
+        case signal_less_counter::cap_evicted: return "cap-evicted";
         case signal_less_counter::kCount: break;
     }
     return "?";
@@ -306,6 +309,22 @@ close_drain_budget_ns()
     return _v;
 }
 
+// N1: reader-quiesce budget per attempt. 0 == "one non-blocking check then treat
+// as timed out". Read once (F3 pattern); reject-and-default via the shared parse
+// contract, never clamp. The [0, 60000] upper bound keeps *1e6 far from overflow.
+uint64_t
+quiesce_budget_ns()
+{
+    static const uint64_t _v = []() {
+        constexpr long _dflt_ms = 100;
+        const long     _ms = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_QUIESCE_MS", 0, 60'000)
+                             .value_or(_dflt_ms);
+        ROCP_INFO << "KFD dispatch-log: reader-quiesce budget = " << _ms << " ms";
+        return static_cast<uint64_t>(_ms) * 1'000'000ull;
+    }();
+    return _v;
+}
+
 void
 signal_less_disable_permanently()
 {
@@ -372,6 +391,11 @@ signal_less_teardown()
     //   6. join tasks-> safe only now: no producer can submit another task
     signal_less_hub().set_mode(session_mode::stopping);
     drain_signal_less_interceptor();
+    // F1: HW-drain every live queue against one shared budget BEFORE the reader
+    // quiesce, so a kernel in flight when main() returned finishes and its EOP is
+    // still copyable when the quiesce below waits for it. Residual: a kernel longer
+    // than the budget still strands, loudly, via the existing drain_for_teardown.
+    drain_signal_less_queues_hw(kfd::steady_now_ns() + close_drain_budget_ns());
     // Safe only here: steps 1-2 closed the set of records the reader still has to
     // drain, so this two-stage wait (drain_epoch then pipe.empty) covers a finite
     // amount of work rather than a moving target. Bounded, and a no-op when the
@@ -418,12 +442,26 @@ signal_less_fence_completions()
 {
     if(g_child_stale.load(std::memory_order_acquire)) return;
     if(!signal_less_feature_enabled()) return;
+    // Finalization already ran: our atexit finalize()+destroy_static_objects() has
+    // nulled the queue-registry static_object, so a second F24 call (from another
+    // DSO's __cxa_finalize teardown) must not rlock it -> NULL deref. finalize() sets
+    // fini_status at its very end, so this no-ops that re-entry (and the provably
+    // redundant F23 call from invoke_client_finalizers, fini_status==-1) while the
+    // genuinely-live detach paths (fini_status==0) still fence.
+    if(registration::get_fini_status() != 0) return;
     // (a) no registration/publication is mid-flight.
     drain_signal_less_interceptor();
     // (b) the two-stage wait: every record present in the ring at this call has
     // been copied+published (Stage 1) and popped+processed (Stage 2), so every
     // completion whose firmware record had reached the ring is emitted or deferred.
-    const bool _quiesced = wait_for_reader_quiesce();
+    // N1: at most TWO attempts with the same budget, the second issued immediately
+    // to absorb one scheduling miss under multi-tool contention -- not to extend
+    // the deadline. reader_unavailable short-circuits to abandon without spending
+    // attempt 2: a reader that is gone will not come back within the budget. The
+    // counter is call-local, so a later fence starts fresh.
+    bool _quiesced = wait_for_reader_quiesce(quiesce_budget_ns());
+    if(!_quiesced && !reader_unavailable())
+        _quiesced = wait_for_reader_quiesce(quiesce_budget_ns());
     if(!_quiesced)
     {
         // abandon-on-timeout: latch g_abandoned under the EXCLUSIVE gate, which

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -25,8 +25,10 @@
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_reader.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
 
 #include <fmt/core.h>
 
@@ -172,6 +174,7 @@ signal_less_counter_name(signal_less_counter which)
         case signal_less_counter::finalizer_emitted: return "emitted";
         case signal_less_counter::finalizer_no_timing: return "no-timing";
         case signal_less_counter::register_refused: return "register-refused";
+        case signal_less_counter::cap_evicted: return "cap-evicted";
         case signal_less_counter::kCount: break;
     }
     return "?";
@@ -306,6 +309,22 @@ close_drain_budget_ns()
     return _v;
 }
 
+// N1: reader-quiesce budget per attempt. 0 == "one non-blocking check then treat
+// as timed out". Read once (F3 pattern); reject-and-default via the shared parse
+// contract, never clamp. The [0, 60000] upper bound keeps *1e6 far from overflow.
+uint64_t
+quiesce_budget_ns()
+{
+    static const uint64_t _v = []() {
+        constexpr long _dflt_ms = 100;
+        const long     _ms =
+            env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_QUIESCE_MS", 0, 60'000).value_or(_dflt_ms);
+        ROCP_INFO << "KFD dispatch-log: reader-quiesce budget = " << _ms << " ms";
+        return static_cast<uint64_t>(_ms) * 1'000'000ull;
+    }();
+    return _v;
+}
+
 void
 signal_less_disable_permanently()
 {
@@ -372,6 +391,11 @@ signal_less_teardown()
     //   6. join tasks-> safe only now: no producer can submit another task
     signal_less_hub().set_mode(session_mode::stopping);
     drain_signal_less_interceptor();
+    // F1: HW-drain every live queue against one shared budget BEFORE the reader
+    // quiesce, so a kernel in flight when main() returned finishes and its EOP is
+    // still copyable when the quiesce below waits for it. Residual: a kernel longer
+    // than the budget still strands, loudly, via the existing drain_for_teardown.
+    drain_signal_less_queues_hw(kfd::steady_now_ns() + close_drain_budget_ns());
     // Safe only here: steps 1-2 closed the set of records the reader still has to
     // drain, so this two-stage wait (drain_epoch then pipe.empty) covers a finite
     // amount of work rather than a moving target. Bounded, and a no-op when the
@@ -418,12 +442,26 @@ signal_less_fence_completions()
 {
     if(g_child_stale.load(std::memory_order_acquire)) return;
     if(!signal_less_feature_enabled()) return;
+    // Finalization already ran: our atexit finalize()+destroy_static_objects() has
+    // nulled the queue-registry static_object, so a second F24 call (from another
+    // DSO's __cxa_finalize teardown) must not rlock it -> NULL deref. finalize() sets
+    // fini_status at its very end, so this no-ops that re-entry (and the provably
+    // redundant F23 call from invoke_client_finalizers, fini_status==-1) while the
+    // genuinely-live detach paths (fini_status==0) still fence.
+    if(registration::get_fini_status() != 0) return;
     // (a) no registration/publication is mid-flight.
     drain_signal_less_interceptor();
     // (b) the two-stage wait: every record present in the ring at this call has
     // been copied+published (Stage 1) and popped+processed (Stage 2), so every
     // completion whose firmware record had reached the ring is emitted or deferred.
-    const bool _quiesced = wait_for_reader_quiesce();
+    // N1: at most TWO attempts with the same budget, the second issued immediately
+    // to absorb one scheduling miss under multi-tool contention -- not to extend
+    // the deadline. reader_unavailable short-circuits to abandon without spending
+    // attempt 2: a reader that is gone will not come back within the budget. The
+    // counter is call-local, so a later fence starts fresh.
+    bool _quiesced = wait_for_reader_quiesce(quiesce_budget_ns());
+    if(!_quiesced && !reader_unavailable())
+        _quiesced = wait_for_reader_quiesce(quiesce_budget_ns());
     if(!_quiesced)
     {
         // abandon-on-timeout: latch g_abandoned under the EXCLUSIVE gate, which

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.hpp
@@ -122,6 +122,11 @@ finalize_complete_signal_less_dispatch(signal_less_hub_t::proven&& p);
 void
 drain_signal_less_interceptor();
 
+// F1: HW-drain every live queue against one absolute deadline, race-free vs a
+// concurrent hsa_queue_destroy. Caller holds no other lock.
+void
+drain_signal_less_queues_hw(uint64_t deadline_ns);
+
 // Wait for every already-submitted completion to finish executing.
 void
 join_signal_less_tasks();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
@@ -39,6 +39,12 @@ namespace kfd
 bool
 signal_less_feature_enabled();
 
+// Populate every env-backed knob's first-use cache from ONE serialized thread,
+// before any worker/producer exists. Call sites read `environ` via
+// common::get_env*, which is unsafe against a concurrent setenv. Idempotent.
+void
+signal_less_prime_env();
+
 // True if the loss policy deliberately leaked this id, in which case
 // correlation_id_finalize() must NOT force-retire it: its kernel may still be
 // running and its references were intentionally not dropped.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
@@ -75,6 +75,7 @@ enum class signal_less_counter
     finalizer_emitted,     // RESULT_READY: record emitted with KFD timestamps
     finalizer_no_timing,   // COMPLETED_NO_TIMING: retired, no record
     register_refused,      // hub refused a batch eligibility had accepted; id retired here
+    cap_evicted,           // closed-window entry evicted under the per-GPU hub cap (D9)
     kCount
 };
 
@@ -102,22 +103,6 @@ signal_less_abandon_in_child();
 // True in a process that inherited signal-less state across a fork.
 bool
 signal_less_child_stale();
-
-// Per-SKU gate. Signal-less window creation is allowed ONLY on a SKU whose GPU
-// clock domain has been validated. On an unvalidated SKU the firmware<->KFD clock
-// offset is bounded but unscreened, so a record could be silently mis-windowed (a
-// wrong-dispatch outcome, not just coverage loss); such an agent takes the signal
-// path instead. Adding a SKU requires validating its clock domain first -- a
-// matching gfx_target_version is not sufficient evidence on its own.
-inline bool
-tclk_validated_sku(uint32_t gfx_target_version)
-{
-    switch(gfx_target_version)
-    {
-        case 90500: return true;  // gfx950 (MI350) -- validated
-        default: return false;    // every other SKU: validate, then add it here
-    }
-}
 
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -152,6 +152,29 @@ rocprofiler_add_unit_test(
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+set(ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES dispatch_hub_cap_test.cpp)
+
+add_executable(kfd-dlog-hub-cap)
+
+target_sources(kfd-dlog-hub-cap PRIVATE ${ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-hub-cap
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+# Pins the per-GPU hub cap to 1 for the whole binary so register_batch admit/refuse and
+# eligible-only eviction are exercised (the accessor caches its env read once).
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-hub-cap
+    SOURCES ${ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU=1;LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 set(ROCPROFILER_LIB_KFD_FEATURE_OFF_TEST_SOURCES feature_off_test.cpp)
 
 add_executable(kfd-dlog-feature-off)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/CMakeLists.txt
@@ -152,6 +152,29 @@ rocprofiler_add_unit_test(
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+set(ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES dispatch_hub_cap_test.cpp)
+
+add_executable(kfd-dlog-hub-cap)
+
+target_sources(kfd-dlog-hub-cap PRIVATE ${ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES})
+
+target_link_libraries(
+    kfd-dlog-hub-cap
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
+            GTest::gtest_main)
+
+# Pins the per-GPU hub cap to 1 for the whole binary so register_batch admit/refuse
+# and eligible-only eviction are exercised (the accessor caches its env read once).
+rocprofiler_add_unit_test(
+    TARGET kfd-dlog-hub-cap
+    SOURCES ${ROCPROFILER_LIB_KFD_DLOG_HUB_CAP_TEST_SOURCES}
+    TIMEOUT 45
+    LABELS "unittests;kfd-dlog"
+    ENVIRONMENT
+        "ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU=1;LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 set(ROCPROFILER_LIB_KFD_FEATURE_OFF_TEST_SOURCES feature_off_test.cpp)
 
 add_executable(kfd-dlog-feature-off)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/data_structures.cpp
@@ -131,14 +131,3 @@ TEST(DoorbellMap, window_open_resolve_close_and_slot_helpers)
         signal_less_disable_latch().store(false);  // reset for other tests
     }
 }
-
-// The T-CLK per-SKU allowlist (section 5.9): gfx950 is discharged; every other SKU
-// is gated off until its own T-CLK Tier-1 screen passes. gfx12 is deliberately off.
-TEST(TclkGate, only_gfx950_is_validated)
-{
-    EXPECT_TRUE(tclk_validated_sku(90500)) << "gfx950 (MI350) discharged, section 5.9(e)";
-    EXPECT_FALSE(tclk_validated_sku(90400)) << "gfx942 not screened";
-    EXPECT_FALSE(tclk_validated_sku(120000)) << "gfx12.0.0 pending its own T-CLK run";
-    EXPECT_FALSE(tclk_validated_sku(120001)) << "gfx12.0.1 pending its own T-CLK run";
-    EXPECT_FALSE(tclk_validated_sku(0)) << "unknown SKU gated off";
-}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_cap_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_cap_test.cpp
@@ -1,0 +1,171 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// D9 (F7) end-to-end per-GPU cap behaviour. hub_max_pending_per_gpu() reads its env
+// once into a function-local static const, so a specific cap can only be pinned for
+// a whole binary: this file's CTest target sets
+// ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU=1 so every test here runs at
+// cap 1. The cap ARITHMETIC (all values, no wrap) is covered deterministically by
+// HubCapArithmetic in dispatch_hub_test.cpp; this file proves the register_batch
+// wiring: admit/refuse, eligible-only eviction, and map-unmutated-on-refusal.
+// Spec 1227-1238.
+
+#include "lib/rocprofiler-sdk/kfd/dispatch_hub.hpp"
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace
+{
+using namespace rocprofiler::kfd;
+
+struct tracked_payload
+{
+    uint64_t id = 0;
+};
+using hub_t = DispatchHub<tracked_payload>;
+
+void
+reset_disable()
+{
+    signal_less_disable_latch().store(false);
+}
+
+correlation_key
+key_of(uint32_t slot, uint32_t dispatch_id, uint32_t gpu = 0)
+{
+    return correlation_key{slot, dispatch_id, gpu};
+}
+
+window_ptr
+mk_window(uint32_t slot, uint64_t t_open, uint64_t t_close = kWindowOpen)
+{
+    auto w    = std::make_shared<owner_window>();
+    w->slot   = slot;
+    w->t_open = t_open;
+    w->t_close.store(t_close);
+    return w;
+}
+
+hub_t::registration
+reg_of(correlation_key key, window_ptr window, uint64_t corr_id)
+{
+    auto r           = hub_t::registration{};
+    r.key            = key;
+    r.correlation_id = corr_id;
+    r.window         = std::move(window);
+    return r;
+}
+}  // namespace
+
+// The binary's cap really is 1 (env pinned by the CTest target); the rest of the
+// suite would be meaningless otherwise, so assert it first.
+TEST(HubCap, cap_is_one_for_this_binary) { EXPECT_EQ(hub_max_pending_per_gpu(), 1u); }
+
+// cap 1, empty GPU: a one-entry batch is admitted; a two-entry batch is refused
+// (no eligible victim exists and it exceeds the cap) with the map unmutated.
+TEST(HubCap, admit_one_refuse_two_on_empty_gpu)
+{
+    reset_disable();
+    auto hub = hub_t{};
+
+    auto one = std::vector<hub_t::registration>{};
+    one.emplace_back(reg_of(key_of(1, 1), mk_window(1, 100), 11));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_TRUE(hub.register_batch(std::move(one), ev1));
+    EXPECT_TRUE(ev1.empty());
+    EXPECT_EQ(hub.pending_count(), 1u);
+
+    auto two = std::vector<hub_t::registration>{};
+    two.emplace_back(reg_of(key_of(2, 1), mk_window(2, 100), 21));
+    two.emplace_back(reg_of(key_of(2, 2), mk_window(2, 100), 22));
+    auto ev2 = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(two), ev2)) << "two entries exceed cap 1";
+    EXPECT_TRUE(ev2.empty());
+    EXPECT_EQ(hub.pending_count(), 1u) << "map unmutated on refusal";
+}
+
+// A batch larger than the whole cap must refuse (the checked arithmetic must not
+// wrap into "no shortfall").
+TEST(HubCap, batch_larger_than_cap_refuses)
+{
+    reset_disable();
+    auto hub   = hub_t{};
+    auto batch = std::vector<hub_t::registration>{};
+    for(uint32_t i = 1; i <= 3; ++i)
+        batch.emplace_back(reg_of(key_of(3, i), mk_window(3, 100), 30 + i));
+    auto ev = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(batch), ev));
+    EXPECT_TRUE(ev.empty());
+    EXPECT_EQ(hub.pending_count(), 0u);
+}
+
+// live == cap with a closed-window (eligible) entry: a new one-entry batch takes
+// the shortfall path and evicts the oldest eligible victim.
+TEST(HubCap, live_equals_cap_evicts_eligible_victim)
+{
+    reset_disable();
+    auto hub = hub_t{};
+    auto w   = mk_window(4, /*t_open=*/100, /*t_close=*/200);  // closed
+    // gc_deadline_ns = 0 so any steady_now_ns() the cap check samples is already past
+    // the grace -- the entry is eligible deterministically, no sleep or clock race.
+    w->gc_deadline_ns = 0;
+    auto first        = std::vector<hub_t::registration>{};
+    first.emplace_back(reg_of(key_of(4, 1), w, /*corr_id=*/41));
+    auto ev0 = std::vector<hub_t::leaked>{};
+    ASSERT_TRUE(hub.register_batch(std::move(first), ev0));  // live == cap (1)
+
+    auto next = std::vector<hub_t::registration>{};
+    next.emplace_back(reg_of(key_of(5, 1), mk_window(5, 700), /*corr_id=*/51));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_TRUE(hub.register_batch(std::move(next), ev1))
+        << "eligible victim evicted, batch admitted";
+    ASSERT_EQ(ev1.size(), 1u);
+    EXPECT_EQ(ev1[0].correlation_id, 41u) << "the closed pre-existing entry was evicted";
+    EXPECT_EQ(hub.pending_count(), 1u);
+    EXPECT_TRUE(hub.is_ledgered(41u)) << "evicted entry ledgered";
+}
+
+// insufficient victim: live == cap but the only entry is OPEN-window (not eligible),
+// so a new batch is refused and the map is unmutated. This is the fail-closed case.
+TEST(HubCap, insufficient_victim_refuses_and_leaves_map_unmutated)
+{
+    reset_disable();
+    auto hub        = hub_t{};
+    auto open_batch = std::vector<hub_t::registration>{};
+    open_batch.emplace_back(reg_of(key_of(6, 1), mk_window(6, /*t_open=*/100), /*corr_id=*/61));
+    auto ev0 = std::vector<hub_t::leaked>{};
+    ASSERT_TRUE(hub.register_batch(std::move(open_batch), ev0));  // live == cap, open window
+
+    auto next = std::vector<hub_t::registration>{};
+    next.emplace_back(reg_of(key_of(7, 1), mk_window(7, 300), /*corr_id=*/71));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(next), ev1))
+        << "no eligible (closed) victim -> refuse";
+    EXPECT_TRUE(ev1.empty());
+    EXPECT_EQ(hub.pending_count(), 1u) << "map unmutated across the refusal";
+    EXPECT_FALSE(hub.is_ledgered(61u)) << "the open-window entry was NOT evicted or ledgered";
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_cap_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_cap_test.cpp
@@ -1,0 +1,169 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// D9 (F7) end-to-end per-GPU cap behaviour. hub_max_pending_per_gpu() reads its env
+// once into a function-local static const, so a specific cap can only be pinned for
+// a whole binary: this file's CTest target sets
+// ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_PER_GPU=1 so every test here runs at
+// cap 1. The cap ARITHMETIC (all values, no wrap) is covered deterministically by
+// HubCapArithmetic in dispatch_hub_test.cpp; this file proves the register_batch
+// wiring: admit/refuse, eligible-only eviction, and map-unmutated-on-refusal.
+// Spec 1227-1238.
+
+#include "lib/rocprofiler-sdk/kfd/dispatch_hub.hpp"
+#include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace
+{
+using namespace rocprofiler::kfd;
+
+struct tracked_payload
+{
+    uint64_t id = 0;
+};
+using hub_t = DispatchHub<tracked_payload>;
+
+void
+reset_disable()
+{
+    signal_less_disable_latch().store(false);
+}
+
+correlation_key
+key_of(uint32_t slot, uint32_t dispatch_id, uint32_t gpu = 0)
+{
+    return correlation_key{slot, dispatch_id, gpu};
+}
+
+window_ptr
+mk_window(uint32_t slot, uint64_t t_open, uint64_t t_close = kWindowOpen)
+{
+    auto w    = std::make_shared<owner_window>();
+    w->slot   = slot;
+    w->t_open = t_open;
+    w->t_close.store(t_close);
+    return w;
+}
+
+hub_t::registration
+reg_of(correlation_key key, window_ptr window, uint64_t corr_id)
+{
+    auto r           = hub_t::registration{};
+    r.key            = key;
+    r.correlation_id = corr_id;
+    r.window         = std::move(window);
+    return r;
+}
+}  // namespace
+
+// The binary's cap really is 1 (env pinned by the CTest target); the rest of the
+// suite would be meaningless otherwise, so assert it first.
+TEST(HubCap, cap_is_one_for_this_binary) { EXPECT_EQ(hub_max_pending_per_gpu(), 1u); }
+
+// cap 1, empty GPU: a one-entry batch is admitted; a two-entry batch is refused
+// (no eligible victim exists and it exceeds the cap) with the map unmutated.
+TEST(HubCap, admit_one_refuse_two_on_empty_gpu)
+{
+    reset_disable();
+    auto hub = hub_t{};
+
+    auto one = std::vector<hub_t::registration>{};
+    one.emplace_back(reg_of(key_of(1, 1), mk_window(1, 100), 11));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_TRUE(hub.register_batch(std::move(one), ev1));
+    EXPECT_TRUE(ev1.empty());
+    EXPECT_EQ(hub.pending_count(), 1u);
+
+    auto two = std::vector<hub_t::registration>{};
+    two.emplace_back(reg_of(key_of(2, 1), mk_window(2, 100), 21));
+    two.emplace_back(reg_of(key_of(2, 2), mk_window(2, 100), 22));
+    auto ev2 = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(two), ev2)) << "two entries exceed cap 1";
+    EXPECT_TRUE(ev2.empty());
+    EXPECT_EQ(hub.pending_count(), 1u) << "map unmutated on refusal";
+}
+
+// A batch larger than the whole cap must refuse (the checked arithmetic must not
+// wrap into "no shortfall").
+TEST(HubCap, batch_larger_than_cap_refuses)
+{
+    reset_disable();
+    auto hub   = hub_t{};
+    auto batch = std::vector<hub_t::registration>{};
+    for(uint32_t i = 1; i <= 3; ++i)
+        batch.emplace_back(reg_of(key_of(3, i), mk_window(3, 100), 30 + i));
+    auto ev = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(batch), ev));
+    EXPECT_TRUE(ev.empty());
+    EXPECT_EQ(hub.pending_count(), 0u);
+}
+
+// live == cap with a closed-window (eligible) entry: a new one-entry batch takes
+// the shortfall path and evicts the oldest eligible victim.
+TEST(HubCap, live_equals_cap_evicts_eligible_victim)
+{
+    reset_disable();
+    auto hub = hub_t{};
+    auto w   = mk_window(4, /*t_open=*/100, /*t_close=*/200);  // closed
+    // gc_deadline_ns = 0 so any steady_now_ns() the cap check samples is already past
+    // the grace -- the entry is eligible deterministically, no sleep or clock race.
+    w->gc_deadline_ns = 0;
+    auto first        = std::vector<hub_t::registration>{};
+    first.emplace_back(reg_of(key_of(4, 1), w, /*corr_id=*/41));
+    auto ev0 = std::vector<hub_t::leaked>{};
+    ASSERT_TRUE(hub.register_batch(std::move(first), ev0));  // live == cap (1)
+
+    auto next = std::vector<hub_t::registration>{};
+    next.emplace_back(reg_of(key_of(5, 1), mk_window(5, 700), /*corr_id=*/51));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_TRUE(hub.register_batch(std::move(next), ev1)) << "eligible victim evicted, batch admitted";
+    ASSERT_EQ(ev1.size(), 1u);
+    EXPECT_EQ(ev1[0].correlation_id, 41u) << "the closed pre-existing entry was evicted";
+    EXPECT_EQ(hub.pending_count(), 1u);
+    EXPECT_TRUE(hub.is_ledgered(41u)) << "evicted entry ledgered";
+}
+
+// insufficient victim: live == cap but the only entry is OPEN-window (not eligible),
+// so a new batch is refused and the map is unmutated. This is the fail-closed case.
+TEST(HubCap, insufficient_victim_refuses_and_leaves_map_unmutated)
+{
+    reset_disable();
+    auto hub = hub_t{};
+    auto open_batch = std::vector<hub_t::registration>{};
+    open_batch.emplace_back(reg_of(key_of(6, 1), mk_window(6, /*t_open=*/100), /*corr_id=*/61));
+    auto ev0 = std::vector<hub_t::leaked>{};
+    ASSERT_TRUE(hub.register_batch(std::move(open_batch), ev0));  // live == cap, open window
+
+    auto next = std::vector<hub_t::registration>{};
+    next.emplace_back(reg_of(key_of(7, 1), mk_window(7, 300), /*corr_id=*/71));
+    auto ev1 = std::vector<hub_t::leaked>{};
+    EXPECT_FALSE(hub.register_batch(std::move(next), ev1)) << "no eligible (closed) victim -> refuse";
+    EXPECT_TRUE(ev1.empty());
+    EXPECT_EQ(hub.pending_count(), 1u) << "map unmutated across the refusal";
+    EXPECT_FALSE(hub.is_ledgered(61u)) << "the open-window entry was NOT evicted or ledgered";
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -225,6 +225,15 @@ TEST(DispatchHub, resolution_rule)
     ASSERT_TRUE(register_win(hub, K, mk_window(5, 200), /*corr_id=*/2));
     EXPECT_FALSE(end_nostart(hub, K, 300).has_value());
 }
+{  // a stale EOP (its own START was lost, it predates this window) must NOT
+   // consume the newer entry: reject BEFORE take, leaving it PENDING for its own.
+    auto hub = hub_t{};
+    ASSERT_TRUE(register_win(hub, K, mk_window(5, 100)));
+    EXPECT_FALSE(end_nostart(hub, K, 50).has_value()) << "EOP before t_open rejected";
+    EXPECT_FALSE(end_nostart(hub, K, 100).has_value()) << "EOP at t_open rejected";
+    EXPECT_EQ(hub.pending_count(), 1u) << "a rejected EOP consumes nothing";
+    EXPECT_TRUE(end_nostart(hub, K, 300).has_value()) << "its own later EOP still resolves";
+}
 }
 {  // a contained START with end < start is dropped (free sanity check).
     auto hub = hub_t{};
@@ -943,6 +952,32 @@ TEST(EnvLongInRange, reject_and_default_never_clamp)
 
     set("1000");
     EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 1000) << "upper endpoint accepted";
+
+    ::unsetenv(var);
+}
+
+// The strict opt-in switch: ONLY an explicit true value enables. Everything else
+// -- unset, empty, a false word, a typo, a number -- is DISABLED (fail-closed),
+// and nothing throws or fatals.
+TEST(EnvBoolOptIn, only_explicit_true_enables)
+{
+    const char* var = "ROCPROFILER_KFD_DLOG_TEST_ENVBOOL";
+    auto        set = [&](const char* v) { ::setenv(var, v, 1); };
+
+    ::unsetenv(var);
+    EXPECT_FALSE(env_bool_opt_in(var)) << "unset -> off";
+
+    for(const char* _yes : {"1", "true", "yes", "on"})
+    {
+        set(_yes);
+        EXPECT_TRUE(env_bool_opt_in(var)) << _yes << " enables";
+    }
+    for(const char* _no :
+        {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
+    {
+        set(_no);
+        EXPECT_FALSE(env_bool_opt_in(var)) << "'" << _no << "' must not enable";
+    }
 
     ::unsetenv(var);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -27,7 +27,9 @@
 #include "lib/rocprofiler-sdk/kfd/dispatch_hub.hpp"
 #include "lib/rocprofiler-sdk/kfd/complete_signal_less_dispatch.hpp"
 #include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/owner_registry.hpp"
+#include "lib/rocprofiler-sdk/kfd/record_pipe.hpp"
 
 #include <gtest/gtest.h>
 
@@ -138,7 +140,8 @@ register_win(hub_t& hub, correlation_key key, window_ptr window, uint64_t corr_i
 {
     auto batch = std::vector<hub_t::registration>{};
     batch.emplace_back(reg_of(key, std::move(window), corr_id));
-    return hub.register_batch(std::move(batch));
+    auto evicted = std::vector<hub_t::leaked>{};
+    return hub.register_batch(std::move(batch), evicted);
 }
 
 std::optional<hub_t::proven>
@@ -257,7 +260,8 @@ TEST(DispatchHub, admissibility_and_batch_atomicity)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(4, 10), mk_window(4, 100)));
         batch.emplace_back(reg_of(key_of(4, 2), mk_window(4, 100)));  // collides (open)
-        EXPECT_FALSE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        EXPECT_FALSE(hub.register_batch(std::move(batch), evicted));
         EXPECT_EQ(hub.pending_count(), 1u) << "no partial registration";
     }
     {  // a duplicate key within one batch is rejected.
@@ -265,7 +269,8 @@ TEST(DispatchHub, admissibility_and_batch_atomicity)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(4, 1), mk_window(4, 100)));
         batch.emplace_back(reg_of(key_of(4, 1), mk_window(4, 100)));
-        EXPECT_FALSE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        EXPECT_FALSE(hub.register_batch(std::move(batch), evicted));
         EXPECT_EQ(hub.pending_count(), 0u);
     }
     {  // quarantine refuses every future registration and is permanent.
@@ -300,7 +305,8 @@ TEST(DispatchHub, gc_closed_windows)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(5, 1), w, /*corr_id=*/11));
         batch.emplace_back(reg_of(key_of(5, 2), w, /*corr_id=*/12));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     w->gc_deadline_ns = 1000;
     w->t_close.store(200, std::memory_order_release);
@@ -374,7 +380,8 @@ TEST(DispatchHub, recycle_maps_each_start_to_its_own_window)
     {
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(K, mk_window(5, 100, 200), /*corr_id=*/10, /*payload_id=*/1));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     {
         auto batch = std::vector<hub_t::registration>{};
@@ -382,7 +389,8 @@ TEST(DispatchHub, recycle_maps_each_start_to_its_own_window)
                                   mk_window(5, 200, kWindowOpen, /*first=*/false),
                                   /*corr_id=*/20,
                                   /*payload_id=*/2));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     EXPECT_EQ(hub.pending_count(), 2u) << "both recycled owners live at once";
 
@@ -822,4 +830,119 @@ TEST(fork_safety, forked_child_short_circuits_and_survives_normal_exit)
 
     EXPECT_EQ(parent_only.pending_count(), 1u);
     EXPECT_TRUE(end_nostart(parent_only, key_of(9, 1), 300).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// D9 (F7) per-GPU cap ARITHMETIC seam. hub_cap_need is the pure branch the review
+// flagged: it must never form `live + batch` (overflow) or subtract into a wrap on
+// a healthy GPU (the underflow that would evict everything). Spec 1191-1202,1227-1230.
+// ---------------------------------------------------------------------------
+TEST(HubCapArithmetic, checked_shortfall_never_wraps)
+{
+    // cap 1, empty GPU: a one-entry batch fits; a two-entry batch needs one victim.
+    EXPECT_EQ(hub_cap_need(/*live=*/0, /*batch=*/1, /*cap=*/1), 0u);
+    EXPECT_EQ(hub_cap_need(0, 2, 1), 1u);
+
+    // A batch LARGER than the whole cap must report the exact shortfall, never wrap
+    // into "no shortfall" (the `live + batch - cap` overflow bug).
+    EXPECT_EQ(hub_cap_need(0, 5, 2), 3u);
+
+    // live == cap exactly with a one-entry batch takes the shortfall path.
+    EXPECT_EQ(hub_cap_need(1, 1, 1), 1u);
+    EXPECT_EQ(hub_cap_need(10, 1, 10), 1u);
+
+    // live < cap on a healthy GPU takes ZERO victims -- the underflow regression the
+    // `live + batch - cap` form causes (it would wrap to a huge need here).
+    EXPECT_EQ(hub_cap_need(1, 1, 10), 0u);
+    EXPECT_EQ(hub_cap_need(5, 1, 10), 0u);
+
+    // live > cap: exact overflow-free shortfall.
+    EXPECT_EQ(hub_cap_need(12, 3, 10), 5u);
+}
+
+// ---------------------------------------------------------------------------
+// D2 (F4) GC gate predicate + counter protocol. The predicate is pure (all four
+// combos); the reserve->publish counter balance is exercised through the real
+// copy/spill helpers. Spec 1324-1329.
+// ---------------------------------------------------------------------------
+TEST(GcGate, predicate_truth_table)
+{
+    EXPECT_TRUE(gc_gate_open(/*inflight=*/0, /*pipe_empty=*/true));  // only open state
+    EXPECT_FALSE(gc_gate_open(1, true)) << "copied-but-unpublished record in flight";
+    EXPECT_FALSE(gc_gate_open(0, false)) << "pipe not drained";
+    EXPECT_FALSE(gc_gate_open(3, false));
+}
+
+// The reader-published in-flight counter is reserved before a record leaves the
+// ring and discharged at publish, so a full copy->publish cycle nets to 0 and the
+// gate reopens; while a batch sits unpublished in overflow the counter stays > 0.
+TEST(GcGate, spill_publish_balances_the_inflight_counter)
+{
+    auto pipe     = record_pipe<4>{};
+    auto overflow = std::deque<record_batch>{};
+    auto inflight = std::atomic<uint64_t>{0};
+
+    // Two batches parked in overflow, reserved by the (simulated) copy: 3 + 2 = 5.
+    auto b0 = record_batch{};
+    b0.records.resize(3);
+    auto b1 = record_batch{};
+    b1.records.resize(2);
+    overflow.emplace_back(std::move(b0));
+    overflow.emplace_back(std::move(b1));
+    inflight.fetch_add(5, std::memory_order_release);  // reserve-per-region analogue
+
+    EXPECT_FALSE(gc_gate_open(inflight.load(std::memory_order_acquire), pipe.empty()))
+        << "GC gated while copied records sit unpublished in overflow";
+
+    ASSERT_TRUE(spill_overflow_to_pipe(pipe, overflow, &inflight));
+    EXPECT_EQ(inflight.load(std::memory_order_acquire), 0u) << "every reservation discharged";
+    EXPECT_FALSE(pipe.empty()) << "batches are now visible to the processor";
+
+    // Drain the pipe; only then is the gate open.
+    while(pipe.peek() != nullptr)
+        pipe.pop();
+    EXPECT_TRUE(gc_gate_open(inflight.load(std::memory_order_acquire), pipe.empty()));
+}
+
+// ---------------------------------------------------------------------------
+// D8 shared env parse contract (env_long_in_range): reject-and-default, never
+// clamp; one verdict per case. Spec 1018-1040. Uses a private env var so no other
+// accessor's cached static-const read is disturbed.
+// ---------------------------------------------------------------------------
+TEST(EnvLongInRange, reject_and_default_never_clamp)
+{
+    const char* var = "ROCPROFILER_KFD_DLOG_TEST_ENVLONG";
+    auto        set = [&](const char* v) { ::setenv(var, v, 1); };
+
+    ::unsetenv(var);
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value())
+        << "unset -> nullopt (caller default)";
+
+    set("100");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 100);  // valid
+
+    set("0");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 0) << "0 is in-range here, honored";
+
+    set("100junk");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "trailing junk rejected";
+
+    set("100 ");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "trailing whitespace rejected";
+
+    set("-5");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "below range rejected";
+
+    set("1001");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value())
+        << "above range rejected, not clamped";
+
+    set("4294967296");  // > INT_MAX: must not be narrowed into range
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value())
+        << "above INT_MAX rejected, not narrowed";
+
+    set("1000");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 1000) << "upper endpoint accepted";
+
+    ::unsetenv(var);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -27,7 +27,9 @@
 #include "lib/rocprofiler-sdk/kfd/dispatch_hub.hpp"
 #include "lib/rocprofiler-sdk/kfd/complete_signal_less_dispatch.hpp"
 #include "lib/rocprofiler-sdk/kfd/doorbell_map.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/owner_registry.hpp"
+#include "lib/rocprofiler-sdk/kfd/record_pipe.hpp"
 
 #include <gtest/gtest.h>
 
@@ -138,7 +140,8 @@ register_win(hub_t& hub, correlation_key key, window_ptr window, uint64_t corr_i
 {
     auto batch = std::vector<hub_t::registration>{};
     batch.emplace_back(reg_of(key, std::move(window), corr_id));
-    return hub.register_batch(std::move(batch));
+    auto evicted = std::vector<hub_t::leaked>{};
+    return hub.register_batch(std::move(batch), evicted);
 }
 
 std::optional<hub_t::proven>
@@ -257,7 +260,8 @@ TEST(DispatchHub, admissibility_and_batch_atomicity)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(4, 10), mk_window(4, 100)));
         batch.emplace_back(reg_of(key_of(4, 2), mk_window(4, 100)));  // collides (open)
-        EXPECT_FALSE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        EXPECT_FALSE(hub.register_batch(std::move(batch), evicted));
         EXPECT_EQ(hub.pending_count(), 1u) << "no partial registration";
     }
     {  // a duplicate key within one batch is rejected.
@@ -265,7 +269,8 @@ TEST(DispatchHub, admissibility_and_batch_atomicity)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(4, 1), mk_window(4, 100)));
         batch.emplace_back(reg_of(key_of(4, 1), mk_window(4, 100)));
-        EXPECT_FALSE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        EXPECT_FALSE(hub.register_batch(std::move(batch), evicted));
         EXPECT_EQ(hub.pending_count(), 0u);
     }
     {  // quarantine refuses every future registration and is permanent.
@@ -300,7 +305,8 @@ TEST(DispatchHub, gc_closed_windows)
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(key_of(5, 1), w, /*corr_id=*/11));
         batch.emplace_back(reg_of(key_of(5, 2), w, /*corr_id=*/12));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     w->gc_deadline_ns = 1000;
     w->t_close.store(200, std::memory_order_release);
@@ -374,7 +380,8 @@ TEST(DispatchHub, recycle_maps_each_start_to_its_own_window)
     {
         auto batch = std::vector<hub_t::registration>{};
         batch.emplace_back(reg_of(K, mk_window(5, 100, 200), /*corr_id=*/10, /*payload_id=*/1));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     {
         auto batch = std::vector<hub_t::registration>{};
@@ -382,7 +389,8 @@ TEST(DispatchHub, recycle_maps_each_start_to_its_own_window)
                                   mk_window(5, 200, kWindowOpen, /*first=*/false),
                                   /*corr_id=*/20,
                                   /*payload_id=*/2));
-        ASSERT_TRUE(hub.register_batch(std::move(batch)));
+        auto evicted = std::vector<hub_t::leaked>{};
+        ASSERT_TRUE(hub.register_batch(std::move(batch), evicted));
     }
     EXPECT_EQ(hub.pending_count(), 2u) << "both recycled owners live at once";
 
@@ -822,4 +830,116 @@ TEST(fork_safety, forked_child_short_circuits_and_survives_normal_exit)
 
     EXPECT_EQ(parent_only.pending_count(), 1u);
     EXPECT_TRUE(end_nostart(parent_only, key_of(9, 1), 300).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// D9 (F7) per-GPU cap ARITHMETIC seam. hub_cap_need is the pure branch the review
+// flagged: it must never form `live + batch` (overflow) or subtract into a wrap on
+// a healthy GPU (the underflow that would evict everything). Spec 1191-1202,1227-1230.
+// ---------------------------------------------------------------------------
+TEST(HubCapArithmetic, checked_shortfall_never_wraps)
+{
+    // cap 1, empty GPU: a one-entry batch fits; a two-entry batch needs one victim.
+    EXPECT_EQ(hub_cap_need(/*live=*/0, /*batch=*/1, /*cap=*/1), 0u);
+    EXPECT_EQ(hub_cap_need(0, 2, 1), 1u);
+
+    // A batch LARGER than the whole cap must report the exact shortfall, never wrap
+    // into "no shortfall" (the `live + batch - cap` overflow bug).
+    EXPECT_EQ(hub_cap_need(0, 5, 2), 3u);
+
+    // live == cap exactly with a one-entry batch takes the shortfall path.
+    EXPECT_EQ(hub_cap_need(1, 1, 1), 1u);
+    EXPECT_EQ(hub_cap_need(10, 1, 10), 1u);
+
+    // live < cap on a healthy GPU takes ZERO victims -- the underflow regression the
+    // `live + batch - cap` form causes (it would wrap to a huge need here).
+    EXPECT_EQ(hub_cap_need(1, 1, 10), 0u);
+    EXPECT_EQ(hub_cap_need(5, 1, 10), 0u);
+
+    // live > cap: exact overflow-free shortfall.
+    EXPECT_EQ(hub_cap_need(12, 3, 10), 5u);
+}
+
+// ---------------------------------------------------------------------------
+// D2 (F4) GC gate predicate + counter protocol. The predicate is pure (all four
+// combos); the reserve->publish counter balance is exercised through the real
+// copy/spill helpers. Spec 1324-1329.
+// ---------------------------------------------------------------------------
+TEST(GcGate, predicate_truth_table)
+{
+    EXPECT_TRUE(gc_gate_open(/*inflight=*/0, /*pipe_empty=*/true));  // only open state
+    EXPECT_FALSE(gc_gate_open(1, true)) << "copied-but-unpublished record in flight";
+    EXPECT_FALSE(gc_gate_open(0, false)) << "pipe not drained";
+    EXPECT_FALSE(gc_gate_open(3, false));
+}
+
+// The reader-published in-flight counter is reserved before a record leaves the
+// ring and discharged at publish, so a full copy->publish cycle nets to 0 and the
+// gate reopens; while a batch sits unpublished in overflow the counter stays > 0.
+TEST(GcGate, spill_publish_balances_the_inflight_counter)
+{
+    auto pipe     = record_pipe<4>{};
+    auto overflow = std::deque<record_batch>{};
+    auto inflight = std::atomic<uint64_t>{0};
+
+    // Two batches parked in overflow, reserved by the (simulated) copy: 3 + 2 = 5.
+    auto b0 = record_batch{};
+    b0.records.resize(3);
+    auto b1 = record_batch{};
+    b1.records.resize(2);
+    overflow.emplace_back(std::move(b0));
+    overflow.emplace_back(std::move(b1));
+    inflight.fetch_add(5, std::memory_order_release);  // reserve-per-region analogue
+
+    EXPECT_FALSE(gc_gate_open(inflight.load(std::memory_order_acquire), pipe.empty()))
+        << "GC gated while copied records sit unpublished in overflow";
+
+    ASSERT_TRUE(spill_overflow_to_pipe(pipe, overflow, &inflight));
+    EXPECT_EQ(inflight.load(std::memory_order_acquire), 0u) << "every reservation discharged";
+    EXPECT_FALSE(pipe.empty()) << "batches are now visible to the processor";
+
+    // Drain the pipe; only then is the gate open.
+    while(pipe.peek() != nullptr)
+        pipe.pop();
+    EXPECT_TRUE(gc_gate_open(inflight.load(std::memory_order_acquire), pipe.empty()));
+}
+
+// ---------------------------------------------------------------------------
+// D8 shared env parse contract (env_long_in_range): reject-and-default, never
+// clamp; one verdict per case. Spec 1018-1040. Uses a private env var so no other
+// accessor's cached static-const read is disturbed.
+// ---------------------------------------------------------------------------
+TEST(EnvLongInRange, reject_and_default_never_clamp)
+{
+    const char* var = "ROCPROFILER_KFD_DLOG_TEST_ENVLONG";
+    auto        set = [&](const char* v) { ::setenv(var, v, 1); };
+
+    ::unsetenv(var);
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "unset -> nullopt (caller default)";
+
+    set("100");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 100);  // valid
+
+    set("0");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 0) << "0 is in-range here, honored";
+
+    set("100junk");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "trailing junk rejected";
+
+    set("100 ");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "trailing whitespace rejected";
+
+    set("-5");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "below range rejected";
+
+    set("1001");
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "above range rejected, not clamped";
+
+    set("4294967296");  // > INT_MAX: must not be narrowed into range
+    EXPECT_FALSE(env_long_in_range(var, 0, 1000).has_value()) << "above INT_MAX rejected, not narrowed";
+
+    set("1000");
+    EXPECT_EQ(env_long_in_range(var, 0, 1000).value_or(-1), 1000) << "upper endpoint accepted";
+
+    ::unsetenv(var);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -310,6 +310,46 @@ TEST(dlog_drain, evict_stale_starts)
     EXPECT_EQ(st.pairing.pending_starts.count(2), 1u);
 }
 
+// The hard size cap bounds pending_starts even when nothing ages out: past the
+// cap an insert evicts the OLDEST retained START (by seen_at_ns) and counts it.
+TEST(dlog_drain, pending_starts_size_cap_evicts_oldest)
+{
+    auto mk_start = [](uint32_t dispatch_id, uint64_t ts) {
+        auto c             = copied_record{};
+        c.rec.record_type  = kRecStart;
+        c.rec.doorbell_off = 4100;
+        c.rec.dispatch_id  = dispatch_id;
+        c.rec.ts_lo        = static_cast<uint32_t>(ts);
+        return c;
+    };
+
+    pair_state pairing;
+    pairing.max_pending_starts = 2;
+    recorder rec;
+
+    // Three distinct keys, each in its own batch so seen_at_ns strictly increases.
+    for(uint32_t i = 1; i <= 3; ++i)
+    {
+        auto batch = std::vector<copied_record>{mk_start(i, 10 * i)};
+        pair_records(batch.data(), batch.size(), pairing, /*now_ns=*/1000 * i, rec.on_record());
+    }
+
+    EXPECT_EQ(pairing.pending_starts.size(), 2u) << "the cap is a hard bound";
+    EXPECT_EQ(pairing.starts_cap_evicted, 1u);
+    const uint64_t k1 = (uint64_t{4100} << 32) | 1u;
+    EXPECT_EQ(pairing.pending_starts.count(k1), 0u) << "the oldest START is the victim";
+
+    // A recurring key is exempt: it cannot grow the map, and evicting there could
+    // pick the very key being touched and reset its ambiguity latch.
+    const uint64_t k3    = (uint64_t{4100} << 32) | 3u;
+    auto           again = std::vector<copied_record>{mk_start(3, 99)};
+    pair_records(again.data(), again.size(), pairing, /*now_ns=*/4000, rec.on_record());
+    EXPECT_EQ(pairing.pending_starts.size(), 2u);
+    EXPECT_EQ(pairing.starts_cap_evicted, 1u) << "no eviction for a recurring key";
+    ASSERT_EQ(pairing.pending_starts.count(k3), 1u);
+    EXPECT_TRUE(pairing.pending_starts[k3].ambiguous) << "the duplicate still latches ambiguous";
+}
+
 // Invalid geometry (0 regions, too many, or non-power-of-two rrc) is rejected.
 TEST(dlog_drain, invalid_geometry_rejected)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -300,8 +300,11 @@ TEST(dlog_drain, pairing_core)
 TEST(dlog_drain, evict_stale_starts)
 {
     drain_state st;
-    st.pairing.pending_starts[1] = pair_state::pending_start{100, 1000};  // old
-    st.pairing.pending_starts[2] = pair_state::pending_start{200, 5000};  // fresh
+    // outstanding=1: a live pending_start always carries at least one outstanding
+    // START (the real emplace path seeds it 1). evict_stale returns the count of
+    // stranded STARTs, not keys, so a single-start stale key contributes 1.
+    st.pairing.pending_starts[1] = pair_state::pending_start{100, 1000, 1, false};  // old
+    st.pairing.pending_starts[2] = pair_state::pending_start{200, 5000, 1, false};  // fresh
     EXPECT_EQ(st.pairing.evict_stale(/*now_ns=*/6000, /*max_age_ns=*/2000), 1u);
     EXPECT_EQ(st.pairing.pending_starts.count(1), 0u);
     EXPECT_EQ(st.pairing.pending_starts.count(2), 1u);
@@ -785,7 +788,9 @@ TEST(dlog_drain, ambiguous_key_ages_from_first_start)
     pair_records(b2.data(), b2.size(), st, /*now_ns=*/2000, nop);
     ASSERT_EQ(st.pending_starts.size(), 1u);
     EXPECT_TRUE(st.pending_starts.begin()->second.ambiguous);
-    EXPECT_EQ(st.evict_stale(/*now_ns=*/2500, /*max_age_ns=*/2000), 1u);
+    // Three STARTs are outstanding on this one ambiguous key; evict_stale counts
+    // stranded STARTs, not keys, so aging the key out reports all three.
+    EXPECT_EQ(st.evict_stale(/*now_ns=*/2500, /*max_age_ns=*/2000), 3u);
     EXPECT_TRUE(st.pending_starts.empty());
 }
 
@@ -1108,4 +1113,187 @@ TEST(stream_geometry, rejection_reason_is_reported)
     bad_offset.records_offset = 64;
     EXPECT_EQ(validate_stream_geometry(bad_offset, buf, kPage).reason,
               geometry_reason::layout_mismatch);
+}
+
+// ---------------------------------------------------------------------------
+// D1 (F9) tick-ordered pairing. The pairer orders each batch by (tick, kind,
+// arrival_seq) with EOP-before-START at equal ticks, so temporal order -- not
+// region/copy position -- decides every pairing. These are the spec's
+// fails-without-fix cases (D1 180-199); they fail under the old all-STARTs-first
+// two-pass pairer.
+// ---------------------------------------------------------------------------
+
+// D1(a): {S_A, E_A, S_B, E_B} on one raw key in true temporal order -> BOTH pair.
+// The old two-pass installed S_A and S_B before any EOP, latching ambiguous and
+// dropping both; tick order runs S_A -> E_A(pair) -> S_B -> E_B(pair).
+TEST(dlog_drain, d1_same_key_in_order_reuse_both_pair)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecEop, 7, db, 200);
+    e.ring.put(0, 2, kRecStart, 7, db, 300);  // same raw key, reused after E_A
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 2u) << "both dispatches pair; key never holds 2 outstanding";
+    EXPECT_EQ(e.rec.pairs.size(), 1u);  // same key -> the map holds the last pair
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u) << "no spurious ambiguity";
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 0u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());
+}
+
+// D1(i): reuse tie -- S_A(1) retained, then {E_A(5), S_B(5), E_B(9)} in one batch.
+// EOP-before-START at the equal tick 5 pairs E_A with the outstanding S_A first,
+// then installs S_B cleanly; both pair, no ambiguity.
+TEST(dlog_drain, d1_reuse_equal_tick_both_pair_no_ambiguous)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 1);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);  // S_A retained
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 5);    // E_A at tick 5
+    e.ring.put(0, 2, kRecStart, 7, db, 5);  // S_B at the same tick 5
+    e.ring.put(0, 3, kRecEop, 7, db, 9);    // E_B at tick 9
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 2u) << "E_A pairs S_A (EOP-first at equal tick), then S_B/E_B pair";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u);
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 0u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());
+}
+
+// D1(d): a START retained from batch N pairs its EOP in batch N+1, and the
+// retained START does NOT latch ambiguous (it is not re-fed into N+1's sort).
+TEST(dlog_drain, d1_cross_batch_pair_no_ambiguous)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 200);
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 1u) << "the retained START pairs its cross-batch EOP";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u) << "retained START never latches ambiguous";
+    EXPECT_EQ(e.st.pairing.starts_overwritten, 0u);
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 100u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].second, 200u);
+}
+
+// D1(e): a latched-ambiguous key drains one outstanding START per ambiguous EOP
+// to 0, then the NEXT START re-inserts a fresh non-ambiguous entry and pairs.
+TEST(dlog_drain, d1_sticky_ambiguous_drains_then_fresh_start_pairs)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    // Two outstanding STARTs latch ambiguous; two EOPs drain outstanding to 0.
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecStart, 7, db, 200);
+    e.ring.put(0, 2, kRecEop, 7, db, 300);
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u);
+    ASSERT_TRUE(e.st.pairing.pending_starts.empty()) << "drained to 0";
+    // A fresh START/EOP on the same raw key now pairs normally.
+    e.rec = recorder{};
+    e.ring.put(0, 4, kRecStart, 7, db, 500);
+    e.ring.put(0, 5, kRecEop, 7, db, 600);
+    e.ring.wptr[0] = 6;
+    EXPECT_EQ(e.drain(), 1u) << "fresh entry after the ambiguous run pairs";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u) << "no new ambiguity";
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 500u);
+}
+
+// D1(g): cross-batch equal tick -- START(t) in batch N, EOP(t) in batch N+1.
+// No firmware guarantee that start<end for a real pair, so an equal-tick EOP is
+// dropped fail-closed (equal_tick_drops), the key drained and re-pairable.
+TEST(dlog_drain, d1_cross_batch_equal_tick_dropped)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 70);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 70);  // equal tick
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 0u) << "equal-tick EOP is not a valid pair";
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 1u);
+    EXPECT_TRUE(e.rec.pairs.empty());
+    EXPECT_TRUE(e.rec.eops_without_start.empty());
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty()) << "key drained to 0, re-pairable";
+}
+
+// D1(h): cross-batch stale EOP -- START(100) retained from batch N, EOP(50) in
+// batch N+1 predates it (belongs to an earlier lost dispatch). The stale EOP is
+// dropped and the retained START is left UNTOUCHED, so its own EOP(120) in batch
+// N+2 still pairs.
+TEST(dlog_drain, d1_cross_batch_stale_eop_leaves_start_and_later_eop_pairs)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    // Batch N+1: EOP(50) < retained START(100) -> stale drop, START untouched.
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 50);
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_EQ(e.st.pairing.stale_eop_drops, 1u);
+    EXPECT_EQ(e.st.pairing.pending_starts.size(), 1u) << "retained START still outstanding";
+    EXPECT_TRUE(e.rec.eops_without_start.empty()) << "stale EOP NOT forwarded startless";
+    // Batch N+2: the START's own EOP(120) pairs.
+    e.rec = recorder{};
+    e.ring.put(0, 2, kRecEop, 7, db, 120);
+    e.ring.wptr[0] = 3;
+    EXPECT_EQ(e.drain(), 1u) << "the retained START pairs its true EOP";
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 100u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].second, 120u);
+}
+
+// D1(f): same-batch {S(t), E(t)} on one key fed in BOTH arrival orders must give
+// a byte-identical outcome -- the EOP-before-START tie rule is a property of the
+// record multiset, not arrival order. Both orders: one startless EOP forwarded,
+// equal_tick_drops == 0, one retained START.
+TEST(dlog_drain, d1_same_batch_equal_tick_is_order_independent)
+{
+    const uint32_t db  = 4100;
+    auto           run = [&](bool eop_first) {
+        env e(1, 2048);
+        if(eop_first)
+        {
+            e.ring.put(0, 0, kRecEop, 7, db, 55);
+            e.ring.put(0, 1, kRecStart, 7, db, 55);
+        }
+        else
+        {
+            e.ring.put(0, 0, kRecStart, 7, db, 55);
+            e.ring.put(0, 1, kRecEop, 7, db, 55);
+        }
+        e.ring.wptr[0] = 2;
+        e.drain();
+        return e;
+    };
+    auto se = run(false);  // {S, E}
+    auto es = run(true);   // {E, S}
+    // Identical outcome: the EOP ran first against an empty key -> startless,
+    // the trailing START is retained; no equal-tick drop in either order.
+    EXPECT_EQ(se.rec.eops_without_start.size(), 1u);
+    EXPECT_EQ(es.rec.eops_without_start.size(), 1u);
+    EXPECT_EQ(se.st.pairing.equal_tick_drops, 0u);
+    EXPECT_EQ(es.st.pairing.equal_tick_drops, 0u);
+    EXPECT_EQ(se.st.pairing.pending_starts.size(), 1u);
+    EXPECT_EQ(es.st.pairing.pending_starts.size(), 1u);
+    EXPECT_TRUE(se.rec.pairs.empty());
+    EXPECT_TRUE(es.rec.pairs.empty());
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -300,8 +300,11 @@ TEST(dlog_drain, pairing_core)
 TEST(dlog_drain, evict_stale_starts)
 {
     drain_state st;
-    st.pairing.pending_starts[1] = pair_state::pending_start{100, 1000};  // old
-    st.pairing.pending_starts[2] = pair_state::pending_start{200, 5000};  // fresh
+    // outstanding=1: a live pending_start always carries at least one outstanding
+    // START (the real emplace path seeds it 1). evict_stale returns the count of
+    // stranded STARTs, not keys, so a single-start stale key contributes 1.
+    st.pairing.pending_starts[1] = pair_state::pending_start{100, 1000, 1, false};  // old
+    st.pairing.pending_starts[2] = pair_state::pending_start{200, 5000, 1, false};  // fresh
     EXPECT_EQ(st.pairing.evict_stale(/*now_ns=*/6000, /*max_age_ns=*/2000), 1u);
     EXPECT_EQ(st.pairing.pending_starts.count(1), 0u);
     EXPECT_EQ(st.pairing.pending_starts.count(2), 1u);
@@ -785,7 +788,9 @@ TEST(dlog_drain, ambiguous_key_ages_from_first_start)
     pair_records(b2.data(), b2.size(), st, /*now_ns=*/2000, nop);
     ASSERT_EQ(st.pending_starts.size(), 1u);
     EXPECT_TRUE(st.pending_starts.begin()->second.ambiguous);
-    EXPECT_EQ(st.evict_stale(/*now_ns=*/2500, /*max_age_ns=*/2000), 1u);
+    // Three STARTs are outstanding on this one ambiguous key; evict_stale counts
+    // stranded STARTs, not keys, so aging the key out reports all three.
+    EXPECT_EQ(st.evict_stale(/*now_ns=*/2500, /*max_age_ns=*/2000), 3u);
     EXPECT_TRUE(st.pending_starts.empty());
 }
 
@@ -1108,4 +1113,187 @@ TEST(stream_geometry, rejection_reason_is_reported)
     bad_offset.records_offset = 64;
     EXPECT_EQ(validate_stream_geometry(bad_offset, buf, kPage).reason,
               geometry_reason::layout_mismatch);
+}
+
+// ---------------------------------------------------------------------------
+// D1 (F9) tick-ordered pairing. The pairer orders each batch by (tick, kind,
+// arrival_seq) with EOP-before-START at equal ticks, so temporal order -- not
+// region/copy position -- decides every pairing. These are the spec's
+// fails-without-fix cases (D1 180-199); they fail under the old all-STARTs-first
+// two-pass pairer.
+// ---------------------------------------------------------------------------
+
+// D1(a): {S_A, E_A, S_B, E_B} on one raw key in true temporal order -> BOTH pair.
+// The old two-pass installed S_A and S_B before any EOP, latching ambiguous and
+// dropping both; tick order runs S_A -> E_A(pair) -> S_B -> E_B(pair).
+TEST(dlog_drain, d1_same_key_in_order_reuse_both_pair)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecEop, 7, db, 200);
+    e.ring.put(0, 2, kRecStart, 7, db, 300);  // same raw key, reused after E_A
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 2u) << "both dispatches pair; key never holds 2 outstanding";
+    EXPECT_EQ(e.rec.pairs.size(), 1u);  // same key -> the map holds the last pair
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u) << "no spurious ambiguity";
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 0u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());
+}
+
+// D1(i): reuse tie -- S_A(1) retained, then {E_A(5), S_B(5), E_B(9)} in one batch.
+// EOP-before-START at the equal tick 5 pairs E_A with the outstanding S_A first,
+// then installs S_B cleanly; both pair, no ambiguity.
+TEST(dlog_drain, d1_reuse_equal_tick_both_pair_no_ambiguous)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 1);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);  // S_A retained
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 5);    // E_A at tick 5
+    e.ring.put(0, 2, kRecStart, 7, db, 5);  // S_B at the same tick 5
+    e.ring.put(0, 3, kRecEop, 7, db, 9);    // E_B at tick 9
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 2u) << "E_A pairs S_A (EOP-first at equal tick), then S_B/E_B pair";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u);
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 0u);
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty());
+}
+
+// D1(d): a START retained from batch N pairs its EOP in batch N+1, and the
+// retained START does NOT latch ambiguous (it is not re-fed into N+1's sort).
+TEST(dlog_drain, d1_cross_batch_pair_no_ambiguous)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 200);
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 1u) << "the retained START pairs its cross-batch EOP";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 0u) << "retained START never latches ambiguous";
+    EXPECT_EQ(e.st.pairing.starts_overwritten, 0u);
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 100u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].second, 200u);
+}
+
+// D1(e): a latched-ambiguous key drains one outstanding START per ambiguous EOP
+// to 0, then the NEXT START re-inserts a fresh non-ambiguous entry and pairs.
+TEST(dlog_drain, d1_sticky_ambiguous_drains_then_fresh_start_pairs)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    // Two outstanding STARTs latch ambiguous; two EOPs drain outstanding to 0.
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.put(0, 1, kRecStart, 7, db, 200);
+    e.ring.put(0, 2, kRecEop, 7, db, 300);
+    e.ring.put(0, 3, kRecEop, 7, db, 400);
+    e.ring.wptr[0] = 4;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u);
+    ASSERT_TRUE(e.st.pairing.pending_starts.empty()) << "drained to 0";
+    // A fresh START/EOP on the same raw key now pairs normally.
+    e.rec = recorder{};
+    e.ring.put(0, 4, kRecStart, 7, db, 500);
+    e.ring.put(0, 5, kRecEop, 7, db, 600);
+    e.ring.wptr[0] = 6;
+    EXPECT_EQ(e.drain(), 1u) << "fresh entry after the ambiguous run pairs";
+    EXPECT_EQ(e.st.pairing.ambiguous_pairs, 2u) << "no new ambiguity";
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 500u);
+}
+
+// D1(g): cross-batch equal tick -- START(t) in batch N, EOP(t) in batch N+1.
+// No firmware guarantee that start<end for a real pair, so an equal-tick EOP is
+// dropped fail-closed (equal_tick_drops), the key drained and re-pairable.
+TEST(dlog_drain, d1_cross_batch_equal_tick_dropped)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 70);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 70);  // equal tick
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 0u) << "equal-tick EOP is not a valid pair";
+    EXPECT_EQ(e.st.pairing.equal_tick_drops, 1u);
+    EXPECT_TRUE(e.rec.pairs.empty());
+    EXPECT_TRUE(e.rec.eops_without_start.empty());
+    EXPECT_TRUE(e.st.pairing.pending_starts.empty()) << "key drained to 0, re-pairable";
+}
+
+// D1(h): cross-batch stale EOP -- START(100) retained from batch N, EOP(50) in
+// batch N+1 predates it (belongs to an earlier lost dispatch). The stale EOP is
+// dropped and the retained START is left UNTOUCHED, so its own EOP(120) in batch
+// N+2 still pairs.
+TEST(dlog_drain, d1_cross_batch_stale_eop_leaves_start_and_later_eop_pairs)
+{
+    const uint32_t db = 4100;
+    env            e(1, 2048);
+    e.ring.put(0, 0, kRecStart, 7, db, 100);
+    e.ring.wptr[0] = 1;
+    EXPECT_EQ(e.drain(), 0u);
+    ASSERT_EQ(e.st.pairing.pending_starts.size(), 1u);
+    // Batch N+1: EOP(50) < retained START(100) -> stale drop, START untouched.
+    e.rec = recorder{};
+    e.ring.put(0, 1, kRecEop, 7, db, 50);
+    e.ring.wptr[0] = 2;
+    EXPECT_EQ(e.drain(), 0u);
+    EXPECT_EQ(e.st.pairing.stale_eop_drops, 1u);
+    EXPECT_EQ(e.st.pairing.pending_starts.size(), 1u) << "retained START still outstanding";
+    EXPECT_TRUE(e.rec.eops_without_start.empty()) << "stale EOP NOT forwarded startless";
+    // Batch N+2: the START's own EOP(120) pairs.
+    e.rec = recorder{};
+    e.ring.put(0, 2, kRecEop, 7, db, 120);
+    e.ring.wptr[0] = 3;
+    EXPECT_EQ(e.drain(), 1u) << "the retained START pairs its true EOP";
+    ASSERT_EQ(e.rec.pairs.count(std::make_pair(db, 7u)), 1u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].first, 100u);
+    EXPECT_EQ(e.rec.pairs[std::make_pair(db, 7u)].second, 120u);
+}
+
+// D1(f): same-batch {S(t), E(t)} on one key fed in BOTH arrival orders must give
+// a byte-identical outcome -- the EOP-before-START tie rule is a property of the
+// record multiset, not arrival order. Both orders: one startless EOP forwarded,
+// equal_tick_drops == 0, one retained START.
+TEST(dlog_drain, d1_same_batch_equal_tick_is_order_independent)
+{
+    const uint32_t db = 4100;
+    auto           run = [&](bool eop_first) {
+        env e(1, 2048);
+        if(eop_first)
+        {
+            e.ring.put(0, 0, kRecEop, 7, db, 55);
+            e.ring.put(0, 1, kRecStart, 7, db, 55);
+        }
+        else
+        {
+            e.ring.put(0, 0, kRecStart, 7, db, 55);
+            e.ring.put(0, 1, kRecEop, 7, db, 55);
+        }
+        e.ring.wptr[0] = 2;
+        e.drain();
+        return e;
+    };
+    auto se = run(false);  // {S, E}
+    auto es = run(true);   // {E, S}
+    // Identical outcome: the EOP ran first against an empty key -> startless,
+    // the trailing START is retained; no equal-tick drop in either order.
+    EXPECT_EQ(se.rec.eops_without_start.size(), 1u);
+    EXPECT_EQ(es.rec.eops_without_start.size(), 1u);
+    EXPECT_EQ(se.st.pairing.equal_tick_drops, 0u);
+    EXPECT_EQ(es.st.pairing.equal_tick_drops, 0u);
+    EXPECT_EQ(se.st.pairing.pending_starts.size(), 1u);
+    EXPECT_EQ(es.st.pairing.pending_starts.size(), 1u);
+    EXPECT_TRUE(se.rec.pairs.empty());
+    EXPECT_TRUE(es.rec.pairs.empty());
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -905,6 +905,11 @@ invoke_client_detaches()
 
             hsa::async_copy_sync();
             hsa::queue_controller_sync();
+            // F23 terminal fail-closed fence: client detach frees the tool's callback
+            // and buffer machinery next, so no callback-capable signal-less completion
+            // may survive. On timeout this abandons+disables signal-less process-wide
+            // (correct here -- the client is going away). No-op with the feature off.
+            kfd::signal_less_fence_completions();
             pc_sampling::service_sync(itr->internal_client_id);
 
             auto _fini_status = get_fini_status();
@@ -957,6 +962,11 @@ invoke_client_finalizer(rocprofiler_client_id_t client_id)
 
                 hsa::async_copy_sync();
                 hsa::queue_controller_sync();
+                // F23 terminal fail-closed fence: the client finalizer frees the
+                // tool's callback/buffer machinery next, so no callback-capable
+                // signal-less completion may survive. On timeout abandon+disable
+                // process-wide. No-op with the feature off.
+                kfd::signal_less_fence_completions();
                 pc_sampling::service_sync(itr->internal_client_id);
 
                 auto _fini_status = get_fini_status();


### PR DESCRIPTION
## Summary
Consolidates the review-driven fixes for the KFD dispatch-log **signal-less** kernel-dispatch completion path. Two independent code reviews plus a hardware-validated capstone produced **29 findings (F1–F29) + N1**; this PR applies the correctness, concurrency, lifetime, and resource-bound fixes, rejects the ones proven false/already-addressed (with evidence), and documents the accepted residuals. Net: **+1592 / −335 across 27 files** (within Systems PR size policy).

## How each original finding was addressed

### Applied (in this PR)
- **F1 — teardown HW-drain parity.** `signal_less_teardown()` now HW-drains live queues (reusing the per-queue-destroy drain) before the reader quiesce, closing the "kernel in flight at `main()` return" gap the signal path already covered.
- **F3 — env read on the processor hot path.** `start_max_age_ns()` is cached in a function-local `static const` (read once) instead of scanning `environ` per batch.
- **F4 — closed-window GC vs copied-but-unpublished EOP.** Added a reader-published in-flight counter (`reader_copied_unpublished`), reserved before the first record copy and discharged after `publish()`; GC gate loads it (acquire) before `pipe.empty()`, and it is reset on reader arm.
- **F6 — missing acquire fence.** Added the acquire fence before the `w2` load in the drain path.
- **F7 — unbounded hub growth.** Per-GPU pending cap (`hub_max_pending_per_gpu`, env-tunable) with checked (non-wrapping) arithmetic, closed-window+past-grace eviction, all-or-nothing preflight under the hub lock, and a distinct `cap_evicted` counter. **Default raised to 2,000,000** after the capstone showed 65,536 refuses 16–41% of dispatches under `hipGraphLaunch` bursts (see Testing).
- **F8 — quarantine must require an empty overflow.** Quarantine now gated on overflow-empty.
- **F9 — pairing drops ordinary same-key doorbell reuse.** Replaced the all-STARTs-first two-pass pairer with a single tick-ordered pass (`(tick, kind, arrival_seq)`, EOP-before-START at equal ticks), fixing HWS region-remap and same-key reuse while still dropping genuine ambiguity.
- **F10 — reader setup/teardown race.** `stop_reader()` now takes `setup_mu` first, latches `reader_unavailable`, sets stop + wakes before the joins, and closes `kfd_fd`/clears `running` under the lock.
- **F13 — fork child fd/map leak + unsafe dtors.** Child now `close`/`munmap`s inherited reader fds/maps (async-signal-safe) and skips the reader-state join dtor via the fork-generation guard.
- **F14 — fork child hangs on the inline interposition TaskGroup.** Added an unconditional `pthread_atfork` child generation bump (`g_fork_generation`, lock-free, async-signal-safe) as the first statement of the existing child handler; `TaskGroup` stamps its generation and its destructor early-returns (leaking the pool) when stale.
- **F15 — profiler arms unconditionally.** `init_kfd_profiler` arm is gated on the existing kernel-dispatch `context_filter` predicate; the `start_context` arm + lazy first-dispatch fallback are unchanged.
- **F16 — drain_epoch advanced with no ready session.** Fixed.
- **F17 — worker-pool construction during shutdown.** Single `submit_inline_async()` primitive gates all inline submissions: `fork_stale()` first, then the handler gate, then the fini check before pool construction; the payload is preserved on refusal; `interposition_sync()` takes the gate exclusive and reads a release-published constructed flag.
- **F22 — evict_stale summed outstanding, not keys.** Fixed.
- **F23 — client-detach completion fence.** `signal_less_fence_completions()` added at the `queue_controller_sync()` detach/finalize sites (guarded — see the crash fix below).
- **F24 — HSA-shutdown completion fence.** Same fence at the `hsa_shut_down` last-reference branch (guarded).
- **F25 — signal-path fallback on `register_batch` refusal.** Refusal now replays the exact signal-path transformation for each dispatch (shared helper, both packet vectors updated via a parallel index) and clears `_signal_less_batch`; the double-releasing correlation-id retire loop is deleted.
- **F29 — dynamic queue discovery.** A dynamically-discovered (never-windowed) `QueueState` now disables signal-less process-wide ("owner we never windowed" invariant).
- **N1 — fence timeout policy.** `quiesce_budget_ns()` env-tunable; the fence does at most two quiesce attempts (second immediate), `reader_unavailable` short-circuits to fail-closed; total blocking bounded at `2×budget`.
- **F18/F20/F21 (docs/naming, partial).** Renamed `correlation_key::doorbell_off`→`doorbell_slot`; corrected several stale comments and the `.rst` HSA-fallback claim. A few items with ambiguous exact targets were deliberately left rather than introduce false comments.

### Applied then removed (simplification — accepted residual)
- **F2 — code-object unload vs late signal-less completion.** A seq-bounded unload sweep + tombstones + counting-fence was implemented, then **removed (~300 LOC)**: the completion payload carries copies (no code-object-owned memory is dereferenced late), so the only exposure is a tool-semantic/buffered-tracing inconsistency, which the design's success criterion explicitly accepts. Removing it also eliminated a latent unbounded-wait/reentrancy hazard under the code-object destroy mutex.

### Rejected / no code needed (with evidence)
- **F5 / F12 — mid-stream `wptr` regression.** False positive per the confirmed KFD driver contract (GPU reset sets `fatal` without regressing `wptr`; `wptr` is monotonic per stream). Documented defensive comment only.
- **F11 — POLLERR+FATAL terminal handling.** Already present; verified in the reader poll path (`KFD_DLOG_STATUS_FATAL`).
- **F26 — raw-terminal admission bounds** / **F27 — finalize under the destroy mutex.** Verified already addressed.

### Additional issues found during hardware validation (fixed here)
- **Teardown SIGSEGV (crash).** The F24 fence could re-enter `signal_less_fence_completions()` from a second `hsa_shut_down` (another DSO's `__cxa_finalize` during `exit()`) after this library's own `atexit` teardown had destroyed the queue-registry singleton → null-deref in `fence_all_queue_gates()`. Fixed with a one-line `registration::get_fini_status() != 0` guard (reuses existing state; no-ops the dangerous re-entry and the redundant in-finalize call, while preserving the fence on genuinely-live per-client/detach paths). Root-caused via reproducible symbolized backtrace + positive control.
- **Duplicate `QueueState` UAF.** Concurrent first-time dynamic discovery of one queue could publish two `QueueState`s, splitting the drain interlock. Fixed with get-or-create under the registry write lock.

## Changes
- Pairing rewrite (`kfd/dlog_drain.hpp`), hub cap + GC gate (`kfd/dispatch_hub.hpp`), reader lifecycle (`kfd/kfd_reader.*`, `kfd/record_pipe.hpp`), inline-submit gate + fork generation (`hsa/queue_interposition.*`, `internal_threading.*`), teardown/fence guarding (`kfd/signal_less.*`, `registration.cpp`, `hsa/hsa.cpp`), shared env-parse helper (`kfd/env_parse.hpp`), arm gating (`kfd/kfd_profiler.*`), naming/docs.
- New unit tests: `kfd/tests/dlog_drain_test.cpp` (D1 pairing), `kfd/tests/dispatch_hub_test.cpp` + `dispatch_hub_cap_test.cpp` (cap arithmetic/env/GC gate), wired in `kfd/tests/CMakeLists.txt`.

## Testing
- `cmake --build` at the project warning level — clean, no new warnings.
- `ctest -L kfd-dlog` — **88/88 pass**.
- ThreadSanitizer (`-DROCPROFILER_MEMCHECK=ThreadSanitizer`) across all 8 kfd-dlog suites — **clean, zero reports**.
- SDK reproducers on MI350: **1031 NOT_REPRODUCED, 1040 pass (3/3, previously crashing), 1041-a/1041-c/1041-d pass**.
- `tclk_tier1 --windows 1000` — **0/8000 window violations, 8/8 agents PASS**.
- stream-harness — **17/17** (tier1 8/8, tier2 5/5, poll 4/4).
- perf-pilot — negligible per-dispatch overhead (+112 ns, within equivalence margin).
- graph-perf (`hipGraphLaunch` burst) — overhead reduction **−44.9%** with the 2M cap default (was −6% to −10% at the old 65,536 default; baseline reference −49.2%).

## Known residuals (documented, non-blocking)
- ~4 pp gap between −44.9% and the −49.2% baseline (small always-on D1–D9 bookkeeping cost).
- `collect_cap_victims_locked` remains an O(live-entries-per-GPU) scan; a workload whose genuine peak concurrency exceeds the 2M cap, or a real EOP-loss leak, still pays that cost. A per-GPU secondary index is the durable fix, intentionally out of scope here.

## Tracking
JIRA ID: AIPROFSDK-1012 AIPROFSDK-1040 AIPROFSDK-1041
