### PR TITLE
[rocjitsu] DBI: Run hardware-gated end-to-end tests on simulator

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -257,6 +257,15 @@ jobs:
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"
+            # The DBI dispatch cases run a full simulator in-process against the
+            # client's own AQL ring and buffers, so they hit the MAP_SHARED alias
+            # limitation described below: every race is GpuMemory::read_mapped
+            # reading a host buffer the test thread wrote. Their gtest assertions
+            # pass. The two non-dispatching HsaDbiNop*Sim cases stay covered.
+            "HsaDbiNopAsmSim\.PatchedKernelDispatchMatchesOriginal"
+            "HsaDbiNopAsmSim\.TrampolineIsActuallyExecutedByGpu"
+            "HsaDbiNopProbeSim\.PatchedKernelDispatchMatchesOriginal"
+            "HsaDbiNopProbeSim\.ProbeBodyIsActuallyCalledByGpu"
           )
 
           TEST_REGEX="${{ matrix.test_regex }}"

--- a/emulation/rocjitsu/cmake/rj_run_filtered_gtest.cmake
+++ b/emulation/rocjitsu/cmake/rj_run_filtered_gtest.cmake
@@ -70,3 +70,16 @@ if(NOT _run_result EQUAL 0)
         "Filtered test '${TEST_FILTER}' exited with status ${_run_result}"
     )
 endif()
+
+# GoogleTest exits 0 when a test calls GTEST_SKIP(). That is the right outcome
+# for a registration whose prerequisite may genuinely be absent, but not for one
+# that runs against a simulated agent the launcher is configured to supply: there
+# a skip means the config, interposer, or launcher regressed. FAIL_ON_SKIP turns
+# that into a hard failure so it cannot report green.
+if(FAIL_ON_SKIP AND _run_output MATCHES "\\[  SKIPPED \\]")
+    message(
+        FATAL_ERROR
+        "Filtered test '${TEST_FILTER}' was SKIPPED, but this registration "
+        "requires it to run"
+    )
+endif()

--- a/emulation/rocjitsu/configs/gfx90a_mi210_kmd.json
+++ b/emulation/rocjitsu/configs/gfx90a_mi210_kmd.json
@@ -14,6 +14,8 @@
         "unique_id": 0,
         "marketing_name": "AMD Instinct MI210",
         "drm_render_minor": 128,
+        "revision_id": 1,
+        "pci_revision_id": 2,
         "simd_count": 416,
         "max_waves_per_simd": 8,
         "num_shader_engines": 8,

--- a/emulation/rocjitsu/configs/gfx90a_mi210_kmd.json
+++ b/emulation/rocjitsu/configs/gfx90a_mi210_kmd.json
@@ -1,0 +1,90 @@
+{
+  "max_ticks": 0,
+  "num_threads": 1,
+  "exec_mode": "functional",
+  "vm": {
+    "arch": "cdna2",
+    "gpu": {
+      "device": {
+        "gpu_id": 50149,
+        "gfx_target_version": 90010,
+        "vendor_id": 4098,
+        "device_id": 29711,
+        "family_id": 141,
+        "unique_id": 0,
+        "marketing_name": "AMD Instinct MI210",
+        "drm_render_minor": 128,
+        "simd_count": 416,
+        "max_waves_per_simd": 8,
+        "num_shader_engines": 8,
+        "num_shader_arrays_per_engine": 1,
+        "num_cu_per_sh": 14,
+        "simd_per_cu": 4,
+        "wave_front_size": 64,
+        "max_slots_scratch_cu": 32,
+        "local_mem_size": 68702699520,
+        "lds_size_kb": 64,
+        "mem_width": 4096,
+        "mem_clk_max": 1600,
+        "l1_size_kb": 16,
+        "l1_line_size": 64,
+        "l1_assoc": 4,
+        "l2_size_kb": 8192,
+        "l2_line_size": 128,
+        "l2_assoc": 16,
+        "num_sdma_engines": 2,
+        "num_sdma_xgmi_engines": 3,
+        "num_sdma_queues_per_engine": 8,
+        "num_cp_queues": 24,
+        "max_engine_clk_fcompute": 1700
+      }
+    }
+  },
+  "topology": {
+    "root": {
+      "name": "soc", "type": "soc",
+      "children": [
+        { "name": "vram", "type": "gpu_memory" },
+        {
+          "name": "xcd[0:1]", "type": "xcd",
+          "children": [
+            { "name": "l2", "type": "l2_cache" },
+            { "name": "cp", "type": "command_processor" },
+            {
+              "name": "se[0:8]", "type": "shader_engine",
+              "children": [{
+                "name": "cu[0:14]", "type": "compute_unit",
+                "config": [
+                  { "key": "num_wf_slots", "value": "32" },
+                  { "key": "sgprs_per_wf", "value": "104" },
+                  { "key": "vgprs_per_wf", "value": "512" },
+                  { "key": "lds_size_kb", "value": "64" }
+                ]
+              }]
+            }
+          ]
+        }
+      ]
+    },
+    "links": [
+      {
+        "pattern": "xcd[i].cp.req_[j*14+k] -> xcd[i].se[j].cu[k].cpl",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 1 },
+          { "var_name": "j", "start": 0, "end": 8 },
+          { "var_name": "k", "start": 0, "end": 14 }
+        ],
+        "latency": 1, "weight": 2
+      },
+      {
+        "pattern": "xcd[i].se[j].cu[k].req -> xcd[i].l2.cpl_[j*14+k]",
+        "for_ranges": [
+          { "var_name": "i", "start": 0, "end": 1 },
+          { "var_name": "j", "start": 0, "end": 8 },
+          { "var_name": "k", "start": 0, "end": 14 }
+        ],
+        "latency": 1, "weight": 10
+      }
+    ]
+  }
+}

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -10,6 +10,7 @@ Pre-built simulator configs are in `configs/`:
 
 | File | Description |
 |---|---|
+| `gfx90a_mi210_kmd.json` | Single CDNA2 GPU (daemon/KFD mode) |
 | `gfx942_cdna3.json` | Single CDNA3 GPU (standalone simulation) |
 | `gfx942_cdna3_kmd.json` | Single CDNA3 GPU (daemon/KFD mode) |
 | `gfx950_mi355x.json` | Single CDNA4 GPU (standalone simulation) |

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -931,6 +931,7 @@ set(RJ_CDNA4_KMD_2GPU_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/gfx950_mi355x_kmd_2gpu.json"
 )
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
+set(RJ_CDNA2_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx90a_mi210_kmd.json")
 set(RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_simulated_gfx942.json"
 )
@@ -951,6 +952,7 @@ set(RJ_HIP_TEST_2GPU_CONFIG
 )
 get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
 get_filename_component(RJ_CDNA3_KMD_CONFIG_NAME "${RJ_CDNA3_KMD_CONFIG}" NAME)
+get_filename_component(RJ_CDNA2_KMD_CONFIG_NAME "${RJ_CDNA2_KMD_CONFIG}" NAME)
 get_filename_component(
     RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG_NAME
     "${RJ_CDNA4_TO_CDNA3_SIM_DBT_CONFIG}"
@@ -2084,7 +2086,15 @@ if(HSA_RUNTIME64)
             hsa_dbi_nop_asm_test
             PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
         )
-        add_dependencies(hsa_dbi_nop_asm_test device_kernels)
+        # rocjitsu_bin/rocjitsu_shared are needed by the Sim registrations
+        # below, which launch this binary through the CLI. A generator
+        # expression in a test COMMAND does not create a build dependency.
+        add_dependencies(
+            hsa_dbi_nop_asm_test
+            device_kernels
+            rocjitsu_bin
+            rocjitsu_shared
+        )
         rj_configure_target(hsa_dbi_nop_asm_test TEST)
         if(RJ_INSTALL_TESTS)
             rj_install_test_target(hsa_dbi_nop_asm_test)
@@ -2094,23 +2104,83 @@ if(HSA_RUNTIME64)
         # CTest entry. <group> is the part of the fixture name after
         # "HsaDbiNopAsm" (Static or Hardware). Scoped here because it's only
         # used by the calls immediately below.
+        #
+        # SIM runs the same gtest case through the rocjitsu CLI against a
+        # simulated gfx90a instead of the host GPU. find_gfx90a_agent() matches
+        # on the HSA ISA name, so it binds to whichever agent the launcher
+        # supplies and the test source needs no backend knowledge. Only the
+        # CTest name encodes the backend; the gtest filter still names the
+        # <group> fixture, as with Cdna4ToCdna3SimulatedDispatchTest.
         function(register_hsa_dbi_nop_asm_case group case)
-            set(oneValueArgs TIMEOUT)
-            cmake_parse_arguments(RJ_DBI "" "${oneValueArgs}" "" ${ARGN})
+            cmake_parse_arguments(RJ_DBI "SIM" "TIMEOUT" "" ${ARGN})
             set(name "HsaDbiNopAsm${group}.${case}")
-            rj_add_test(
-                NAME "${name}"
-                COMMAND hsa_dbi_nop_asm_test --gtest_filter=${name}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                INSTALL_COMMAND
+            if(RJ_DBI_SIM)
+                set(_ctest_name "HsaDbiNopAsmSim.${case}")
+                set(_command
+                    ${CMAKE_COMMAND}
+                    "-DTEST_EXECUTABLE=$<TARGET_FILE:hsa_dbi_nop_asm_test>"
+                    "-DTEST_FILTER=${name}"
+                    "-DTEST_LAUNCHER=${RJ_CLI}"
+                    "-DTEST_CONFIG=${RJ_CDNA2_KMD_CONFIG}"
+                    "-DFAIL_ON_SKIP=ON"
+                    -P
+                    "${PROJECT_SOURCE_DIR}/cmake/rj_run_filtered_gtest.cmake"
+                )
+                set(_install_command
+                    "${CMAKE_COMMAND}"
+                    "-DTEST_EXECUTABLE=bin/hsa_dbi_nop_asm_test"
+                    "-DTEST_FILTER=${name}"
+                    "-DTEST_LAUNCHER=\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                    "-DTEST_CONFIG=\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA2_KMD_CONFIG_NAME}"
+                    "-DFAIL_ON_SKIP=ON"
+                    "-P"
+                    "rj_run_filtered_gtest.cmake"
+                )
+            else()
+                set(_ctest_name "${name}")
+                set(_command hsa_dbi_nop_asm_test --gtest_filter=${name})
+                set(_install_command
                     "bin/hsa_dbi_nop_asm_test"
                     "--gtest_filter=${name}"
-                ${ARGN}
+                )
+            endif()
+            set(_timeout)
+            if(RJ_DBI_TIMEOUT)
+                set(_timeout TIMEOUT ${RJ_DBI_TIMEOUT})
+            endif()
+            rj_add_test(
+                NAME "${_ctest_name}"
+                COMMAND ${_command}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                INSTALL_COMMAND ${_install_command}
+                ${_timeout}
             )
         endfunction()
 
         # Static-only test: no GPU needed, runs anywhere the binary is built.
         register_hsa_dbi_nop_asm_case(Static PatchedElfActuallyContainsInstrumentation)
+
+        # The same three cases on the simulator. Registered unconditionally so
+        # CI covers the DBI dispatch path without a CDNA2 host; the timeouts are
+        # the hardware ones scaled for simulated execution.
+        register_hsa_dbi_nop_asm_case(
+            Hardware
+            PatchedElfLoadsAndValidatesInHsaExecutable
+            SIM
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Hardware
+            PatchedKernelDispatchMatchesOriginal
+            SIM
+            TIMEOUT 300
+        )
+        register_hsa_dbi_nop_asm_case(
+            Hardware
+            TrampolineIsActuallyExecutedByGpu
+            SIM
+            TIMEOUT 300
+        )
 
         if(HAS_CDNA2_GPU)
             # Hardware-gated tests. The two that dispatch get an explicit
@@ -2123,8 +2193,8 @@ if(HSA_RUNTIME64)
         else()
             message(
                 STATUS
-                "HSA DBI nop-asm test built but NOT registered with CTest "
-                "(no gfx90a)"
+                "HSA DBI nop-asm hardware cases NOT registered with CTest "
+                "(no gfx90a); the Sim cases still run"
             )
         endif()
 
@@ -2162,8 +2232,16 @@ if(HSA_RUNTIME64)
                 hsa_dbi_nop_probe_test
                 PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
             )
-            add_dependencies(hsa_dbi_nop_probe_test device_kernels)
-            add_dependencies(hsa_dbi_nop_probe_test probe_rj_nop_probe_gfx90a)
+            # rocjitsu_bin/rocjitsu_shared are needed by the Sim registrations
+            # below, which launch this binary through the CLI. A generator
+            # expression in a test COMMAND does not create a build dependency.
+            add_dependencies(
+                hsa_dbi_nop_probe_test
+                device_kernels
+                probe_rj_nop_probe_gfx90a
+                rocjitsu_bin
+                rocjitsu_shared
+            )
             rj_configure_target(hsa_dbi_nop_probe_test TEST)
             if(RJ_INSTALL_TESTS)
                 rj_install_test_target(hsa_dbi_nop_probe_test)
@@ -2172,18 +2250,50 @@ if(HSA_RUNTIME64)
             # Local helper: register one TEST_F case as a CTest entry, in both the
             # build tree and (under RJ_INSTALL_TESTS) the installed CTest tree.
             # <group> is the part of the fixture name after "HsaDbiNopProbe".
+            # SIM behaves as in register_hsa_dbi_nop_asm_case above.
             function(register_hsa_dbi_nop_probe_case group case)
-                set(oneValueArgs TIMEOUT)
-                cmake_parse_arguments(RJ_DBIP "" "${oneValueArgs}" "" ${ARGN})
+                cmake_parse_arguments(RJ_DBIP "SIM" "TIMEOUT" "" ${ARGN})
                 set(name "HsaDbiNopProbe${group}.${case}")
-                rj_add_test(
-                    NAME "${name}"
-                    COMMAND hsa_dbi_nop_probe_test --gtest_filter=${name}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                    INSTALL_COMMAND
+                if(RJ_DBIP_SIM)
+                    set(_ctest_name "HsaDbiNopProbeSim.${case}")
+                    set(_command
+                        ${CMAKE_COMMAND}
+                        "-DTEST_EXECUTABLE=$<TARGET_FILE:hsa_dbi_nop_probe_test>"
+                        "-DTEST_FILTER=${name}"
+                        "-DTEST_LAUNCHER=${RJ_CLI}"
+                        "-DTEST_CONFIG=${RJ_CDNA2_KMD_CONFIG}"
+                        "-DFAIL_ON_SKIP=ON"
+                        -P
+                        "${PROJECT_SOURCE_DIR}/cmake/rj_run_filtered_gtest.cmake"
+                    )
+                    set(_install_command
+                        "${CMAKE_COMMAND}"
+                        "-DTEST_EXECUTABLE=bin/hsa_dbi_nop_probe_test"
+                        "-DTEST_FILTER=${name}"
+                        "-DTEST_LAUNCHER=\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                        "-DTEST_CONFIG=\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA2_KMD_CONFIG_NAME}"
+                        "-DFAIL_ON_SKIP=ON"
+                        "-P"
+                        "rj_run_filtered_gtest.cmake"
+                    )
+                else()
+                    set(_ctest_name "${name}")
+                    set(_command hsa_dbi_nop_probe_test --gtest_filter=${name})
+                    set(_install_command
                         "bin/hsa_dbi_nop_probe_test"
                         "--gtest_filter=${name}"
-                    ${ARGN}
+                    )
+                endif()
+                set(_timeout)
+                if(RJ_DBIP_TIMEOUT)
+                    set(_timeout TIMEOUT ${RJ_DBIP_TIMEOUT})
+                endif()
+                rj_add_test(
+                    NAME "${_ctest_name}"
+                    COMMAND ${_command}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                    INSTALL_COMMAND ${_install_command}
+                    ${_timeout}
                 )
             endfunction()
 
@@ -2191,6 +2301,27 @@ if(HSA_RUNTIME64)
             register_hsa_dbi_nop_probe_case(
                 Static
                 PatchedElfContainsProbeCallInstrumentation
+            )
+
+            # The same three cases on the simulator, registered unconditionally
+            # so CI covers the probe-call dispatch path without a CDNA2 host.
+            register_hsa_dbi_nop_probe_case(
+                Hardware
+                PatchedElfLoadsAndValidatesInHsaExecutable
+                SIM
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Hardware
+                PatchedKernelDispatchMatchesOriginal
+                SIM
+                TIMEOUT 300
+            )
+            register_hsa_dbi_nop_probe_case(
+                Hardware
+                ProbeBodyIsActuallyCalledByGpu
+                SIM
+                TIMEOUT 300
             )
 
             if(HAS_CDNA2_GPU)
@@ -2218,8 +2349,8 @@ if(HSA_RUNTIME64)
             else()
                 message(
                     STATUS
-                    "HSA DBI nop-probe smoke test built but NOT registered "
-                    "with CTest (no gfx90a)"
+                    "HSA DBI nop-probe hardware cases NOT registered with "
+                    "CTest (no gfx90a); the Sim cases still run"
                 )
             endif()
         else()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2198,6 +2198,26 @@ if(HSA_RUNTIME64)
             )
         endif()
 
+        # Pin the FAIL_ON_SKIP guard, the way GtestFilterGuard.RejectsMissingTest
+        # pins the zero-test guard. Launching the gfx90a fixture against a
+        # simulated gfx942 selects one test, find_gfx90a_agent() finds no match,
+        # and GoogleTest exits 0 after skipping it -- so success here means the
+        # wrapper turned that skip into a failure instead of a false pass.
+        add_test(
+            NAME GtestFilterGuard.RejectsSkippedTest
+            COMMAND
+                ${CMAKE_COMMAND}
+                "-DTEST_EXECUTABLE=$<TARGET_FILE:hsa_dbi_nop_asm_test>"
+                "-DTEST_FILTER=HsaDbiNopAsmHardware.PatchedElfLoadsAndValidatesInHsaExecutable"
+                "-DTEST_LAUNCHER=${RJ_CLI}"
+                "-DTEST_CONFIG=${RJ_CDNA3_KMD_CONFIG}" -DFAIL_ON_SKIP=ON -P
+                "${PROJECT_SOURCE_DIR}/cmake/rj_run_filtered_gtest.cmake"
+        )
+        set_tests_properties(
+            GtestFilterGuard.RejectsSkippedTest
+            PROPERTIES WILL_FAIL TRUE TIMEOUT 300
+        )
+
         # --- HSA DBI nop-probe smoke test: gfx90a kernel patched to CALL the
         # compiled rj_nop_probe via an s_swappc_b64 trampoline (PC01-B). Needs
         # the compiled probe fixture (amdclang++ + clang-offload-bundler), so it

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -58,6 +58,38 @@ std::vector<uint8_t> read_binary_file(const std::string &path) {
   return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
 }
 
+TEST(ConfigLoaderTest, LoadCdna2Config) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx90a_mi210_kmd.json", rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+
+  EXPECT_EQ(soc->arch(), ROCJITSU_CODE_ARCH_CDNA2);
+  EXPECT_EQ(loaded.device.gpu_id, 50149u);
+  EXPECT_EQ(loaded.device.device_id, 0x740fu);
+  EXPECT_EQ(loaded.device.family_id, 0x8du);
+  EXPECT_EQ(loaded.device.gfx_target_version, 90010u);
+  EXPECT_EQ(loaded.device.revision_id, 1u);
+  EXPECT_EQ(loaded.device.pci_revision_id, 2u);
+  EXPECT_EQ(loaded.device.wave_front_size, 64u);
+  EXPECT_EQ(loaded.device.max_waves_per_simd, 8u);
+  EXPECT_EQ(loaded.device.lds_size_kb, 64u);
+
+  // Aldebaran is a single-die part: one XCD of 8 SEs, 14 CUs per SE. MI210
+  // exposes 104 active CUs through simd_count but has capacity of 112
+  EXPECT_EQ(soc->num_xcds(), 1u);
+  EXPECT_EQ(loaded.device.num_shader_engines, 8u);
+  EXPECT_EQ(loaded.device.num_shader_arrays_per_engine, 1u);
+  EXPECT_EQ(loaded.device.num_cu_per_sh, 14u);
+  EXPECT_EQ(loaded.device.simd_per_cu, 4u);
+  EXPECT_EQ(loaded.device.simd_count, 416u);
+  EXPECT_EQ(soc->xcd(0)->num_shader_engines(), 8u);
+  EXPECT_EQ(soc->xcd(0)->shader_engine(0)->num_compute_units(), 14u);
+  EXPECT_EQ(kmd::drm_cu_active_number(loaded.device.simd_count, loaded.device.simd_per_cu), 104u);
+  EXPECT_LE(loaded.device.simd_count, loaded.device.num_shader_engines *
+                                          loaded.device.num_shader_arrays_per_engine *
+                                          loaded.device.num_cu_per_sh * loaded.device.simd_per_cu);
+}
+
 TEST(ConfigLoaderTest, LoadCdna4Config) {
   std::string json = CONFIG_DIR_PATH + "/gfx950_mi355x.json";
   auto loaded = config::load_config(json, rocjitsu::kEmbeddedSchema);


### PR DESCRIPTION

## Motivation

DBI tests were originally developed on a CDNA2 and were gated for that hardware. We have a simulator so we should run them there too.

## Technical Details

* Added a configuration file for MI210 at `configs/gfx90a_mi210_kmd.json`.
* Register all hardware cases a second time through rocjitsu CLI against simulated gfx90a
* Follows similar Cdna4ToCdna3SimulatedDispatchTest configurations

## Issue Tracking

Relevant to Issue #8879.

## Test Plan

New tests should work. Old tests should not stop working.

## Test Result

Hardware tests work! Simulator tests work! All other tests work!

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
