### PR TITLE
feat(hipfile): Break up fallback async ios into smaller chunks reusing a single bounce buffer

### DIFF
--- a/projects/hipfile/docs/reference/hipFile-environment-variables.rst
+++ b/projects/hipfile/docs/reference/hipFile-environment-variables.rst
@@ -35,4 +35,4 @@ The following environment variables affect the hipFile runtime.
        | Must be set to ``true`` when using NFSoRDMA on Linux
    * - ``HIPFILE_ASYNC_BUFFER_SIZE``
      - | Controls the size of the host bounce buffer allocated for asynchronous fallback I/O.
-       | Default size is 1 MiB. Setting to 0 will use the default size.
+       | Default size is 16 MiB. Setting to 0 will use the default size.

--- a/projects/hipfile/docs/reference/hipFile-environment-variables.rst
+++ b/projects/hipfile/docs/reference/hipFile-environment-variables.rst
@@ -33,3 +33,6 @@ The following environment variables affect the hipFile runtime.
        | ``true``: Fastpath is used with any file system without validation.
        | ``false``: Fastpath is only used with supported file systems. (default)
        | Must be set to ``true`` when using NFSoRDMA on Linux
+   * - ``HIPFILE_ASYNC_BUFFER_SIZE``
+     - | Controls the size of the host bounce buffer allocated for asynchronous fallback I/O.
+       | Default size is 1 MiB. Setting to 0 will use the default size.

--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -62,7 +62,6 @@ AsyncMonitor::completeOp(AsyncOp *op)
         }
         op->file.reset();
         op->buffer.reset();
-        op->stream.reset();
         completed_ops.push_back(op);
     }
     cv.notify_one();

--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "async.h"
+#include "backend.h"
 #include "context.h"
 #include "hipfile.h"
 #include "stream.h"
@@ -95,7 +96,7 @@ AsyncOp::AsyncOp(IoType _io_type, std::shared_ptr<IFile> _file, std::shared_ptr<
                  hoff_t *_buffer_offset, ssize_t *_bytes_transferred)
     : io_type{_io_type}, file{std::move(_file)}, buffer{std::move(_buffer)}, stream{std::move(_stream)},
 
-      size{stream->fixedIOSize() ? std::variant<size_t, size_t *>{*_size}
+      size{stream->fixedIOSize() ? std::variant<size_t, size_t *>{std::min(*_size, hipFile::getMaxRwCount())}
                                  : std::variant<size_t, size_t *>{_size}},
       file_offset{stream->fixedFileOffset() ? std::variant<const hoff_t, hoff_t *>{*_file_offset}
                                             : std::variant<const hoff_t, hoff_t *>{_file_offset}},

--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -60,6 +60,8 @@ AsyncMonitor::completeOp(AsyncOp *op)
         if (auto found = submitted_ops.find(op); found == submitted_ops.end()) {
             throw std::invalid_argument("Op does not appear in submitted_ops");
         }
+        op->file.reset();
+        op->buffer.reset();
         completed_ops.push_back(op);
     }
     cv.notify_one();

--- a/projects/hipfile/src/amd_detail/async.cpp
+++ b/projects/hipfile/src/amd_detail/async.cpp
@@ -60,9 +60,6 @@ AsyncMonitor::completeOp(AsyncOp *op)
         if (auto found = submitted_ops.find(op); found == submitted_ops.end()) {
             throw std::invalid_argument("Op does not appear in submitted_ops");
         }
-        op->file.reset();
-        op->buffer.reset();
-        op->stream.reset();
         completed_ops.push_back(op);
     }
     cv.notify_one();

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
@@ -27,37 +27,16 @@ enum class IoType;
 
 using namespace hipFile;
 
-static void
-hipHostDeleter(void *buffer)
-{
-    try {
-        Context<Hip>::get()->hipHostFree(buffer);
-    }
-    catch (...) {
-        Context<Sys>::get()->syslog(LOG_CRIT, "Error freeing pinned host memory.");
-    }
-}
-
 AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
                                  std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IStream> _stream,
                                  size_t *_size, hoff_t *_file_offset, hoff_t *_buffer_offset,
                                  ssize_t *_bytes_transferred)
     : AsyncOp{_io_type, std::move(_file), std::move(_buffer), std::move(_stream),
               _size,    _file_offset,     _buffer_offset,     _bytes_transferred},
-      submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, gpu_buffer{buffer->getBuffer()},
-      bounce_buffer_dev_ptr{nullptr}, bounce_buffer{nullptr, [](void *addr) { (void)addr; }}
+      submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, chunk_bytes_copied{},
+      gpu_buffer{buffer->getBuffer()}, bounce_buffer_host_ptr{stream->asyncBufferHostPtr()},
+      bounce_buffer_dev_ptr{stream->asyncBufferDevPtr()}, bounce_buffer_size{stream->asyncBufferSize()}
 {
-    void *host_ptr = Context<Hip>::get()->hipHostMalloc(submitted_size, 0);
-    std::unique_ptr<void, decltype(&hipHostDeleter)> _bounce_buffer{host_ptr, hipHostDeleter};
-    std::swap(bounce_buffer, _bounce_buffer);
-    void *dev_ptr         = Context<Hip>::get()->hipHostGetDevicePointer(bounce_buffer.get(), 0);
-    bounce_buffer_dev_ptr = dev_ptr;
-}
-
-void *
-AsyncOpFallback::bounceBufferHostPtr()
-{
-    return bounce_buffer.get();
 }
 
 void *

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
@@ -27,18 +27,16 @@ namespace hipFile {
 
 struct AsyncOpFallback : AsyncOp {
     size_t      submitted_size;
+    size_t      chunk_bytes_copied;
     void *const gpu_buffer;
+    void       *bounce_buffer_host_ptr;
     void       *bounce_buffer_dev_ptr;
+    size_t      bounce_buffer_size;
 
-private:
-    std::unique_ptr<void, void (*)(void *)> bounce_buffer;
-
-public:
     AsyncOpFallback(IoType ioType, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
                     std::shared_ptr<IStream> stream, size_t *size, hoff_t *fileOffset, hoff_t *bufferOffset,
                     ssize_t *bytesTransferred);
 
-    void *bounceBufferHostPtr();
     void *devPtr();
 
     virtual ~AsyncOpFallback() override;

--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -201,6 +201,9 @@ Fallback::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
         return;
     }
 
+    size_t chunk_size  = stream->asyncBufferSize();
+    size_t chunk_count = (limited_size + chunk_size - 1) / chunk_size;
+
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback(
         type, std::move(file), buffer, stream, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p));
     Context<AsyncMonitor>::get()->addOp(op);
@@ -218,26 +221,29 @@ Fallback::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
             Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_bind_params,
                                                    op.get());
         }
-
-        switch (op->io_type) {
-            case IoType::Read:
-                Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cpu_copy,
-                                                       op.get());
-                Context<Hip>::get()->hipLaunchKernel(reinterpret_cast<void *>(hipFileMemcpyKernel), dim3(1),
-                                                     dim3(static_cast<uint32_t>(max_threads_per_block)),
-                                                     kernel_args, 0, op->stream->getHipStream());
-                break;
-            case IoType::Write:
-                Context<Hip>::get()->hipLaunchKernel(reinterpret_cast<void *>(hipFileMemcpyKernel), dim3(1),
-                                                     dim3(static_cast<uint32_t>(max_threads_per_block)),
-                                                     kernel_args, 0, op->stream->getHipStream());
-                Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cpu_copy,
-                                                       op.get());
-                break;
-            default:
-                throw std::runtime_error("Invalid IO type");
+        for (size_t i{}; i < chunk_count; ++i) {
+            switch (op->io_type) {
+                case IoType::Read:
+                    Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cpu_copy,
+                                                           op.get());
+                    Context<Hip>::get()->hipLaunchKernel(reinterpret_cast<void *>(hipFileMemcpyKernel),
+                                                         dim3(1),
+                                                         dim3(static_cast<uint32_t>(max_threads_per_block)),
+                                                         kernel_args, 0, op->stream->getHipStream());
+                    break;
+                case IoType::Write:
+                    Context<Hip>::get()->hipLaunchKernel(reinterpret_cast<void *>(hipFileMemcpyKernel),
+                                                         dim3(1),
+                                                         dim3(static_cast<uint32_t>(max_threads_per_block)),
+                                                         kernel_args, 0, op->stream->getHipStream());
+                    Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cpu_copy,
+                                                           op.get());
+                    break;
+                default:
+                    throw std::runtime_error("Invalid IO type");
+            }
+            Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_advance, op.get());
         }
-
         Context<Hip>::get()->hipLaunchHostFunc(op->stream->getHipStream(), async_io_cleanup, op.get());
     }
     catch (...) {
@@ -289,11 +295,15 @@ async_io_cpu_copy(void *userargs)
         return;
     }
 
-    while (bytes_transferred < size) {
+    const size_t chunk_offset = static_cast<size_t>(op->bytes_transferred_internal);
+    const size_t chunk_count  = op->io_type == IoType::Read ? min(op->bounce_buffer_size, size - chunk_offset)
+                                                            : op->chunk_bytes_copied;
+
+    while (bytes_transferred < chunk_count) {
         void *cur_buf_position = reinterpret_cast<void *>(
-            reinterpret_cast<uintptr_t>(op->bounceBufferHostPtr()) + bytes_transferred);
-        hoff_t cur_file_offset = file_offset + static_cast<hoff_t>(bytes_transferred);
-        size_t remaining_bytes = size - bytes_transferred;
+            reinterpret_cast<uintptr_t>(op->bounce_buffer_host_ptr) + bytes_transferred);
+        hoff_t cur_file_offset = file_offset + static_cast<hoff_t>(chunk_offset + bytes_transferred);
+        size_t remaining_bytes = chunk_count - bytes_transferred;
         try {
             switch (op->io_type) {
                 case IoType::Read:
@@ -320,6 +330,18 @@ async_io_cpu_copy(void *userargs)
         }
         bytes_transferred += static_cast<size_t>(ret);
     }
-    op->bytes_transferred_internal = static_cast<ssize_t>(bytes_transferred);
+    op->chunk_bytes_copied = bytes_transferred;
+}
+
+void
+async_io_advance(void *userargs)
+{
+    auto op = static_cast<AsyncOpFallback *>(userargs);
+    if (op->bytes_transferred_internal < 0) {
+        return;
+    }
+    if (op->chunk_bytes_copied > 0) {
+        op->bytes_transferred_internal += op->chunk_bytes_copied;
+    }
 }
 }

--- a/projects/hipfile/src/amd_detail/backend/fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/fallback.h
@@ -53,4 +53,5 @@ protected:
 extern "C" {
 void async_io_bind_params(void *userargs);
 void async_io_cpu_copy(void *userargs);
+void async_io_advance(void *userargs);
 }

--- a/projects/hipfile/src/amd_detail/backend/memcpy-kernel.hip
+++ b/projects/hipfile/src/amd_detail/backend/memcpy-kernel.hip
@@ -31,7 +31,7 @@ hipFileMemcpyKernel(AsyncOpFallback *op)
         }
         return;
     }
-    const size_t size = io_type == IoType::Read ? static_cast<size_t>(bytes_transferred_internal) : *size_p;
+    const size_t bytes_completed = static_cast<size_t>(bytes_transferred_internal);
 
     const hoff_t *buffer_offset_p = std::get_if<const hoff_t>(&op->buffer_offset);
     if (!buffer_offset_p) {
@@ -57,9 +57,19 @@ hipFileMemcpyKernel(AsyncOpFallback *op)
         }
         return;
     }
-    size_t *const gpu_buffer_region = reinterpret_cast<size_t *>(reinterpret_cast<uintptr_t>(op->gpu_buffer) +
-                                                                 static_cast<uintptr_t>(buffer_offset));
-    const size_t  num_chunks        = size / sizeof(size_t);
+    // Read consumes the chunk cpu_copy already staged in the bounce buffer; Write sizes the chunk
+    // here and publishes it so cpu_copy knows how much to flush.
+    const size_t remaining = *size_p - bytes_completed;
+    const size_t size      = io_type == IoType::Read
+                                 ? op->chunk_bytes_copied
+                                 : (op->bounce_buffer_size < remaining ? op->bounce_buffer_size : remaining);
+    if (io_type == IoType::Write && start_idx == 0) {
+        op->chunk_bytes_copied = size;
+    }
+
+    size_t *const gpu_buffer_region = reinterpret_cast<size_t *>(
+        reinterpret_cast<uintptr_t>(op->gpu_buffer) + static_cast<uintptr_t>(buffer_offset) + bytes_completed);
+    const size_t num_chunks = size / sizeof(size_t);
 
     switch (io_type) {
         case IoType::Read:

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -6,6 +6,7 @@
 #include "configuration.h"
 #include "environment.h"
 #include "hip.h"
+#include "hipfile-literals.h"
 
 #include <cstdio>
 #include <optional>
@@ -63,4 +64,15 @@ Configuration::unsupportedFileSystems() const noexcept
 {
     static bool unsupported_file_systems_env{Environment::unsupported_file_systems().value_or(false)};
     return unsupported_file_systems_env;
+}
+
+size_t
+Configuration::asyncBufferSize() const noexcept
+{
+    static size_t async_buffer_size_env{[] {
+        constexpr size_t default_size{1_MiB};
+        auto             env = Environment::async_buffer_size();
+        return (env && *env > 0) ? *env : default_size;
+    }()};
+    return async_buffer_size_env;
 }

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -70,7 +70,7 @@ size_t
 Configuration::asyncBufferSize() const noexcept
 {
     static size_t async_buffer_size_env{[] {
-        constexpr size_t default_size{1_MiB};
+        constexpr size_t default_size{16_MiB};
         auto             env = Environment::async_buffer_size();
         return (env && *env > 0) ? *env : default_size;
     }()};

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -64,3 +64,14 @@ Configuration::unsupportedFileSystems() const noexcept
     static bool unsupported_file_systems_env{Environment::unsupported_file_systems().value_or(false)};
     return unsupported_file_systems_env;
 }
+
+size_t
+Configuration::asyncBufferSize() const noexcept
+{
+    static size_t async_buffer_size_env{[] {
+        constexpr size_t default_size{1 << 20}; // 1 MiB
+        auto             env = Environment::async_buffer_size();
+        return (env && *env > 0) ? *env : default_size;
+    }()};
+    return async_buffer_size_env;
+}

--- a/projects/hipfile/src/amd_detail/configuration.h
+++ b/projects/hipfile/src/amd_detail/configuration.h
@@ -42,6 +42,10 @@ public:
     /// @return true if unsupported file systems are allowed, false if only supported file systems are
     /// permitted (default)
     virtual bool unsupportedFileSystems() const noexcept;
+
+    /// @brief Gets the size of the async buffer used for I/O operations
+    /// @return the size of the async buffer in bytes
+    virtual size_t asyncBufferSize() const noexcept;
 };
 
 }

--- a/projects/hipfile/src/amd_detail/environment.cpp
+++ b/projects/hipfile/src/amd_detail/environment.cpp
@@ -7,9 +7,6 @@
 #include "environment.h"
 #include "sys.h"
 
-#include <cerrno>
-#include <cstdlib>
-#include <limits>
 #include <strings.h>
 
 using namespace hipFile;
@@ -29,27 +26,6 @@ Environment::get<bool>(const char *key)
         }
     }
     return std::nullopt;
-}
-
-template <>
-std::optional<unsigned int>
-Environment::get<unsigned int>(const char *key)
-{
-    const char *value{Context<Sys>::get()->getenv(key)};
-    if (value == nullptr)
-        return std::nullopt;
-    errno = 0;
-    char         *end;
-    unsigned long x{std::strtoul(value, &end, 10)};
-    if (errno != 0)
-        return std::nullopt;
-    if (end == value)
-        return std::nullopt;
-    if (*end != '\0')
-        return std::nullopt;
-    if (x > static_cast<unsigned long>(std::numeric_limits<unsigned int>::max()))
-        return std::numeric_limits<unsigned int>::max();
-    return static_cast<unsigned int>(x);
 }
 
 optional<bool>
@@ -74,4 +50,10 @@ optional<unsigned int>
 Environment::stats_level()
 {
     return Environment::get<unsigned int>(Environment::STATS_LEVEL);
+}
+
+optional<size_t>
+Environment::async_buffer_size()
+{
+    return Environment::get<size_t>(Environment::ASYNC_BUFFER_SIZE);
 }

--- a/projects/hipfile/src/amd_detail/environment.h
+++ b/projects/hipfile/src/amd_detail/environment.h
@@ -5,7 +5,15 @@
 
 #pragma once
 
+#include "context.h"
+#include "sys.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <concepts>
+#include <limits>
 #include <optional>
+#include <strings.h>
 
 namespace hipFile {
 
@@ -16,6 +24,27 @@ public:
     /// @return An optional value of type T if the key was set, nullopt if the key
     /// was not set or had an invalid value for the type T
     template <typename T> static std::optional<T> get(const char *key);
+
+    template <typename T>
+        requires std::unsigned_integral<T> && (!std::same_as<T, bool>)
+    static std::optional<T> get(const char *key)
+    {
+        const char *value{Context<Sys>::get()->getenv(key)};
+        if (value == nullptr)
+            return std::nullopt;
+        errno = 0;
+        char         *end;
+        unsigned long x{std::strtoul(value, &end, 10)};
+        if (errno != 0)
+            return std::nullopt;
+        if (end == value)
+            return std::nullopt;
+        if (*end != '\0')
+            return std::nullopt;
+        if (x > static_cast<unsigned long>(std::numeric_limits<T>::max()))
+            return std::numeric_limits<T>::max();
+        return static_cast<T>(x);
+    }
 
     /// @brief Allow I/O operations to fallback to POSIX I/O APIs
     ///
@@ -60,6 +89,12 @@ public:
     /// nullopt if HIPFILE_UNSUPPORTED_FILE_SYSTEMS was unset or had a value other than
     /// true or false.
     static std::optional<bool> unsupported_file_systems();
-};
 
+    /// @brief Control the size of the host bounce buffer used for async fallback I/O operations
+    ///
+    /// The default value is 1 MiB.
+    static constexpr const char *const ASYNC_BUFFER_SIZE{"HIPFILE_ASYNC_BUFFER_SIZE"};
+
+    static std::optional<size_t> async_buffer_size();
+};
 }

--- a/projects/hipfile/src/amd_detail/environment.h
+++ b/projects/hipfile/src/amd_detail/environment.h
@@ -5,7 +5,16 @@
 
 #pragma once
 
+#include "context.h"
+#include "sys.h"
+
+#include <charconv>
+#include <concepts>
+#include <cstdlib>
+#include <limits>
 #include <optional>
+#include <strings.h>
+#include <string_view>
 
 namespace hipFile {
 
@@ -16,6 +25,23 @@ public:
     /// @return An optional value of type T if the key was set, nullopt if the key
     /// was not set or had an invalid value for the type T
     template <typename T> static std::optional<T> get(const char *key);
+
+    template <typename T>
+        requires std::integral<T> && (!std::same_as<T, bool>)
+    static std::optional<T> get(const char *key)
+    {
+        const char *value{Context<Sys>::get()->getenv(key)};
+        if (value == nullptr)
+            return std::nullopt;
+        std::string_view sv{value};
+        T                x{};
+        auto [ptr, ec]{std::from_chars(sv.data(), sv.data() + sv.size(), x, 10)};
+        if (ec == std::errc::invalid_argument || *ptr != '\0')
+            return std::nullopt;
+        else if (ec == std::errc::result_out_of_range)
+            return std::numeric_limits<T>::max();
+        return x;
+    }
 
     /// @brief Allow I/O operations to fallback to POSIX I/O APIs
     ///
@@ -60,6 +86,12 @@ public:
     /// nullopt if HIPFILE_UNSUPPORTED_FILE_SYSTEMS was unset or had a value other than
     /// true or false.
     static std::optional<bool> unsupported_file_systems();
-};
 
+    /// @brief Control the size of the host bounce buffer used for async fallback I/O operations
+    ///
+    /// The default value is 1 MiB.
+    static constexpr const char *const ASYNC_BUFFER_SIZE{"HIPFILE_ASYNC_BUFFER_SIZE"};
+
+    static std::optional<size_t> async_buffer_size();
+};
 }

--- a/projects/hipfile/src/amd_detail/stream.cpp
+++ b/projects/hipfile/src/amd_detail/stream.cpp
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
+#include "configuration.h"
 #include "context.h"
 #include "hip.h"
 #include "hipfile.h"
@@ -17,12 +18,23 @@
 #include <utility>
 
 namespace hipFile {
+static void
+hipHostDeleter(void *buffer)
+{
+    try {
+        Context<Hip>::get()->hipHostFree(buffer);
+    }
+    catch (...) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "Error freeing pinned host memory.");
+    }
+}
 
 Stream::Stream(const hipStream_t _hip_stream, uint32_t flags, const PassKey<StreamMap> &)
     : hip_stream{_hip_stream}, device_id{0}, fixed_buf_offset{(flags & HIPFILE_STREAM_FIXED_BUF_OFFSET) != 0},
       fixed_file_offset{(flags & HIPFILE_STREAM_FIXED_FILE_OFFSET) != 0},
       fixed_io_size{(flags & HIPFILE_STREAM_FIXED_FILE_SIZE) != 0},
-      page_aligned{(flags & HIPFILE_STREAM_PAGE_ALIGNED_INPUTS) != 0}
+      page_aligned{(flags & HIPFILE_STREAM_PAGE_ALIGNED_INPUTS) != 0}, async_buffer{nullptr, hipHostDeleter},
+      async_buffer_dev_ptr{nullptr}, async_buffer_size{0}
 
 {
     if ((flags & HIPFILE_STREAM_FLAGS_MASK) != flags) {
@@ -30,6 +42,15 @@ Stream::Stream(const hipStream_t _hip_stream, uint32_t flags, const PassKey<Stre
     }
 
     device_id = Context<Hip>::get()->hipStreamGetDevice(hip_stream);
+
+    size_t buffer_size = Context<Configuration>::get()->asyncBufferSize();
+    void  *host_ptr    = Context<Hip>::get()->hipHostMalloc(buffer_size, 0);
+    if (!host_ptr) {
+        throw std::runtime_error("Failed to allocate pinned host memory for async buffer");
+    }
+    async_buffer.reset(host_ptr);
+    async_buffer_dev_ptr = Context<Hip>::get()->hipHostGetDevicePointer(async_buffer.get(), 0);
+    async_buffer_size    = buffer_size;
 }
 
 hipStream_t
@@ -99,6 +120,24 @@ StreamMap::getStream(hipStream_t hip_stream)
     }
 
     return itr->second;
+}
+
+void *
+Stream::asyncBufferHostPtr() const
+{
+    return async_buffer.get();
+}
+
+void *
+Stream::asyncBufferDevPtr() const
+{
+    return async_buffer_dev_ptr;
+}
+
+size_t
+Stream::asyncBufferSize() const
+{
+    return async_buffer_size;
 }
 
 StreamMap::~StreamMap()

--- a/projects/hipfile/src/amd_detail/stream.h
+++ b/projects/hipfile/src/amd_detail/stream.h
@@ -18,13 +18,16 @@ class IStream {
 public:
     virtual ~IStream() = default;
 
-    virtual hipStream_t                  getHipStream() const      = 0;
-    virtual hipDevice_t                  getHipDevice() const      = 0;
-    virtual bool                         fixedBufferOffset() const = 0;
-    virtual bool                         fixedFileOffset() const   = 0;
-    virtual bool                         fixedIOSize() const       = 0;
-    virtual bool                         pageAligned() const       = 0;
-    virtual std::unique_lock<std::mutex> getLock()                 = 0;
+    virtual hipStream_t                  getHipStream() const       = 0;
+    virtual hipDevice_t                  getHipDevice() const       = 0;
+    virtual bool                         fixedBufferOffset() const  = 0;
+    virtual bool                         fixedFileOffset() const    = 0;
+    virtual bool                         fixedIOSize() const        = 0;
+    virtual bool                         pageAligned() const        = 0;
+    virtual std::unique_lock<std::mutex> getLock()                  = 0;
+    virtual void                        *asyncBufferHostPtr() const = 0;
+    virtual void                        *asyncBufferDevPtr() const  = 0;
+    virtual size_t                       asyncBufferSize() const    = 0;
 };
 
 class StreamMap;
@@ -40,6 +43,9 @@ public:
     virtual bool                         fixedIOSize() const override;
     virtual bool                         pageAligned() const override;
     virtual std::unique_lock<std::mutex> getLock() override;
+    virtual void                        *asyncBufferHostPtr() const override;
+    virtual void                        *asyncBufferDevPtr() const override;
+    virtual size_t                       asyncBufferSize() const override;
 
     Stream(const hipStream_t hip_stream, uint32_t flags, const PassKey<StreamMap> &k);
 
@@ -56,6 +62,10 @@ private:
     bool        fixed_io_size;
     bool        page_aligned;
     std::mutex  mutex;
+
+    std::unique_ptr<void, void (*)(void *)> async_buffer;
+    void                                   *async_buffer_dev_ptr;
+    size_t                                  async_buffer_size;
 };
 
 class StreamMap {

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -161,9 +161,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
         IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
@@ -177,10 +178,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallbackLimitsMaxIoSize)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(1_KiB);
-    EXPECT_CALL(mhip, hipHostMalloc(hipFile::getMaxRwCount(), _)).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostMalloc(sizeof(AsyncOpFallback), _)).WillOnce(Return(op_data.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(1_KiB));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
         IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
@@ -201,41 +202,6 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
                  std::bad_alloc);
 }
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
-{
-    size_t  size              = 100;
-    hoff_t  file_offset       = 0;
-    hoff_t  buffer_offset     = 0;
-    ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
-    EXPECT_CALL(mhip, hipHostMalloc)
-        .WillOnce(Return(op_data.get()))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
-    EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
-                                                                      &size, &file_offset, &buffer_offset,
-                                                                      &bytes_transferred}),
-                 Hip::RuntimeError);
-}
-
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslog)
-{
-    size_t  size              = 100;
-    hoff_t  file_offset       = 0;
-    hoff_t  buffer_offset     = 0;
-    ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
-    EXPECT_CALL(msys, syslog);
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
-        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
-}
-
 TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
 {
     size_t  size              = 100;
@@ -244,9 +210,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())))
         .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
     EXPECT_CALL(msys, syslog);
@@ -258,16 +225,14 @@ struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
     HipFileAsyncOpFallbackMethods() : bounce_buffer{make_shared_void(size)}
     {
         //  make_shared uses placement new, which will not use hipHostMalloc/hipHostFree for
-        //  AsyncOpFallback
-        EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer).WillOnce(Return(bounce_buffer_dev_ptr));
+        //  AsyncOpFallback. The bounce buffer is now owned by Stream.
+        EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer_dev_ptr));
+        EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
         op = std::make_shared<AsyncOpFallback>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                                &buffer_offset, &bytes_transferred);
     }
-    ~HipFileAsyncOpFallbackMethods() override
-    {
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    }
+    ~HipFileAsyncOpFallbackMethods() override              = default;
     void                            *bounce_buffer_dev_ptr = reinterpret_cast<void *>(0xDECDECDE);
     size_t                           size                  = 100;
     hoff_t                           file_offset           = 0;
@@ -279,7 +244,7 @@ struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
 
 TEST_F(HipFileAsyncOpFallbackMethods, bounceBufferHostPtr_returns_pointer)
 {
-    ASSERT_EQ(op->bounceBufferHostPtr(), bounce_buffer.get());
+    ASSERT_EQ(op->bounce_buffer_host_ptr, bounce_buffer.get());
 }
 
 TEST_F(HipFileAsyncOpFallbackMethods, devPtr_calls_hipHostGetDevicePointer)
@@ -503,15 +468,14 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     auto op_data = malloc(sizeof(AsyncOpFallback));
     // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
     ASSERT_NE(op_data, nullptr);
-    auto bounce_buffer = malloc(size);
-    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
-    ASSERT_NE(bounce_buffer, nullptr);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data)).WillOnce(Return(bounce_buffer));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer), _))
-        .WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    auto bounce_buffer = make_shared_void(size);
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data));
+    EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    // asyncBufferSize is called once by async_io to compute chunk_count, and once in the constructor
+    EXPECT_CALL(*mstream, asyncBufferSize).Times(2).WillRepeatedly(Return(size));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
         .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer))).WillOnce([](void *ptr) { free(ptr); });
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data))).WillOnce([](void *ptr) { free(ptr); });
     EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
     EXPECT_CALL(*mstream, getLock);
@@ -522,7 +486,51 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     EXPECT_THROW(Fallback().async_io(io_type, mfile, mbuffer, &size, &file_offset, &buffer_offset,
                                      &bytes_written, mstream),
                  Hip::RuntimeError);
-    // Call to allow destruction of the op and bounce buffer
+    // Call to allow destruction of the op; bounce buffer is owned by mstream, free it here
+    async_io_cleanup(op_data);
+    // Sleep to allow cleanup thread to destruct op
+    std::this_thread::sleep_for(500ms);
+}
+
+TEST_P(FallbackAsyncIO, multipleChunksAreQueued)
+{
+    size               = 1_MiB;
+    size_t chunk_size  = 256_KiB;
+    int    chunk_count = 4;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).Times(AnyNumber()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<hipStream_t>(0xBADBADBB)));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    // All params fixed so no bind_params host function is enqueued.
+    EXPECT_CALL(*mstream, fixedIOSize).Times(AnyNumber()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mstream, fixedFileOffset).Times(AnyNumber()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mstream, fixedBufferOffset).Times(AnyNumber()).WillRepeatedly(Return(true));
+
+    auto op_data = malloc(sizeof(AsyncOpFallback));
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
+    ASSERT_NE(op_data, nullptr);
+    auto bounce_buffer = make_shared_void(chunk_size);
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data));
+    EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    // asyncBufferSize is called once by async_io to compute chunk_count, and once in the constructor
+    EXPECT_CALL(*mstream, asyncBufferSize).Times(2).WillRepeatedly(Return(chunk_size));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
+        .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
+    EXPECT_CALL(mhip, hipHostFree(Eq(op_data))).WillOnce([](void *ptr) { free(ptr); });
+    EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
+    // Each chunk enqueues a cpu copy, a memcpy kernel, and an advance; cleanup runs once at the end.
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cpu_copy), _)).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchKernel).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_advance), _)).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _));
+
+    Fallback().async_io(io_type, mfile, mbuffer, &size, &file_offset, &buffer_offset, &bytes_written,
+                        mstream);
+    // The enqueued host functions are mocked and never run; free the op manually.
+    // Bounce buffer is owned by mstream, free it here.
     async_io_cleanup(op_data);
     // Sleep to allow cleanup thread to destruct op
     std::this_thread::sleep_for(500ms);
@@ -542,11 +550,10 @@ struct AsyncIoOp : public ::testing::Test {
     {
         op_data       = make_shared_void(sizeof(AsyncOpFallback));
         bounce_buffer = make_shared_void(size);
-        EXPECT_CALL(mhip, hipHostMalloc)
-            .WillOnce(Return(op_data.get()))
-            .WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+        EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+        EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*mstream, asyncBufferSize).WillOnce(Return(size));
         EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
         EXPECT_CALL(*mstream, fixedBufferOffset)
             .Times(AnyNumber())
@@ -677,11 +684,12 @@ TEST_P(AsyncIoOpWithParams, cpuIOReturnsFullSize)
         EXPECT_CALL(msys, pread).WillOnce(Return(size));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite).WillOnce(Return(size));
     }
     EXPECT_CALL(*mfile, bufferedFd);
     async_io_cpu_copy(op.get());
-    ASSERT_EQ(op->bytes_transferred_internal, size);
+    ASSERT_EQ(op->chunk_bytes_copied, size);
 }
 
 TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteErrorReturnsError)
@@ -690,6 +698,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteErrorReturnsError)
         EXPECT_CALL(msys, pread).WillOnce(Throw(std::system_error(3, std::generic_category())));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite).WillOnce(Throw(std::system_error(3, std::generic_category())));
     }
     EXPECT_CALL(*mfile, bufferedFd);
@@ -705,6 +714,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
             .WillOnce(Return(size));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite)
             .WillOnce(Throw(std::system_error(EINTR, std::generic_category())))
             .WillOnce(Return(size));
@@ -712,12 +722,77 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
     EXPECT_CALL(*mfile, bufferedFd).Times(2);
     async_io_cpu_copy(op.get());
 
-    ASSERT_EQ(op->bytes_transferred_internal, size);
+    ASSERT_EQ(op->chunk_bytes_copied, size);
 }
 
 INSTANTIATE_TEST_SUITE_P(AsyncIoOpWithParamsSuite, AsyncIoOpWithParams,
                          ::testing::Values(AsyncIoOpBindParams{IoType::Read, true, true, true},
                                            AsyncIoOpBindParams{IoType::Write, true, true, true}));
+
+struct AsyncIoCpuCopyChunkParams {
+    IoType io_type;
+    size_t io_size;         // Total size of the op
+    size_t chunk_size;      // op->chunk_size (async buffer size)
+    size_t bytes_completed; // op->bytes_transferred_internal at entry (offset already transferred)
+    size_t expected_chunk;  // Bytes this single cpu_copy call should transfer
+};
+
+struct AsyncIoOpChunked : public AsyncIoOp, public ::testing::WithParamInterface<AsyncIoCpuCopyChunkParams> {
+    void SetUp() override
+    {
+        auto params         = GetParam();
+        io_type             = params.io_type;
+        size                = params.io_size;
+        fixed_buffer_offset = true;
+        fixed_file_offset   = true;
+        fixed_io_size       = true;
+        AsyncIoOp::SetUp();
+        op->bounce_buffer_size         = params.chunk_size;
+        op->bytes_transferred_internal = static_cast<ssize_t>(params.bytes_completed);
+        // The write path consumes the chunk length the kernel publishes before cpu_copy runs.
+        if (io_type == IoType::Write) {
+            op->chunk_bytes_copied = params.expected_chunk;
+        }
+    }
+};
+
+// cpu_copy transfers only the current chunk of a larger IO, at the file offset implied by the bytes
+// already completed, and reports the chunk length back through chunk_bytes_copied.
+TEST_P(AsyncIoOpChunked, cpuCopyTransfersSingleChunkOfLargerIo)
+{
+    auto        params          = GetParam();
+    void       *bounce_host     = op->bounce_buffer_host_ptr;
+    const off_t expected_offset = file_offset + static_cast<off_t>(params.bytes_completed);
+    EXPECT_CALL(*mfile, bufferedFd).WillOnce(Return(7));
+    if (io_type == IoType::Read) {
+        EXPECT_CALL(msys, pread(Eq(7), Eq(bounce_host), Eq(params.expected_chunk), Eq(expected_offset)))
+            .WillOnce(Return(params.expected_chunk));
+    }
+    else {
+        EXPECT_CALL(msys, pwrite(Eq(7), Eq(bounce_host), Eq(params.expected_chunk), Eq(expected_offset)))
+            .WillOnce(Return(params.expected_chunk));
+    }
+    async_io_cpu_copy(op.get());
+    ASSERT_EQ(op->chunk_bytes_copied, params.expected_chunk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AsyncIoOpChunkedSuite, AsyncIoOpChunked,
+    ::testing::Values(
+        // Read: first, middle, and clamped-tail chunks of a 1 MiB IO with a 256 KiB buffer
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 0, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 512_KiB, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 896_KiB, 128_KiB},
+        // Write: middle and clamped-tail chunks; the length comes from chunk_bytes_copied
+        AsyncIoCpuCopyChunkParams{IoType::Write, 1_MiB, 256_KiB, 512_KiB, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Write, 1_MiB, 256_KiB, 896_KiB, 128_KiB}),
+    [](const testing::TestParamInfo<AsyncIoOpChunked::ParamType> &param_info) {
+        const auto &p    = param_info.param;
+        std::string name = p.io_type == IoType::Read ? "Read" : "Write";
+        name += "_chunk" + std::to_string(p.chunk_size);
+        name += "_at" + std::to_string(p.bytes_completed);
+        return name;
+    });
 
 struct FastpathAsyncIO : public HipFileOpened {
     FastpathAsyncIO()

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -188,6 +188,26 @@ TEST_F(HipFileAsyncOp, AsyncOpFallbackLimitsMaxIoSize)
     ASSERT_EQ(op->submitted_size, hipFile::getMaxRwCount());
 }
 
+TEST_F(HipFileAsyncOp, AsyncOpLimitsFixedIoSize)
+{
+    size_t  size              = 4_GiB;
+    hoff_t  file_offset       = 0;
+    hoff_t  buffer_offset     = 0;
+    ssize_t bytes_transferred = 0;
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
+    auto    bounce_buffer     = make_shared_void(1_KiB);
+    EXPECT_CALL(mhip, hipHostMalloc(sizeof(AsyncOpFallback), _)).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(1_KiB));
+    EXPECT_CALL(*stream, fixedIOSize).WillOnce(Return(true));
+    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
+        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
+    ASSERT_EQ(op->submitted_size, hipFile::getMaxRwCount());
+    ASSERT_EQ(std::get<size_t>(op->size), hipFile::getMaxRwCount());
+}
+
 TEST_F(HipFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
 {
     size_t  size              = 100;

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -161,9 +161,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
         IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
@@ -177,10 +178,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallbackLimitsMaxIoSize)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(1_KiB);
-    EXPECT_CALL(mhip, hipHostMalloc(hipFile::getMaxRwCount(), _)).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostMalloc(sizeof(AsyncOpFallback), _)).WillOnce(Return(op_data.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(1_KiB));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
         IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
@@ -201,39 +202,20 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
                  std::bad_alloc);
 }
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
+TEST_F(HipFileAsyncOp, AsyncOpFallback_stream_buffer_ptr_failure_throws)
 {
     size_t  size              = 100;
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
-    EXPECT_CALL(mhip, hipHostMalloc)
-        .WillOnce(Return(op_data.get()))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
     EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
                                                                       &size, &file_offset, &buffer_offset,
                                                                       &bytes_transferred}),
                  Hip::RuntimeError);
-}
-
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslog)
-{
-    size_t  size              = 100;
-    hoff_t  file_offset       = 0;
-    hoff_t  buffer_offset     = 0;
-    ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
-    EXPECT_CALL(msys, syslog);
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
-        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
 }
 
 TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
@@ -244,9 +226,10 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
     ssize_t bytes_transferred = 0;
     auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     auto    bounce_buffer     = make_shared_void(size);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+    EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+    EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())))
         .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
     EXPECT_CALL(msys, syslog);
@@ -258,16 +241,14 @@ struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
     HipFileAsyncOpFallbackMethods() : bounce_buffer{make_shared_void(size)}
     {
         //  make_shared uses placement new, which will not use hipHostMalloc/hipHostFree for
-        //  AsyncOpFallback
-        EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer).WillOnce(Return(bounce_buffer_dev_ptr));
+        //  AsyncOpFallback. The bounce buffer is now owned by Stream.
+        EXPECT_CALL(*stream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*stream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer_dev_ptr));
+        EXPECT_CALL(*stream, asyncBufferSize).WillOnce(Return(size));
         op = std::make_shared<AsyncOpFallback>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                                &buffer_offset, &bytes_transferred);
     }
-    ~HipFileAsyncOpFallbackMethods() override
-    {
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    }
+    ~HipFileAsyncOpFallbackMethods() override              = default;
     void                            *bounce_buffer_dev_ptr = reinterpret_cast<void *>(0xDECDECDE);
     size_t                           size                  = 100;
     hoff_t                           file_offset           = 0;
@@ -279,7 +260,7 @@ struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
 
 TEST_F(HipFileAsyncOpFallbackMethods, bounceBufferHostPtr_returns_pointer)
 {
-    ASSERT_EQ(op->bounceBufferHostPtr(), bounce_buffer.get());
+    ASSERT_EQ(op->bounce_buffer_host_ptr, bounce_buffer.get());
 }
 
 TEST_F(HipFileAsyncOpFallbackMethods, devPtr_calls_hipHostGetDevicePointer)
@@ -504,14 +485,15 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
     ASSERT_NE(op_data, nullptr);
     auto bounce_buffer = malloc(size);
-    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): owned by mstream mock
     ASSERT_NE(bounce_buffer, nullptr);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data)).WillOnce(Return(bounce_buffer));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer), _))
-        .WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data));
+    EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer));
+    EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    // asyncBufferSize is called once by async_io to compute chunk_count, and once in the constructor
+    EXPECT_CALL(*mstream, asyncBufferSize).Times(2).WillRepeatedly(Return(size));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
         .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer))).WillOnce([](void *ptr) { free(ptr); });
     EXPECT_CALL(mhip, hipHostFree(Eq(op_data))).WillOnce([](void *ptr) { free(ptr); });
     EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
     EXPECT_CALL(*mstream, getLock);
@@ -522,7 +504,55 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     EXPECT_THROW(Fallback().async_io(io_type, mfile, mbuffer, &size, &file_offset, &buffer_offset,
                                      &bytes_written, mstream),
                  Hip::RuntimeError);
-    // Call to allow destruction of the op and bounce buffer
+    // Call to allow destruction of the op; bounce buffer is owned by mstream, free it here
+    free(bounce_buffer);
+    async_io_cleanup(op_data);
+    // Sleep to allow cleanup thread to destruct op
+    std::this_thread::sleep_for(500ms);
+}
+
+TEST_P(FallbackAsyncIO, multipleChunksAreQueued)
+{
+    size               = 1_MiB;
+    size_t chunk_size  = 256_KiB;
+    int    chunk_count = 4;
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(size));
+    EXPECT_CALL(*mbuffer, getGpuId).Times(AnyNumber()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<hipStream_t>(0xBADBADBB)));
+    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    // All params fixed so no bind_params host function is enqueued.
+    EXPECT_CALL(*mstream, fixedIOSize).Times(AnyNumber()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mstream, fixedFileOffset).Times(AnyNumber()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mstream, fixedBufferOffset).Times(AnyNumber()).WillRepeatedly(Return(true));
+
+    auto op_data = malloc(sizeof(AsyncOpFallback));
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
+    ASSERT_NE(op_data, nullptr);
+    auto bounce_buffer = malloc(chunk_size);
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): owned by mstream mock
+    ASSERT_NE(bounce_buffer, nullptr);
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data));
+    EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer));
+    EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
+    // asyncBufferSize is called once by async_io to compute chunk_count, and once in the constructor
+    EXPECT_CALL(*mstream, asyncBufferSize).Times(2).WillRepeatedly(Return(chunk_size));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
+        .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
+    EXPECT_CALL(mhip, hipHostFree(Eq(op_data))).WillOnce([](void *ptr) { free(ptr); });
+    EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
+    EXPECT_CALL(*mstream, getLock);
+    EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
+    // Each chunk enqueues a cpu copy, a memcpy kernel, and an advance; cleanup runs once at the end.
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cpu_copy), _)).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchKernel).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_advance), _)).Times(chunk_count);
+    EXPECT_CALL(mhip, hipLaunchHostFunc(_, Eq(&async_io_cleanup), _));
+
+    Fallback().async_io(io_type, mfile, mbuffer, &size, &file_offset, &buffer_offset, &bytes_written,
+                        mstream);
+    // The enqueued host functions are mocked and never run; free the op manually.
+    // Bounce buffer is owned by mstream, free it here.
+    free(bounce_buffer);
     async_io_cleanup(op_data);
     // Sleep to allow cleanup thread to destruct op
     std::this_thread::sleep_for(500ms);
@@ -542,11 +572,10 @@ struct AsyncIoOp : public ::testing::Test {
     {
         op_data       = make_shared_void(sizeof(AsyncOpFallback));
         bounce_buffer = make_shared_void(size);
-        EXPECT_CALL(mhip, hipHostMalloc)
-            .WillOnce(Return(op_data.get()))
-            .WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+        EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get()));
+        EXPECT_CALL(*mstream, asyncBufferHostPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*mstream, asyncBufferDevPtr).WillOnce(Return(bounce_buffer.get()));
+        EXPECT_CALL(*mstream, asyncBufferSize).WillOnce(Return(size));
         EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
         EXPECT_CALL(*mstream, fixedBufferOffset)
             .Times(AnyNumber())
@@ -677,11 +706,12 @@ TEST_P(AsyncIoOpWithParams, cpuIOReturnsFullSize)
         EXPECT_CALL(msys, pread).WillOnce(Return(size));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite).WillOnce(Return(size));
     }
     EXPECT_CALL(*mfile, bufferedFd);
     async_io_cpu_copy(op.get());
-    ASSERT_EQ(op->bytes_transferred_internal, size);
+    ASSERT_EQ(op->chunk_bytes_copied, size);
 }
 
 TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteErrorReturnsError)
@@ -690,6 +720,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteErrorReturnsError)
         EXPECT_CALL(msys, pread).WillOnce(Throw(std::system_error(3, std::generic_category())));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite).WillOnce(Throw(std::system_error(3, std::generic_category())));
     }
     EXPECT_CALL(*mfile, bufferedFd);
@@ -705,6 +736,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
             .WillOnce(Return(size));
     }
     else {
+        op->chunk_bytes_copied = size;
         EXPECT_CALL(msys, pwrite)
             .WillOnce(Throw(std::system_error(EINTR, std::generic_category())))
             .WillOnce(Return(size));
@@ -712,12 +744,77 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
     EXPECT_CALL(*mfile, bufferedFd).Times(2);
     async_io_cpu_copy(op.get());
 
-    ASSERT_EQ(op->bytes_transferred_internal, size);
+    ASSERT_EQ(op->chunk_bytes_copied, size);
 }
 
 INSTANTIATE_TEST_SUITE_P(AsyncIoOpWithParamsSuite, AsyncIoOpWithParams,
                          ::testing::Values(AsyncIoOpBindParams{IoType::Read, true, true, true},
                                            AsyncIoOpBindParams{IoType::Write, true, true, true}));
+
+struct AsyncIoCpuCopyChunkParams {
+    IoType io_type;
+    size_t io_size;         // Total size of the op
+    size_t chunk_size;      // op->chunk_size (async buffer size)
+    size_t bytes_completed; // op->bytes_transferred_internal at entry (offset already transferred)
+    size_t expected_chunk;  // Bytes this single cpu_copy call should transfer
+};
+
+struct AsyncIoOpChunked : public AsyncIoOp, public ::testing::WithParamInterface<AsyncIoCpuCopyChunkParams> {
+    void SetUp() override
+    {
+        auto params         = GetParam();
+        io_type             = params.io_type;
+        size                = params.io_size;
+        fixed_buffer_offset = true;
+        fixed_file_offset   = true;
+        fixed_io_size       = true;
+        AsyncIoOp::SetUp();
+        op->bounce_buffer_size         = params.chunk_size;
+        op->bytes_transferred_internal = static_cast<ssize_t>(params.bytes_completed);
+        // The write path consumes the chunk length the kernel publishes before cpu_copy runs.
+        if (io_type == IoType::Write) {
+            op->chunk_bytes_copied = params.expected_chunk;
+        }
+    }
+};
+
+// cpu_copy transfers only the current chunk of a larger IO, at the file offset implied by the bytes
+// already completed, and reports the chunk length back through chunk_bytes_copied.
+TEST_P(AsyncIoOpChunked, cpuCopyTransfersSingleChunkOfLargerIo)
+{
+    auto        params          = GetParam();
+    void       *bounce_host     = op->bounce_buffer_host_ptr;
+    const off_t expected_offset = file_offset + static_cast<off_t>(params.bytes_completed);
+    EXPECT_CALL(*mfile, bufferedFd).WillOnce(Return(7));
+    if (io_type == IoType::Read) {
+        EXPECT_CALL(msys, pread(Eq(7), Eq(bounce_host), Eq(params.expected_chunk), Eq(expected_offset)))
+            .WillOnce(Return(params.expected_chunk));
+    }
+    else {
+        EXPECT_CALL(msys, pwrite(Eq(7), Eq(bounce_host), Eq(params.expected_chunk), Eq(expected_offset)))
+            .WillOnce(Return(params.expected_chunk));
+    }
+    async_io_cpu_copy(op.get());
+    ASSERT_EQ(op->chunk_bytes_copied, params.expected_chunk);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AsyncIoOpChunkedSuite, AsyncIoOpChunked,
+    ::testing::Values(
+        // Read: first, middle, and clamped-tail chunks of a 1 MiB IO with a 256 KiB buffer
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 0, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 512_KiB, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Read, 1_MiB, 256_KiB, 896_KiB, 128_KiB},
+        // Write: middle and clamped-tail chunks; the length comes from chunk_bytes_copied
+        AsyncIoCpuCopyChunkParams{IoType::Write, 1_MiB, 256_KiB, 512_KiB, 256_KiB},
+        AsyncIoCpuCopyChunkParams{IoType::Write, 1_MiB, 256_KiB, 896_KiB, 128_KiB}),
+    [](const testing::TestParamInfo<AsyncIoOpChunked::ParamType> &param_info) {
+        const auto &p    = param_info.param;
+        std::string name = p.io_type == IoType::Read ? "Read" : "Write";
+        name += "_chunk" + std::to_string(p.chunk_size);
+        name += "_at" + std::to_string(p.bytes_completed);
+        return name;
+    });
 
 struct FastpathAsyncIO : public HipFileOpened {
     FastpathAsyncIO()

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -246,13 +246,13 @@ TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariable
 TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsNotSet)
 {
     expect_configuration_async_buffer_size(nullptr);
-    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
+    ASSERT_EQ(16_MiB, Configuration().asyncBufferSize());
 }
 
 TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsInvalid)
 {
     expect_configuration_async_buffer_size("not-a-number");
-    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
+    ASSERT_EQ(16_MiB, Configuration().asyncBufferSize());
 }
 
 TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsSet)
@@ -264,7 +264,7 @@ TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsSet)
 TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsZero)
 {
     expect_configuration_async_buffer_size("0");
-    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
+    ASSERT_EQ(16_MiB, Configuration().asyncBufferSize());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -5,6 +5,7 @@
 
 #include "configuration.h"
 #include "environment.h"
+#include "hipfile-literals.h"
 #include "hipfile-warnings.h"
 #include "mhip.h"
 #include "msys.h"
@@ -56,6 +57,12 @@ struct HipFileConfiguration : public Test {
     {
         EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::UNSUPPORTED_FILE_SYSTEMS)))
             .WillOnce(Return(const_cast<char *>(hipfile_unsupported_file_systems)));
+    }
+
+    void expect_configuration_async_buffer_size(const char *hipfile_async_buffer_size)
+    {
+        EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::ASYNC_BUFFER_SIZE)))
+            .WillOnce(Return(const_cast<char *>(hipfile_async_buffer_size)));
     }
 };
 
@@ -234,6 +241,30 @@ TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariable
 {
     expect_configuration_unsupported_file_systems("false");
     ASSERT_FALSE(Configuration().unsupportedFileSystems());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsNotSet)
+{
+    expect_configuration_async_buffer_size(nullptr);
+    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsInvalid)
+{
+    expect_configuration_async_buffer_size("not-a-number");
+    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsSet)
+{
+    expect_configuration_async_buffer_size("2097152");
+    ASSERT_EQ(2097152, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsZero)
+{
+    expect_configuration_async_buffer_size("0");
+    ASSERT_EQ(1_MiB, Configuration().asyncBufferSize());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -57,6 +57,12 @@ struct HipFileConfiguration : public Test {
         EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::UNSUPPORTED_FILE_SYSTEMS)))
             .WillOnce(Return(const_cast<char *>(hipfile_unsupported_file_systems)));
     }
+
+    void expect_configuration_async_buffer_size(const char *hipfile_async_buffer_size)
+    {
+        EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::ASYNC_BUFFER_SIZE)))
+            .WillOnce(Return(const_cast<char *>(hipfile_async_buffer_size)));
+    }
 };
 
 TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsNotSet)
@@ -234,6 +240,30 @@ TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariable
 {
     expect_configuration_unsupported_file_systems("false");
     ASSERT_FALSE(Configuration().unsupportedFileSystems());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsNotSet)
+{
+    expect_configuration_async_buffer_size(nullptr);
+    ASSERT_EQ(1 << 20, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsInvalid)
+{
+    expect_configuration_async_buffer_size("not-a-number");
+    ASSERT_EQ(1 << 20, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsSet)
+{
+    expect_configuration_async_buffer_size("2097152");
+    ASSERT_EQ(2097152, Configuration().asyncBufferSize());
+}
+
+TEST_F(HipFileConfiguration, AsyncBufferSizeEnvironmentVariableIsZero)
+{
+    expect_configuration_async_buffer_size("0");
+    ASSERT_EQ(1 << 20, Configuration().asyncBufferSize());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/environment.cpp
+++ b/projects/hipfile/test/amd_detail/environment.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <limits>
 #include <memory>
 
 using namespace hipFile;
@@ -63,7 +64,7 @@ TEST(HipFileEnvironment, GetBoolReturnsOptionalFalseIfFalse)
     ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(false));
 }
 
-TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfNotSet)
+TEST(HipFileEnvironment, GetIntReturnsNulloptIfNotSet)
 {
     StrictMock<MSys> msys;
 
@@ -71,7 +72,7 @@ TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfNotSet)
     ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
 }
 
-TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfValueIsInvalid)
+TEST(HipFileEnvironment, GetIntReturnsNulloptIfValueIsInvalid)
 {
     StrictMock<MSys> msys;
 
@@ -83,12 +84,46 @@ TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfValueIsInvalid)
     ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
 }
 
-TEST(HipFileEnvironment, GetUnsignedIntReturnsIntIfValueIsInt)
+TEST(HipFileEnvironment, GetIntReturnsIntIfValueIsInt)
 {
     StrictMock<MSys> msys;
 
     EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("0")));
     ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), make_optional<>(0));
+}
+
+TEST(HipFileEnvironment, GetIntReturnsResultOutOfRange)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("999999999999999999999999")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), std::numeric_limits<unsigned int>::max());
+}
+
+TEST(HipFileEnvironment, GetIntReturnsNegative)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("-1")));
+    ASSERT_EQ(hipFile::Environment::get<int>(""), make_optional<>(-1));
+}
+
+TEST(HipFileEnvironment, GetIntegralOverloads)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("1")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), make_optional<>(1));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("2")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned long>(""), make_optional<>(2ul));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("3")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned short>(""), make_optional<>(static_cast<unsigned short>(3)));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("4")));
+    ASSERT_EQ(hipFile::Environment::get<int>(""), make_optional<>(4));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("5")));
+    ASSERT_EQ(hipFile::Environment::get<long>(""), make_optional<>(5l));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("6")));
+    ASSERT_EQ(hipFile::Environment::get<short>(""), make_optional<>(static_cast<short>(6)));
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/environment.cpp
+++ b/projects/hipfile/test/amd_detail/environment.cpp
@@ -91,4 +91,16 @@ TEST(HipFileEnvironment, GetUnsignedIntReturnsIntIfValueIsInt)
     ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), make_optional<>(0));
 }
 
+TEST(HipFileEnvironment, GetUnsignedIntegralOverloads)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("1")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), make_optional<>(1));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("2")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned long>(""), make_optional<>(2ul));
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("3")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned short>(""), make_optional<>(static_cast<unsigned short>(3)));
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/mconfiguration.h
+++ b/projects/hipfile/test/amd_detail/mconfiguration.h
@@ -23,6 +23,7 @@ struct MConfiguration : Configuration {
     MOCK_METHOD(void, fallback, (bool), (noexcept, override));
     MOCK_METHOD(unsigned int, statsLevel, (), (const, noexcept, override));
     MOCK_METHOD(bool, unsupportedFileSystems, (), (const, noexcept, override));
+    MOCK_METHOD(size_t, asyncBufferSize, (), (const, noexcept, override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mstream.h
+++ b/projects/hipfile/test/amd_detail/mstream.h
@@ -19,6 +19,9 @@ public:
     MOCK_METHOD(bool, fixedIOSize, (), (const, override));
     MOCK_METHOD(bool, pageAligned, (), (const, override));
     MOCK_METHOD(std::unique_lock<std::mutex>, getLock, (), (override));
+    MOCK_METHOD(void *, asyncBufferHostPtr, (), (const, override));
+    MOCK_METHOD(void *, asyncBufferDevPtr, (), (const, override));
+    MOCK_METHOD(size_t, asyncBufferSize, (), (const, override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/stream.cpp
+++ b/projects/hipfile/test/amd_detail/stream.cpp
@@ -6,6 +6,7 @@
 #include "hipfile.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
+#include "mconfiguration.h"
 #include "mhip.h"
 #include "msys.h"
 #include "stream.h"
@@ -35,15 +36,32 @@ hipFileFlagsPowerSet()
                               ::testing::Values(0, HIPFILE_STREAM_PAGE_ALIGNED_INPUTS));
 }
 
+static void
+expectStreamBuffer(StrictMock<MConfiguration> &mconfig, StrictMock<MHip> &mhip)
+{
+    EXPECT_CALL(mconfig, asyncBufferSize)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(1 << 20));
+    EXPECT_CALL(mhip, hipHostMalloc)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x1234)));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x5678)));
+    EXPECT_CALL(mhip, hipHostFree).Times(::testing::AnyNumber());
+}
+
 struct HipFileStream : public ::testing::Test {
     HipFileStream()
     {
         nonnull_stream = reinterpret_cast<hipStream_t>(1);
+        expectStreamBuffer(mconfig, mhip);
     }
-    StrictMock<MHip> mhip;
-    StrictMock<MSys> msys;
-    hipStream_t      nonnull_stream;
-    StreamMap        stream_map;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    hipStream_t                nonnull_stream;
+    StreamMap                  stream_map;
 };
 
 struct HipFileStreamValidParams
@@ -108,11 +126,46 @@ TEST_F(HipFileStream, deregister_with_unregistered_stream_throws)
     ASSERT_THROW(stream_map.deregisterStream(nonnull_stream), std::invalid_argument);
 }
 
+TEST_F(HipFileStream, register_buffer_alloc_fails_throws)
+{
+    EXPECT_CALL(mhip, hipStreamGetDevice);
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(::testing::Return(nullptr));
+    ASSERT_THROW(stream_map.registerStream(nonnull_stream, 0), std::runtime_error);
+}
+
+TEST(HipFileStreamDestructor, buffer_free_failure_logs)
+{
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    EXPECT_CALL(mconfig, asyncBufferSize)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(1 << 20));
+    EXPECT_CALL(mhip, hipHostMalloc)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x1234)));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x5678)));
+    EXPECT_CALL(mhip, hipHostFree)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Throw(Hip::RuntimeError(hipErrorInvalidValue)));
+    EXPECT_CALL(msys, syslog);
+    {
+        StreamMap stream_map;
+        EXPECT_CALL(mhip, hipStreamGetDevice);
+        stream_map.registerStream(reinterpret_cast<hipStream_t>(1), 0);
+        stream_map.deregisterStream(reinterpret_cast<hipStream_t>(1));
+    }
+}
+
 TEST(HipFileStreamDestructor, destructor_with_streams_in_use_logs)
 {
-    StrictMock<MHip>         mhip;
-    StrictMock<MSys>         msys;
-    std::shared_ptr<IStream> stream;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    std::shared_ptr<IStream>   stream;
+    expectStreamBuffer(mconfig, mhip);
     {
         StreamMap stream_map;
         EXPECT_CALL(mhip, hipStreamGetDevice);
@@ -126,10 +179,12 @@ struct HipFileStreamExternal : public HipFileOpened {
     HipFileStreamExternal()
     {
         nonnull_stream = reinterpret_cast<hipStream_t>(1);
+        expectStreamBuffer(mconfig, mhip);
     }
-    StrictMock<MHip> mhip;
-    StrictMock<MSys> msys;
-    hipStream_t      nonnull_stream;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    hipStream_t                nonnull_stream;
 };
 
 TEST_F(HipFileStreamExternal, register_and_deregister_with_valid_stream_works)

--- a/projects/hipfile/test/amd_detail/stream.cpp
+++ b/projects/hipfile/test/amd_detail/stream.cpp
@@ -6,6 +6,7 @@
 #include "hipfile.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
+#include "mconfiguration.h"
 #include "mhip.h"
 #include "msys.h"
 #include "stream.h"
@@ -35,15 +36,32 @@ hipFileFlagsPowerSet()
                               ::testing::Values(0, HIPFILE_STREAM_PAGE_ALIGNED_INPUTS));
 }
 
+static void
+expectStreamBuffer(StrictMock<MConfiguration> &mconfig, StrictMock<MHip> &mhip)
+{
+    EXPECT_CALL(mconfig, asyncBufferSize)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(1 << 20));
+    EXPECT_CALL(mhip, hipHostMalloc)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x1234)));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void *>(0x5678)));
+    EXPECT_CALL(mhip, hipHostFree).Times(::testing::AnyNumber());
+}
+
 struct HipFileStream : public ::testing::Test {
     HipFileStream()
     {
         nonnull_stream = reinterpret_cast<hipStream_t>(1);
+        expectStreamBuffer(mconfig, mhip);
     }
-    StrictMock<MHip> mhip;
-    StrictMock<MSys> msys;
-    hipStream_t      nonnull_stream;
-    StreamMap        stream_map;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    hipStream_t                nonnull_stream;
+    StreamMap                  stream_map;
 };
 
 struct HipFileStreamValidParams
@@ -108,11 +126,20 @@ TEST_F(HipFileStream, deregister_with_unregistered_stream_throws)
     ASSERT_THROW(stream_map.deregisterStream(nonnull_stream), std::invalid_argument);
 }
 
+TEST_F(HipFileStream, register_buffer_alloc_fails_throws)
+{
+    EXPECT_CALL(mhip, hipStreamGetDevice);
+    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(::testing::Return(nullptr));
+    ASSERT_THROW(stream_map.registerStream(nonnull_stream, 0), std::runtime_error);
+}
+
 TEST(HipFileStreamDestructor, destructor_with_streams_in_use_logs)
 {
-    StrictMock<MHip>         mhip;
-    StrictMock<MSys>         msys;
-    std::shared_ptr<IStream> stream;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    std::shared_ptr<IStream>   stream;
+    expectStreamBuffer(mconfig, mhip);
     {
         StreamMap stream_map;
         EXPECT_CALL(mhip, hipStreamGetDevice);
@@ -126,10 +153,12 @@ struct HipFileStreamExternal : public HipFileOpened {
     HipFileStreamExternal()
     {
         nonnull_stream = reinterpret_cast<hipStream_t>(1);
+        expectStreamBuffer(mconfig, mhip);
     }
-    StrictMock<MHip> mhip;
-    StrictMock<MSys> msys;
-    hipStream_t      nonnull_stream;
+    StrictMock<MConfiguration> mconfig;
+    StrictMock<MHip>           mhip;
+    StrictMock<MSys>           msys;
+    hipStream_t                nonnull_stream;
 };
 
 TEST_F(HipFileStreamExternal, register_and_deregister_with_valid_stream_works)

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -1073,14 +1073,14 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 // Fallback path where the IO is several times the async buffer size, so the fallback loops over
-// multiple chunks. The async buffer defaults to 1 MiB, so a 4 MiB IO spans four chunks.
+// multiple chunks. The async buffer defaults to 16 MiB, so a 64 MiB IO spans four chunks.
 class HipAsyncFallbackMultiChunk : public HipAsync, public ::testing::WithParamInterface<AsyncIoFunction> {
 public:
     HipAsyncFallbackMultiChunk()
     {
-        io_size     = 4_MiB;
-        file_size   = 4_MiB;
-        buffer_size = 4_MiB;
+        io_size     = 64_MiB;
+        file_size   = 64_MiB;
+        buffer_size = 64_MiB;
     }
     void SetUp() override
     {
@@ -1141,9 +1141,9 @@ class HipAsyncFallbackMultiChunkShrink : public HipAsyncStreamUnfixedPaused,
 public:
     HipAsyncFallbackMultiChunkShrink()
     {
-        io_size     = 4_MiB;
-        file_size   = 4_MiB;
-        buffer_size = 4_MiB;
+        io_size     = 64_MiB;
+        file_size   = 64_MiB;
+        buffer_size = 64_MiB;
     }
     void SetUp() override
     {
@@ -1175,10 +1175,10 @@ public:
 
 TEST_P(HipAsyncFallbackMultiChunkShrink, shrinkBelowChunkCountStillCorrect)
 {
-    // Submit the full 4 MiB (four 1 MiB chunks) while paused, then shrink to 1.5 MiB before releasing.
+    // Submit the full 64 MiB (four 16 MiB chunks) while paused, then shrink to 24 MiB before releasing.
     // That leaves two real chunks plus two surplus chunks that must no-op; bytes_transferred must
     // reflect the shrunken size and the untouched tail of the destination must stay zero.
-    const size_t shrunk_size = 1_MiB + 512_KiB;
+    const size_t shrunk_size = 16_MiB + 8_MiB;
     ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
               HIPFILE_SUCCESS);
     io_size = shrunk_size;

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -259,7 +259,7 @@ public:
             // For a read, bytes_transferred_internal needs to be set to simulate that the read from disk
             // occurred. We fill the source (CPU bounce buffer) with random data and memset the destination
             // (GPU buffer) to zero.
-            HipFileDataOps::randomizeMemoryRegion(op->bounceBufferHostPtr(), 0, io_size);
+            HipFileDataOps::randomizeMemoryRegion(op->bounce_buffer_host_ptr, 0, io_size);
             op->bytes_transferred_internal = static_cast<ssize_t>(io_size);
             ASSERT_EQ(hipMemset(op->gpu_buffer, 0, buffer_size), hipSuccess);
             ASSERT_EQ(hipStreamSynchronize(nullptr), hipSuccess);
@@ -268,7 +268,7 @@ public:
             // For a write, we fill the source (GPU bounce buffer) with random data and memset the destination
             // (CPU bounce buffer) to zero.
             HipFileDataOps::randomizeMemoryRegion(op->gpu_buffer, 0, buffer_size);
-            memset(op->bounceBufferHostPtr(), 0, io_size);
+            memset(op->bounce_buffer_host_ptr, 0, io_size);
         }
         op_dev_ptr            = op->devPtr();
         kernel_args[0]        = {&op_dev_ptr};
@@ -288,6 +288,7 @@ public:
     size_t                           file_size         = 4_KiB;
     size_t                           buffer_size       = 4_KiB;
     size_t                           io_size           = 4_KiB;
+    size_t                           chunk_size        = 1_MiB;
     hoff_t                           file_offset       = 0;
     hoff_t                           buffer_offset     = 0;
     ssize_t                          bytes_transferred = 0;
@@ -332,14 +333,13 @@ TEST_F(HipAsyncMemcpyKernel, nullCpuBufferDevPointerReturnsInval)
 }
 
 struct AsyncMemcpyKernelTestParams {
-    IoType  io_type;
-    size_t  file_size;
-    size_t  buffer_size;
-    size_t  io_size;
-    hoff_t  file_offset;
-    hoff_t  buffer_offset;
-    ssize_t bytes_transferred_start;
-    ssize_t bytes_transferred_result;
+    IoType io_type;
+    size_t buffer_size;
+    size_t io_size;
+    hoff_t buffer_offset;
+    size_t chunk_size;
+    size_t bytes_completed; // op->bytes_transferred_internal at kernel launch (offset already done)
+    size_t expected_chunk;  // bytes this single kernel invocation copies
 };
 
 class HipAsyncMemcpyKernelWithParams : public HipAsyncMemcpyKernel,
@@ -347,25 +347,33 @@ class HipAsyncMemcpyKernelWithParams : public HipAsyncMemcpyKernel,
 public:
     void SetUp() override
     {
-        auto [_io_type, _file_size, _buffer_size, _io_size, _file_offset, _buffer_offset,
-              _bytes_transferred_start, _bytes_transferred_result] = GetParam();
-        io_type                                                    = _io_type;
-        file_size                                                  = _file_size;
-        buffer_size                                                = _buffer_size;
-        io_size                                                    = _io_size;
-        file_offset                                                = _file_offset;
-        buffer_offset                                              = _buffer_offset;
-        bytes_transferred_start                                    = _bytes_transferred_start;
-        bytes_transferred_result                                   = _bytes_transferred_result;
+        auto [_io_type, _buffer_size, _io_size, _buffer_offset, _chunk_size, _bytes_completed,
+              _expected_chunk] = GetParam();
+        io_type                = _io_type;
+        buffer_size            = _buffer_size;
+        io_size                = _io_size;
+        buffer_offset          = _buffer_offset;
+        chunk_size             = _chunk_size;
+        bytes_completed        = _bytes_completed;
+        expected_chunk         = _expected_chunk;
         HipAsyncMemcpyKernel::SetUp();
-        op->bytes_transferred_internal = bytes_transferred_start;
+        // The op's bounce buffer size normally comes from the stream's async buffer. Override it with the
+        // chunk_size param so the write path stages at most one chunk per kernel invocation, letting a
+        // full interior chunk sit strictly in the middle of a larger IO.
+        op->bounce_buffer_size         = chunk_size;
+        op->bytes_transferred_internal = static_cast<ssize_t>(bytes_completed);
+        // On a read, cpu_copy runs before the kernel and publishes how many bytes it staged in the
+        // bounce buffer; simulate that here. On a write, the kernel computes and publishes it.
+        if (io_type == IoType::Read) {
+            op->chunk_bytes_copied = expected_chunk;
+        }
     }
     void TearDown() override
     {
         HipAsyncMemcpyKernel::TearDown();
     }
-    ssize_t bytes_transferred_start;
-    ssize_t bytes_transferred_result;
+    size_t bytes_completed;
+    size_t expected_chunk;
 };
 
 TEST_P(HipAsyncMemcpyKernelWithParams, verifyIoRegions)
@@ -374,38 +382,53 @@ TEST_P(HipAsyncMemcpyKernelWithParams, verifyIoRegions)
                                          dim3(static_cast<uint32_t>(max_threads_per_block)), kernel_args, 0,
                                          op->stream->getHipStream());
     Context<Hip>::get()->hipStreamSynchronize(op->stream->getHipStream());
-    ASSERT_EQ(op->bytes_transferred_internal, bytes_transferred_result);
-    if (op->bytes_transferred_internal > 0) {
-        if (io_type == IoType::Read) {
-            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(buffer_offset));
-        }
-        HipFileDataOps::assertMemoryRegionsMatch(op->bounceBufferHostPtr(), 0, op->gpu_buffer, buffer_offset,
-                                                 static_cast<size_t>(op->bytes_transferred_internal));
-        if (io_type == IoType::Read) {
-            size_t end_length = buffer_size - (static_cast<size_t>(buffer_offset) +
-                                               static_cast<size_t>(op->bytes_transferred_internal));
-            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer,
-                                                  buffer_offset + op->bytes_transferred_internal, end_length);
-        }
+    // The kernel copies a single chunk; it leaves the running offset for async_io_advance to update.
+    ASSERT_EQ(op->bytes_transferred_internal, static_cast<ssize_t>(bytes_completed));
+    ASSERT_EQ(op->chunk_bytes_copied, expected_chunk);
+    if (expected_chunk == 0) {
+        return;
+    }
+    // The chunk lands at buffer_offset plus however much has already been transferred.
+    const hoff_t chunk_gpu_offset = buffer_offset + static_cast<hoff_t>(bytes_completed);
+    if (io_type == IoType::Read) {
+        HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(chunk_gpu_offset));
+    }
+    HipFileDataOps::assertMemoryRegionsMatch(op->bounce_buffer_host_ptr, 0, op->gpu_buffer, chunk_gpu_offset,
+                                             expected_chunk);
+    if (io_type == IoType::Read) {
+        size_t end_length = buffer_size - (static_cast<size_t>(chunk_gpu_offset) + expected_chunk);
+        HipFileDataOps::assertZeroedMemRegion(
+            op->gpu_buffer, chunk_gpu_offset + static_cast<hoff_t>(expected_chunk), end_length);
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(
     HipAsyncMemcpyKernelSuite, HipAsyncMemcpyKernelWithParams,
     testing::Values(
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB, 0, 0, 1_MiB, 1_MiB},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB, 0, 0, 1_MiB, 1_MiB},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 8_KiB, 0, 4_KiB, 1_MiB - 8_KiB,
-                                    1_MiB - 8_KiB},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 8_KiB, 0, 4_KiB, 1_MiB - 8_KiB,
-                                    1_MiB - 8_KiB},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 1, 0, 0, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 1, 0, 0, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 1, 0, 1, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 1, 0, 1, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 2, 0, 1, 1_MiB - 2, 1_MiB - 2},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 2, 0, 1, 1_MiB - 2, 1_MiB - 2},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB, 0, 0, 512_KiB, 512_KiB}),
+        // Single chunk covers the whole transfer (chunk_size >= io_size, nothing completed yet).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 1_MiB, 0, 1_MiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 1_MiB, 0, 1_MiB},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 8_KiB, 4_KiB, 1_MiB, 0, 1_MiB - 8_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 8_KiB, 4_KiB, 1_MiB, 0, 1_MiB - 8_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 1, 0, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 1, 0, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 1, 1, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 1, 1, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 2, 1, 1_MiB, 0, 1_MiB - 2},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 2, 1, 1_MiB, 0, 1_MiB - 2},
+        // Short read: cpu_copy staged fewer bytes than a full chunk (e.g. EOF).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 1_MiB, 0, 512_KiB},
+        // Middle chunk: a full interior chunk, with bytes already transferred before it and untouched
+        // buffer still remaining after it (1 MiB IO, 256 KiB chunk, second of four chunks).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 256_KiB, 256_KiB, 256_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 256_KiB, 256_KiB, 256_KiB},
+        // Final full chunk: the last chunk is a full chunk that lands exactly at the buffer end
+        // (1 MiB IO, 512 KiB chunk, second of two chunks).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 512_KiB, 512_KiB, 512_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 512_KiB, 512_KiB, 512_KiB},
+        // Tail chunk: chunk_size larger than what remains, so the kernel clamps to the remainder.
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 512_KiB, 768_KiB, 256_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 512_KiB, 768_KiB, 256_KiB}),
     [](const testing::TestParamInfo<HipAsyncMemcpyKernelWithParams::ParamType> &param_info) {
         auto params = param_info.param;
 
@@ -416,9 +439,8 @@ INSTANTIATE_TEST_SUITE_P(
         else {
             label << "write";
         }
-        label << "_" << params.file_size << "_" << params.buffer_size << "_" << params.io_size << "_"
-              << params.file_offset << "_" << params.buffer_offset << "_" << params.bytes_transferred_start
-              << "_" << params.bytes_transferred_result;
+        label << "_" << params.buffer_size << "_" << params.io_size << "_" << params.buffer_offset << "_"
+              << params.chunk_size << "_" << params.bytes_completed << "_" << params.expected_chunk;
         return label.str();
     });
 #endif
@@ -1047,6 +1069,136 @@ TEST_P(HipAsyncStreamUnfixedPausedReadWrite, changedIOSizeAndBufferOffsetAndFile
 INSTANTIATE_TEST_SUITE_P(
     HipAsyncStreamUnfixed, HipAsyncStreamUnfixedPausedReadWrite, ::testing::ValuesIn(asyncIOFns),
     [](const testing::TestParamInfo<HipAsyncStreamUnfixedPausedReadWrite::ParamType> &param_info) {
+        return param_info.param.name;
+    });
+
+// Fallback path where the IO is several times the async buffer size, so the fallback loops over
+// multiple chunks. The async buffer defaults to 1 MiB, so a 4 MiB IO spans four chunks.
+class HipAsyncFallbackMultiChunk : public HipAsync, public ::testing::WithParamInterface<AsyncIoFunction> {
+public:
+    HipAsyncFallbackMultiChunk()
+    {
+        io_size     = 4_MiB;
+        file_size   = 4_MiB;
+        buffer_size = 4_MiB;
+    }
+    void SetUp() override
+    {
+        HipAsync::SetUp();
+        io_op = GetParam().function;
+        name  = GetParam().name;
+
+        // Force the fallback backend. Disabling fastpath means backend selection throws rather than
+        // silently choosing fastpath, guaranteeing the fallback path is exercised.
+        Context<Configuration>::get()->fastpath(false);
+        Context<Configuration>::get()->fallback(true);
+
+        if (name == "hipFileReadAsync") {
+            HipFileDataOps::zeroMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
+        }
+        else {
+            HipFileDataOps::zeroFileRegion(tf.fd, file_size);
+            HipFileDataOps::randomizeMemoryRegion(dev_ptr, 0, buffer_size);
+        }
+
+        ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
+        ASSERT_EQ(hipFileStreamRegister(stream, 0xf), HIPFILE_SUCCESS);
+    }
+    void TearDown() override
+    {
+        ASSERT_EQ(hipFileStreamDeregister(stream), HIPFILE_SUCCESS);
+        ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
+        Context<Configuration>::get()->fastpath(true);
+        Context<Configuration>::get()->fallback(true);
+        HipAsync::TearDown();
+    }
+    hipFileError_t (*io_op)(hipFileHandle_t, void *, size_t *, hoff_t *, hoff_t *, ssize_t *, hipStream_t);
+    std::string name;
+    hipStream_t stream;
+};
+
+TEST_P(HipAsyncFallbackMultiChunk, spansMultipleChunks)
+{
+    ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
+              HIPFILE_SUCCESS);
+    ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+    ASSERT_EQ(bytes_transferred, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(HipAsyncFallbackMultiChunkSuite, HipAsyncFallbackMultiChunk,
+                         ::testing::ValuesIn(asyncIOFns),
+                         [](const testing::TestParamInfo<HipAsyncFallbackMultiChunk::ParamType> &param_info) {
+                             return param_info.param.name;
+                         });
+
+// Fallback path on an unfixed, paused stream where the IO shrinks by more than a whole chunk after
+// submission. The fallback fixes the chunk count from the original (multi-chunk) size at submission
+// time, so the surplus chunks must safely no-op once bind_params publishes the smaller size.
+class HipAsyncFallbackMultiChunkShrink : public HipAsyncStreamUnfixedPaused,
+                                         public ::testing::WithParamInterface<AsyncIoFunction> {
+public:
+    HipAsyncFallbackMultiChunkShrink()
+    {
+        io_size     = 4_MiB;
+        file_size   = 4_MiB;
+        buffer_size = 4_MiB;
+    }
+    void SetUp() override
+    {
+        HipAsyncStreamUnfixedPaused::SetUp();
+        io_op = GetParam().function;
+        name  = GetParam().name;
+
+        Context<Configuration>::get()->fastpath(false);
+        Context<Configuration>::get()->fallback(true);
+
+        if (name == "hipFileReadAsync") {
+            HipFileDataOps::zeroMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
+        }
+        else {
+            HipFileDataOps::randomizeMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::zeroFileRegion(tf.fd, file_size);
+        }
+    }
+    void TearDown() override
+    {
+        Context<Configuration>::get()->fastpath(true);
+        Context<Configuration>::get()->fallback(true);
+        HipAsyncStreamUnfixedPaused::TearDown();
+    }
+    hipFileError_t (*io_op)(hipFileHandle_t, void *, size_t *, hoff_t *, hoff_t *, ssize_t *, hipStream_t);
+    std::string name;
+};
+
+TEST_P(HipAsyncFallbackMultiChunkShrink, shrinkBelowChunkCountStillCorrect)
+{
+    // Submit the full 4 MiB (four 1 MiB chunks) while paused, then shrink to 1.5 MiB before releasing.
+    // That leaves two real chunks plus two surplus chunks that must no-op; bytes_transferred must
+    // reflect the shrunken size and the untouched tail of the destination must stay zero.
+    const size_t shrunk_size = 1_MiB + 512_KiB;
+    ASSERT_EQ(io_op(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
+              HIPFILE_SUCCESS);
+    io_size = shrunk_size;
+    updateFlag(1);
+    ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+    ASSERT_EQ(bytes_transferred, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    if (name == "hipFileReadAsync") {
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(shrunk_size),
+                                              buffer_size - shrunk_size);
+    }
+    else {
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(shrunk_size),
+                                               file_size - shrunk_size);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HipAsyncFallbackMultiChunkShrinkSuite, HipAsyncFallbackMultiChunkShrink, ::testing::ValuesIn(asyncIOFns),
+    [](const testing::TestParamInfo<HipAsyncFallbackMultiChunkShrink::ParamType> &param_info) {
         return param_info.param.name;
     });
 

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -259,7 +259,7 @@ public:
             // For a read, bytes_transferred_internal needs to be set to simulate that the read from disk
             // occurred. We fill the source (CPU bounce buffer) with random data and memset the destination
             // (GPU buffer) to zero.
-            HipFileDataOps::randomizeMemoryRegion(op->bounceBufferHostPtr(), 0, io_size);
+            HipFileDataOps::randomizeMemoryRegion(op->bounce_buffer_host_ptr, 0, io_size);
             op->bytes_transferred_internal = static_cast<ssize_t>(io_size);
             ASSERT_EQ(hipMemset(op->gpu_buffer, 0, buffer_size), hipSuccess);
             ASSERT_EQ(hipStreamSynchronize(nullptr), hipSuccess);
@@ -268,7 +268,7 @@ public:
             // For a write, we fill the source (GPU bounce buffer) with random data and memset the destination
             // (CPU bounce buffer) to zero.
             HipFileDataOps::randomizeMemoryRegion(op->gpu_buffer, 0, buffer_size);
-            memset(op->bounceBufferHostPtr(), 0, io_size);
+            memset(op->bounce_buffer_host_ptr, 0, io_size);
         }
         op_dev_ptr            = op->devPtr();
         kernel_args[0]        = {&op_dev_ptr};
@@ -288,6 +288,7 @@ public:
     size_t                           file_size         = 4_KiB;
     size_t                           buffer_size       = 4_KiB;
     size_t                           io_size           = 4_KiB;
+    size_t                           chunk_size        = 1_MiB;
     hoff_t                           file_offset       = 0;
     hoff_t                           buffer_offset     = 0;
     ssize_t                          bytes_transferred = 0;
@@ -332,14 +333,13 @@ TEST_F(HipAsyncMemcpyKernel, nullCpuBufferDevPointerReturnsInval)
 }
 
 struct AsyncMemcpyKernelTestParams {
-    IoType  io_type;
-    size_t  file_size;
-    size_t  buffer_size;
-    size_t  io_size;
-    hoff_t  file_offset;
-    hoff_t  buffer_offset;
-    ssize_t bytes_transferred_start;
-    ssize_t bytes_transferred_result;
+    IoType io_type;
+    size_t buffer_size;
+    size_t io_size;
+    hoff_t buffer_offset;
+    size_t chunk_size;
+    size_t bytes_completed; // op->bytes_transferred_internal at kernel launch (offset already done)
+    size_t expected_chunk;  // bytes this single kernel invocation copies
 };
 
 class HipAsyncMemcpyKernelWithParams : public HipAsyncMemcpyKernel,
@@ -347,25 +347,29 @@ class HipAsyncMemcpyKernelWithParams : public HipAsyncMemcpyKernel,
 public:
     void SetUp() override
     {
-        auto [_io_type, _file_size, _buffer_size, _io_size, _file_offset, _buffer_offset,
-              _bytes_transferred_start, _bytes_transferred_result] = GetParam();
-        io_type                                                    = _io_type;
-        file_size                                                  = _file_size;
-        buffer_size                                                = _buffer_size;
-        io_size                                                    = _io_size;
-        file_offset                                                = _file_offset;
-        buffer_offset                                              = _buffer_offset;
-        bytes_transferred_start                                    = _bytes_transferred_start;
-        bytes_transferred_result                                   = _bytes_transferred_result;
+        auto [_io_type, _buffer_size, _io_size, _buffer_offset, _chunk_size, _bytes_completed,
+              _expected_chunk] = GetParam();
+        io_type                = _io_type;
+        buffer_size            = _buffer_size;
+        io_size                = _io_size;
+        buffer_offset          = _buffer_offset;
+        chunk_size             = _chunk_size;
+        bytes_completed        = _bytes_completed;
+        expected_chunk         = _expected_chunk;
         HipAsyncMemcpyKernel::SetUp();
-        op->bytes_transferred_internal = bytes_transferred_start;
+        op->bytes_transferred_internal = static_cast<ssize_t>(bytes_completed);
+        // On a read, cpu_copy runs before the kernel and publishes how many bytes it staged in the
+        // bounce buffer; simulate that here. On a write, the kernel computes and publishes it.
+        if (io_type == IoType::Read) {
+            op->chunk_bytes_copied = expected_chunk;
+        }
     }
     void TearDown() override
     {
         HipAsyncMemcpyKernel::TearDown();
     }
-    ssize_t bytes_transferred_start;
-    ssize_t bytes_transferred_result;
+    size_t bytes_completed;
+    size_t expected_chunk;
 };
 
 TEST_P(HipAsyncMemcpyKernelWithParams, verifyIoRegions)
@@ -374,38 +378,48 @@ TEST_P(HipAsyncMemcpyKernelWithParams, verifyIoRegions)
                                          dim3(static_cast<uint32_t>(max_threads_per_block)), kernel_args, 0,
                                          op->stream->getHipStream());
     Context<Hip>::get()->hipStreamSynchronize(op->stream->getHipStream());
-    ASSERT_EQ(op->bytes_transferred_internal, bytes_transferred_result);
-    if (op->bytes_transferred_internal > 0) {
-        if (io_type == IoType::Read) {
-            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(buffer_offset));
-        }
-        HipFileDataOps::assertMemoryRegionsMatch(op->bounceBufferHostPtr(), 0, op->gpu_buffer, buffer_offset,
-                                                 static_cast<size_t>(op->bytes_transferred_internal));
-        if (io_type == IoType::Read) {
-            size_t end_length = buffer_size - (static_cast<size_t>(buffer_offset) +
-                                               static_cast<size_t>(op->bytes_transferred_internal));
-            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer,
-                                                  buffer_offset + op->bytes_transferred_internal, end_length);
-        }
+    // The kernel copies a single chunk; it leaves the running offset for async_io_advance to update.
+    ASSERT_EQ(op->bytes_transferred_internal, static_cast<ssize_t>(bytes_completed));
+    ASSERT_EQ(op->chunk_bytes_copied, expected_chunk);
+    if (expected_chunk == 0) {
+        return;
+    }
+    // The chunk lands at buffer_offset plus however much has already been transferred.
+    const hoff_t chunk_gpu_offset = buffer_offset + static_cast<hoff_t>(bytes_completed);
+    if (io_type == IoType::Read) {
+        HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(chunk_gpu_offset));
+    }
+    HipFileDataOps::assertMemoryRegionsMatch(op->bounce_buffer_host_ptr, 0, op->gpu_buffer, chunk_gpu_offset,
+                                             expected_chunk);
+    if (io_type == IoType::Read) {
+        size_t end_length = buffer_size - (static_cast<size_t>(chunk_gpu_offset) + expected_chunk);
+        HipFileDataOps::assertZeroedMemRegion(
+            op->gpu_buffer, chunk_gpu_offset + static_cast<hoff_t>(expected_chunk), end_length);
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(
     HipAsyncMemcpyKernelSuite, HipAsyncMemcpyKernelWithParams,
     testing::Values(
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB, 0, 0, 1_MiB, 1_MiB},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB, 0, 0, 1_MiB, 1_MiB},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 8_KiB, 0, 4_KiB, 1_MiB - 8_KiB,
-                                    1_MiB - 8_KiB},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 8_KiB, 0, 4_KiB, 1_MiB - 8_KiB,
-                                    1_MiB - 8_KiB},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 1, 0, 0, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 1, 0, 0, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 1, 0, 1, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 1, 0, 1, 1_MiB - 1, 1_MiB - 1},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB - 2, 0, 1, 1_MiB - 2, 1_MiB - 2},
-        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 1_MiB - 2, 0, 1, 1_MiB - 2, 1_MiB - 2},
-        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 1_MiB, 0, 0, 512_KiB, 512_KiB}),
+        // Single chunk covers the whole transfer (chunk_size >= io_size, nothing completed yet).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 1_MiB, 0, 1_MiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 1_MiB, 0, 1_MiB},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 8_KiB, 4_KiB, 1_MiB, 0, 1_MiB - 8_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 8_KiB, 4_KiB, 1_MiB, 0, 1_MiB - 8_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 1, 0, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 1, 0, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 1, 1, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 1, 1, 1_MiB, 0, 1_MiB - 1},
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB - 2, 1, 1_MiB, 0, 1_MiB - 2},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB - 2, 1, 1_MiB, 0, 1_MiB - 2},
+        // Short read: cpu_copy staged fewer bytes than a full chunk (e.g. EOF).
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 1_MiB, 0, 512_KiB},
+        // Middle chunk: half already transferred, one full chunk remaining.
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 512_KiB, 512_KiB, 512_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 512_KiB, 512_KiB, 512_KiB},
+        // Tail chunk: chunk_size larger than what remains, so the kernel clamps to the remainder.
+        AsyncMemcpyKernelTestParams{IoType::Read, 1_MiB, 1_MiB, 0, 512_KiB, 768_KiB, 256_KiB},
+        AsyncMemcpyKernelTestParams{IoType::Write, 1_MiB, 1_MiB, 0, 512_KiB, 768_KiB, 256_KiB}),
     [](const testing::TestParamInfo<HipAsyncMemcpyKernelWithParams::ParamType> &param_info) {
         auto params = param_info.param;
 
@@ -416,9 +430,8 @@ INSTANTIATE_TEST_SUITE_P(
         else {
             label << "write";
         }
-        label << "_" << params.file_size << "_" << params.buffer_size << "_" << params.io_size << "_"
-              << params.file_offset << "_" << params.buffer_offset << "_" << params.bytes_transferred_start
-              << "_" << params.bytes_transferred_result;
+        label << "_" << params.buffer_size << "_" << params.io_size << "_" << params.buffer_offset << "_"
+              << params.chunk_size << "_" << params.bytes_completed << "_" << params.expected_chunk;
         return label.str();
     });
 #endif


### PR DESCRIPTION
## Motivation

The plan is to potentially lower the memory footprint of an async workload by reusing a single bounce buffer for all async IOs performed on a stream. To accommodate this the IOs may need to be broken into smaller chunks that fit on the bounce buffer.

## Technical Details

- Introduce HIPFILE_ASYNC_BUFFER_SIZE environment variable for controlling the bounce buffer size.
- Add a pinned bounce buffer to hipFile::Stream to be used by async IOs on that stream.
- Modify Fallback::async_io to queue many copies of the host and kernel functions to perform large IOs using the bounce buffer.

## Issue Tracking

JIRA ID: AIHIPFILE-235

## Test Plan

Running unit tests and system tests on Rowlet.

## Test Result

Tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
