### PR TITLE
docs(rocm-smi-lib): bump TheRock removal notice to ROCm 10.1

### DIFF
--- a/projects/rocm-smi-lib/README.md
+++ b/projects/rocm-smi-lib/README.md
@@ -3,7 +3,7 @@
 Starting with ROCm 7.0, only critical bug fixes will be applied to ROCm-SMI.
 For a seamless experience and continued support, please switch to [AMD-SMI](https://github.com/ROCm/amdsmi).
 
-As of ROCm 10.0, ROCm-SMI is no longer included in TheRock builds. It can still be built from source if desired (see the [installation guide](https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/install/install.html)).
+As of ROCm 10.1, ROCm-SMI is no longer included in TheRock builds. It can still be built from source if desired (see the [installation guide](https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/install/install.html)).
 
 ## Use C++ in ROCm SMI
 


### PR DESCRIPTION
## Motivation

The ROCm-SMI maintenance-mode notice tells users that ROCm-SMI is no longer included in TheRock builds "as of ROCm 10.0." The removal actually lands in ROCm 10.1, so the current wording misstates which release still bundles ROCm-SMI.

## Technical Details

**Docs** (`projects/rocm-smi-lib/README.md`):
- Bump the "no longer included in TheRock builds" notice from ROCm 10.0 to ROCm 10.1

## Issue Tracking

JIRA ID: pending — doc-only correction, ticket to be added before merge.

## Test Plan

- Documentation-only change; no build or unit tests required
- Verified the notice now reads "As of ROCm 10.1"

## Test Result

- N/A (documentation only)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
