### PR TITLE
Sync 2.30.7 - Defect - Reintroduced cudaGridDependencySynchronize in …

### DIFF
--- a/projects/rccl/src/device/symmetric/generate.py
+++ b/projects/rccl/src/device/symmetric/generate.py
@@ -168,11 +168,17 @@ def kernel_conds(k):
 def instantiate(k):
   form_red_ty = (
     "__global__ void {cname}(ncclSymkDevWorkArgs4K NCCL_GRID_CONSTANT const args4K) {{\n"
+    "  #if CUDART_VERSION >= 12030 && __CUDA_ARCH__ >= 900\n"
+    "    cudaGridDependencySynchronize();\n"
+    "  #endif\n"
     "  ncclSymkRun_{id}<{red}, {ty}>(&args4K.args);\n"
     "}}"
   )
   form = (
     "__global__ void {cname}(ncclSymkDevWorkArgs4K NCCL_GRID_CONSTANT const args4K) {{\n"
+    "  #if CUDART_VERSION >= 12030 && __CUDA_ARCH__ >= 900\n"
+    "    cudaGridDependencySynchronize();\n"
+    "  #endif\n"
     "  ncclSymkRun_{id}(&args4K.args);\n"
     "}}"
   )


### PR DESCRIPTION
NCCL v2.30.7 sync

## Motivation

Sync with upstream change.

## Technical Details

Reintroduce cudaGridDependencySynchronize in built-in symmetric kernels
The call was accidentally left out when transitioning to DeviceAPI in NCCL
2.28.

## Issue Tracking

JIRA ID: AICOMRCCL-1847

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
