### PR TITLE
docs(amdsmi): document AddressSanitizer build and preload requirement

### DIFF
--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -73,6 +73,8 @@ Users that wish to also build the AMD SMI Rust interface will also need the foll
    make package
    ```
 
+   To build with AddressSanitizer instrumentation, see [Build with AddressSanitizer](#build_asan).
+
 (rebuild_py_wrapper)=
 ## Rebuild the Python wrapper
 
@@ -146,9 +148,14 @@ Preload the runtime the library was linked against. Leak detection has to be off
 because CPython does not free everything at shutdown.
 
 ```bash
-ASAN_RT=$(ldd build/lib/libamd_smi.so | awk '/libclang_rt\.asan|libasan/ {print $3}')
+ASAN_RT=$(ldd build/lib/libamd_smi.so | awk '/libclang_rt\.asan|libasan/ && $3 ~ /^\// {print $3}')
+[ -n "$ASAN_RT" ] || echo "No ASAN runtime resolved; rebuild with -DADDRESS_SANITIZER=ON."
 LD_PRELOAD=$ASAN_RT ASAN_OPTIONS=detect_leaks=0 amd-smi static
 ```
+
+An empty `ASAN_RT` means the library is either uninstrumented or instrumented
+against a runtime that is not on the search path, which `ldd` reports as
+`=> not found`.
 
 This applies to any Python process that imports `amdsmi`, not just the CLI. C and
 C++ consumers linked with `-fsanitize=address` need no preload, because the

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -115,6 +115,45 @@ make -j $(nproc)
 Once the tests are [built](#build_tests), you can run them by executing the
 `amdsmitst` program. The executable can be found at `build/tests/amd_smi_test/`.
 
+(build_asan)=
+## Build with AddressSanitizer
+
+`-DADDRESS_SANITIZER=ON` instruments the library and the C/C++ tests.
+
+```bash
+cmake -DADDRESS_SANITIZER=ON ..
+make -j $(nproc)
+```
+
+`-DENABLE_ASAN_PACKAGING=ON` produces a library-only `amd-smi-lib-asan` package.
+The CLI and the Python bindings are excluded from it because neither can load an
+instrumented `libamd_smi.so` unaided; see below.
+
+(asan_python)=
+### Run the CLI or the Python bindings against an instrumented library
+
+`amd-smi` is a Python script, and the bindings are `ctypes`, so both reach the
+library through `dlopen`. AddressSanitizer has to be initialized before the
+process allocates any memory, which is long before `dlopen` runs, so an
+uninstrumented Python aborts with:
+
+```text
+==1234==ASan runtime does not come first in initial library list; you should
+either link runtime to your application or manually preload it with LD_PRELOAD.
+```
+
+Preload the runtime the library was linked against. Leak detection has to be off
+because CPython does not free everything at shutdown.
+
+```bash
+ASAN_RT=$(ldd build/lib/libamd_smi.so | awk '/libclang_rt\.asan|libasan/ {print $3}')
+LD_PRELOAD=$ASAN_RT ASAN_OPTIONS=detect_leaks=0 amd-smi static
+```
+
+This applies to any Python process that imports `amdsmi`, not just the CLI. C and
+C++ consumers linked with `-fsanitize=address` need no preload, because the
+runtime is already in their initial library list.
+
 (build_docs)=
 ## Build the docs
 


### PR DESCRIPTION
## Motivation

`docs/` has no AddressSanitizer content today, so two things that are already
true of the build are undiscoverable: the ASAN package is library-only by
design, and the Python CLI and bindings cannot load an instrumented
`libamd_smi.so` without preloading the ASAN runtime. A downstream ASAN CI hit
the second one and filed it against AMD SMI as a crash.

## Technical Details

**Build guide** (`docs/install/build.md`):
- Add `## Build with AddressSanitizer` covering `-DADDRESS_SANITIZER=ON`, and
  note that `-DENABLE_ASAN_PACKAGING=ON` emits a library-only
  `amd-smi-lib-asan` package with no CLI and no Python bindings
- Add `### Run the CLI or the Python bindings against an instrumented library`
  explaining that both reach the library through `dlopen`, which is too late
  for ASAN to initialize, and quoting the resulting abort message
- Give the working invocation: `LD_PRELOAD` the runtime resolved from the
  library itself, plus `ASAN_OPTIONS=detect_leaks=0` for CPython
- Note that C and C++ consumers linked with `-fsanitize=address` need no preload

Docs-only. No source, packaging, or CMake behavior changes.

## Issue Tracking

JIRA ID: ROCM-30221

## Test Plan

- Built ROCm 27.0.0 ASAN artifacts and reproduced the documented failure:
  `amd-smi static` exits 1 with `ASan runtime does not come first in initial
  library list`
- Ran the exact command block from the new section against that same tree
- `pre-commit run --files docs/install/build.md`

## Test Result

- Without the preload: exit 1, the quoted abort message, no other output
- With the documented `LD_PRELOAD` + `ASAN_OPTIONS=detect_leaks=0`: exit 0 and
  full `amd-smi static` output, confirming the recipe as written
- pre-commit: all hooks skip `docs/` per the repo's lint exclusions

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
