### PR TITLE
fix(rocprofiler-sdk): KFD dispatch-log signal-less re-review fixes

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -1713,6 +1713,16 @@ interposition_fini()
     // disable active interception
     s_intercept_active.store(false, std::memory_order_release);
 
+    // A fork child that never exec'd still runs this at exit, and everything below
+    // it is unsafe there: the registry wlock and the signal pool's lock may have
+    // been held by a thread that did not survive the fork, so acquiring them hangs
+    // the child, and destroying inherited HSA signals reaches into a runtime the
+    // child does not own. The child abandoned all of this state (D6) and is on its
+    // way out, so skip it -- the same treatment interposition_sync() and
+    // submit_inline_async() already give the fork generation. The atomic stores
+    // above are kept: they are safe and make the child's interception inert.
+    if(internal_threading::fork_stale()) return;
+
     // wait for any in-flight signal handlers to complete and clean up the signal pool
     interposition_sync();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
@@ -272,7 +272,9 @@ public:
     // (containment applied even for a sole candidate -- a stale pending entry could
     // be the sole candidate while the record's true owner is an unregistered later
     // dispatch on a colliding low-32 id). With no START (shape ii), accept only a
-    // sole candidate on a first_owner, non-superseded window. Otherwise drop.
+    // sole candidate on a first_owner, non-superseded window whose t_open the EOP
+    // postdates. Otherwise drop. EVERY acceptance test runs before the entry is
+    // taken, so a rejected record never consumes or retires anything.
     //
     // NO session-mode gate: an EOP arriving during the teardown drain still proves
     // its kernel finished. A key with no live entry is REJECTED, never cached.
@@ -318,6 +320,20 @@ public:
         const auto& w = first->second.window;
         if(!w || !w->first_owner) return std::nullopt;
         if(w->superseded.load(std::memory_order_acquire)) return std::nullopt;
+        // Terminal-time sanity, applied BEFORE take(): a kernel registered in this
+        // window cannot have ended at or before the window opened, so such an EOP
+        // belongs to an earlier dispatch on this raw key whose START was lost.
+        // Taking it would consume and retire a NEWER dispatch's entry against a
+        // foreign record -- the finalizer's staleness bound runs too late to undo
+        // that. Rejected here the entry stays PENDING for its own EOP. Same clock
+        // domain as the containment test above: raw agent GPU ticks, so no
+        // conversion and no host clock is involved. There is deliberately no upper
+        // bound: t_close bounds STARTs, not ends -- a kernel legitimately outlives
+        // its window -- and the hub holds no tick-domain `now` to bound the future
+        // with, so an implausibly-future EOP is still taken here and rejected by
+        // the finalizer's kMaxFutureNs test (a no-timing record, not a misattributed
+        // one).
+        if(end_ticks <= w->t_open) return std::nullopt;
         return take(first);
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dispatch_hub.hpp
@@ -271,7 +271,9 @@ public:
     // (containment applied even for a sole candidate -- a stale pending entry could
     // be the sole candidate while the record's true owner is an unregistered later
     // dispatch on a colliding low-32 id). With no START (shape ii), accept only a
-    // sole candidate on a first_owner, non-superseded window. Otherwise drop.
+    // sole candidate on a first_owner, non-superseded window whose t_open the EOP
+    // postdates. Otherwise drop. EVERY acceptance test runs before the entry is
+    // taken, so a rejected record never consumes or retires anything.
     //
     // NO session-mode gate: an EOP arriving during the teardown drain still proves
     // its kernel finished. A key with no live entry is REJECTED, never cached.
@@ -317,6 +319,20 @@ public:
         const auto& w = first->second.window;
         if(!w || !w->first_owner) return std::nullopt;
         if(w->superseded.load(std::memory_order_acquire)) return std::nullopt;
+        // Terminal-time sanity, applied BEFORE take(): a kernel registered in this
+        // window cannot have ended at or before the window opened, so such an EOP
+        // belongs to an earlier dispatch on this raw key whose START was lost.
+        // Taking it would consume and retire a NEWER dispatch's entry against a
+        // foreign record -- the finalizer's staleness bound runs too late to undo
+        // that. Rejected here the entry stays PENDING for its own EOP. Same clock
+        // domain as the containment test above: raw agent GPU ticks, so no
+        // conversion and no host clock is involved. There is deliberately no upper
+        // bound: t_close bounds STARTs, not ends -- a kernel legitimately outlives
+        // its window -- and the hub holds no tick-domain `now` to bound the future
+        // with, so an implausibly-future EOP is still taken here and rejected by
+        // the finalizer's kMaxFutureNs test (a no-timing record, not a misattributed
+        // one).
+        if(end_ticks <= w->t_open) return std::nullopt;
         return take(first);
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -202,6 +202,35 @@ struct pair_state
     uint64_t equal_tick_drops   = 0;  // EOP tick == retained START tick (fail-closed)
     uint64_t stale_eop_drops    = 0;  // EOP tick < retained START tick (belongs earlier)
     uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
+    uint64_t starts_cap_evicted = 0;  // retained STARTs dropped by the hard size cap
+
+    // Hard bound on pending_starts, mirroring D9's per-GPU hub cap (this map is
+    // per-GPU too, and a START is of the same order in size). evict_stale is only
+    // an AGE backstop -- at the 30-min default a sustained EOP loss exhausts memory
+    // long before it fires -- and D9's cap does not cover this map, because
+    // firmware emits records for signal-fallback dispatches the hub never saw.
+    // Overridden from ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS by the
+    // reader; the default stands for a unit test that never sets it.
+    size_t max_pending_starts = 2'000'000;
+
+    // Drop the single oldest retained START, counting its outstanding STARTs as
+    // lost (each is a dispatch that will now complete start-unknown -- coverage
+    // loss, not a wrong record). RESIDUAL, accepted: this is an O(live) scan, paid
+    // on every insert while the map sits AT the cap. Reaching the cap already means
+    // EOPs are being lost at a rate no sane workload produces, and the alternative
+    // there is memory exhaustion; a cheap victim lookup would need a second index
+    // ordered by seen_at_ns, the same secondary-index work D9 deferred.
+    void evict_oldest_start()
+    {
+        auto _oldest = pending_starts.end();
+        for(auto it = pending_starts.begin(); it != pending_starts.end(); ++it)
+            if(_oldest == pending_starts.end() ||
+               it->second.seen_at_ns < _oldest->second.seen_at_ns)
+                _oldest = it;
+        if(_oldest == pending_starts.end()) return;
+        starts_cap_evicted += _oldest->second.outstanding;
+        pending_starts.erase(_oldest);
+    }
 
     // Stream-driven eviction watermark: the copy timestamp of the last batch that
     // triggered an evict for this GPU. Compared against batch.now_ns,
@@ -424,6 +453,13 @@ pair_records(const copied_record* records,
         if(rec.record_type == kRecStart)
         {
             ++state.starts_seen;
+            // Hard size cap. Only an insert that GROWS the map can breach it, so a
+            // recurring key is exempt -- evicting there could pick the very key
+            // about to be touched and silently reset its `ambiguous` latch. The
+            // size test short-circuits, so the normal path pays no extra lookup.
+            if(state.pending_starts.size() >= state.max_pending_starts &&
+               state.pending_starts.find(key) == state.pending_starts.end())
+                state.evict_oldest_start();
             // dispatch_id is only low-32, so a raw key can recur. A second
             // outstanding START on one key makes it AMBIGUOUS: keep the first
             // START's ticks and age unchanged (so an unpairable key still ages out

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/dlog_drain.hpp
@@ -202,6 +202,35 @@ struct pair_state
     uint64_t equal_tick_drops   = 0;  // EOP tick == retained START tick (fail-closed)
     uint64_t stale_eop_drops    = 0;  // EOP tick < retained START tick (belongs earlier)
     uint64_t starts_evicted     = 0;  // retained STARTs aged out by the watermark
+    uint64_t starts_cap_evicted = 0;  // retained STARTs dropped by the hard size cap
+
+    // Hard bound on pending_starts, mirroring D9's per-GPU hub cap (this map is
+    // per-GPU too, and a START is of the same order in size). evict_stale is only
+    // an AGE backstop -- at the 30-min default a sustained EOP loss exhausts memory
+    // long before it fires -- and D9's cap does not cover this map, because
+    // firmware emits records for signal-fallback dispatches the hub never saw.
+    // Overridden from ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS by the
+    // reader; the default stands for a unit test that never sets it.
+    size_t max_pending_starts = 2'000'000;
+
+    // Drop the single oldest retained START, counting its outstanding STARTs as
+    // lost (each is a dispatch that will now complete start-unknown -- coverage
+    // loss, not a wrong record). RESIDUAL, accepted: this is an O(live) scan, paid
+    // on every insert while the map sits AT the cap. Reaching the cap already means
+    // EOPs are being lost at a rate no sane workload produces, and the alternative
+    // there is memory exhaustion; a cheap victim lookup would need a second index
+    // ordered by seen_at_ns, the same secondary-index work D9 deferred.
+    void evict_oldest_start()
+    {
+        auto _oldest = pending_starts.end();
+        for(auto it = pending_starts.begin(); it != pending_starts.end(); ++it)
+            if(_oldest == pending_starts.end() ||
+               it->second.seen_at_ns < _oldest->second.seen_at_ns)
+                _oldest = it;
+        if(_oldest == pending_starts.end()) return;
+        starts_cap_evicted += _oldest->second.outstanding;
+        pending_starts.erase(_oldest);
+    }
 
     // Stream-driven eviction watermark: the copy timestamp of the last batch that
     // triggered an evict for this GPU. Compared against batch.now_ns,
@@ -426,6 +455,13 @@ pair_records(const copied_record* records,
         if(rec.record_type == kRecStart)
         {
             ++state.starts_seen;
+            // Hard size cap. Only an insert that GROWS the map can breach it, so a
+            // recurring key is exempt -- evicting there could pick the very key
+            // about to be touched and silently reset its `ambiguous` latch. The
+            // size test short-circuits, so the normal path pays no extra lookup.
+            if(state.pending_starts.size() >= state.max_pending_starts &&
+               state.pending_starts.find(key) == state.pending_starts.end())
+                state.evict_oldest_start();
             // dispatch_id is only low-32, so a raw key can recur. A second
             // outstanding START on one key makes it AMBIGUOUS: keep the first
             // START's ticks and age unchanged (so an unpairable key still ages out

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/env_parse.hpp
@@ -67,5 +67,30 @@ env_long_in_range(std::string_view name, long lo, long hi)
     }
     return _val;
 }
+
+// Same reject-and-default policy for a STRICT OPT-IN switch: only an explicit
+// true value turns the feature on. Unset, empty, a recognized false value, or
+// anything unrecognized all yield false -- the unrecognized case with exactly one
+// warning naming the variable and the value.
+//
+// common::get_env<bool> cannot serve here: it maps an unrecognized word ("flase")
+// to TRUE, fatals on empty, and throws on an out-of-range number. For an
+// LD_PRELOAD switch that changes completion semantics, every one of those is the
+// wrong direction -- a typo must never silently enable it and a bad value must
+// never throw out of a static initializer.
+inline bool
+env_bool_opt_in(std::string_view name)
+{
+    auto _raw = common::get_env_optional(name);
+    if(!_raw) return false;  // unset: off, no warning
+
+    const std::string& _s = *_raw;
+    if(_s == "1" || _s == "true" || _s == "yes" || _s == "on") return true;
+    if(_s == "0" || _s == "false" || _s == "no" || _s == "off" || _s.empty()) return false;
+
+    ROCP_WARNING << "KFD dispatch-log: " << name << "='" << _s
+                 << "' is not one of 1/true/yes/on or 0/false/no/off; treating as DISABLED";
+    return false;
+}
 }  // namespace kfd
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -882,9 +882,14 @@ processor_loop()
         // reader's release so the following pipe.empty() is guaranteed to see it.
         // Covers only copied-but-unpublished EOPs (F4); an EOP still in the ring is
         // the accepted R10 residual and is not gated here.
-        const uint64_t _gc_now = common::timestamp_ns();
-        if(gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
-                        st.pipe.empty()) &&
+        // Sequenced into named locals rather than passed inline: the order of
+        // evaluation of function arguments is UNSPECIFIED, so the required
+        // "in-flight load, THEN pipe.empty()" ordering cannot be expressed by
+        // argument position.
+        const uint64_t _gc_now      = common::timestamp_ns();
+        const uint64_t _unpublished = st.reader_copied_unpublished.load(std::memory_order_acquire);
+        const bool     _pipe_empty  = st.pipe.empty();
+        if(gc_gate_open(_unpublished, _pipe_empty) &&
            _gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
         {
             last_gc_ns = _gc_now;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -138,7 +138,8 @@ pending_starts_cap()
 {
     static const size_t _cached = []() -> size_t {
         constexpr long _dflt = 2'000'000;
-        auto _v = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
+        auto           _v =
+            env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
         return static_cast<size_t>(_v.value_or(_dflt));
     }();
     return _cached;
@@ -1170,7 +1171,8 @@ reader_loop()
             // session would stay `ready`, handing out correlation keys nothing can
             // ever deliver. Restricted to the backstop's poll TIMEOUT so the extra
             // ioctl runs at the poll-timeout cadence, not per wake.
-            const bool _probe_fatal = (_act == terminal_action::keep_live) || (_backstop && rc == 0);
+            const bool _probe_fatal =
+                (_act == terminal_action::keep_live) || (_backstop && rc == 0);
             if(_probe_fatal && (read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
             {
                 // Drain-first: defer while records remain (the top-of-loop drain

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -1423,6 +1423,15 @@ start_kfd_reader()
     // the ring, so a first-use allocation there cannot cause an overrun.)
     overrun_reported();
 
+    // Same reasoning for the env-backed knobs: each caches its read in a
+    // function-local static on first use, and common::get_env* scans `environ`,
+    // which races a concurrent setenv. Populate them all HERE, on the one
+    // serialized start path under setup_mu with no worker thread yet in existence,
+    // instead of letting a processor/producer/teardown thread do it lazily.
+    start_max_age_ns();
+    pending_starts_cap();
+    signal_less_prime_env();
+
     // Processor first: it must be ready to consume before the reader can publish,
     // otherwise the first batches are dropped for no reason.
     internal_threading::notify_pre_internal_thread_create(ROCPROFILER_LIBRARY);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -1152,6 +1152,63 @@ reader_loop()
             auto&                 _s   = st.sessions[slot_of[k - kFirstStreamPollSlot]];
             if(_s.quarantined) continue;
 
+            // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
+            // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal are
+            // independent latches in the driver) after which the stream never produces
+            // again ("no live consumer, do not arm"). Read STREAM_OP_STATUS to tell
+            // them apart; FATAL is terminal.
+            //
+            // Also probed with NO revents at all while the empty-wake backstop is
+            // tripped: the backstop polls only the control fd and zeroes the stream
+            // revents, so classify_terminal_revents() reports `none` forever and a
+            // stream that went fatal underneath it would never be re-examined -- the
+            // session would stay `ready`, handing out correlation keys nothing can
+            // ever deliver. Restricted to the backstop's poll TIMEOUT so the extra
+            // ioctl runs at the poll-timeout cadence, not per wake.
+            const bool _probe_fatal = (_act == terminal_action::keep_live) || (_backstop && rc == 0);
+            if(_probe_fatal && (read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
+            {
+                // Drain-first: defer while records remain (the top-of-loop drain
+                // already ran this pass; firmware produces nothing more after
+                // FATAL, so this converges) so no already-published record is lost.
+                if(session_has_pending(_s) || !_s.overflow.empty()) continue;
+                log_stream_status(_s);
+                ROCP_WARNING << fmt::format(
+                    "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
+                    "draining, quarantining, and disabling signal-less process-wide",
+                    _s.gpu_id,
+                    static_cast<unsigned>(fds[k].revents));
+                // Clear ready before quarantine so find_session()/establish_session()
+                // stop handing out keys for a stream that can never deliver them.
+                _s.ready.store(false, std::memory_order_release);
+                _s.quarantined   = true;
+                _quarantined_any = true;
+                // Smallest safe containment: the reset invalidated the clock domain
+                // this stream's windows were opened against, so drop the whole
+                // signal-less path process-wide (hub disable latch drains+ledgers
+                // live entries) rather than risk mis-windowing against a reset clock.
+                //
+                // Ring and overflow are dry above, but the batches already PUBLISHED
+                // into the pipe are not: this session's final EOP, and the EOPs of
+                // every healthy GPU queued behind it, are still waiting on the
+                // processor. Draining the hub first would ledger their entries and
+                // leave those records unmatched. So latch admission closed, let the
+                // processor consume what is published (the same gate the closed-window
+                // GC uses -- copied-unpublished first, then pipe.empty), and only then
+                // ledger the residual. Bounded by the close budget so one wedged
+                // processor cannot stall the ring for the other GPUs; on timeout the
+                // disable proceeds exactly as it did before.
+                signal_less_disable_latch().store(true, std::memory_order_release);
+                const uint64_t _pipe_deadline = common::timestamp_ns() + close_drain_budget_ns();
+                while(!gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
+                                    st.pipe.empty()) &&
+                      common::timestamp_ns() < _pipe_deadline &&
+                      !st.stop.load(std::memory_order_acquire))
+                    std::this_thread::sleep_for(std::chrono::microseconds{200});
+                signal_less_disable_permanently();
+                continue;
+            }
+
             if(_act == terminal_action::none)
             {
                 // A real poll of this stream showing no error clears the edge trigger
@@ -1163,36 +1220,6 @@ reader_loop()
 
             if(_act == terminal_action::keep_live)
             {
-                // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
-                // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal
-                // are independent latches in the driver) after which the stream never
-                // produces again ("no live consumer, do not arm"). Read STREAM_OP_STATUS
-                // to tell them apart; FATAL is terminal.
-                if((read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
-                {
-                    // Drain-first: defer while records remain (the top-of-loop drain
-                    // already ran this pass; firmware produces nothing more after
-                    // FATAL, so this converges) so no already-published record is lost.
-                    if(session_has_pending(_s) || !_s.overflow.empty()) continue;
-                    log_stream_status(_s);
-                    ROCP_WARNING << fmt::format(
-                        "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
-                        "draining, quarantining, and disabling signal-less process-wide",
-                        _s.gpu_id,
-                        static_cast<unsigned>(fds[k].revents));
-                    // Clear ready before quarantine so find_session()/establish_session()
-                    // stop handing out keys for a stream that can never deliver them.
-                    _s.ready.store(false, std::memory_order_release);
-                    _s.quarantined   = true;
-                    _quarantined_any = true;
-                    // Smallest safe containment: the reset invalidated the clock domain
-                    // this stream's windows were opened against, so drop the whole
-                    // signal-less path process-wide (hub disable latch drains+ledgers
-                    // live entries) rather than risk mis-windowing against a reset clock.
-                    signal_less_disable_permanently();
-                    continue;
-                }
-
                 // Recoverable reset: describe it ONCE per episode -- POLLERR is
                 // returned by poll() every pass, so an unlatched warning would spin
                 // the log -- then keep the stream live. The wake already fed the

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -29,6 +29,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
 #include "lib/rocprofiler-sdk/kfd/poll_reader.hpp"
@@ -125,6 +126,24 @@ start_max_age_ns()
     return _cached;
 }
 
+// Hard size cap on a GPU's retained-START map. start_max_age_ns() above is only
+// the slow age backstop, so this is the bound that actually holds under a
+// sustained EOP loss -- exactly the role D9's cap plays for the hub, sized the
+// same way and for the same reason (the map is per-GPU, and a workload's genuine
+// in-flight peak is hundreds of thousands of dispatches). The [1, 4194304] range
+// and the reject-and-default parse are D8/D9's shared contract; read once, forced
+// at reader start so no worker thread races a concurrent setenv.
+size_t
+pending_starts_cap()
+{
+    static const size_t _cached = []() -> size_t {
+        constexpr long _dflt = 2'000'000;
+        auto _v = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
+        return static_cast<size_t>(_v.value_or(_dflt));
+    }();
+    return _cached;
+}
+
 // Overflow depth at which the processor is clearly not keeping up. Not a cap:
 // dropping here would lose records the ring already gave us.
 constexpr size_t kOverflowWarnDepth = 256;
@@ -157,7 +176,12 @@ struct processor_state
 {
     std::unordered_map<uint32_t, pair_state> by_gpu = {};
 
-    pair_state& for_gpu(uint32_t gpu_id) { return by_gpu[gpu_id]; }
+    pair_state& for_gpu(uint32_t gpu_id)
+    {
+        auto [it, ins] = by_gpu.try_emplace(gpu_id);
+        if(ins) it->second.max_pending_starts = pending_starts_cap();
+        return it->second;
+    }
 };
 
 // Validated before any sizing math uses it.
@@ -910,7 +934,8 @@ processor_loop()
             "KFD dispatch-log pairing census (gpu_id={}): {} START record(s) drained, {} EOP "
             "record(s) drained, {} EOP(s) unmatched, {} START(s) overwritten on a live key, {} "
             "ambiguous EOP(s) dropped, {} equal-tick EOP(s) dropped, {} stale EOP(s) dropped, {} "
-            "START(s) evicted stale, {} START(s) still retained at exit",
+            "START(s) evicted stale, {} START(s) evicted by the size cap, {} START(s) still "
+            "retained at exit",
             _gpu_itr.first,
             _p.starts_seen,
             _p.eops_seen,
@@ -920,6 +945,7 @@ processor_loop()
             _p.equal_tick_drops,
             _p.stale_eop_drops,
             _p.starts_evicted,
+            _p.starts_cap_evicted,
             _p.pending_starts.size());
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -1421,6 +1421,15 @@ start_kfd_reader()
     // the ring, so a first-use allocation there cannot cause an overrun.)
     overrun_reported();
 
+    // Same reasoning for the env-backed knobs: each caches its read in a
+    // function-local static on first use, and common::get_env* scans `environ`,
+    // which races a concurrent setenv. Populate them all HERE, on the one
+    // serialized start path under setup_mu with no worker thread yet in existence,
+    // instead of letting a processor/producer/teardown thread do it lazily.
+    start_max_age_ns();
+    pending_starts_cap();
+    signal_less_prime_env();
+
     // Processor first: it must be ready to consume before the reader can publish,
     // otherwise the first batches are dropped for no reason.
     internal_threading::notify_pre_internal_thread_create(ROCPROFILER_LIBRARY);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -29,6 +29,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/kfd/dlog_drain.hpp"
+#include "lib/rocprofiler-sdk/kfd/env_parse.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_correlation.hpp"
 #include "lib/rocprofiler-sdk/kfd/kfd_profiler.hpp"
 #include "lib/rocprofiler-sdk/kfd/poll_reader.hpp"
@@ -123,6 +124,24 @@ start_max_age_ns()
     return _cached;
 }
 
+// Hard size cap on a GPU's retained-START map. start_max_age_ns() above is only
+// the slow age backstop, so this is the bound that actually holds under a
+// sustained EOP loss -- exactly the role D9's cap plays for the hub, sized the
+// same way and for the same reason (the map is per-GPU, and a workload's genuine
+// in-flight peak is hundreds of thousands of dispatches). The [1, 4194304] range
+// and the reject-and-default parse are D8/D9's shared contract; read once, forced
+// at reader start so no worker thread races a concurrent setenv.
+size_t
+pending_starts_cap()
+{
+    static const size_t _cached = []() -> size_t {
+        constexpr long _dflt = 2'000'000;
+        auto _v = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
+        return static_cast<size_t>(_v.value_or(_dflt));
+    }();
+    return _cached;
+}
+
 // Overflow depth at which the processor is clearly not keeping up. Not a cap:
 // dropping here would lose records the ring already gave us.
 constexpr size_t kOverflowWarnDepth = 256;
@@ -155,7 +174,12 @@ struct processor_state
 {
     std::unordered_map<uint32_t, pair_state> by_gpu = {};
 
-    pair_state& for_gpu(uint32_t gpu_id) { return by_gpu[gpu_id]; }
+    pair_state& for_gpu(uint32_t gpu_id)
+    {
+        auto [it, ins] = by_gpu.try_emplace(gpu_id);
+        if(ins) it->second.max_pending_starts = pending_starts_cap();
+        return it->second;
+    }
 };
 
 // Validated before any sizing math uses it.
@@ -908,7 +932,8 @@ processor_loop()
             "KFD dispatch-log pairing census (gpu_id={}): {} START record(s) drained, {} EOP "
             "record(s) drained, {} EOP(s) unmatched, {} START(s) overwritten on a live key, {} "
             "ambiguous EOP(s) dropped, {} equal-tick EOP(s) dropped, {} stale EOP(s) dropped, {} "
-            "START(s) evicted stale, {} START(s) still retained at exit",
+            "START(s) evicted stale, {} START(s) evicted by the size cap, {} START(s) still "
+            "retained at exit",
             _gpu_itr.first,
             _p.starts_seen,
             _p.eops_seen,
@@ -918,6 +943,7 @@ processor_loop()
             _p.equal_tick_drops,
             _p.stale_eop_drops,
             _p.starts_evicted,
+            _p.starts_cap_evicted,
             _p.pending_starts.size());
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -136,7 +136,8 @@ pending_starts_cap()
 {
     static const size_t _cached = []() -> size_t {
         constexpr long _dflt = 2'000'000;
-        auto _v = env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
+        auto           _v =
+            env_long_in_range("ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS", 1, 4'194'304);
         return static_cast<size_t>(_v.value_or(_dflt));
     }();
     return _cached;
@@ -1168,7 +1169,8 @@ reader_loop()
             // session would stay `ready`, handing out correlation keys nothing can
             // ever deliver. Restricted to the backstop's poll TIMEOUT so the extra
             // ioctl runs at the poll-timeout cadence, not per wake.
-            const bool _probe_fatal = (_act == terminal_action::keep_live) || (_backstop && rc == 0);
+            const bool _probe_fatal =
+                (_act == terminal_action::keep_live) || (_backstop && rc == 0);
             if(_probe_fatal && (read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
             {
                 // Drain-first: defer while records remain (the top-of-loop drain

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -1150,6 +1150,63 @@ reader_loop()
             auto&                 _s   = st.sessions[slot_of[k - kFirstStreamPollSlot]];
             if(_s.quarantined) continue;
 
+            // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
+            // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal are
+            // independent latches in the driver) after which the stream never produces
+            // again ("no live consumer, do not arm"). Read STREAM_OP_STATUS to tell
+            // them apart; FATAL is terminal.
+            //
+            // Also probed with NO revents at all while the empty-wake backstop is
+            // tripped: the backstop polls only the control fd and zeroes the stream
+            // revents, so classify_terminal_revents() reports `none` forever and a
+            // stream that went fatal underneath it would never be re-examined -- the
+            // session would stay `ready`, handing out correlation keys nothing can
+            // ever deliver. Restricted to the backstop's poll TIMEOUT so the extra
+            // ioctl runs at the poll-timeout cadence, not per wake.
+            const bool _probe_fatal = (_act == terminal_action::keep_live) || (_backstop && rc == 0);
+            if(_probe_fatal && (read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
+            {
+                // Drain-first: defer while records remain (the top-of-loop drain
+                // already ran this pass; firmware produces nothing more after
+                // FATAL, so this converges) so no already-published record is lost.
+                if(session_has_pending(_s) || !_s.overflow.empty()) continue;
+                log_stream_status(_s);
+                ROCP_WARNING << fmt::format(
+                    "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
+                    "draining, quarantining, and disabling signal-less process-wide",
+                    _s.gpu_id,
+                    static_cast<unsigned>(fds[k].revents));
+                // Clear ready before quarantine so find_session()/establish_session()
+                // stop handing out keys for a stream that can never deliver them.
+                _s.ready.store(false, std::memory_order_release);
+                _s.quarantined   = true;
+                _quarantined_any = true;
+                // Smallest safe containment: the reset invalidated the clock domain
+                // this stream's windows were opened against, so drop the whole
+                // signal-less path process-wide (hub disable latch drains+ledgers
+                // live entries) rather than risk mis-windowing against a reset clock.
+                //
+                // Ring and overflow are dry above, but the batches already PUBLISHED
+                // into the pipe are not: this session's final EOP, and the EOPs of
+                // every healthy GPU queued behind it, are still waiting on the
+                // processor. Draining the hub first would ledger their entries and
+                // leave those records unmatched. So latch admission closed, let the
+                // processor consume what is published (the same gate the closed-window
+                // GC uses -- copied-unpublished first, then pipe.empty), and only then
+                // ledger the residual. Bounded by the close budget so one wedged
+                // processor cannot stall the ring for the other GPUs; on timeout the
+                // disable proceeds exactly as it did before.
+                signal_less_disable_latch().store(true, std::memory_order_release);
+                const uint64_t _pipe_deadline = common::timestamp_ns() + close_drain_budget_ns();
+                while(!gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
+                                    st.pipe.empty()) &&
+                      common::timestamp_ns() < _pipe_deadline &&
+                      !st.stop.load(std::memory_order_acquire))
+                    std::this_thread::sleep_for(std::chrono::microseconds{200});
+                signal_less_disable_permanently();
+                continue;
+            }
+
             if(_act == terminal_action::none)
             {
                 // A real poll of this stream showing no error clears the edge trigger
@@ -1161,36 +1218,6 @@ reader_loop()
 
             if(_act == terminal_action::keep_live)
             {
-                // F11: POLLERR alone is usually a recoverable reset, but a GPU reset
-                // raises the FATAL latch (EPOLLERR without HUP -- fatal and terminal
-                // are independent latches in the driver) after which the stream never
-                // produces again ("no live consumer, do not arm"). Read STREAM_OP_STATUS
-                // to tell them apart; FATAL is terminal.
-                if((read_stream_status_flags(_s) & KFD_DLOG_STATUS_FATAL) != 0)
-                {
-                    // Drain-first: defer while records remain (the top-of-loop drain
-                    // already ran this pass; firmware produces nothing more after
-                    // FATAL, so this converges) so no already-published record is lost.
-                    if(session_has_pending(_s) || !_s.overflow.empty()) continue;
-                    log_stream_status(_s);
-                    ROCP_WARNING << fmt::format(
-                        "KFD dispatch-log: gpu_id={} stream FATAL (revents=0x{:x}); GPU reset, "
-                        "draining, quarantining, and disabling signal-less process-wide",
-                        _s.gpu_id,
-                        static_cast<unsigned>(fds[k].revents));
-                    // Clear ready before quarantine so find_session()/establish_session()
-                    // stop handing out keys for a stream that can never deliver them.
-                    _s.ready.store(false, std::memory_order_release);
-                    _s.quarantined   = true;
-                    _quarantined_any = true;
-                    // Smallest safe containment: the reset invalidated the clock domain
-                    // this stream's windows were opened against, so drop the whole
-                    // signal-less path process-wide (hub disable latch drains+ledgers
-                    // live entries) rather than risk mis-windowing against a reset clock.
-                    signal_less_disable_permanently();
-                    continue;
-                }
-
                 // Recoverable reset: describe it ONCE per episode -- POLLERR is
                 // returned by poll() every pass, so an unlatched warning would spin
                 // the log -- then keep the stream live. The wake already fed the

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/kfd_reader.cpp
@@ -880,9 +880,14 @@ processor_loop()
         // reader's release so the following pipe.empty() is guaranteed to see it.
         // Covers only copied-but-unpublished EOPs (F4); an EOP still in the ring is
         // the accepted R10 residual and is not gated here.
-        const uint64_t _gc_now = common::timestamp_ns();
-        if(gc_gate_open(st.reader_copied_unpublished.load(std::memory_order_acquire),
-                        st.pipe.empty()) &&
+        // Sequenced into named locals rather than passed inline: the order of
+        // evaluation of function arguments is UNSPECIFIED, so the required
+        // "in-flight load, THEN pipe.empty()" ordering cannot be expressed by
+        // argument position.
+        const uint64_t _gc_now      = common::timestamp_ns();
+        const uint64_t _unpublished = st.reader_copied_unpublished.load(std::memory_order_acquire);
+        const bool     _pipe_empty  = st.pipe.empty();
+        if(gc_gate_open(_unpublished, _pipe_empty) &&
            _gc_now - last_gc_ns >= kProcessorEvictIntervalNs)
         {
             last_gc_ns = _gc_now;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -69,7 +69,9 @@ signal_less_feature_enabled()
     // Read once: the answer must not change under a running process, and the
     // enqueue path cannot afford an env lookup per batch.
     static const bool _enabled = []() {
-        if(!common::get_env("ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS", false)) return false;
+        // Strict opt-in, fail-closed: only an explicit true value activates a
+        // feature that changes completion semantics process-wide.
+        if(!env_bool_opt_in("ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS")) return false;
         // register the fork-child abandon handler HERE, where the feature
         // is decided -- every path that creates signal-less state passes this gate
         // first, so "state exists => a handler is registered" is a property of the

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -389,11 +389,17 @@ signal_less_id_is_leaked(uint64_t correlation_id)
 
 namespace
 {
-// The one TERMINAL transition, fail-closed and idempotent: latch no-new-
-// eligibility, stop and JOIN the reader+processor so no further completion can
-// ever be produced, finalize what was left deferred, then ledger everything still
-// PENDING. Runs at most once per process; every later call no-ops. Returns
-// {deferred completions finalized, loss stats}.
+// The one TERMINAL transition, fail-closed: latch no-new-eligibility, stop and
+// JOIN the reader+processor so no further completion can ever be produced, then
+// ledger everything still PENDING. Returns the loss stats.
+//
+// IDEMPOTENT BY CONSTRUCTION, deliberately with no run-once latch: every step
+// already no-ops when it has nothing to do (stop_kfd_reader() returns on
+// !running, drain_for_teardown() on an empty hub, the latch store is a repeat).
+// A latch would be actively worse twice over -- a second caller would return
+// BEFORE the first one's stop completed, which is exactly the guarantee a
+// terminal fence owes; and a reader legitimately restarted after an earlier
+// fence would then never be stopped at all.
 //
 // NOT DEADLOCK-PRONE BY CONSTRUCTION, two ways:
 //  - it never joins the task group. A signal-less completion runs as a TaskGroup
@@ -407,12 +413,9 @@ namespace
 //    stop_kfd_reader() would deadlock against the very thread being joined. The
 //    threads joined here (reader, processor) never run client code and never
 //    submit-and-wait, so joining them from any other thread terminates.
-std::pair<size_t, loss_stats>
+loss_stats
 signal_less_terminal_stop()
 {
-    static auto _once = std::atomic<bool>{false};
-    if(_once.exchange(true, std::memory_order_acq_rel)) return {};
-
     // Latched BEFORE the stop so a batch that already passed eligibility cannot
     // register into the hub after the drain below empties it: register_batch tests
     // this latch under m_mu, which orders it against drain_for_teardown().
@@ -420,10 +423,9 @@ signal_less_terminal_stop()
     // The sole producer of PENDING->EOP_PROVEN. Once joined, no record_kernel_end
     // and therefore no hand_off_proven can run again.
     stop_kfd_reader();
-    const size_t _flushed = flush_deferred_completions();
-    auto         _loss    = signal_less_hub().drain_for_teardown();
+    auto _loss = signal_less_hub().drain_for_teardown();
     if(_loss.second.dispatches > 0) note_signal_less_losses();
-    return {_flushed, _loss.second};
+    return _loss.second;
 }
 }  // namespace
 
@@ -444,8 +446,10 @@ signal_less_teardown()
     //   2. quiesce   -> fences in-flight registration/publication
     //   3. join      -> only the reader creates PENDING->EOP_PROVEN, so after this
     //                   nothing can be added to the retry owner
-    //   4. flush     -> therefore final; leftovers finalize in place on THIS thread
-    //   5. leak      -> whatever never got an EOP is ledgered, so finalize skips it
+    //   4. leak      -> whatever never got an EOP is ledgered, so finalize skips it
+    //   5. flush     -> therefore final; leftovers finalize in place on THIS thread.
+    //                   Order against step 4 is free: a deferred completion left the
+    //                   hub at record_kernel_end, so the two touch disjoint sets
     //   6. join tasks-> safe only now: no producer can submit another task
     signal_less_hub().set_mode(session_mode::stopping);
     drain_signal_less_interceptor();
@@ -461,19 +465,21 @@ signal_less_teardown()
     // below is stronger than the fence's abandon, and drain_for_teardown() ledgers
     // whatever is left.
     wait_for_reader_quiesce();
-    // Steps 3-5 in one idempotent primitive, shared with the F23/F24 fence: it may
-    // already have run there, in which case this no-ops and reports nothing left.
-    const auto   _stopped = signal_less_terminal_stop();
-    const size_t _flushed = _stopped.first;
-    const size_t _leaked  = _stopped.second.dispatches;
+    // Steps 3 and 5 in the primitive shared with the F23/F24 fence; step 4 (the
+    // flush) stays here, outside it, so it runs on EVERY call -- the fence may
+    // already have stopped an earlier reader, and a reader restarted since then can
+    // still have deferred completions this thread must finalize.
+    const auto   _loss    = signal_less_terminal_stop();
+    const size_t _flushed = flush_deferred_completions();
+    const size_t _leaked  = _loss.dispatches;
     if(_leaked > 0)
     {
         ROCP_WARNING << fmt::format(
             "KFD dispatch-log: {} signal-less dispatch(es) across {} correlation id(s) were still "
             "in flight at finalization; they emit no record and their correlation ids are not "
             "retired.",
-            _stopped.second.dispatches,
-            _stopped.second.correlation_ids);
+            _loss.dispatches,
+            _loss.correlation_ids);
     }
 
     join_signal_less_tasks();
@@ -552,17 +558,18 @@ signal_less_fence_completions()
     // terminal instead: stop+join the reader/processor so no completion can be
     // produced at all, and ledger whatever never got an EOP. Fail-closed --
     // signal-less stays off for the rest of the process, the accepted cost of a
-    // detach or an HSA shutdown. Idempotent, so the second fence call no-ops.
-    const auto _stopped = signal_less_terminal_stop();
-    ROCP_WARNING_IF(_stopped.second.dispatches > 0) << fmt::format(
+    // detach or an HSA shutdown. Idempotent, so a second fence call is harmless.
+    const auto _loss = signal_less_terminal_stop();
+    ROCP_WARNING_IF(_loss.dispatches > 0) << fmt::format(
         "KFD dispatch-log fence: signal-less stopped terminally (client detach or HSA shutdown); "
-        "{} deferred completion(s) finalized, {} dispatch(es) across {} correlation id(s) were "
-        "still in flight and are ledgered.",
-        _stopped.first,
-        _stopped.second.dispatches,
-        _stopped.second.correlation_ids);
-    // (d) every submitted completion has finished executing before we return: the
-    // terminal stop closed every producer, but not already-queued tasks.
+        "{} dispatch(es) across {} correlation id(s) were still in flight and are ledgered.",
+        _loss.dispatches,
+        _loss.correlation_ids);
+    // (d) nothing is left deferred waiting to be finalized, and (e) every submitted
+    // completion has finished executing -- both before returning. The flush is safe
+    // here and not on a worker: the reader and processor are joined, so this thread
+    // is the only one that can still touch a deferred completion.
+    flush_deferred_completions();
     join_signal_less_tasks();
 }
 }  // namespace kfd

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -328,6 +328,22 @@ quiesce_budget_ns()
 }
 
 void
+signal_less_prime_env()
+{
+    // Every knob below caches its env read in a function-local static on FIRST USE,
+    // and common::get_env* scans `environ`, which is not safe against a concurrent
+    // setenv. Left lazy, that first use lands on whichever worker, producer or
+    // teardown thread happens to reach it first. Calling them here -- from the one
+    // serialized reader-start path, before any worker thread exists and before the
+    // application is dispatching -- makes the cached value deterministic and takes
+    // the environ scan off every concurrent thread.
+    signal_less_feature_enabled();
+    hub_max_pending_per_gpu();
+    close_drain_budget_ns();
+    quiesce_budget_ns();
+}
+
+void
 signal_less_disable_permanently()
 {
     if(g_child_stale.load(std::memory_order_acquire)) return;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less.cpp
@@ -369,6 +369,46 @@ signal_less_id_is_leaked(uint64_t correlation_id)
     return signal_less_hub().is_ledgered(correlation_id);
 }
 
+namespace
+{
+// The one TERMINAL transition, fail-closed and idempotent: latch no-new-
+// eligibility, stop and JOIN the reader+processor so no further completion can
+// ever be produced, finalize what was left deferred, then ledger everything still
+// PENDING. Runs at most once per process; every later call no-ops. Returns
+// {deferred completions finalized, loss stats}.
+//
+// NOT DEADLOCK-PRONE BY CONSTRUCTION, two ways:
+//  - it never joins the task group. A signal-less completion runs as a TaskGroup
+//    task and may synchronously call a client callback that finalizes, reaching
+//    here on a task-group worker; TaskGroup::join spins on a task count that very
+//    task still holds, so joining there would wait for itself forever. Callers
+//    that must also wait out already-submitted completions do that themselves,
+//    after this returns.
+//  - it holds NO lock across the join. The processor takes g_submit_gate SHARED
+//    on its handoff path, so latching that gate exclusively around
+//    stop_kfd_reader() would deadlock against the very thread being joined. The
+//    threads joined here (reader, processor) never run client code and never
+//    submit-and-wait, so joining them from any other thread terminates.
+std::pair<size_t, loss_stats>
+signal_less_terminal_stop()
+{
+    static auto _once = std::atomic<bool>{false};
+    if(_once.exchange(true, std::memory_order_acq_rel)) return {};
+
+    // Latched BEFORE the stop so a batch that already passed eligibility cannot
+    // register into the hub after the drain below empties it: register_batch tests
+    // this latch under m_mu, which orders it against drain_for_teardown().
+    signal_less_disable_latch().store(true, std::memory_order_release);
+    // The sole producer of PENDING->EOP_PROVEN. Once joined, no record_kernel_end
+    // and therefore no hand_off_proven can run again.
+    stop_kfd_reader();
+    const size_t _flushed = flush_deferred_completions();
+    auto         _loss    = signal_less_hub().drain_for_teardown();
+    if(_loss.second.dispatches > 0) note_signal_less_losses();
+    return {_flushed, _loss.second};
+}
+}  // namespace
+
 void
 signal_less_teardown()
 {
@@ -403,20 +443,19 @@ signal_less_teardown()
     // below is stronger than the fence's abandon, and drain_for_teardown() ledgers
     // whatever is left.
     wait_for_reader_quiesce();
-    stop_kfd_reader();
-    const size_t _flushed = flush_deferred_completions();
-
-    auto         _loss   = signal_less_hub().drain_for_teardown();
-    const size_t _leaked = _loss.second.dispatches;
+    // Steps 3-5 in one idempotent primitive, shared with the F23/F24 fence: it may
+    // already have run there, in which case this no-ops and reports nothing left.
+    const auto   _stopped = signal_less_terminal_stop();
+    const size_t _flushed = _stopped.first;
+    const size_t _leaked  = _stopped.second.dispatches;
     if(_leaked > 0)
     {
-        note_signal_less_losses();
         ROCP_WARNING << fmt::format(
             "KFD dispatch-log: {} signal-less dispatch(es) across {} correlation id(s) were still "
             "in flight at finalization; they emit no record and their correlation ids are not "
             "retired.",
-            _loss.second.dispatches,
-            _loss.second.correlation_ids);
+            _stopped.second.dispatches,
+            _stopped.second.correlation_ids);
     }
 
     join_signal_less_tasks();
@@ -487,10 +526,25 @@ signal_less_fence_completions()
             _loss.second.dispatches,
             _loss.second.correlation_ids);
     }
-    // (c) nothing is left deferred waiting to be finalized, and (d) every submitted
-    // completion has finished executing -- both before returning, because closing
-    // the gate stops further submissions but not already-queued ones.
-    flush_deferred_completions();
+    // (c) BOTH fence sites are TERMINAL, so quiescing is not enough: F23 frees the
+    // client's callback/buffer machinery and F24 lets the HSA runtime unload, both
+    // immediately after we return. A dispatch still PENDING here would otherwise
+    // complete afterwards and deref a freed context* out of the copied
+    // tracing_data, or convert ticks against a dead runtime. Make the transition
+    // terminal instead: stop+join the reader/processor so no completion can be
+    // produced at all, and ledger whatever never got an EOP. Fail-closed --
+    // signal-less stays off for the rest of the process, the accepted cost of a
+    // detach or an HSA shutdown. Idempotent, so the second fence call no-ops.
+    const auto _stopped = signal_less_terminal_stop();
+    ROCP_WARNING_IF(_stopped.second.dispatches > 0) << fmt::format(
+        "KFD dispatch-log fence: signal-less stopped terminally (client detach or HSA shutdown); "
+        "{} deferred completion(s) finalized, {} dispatch(es) across {} correlation id(s) were "
+        "still in flight and are ledgered.",
+        _stopped.first,
+        _stopped.second.dispatches,
+        _stopped.second.correlation_ids);
+    // (d) every submitted completion has finished executing before we return: the
+    // terminal stop closed every producer, but not already-queued tasks.
     join_signal_less_tasks();
 }
 }  // namespace kfd

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/signal_less_gate.hpp
@@ -39,6 +39,12 @@ namespace kfd
 bool
 signal_less_feature_enabled();
 
+// Populate every env-backed knob's first-use cache from ONE serialized thread,
+// before any worker/producer exists. Call sites read `environ` via
+// common::get_env*, which is unsafe against a concurrent setenv. Idempotent.
+void
+signal_less_prime_env();
+
 // True if the loss policy deliberately leaked this id, in which case
 // correlation_id_finalize() must NOT force-retire it: its kernel may still be
 // running and its references were intentionally not dropped.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -225,6 +225,15 @@ TEST(DispatchHub, resolution_rule)
     ASSERT_TRUE(register_win(hub, K, mk_window(5, 200), /*corr_id=*/2));
     EXPECT_FALSE(end_nostart(hub, K, 300).has_value());
 }
+{  // a stale EOP (its own START was lost, it predates this window) must NOT
+   // consume the newer entry: reject BEFORE take, leaving it PENDING for its own.
+    auto hub = hub_t{};
+    ASSERT_TRUE(register_win(hub, K, mk_window(5, 100)));
+    EXPECT_FALSE(end_nostart(hub, K, 50).has_value()) << "EOP before t_open rejected";
+    EXPECT_FALSE(end_nostart(hub, K, 100).has_value()) << "EOP at t_open rejected";
+    EXPECT_EQ(hub.pending_count(), 1u) << "a rejected EOP consumes nothing";
+    EXPECT_TRUE(end_nostart(hub, K, 300).has_value()) << "its own later EOP still resolves";
+}
 }
 {  // a contained START with end < start is dropped (free sanity check).
     auto hub = hub_t{};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -955,3 +955,28 @@ TEST(EnvLongInRange, reject_and_default_never_clamp)
 
     ::unsetenv(var);
 }
+
+// The strict opt-in switch: ONLY an explicit true value enables. Everything else
+// -- unset, empty, a false word, a typo, a number -- is DISABLED (fail-closed),
+// and nothing throws or fatals.
+TEST(EnvBoolOptIn, only_explicit_true_enables)
+{
+    const char* var = "ROCPROFILER_KFD_DLOG_TEST_ENVBOOL";
+    auto        set = [&](const char* v) { ::setenv(var, v, 1); };
+
+    ::unsetenv(var);
+    EXPECT_FALSE(env_bool_opt_in(var)) << "unset -> off";
+
+    for(const char* _yes : {"1", "true", "yes", "on"})
+    {
+        set(_yes);
+        EXPECT_TRUE(env_bool_opt_in(var)) << _yes << " enables";
+    }
+    for(const char* _no : {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
+    {
+        set(_no);
+        EXPECT_FALSE(env_bool_opt_in(var)) << "'" << _no << "' must not enable";
+    }
+
+    ::unsetenv(var);
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -972,7 +972,8 @@ TEST(EnvBoolOptIn, only_explicit_true_enables)
         set(_yes);
         EXPECT_TRUE(env_bool_opt_in(var)) << _yes << " enables";
     }
-    for(const char* _no : {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
+    for(const char* _no :
+        {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
     {
         set(_no);
         EXPECT_FALSE(env_bool_opt_in(var)) << "'" << _no << "' must not enable";

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -952,3 +952,28 @@ TEST(EnvLongInRange, reject_and_default_never_clamp)
 
     ::unsetenv(var);
 }
+
+// The strict opt-in switch: ONLY an explicit true value enables. Everything else
+// -- unset, empty, a false word, a typo, a number -- is DISABLED (fail-closed),
+// and nothing throws or fatals.
+TEST(EnvBoolOptIn, only_explicit_true_enables)
+{
+    const char* var = "ROCPROFILER_KFD_DLOG_TEST_ENVBOOL";
+    auto        set = [&](const char* v) { ::setenv(var, v, 1); };
+
+    ::unsetenv(var);
+    EXPECT_FALSE(env_bool_opt_in(var)) << "unset -> off";
+
+    for(const char* _yes : {"1", "true", "yes", "on"})
+    {
+        set(_yes);
+        EXPECT_TRUE(env_bool_opt_in(var)) << _yes << " enables";
+    }
+    for(const char* _no : {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
+    {
+        set(_no);
+        EXPECT_FALSE(env_bool_opt_in(var)) << "'" << _no << "' must not enable";
+    }
+
+    ::unsetenv(var);
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dispatch_hub_test.cpp
@@ -969,7 +969,8 @@ TEST(EnvBoolOptIn, only_explicit_true_enables)
         set(_yes);
         EXPECT_TRUE(env_bool_opt_in(var)) << _yes << " enables";
     }
-    for(const char* _no : {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
+    for(const char* _no :
+        {"0", "false", "no", "off", "", "flase", "2", "TRUE", "99999999999999999"})
     {
         set(_no);
         EXPECT_FALSE(env_bool_opt_in(var)) << "'" << _no << "' must not enable";

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -310,6 +310,46 @@ TEST(dlog_drain, evict_stale_starts)
     EXPECT_EQ(st.pairing.pending_starts.count(2), 1u);
 }
 
+// The hard size cap bounds pending_starts even when nothing ages out: past the
+// cap an insert evicts the OLDEST retained START (by seen_at_ns) and counts it.
+TEST(dlog_drain, pending_starts_size_cap_evicts_oldest)
+{
+    auto mk_start = [](uint32_t dispatch_id, uint64_t ts) {
+        auto c              = copied_record{};
+        c.rec.record_type   = kRecStart;
+        c.rec.doorbell_off  = 4100;
+        c.rec.dispatch_id   = dispatch_id;
+        c.rec.ts_lo         = static_cast<uint32_t>(ts);
+        return c;
+    };
+
+    pair_state pairing;
+    pairing.max_pending_starts = 2;
+    recorder rec;
+
+    // Three distinct keys, each in its own batch so seen_at_ns strictly increases.
+    for(uint32_t i = 1; i <= 3; ++i)
+    {
+        auto batch = std::vector<copied_record>{mk_start(i, 10 * i)};
+        pair_records(batch.data(), batch.size(), pairing, /*now_ns=*/1000 * i, rec.on_record());
+    }
+
+    EXPECT_EQ(pairing.pending_starts.size(), 2u) << "the cap is a hard bound";
+    EXPECT_EQ(pairing.starts_cap_evicted, 1u);
+    const uint64_t k1 = (uint64_t{4100} << 32) | 1u;
+    EXPECT_EQ(pairing.pending_starts.count(k1), 0u) << "the oldest START is the victim";
+
+    // A recurring key is exempt: it cannot grow the map, and evicting there could
+    // pick the very key being touched and reset its ambiguity latch.
+    const uint64_t k3    = (uint64_t{4100} << 32) | 3u;
+    auto           again = std::vector<copied_record>{mk_start(3, 99)};
+    pair_records(again.data(), again.size(), pairing, /*now_ns=*/4000, rec.on_record());
+    EXPECT_EQ(pairing.pending_starts.size(), 2u);
+    EXPECT_EQ(pairing.starts_cap_evicted, 1u) << "no eviction for a recurring key";
+    ASSERT_EQ(pairing.pending_starts.count(k3), 1u);
+    EXPECT_TRUE(pairing.pending_starts[k3].ambiguous) << "the duplicate still latches ambiguous";
+}
+
 // Invalid geometry (0 regions, too many, or non-power-of-two rrc) is rejected.
 TEST(dlog_drain, invalid_geometry_rejected)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kfd/tests/dlog_drain_test.cpp
@@ -315,11 +315,11 @@ TEST(dlog_drain, evict_stale_starts)
 TEST(dlog_drain, pending_starts_size_cap_evicts_oldest)
 {
     auto mk_start = [](uint32_t dispatch_id, uint64_t ts) {
-        auto c              = copied_record{};
-        c.rec.record_type   = kRecStart;
-        c.rec.doorbell_off  = 4100;
-        c.rec.dispatch_id   = dispatch_id;
-        c.rec.ts_lo         = static_cast<uint32_t>(ts);
+        auto c             = copied_record{};
+        c.rec.record_type  = kRecStart;
+        c.rec.doorbell_off = 4100;
+        c.rec.dispatch_id  = dispatch_id;
+        c.rec.ts_lo        = static_cast<uint32_t>(ts);
         return c;
     };
 


### PR DESCRIPTION
## Summary
Addresses a 15-point static re-review of the KFD dispatch-log signal-less path (on top of `review-fixes`). Each finding was evaluated against the code and the prior design history; this PR **fixes the genuine correctness/safety/resource issues** (potential misattribution, UAF on terminal teardown, unbounded pairer-map growth, plus FATAL-handling, env-race, and robustness items) and **documents the ones intentionally left as accepted residuals or pre-existing**, with rationale. `+365 / −49` across 9 files.

## Fixed

- **#4 (misattribution) — validate identity before claiming an unknown-START EOP.** The unknown-START path in `dispatch_hub.hpp::record_kernel_end` took the sole first-owner entry with no timestamp check, and terminal-time validation ran only *after* the entry was consumed/retired — so a stale EOP could claim a newer dispatch's entry. Now rejects an EOP whose `end_ticks <= window.t_open` (a kernel cannot end at/before its window opened; same GPU-tick domain the known-START path already uses) **before** taking the entry, so a rejected EOP consumes/retires nothing. Fail-first verified.
- **#3 + #2 (UAF) — the terminal fences are now truly terminal (fail-closed).** `signal_less_fence_completions()` previously quiesced visible work but did not stop the reader on success, so a still-PENDING kernel could complete after the client's callback/buffer state (detach/finalize, F23) or the HSA runtime (final `hsa_shut_down`, F24) was freed. A new `signal_less_terminal_stop()` (factored from teardown) latches disable → stops+joins the reader/processor → drains+ledgers PENDING, and is called from the F23/F24 sites. Verified deadlock-free (never joins its own task group, holds no lock across the join, joined threads never block on the joiner) and 5/5 clean under a shutdown watchdog. The existing `get_fini_status()` re-entry guard (the earlier crash fix) is preserved.
- **#11 (unbounded growth) — hard size cap on the pairer START map.** `pair_state::pending_starts` was bounded only by a 30-minute age timer. Added `ROCPROFILER_KFD_DISPATCH_LOG_MAX_PENDING_STARTS` (default 2M, shared reject-and-default parser) with oldest-first eviction (recurring key exempted so the `ambiguous` latch is preserved).
- **#7 (coverage) + #10 (liveness) — FATAL handling.** FATAL now latches admission and waits for the processor to consume the already-published pipe **before** draining the hub (so a fatal session's final EOP and healthy-GPU EOPs behind it aren't dropped), and the FATAL status is re-probed while the empty-wake backstop is tripped (so a fatal stream that produces no records is still detected).
- **#5 (robustness) — master switch is a strict fail-closed opt-in.** `ROCPROFILER_KFD_DISPATCH_LOG_SIGNAL_LESS` now accepts only explicit true values; anything else is disabled with a one-time warning (no throw on malformed input).
- **#9 (arg-order) — deterministic GC-gate operand ordering.** `gc_gate_open`'s two operands are read into named locals in the intended order rather than relying on unspecified argument-evaluation order.
- **#12 (race) — env knobs primed at serialized init.** The age/cap/quiesce/switch env reads are populated during reader start-up rather than lazily on a worker thread.
- **#14(b) — fork child no longer hangs in `interposition_fini()`.** A normal (non-exec) child now short-circuits `interposition_fini()` under the existing `fork_stale()` guard, avoiding a wlock on a registry a vanished parent thread may hold.

## Intentionally not changed (accepted residuals / design decisions / pre-existing)

- **#1 — teardown coverage loss** (a kernel in flight at exit may emit no record): the accepted D8/F1 coverage residual. The *UAF* variant of this concern is #3, which is fixed.
- **#8 — equal-tick START/EOP**: the accepted D1 residual. The code emits a **no-timing / zero-duration drop**, not a fabricated 1 ns; no misattribution.
- **#9-main — GC gate "race"**: the copied-but-still-in-ring window is the accepted **R10** residual (an EOP still in the ring is intentionally not gated), and cap-eviction's bypass of the in-flight gate is D9's documented coverage-loss residual. The operand-ordering nit is fixed (#9-arg above); the residual is by design (coverage loss, never misattribution).
- **#13 — cross-batch inversion**: the explicitly-accepted D1 residual (coverage loss under queue churn, never misattribution). A cross-batch reorder buffer is a larger design change weighed against measured coverage impact, which the benchmarks do not show hitting.
- **#6 — completion-callback self-deadlock**: a **pre-existing** reentrancy defect on the generic signal path (a client callback that calls its own finalize). The new terminal-stop path was specifically designed **not** to add another instance of it.
- **#14(a) — session mid-construction skipped by a concurrent fork**: a child-lifetime resource leak (not a hang); the parent is unaffected and the child drops it at exit. The "fix" would introduce a formal data race on an `smap` pointer a vanished thread was mid-write on, to reclaim memory about to be freed — not worth it. Left as-is.
- **#15 — eager arming on a registered (vs active) context**: an efficiency consideration, not a correctness issue; arming stays gated on a registered kernel-dispatch context.

## Known residuals in the fixes (documented)
- #4 adds no upper time bound (an implausibly-future EOP is still taken and rejected by the finalizer as no-timing, never misattributed).
- #10 restores FATAL *detection* under the backstop; a *persistently failing* status ioctl still isn't fail-closed (separate follow-up).
- #11 eviction is O(live) per over-cap insert (same tradeoff as the D9 cap; only reached under pathological EOP loss).

## Testing (MI350, host ROCm 7.2.1, build `fd06e1407c`)
- Build clean at the project warning level — **0 new warnings**.
- `ctest -L kfd-dlog` — **90/90 pass** (incl. 2 new tests: pairer-map cap, strict opt-in).
- ThreadSanitizer, all 8 kfd-dlog suites — **90/90, zero reports** (covers the terminal-stop join, FATAL drain-wait, GC-gate ordering).
- Shutdown crash/hang reproducer (1040), **5 runs under a watchdog — 5/5 clean, no hang, no crash** (the decisive check for the terminal-stop rework).
- 1041-d (20k kernels ×3), 1031, 1041-a, 1041-c — all pass, no attribution regression.
- graph-perf — **−44.21%** overhead reduction, `register-refused=0`/block (no throughput regression).

## Tracking
JIRA ID: AIPROFSDK-1012 AIPROFSDK-1040 AIPROFSDK-1041
