### PR TITLE
fix(rocr): mark PC sampling sample record stores coherent

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -176,9 +176,9 @@
 
  .macro  S_STORE_DWORD_PCS_TTMP_REG1 base, offset
   .if (.amdgcn.gfx_generation_minor >= 4)
-    s_store_dword    ttmp6, \base, \offset
+    s_store_dword    ttmp6, \base, \offset glc
   .else
-    s_store_dword    ttmp13, \base, \offset
+    s_store_dword    ttmp13, \base, \offset glc
   .endif
  .endm
 
@@ -532,28 +532,28 @@ trap_entry:
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&bufferX[local_entry]
   s_memrealtime                         ttmp[4:5]
   s_and_b32                             ttmp1, ttmp1, 0xffff            // clear out extra data from PC_HI
-  s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
+  s_store_dwordx2                       ttmp[0:1], ttmp[2:3] glc        // store PC
   s_waitcnt                             lgkmcnt(0)                      // wait for timestamp
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_lo
   S_STORE_DWORD_PCS_TTMP_REG1           ttmp[2:3], 0x8                  // store EXEC_LO
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_hi
   S_STORE_DWORD_PCS_TTMP_REG1           ttmp[2:3], 0xc                  // store EXEC_HI
-  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
-  s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30      // store timestamp
+  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10 glc  // store wg_id_x and wg_id_y
+  s_store_dword                         ttmp10, ttmp[2:3], 0x18 glc     // store wg_id_z
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30 glc  // store timestamp
 
 .if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
   s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)     //store XCC_ID
   s_lshl_b32                            ttmp4, ttmp4, 8
   s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
   s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
+  s_store_dword                         ttmp4, ttmp[2:3], 0x1c glc      // store wave_in_wg
 .else
   s_and_b32                             ttmp4, ttmp11, 0x3f
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
+  s_store_dword                         ttmp4, ttmp[2:3], 0x1c glc      // store wave_in_wg
 .endif
   s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
-  s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+  s_store_dword                         ttmp4, ttmp[2:3], 0x20 glc      // store HW_ID
 
   s_branch                              .get_correlation_id
 
@@ -565,29 +565,29 @@ trap_entry:
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&buffer[local_entry]
   s_memrealtime                         ttmp[4:5]
   s_waitcnt                             lgkmcnt(0)                      // Wait for timestamp
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x30       // Store timestamp
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x30 glc   // Store timestamp
 
   s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
   s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x00       // store snapshot data
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x00 glc   // store snapshot data
   s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
   s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x24            // store snapshot PC
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x24 glc        // store snapshot PC
 
   s_mov_b32                             ttmp6, exec_lo
-  s_store_dword                         ttmp6, ttmp[2:3], 0x8           // store EXEC_LO
+  s_store_dword                         ttmp6, ttmp[2:3], 0x8 glc       // store EXEC_LO
   s_mov_b32                             ttmp6, exec_hi
-  s_store_dword                         ttmp6, ttmp[2:3], 0xc           // store EXEC_HI
+  s_store_dword                         ttmp6, ttmp[2:3], 0xc glc       // store EXEC_HI
 
-  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
-  s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
+  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10 glc  // store wg_id_x and wg_id_y
+  s_store_dword                         ttmp10, ttmp[2:3], 0x18 glc     // store wg_id_z
   s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
   s_lshl_b32                            ttmp4, ttmp4, 8
   s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
   s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store chiplet_and_wave_id
+  s_store_dword                         ttmp4, ttmp[2:3], 0x1c glc      // store chiplet_and_wave_id
   s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
-  s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+  s_store_dword                         ttmp4, ttmp[2:3], 0x20 glc      // store HW_ID
   // ttmp[2:3]=&buffer[local_entry]; ttmp[4:5], ttmp[6:7] are free
   // ttmp[14:15]=ptr to ‘tma’ and is live out; ttmp11.b31 is buf_to_use, 0 or 1
   s_branch                              .get_correlation_id
@@ -635,7 +635,7 @@ trap_entry:
 .else
   s_and_b32                             ttmp4, ttmp6, 0x1ffffff         // extract low 25 bits from ttmp6 (DispatchPktIndx[24:0])
 .endif
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x38      // ttmp[4:5] is correlation ID. Store correlation_id to sample
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x38 glc  // ttmp[4:5] is correlation ID. Store correlation_id to sample
   // get_correlation_id() -- end //
 
   // complete stores before returning


### PR DESCRIPTION
## Motivation

On gfx950, PC sampling emits sample records whose contents have not fully reached the host at the time the host copies them out of the device buffer. **Both host-trap and stochastic sampling are affected by this defect**, but it presents differently on each because rocprofiler-sdk filters the stochastic path and not the host-trap path.

On host-trap it is visible directly: on an MI350X, 23.3% of samples arrive without a decoded instruction and the `exec_mask_manipulation` validator fails on every run. On stochastic the corrupted records are silently discarded before reaching the output, so the correlation-ID symptom is hidden and only the exec-mask damage surfaces, failing 6 of 15 runs.

This PR makes the sample record coherent so it is fully visible before its completion is published.

## Technical Details

The 2nd-level trap handler fills a 64-byte sample record with scalar stores that are not marked coherent, then signals completion by incrementing `buf_written_val` with a coherent atomic (`s_atomic_add ttmp7, ttmp[14:15], 0x10 glc`, `trap_handler.s:653`). On the host side, `GpuAgent::PcSamplingFlushDeviceBuffersPerXCC` swaps the ping-pong buffer, waits for that counter to reach the reserved sample count, and then `memcpy`s the records. Because completion is published coherently while the record contents are not, the host can copy a record whose fields have not yet reached it.

Because the PC is written first and the correlation ID last, a torn record arrives with a valid correlation ID next to an undecodable PC, so the consumer attributes a bad PC to a live kernel rather than discarding the sample.

### Why stochastic appears healthier than it is

Both fill paths share the same trap handler and the same non-coherent stores, so both tear. What differs is downstream. In `correlation.hpp`, a sample whose PC cannot be resolved to a code object has its `size` set to zero. In `pc_record_interface.cpp`, the conversion of `size == 0` into an `INVALID_SAMPLE` record is a template specialization for the **stochastic** record type only; host-trap records go through the generic `emplace_records_in_buffer`, which ignores `size` entirely.

The result is that stochastic's torn records are converted to invalid records and never reach the CSV, so the path reports zero undecoded samples and fails only on the exec-mask assertion, while host-trap's torn records are emitted as ordinary rows and trip the correlation-ID invariant.

This is confirmed by removing the `size = 0` marking on unmodified `develop`: correlation-ID violations (`csv.py:104`) then appear on **both** paths, having previously been visible on neither for stochastic. The filtering was masking the stochastic side of the same defect, not preventing it.

### The change

This change marks every store to the sample record coherent, in both the host-trap and stochastic fill paths, and in the shared exec-mask store macro — 19 store instructions in total:

```diff
-  s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
+  s_store_dwordx2                       ttmp[0:1], ttmp[2:3] glc        // store PC
...
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x38      // ttmp[4:5] is correlation ID. Store correlation_id to sample
+  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x38 glc  // ttmp[4:5] is correlation ID. Store correlation_id to sample
```

On why every store rather than the minimum: marking every store coherent means each is individually coherent, which is what `glc` means, so correctness does not depend on which store happens to be written last. Measured overhead is unchanged either way (see Test Result), so the redundancy is free.

One note for future maintenance: these stores must not be swept up by a change that removes GLC from the trap handler for other reasons. Removing them silently reintroduces the sample corruption, and only the full validator detects it.

Scope: the modified stores exist only in the gfx9 PC-sampling path, which is guarded by `.if .amdgcn.gfx_generation_number == 9`. Disassembly of the built trap handler variants confirms the change is present in `kCodeTrapHandlerV2_9` (gfx900), `kCodeTrapHandlerV2_942` (gfx942) and `kCodeTrapHandlerV2_950` (gfx950), and absent from `kCodeTrapHandlerV2_1010`, `_10`, `_11`, `_12` and `_1250`, whose objects are unaffected.

## Issue Tracking

ROCM-29593

## Test Plan

Testing was done on a single MI350X (gfx950, `num_xcc 8`, partition 0), amdgpu driver `6.19.14.31400000`, ROCm `10.0.0a20260730`, with rocprofiler-sdk built from `a50677cd` with no local modifications except where noted.

Each run executes `rocprofv3` against the `exec-mask-manipulation` test application and grades the resulting CSV with the project's own validator, `exec_mask_manipulation_validate_csv` from `tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py`, rather than a reimplementation. That validator asserts both directions of the correlation-ID invariant (`csv.py:100-113`) as well as the exec-mask relation (`csv.py:120-130`).

ROCr configurations compared: unmodified `develop` (`ee0712b699`); a variant marking the PC, exec-mask, workgroup and wave-id stores coherent but not the correlation ID; a variant marking only the correlation-ID store coherent; and this change. Both `--pc-sampling-method host_trap` and `--pc-sampling-method stochastic` were exercised.

To establish that the stochastic path is affected rather than immune, unmodified `develop` was additionally run with the `size = 0` marking removed from `correlation.hpp`, which disables the SDK-side filtering of undecodable stochastic samples.

Application overhead was also measured as a regression check, 10 runs per configuration, comparing wall time and sample throughput against an unprofiled baseline.

## Test Result

| ROCr configuration | method | runs passing | failing assertions | samples with no decoded instruction | samples with decoded instruction and correlation ID 0 |
|---|---|---|---|---|---|
| unmodified `develop` | host_trap | 0/15 | `csv.py:128` | 58,679 of 251,355 (23.3%) | 0 |
| unmodified `develop` | stochastic | 9/15 | `csv.py:128` | 0 | 0 |
| unmodified `develop`, SDK filtering disabled | host_trap | 0/15 | `csv.py:104`, `csv.py:128` | ~53,000–65,000 | 0 |
| unmodified `develop`, SDK filtering disabled | stochastic | 6/15 | `csv.py:104`, `csv.py:128` | ~0 | 0 |
| PC/exec/workgroup/wave-id coherent, correlation ID not | host_trap | 0/15 | `csv.py:108` | 0 | 21,899 of 256,481 (8.5%) |
| correlation-ID store only | host_trap | 30/30 | — | 0 | 0 |
| correlation-ID store only | stochastic | 15/15 | — | 0 | 0 |
| **this change** | **host_trap** | **30/30** | — | **0** | **0** |
| **this change** | **stochastic** | **15/15** | — | **0** | **0** |

The two "SDK filtering disabled" rows are the evidence that stochastic is affected by the same defect: with the `size = 0` marking removed, correlation-ID violations at `csv.py:104` appear on both paths. With the marking in place, stochastic reports zero undecoded samples because those records are converted to `INVALID_SAMPLE` and never reach the CSV.

Overhead, 10 runs per configuration:

| configuration | mean wall time | samples per run | samples/s |
|---|---|---|---|
| unprofiled baseline | 0.753 s | — | — |
| unmodified `develop`, host_trap | 1.855 s (sd 0.012) | 252,963 | 136,387 |
| this change, host_trap | 1.787 s (sd 0.040) | 266,626 | 149,231 |

Profiling overhead is 1.102 s unmodified and 1.034 s with this change, a difference within one standard deviation. Marking all 19 stores coherent measured the same as marking only the correlation-ID store (1.787 s versus 1.807 s, also within noise), so the additional coherent stores carry no observable cost.

Apart from the two rows where SDK filtering was deliberately disabled, all results use rocprofiler-sdk unmodified, so no rocprofiler-sdk change is required for either sampling method to pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.