### PR TITLE
[rocjitsu][CI] Exclude additional ROCr races from TSan

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -245,15 +245,18 @@ jobs:
             # async-event bookkeeping, outside rocjitsu-owned code.
             "HsaTranslateTest\.TranslateAndDispatchVectorAdd"
             "HsaTranslateTest\.TranslateAndDispatchMfma16x16"
-            # HIP test discovery initializes the instrumented ROCr client, which
-            # reports a ConcurrentAsyncEvents race. The device-to-device case also
-            # reaches that ROCr race through the daemon client; vector add exposes
-            # unsynchronized simulator/client buffer access as well.
+            # HIP test discovery and the daemon HIP clients initialize the
+            # instrumented ROCr runtime, which can report a ConcurrentAsyncEvents
+            # race during asynchronous-event teardown outside rocjitsu-owned code.
+            # Vector add also exposes unsynchronized simulator/client buffer access.
             "HipMemcpyTest\.RoundTripFloat"
             "HipMemcpyTest\.RoundTripInt"
             "HipMemcpyTest\.DeviceToDevice"
             "HipVectorAddTest\.CorrectResult"
+            "DaemonTest\.HipMemcpyRoundTripFloat"
+            "DaemonTest\.HipMemcpyRoundTripInt"
             "DaemonTest\.HipMemcpyDeviceToDevice"
+            "DaemonTest\.TwoIndependentClients"
             # This test has a five-second wall-clock assertion that becomes
             # load-sensitive at the TSan job's CI-level parallelism.
             "DaemonApi\.FullListenerQueueDoesNotBlockOrRemoveSocket"


### PR DESCRIPTION
## Summary

This PR extends the narrowly scoped TSan exclusions introduced by [#10472](https://github.com/ROCm/rocm-systems/pull/10472) to three additional daemon tests:

- `DaemonTest.HipMemcpyRoundTripFloat`
- `DaemonTest.HipMemcpyRoundTripInt`
- `DaemonTest.TwoIndependentClients`

These tests exercise valid rocjitsu daemon/client paths, but their instrumented HIP client processes intermittently report the same race in ROCr asynchronous-event teardown. This PR changes only `TSAN_EXCLUDED_TESTS`; it does not change rocjitsu product code, Release coverage, or the existing ASan+UBSan test selection.

## Failure signature

The daemon test launches a HIP test client through rocjitsu and checks that the child exits successfully. In the observed failures, the inner HIP functional test completes and prints `[ OK ]`. During client shutdown, however, TSan reports a race and changes the child exit status to 66. The parent daemon test then fails its `r.exit_code == 0` assertion in `daemon_test.cpp`.

The stable TSan signature is:

- one write is an 8-byte `free` on ROCr worker thread T1;
- the first runtime frame is `rocr::core::Runtime::ConcurrentAsyncEvents::GetAllEvents(...)` in `libhsa-runtime64.so.1`;
- the conflicting prior write is an allocation on the main HIP client thread;
- T1 is created through `rocr::os::os_thread`;
- the report contains allocator, ROCr, HIP, and GoogleTest frames, but no conflicting access in a `rocjitsu::` frame.

For example, the float failure shows the inner `HipMemcpyTest.RoundTripFloat` passing before TSan emits `SUMMARY: ThreadSanitizer: data race ... ConcurrentAsyncEvents::GetAllEvents`; only then does `DaemonTest.HipMemcpyRoundTripFloat` fail because the child returned 66. This places the reported race in ROCr client teardown rather than in the simulated dispatch or rocjitsu daemon logic.

## CI provenance

The same signature has appeared repeatedly across unrelated branches and on `develop`, with the individual daemon cases varying according to thread scheduling:

| Date (UTC) | Workflow/job | Source revision | Triggering test | Evidence |
| --- | --- | --- | --- | --- |
| 2026-08-26 | [run 32984422226, TSan job 98228396290](https://github.com/ROCm/rocm-systems/actions/runs/32984422226/job/98228396290) | `users/agutierr/vfu-msix-vectors-stage5` at `0cf35c4c4ecbf10bd16bad5654899a59b8808dc3` | `DaemonTest.TwoIndependentClients` | The inner float client passes; ROCr T1 frees memory in `ConcurrentAsyncEvents::GetAllEvents`; the daemon test fails. |
| 2026-08-26 | [run 32999233616, TSan job 98276347922](https://github.com/ROCm/rocm-systems/actions/runs/32999233616/job/98276347922) | `users/agutierr/vfu-pci-device-stage0` at `3429877a85455f446b30684198ec44060938e0ed` | `DaemonTest.HipMemcpyRoundTripFloat` | TSan reports the ROCr `ConcurrentAsyncEvents::GetAllEvents` free/allocation race after the inner test succeeds. |
| 2026-08-26 | [run 32999740064, TSan job 98278121081](https://github.com/ROCm/rocm-systems/actions/runs/32999740064/job/98278121081) | `develop` at `b732b329dfed0c7a80d826b6604f8ac3130caf7c` | `DaemonTest.HipMemcpyRoundTripInt` | The integer client reaches the same ROCr teardown signature and exits under TSan. |
| 2026-08-26 | [run 33006644777, TSan job 98302004904](https://github.com/ROCm/rocm-systems/actions/runs/33006644777/job/98302004904) | `mfma-native-width-simd` at `736a69a47458e36d4611be56aad48d1d003cf62d` | `DaemonTest.HipMemcpyRoundTripInt` | Repeated integer-case failure with the same first runtime frame and no rocjitsu access frame. |
| 2026-08-26 | [run 33009069029, TSan job 98310305694](https://github.com/ROCm/rocm-systems/actions/runs/33009069029/job/98310305694) | `develop` at `19edfdf9dcc6e701cc07d5a5db897a48f8580617` | `DaemonTest.HipMemcpyRoundTripFloat` | The inner test passes in 4.399 seconds, TSan reports one `ConcurrentAsyncEvents` warning, and the daemon wrapper fails with exit code 66. |

The failures on unrelated changes and two separate `develop` revisions support treating this as a runtime-owned scheduling flake rather than a regression caused by any one rocjitsu patch.

## Scope and coverage

The direct HIP memcpy tests are already excluded from TSan for this ROCr limitation, and #10472 applied the same treatment to `DaemonTest.HipMemcpyDeviceToDevice`. This PR completes that targeted treatment for the remaining daemon wrappers observed to reach the identical runtime teardown path.

The exclusion remains test-specific rather than suppressing `ConcurrentAsyncEvents::GetAllEvents` globally. A broad function or library suppression could hide unrelated ROCr reports elsewhere in the suite; exact GTest filters remove only the known external-runtime triggers. Release continues to exercise these functional paths, the ASan+UBSan selection is unchanged, and the rest of the daemon suite remains enabled under TSan.

The updated selection is validated by the passing [PR TSan job](https://github.com/ROCm/rocm-systems/actions/runs/33013370670/job/98325138493).

Co-authored-by: GPT-5.6 Sol <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)