### PR TITLE
fix(rocprofiler-compute): show stall reason in doc of pc sampling

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -83,6 +83,14 @@ Selecting a single kernel with ``host_trap`` PC sampling:
 Selecting a single kernel with ``stochastic`` PC sampling, which adds the
 ``count_issued``, ``count_stalled``, and ``stall_reason`` columns:
 
+Stall reasons
+-------------
+
+The ``stall_reason`` column reports the raw ROCprofiler-SDK reason names for
+samples where a wave did not issue an instruction. For definitions of values
+such as ``WAITCNT``, ``ARBITER_NOT_WIN``, and ``ARBITER_WIN_EX_STALL``, see
+the `ROCprofiler-SDK stall reasons table <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/cdna3-cdna4-pc-sampling.html#stall-reasons>`_.
+
 .. code-block:: shell-session
 
    $ rocprof-compute analyze -p <workload_dir> -k 0

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -839,6 +839,13 @@ def format_table_output(
             get_table_string(df, transpose=transpose, decimal=args.decimal) + "\n"
         )
 
+    if table_id_str == "21.1":
+        content += (
+            "Stall reason definitions: https://rocm.docs.amd.com/projects/"
+            "rocprofiler-sdk/en/latest/how-to/"
+            "cdna3-cdna4-pc-sampling.html#stall-reasons\n"
+        )
+
     return content
 
 

--- a/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
+++ b/projects/rocprofiler-compute/tests/unit/utils/test_tty.py
@@ -102,6 +102,8 @@ def test_format_table_output_keeps_pc_sampling_table_21_1() -> None:
     )
     assert content != ""
     assert "v_mov" in content
+    assert "Stall reason definitions:" in content
+    assert "cdna3-cdna4-pc-sampling.html#stall-reasons" in content
 
 
 def test_has_time_data_detection() -> None:


### PR DESCRIPTION
## Motivation
Stochastic PC sampling exposes raw stall-reason values in both the analysis CLI output and the PC-sampling documentation. Without an explanation or reference, users must infer the meaning of values such as WAITCNT, ARBITER_NOT_WIN, and ARBITER_WIN_EX_STALL, making the results difficult to interpret.

This change connects those raw values to the ROCprofiler-SDK’s authoritative stall-reason glossary. It improves the usability of PC-sampling output while keeping stall-reason definitions maintained in their owning project. Optiq integration is intentionally out of scope and will be handled by the Optiq team.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Added a Stall reasons subsection to docs/how-to/pc_sampling.rst.

Explains that stall_reason contains raw ROCprofiler-SDK not-issued reason names.
Links to the ROCprofiler-SDK CDNA3/CDNA4 PC-sampling stall-reasons table as the authoritative source.
Avoids duplicating enum descriptions that could diverge from the SDK documentation.
Updated the CLI PC-sampling table renderer in src/utils/tty.py.

When table 21.1 PC Sampling is printed, the output now includes a direct reference to the canonical stall-reasons documentation.
The behavior is centralized in the common table formatting path, so it applies to PC-sampling results across supported GPU architectures.
Extended tests/unit/utils/test_tty.py to assert that the PC-sampling CLI output includes the stall-reasons reference.

<!-- Explain the changes along with any relevant GitHub links. -->

## Issue Tracking
JIRA ID: AIPROFCOMP-703
<!-- Include a GitHub Issue and/or JIRA ID. Do not post any full JIRA links here. -->
<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->
<!-- JIRA ID: EXAMPLECOMPONENT-1234 -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
