### PR TITLE
fix(rccl): stop rccl-UnitTests from preempting librccl's ncclDebugLog

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -289,12 +289,9 @@ if(BUILD_TESTS)
   target_link_options(rccl-UnitTests PRIVATE
     "LINKER:--export-dynamic-symbol=ncclNetPlugin_v12")
 
-  # AICOMRCCL-2183: RcclMockFuncs.hpp defines an empty ncclDebugLog, needed to link the RCCL
-  # sources added above in Release. A definition in the executable also overrides the shared
-  # library's, so in Debug, where librccl.so exports its own ncclDebugLog, the library was
-  # calling that empty stub instead: no log output from librccl at all, and NCCL_DEBUG* silently
-  # ignored. Hiding this binary's symbols keeps the stub linkable here but invisible to the dynamic
-  # linker, so librccl keeps its own. rccl-UnitTestsFixturesDebug below does the same.
+  # AICOMRCCL-2183: RcclMockFuncs.hpp's empty ncclDebugLog, needed to link the Release-only
+  # sources above, overrides librccl.so's own in Debug and silences all library logging. Hidden
+  # keeps it linkable here but out of .dynsym, as rccl-UnitTestsFixturesDebug does below.
   target_compile_options(rccl-UnitTests PRIVATE
     -fvisibility=hidden -fvisibility-inlines-hidden)
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -289,6 +289,15 @@ if(BUILD_TESTS)
   target_link_options(rccl-UnitTests PRIVATE
     "LINKER:--export-dynamic-symbol=ncclNetPlugin_v12")
 
+  # AICOMRCCL-2183: RcclMockFuncs.hpp defines an empty ncclDebugLog, needed to link the RCCL
+  # sources added above in Release. A definition in the executable also overrides the shared
+  # library's, so in Debug, where librccl.so exports its own ncclDebugLog, the library was
+  # calling that empty stub instead: no log output from librccl at all, and NCCL_DEBUG* silently
+  # ignored. Hiding this binary's symbols keeps the stub linkable here but invisible to the dynamic
+  # linker, so librccl keeps its own. rccl-UnitTestsFixturesDebug below does the same.
+  target_compile_options(rccl-UnitTests PRIVATE
+    -fvisibility=hidden -fvisibility-inlines-hidden)
+
   # A real shared library, unlike the net plugin above: ProfilerPluginCloseTests checks
   # that RCCL unloads an external profiler plugin, so it needs a separately loadable
   # object. It lands beside rccl-UnitTests in the build tree and is installed beside it

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1105,7 +1105,16 @@
         {"name": "CollTraceUtils.EventQueueOperation", "description": "CollTrace utils event queue operation", "test_filter": "CollTraceUtilsTest.EventQueueOperationTest"},
         {"name": "CollTraceUtils.EventQueueMultiThread", "description": "CollTrace utils event queue multithread", "test_filter": "CollTraceUtilsTest.EventQueueMultiThreadTest"},
         {"name": "CollTraceUtils.getSizeMb", "description": "CollTrace utils get size MB", "test_filter": "CollTraceUtilsTest.getSizeMbTest"},
-        {"name": "CpuAffinity.RestoredAfterInitRank", "description": "Verify CPU affinity mask is restored after ncclCommInitRank (NCCL #2033 regression)", "test_filter": "CpuAffinity.RestoredAfterInitRank"}
+        {"name": "CpuAffinity.RestoredAfterInitRank", "description": "Verify CPU affinity mask is restored after ncclCommInitRank (NCCL #2033 regression)", "test_filter": "CpuAffinity.RestoredAfterInitRank"},
+        {"name": "CollImplInfo.AllReduceMatchesDispatchLog", "description": "rcclGetCollImplInfo reports the AllReduce algo/proto/channels the dispatch log recorded, at every size", "test_filter": "CollImplInfo.AllReduceMatchesDispatchLog"},
+        {"name": "CollImplInfo.AllGatherMatchesDispatchLog", "description": "rcclGetCollImplInfo reports the AllGather algo/proto/channels the dispatch log recorded, at every size", "test_filter": "CollImplInfo.AllGatherMatchesDispatchLog"},
+        {"name": "CollImplInfo.AllReduceSymmetricMatchesDispatchLog", "description": "Same for AllReduce with buffers registered as symmetric windows (-R 2 path)", "test_filter": "CollImplInfo.AllReduceSymmetricMatchesDispatchLog"},
+        {"name": "CollImplInfo.AllGatherSymmetricMatchesDispatchLog", "description": "Same for AllGather with buffers registered as symmetric windows (-R 2 path)", "test_filter": "CollImplInfo.AllGatherSymmetricMatchesDispatchLog"},
+        {"name": "CollImplInfo.AllReduceSymkNotReportedWhenCuMemDisabled", "description": "With cuMem disabled, rcclSymKGetInfo falls back to the real AllReduce backend and never claims SYM", "test_filter": "CollImplInfo.AllReduceSymkNotReportedWhenCuMemDisabled"},
+        {"name": "CollImplInfo.AllGatherSymkNotReportedWhenCuMemDisabled", "description": "With cuMem disabled, rcclSymKGetInfo falls back to the real AllGather backend and never claims SYM", "test_filter": "CollImplInfo.AllGatherSymkNotReportedWhenCuMemDisabled"},
+        {"name": "CollImplInfo.ReduceScatterMatchesDispatchLog", "description": "rcclGetCollImplInfo reports the ReduceScatter algo/proto/channels the dispatch log recorded, at every size", "test_filter": "CollImplInfo.ReduceScatterMatchesDispatchLog"},
+        {"name": "CollImplInfo.ReduceScatterSymmetricMatchesDispatchLog", "description": "Same for ReduceScatter with buffers registered as symmetric windows (-R 2 path)", "test_filter": "CollImplInfo.ReduceScatterSymmetricMatchesDispatchLog"},
+        {"name": "CollImplInfo.ReduceScatterSymkNotReportedWhenCuMemDisabled", "description": "With cuMem disabled, rcclSymKGetInfo falls back to the real ReduceScatter backend and never claims SYM", "test_filter": "CollImplInfo.ReduceScatterSymkNotReportedWhenCuMemDisabled"}
       ]
     },
     "asymmetric_visibility": {


### PR DESCRIPTION
## Motivation

In a Debug build, `rccl-UnitTests` throws away every log line from `librccl.so`, and `NCCL_DEBUG`, `NCCL_DEBUG_SUBSYS` and `NCCL_DEBUG_FILE` do nothing. Tests that read that log fail because of it: `CollImplInfo.*` fails 9/9. Re-running any failing test with `NCCL_DEBUG=INFO` also prints nothing.

## Technical Details

`test/common/RcclMockFuncs.hpp` defines an empty `ncclDebugLog`. It is needed to link the RCCL sources that `test/CMakeLists.txt` compiles into the test binary in Release. But a definition in an executable overrides the one in a shared library, so in Debug, where `librccl.so` exports its own `ncclDebugLog`, the library calls the empty stub instead. `ncclDebugInit()` is only called from `ncclDebugLog`, so `ncclDebugLevel` stays at `-1` and the debug file is never opened.

Building the test target with `-fvisibility=hidden -fvisibility-inlines-hidden` keeps the stub for static linking inside the binary, which Release needs, but hides it from the dynamic linker, so `librccl` uses its own. `rccl-UnitTestsFixturesDebug` already does the same.

Release build was never broken: it does not export `ncclDebugLog`, and a hidden symbol cannot be overridden.

A second commit adds the nine `CollImplInfo` tests to `unit_tests_standard` in `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`.

## Issue Tracking

JIRA ID : AICOMRCCL-2183

## Test Plan

Built `rccl-UnitTests` in Debug and Release on a gfx950 system, before and after the change, and ran `CollImplInfo.*`, `Recorder.*`, `ProxyTrace*` and the net-plugin tests with `UT_MAX_GPUS=4`.

For the config change, the filter strings were checked against `--gtest_list_tests`; that config targets gfx942 with Mellanox IB and was not executed here.

## Test Result

| | CollImplInfo | Recorder | ProxyTrace | NetPlugin |
|---|---|---|---|---|
| Debug, before | 0/9 | 3/3 | 5/5 | 7/7 |
| Debug, with fix | 9/9 | 3/3 | 5/5 | 7/7 |
| Release, before | 9/9 | 3/3 | 5/5 | 7/7 |
| Release, with fix | 9/9 | 3/3 | 5/5 | 7/7 |

**(AI Asist)**

Made with [Cursor](https://cursor.com)
