### PR TITLE
[rocjitsu] Make XCD packet replication test deterministic

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -258,6 +258,15 @@ public:
     return qs == nullptr ? 0 : qs->accepted_entries;
   }
 
+  /// @brief Kinds of the first two entries accepted on this CP for the queue.
+  /// @details Test-only. The order matches the queue's ordered push site.
+  [[nodiscard]] std::array<DispatchPacketKind, 2>
+  first_accepted_entry_kinds_for_test(uint32_t queue_id, uint32_t process_id) {
+    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+    const auto *qs = find_queue_state(queue_id, process_id);
+    return qs == nullptr ? std::array<DispatchPacketKind, 2>{} : qs->first_accepted_entry_kinds;
+  }
+
   /// @brief Hardware queues registered with this CP, including fan-out replicas.
   ///
   /// @details Test-only. Whether a queue is present here as an owner or as a

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -246,20 +246,16 @@ public:
 
   [[nodiscard]] size_t next_cu_index() const { return next_cu_; }
 
-  /// @brief Deepest (@p queue_id, @p process_id) ever got on this CP.
+  /// @brief Number of entries (@p queue_id, @p process_id) accepted on this CP.
   ///
-  /// @details Test-only. A replica's entry list is otherwise unobservable: a packet
-  /// that runs no shader retires in zero time, so once a run finishes every queue is
-  /// empty whether or not those packets were ever placed on the peers at all. The
-  /// peak is recorded by the owning CP as it pushes, under its own queue mutex, so
-  /// this is read AFTER a run rather than sampled during one. Sampling was the
-  /// earlier design and was wrong: it reached into every peer CP from inside a
-  /// workgroup callback that already held the dispatching CP's mutex, which is a
-  /// lock-order inversion between any two CPs the moment more than one thread runs.
-  [[nodiscard]] size_t peak_queued_entry_count_for_test(uint32_t queue_id, uint32_t process_id) {
+  /// @details Test-only. Acceptance is recorded at the queue's single ordered push
+  /// site under this CP's queue mutex and read AFTER a run. Unlike queue depth, the
+  /// count does not depend on whether a peer retires an earlier entry before the
+  /// next one arrives.
+  [[nodiscard]] size_t accepted_entry_count_for_test(uint32_t queue_id, uint32_t process_id) {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     const auto *qs = find_queue_state(queue_id, process_id);
-    return qs == nullptr ? 0 : qs->peak_entries;
+    return qs == nullptr ? 0 : qs->accepted_entries;
   }
 
   /// @brief Hardware queues registered with this CP, including fan-out replicas.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -457,8 +457,8 @@ struct HwQueueState {
   bool fanout_replica = false;
 
   /// @brief Append an entry, maintaining accepted_entries.
-  /// @details The single ordered push site, so the acceptance count cannot drift
-  /// from the deque. Callers already hold the CP's queue mutex.
+  /// @details The single ordered push site, so the acceptance count tracks the number
+  /// of pushed entries. Callers already hold the CP's queue mutex.
   void push_entry(DispatchEntry entry) {
     if (accepted_entries < first_accepted_entry_kinds.size())
       first_accepted_entry_kinds[accepted_entries] = entry.kind;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -436,13 +436,12 @@ struct HwQueueState {
 
   Status status = Status::IDLE;
   std::deque<DispatchEntry> entries;
-  /// @brief High-water mark of entries.size(), for tests.
-  /// @details A replica's entry list is otherwise unobservable: a packet that runs
-  /// no shader retires in zero time, so once a run finishes every queue is empty
-  /// whether or not those packets were ever placed on the peers at all. Recording
-  /// the peak as entries are pushed lets the assertion happen AFTER the run, so a
-  /// test never has to reach into a peer CP while that peer is running.
-  size_t peak_entries = 0;
+  /// @brief Total entries accepted by this queue, for tests.
+  /// @details A replica's entry list is otherwise unobservable after its packets
+  /// retire. Recording acceptance at the queue's single ordered push site lets a
+  /// test verify delivery AFTER the run without depending on how many entries
+  /// happened to coexist in the queue or reaching into a running peer CP.
+  size_t accepted_entries = 0;
   bool implicit_barrier_next = false;
   size_t next_dispatch_idx = 0;
   uint64_t queue_desc_va = 0;
@@ -451,12 +450,12 @@ struct HwQueueState {
   /// dispatch shards from the XCD that does.
   bool fanout_replica = false;
 
-  /// @brief Append an entry, maintaining peak_entries.
-  /// @details The single push site, so the high-water mark cannot drift from the
-  /// deque. Callers already hold the CP's queue mutex.
+  /// @brief Append an entry, maintaining accepted_entries.
+  /// @details The single ordered push site, so the acceptance count cannot drift
+  /// from the deque. Callers already hold the CP's queue mutex.
   void push_entry(DispatchEntry entry) {
     entries.push_back(std::move(entry));
-    peak_entries = std::max(peak_entries, entries.size());
+    ++accepted_entries;
   }
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -14,7 +14,6 @@
 
 #include "rocjitsu/vm/amdgpu/xcd_shard.h"
 
-#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cassert>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -15,6 +15,7 @@
 #include "rocjitsu/vm/amdgpu/xcd_shard.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -442,6 +443,11 @@ struct HwQueueState {
   /// test verify delivery AFTER the run without depending on how many entries
   /// happened to coexist in the queue or reaching into a running peer CP.
   size_t accepted_entries = 0;
+  /// @brief Kinds of the first two accepted entries, for tests.
+  /// @details Bounded because the replication-order test needs only the submitted
+  /// kernel and the non-kernel packet behind it; production queues must not retain
+  /// an unbounded history after entries retire.
+  std::array<DispatchPacketKind, 2> first_accepted_entry_kinds{};
   bool implicit_barrier_next = false;
   size_t next_dispatch_idx = 0;
   uint64_t queue_desc_va = 0;
@@ -454,6 +460,8 @@ struct HwQueueState {
   /// @details The single ordered push site, so the acceptance count cannot drift
   /// from the deque. Callers already hold the CP's queue mutex.
   void push_entry(DispatchEntry entry) {
+    if (accepted_entries < first_accepted_entry_kinds.size())
+      first_accepted_entry_kinds[accepted_entries] = entry.kind;
     entries.push_back(std::move(entry));
     ++accepted_entries;
   }

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -412,9 +412,8 @@ TEST(XcdDistributionTest, FanoutReplicatesNonKernelPacketsButSignalsThemOnce) {
       << "a replicated packet must still signal once, not once per XCD";
 }
 
-// The replication itself. Every XCD must accept the IB entry after its share of
-// the kernel ahead of it, so the ordering each XCD reads from the entries in front
-// of a barrier'd packet is the owner's ordering and not a shortened one.
+// The replication itself. Every XCD must accept its share of the kernel and then
+// the following IB.
 //
 // The acceptance count and first two packet kinds are read from each CP AFTER the
 // run. Together they prove that the kernel and then the IB reached each queue

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -416,10 +416,10 @@ TEST(XcdDistributionTest, FanoutReplicatesNonKernelPacketsButSignalsThemOnce) {
 // the kernel ahead of it, so the ordering each XCD reads from the entries in front
 // of a barrier'd packet is the owner's ordering and not a shortened one.
 //
-// The acceptance count is read from each CP AFTER the run. It proves both entries
-// reached each queue without requiring them to coexist there: with one thread per
-// XCD, a peer may legitimately retire its kernel shard before the owner fans out
-// the IB behind it.
+// The acceptance count and first two packet kinds are read from each CP AFTER the
+// run. Together they prove that the kernel and then the IB reached each queue
+// without requiring them to coexist there: with one thread per XCD, a peer may
+// legitimately retire its kernel shard before the owner fans out the IB behind it.
 TEST(XcdDistributionTest, EveryXcdAcceptsNonKernelPacketsInQueueOrder) {
   XcdDistributionFixture fx(Threading::ThreadPerXcd);
 
@@ -433,10 +433,15 @@ TEST(XcdDistributionTest, EveryXcdAcceptsNonKernelPacketsInQueueOrder) {
   fx.engine->run();
 
   for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
-    EXPECT_EQ(fx.soc->xcd(xi)->command_processor()->accepted_entry_count_for_test(
-                  /*queue_id=*/1, /*process_id=*/0),
-              2u)
+    auto *xcd_cp = fx.soc->xcd(xi)->command_processor();
+    EXPECT_EQ(xcd_cp->accepted_entry_count_for_test(/*queue_id=*/1, /*process_id=*/0), 2u)
         << "xcd" << xi << " did not accept the kernel share and the IB behind it";
+    const auto kinds =
+        xcd_cp->first_accepted_entry_kinds_for_test(/*queue_id=*/1, /*process_id=*/0);
+    EXPECT_EQ(kinds[0], amdgpu::DispatchPacketKind::Kernel)
+        << "xcd" << xi << " did not accept the kernel share first";
+    EXPECT_EQ(kinds[1], amdgpu::DispatchPacketKind::NonKernel)
+        << "xcd" << xi << " did not accept the IB after the kernel share";
   }
 }
 

--- a/emulation/rocjitsu/tests/xcd_distribution_test.cpp
+++ b/emulation/rocjitsu/tests/xcd_distribution_test.cpp
@@ -412,36 +412,31 @@ TEST(XcdDistributionTest, FanoutReplicatesNonKernelPacketsButSignalsThemOnce) {
       << "a replicated packet must still signal once, not once per XCD";
 }
 
-// The replication itself. Every XCD must end up holding the IB entry alongside
-// its share of the kernel ahead of it, so the ordering each XCD reads from the
-// entries in front of a barrier'd packet is the owner's ordering and not a
-// shortened one.
+// The replication itself. Every XCD must accept the IB entry after its share of
+// the kernel ahead of it, so the ordering each XCD reads from the entries in front
+// of a barrier'd packet is the owner's ordering and not a shortened one.
 //
-// The depth is read from each CP's own high-water mark AFTER the run, not sampled
-// during it. An earlier version sampled every peer from inside a workgroup callback,
-// which took a second CP's queue mutex while already holding the dispatching CP's --
-// an inversion between any two CPs, and one ThreadSanitizer reports even on a
-// single-threaded run. Recording the peak where the push happens removes the
-// cross-CP reach entirely, which is why this can run one thread per XCD.
-TEST(XcdDistributionTest, EveryXcdHoldsTheNonKernelPacketsOfItsQueue) {
+// The acceptance count is read from each CP AFTER the run. It proves both entries
+// reached each queue without requiring them to coexist there: with one thread per
+// XCD, a peer may legitimately retire its kernel shard before the owner fans out
+// the IB behind it.
+TEST(XcdDistributionTest, EveryXcdAcceptsNonKernelPacketsInQueueOrder) {
   XcdDistributionFixture fx(Threading::ThreadPerXcd);
 
   auto *cp = fx.soc->assign_queue_owner_cp(/*queue_ordinal=*/0);
   ASSERT_NE(cp, nullptr);
   auto queue = test::make_fanout_queue(fx.memory, cp);
 
-  // A long kernel, so the IB behind it is still queued while workgroups run and the
-  // queue genuinely reaches depth two.
   queue->dispatch(kKdAddr, kTotalCus * kWavefrontSize, kWavefrontSize);
   queue->pm4_ib();
 
   fx.engine->run();
 
   for (uint32_t xi = 0; xi < kTotalXcds; ++xi) {
-    EXPECT_GE(fx.soc->xcd(xi)->command_processor()->peak_queued_entry_count_for_test(
+    EXPECT_EQ(fx.soc->xcd(xi)->command_processor()->accepted_entry_count_for_test(
                   /*queue_id=*/1, /*process_id=*/0),
               2u)
-        << "xcd" << xi << " never held both the kernel share and the IB behind it";
+        << "xcd" << xi << " did not accept the kernel share and the IB behind it";
   }
 }
 


### PR DESCRIPTION
This makes the XCD non-kernel packet replication test deterministic by recording ordered queue acceptance instead of requiring the kernel shard and following IB to coexist at a peak queue depth of two. A peer XCD can legitimately retire the one-instruction kernel shard before the owner fans out the IB, so the old assertion depended on thread scheduling rather than the replication contract.

The same flake was observed in two independent CI configurations:

- [develop TSAN job](https://github.com/ROCm/rocm-systems/actions/runs/33009069029/job/98310305694) at commit 19edfdf9dcc6e701cc07d5a5db897a48f8580617: XCD1 reported peak depth 1 instead of 2.
- [PR #10797 Release job](https://github.com/ROCm/rocm-systems/actions/runs/33013370670/job/98325138857) at commit 41dafcf9add15e2595cd857cf06e9d2d720471e9: XCD3 reported peak depth 1 instead of 2.

The replacement assertion verifies that every XCD accepted exactly the submitted kernel shard and following IB through the single ordered queue push site. Locally, the focused test passed 100 consecutive Debug runs and 20 consecutive TSAN runs with no race reports; all 20 XCD distribution tests and the affected pre-commit checks also passed.

Co-authored-by: GPT-5.6 Sol <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)