### PR TITLE
Bump the rocm-bootstrap version to 0.2.0

### DIFF
--- a/python/rocm-bootstrap/pyproject.toml
+++ b/python/rocm-bootstrap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocm-bootstrap"
-version = "0.1.0"
+version = "0.2.0"
 description = "GPU detection and target groupings for the ROCm Python ecosystem"
 authors = [{ name = "Advanced Micro Devices, Inc." }]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Motivation

Bumps rocm-bootstrap's minor version to manually release an updated version.

Related issues #3975, ROCm/TheRock#4865

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
