### PR TITLE
Fixing the Unit_hipDeviceGetGraphMemAttribute_Functional test bug

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -248,6 +248,7 @@ static void hipDeviceGetGraphMemAttribute_Functional_Test(unsigned deviceId = 0)
 
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
   HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipStreamDestroy(stream));


### PR DESCRIPTION
## Motivation

Fixing the Unit_hipDeviceGetGraphMemAttribute_Functional test bug

## Technical Details
Unit_hipDeviceGetGraphMemAttribute_Functional is a test bug. It queries the graph memory attributes after only hipGraphDestroy/hipStreamDestroy, but hipStreamDestroy does not block — it releases asynchronously once pending work finishes. So the query races the graph's MemFree node and intermittently sees the full 512 MiB allocation still in use. My minimal repro settles it: 4 of 30 iterations report non-zero without a sync, 0 of 30 with hipStreamSynchronize added before the trim

## JIRA ID
JIRA ID : PAVSDEV-8603

## Test Plan

ctest --tests-information 0,,4 --test-dir /opt/rocm/share/hip/catch_tests --output-on-failure --timeout 600

## Test Result

graph tests should pass without any error.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.