### PR TITLE
rccl: keep GIN enabled on unpartitioned GPUs

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1506,7 +1506,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
     if (comm->peerInfo[i].hostHash != comm->peerInfo[rank].hostHash) nNodes++;
     if (!comm->peerInfo[i].cuMemSupport) comm->cuMemSupport = 0;
-    if (comm->peerInfo[i].mloPart != -1) comm->hasMloPart = true;
+    if (comm->peerInfo[i].mloPart > 0) comm->hasMloPart = true;
     for (int j = 0; j < i; j++) {
       // NVML device is agnostic to MloPart being used. With MloPart, each partition has a different GPU UUID.
       comm->hasMultiRankNvml = (comm->peerInfo[i].hostHash == comm->peerInfo[j].hostHash) &&


### PR DESCRIPTION
## Motivation

On an unpartitioned MI350X node RCCL reports GIN as unavailable, so applications that require GIN, such as DeepEP v2 ElasticBuffer, abort even though the GIN plugin itself came up correctly.

## Technical Details

`fillInfo()` assigns `mloPart = 0` to a PCI function-0 GPU, which is a full physical device with no CPX/DPX split. `initTransportsRank()` treats any `mloPart != -1` as "MLO partitioning in use", and that gate clears `comm->globalGinSupport`. As a result `ncclCommQueryProperties()` returns `ginType=NONE` and `railedGinType=NONE` while the plugin is in fact assigned (`GIN/Plugin: Assigned plugin RMA_IB_PROXY type 2 to comm`, GPU Direct RDMA enabled on all 8 bnxt_re devices). No combination of `NCCL_GIN_ENABLE`, `NCCL_GIN_TYPE`, `NCCL_CROSS_NIC` or `NCCL_P2P_DISABLE` recovers it.

Only a positive index denotes a real MLO partition, so the gate now checks `mloPart > 0`.

## Issue Tracking

@skip-pr-bot

## Test Plan

Single node, 8x MI350X (gfx950), RCCL built from `develop` for gfx950:

1. Standalone probe: `ncclCommInitAll()` across the 8 GPUs, then `ncclCommQueryProperties()` per rank.
2. sglang with the DeepEP v2 MoE all-to-all backend (DeepSeek-V2-Lite, TP/EP 8, BF16 dispatch), started with `EP_DISABLE_GIN=0` and `NCCL_GIN_ENABLE=1`.

## Test Result

1. Probe before the change: `ginType=0 railedGinType=0` on all 8 ranks. After: `ginType=2 railedGinType=2` on all 8 ranks.
2. sglang before the change: 8 aborts with "NCCL GIN is unavailable", 0/8 ranks initialise. After: 8/8 ranks initialise ElasticBuffer, no aborts, and the server returns correct output.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
