### PR TITLE
fix(rccl): mirror src/algorithms into topo_expl's hipify staging tree

### DIFF
--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -118,6 +118,9 @@ hipify:
 	cp -a ../../src/nccl.h.in include/rccl/rccl.h
 	cp -a ../../src/include/ hipify_rccl/
 	cp -a ../../src/graph/ hipify_rccl/
+	mkdir -p hipify_rccl/include
+	(cd ../../src && find algorithms -name '*.h' \
+	    -exec cp --parents -t ../tools/topo_expl/hipify_rccl/include/ {} +)
 	cp -a ../../src/device/*.h hipify_rccl/src/device/include
 	cp -a ../../src/device/network/unpack/*.h hipify_rccl/include/network/unpack
 	# src/include/sym_kernels.h includes "../device/symmetric/gin_scratch.h"


### PR DESCRIPTION
## Motivation

The DDA source reorg (#10072) moved dda_all_reduce.h, dda_reduce_scatter.h,
dda_all_gather.h, and dda_alltoall.h from src/ to src/algorithms/dda/*/,
which collectives.cc and rccl_wrap.cc now #include. topo_expl's Makefile
bypasses CMake and hand-mirrors the headers it needs into hipify_rccl/,
but never copied the new algorithms/ subtree, so its build broke as soon
as #10072 landed.
Mirror algorithms/*.h into hipify_rccl/include/ alongside the existing
include/ and graph/ copies so the include path resolves again.

## Technical Details

update makefile to copy over the moved header files. 

## Issue Tracking

JIRA ID: AICOMRCCL-2170

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
```

.../rocm-systems$ cd projects/rccl/tools/topo_expl/
.../topo_expl$ make
rm -rf hipify_rccl
mkdir -p hipify_rccl/src/device/include hipify_rccl/include/network/unpack hipify_rccl/device/symmetric include/rccl
# Copy nccl.h.in from rccl source to always get latest API definitions
cp -a ../../src/nccl.h.in include/nccl.h
# Also copy to rccl/rccl.h for files that use #include <rccl/rccl.h>
cp -a ../../src/nccl.h.in include/rccl/rccl.h
cp -a ../../src/include/ hipify_rccl/
cp -a ../../src/graph/ hipify_rccl/
mkdir -p hipify_rccl/include
(cd ../../src && find algorithms -name '*.h' \
    -exec cp --parents -t ../tools/topo_expl/hipify_rccl/include/ {} +)
cp -a ../../src/device/*.h hipify_rccl/src/device/include
cp -a ../../src/device/network/unpack/*.h hipify_rccl/include/network/unpack
# src/include/sym_kernels.h includes "../device/symmetric/gin_scratch.h"
# (relative path), so mirror those headers under hipify_rccl/device/symmetric/.
cp -a ../../src/device/symmetric/*.h hipify_rccl/device/symmetric/
cp -a ../../src/enqueue.cc hipify_rccl/
cp -a ../../src/register/register.cc hipify_rccl/
cp -a ../../src/collectives.cc hipify_rccl/
cp -a ../../src/rccl_wrap.cc hipify_rccl/
cp -a ../../src/misc/archinfo.cc hipify_rccl/graph/
# Hipify all header and source files (CUDA -> HIP).
# Walk every subdirectory under hipify_rccl/include/ recursively so that
# any new subtrees added by future NCCL syncs (e.g. rma/, gin/, ionic/,
# mlx5/, algorithms/, etc.) are covered automatically.
# nvtx3/ is intentionally excluded because we swap in a stub via PATCH 2.
>>> Hipifying RCCL header files...
find hipify_rccl/include -type f -name '*.h' -not -path 'hipify_rccl/include/nvtx3/*' \
    -exec /opt/rocm/bin/hipify-perl -inplace -quiet-warnings {} +
/opt/rocm/bin/hipify-perl -inplace -quiet-warnings hipify_rccl/src/device/include/*.h
# PATCH 1: Fix device includes - remove "device/" prefix since files are in same directory
sed -i 's|#include "device/|#include "|g' hipify_rccl/src/device/include/*.h
sed -i 's|#include "device/|#include "|g' hipify_rccl/include/*.h
sed -i 's|#include "device/|#include "|g' hipify_rccl/*.cc
# PATCH 2: Use NVTX stubs - topo_expl doesn't need full NVTX implementation
cp hipify_rccl/include/nvtx_stub.h hipify_rccl/include/nvtx.h
bash ../../cmake/scripts/add_unroll.sh "hipify_rccl/src/device/include/common.h"
>>> Hipifying RCCL source files...
/opt/rocm/bin/hipify-perl -inplace -quiet-warnings hipify_rccl/graph/*
/opt/rocm/bin/hipify-perl -inplace -quiet-warnings hipify_rccl/include/network/unpack/*
/opt/rocm/bin/hipify-perl -inplace -quiet-warnings hipify_rccl/*.cc
# PATCH 3: Generate *_tmp.h files - these are build-time generated headers in rccl
cp hipify_rccl/include/nccl_device/core.h hipify_rccl/include/nccl_device/core_tmp.h
cp hipify_rccl/include/nccl_device/comm.h hipify_rccl/include/nccl_device/comm_tmp.h
cp hipify_rccl/include/nccl_device/gin.h hipify_rccl/include/nccl_device/gin_tmp.h
# PATCH 3b: The param/ headers (param.h, common.h, utils.h) collide in basename
# with include/{param,utils}.h and device/common.h, so the main RCCL build's
# add_file_unique() renames the staged copies to *_tmp.h. Sources reference the
# _tmp names (see src/include/param/param.h), so mirror those staged names here.
cp hipify_rccl/include/param/param.h hipify_rccl/include/param/param_tmp.h
cp hipify_rccl/include/param/common.h hipify_rccl/include/param/common_tmp.h
cp hipify_rccl/include/param/utils.h hipify_rccl/include/param/utils_tmp.h
# PATCH 4: Add missing NVTX stub macros for topo_expl build
echo '#define NCCL_NVTX3_FUNC_RANGE do {} while(0)' >> hipify_rccl/include/nvtx.h
echo 'inline void initNvtxRegisteredEnums() {}' >> hipify_rccl/include/nvtx.h
# PATCH 5: Add nccl_tuner.h include to get NCCL_NUM_ALGORITHMS and NCCL_NUM_PROTOCOLS macros
sed -i '/#include "core.h"/a #include "plugin/nccl_tuner.h"' hipify_rccl/include/rccl_common.h
# PATCH 7: hipify-perl rewrites __CUDACC__ -> __HIPCC__ in nccl_device/*.h.
# Restore the original __CUDACC__ guard so device-only blocks are skipped
# on the topo_expl host pass (no -x hip device compile here). This keeps
# caller-side guards aligned with the device-API *declarations* in
# nccl_device/core.h that are also gated on __CUDACC__.
find hipify_rccl/include/nccl_device -type f -name '*.h' \
    -exec sed -i 's|__HIPCC__|__CUDACC__|g' {} +
# PATCH 7b: nccl_device/hip_compat.h binds NCCL_CHECK_CUDACC to
# NCCL_DEVICE_COMPILE, which is true under defined(__HIP_PLATFORM_AMD__)
# on both host and device passes. Without this patch, callers under
# `#if NCCL_CHECK_CUDACC` (e.g. gin_scratch__types.h, ll_a2a__funcs.h,
# barrier__funcs.h) would reference device-API declarations from
# nccl_device/core.h that were skipped by PATCH 7's __CUDACC__ guard,
# producing 'undeclared identifier' errors. Force NCCL_CHECK_CUDACC to
# track __CUDACC__ so both sides are uniformly skipped on the host build.
sed -i 's|^#define NCCL_CHECK_CUDACC NCCL_DEVICE_COMPILE$|#define NCCL_CHECK_CUDACC __CUDACC__|' \
    hipify_rccl/include/nccl_device/hip_compat.h
# PATCH 6: Guard RCCL_EXPOSE_STATIC so -DRCCL_EXPOSE_STATIC from CXXFLAGS does not trigger redefinition warning
sed -i 's|^#define RCCL_EXPOSE_STATIC \(.*\)|#ifndef RCCL_EXPOSE_STATIC\n#define RCCL_EXPOSE_STATIC \1\n#endif|' hipify_rccl/include/rccl_vars.h
>>> Hipify complete.
/opt/rocm/bin/hipcc -g -ffunction-sections -fdata-sections -DROCM_VERSION=70201 -std=c++17 -Wl,--gc-sections -fgpu-rdc -Iinclude -Itest -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/include/nccl_device -Ihipify_rccl/src/device/include -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -DNCCL_OS_LINUX  -lpthread -Ithird_party/fmt/include src/topo_expl.cpp src/topo_expl_api.cpp src/model.cpp src/topo_expl_impl.cpp src/utils.cpp src/stubs.cc test/topo_expl_tests.cpp hipify_rccl/graph/topo.cc hipify_rccl/graph/rings.cc hipify_rccl/graph/paths.cc hipify_rccl/graph/trees.cc hipify_rccl/graph/search.cc hipify_rccl/graph/connect.cc hipify_rccl/graph/tuning.cc hipify_rccl/graph/xml.cc hipify_rccl/graph/rome_models.cc hipify_rccl/graph/archinfo.cc ../../src/misc/param.cc ../../src/misc/nvmlwrap_stub.cc hipify_rccl/rccl_wrap.cc hipify_rccl/collectives.cc hipify_rccl/register.cc hipify_rccl/enqueue.cc -o topo_expl
hipify_rccl/rccl_wrap.cc:805:22: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'unsigned long long' [-Wformat]
  804 |       WARN("Skipping CE AllReduce despite RCCL_FORCE_CE_ALLREDUCE=1: msgBytes (%zu) > NCCL_CE_AR_MAX_MSG_BYTES (%zu)",
      |                                                                                                                 ~~~
      |                                                                                                                 %llu
  805 |            msgBytes, NCCL_CE_AR_MAX_MSG_BYTES);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/ce_coll.h:24:34: note: expanded from macro 'NCCL_CE_AR_MAX_MSG_BYTES'
   24 | #define NCCL_CE_AR_MAX_MSG_BYTES (256ull * 1024 * 1024)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/debug.h:40:77: note: expanded from macro 'WARN'
   40 | #define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __LINE__, __VA_ARGS__)
      |                                                                             ^~~~~~~~~~~
hipify_rccl/rccl_wrap.cc:810:94: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'unsigned long long' [-Wformat]
  810 |     WARN("Skipping CE AllReduce: msgBytes (%zu) > NCCL_CE_AR_MAX_MSG_BYTES (%zu)", msgBytes, NCCL_CE_AR_MAX_MSG_BYTES);
      |                                                                             ~~~              ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                             %llu
hipify_rccl/include/ce_coll.h:24:34: note: expanded from macro 'NCCL_CE_AR_MAX_MSG_BYTES'
   24 | #define NCCL_CE_AR_MAX_MSG_BYTES (256ull * 1024 * 1024)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/debug.h:40:77: note: expanded from macro 'WARN'
   40 | #define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __LINE__, __VA_ARGS__)
      |                                                                             ^~~~~~~~~~~
2 warnings generated when compiling for host.
hipify_rccl/enqueue.cc:116:11: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
  116 |       if (!CUDASUCCESS(hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(fn)))) continue; // Silently ignore failures
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/enqueue.cc:116:11: note: add parentheses after the '!' to evaluate the comparison first
  116 |       if (!CUDASUCCESS(hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(fn)))) continue; // Silently ignore failures
      |           ^                                                                           
      |            (                                                                          )
hipify_rccl/enqueue.cc:116:11: note: add parentheses around left hand side expression to silence this warning
1 warning generated when compiling for host.
hipify_rccl/rccl_wrap.cc:805:22: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'unsigned long long' [-Wformat]
  804 |       WARN("Skipping CE AllReduce despite RCCL_FORCE_CE_ALLREDUCE=1: msgBytes (%zu) > NCCL_CE_AR_MAX_MSG_BYTES (%zu)",
      |                                                                                                                 ~~~
      |                                                                                                                 %llu
  805 |            msgBytes, NCCL_CE_AR_MAX_MSG_BYTES);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/ce_coll.h:24:34: note: expanded from macro 'NCCL_CE_AR_MAX_MSG_BYTES'
   24 | #define NCCL_CE_AR_MAX_MSG_BYTES (256ull * 1024 * 1024)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/debug.h:40:77: note: expanded from macro 'WARN'
   40 | #define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __LINE__, __VA_ARGS__)
      |                                                                             ^~~~~~~~~~~
hipify_rccl/rccl_wrap.cc:810:94: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'unsigned long long' [-Wformat]
  810 |     WARN("Skipping CE AllReduce: msgBytes (%zu) > NCCL_CE_AR_MAX_MSG_BYTES (%zu)", msgBytes, NCCL_CE_AR_MAX_MSG_BYTES);
      |                                                                             ~~~              ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                             %llu
hipify_rccl/include/ce_coll.h:24:34: note: expanded from macro 'NCCL_CE_AR_MAX_MSG_BYTES'
   24 | #define NCCL_CE_AR_MAX_MSG_BYTES (256ull * 1024 * 1024)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/include/debug.h:40:77: note: expanded from macro 'WARN'
   40 | #define WARN(...) ncclDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __LINE__, __VA_ARGS__)
      |                                                                             ^~~~~~~~~~~
2 warnings generated when compiling for gfx1030.
hipify_rccl/enqueue.cc:116:11: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
  116 |       if (!CUDASUCCESS(hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(fn)))) continue; // Silently ignore failures
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hipify_rccl/enqueue.cc:116:11: note: add parentheses after the '!' to evaluate the comparison first
  116 |       if (!CUDASUCCESS(hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(fn)))) continue; // Silently ignore failures
      |           ^                                                                           
      |            (                                                                          )
hipify_rccl/enqueue.cc:116:11: note: add parentheses around left hand side expression to silence this warning
1 warning generated when compiling for gfx1030.
Built with ROCm version: 7.2.1 (ROCM_VERSION=70201)
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
