### PR TITLE
fix(rccl): return ncclInProgress from non-blocking group init when a rank is missing

### DIFF
--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -485,6 +485,29 @@ static void reclaimPlannerState(struct ncclComm* comm) {
   }
 }
 
+// Undo the comm->groupJob links published by the non-blocking branch of
+// ncclGroupEndInternal before that groupJob is destroyed on the fail path.
+// Without this a later ncclCommAbort -> ncclCommEnsureReady -> ncclGroupJobAbort
+// would dereference freed memory. An init/split comm is only reachable via
+// asyncJobs (it is never placed on the groupCommHead chains), so both lists
+// must be walked. Only clears comms that adopted this exact groupJob.
+static void groupJobUnlinkComms(struct ncclGroupJob* groupJob) {
+  if (!ncclIntruQueueEmpty(&groupJob->asyncJobs)) {
+    struct ncclAsyncJob* job = ncclIntruQueueHead(&groupJob->asyncJobs);
+    do {
+      if (job->comm && job->comm->groupJob == groupJob) job->comm->groupJob = NULL;
+      job = job->next;
+    } while (job);
+  }
+  for (int type = 0; type < ncclGroupTaskTypeNum; ++type) {
+    struct ncclComm* comm = groupJob->groupCommHead[type];
+    while (comm != nullptr) {
+      if (comm->groupJob == groupJob) comm->groupJob = NULL;
+      comm = comm->groupNext[type];
+    }
+  }
+}
+
 static void groupCleanup(struct ncclComm** groupCommHeadPtr,
                          struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsPtr,
                          ncclResult_t error) {
@@ -950,6 +973,7 @@ exit:
   return ret;
 fail:
   if (groupJob) {
+    groupJobUnlinkComms(groupJob);
     groupCleanup(groupJob->groupCommHead, &groupJob->asyncJobs, ret);
     delete groupJob;
   } else {

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -895,7 +895,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
 
     /* make sure ncclGroupBlocking has been set. */
     assert(ncclGroupBlocking == 0 || ncclGroupBlocking == 1);
-    if (ncclGroupBlocking == 0 && (ncclGroupCommPreconnectHead != nullptr || !ncclIntruQueueEmpty(&ncclAsyncJobs))) {
+    if (ncclGroupBlocking == 0 && (ncclGroupCommPreconnectHead != nullptr || !ncclIntruQueueEmpty(&groupJob->asyncJobs))) {
       /* nonblocking group */
       if (!ncclIntruQueueEmpty(&groupJob->asyncJobs)) {
         ncclAsyncJob* job = ncclIntruQueueHead(&groupJob->asyncJobs);

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -25,9 +25,12 @@ if(BUILD_TESTS)
   set(TEST_MICRO_SOURCE_FILES
     p2p-test.cc
     rma-proxy-progress-test.cc          # RMA proxy inflight-request coverage
+    group-test.cc
     fakes/nccl_fakes.cc                  # reusable stubs for nccl* symbols
     fakes/p2p_fakes.cc                   # p2p-specific stubs (arch/topo + alloc emulators)
     fakes/rma_fakes.cc                   # rma_proxy_progress externals (circular-buf / destroy)
+    fakes/comm_fakes.cc                  # comm-lifecycle seams (real in init.cc; faked here)
+    fakes/collective_stubs.cc            # fail-loud collective launch + transport floor
     fakes/hip_fakes.cc                   # HIP runtime seams + link-satisfying stubs
     ../common/main_altrsmi.cpp           # minimal gtest main, no RCCL deps
     ../common/ProcessIsolatedTestRunner.cpp
@@ -63,6 +66,7 @@ if(BUILD_TESTS)
   target_compile_definitions(rccl-UnitTestsMicro PRIVATE
     P2P_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/transport/p2p_tmp.cc"
     RMA_PROXY_PROGRESS_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/rma/rma_proxy_progress.cc"
+    GROUP_CC_PATH="${PROJECT_BINARY_DIR}/hipify/src/group.cc"
   )
 
   # Make sure the hipify step has run before trying to compile the test.
@@ -495,9 +499,12 @@ target_link_libraries(rccl-HostUnitTests PRIVATE
 add_executable(rccl-UnitTestsMicro
   p2p-test.cc
   rma-proxy-progress-test.cc
+  group-test.cc
   fakes/nccl_fakes.cc
   fakes/p2p_fakes.cc
   fakes/rma_fakes.cc
+  fakes/comm_fakes.cc
+  fakes/collective_stubs.cc
   fakes/hip_fakes.cc
   ${RCCL_TEST_DIR}/common/main_altrsmi.cpp
   ${RCCL_TEST_DIR}/common/ProcessIsolatedTestRunner.cpp
@@ -517,6 +524,7 @@ target_compile_definitions(rccl-UnitTestsMicro PRIVATE
   ROCM_VERSION=70000
   P2P_CC_PATH="${RCCL_HIPIFY_DIR}/src/transport/p2p_tmp.cc"
   RMA_PROXY_PROGRESS_CC_PATH="${RCCL_HIPIFY_DIR}/src/rma/rma_proxy_progress.cc"
+  GROUP_CC_PATH="${RCCL_HIPIFY_DIR}/src/group.cc"
   # Same fallback-vs-runtime conflicts the host target guards against: without
   # these, p2p-test.cc redefines hipMemFabricHandle_st and the amdsmi fabric
   # enumerators on ROCm 7.14+, and the standalone build fails.

--- a/projects/rccl/test/host/fakes/collective_stubs.cc
+++ b/projects/rccl/test/host/fakes/collective_stubs.cc
@@ -1,0 +1,73 @@
+/*************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+//
+// Fail-loud (::abort()) link-satisfiers for the collective launch/registration
+// pipeline plus the transport connect entry points a group/enqueue TU
+// references but that a host-only control-flow test never executes. Reaching
+// one at run time is a real escape and the abort surfaces it immediately.
+//
+// Self-contained by design: unlike the init binary's transport_stubs.cc (whose
+// NVLS/P2P-level stubs now route through test-driven seam globals defined in
+// the init test's own TUs), this floor has no external seam globals, so it
+// links into any micro-test binary on its own.
+
+#include <cstdlib>
+
+#include "nccl.h"
+#include "comm.h"
+#include "enqueue.h"
+#include "ce_coll.h"
+#include "rma/rma.h"
+#include "rma/rma_ce.h"
+#include "argcheck.h"
+#include "dev_runtime.h"
+#include "transport.h"
+#include "os.h"
+
+// enqueue.h
+ncclResult_t ncclPrepareTasks(struct ncclComm*, bool*, bool*, ncclSimInfo_t*) { ::abort(); }
+ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclLaunchPrepare(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclLaunchKernelBefore_NoUncapturedCuda(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+ncclResult_t ncclLaunchKernel(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+ncclResult_t ncclLaunchKernelAfter_NoCuda(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+ncclResult_t ncclLaunchFinish(struct ncclComm*) { ::abort(); }
+
+// ce_coll.h
+ncclResult_t ncclCeInit(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclLaunchCeColl(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+
+// rma/rma.h, rma/rma_ce.h
+ncclResult_t ncclLaunchRma(struct ncclComm*, struct ncclKernelPlan*) { ::abort(); }
+ncclResult_t ncclRmaCeInit(struct ncclComm*) { ::abort(); }
+
+// dev_runtime.h
+ncclResult_t ncclDevrCommCreateInternal(struct ncclComm*, struct ncclDevCommRequirements*,
+                                        struct ncclDevComm*, bool, struct ncclDevCommCompat*) { ::abort(); }
+ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm*, void*, size_t, int,
+                                           struct ncclWindow_vidmem**) { ::abort(); }
+void freeDevCommRequirements(struct ncclDevCommRequirements*) { ::abort(); }
+
+// mem_manager.h
+ncclResult_t ncclCommMemSuspend(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclCommMemResume(struct ncclComm*) { ::abort(); }
+
+// argcheck.h
+ncclResult_t ncclArgsGlobalCheck(struct ncclArgsInfo*) { ::abort(); }
+
+// os.h
+int ncclOsCpuCount(const ncclAffinity&) { ::abort(); }
+ncclResult_t ncclOsSetAffinity(const ncclAffinity&) { ::abort(); }
+
+// transport.h -- only the connect/setup entry points group.cc references.
+ncclResult_t ncclTransportP2pSetup(struct ncclComm*, struct ncclTopoGraph*, int, bool*) { ::abort(); }
+ncclResult_t ncclTransportRingConnect(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclTransportTreeConnect(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclTransportPatConnect(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclNvlsBufferSetup(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclNvlsTreeConnect(struct ncclComm*) { ::abort(); }
+ncclResult_t ncclCollNetChainBufferSetup(ncclComm_t) { ::abort(); }
+ncclResult_t ncclCollNetDirectBufferSetup(ncclComm_t) { ::abort(); }

--- a/projects/rccl/test/host/fakes/collective_stubs.cc
+++ b/projects/rccl/test/host/fakes/collective_stubs.cc
@@ -18,6 +18,7 @@
 
 #include "nccl.h"
 #include "comm.h"
+#include "mem_manager.h"
 #include "enqueue.h"
 #include "ce_coll.h"
 #include "rma/rma.h"

--- a/projects/rccl/test/host/fakes/comm_fakes.cc
+++ b/projects/rccl/test/host/fakes/comm_fakes.cc
@@ -16,6 +16,12 @@
 
 #include "fakes/comm_fakes.h"
 
+#include "signature-drift.h"
+
+ASSERT_HOOK_MATCHES_PROD(g_commSetAsyncError, ncclCommSetAsyncError);
+
+#undef ASSERT_HOOK_MATCHES_PROD
+
 // --- Controllable seam ----------------------------------------------------
 static ncclResult_t DefaultCommSetAsyncError(struct ncclComm*, ncclResult_t) {
   return ncclSuccess;

--- a/projects/rccl/test/host/fakes/comm_fakes.cc
+++ b/projects/rccl/test/host/fakes/comm_fakes.cc
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+//
+// See comm_fakes.h. Communicator-lifecycle symbols real in the init unit but
+// faked for other micro-test units: the ncclCommSetAsyncError seam, a couple of
+// comm/util globals, and the pure-instrumentation recorder / nvtx no-ops.
+
+#include "nccl.h"
+#include "comm.h"      // also pulls recorder.h (no include guard)
+#include "utils.h"
+#include "roctx.h"
+#include "profiler.h"
+
+#include "fakes/comm_fakes.h"
+
+// --- Controllable seam ----------------------------------------------------
+static ncclResult_t DefaultCommSetAsyncError(struct ncclComm*, ncclResult_t) {
+  return ncclSuccess;
+}
+std::function<ncclResult_t(struct ncclComm*, ncclResult_t)> g_commSetAsyncError =
+    DefaultCommSetAsyncError;
+
+ncclResult_t ncclCommSetAsyncError(struct ncclComm* comm, ncclResult_t nextState) {
+  return g_commSetAsyncError(comm, nextState);
+}
+
+void ResetCommFakes() {
+  g_commSetAsyncError = DefaultCommSetAsyncError;
+}
+
+// --- Comm / util globals (real in init.cc / utils.cc) ---------------------
+enum ncclLaunchMode ncclParamLaunchMode = ncclLaunchModeParallel;
+
+// Per-thread wait signal referenced by the inline MPSC-callback drain helpers
+// in utils.h.
+thread_local struct ncclThreadSignal ncclThreadSignalLocalInstance = {};
+
+// --- Pure instrumentation (no behaviour to assert) ------------------------
+namespace rccl {
+Recorder::Recorder() {}
+Recorder::~Recorder() {}
+Recorder& Recorder::instance() {
+  static Recorder inst;
+  return inst;
+}
+ncclResult_t Recorder::record(rcclCall_t, int) { return ncclSuccess; }  // group op
+void Recorder::record(int, ncclSimInfo_t*) {}                           // SimulatedGroupEnd
+}  // namespace rccl
+
+roctx_scoped_range_in::roctx_scoped_range_in(const char*) noexcept {}
+roctx_scoped_range_in::~roctx_scoped_range_in() {}
+
+thread_local ncclProfilerApiState_t ncclProfilerApiState = {};
+ncclResult_t ncclProfilerRecordGroupApiEventState(ncclProfilerEventState_t) { return ncclSuccess; }
+ncclResult_t ncclProfilerStopGroupApiEvent() { return ncclSuccess; }

--- a/projects/rccl/test/host/fakes/comm_fakes.h
+++ b/projects/rccl/test/host/fakes/comm_fakes.h
@@ -1,0 +1,33 @@
+/*************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Reusable fakes for communicator-lifecycle symbols that are real in the
+// init unit under test (init.cc / utils.cc) but must be faked for any other
+// micro-test unit that instantiates a comm or group. Kept out of the shared
+// nccl_fakes.cc precisely because the init binary compiles the real
+// definitions and would otherwise get a duplicate symbol.
+//
+// The one symbol worth controlling from a test -- ncclCommSetAsyncError -- is
+// exposed as a std::function seam; tests install per-test behaviour from a
+// fixture and call ResetCommFakes() in TearDown.
+
+#ifndef RCCL_TEST_HOST_FAKES_COMM_FAKES_H_
+#define RCCL_TEST_HOST_FAKES_COMM_FAKES_H_
+
+#include <functional>
+
+#include "nccl.h"
+
+struct ncclComm;
+
+// Controllable seam: the async-error state a communicator is moved to. Default
+// returns ncclSuccess; a test observes/injects by overwriting the hook.
+extern std::function<ncclResult_t(struct ncclComm*, ncclResult_t)> g_commSetAsyncError;
+
+// Restore every comm_fakes seam to its default. Call from a fixture TearDown.
+void ResetCommFakes();
+
+#endif  // RCCL_TEST_HOST_FAKES_COMM_FAKES_H_

--- a/projects/rccl/test/host/group-test.cc
+++ b/projects/rccl/test/host/group-test.cc
@@ -32,10 +32,36 @@
 
 #include "fakes/comm_fakes.h"    // controllable ncclCommSetAsyncError seam
 #include "fakes/nccl_fakes.h"    // g_loadParam, used by param_redirect.h
+#include "ScopedHook.h"          // RAII install/restore for controllable seams
 
 // Route group.cc's NCCL_PARAM sites through g_loadParam instead of the real
 // ncclLoadParam (see param_redirect.h); must precede the unit under test.
 #include "fakes/param_redirect.h"
+
+// Controllable thread-creation seam. group.cc creates the non-blocking init
+// background thread via STDTHREADCREATE_GOTO; when the seam returns true the
+// macro takes its failure branch (goto fail with ncclSystemError) without
+// actually spawning a thread, so the fail: path can be exercised
+// deterministically. Tests install the failing behaviour via ScopedHook so it
+// is restored automatically. checks.h is included first (with its own guard)
+// so the real STDTHREADCREATE_IMPL stays available; only the _GOTO wrapper is
+// replaced, and the redefinition survives into the textual include of group.cc
+// below.
+static std::function<bool()> g_threadCreateShouldFail = [] { return false; };
+#include "checks.h"
+#undef STDTHREADCREATE_GOTO
+#define STDTHREADCREATE_GOTO(var, func, RES, label, ...) \
+  do { \
+    if (g_threadCreateShouldFail && g_threadCreateShouldFail()) { \
+      (RES) = ncclSystemError; \
+      goto label; \
+    } else { \
+      STDTHREADCREATE_IMPL( \
+          var, func, \
+          do { (RES) = ncclSystemError; goto label; } while (0), \
+          __VA_ARGS__); \
+    } \
+  } while (0)
 
 // Pull in the unit under test so its file-static helpers (groupLaunch,
 // asyncJobLaunch, groupLaunchNonBlocking, ...) are visible. Must come after the
@@ -80,7 +106,9 @@ class GroupEndInternalTest : public ::testing::Test {
 
   void TearDown() override {
     // If a non-blocking init spawned a background job, join it and release the
-    // group job before the fixture (and its comm) go away.
+    // group job before the fixture (and its comm) go away. A comm that reached
+    // the fail: path has had its groupJob nulled by group.cc, so this is skipped
+    // for it (and must be -- that groupJob is already deleted).
     if (comm_ && comm_->groupJob) {
       ncclGroupJobComplete(comm_->groupJob);
       comm_->groupJob = nullptr;
@@ -129,6 +157,23 @@ TEST_F(GroupEndInternalTest, NonBlockingGroupWithPendingJob_PublishesGroupJobOnC
   (void)ncclGroupEndInternal();
 
   EXPECT_NE(nullptr, comm_->groupJob);
+}
+
+// If the background thread fails to launch, ncclGroupEndInternal takes the fail:
+// path and destroys the group job. Every comm that adopted that job (an init
+// comm is reachable only via the async-jobs list, never the groupCommHead
+// chains) must have comm->groupJob cleared, otherwise a later ncclCommAbort ->
+// ncclCommEnsureReady -> ncclGroupJobAbort dereferences freed memory.
+TEST_F(GroupEndInternalTest, ThreadCreateFailure_LeavesNoDanglingGroupJob) {
+  EnterGroupWithOnePendingJob(/*blocking=*/0);
+  ScopedHook failThreadCreate(g_threadCreateShouldFail, [] { return true; });
+
+  // The fail: path really ran (system error), and the comm's groupJob -- which
+  // the non-blocking branch published before the thread create -- was cleared
+  // rather than left dangling into the just-deleted group job.
+  EXPECT_EQ(ncclSystemError, ncclGroupEndInternal());
+  EXPECT_EQ(nullptr, comm_->groupJob);
+  EXPECT_EQ(1, failThreadCreate.calls);
 }
 
 // Contrast: a blocking group runs its jobs on the caller and reports the final

--- a/projects/rccl/test/host/group-test.cc
+++ b/projects/rccl/test/host/group-test.cc
@@ -1,0 +1,137 @@
+/*************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+//
+// Host-only microtests for ncclGroupEndInternal's blocking-vs-non-blocking
+// path selection (src/group.cc).
+//
+// These pin the contract that a non-blocking group (config.blocking == 0) with
+// pending async init jobs hands the work to a background thread and returns
+// ncclInProgress immediately -- it must NOT run the jobs synchronously on the
+// caller. That is exactly the guarantee ncclCommInitRankConfig(blocking=0)
+// relies on so a caller can poll / time out / abort when a peer rank never
+// shows up.
+//
+// The suite compiles the hipified src/group.cc directly (via GROUP_CC_PATH) so
+// the file-static launch helpers are reachable, and satisfies every external
+// group.cc references with the module-organised test doubles in fakes/
+// (comm_fakes, collective_stubs, ...). No GPU, no librccl.so, no
+// HIP runtime.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "nccl.h"
+#include "comm.h"
+#include "group.h"
+
+#include "fakes/comm_fakes.h"    // controllable ncclCommSetAsyncError seam
+#include "fakes/nccl_fakes.h"    // g_loadParam, used by param_redirect.h
+
+// Route group.cc's NCCL_PARAM sites through g_loadParam instead of the real
+// ncclLoadParam (see param_redirect.h); must precede the unit under test.
+#include "fakes/param_redirect.h"
+
+// Pull in the unit under test so its file-static helpers (groupLaunch,
+// asyncJobLaunch, groupLaunchNonBlocking, ...) are visible. Must come after the
+// headers / fakes it depends on are in scope.
+#include GROUP_CC_PATH
+
+namespace {
+
+// A job body that succeeds instantly, standing in for a real communicator-init
+// job. The behaviour under test is which *thread* runs this (background vs
+// caller), not what the job itself does.
+ncclResult_t FakeInitJobSucceeds(struct ncclAsyncJob*) { return ncclSuccess; }
+
+class GroupEndInternalTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<ncclComm> comm_;
+  std::unique_ptr<ncclAsyncJob> job_;
+
+  // Records every ncclCommSetAsyncError state pushed to comm_.
+  std::vector<ncclResult_t> asyncStates_;
+
+  void SetUp() override {
+    ResetCommFakes();
+
+    // Reset the thread-local group state group.cc reads. ncclGroupEndInternal
+    // runs on this thread, so the thread-locals it inspects are these.
+    ncclGroupDepth = 0;
+    ncclGroupError = ncclSuccess;
+    for (int type = 0; type < ncclGroupTaskTypeNum; ++type) ncclGroupCommHead[type] = nullptr;
+    ncclGroupCommPreconnectHead = nullptr;
+    ncclGroupBlocking = -1;
+    ncclIntruQueueConstruct(&ncclAsyncJobs);
+
+    comm_ = std::make_unique<ncclComm>();  // value-initialised => zeroed
+    comm_->groupJob = nullptr;
+
+    g_commSetAsyncError = [this](struct ncclComm*, ncclResult_t state) {
+      asyncStates_.push_back(state);
+      return ncclSuccess;
+    };
+  }
+
+  void TearDown() override {
+    // If a non-blocking init spawned a background job, join it and release the
+    // group job before the fixture (and its comm) go away.
+    if (comm_ && comm_->groupJob) {
+      ncclGroupJobComplete(comm_->groupJob);
+      comm_->groupJob = nullptr;
+    }
+    ResetCommFakes();
+  }
+
+  // Queue a single pending async job owned by comm_ and enter a group whose
+  // blocking mode is `blocking`, mirroring the state ncclCommInitRankConfig
+  // leaves behind just before ncclGroupEnd.
+  void EnterGroupWithOnePendingJob(int blocking) {
+    comm_->config.blocking = blocking;
+
+    job_ = std::make_unique<ncclAsyncJob>();
+    job_->func = FakeInitJobSucceeds;
+    job_->comm = comm_.get();
+    job_->state = ncclGroupJobRunning;
+
+    ncclGroupStartInternal();  // ncclGroupDepth = 1
+    ncclGroupBlocking = blocking;
+    ncclIntruQueueEnqueue(&ncclAsyncJobs, job_.get());
+  }
+};
+
+// The fix: a non-blocking group carrying pending init work must return
+// ncclInProgress (handing the work to a background thread) rather than running
+// it on the caller. Before the fix, ncclGroupEndInternal tested the already-
+// drained ncclAsyncJobs queue, mis-selected the blocking path, and ran the jobs
+// synchronously -- which for a missing peer rank blocks forever.
+TEST_F(GroupEndInternalTest, NonBlockingGroupWithPendingJob_ReturnsInProgress) {
+  EnterGroupWithOnePendingJob(/*blocking=*/0);
+
+  EXPECT_EQ(ncclInProgress, ncclGroupEndInternal());
+}
+
+// The non-blocking path also publishes a group job on the communicator, which
+// is what lets the caller subsequently poll or abort it.
+TEST_F(GroupEndInternalTest, NonBlockingGroupWithPendingJob_PublishesGroupJobOnComm) {
+  EnterGroupWithOnePendingJob(/*blocking=*/0);
+
+  (void)ncclGroupEndInternal();
+
+  EXPECT_NE(nullptr, comm_->groupJob);
+}
+
+// Contrast: a blocking group runs its jobs on the caller and reports the final
+// result (ncclSuccess here), leaving no group job to poll.
+TEST_F(GroupEndInternalTest, BlockingGroupWithPendingJob_RunsSynchronouslyAndReturnsSuccess) {
+  EnterGroupWithOnePendingJob(/*blocking=*/1);
+
+  EXPECT_EQ(ncclSuccess, ncclGroupEndInternal());
+  EXPECT_EQ(nullptr, comm_->groupJob);
+}
+
+}  // namespace

--- a/projects/rccl/test/host/group-test.cc
+++ b/projects/rccl/test/host/group-test.cc
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -113,6 +114,11 @@ TEST_F(GroupEndInternalTest, NonBlockingGroupWithPendingJob_ReturnsInProgress) {
   EnterGroupWithOnePendingJob(/*blocking=*/0);
 
   EXPECT_EQ(ncclInProgress, ncclGroupEndInternal());
+
+  // The non-blocking path publishes ncclInProgress on the comm's async error;
+  // that is the state a caller polls on until the background job completes.
+  EXPECT_NE(asyncStates_.end(),
+            std::find(asyncStates_.begin(), asyncStates_.end(), ncclInProgress));
 }
 
 // The non-blocking path also publishes a group job on the communicator, which

--- a/projects/rccl/test/test_categories_micro.yaml
+++ b/projects/rccl/test/test_categories_micro.yaml
@@ -16,6 +16,7 @@ test_categories:
       - "FreshRegistrationMicrotest.*"
       - "FreshRegistrationLegacyIpcSucceedsFixture.*"
       - "RmaProxyProgressTest.*"
+      - "GroupEndInternalTest.*"
     exclude_windows:
       - "*"
     labels:


### PR DESCRIPTION
## What

`ncclCommInitRankConfig` with `ncclConfig_t.blocking = 0` could block inside the
call instead of returning promptly. In the simplest case — a 2-rank
communicator where rank 1 never starts — rank 0's non-blocking init should
return at once with `ncclInProgress` so the caller can poll, time out, or abort.
On stock RCCL it instead waited for the missing rank and hung.

## Why / root cause

In `ncclGroupEndInternal` (`src/group.cc`), the pending async jobs are moved out
of `ncclAsyncJobs` into `groupJob->asyncJobs` via `ncclIntruQueueTransfer`, which
empties `ncclAsyncJobs`. The subsequent non-blocking-vs-blocking decision still
inspected the now-empty `ncclAsyncJobs`, so a non-blocking init with pending work
mis-selected the blocking path and ran the jobs synchronously on the caller —
blocking forever when a peer rank is absent. The check must look at
`groupJob->asyncJobs`, which owns the jobs after the move.

The fix is a one-line change to inspect `groupJob->asyncJobs` in that predicate.

## Testing

- Ran the reproducer provided on the ticket on an 8xgfx950 machine: it hangs on
  `develop` (reproducing the bug) and passes with this fix, returning
  `ncclInProgress` promptly.
- Added a host-only microtest (`GroupEndInternalTest` in `rccl-UnitTestsMicro`)
  that pins the branch selection: a non-blocking group carrying a pending init
  job returns `ncclInProgress` and publishes a group job on the communicator,
  while the blocking-group contrast test still runs synchronously and returns
  `ncclSuccess`.
- Proved the guard is real: reverting the one-line fix in the hipified tree
  turns the two non-blocking assertions red and leaves the blocking test green.
- Full `test/host/run_host_tests.sh all` pipeline passes (`rccl-UnitTestsMicro`
  33 tests, plus the HostUnitTests and init micro-test binaries).
- The externals `group.cc` reaches are satisfied by module-organised fakes
  (`comm_fakes`, `enqueue_stubs`, reused `transport_stubs`, `param_redirect.h`).

This branch also cherry-picks the `AMDSMI_FABRIC_DIRECT` / `HIP_FABRIC_API`
init-target defines so the host micro-test binaries build cleanly.

JIRA ID : ROCM-30165
