### PR TITLE
fix(rccl): remove crash during collective protocol selection

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -103,8 +103,8 @@
 
 using namespace rccl;
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS + 4] = {"AllGather",    "AllReduce", "AlltoAllPivot", "AlltoAllGda",
-                                                   "AlltoAllvGda", "Broadcast", "Reduce",        "ReduceScatter",
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS + 4] = {"Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce",
+                                                   "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda",
                                                    "SendRecv"}; // Increased numFunc by 1 for AlltollvGda
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = {"Tree",     "Ring", "CollNetDirect", "CollNetChain", "NVLS",
                                                 "NVLSTree", "PAT"};

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -525,6 +525,7 @@ if(BUILD_TESTS)
       TimeoutTests.cpp
       mem_manager/MemManagerTests.cpp
       graph/SearchTests.cpp
+      graph/TuningTests.cpp
       graph/XmlTests.cpp
       graph/NetDevsPolicyP2pNetTests.cpp
       graph/TopoTests.cpp

--- a/projects/rccl/test/graph/TuningTests.cpp
+++ b/projects/rccl/test/graph/TuningTests.cpp
@@ -1,0 +1,122 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Regression tests for NCCL_PROTO / NCCL_ALGO prefix parsing in graph/tuning.cc.
+//
+// ncclFuncStr[] must stay aligned with ncclFunc_t enum order: parseList() resolves
+// a prefix like "broadcast" to an index p and writes protoEnable[p * nelems + e].
+// When ncclFuncStr[ncclFuncBroadcast] was not "Broadcast" (pre-fix ordering placed
+// Broadcast at index 5 while NCCL_NUM_FUNCTIONS is 5), NCCL_PROTO=broadcast:simple
+// could not match any prefix and init failed or misconfigured protocol enablement.
+
+#include "device.h"
+#include "gtest/gtest.h"
+#include "nccl_common.h"
+#include "plugin/nccl_tuner.h"
+
+#include <cstring>
+
+// parseList() lives in graph/tuning.cc and is exported from librccl in Debug builds.
+ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes, const char* elems[],
+                       int nelems, int* list);
+
+namespace RcclUnitTesting
+{
+namespace
+{
+
+constexpr const char* kCoreFuncNames[NCCL_NUM_FUNCTIONS] = {
+    "Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce",
+};
+
+TEST(TuningParseList, NcclFuncStrMatchesEnumOrder)
+{
+    for(int f = 0; f < NCCL_NUM_FUNCTIONS; ++f)
+    {
+        ASSERT_NE(ncclFuncStr[f], nullptr);
+        EXPECT_STRCASEEQ(ncclFuncStr[f], kCoreFuncNames[f])
+            << "ncclFuncStr[" << f << "] must match ncclFunc_t value " << f;
+    }
+}
+
+TEST(TuningParseList, BroadcastSimpleSelectsBroadcastRow)
+{
+    int protoEnable[NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS];
+    for(int i = 0; i < NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS; ++i)
+        protoEnable[i] = 1;
+
+    ASSERT_EQ(parseList("broadcast:simple", ncclFuncStr, NCCL_NUM_FUNCTIONS, ncclProtoStr, NCCL_NUM_PROTOCOLS,
+                        protoEnable),
+              ncclSuccess);
+
+    for(int p = 0; p < NCCL_NUM_PROTOCOLS; ++p)
+    {
+        const int broadcastSlot = ncclFuncBroadcast * NCCL_NUM_PROTOCOLS + p;
+        if(p == NCCL_PROTO_SIMPLE)
+            EXPECT_EQ(protoEnable[broadcastSlot], 1) << "Broadcast should enable Simple only";
+        else
+            EXPECT_EQ(protoEnable[broadcastSlot], 0) << "Broadcast should disable non-Simple protocols";
+    }
+
+    // Other core collectives are untouched by a broadcast-prefixed entry.
+    for(int f = 1; f < NCCL_NUM_FUNCTIONS; ++f)
+        for(int p = 0; p < NCCL_NUM_PROTOCOLS; ++p)
+            EXPECT_EQ(protoEnable[f * NCCL_NUM_PROTOCOLS + p], 1)
+                << "Unprefixed rows should retain their prior enablement";
+}
+
+TEST(TuningParseList, BroadcastSimpleCaseInsensitive)
+{
+    int protoEnable[NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS] = {};
+    for(int i = 0; i < NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS; ++i)
+        protoEnable[i] = 1;
+
+    ASSERT_EQ(parseList("Broadcast:Simple", ncclFuncStr, NCCL_NUM_FUNCTIONS, ncclProtoStr, NCCL_NUM_PROTOCOLS,
+                        protoEnable),
+              ncclSuccess);
+    EXPECT_EQ(protoEnable[ncclFuncBroadcast * NCCL_NUM_PROTOCOLS + NCCL_PROTO_SIMPLE], 1);
+    EXPECT_EQ(protoEnable[ncclFuncBroadcast * NCCL_NUM_PROTOCOLS + NCCL_PROTO_LL], 0);
+    EXPECT_EQ(protoEnable[ncclFuncBroadcast * NCCL_NUM_PROTOCOLS + NCCL_PROTO_LL128], 0);
+}
+
+TEST(TuningParseList, GlobalSimpleThenBroadcastOverride)
+{
+    // Mirrors NCCL_PROTO="Simple;broadcast:LL" from tuning.cc comments: enable Simple
+    // globally, then restrict Broadcast to LL.
+    int protoEnable[NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS] = {};
+    for(int i = 0; i < NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS; ++i)
+        protoEnable[i] = 2; // non-zero default, distinct from parseList set/unset values
+
+    ASSERT_EQ(parseList("Simple;broadcast:LL", ncclFuncStr, NCCL_NUM_FUNCTIONS, ncclProtoStr, NCCL_NUM_PROTOCOLS,
+                        protoEnable),
+              ncclSuccess);
+
+    for(int f = 0; f < NCCL_NUM_FUNCTIONS; ++f)
+    {
+        for(int p = 0; p < NCCL_NUM_PROTOCOLS; ++p)
+        {
+            const int slot = f * NCCL_NUM_PROTOCOLS + p;
+            if(f == ncclFuncBroadcast)
+            {
+                if(p == NCCL_PROTO_LL)
+                    EXPECT_EQ(protoEnable[slot], 1);
+                else
+                    EXPECT_EQ(protoEnable[slot], 0);
+            }
+            else if(p == NCCL_PROTO_SIMPLE)
+            {
+                EXPECT_EQ(protoEnable[slot], 1);
+            }
+            else
+            {
+                EXPECT_EQ(protoEnable[slot], 0);
+            }
+        }
+    }
+}
+
+} // namespace
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/graph/TuningTests.cpp
+++ b/projects/rccl/test/graph/TuningTests.cpp
@@ -6,8 +6,8 @@
 
 // Regression tests for NCCL_PROTO / NCCL_ALGO prefix parsing in graph/tuning.cc.
 //
-// ncclFuncStr[] must stay aligned with ncclFunc_t enum order: parseList() resolves
-// a prefix like "broadcast" to an index p and writes protoEnable[p * nelems + e].
+// The first NCCL_NUM_FUNCTIONS entries of ncclFuncStr[] must stay aligned with the
+// core ncclFunc_t enum order (Broadcast..AllReduce): parseList() resolves
 // When ncclFuncStr[ncclFuncBroadcast] was not "Broadcast" (pre-fix ordering placed
 // Broadcast at index 5 while NCCL_NUM_FUNCTIONS is 5), NCCL_PROTO=broadcast:simple
 // could not match any prefix and init failed or misconfigured protocol enablement.


### PR DESCRIPTION
## Motivation

Setting NCCL_PROTO=broadcast:simple could crash or misconfigure RCCL because the ncclFuncStr[] name table did not follow ncclFunc_t enum order. This change realigns that table and adds unit tests so per-collective protocol overrides for broadcast keep working.

## Technical Details

- parseList() in graph/tuning.cc resolves prefixes like broadcast by scanning ncclFuncStr[] and writes protoEnable[f * NCCL_NUM_PROTOCOLS + p].
- Before the fix, ncclFuncStr[0] was "AllGather" while ncclFuncBroadcast == 0, and "Broadcast" sat at index 5.
- With NCCL_NUM_FUNCTIONS == 5, the prefix scan never reached index 5, so NCCL_PROTO=broadcast:simple failed to match and broadcast protocol enablement was wrong.
- The fix reorders ncclFuncStr[] in init.cc to match enum order: Broadcast, Reduce, AllGather, ReduceScatter, AllReduce, ...
- Added test/graph/TuningTests.cpp to verify enum alignment and that parseList("broadcast:simple", ...) enables Simple only on the broadcast row.

## Issue Tracking

JIRA ID : 2178

## Test Plan

Run by benchmark by setting NCCL_PROTO to broadcast:simple and run the 4 unit tests added

## Test Result

benchmark runs without crashing.

[----------] 4 tests from TuningParseList (0 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 4 tests.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
