### PR TITLE
fix(ci): sanity GPU check excluded for CPU runners

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -92,6 +92,7 @@ jobs:
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: Driver / GPU sanity check
+        if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
         timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -148,7 +148,7 @@ jobs:
           (matrix.components.multi_gpu_runner != '' &&
             matrix.components.multi_gpu_runner) ||
           (matrix.components.linux_cpu_runner == true &&
-            'azure-linux-scale-rocm') ||
+            'aws-linux-scale-rocm-prod') ||
           matrix.components.test_runner
         }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}


### PR DESCRIPTION
after https://github.com/ROCm/TheRock/commit/a1b91c2e57bd58c00367402a029d29546aad7500 landed, rocgdb CPU was failing as GPU check was exit code 1. with this update, it works! https://github.com/ROCm/rocm-systems/actions/runs/33085683563/job/98565637000

also updated to correct CPU runner