### PR TITLE
rocjitsu: suppress GCC false-positive warnings on ppc64le

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -56,6 +56,9 @@ if(
     AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14"
 )
     add_compile_options(-Wno-uninitialized)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64")
+        add_compile_options(-Wno-maybe-uninitialized -Wno-stringop-overflow)
+    endif()
 endif()
 
 # HSA/KFD headers (local copies from rocr-runtime).


### PR DESCRIPTION

## Motivation

Part of https://github.com/ROCm/TheRock/issues/5518 non-x86 portability

## Technical Details

Extends the existing GCC 14+ false-positive workaround to ppc64le. 

## Test Plan

* Verify build successfully on ppc64le
* Verify tests run successfully on ppc64le

## Test Result

* Builds successfully on ppc64le
* Tests run successfully on ppc64le

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
