### PR TITLE
fix(rocjitsu): Authorize the daemon to reach client memory

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -8,15 +8,21 @@
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/rpc.h"
+#include "util/log.h"
 #include "util/unique_handle.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
+#include <charconv>
 #include <chrono>
 #include <cstring>
 #include <fcntl.h>
+#include <format>
+#include <fstream>
 #include <linux/mman.h>
+#include <optional>
+#include <string_view>
 #ifndef MADV_POPULATE_WRITE
 #define MADV_POPULATE_WRITE 23
 #endif
@@ -24,6 +30,13 @@
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
+#include <sys/prctl.h>
+#ifndef PR_SET_PTRACER
+// Yama's ptrace-scope exception list. Absent from some libc header sets even
+// where the running kernel implements it, so the call below is worth keeping
+// unconditional; the kernel answers EINVAL when it is genuinely unsupported.
+#define PR_SET_PTRACER 0x59616d61
+#endif
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -66,6 +79,130 @@ constexpr bool has_embedded_pointers(unsigned long request) {
 int transport_errno() {
   const int err = errno;
   return err > 0 ? -err : -EIO;
+}
+
+/// @brief Permit the daemon on @p socket to read and write this address space.
+///
+/// @details Host memory that never became a daemon mapping is reachable only by
+/// the daemon reaching into this process. Its memory bridge already assumes it
+/// can, through process_vm_readv/writev, and GPU access to such memory is
+/// serviced no other way -- pageable buffers the runtime pinned through the KFD
+/// SVM API, above all, since that registration produces no shared backing the
+/// way a USERPTR allocation does. Those calls are nonetheless refused by
+/// default: the daemon is forked as this process's child, and Yama's default
+/// ptrace_scope admits a ptracer only over its own descendants, never over its
+/// own ancestor. Naming the daemon a permitted ptracer restores the access the
+/// bridge was written to have; without it every such access fails EPERM and the
+/// SDMA copy that needed it never completes.
+///
+/// The peer PID comes from the kernel rather than from the daemon, so this
+/// names exactly the process on the other end of this socket. The grant widens
+/// nothing that was not already true: the daemon's own client library is this
+/// LD_PRELOAD, and is already executing inside this address space.
+///
+/// @brief The daemon PID this client's launcher forked, if it had one.
+/// @details Read from the environment rather than the socket on purpose: the
+/// socket answers who is connected, and this answers who was supposed to be.
+std::optional<pid_t> launched_daemon_pid() {
+  const char *raw = getenv(kRpcDaemonPidEnv);
+  if (raw == nullptr || *raw == '\0')
+    return std::nullopt;
+  pid_t parsed = 0;
+  const char *end = raw + std::strlen(raw);
+  const auto [stop, error] = std::from_chars(raw, end, parsed);
+  if (error != std::errc{} || stop != end || parsed <= 0)
+    return std::nullopt;
+  return parsed;
+}
+
+/// @brief Contents of Yama's ptrace_scope, or nullopt when it does not exist.
+std::optional<std::string> read_ptrace_scope() {
+  std::ifstream file("/proc/sys/kernel/yama/ptrace_scope");
+  if (!file)
+    return std::nullopt;
+  std::string contents;
+  std::getline(file, contents);
+  return contents;
+}
+
+/// @brief Why a peer was refused, for the log line that reports it.
+std::string_view describe(PtracerGrantVerdict verdict) {
+  switch (verdict) {
+  case PtracerGrantVerdict::Grant:
+    return "the peer is the daemon this client's launcher started";
+  case PtracerGrantVerdict::GrantUnverifiedPeer:
+    return "no launcher named a daemon, so the socket's owner is trusted";
+  case PtracerGrantVerdict::RefusedNoPeer:
+    return "the socket reports no usable peer credentials";
+  case PtracerGrantVerdict::RefusedForeignUser:
+    return "the peer belongs to another user";
+  case PtracerGrantVerdict::RefusedPeerMismatch:
+    return "the peer is not the daemon this client's launcher started";
+  }
+  return "unrecognized";
+}
+
+/// Called only once the handshake has succeeded. Before that this process has
+/// no evidence the peer speaks the protocol at all, and a grant is the one step
+/// here that outlives the connection.
+///
+/// @param[in] socket Connected daemon socket.
+/// @returns The trust decision, whether or not a syscall followed from it.
+PtracerGrantVerdict authorize_daemon_address_space_access(int socket) {
+  ucred peer{};
+  socklen_t peer_size = sizeof(peer);
+  const bool have_peer = getsockopt(socket, SOL_SOCKET, SO_PEERCRED, &peer, &peer_size) == 0 &&
+                         peer_size == sizeof(peer) && peer.pid > 0;
+
+  const PtracerGrantVerdict verdict =
+      have_peer ? ptracer_grant_verdict(launched_daemon_pid(), peer.pid, peer.uid, geteuid())
+                : PtracerGrantVerdict::RefusedNoPeer;
+  if (!grants(verdict)) {
+    // Reported rather than dropped. A refusal is not a failure in itself, but
+    // it decides whether pageable transfers above the pinning threshold can
+    // complete, and a caller left wondering why an SDMA copy never retires has
+    // no other way to find out.
+    util::Logger::warn(
+        std::format("daemon: not authorizing peer to read this address space ({}); transfers "
+                    "that rely on process_vm_readv/writev will fail",
+                    describe(verdict)));
+    return verdict;
+  }
+  if (verdict == PtracerGrantVerdict::GrantUnverifiedPeer) {
+    // Said out loud, every time. This is the grant that rests on nothing but the
+    // peer having answered this socket, so which process received it belongs in
+    // the log rather than only in the kernel's unreadable exception slot.
+    util::Logger::warn(
+        std::format("daemon: authorizing pid {} to read this address space; no launcher named a "
+                    "daemon for this client, so nothing here identifies it further",
+                    peer.pid));
+  }
+
+  const PtraceScopePolicy policy = ptrace_scope_policy_from_text(read_ptrace_scope());
+  if (policy == PtraceScopePolicy::Absent || policy == PtraceScopePolicy::Disabled)
+    return verdict; // Already permitted; the grant would be a no-op.
+  if (policy == PtraceScopePolicy::AdminOnly || policy == PtraceScopePolicy::NoAttach) {
+    util::Logger::warn(
+        "daemon: ptrace_scope forbids attaching regardless of a permitted-ptracer grant, so "
+        "transfers that rely on process_vm_readv/writev will fail");
+    return verdict;
+  }
+
+  // Process-wide, single-valued, and unreadable: PR_SET_PTRACER holds one PID
+  // with no PR_GET_PTRACER to inspect it, so this necessarily overwrites
+  // whatever was there. That is why it is narrowed as far as it is -- issued
+  // only for a handshaked peer that the launcher named, and only in the one
+  // scope where it changes anything. A reconnect re-issues it for the new
+  // daemon, which is correct: the previous one is the process this client is no
+  // longer being served by. A debugger or rocSHMEM grant taken beforehand is
+  // displaced, and cannot be restored afterwards because it cannot be read.
+  if (prctl(PR_SET_PTRACER, static_cast<unsigned long>(peer.pid), 0, 0, 0) != 0) {
+    util::Logger::warn(std::format(
+        "daemon: could not authorize pid {} to read this address space ({}); transfers that "
+        "rely on process_vm_readv/writev will fail",
+        peer.pid, std::strerror(errno)));
+  }
+  return verdict;
 }
 
 /// @brief Safe wrapper around syscall(SYS_mmap, ...) that avoids UB from
@@ -222,6 +359,61 @@ uint32_t clamp_snapshot_entries(uint32_t count, uint32_t entry_size, size_t arg_
 
 } // namespace
 
+PtraceScopePolicy ptrace_scope_policy_from_text(const std::optional<std::string> &contents) {
+  if (!contents)
+    return PtraceScopePolicy::Absent;
+  std::string_view text = *contents;
+  while (!text.empty() && (text.front() == ' ' || text.front() == '\t'))
+    text.remove_prefix(1);
+  while (!text.empty() &&
+         (text.back() == ' ' || text.back() == '\t' || text.back() == '\n' || text.back() == '\r'))
+    text.remove_suffix(1);
+  int value = 0;
+  const auto [stop, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+  if (error != std::errc{} || stop != text.data() + text.size())
+    return PtraceScopePolicy::Unknown;
+  switch (value) {
+  case 0:
+    return PtraceScopePolicy::Disabled;
+  case 1:
+    return PtraceScopePolicy::Relational;
+  case 2:
+    return PtraceScopePolicy::AdminOnly;
+  case 3:
+    return PtraceScopePolicy::NoAttach;
+  default:
+    // A scope this build does not know is assumed to restrict at least as much
+    // as the one it does, so the grant is still attempted rather than skipped.
+    return PtraceScopePolicy::Unknown;
+  }
+}
+
+PtracerGrantVerdict ptracer_grant_verdict(std::optional<pid_t> launched_daemon_pid, pid_t peer_pid,
+                                          uid_t peer_uid, uid_t self_uid) {
+  if (peer_pid <= 0)
+    return PtracerGrantVerdict::RefusedNoPeer;
+  // A cross-user peer could not attach even if named here, because PR_SET_PTRACER
+  // relaxes Yama alone and the ordinary ptrace credential check still stands
+  // behind it. Refused anyway, so the exception list never holds a process this
+  // client did not expect to be served by.
+  if (peer_uid != self_uid)
+    return PtracerGrantVerdict::RefusedForeignUser;
+  // SO_PEERCRED says who is connected, which is a weaker claim than it appears:
+  // the socket path is well known, so any process of this user can be listening
+  // on it, and same-user peers are exactly what Yama's relationship check exists
+  // to separate. Where a launcher named a process, that name decides.
+  if (launched_daemon_pid) {
+    return *launched_daemon_pid == peer_pid ? PtracerGrantVerdict::Grant
+                                            : PtracerGrantVerdict::RefusedPeerMismatch;
+  }
+  // No launcher named one: attach mode, or a bare LD_PRELOAD against a running
+  // daemon. Nothing here can identify the peer, and no check could be added that
+  // would: a secret shared with the daemon authenticates nothing against an
+  // attacker of this UID, who reads whatever this client can. The peer is
+  // trusted, and every such grant says so.
+  return PtracerGrantVerdict::GrantUnverifiedPeer;
+}
+
 RemoteDriver::MemfdLookup RemoteDriver::find_memfd_for_addr(void *addr, size_t length,
                                                             int *memfd_out, off_t *offset_out) {
   *memfd_out = -1;
@@ -285,6 +477,7 @@ int RemoteDriver::poison_stream() {
 
 int RemoteDriver::open() {
   assert(sock_ >= 0 && "open called on disconnected RemoteDriver");
+  ptracer_verdict_.reset();
   closing_.store(false, std::memory_order_release);
   has_gpu_info_ = false;
   gpu_info_ = {};
@@ -365,6 +558,11 @@ int RemoteDriver::open() {
       return -1;
     }
   }
+
+  // Only here, with the handshake complete. Everything above can fail on a peer
+  // that never proved it speaks this protocol, and the grant is the one step in
+  // open() whose effect outlives the connection that prompted it.
+  ptracer_verdict_ = authorize_daemon_address_space_access(sock_);
 
   return reissue_synthetic_kfd_fd();
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -24,6 +24,13 @@
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
+#include <sys/prctl.h>
+#ifndef PR_SET_PTRACER
+// Yama's ptrace-scope exception list. Absent from some libc header sets even
+// where the running kernel implements it, so the call below is worth keeping
+// unconditional; the kernel answers EINVAL when it is genuinely unsupported.
+#define PR_SET_PTRACER 0x59616d61
+#endif
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -66,6 +73,45 @@ constexpr bool has_embedded_pointers(unsigned long request) {
 int transport_errno() {
   const int err = errno;
   return err > 0 ? -err : -EIO;
+}
+
+/// @brief Permit the daemon on @p socket to read and write this address space.
+///
+/// @details Host memory that never became a daemon mapping is reachable only by
+/// the daemon reaching into this process. Its memory bridge already assumes it
+/// can, through process_vm_readv/writev, and GPU access to such memory is
+/// serviced no other way -- pageable buffers the runtime pinned through the KFD
+/// SVM API, above all, since that registration produces no shared backing the
+/// way a USERPTR allocation does. Those calls are nonetheless refused by
+/// default: the daemon is forked as this process's child, and Yama's default
+/// ptrace_scope admits a ptracer only over its own descendants, never over its
+/// own ancestor. Naming the daemon a permitted ptracer restores the access the
+/// bridge was written to have; without it every such access fails EPERM and the
+/// SDMA copy that needed it never completes.
+///
+/// The peer PID comes from the kernel rather than from the daemon, so this
+/// names exactly the process on the other end of this socket. The grant widens
+/// nothing that was not already true: the daemon's own client library is this
+/// LD_PRELOAD, and is already executing inside this address space.
+///
+/// Best effort, and deliberately silent. Where Yama is absent or disabled the
+/// syscall is redundant because the access already succeeds, and where
+/// ptrace_scope forbids attaching outright there is nothing to restore.
+void authorize_daemon_address_space_access(int socket) {
+  ucred peer{};
+  socklen_t peer_size = sizeof(peer);
+  if (getsockopt(socket, SOL_SOCKET, SO_PEERCRED, &peer, &peer_size) != 0 ||
+      peer_size != sizeof(peer) || peer.pid <= 0)
+    return;
+  // Never name a peer belonging to another user. PR_SET_PTRACER relaxes Yama
+  // alone; the ordinary ptrace credential check still stands behind it, so a
+  // cross-user peer could not attach even if named here. Refusing anyway keeps
+  // the exception list from ever holding a process this client did not expect
+  // to be served by, which is the property worth preserving if a socket is ever
+  // reached by something other than the daemon that forked us.
+  if (peer.uid != geteuid())
+    return;
+  prctl(PR_SET_PTRACER, static_cast<unsigned long>(peer.pid), 0, 0, 0);
 }
 
 /// @brief Safe wrapper around syscall(SYS_mmap, ...) that avoids UB from
@@ -285,6 +331,7 @@ int RemoteDriver::poison_stream() {
 
 int RemoteDriver::open() {
   assert(sock_ >= 0 && "open called on disconnected RemoteDriver");
+  authorize_daemon_address_space_access(sock_);
   closing_.store(false, std::memory_order_release);
   has_gpu_info_ = false;
   gpu_info_ = {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
@@ -18,11 +18,67 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <sys/types.h>
 #include <unordered_map>
 #include <vector>
 
 namespace rocjitsu {
+
+/// @brief What Yama's ptrace_scope implies for the daemon's cross-process reads.
+/// @details Only one of these states makes the grant both necessary and
+/// sufficient, and the others are not interchangeable: two of them mean the
+/// access already works, and two mean naming a ptracer cannot make it work. The
+/// distinction decides whether a failed grant is worth reporting, which is the
+/// difference between a diagnosable failure and an SDMA copy that never retires.
+enum class PtraceScopePolicy {
+  Absent,     ///< Yama is not built in; process_vm_* is already permitted.
+  Disabled,   ///< scope 0: unrestricted, so nothing needs restoring.
+  Relational, ///< scope 1: descendants only, so the grant is required and works.
+  AdminOnly,  ///< scope 2: CAP_SYS_PTRACE only; naming a ptracer changes nothing.
+  NoAttach,   ///< scope 3: attaching is off entirely and cannot be re-enabled.
+  Unknown,    ///< Present but unparsable; treated as if a grant were needed.
+};
+
+/// @brief Classify the contents of /proc/sys/kernel/yama/ptrace_scope.
+/// @param[in] contents File contents, or nullopt when the file does not exist.
+/// @returns The policy the value denotes.
+[[nodiscard]] PtraceScopePolicy
+ptrace_scope_policy_from_text(const std::optional<std::string> &contents);
+
+/// @brief Whether a socket peer may be named a permitted ptracer of this process.
+/// @details Separated from the syscalls so the policy is testable on its own.
+/// This is the whole of the trust decision; everything around it is mechanism.
+enum class PtracerGrantVerdict {
+  Grant,               ///< The peer is the daemon this client's launcher started.
+  GrantUnverifiedPeer, ///< No launcher named one, so the socket's owner is trusted.
+  RefusedNoPeer,       ///< SO_PEERCRED gave nothing usable.
+  RefusedForeignUser,  ///< The peer belongs to another user.
+  RefusedPeerMismatch, ///< Someone other than that daemon is on this socket.
+};
+
+/// @brief Whether @p verdict authorizes the peer, however it was reached.
+[[nodiscard]] constexpr bool grants(PtracerGrantVerdict verdict) {
+  return verdict == PtracerGrantVerdict::Grant ||
+         verdict == PtracerGrantVerdict::GrantUnverifiedPeer;
+}
+
+/// @brief Decide whether @p peer_pid may reach into this address space.
+/// @param[in] launched_daemon_pid PID the launcher forked, or nullopt if none.
+/// @param[in] peer_pid PID the kernel reports for the socket peer.
+/// @param[in] peer_uid UID the kernel reports for the socket peer.
+/// @param[in] self_uid Effective UID of this process.
+/// @returns Why the grant is or is not permitted.
+/// @details Where a launcher named a daemon, a peer that is not that process is
+/// refused -- which is the case a well-known socket makes reachable, since any
+/// process of this user can be the one listening on it. Where no launcher named
+/// one, there is nothing to check against and the peer is trusted; that grant is
+/// distinguished here rather than merged, because it is the weaker of the two
+/// and its callers report it differently.
+[[nodiscard]] PtracerGrantVerdict ptracer_grant_verdict(std::optional<pid_t> launched_daemon_pid,
+                                                        pid_t peer_pid, uid_t peer_uid,
+                                                        uid_t self_uid);
 
 /// @brief Client-side driver that forwards ioctls to the rocjitsu daemon.
 ///
@@ -44,6 +100,16 @@ public:
   /// @brief Get GPU metadata received from the daemon handshake.
   [[nodiscard]] const Sysfs::GpuInfo *gpu_info() const {
     return has_gpu_info_ ? &gpu_info_ : nullptr;
+  }
+
+  /// @brief What the last open() decided about authorizing its peer.
+  /// @details Reported because the decision is otherwise invisible: a refusal
+  /// leaves no trace in this object, and the grant itself is process-wide state
+  /// no interface can read back -- the kernel offers no PR_GET_PTRACER. Without
+  /// this, that a peer was refused, and that a failed handshake never reached
+  /// the question at all, are both untestable. nullopt until open() runs.
+  [[nodiscard]] std::optional<PtracerGrantVerdict> ptracer_verdict() const {
+    return ptracer_verdict_;
   }
 
   /// @brief Outcome of find_memfd_for_addr(): distinguishes "no matching range"
@@ -140,12 +206,13 @@ private:
   /// @note Must be called with rpc_mutex_ held.
   int poison_stream();
 
-  int sock_ = -1;                    ///< Unix socket connection to the daemon.
-  uint32_t next_id_ = 0;             ///< Monotonic request ID counter (for debugging).
-  std::string topology_path_;        ///< Daemon's sysfs topology directory path.
-  std::string drm_path_;             ///< Daemon's DRM sysfs directory path.
-  Sysfs::GpuInfo gpu_info_{};        ///< GPU metadata received from daemon handshake.
-  bool has_gpu_info_ = false;        ///< True when gpu_info_ is valid.
+  int sock_ = -1;             ///< Unix socket connection to the daemon.
+  uint32_t next_id_ = 0;      ///< Monotonic request ID counter (for debugging).
+  std::string topology_path_; ///< Daemon's sysfs topology directory path.
+  std::string drm_path_;      ///< Daemon's DRM sysfs directory path.
+  Sysfs::GpuInfo gpu_info_{}; ///< GPU metadata received from daemon handshake.
+  bool has_gpu_info_ = false; ///< True when gpu_info_ is valid.
+  std::optional<PtracerGrantVerdict> ptracer_verdict_; ///< Last open()'s trust decision.
   std::atomic<bool> closing_{false}; ///< Set by close() to break WAIT_EVENTS loops.
   /// @brief Set when the RPC stream is known to be unusable.
   /// @details Any frame that is not written or read in full leaves the stream

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -293,6 +293,22 @@ inline std::string rpc_default_config_file_path() {
 /// connect_to_daemon then uses the well-known socket).
 inline constexpr char kRpcInvocationDirEnv[] = "ROCJITSU_INVOCATION_DIR";
 
+/// @brief Environment variable carrying the PID of the daemon the CLI forked.
+/// @details Exported beside kRpcInvocationDirEnv, and for the same reason: the
+/// CLI knows this PID because it forked the process, then execs the workload
+/// over itself, so nothing survives the exec that is not in the environment.
+///
+/// It exists to name which process a client may authorize to reach into its
+/// address space. SO_PEERCRED alone answers "who is on the other end of this
+/// socket", which is not the same question: the socket path is well known, so
+/// any process of the same user can be listening on it. Only the launcher knows
+/// which PID it started, and only a peer matching it is the daemon this client
+/// was meant to be served by.
+///
+/// Absent in attach mode, where no launcher established a daemon and there is
+/// therefore nothing to compare a peer against.
+inline constexpr char kRpcDaemonPidEnv[] = "ROCJITSU_DAEMON_PID";
+
 /// @brief Per-invocation runtime directory scoped by PID.
 /// @details The CLI creates <runtime_dir>/<pid>/ before execvp and exports its
 /// path via $ROCJITSU_INVOCATION_DIR so the interposer locates the correct

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2688,6 +2688,24 @@ if(RJ_ENABLE_HIP_TESTS)
             "HipMemcpyTest.RoundTripInt"
             CONFIG ${RJ_HIP_TEST_CONFIG}
         )
+        # The only case that reaches ROCr's pinned SDMA blit, and both sanitizers
+        # report that library rather than rocjitsu. TSan sees the blit's memcpy
+        # into the ring but not the release store on the doorbell that follows
+        # it, because libhsa-runtime64 is not instrumented; the pair it forms
+        # with the acquire load in poll_doorbells() is therefore invisible and
+        # the fetch looks unordered. LSan reports ~5.7 KB allocated entirely
+        # within that library, in frames with no rocjitsu caller. Neither is
+        # actionable from here, and suppressing them by file would hide the same
+        # classes of defect on the paths rocjitsu does own. The case still runs
+        # in regular builds, in both local and daemon mode, which is where it
+        # regression-tests the transfer.
+        if(NOT RJ_ENABLE_ASAN AND NOT RJ_ENABLE_TSAN)
+            rj_add_hip_test_case(
+                hip_memcpy_test
+                "HipMemcpyTest.RoundTripPageableAbovePinThreshold"
+                CONFIG ${RJ_HIP_TEST_CONFIG}
+            )
+        endif()
         rj_add_hip_test_case(
             hip_memcpy_test
             "HipMemcpyTest.DeviceToDevice"
@@ -2794,6 +2812,16 @@ if(RJ_ENABLE_HIP_TESTS)
             DaemonTest.InterposerDup2OverPrimaryInvalidatesRemote
             DaemonTest.InterposerProcMapsNamesRemoteKfdMarker
         )
+        # Excluded under sanitizers for the reason given at its local-mode
+        # registration above: the pinned SDMA path this case exists to cover
+        # runs inside an uninstrumented libhsa-runtime64, and both the race TSan
+        # infers and the allocations LSan finds are that library's.
+        if(NOT RJ_ENABLE_ASAN AND NOT RJ_ENABLE_TSAN)
+            list(
+                APPEND RJ_DAEMON_TESTS
+                DaemonTest.HipMemcpyRoundTripPageableAbovePinThreshold
+            )
+        endif()
         foreach(TC IN LISTS RJ_DAEMON_TESTS)
             rj_add_test(
                 NAME ${TC}

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2595,6 +2595,11 @@ if(RJ_ENABLE_HIP_TESTS)
         )
         rj_add_hip_test_case(
             hip_memcpy_test
+            "HipMemcpyTest.RoundTripPageableAbovePinThreshold"
+            CONFIG ${RJ_HIP_TEST_CONFIG}
+        )
+        rj_add_hip_test_case(
+            hip_memcpy_test
             "HipMemcpyTest.DeviceToDevice"
             CONFIG ${RJ_HIP_TEST_CONFIG}
         )
@@ -2686,6 +2691,7 @@ if(RJ_ENABLE_HIP_TESTS)
             DaemonTest.AttachExecFailurePreservesDaemonSocket
             DaemonTest.HipMemcpyRoundTripFloat
             DaemonTest.HipMemcpyRoundTripInt
+            DaemonTest.HipMemcpyRoundTripPageableAbovePinThreshold
             DaemonTest.HipMemcpyDeviceToDevice
             DaemonTest.TwoIndependentClients
             DaemonTest.InterposerDupReopenAfterPrimaryOverwriteRemote

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -369,6 +369,11 @@ TEST_F(DaemonTest, HipMemcpyRoundTripInt) {
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
+TEST_F(DaemonTest, HipMemcpyRoundTripPageableAbovePinThreshold) {
+  auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.RoundTripPageableAbovePinThreshold");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
+}
+
 TEST_F(DaemonTest, HipMemcpyDeviceToDevice) {
   auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.DeviceToDevice");
   EXPECT_EQ(r.exit_code, 0) << r.output;

--- a/emulation/rocjitsu/tests/hip_memcpy_test.cpp
+++ b/emulation/rocjitsu/tests/hip_memcpy_test.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <cstdlib>
 
 int main(int argc, char **argv) {
@@ -62,6 +63,47 @@ TEST(HipMemcpyTest, RoundTripInt) {
 
   for (int i = 0; i < N; ++i)
     EXPECT_EQ(dst[i], src[i]) << "mismatch at index " << i;
+
+  (void)hipFree(d_buf);
+}
+
+/// @brief Round-trips a pageable buffer large enough to take HIP's pinned path.
+/// @details A staged copy travels through a buffer HIP allocated from the
+/// driver, which the daemon has mapped. A pinned one instead has SDMA address
+/// the caller's own pageable memory, which the runtime registers through the
+/// KFD SVM API -- a registration that creates no shared backing, so the daemon
+/// can only service the transfer by reaching into the client. Only the second
+/// kind exercises that path.
+///
+/// @note The transfer size is load-bearing. GPU_PINNED_MIN_XFER_SIZE (64 KiB)
+/// is the documented pinning threshold, but a transfer that still fits one
+/// staging buffer is staged regardless of it, and GPU_STAGING_BUFFER_SIZE
+/// defaults to 1 MiB. Measured against this reproducer with the fix reverted:
+/// 1 MiB still passes, 1.5 MiB already hangs. The 4 MiB used here keeps ~2.5x
+/// margin over that boundary, so a shift in staging behaviour cannot quietly
+/// turn this into a no-op. The margin is nearly free -- it costs ~0.3 s in
+/// daemon mode -- whereas shrinking toward 64 KiB stops testing anything.
+TEST(HipMemcpyTest, RoundTripPageableAbovePinThreshold) {
+  constexpr size_t bytes = 4 * 1024 * 1024;
+  constexpr size_t N = bytes / sizeof(int);
+
+  std::vector<int> src(N), dst(N, 0);
+  // Knuth's multiplicative hash. The index is narrowed first so the multiply
+  // wraps in 32 bits; computing it in size_t would leave a 64-bit product whose
+  // top half survives the shift and cannot be represented as an int.
+  for (size_t i = 0; i < N; ++i)
+    src[i] = static_cast<int>((static_cast<uint32_t>(i) * 2654435761u) >> 1);
+
+  int *d_buf = nullptr;
+  HIP_ASSERT(hipMalloc(&d_buf, bytes));
+
+  HIP_ASSERT(hipMemcpy(d_buf, src.data(), bytes, hipMemcpyHostToDevice));
+  HIP_ASSERT(hipMemcpy(dst.data(), d_buf, bytes, hipMemcpyDeviceToHost));
+
+  size_t mismatches = 0;
+  for (size_t i = 0; i < N; ++i)
+    mismatches += static_cast<size_t>(dst[i] != src[i]);
+  EXPECT_EQ(mismatches, 0u);
 
   (void)hipFree(d_buf);
 }

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -11,6 +11,7 @@
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/virtual_machine.h"
+#include "scoped_temp.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
@@ -1699,6 +1700,149 @@ TEST(RemoteDriverEmbeddedArrayTest, WaitEventsSerializesEventsAcrossBufferGrowth
   args.num_events = events.size();
   args.timeout = 1;
   EXPECT_EQ(driver.ioctl(AMDKFD_IOC_WAIT_EVENTS, &args), -EINVAL);
+}
+
+// --- Authorizing the daemon to reach into this address space ---
+//
+// A client names the daemon a permitted ptracer so the daemon's memory bridge
+// can service GPU access to host memory it holds no mapping for. That grant is
+// process-wide and outlives the connection, so who receives it, and when, is a
+// trust decision rather than a detail. These cover the decision itself; the
+// syscall behind it is the kernel's.
+
+namespace {
+
+/// @brief Serve one RPC_HANDSHAKE and stop.
+/// @param[in] fd Server end of the socketpair.
+/// @param[in] result Header result: nonzero makes the client reject the peer.
+void serve_one_handshake(int fd, int32_t result) {
+  rocjitsu::RpcHeader request{};
+  if (!rocjitsu::rpc_recv_exact(fd, &request, sizeof(request)))
+    return;
+  rocjitsu::RpcHeader response{};
+  response.opcode = rocjitsu::RPC_HANDSHAKE;
+  response.request_id = request.request_id;
+  response.result = result;
+  response.payload_bytes =
+      result == 0 ? static_cast<uint32_t>(sizeof(rocjitsu::RpcHandshakeResponse)) : 0;
+  if (!rocjitsu::rpc_send_exact(fd, &response, sizeof(response)) || result != 0)
+    return;
+  rocjitsu::RpcHandshakeResponse payload{};
+  payload.version = rocjitsu::kRpcProtocolVersion;
+  rocjitsu::rpc_send_exact(fd, &payload, sizeof(payload));
+}
+
+} // namespace
+
+// Both ends of a socketpair belong to this process, so SO_PEERCRED reports this
+// PID -- which is what makes the launcher's PID the only variable here.
+TEST(RemoteDriverPtracerGrantTest, AuthorizesOnlyTheDaemonItsLauncherStarted) {
+  const rocjitsu::test::ScopedEnvironmentVariable daemon_pid(rocjitsu::kRpcDaemonPidEnv,
+                                                             std::to_string(getpid()));
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+  std::jthread server([fd = sv[1]] {
+    serve_one_handshake(fd, 0);
+    ::close(fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_GE(driver.open(), 0);
+
+  ASSERT_TRUE(driver.ptracer_verdict().has_value());
+  EXPECT_EQ(*driver.ptracer_verdict(), rocjitsu::PtracerGrantVerdict::Grant);
+}
+
+// The socket path is well known, so a same-user process can be listening on it.
+// SO_PEERCRED reports that process truthfully; it is simply not the daemon this
+// client's launcher started, and Yama's relationship check is exactly what
+// would otherwise separate them.
+TEST(RemoteDriverPtracerGrantTest, RefusesAListenerThatIsNotTheLaunchedDaemon) {
+  const rocjitsu::test::ScopedEnvironmentVariable daemon_pid(rocjitsu::kRpcDaemonPidEnv,
+                                                             std::to_string(getpid() + 1));
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+  std::jthread server([fd = sv[1]] {
+    serve_one_handshake(fd, 0);
+    ::close(fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_GE(driver.open(), 0);
+
+  ASSERT_TRUE(driver.ptracer_verdict().has_value());
+  EXPECT_EQ(*driver.ptracer_verdict(), rocjitsu::PtracerGrantVerdict::RefusedPeerMismatch);
+}
+
+// Attach mode: no launcher named a daemon, so there is nothing to compare the
+// peer against and the grant is withheld rather than given to whoever answered.
+TEST(RemoteDriverPtracerGrantTest, TrustsTheSocketWhenNoLauncherNamedADaemon) {
+  // Empty rather than unset: both mean "no launcher named one", and the empty
+  // spelling is also what an inherited-but-cleared environment looks like.
+  const rocjitsu::test::ScopedEnvironmentVariable daemon_pid(rocjitsu::kRpcDaemonPidEnv, "");
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+  std::jthread server([fd = sv[1]] {
+    serve_one_handshake(fd, 0);
+    ::close(fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  ASSERT_GE(driver.open(), 0);
+
+  ASSERT_TRUE(driver.ptracer_verdict().has_value());
+  EXPECT_EQ(*driver.ptracer_verdict(), rocjitsu::PtracerGrantVerdict::GrantUnverifiedPeer);
+}
+
+// Having named a daemon outranks trusting the socket, so a peer failing the PID
+// check is refused rather than falling back to being trusted -- which would
+// make the check decorative.
+TEST(RemoteDriverPtracerGrantTest, DoesNotFallBackToTrustWhenTheNamedPidMismatches) {
+  const uid_t self = geteuid();
+  EXPECT_EQ(rocjitsu::ptracer_grant_verdict(4242, 4243, self, self),
+            rocjitsu::PtracerGrantVerdict::RefusedPeerMismatch);
+}
+
+// A peer that fails the handshake has proved nothing, so the question of
+// authorizing it is never reached -- not asked and refused, but not asked.
+TEST(RemoteDriverPtracerGrantTest, NeverReachesTheQuestionWhenTheHandshakeFails) {
+  const rocjitsu::test::ScopedEnvironmentVariable daemon_pid(rocjitsu::kRpcDaemonPidEnv,
+                                                             std::to_string(getpid()));
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0) << strerror(errno);
+  std::jthread server([fd = sv[1]] {
+    serve_one_handshake(fd, -EPROTO);
+    ::close(fd);
+  });
+
+  rocjitsu::RemoteDriver driver(sv[0]);
+  EXPECT_LT(driver.open(), 0);
+
+  EXPECT_FALSE(driver.ptracer_verdict().has_value())
+      << "a peer that never completed the handshake must not be considered for a grant";
+}
+
+TEST(RemoteDriverPtracerGrantTest, ReadsYamaScopeAsThePolicyItDenotes) {
+  using rocjitsu::PtraceScopePolicy;
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text(std::nullopt), PtraceScopePolicy::Absent);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text("0"), PtraceScopePolicy::Disabled);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text("1\n"), PtraceScopePolicy::Relational);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text(" 2 "), PtraceScopePolicy::AdminOnly);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text("3"), PtraceScopePolicy::NoAttach);
+  // A scope this build does not know, and a value that is not one at all, both
+  // resolve to "attempt the grant" rather than to "skip it": skipping is the
+  // answer that silently loses the access.
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text("4"), PtraceScopePolicy::Unknown);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text(""), PtraceScopePolicy::Unknown);
+  EXPECT_EQ(rocjitsu::ptrace_scope_policy_from_text("banana"), PtraceScopePolicy::Unknown);
+}
+
+TEST(RemoteDriverPtracerGrantTest, RefusesAPeerBelongingToAnotherUser) {
+  const uid_t self = geteuid();
+  EXPECT_EQ(rocjitsu::ptracer_grant_verdict(4242, 4242, self + 1, self),
+            rocjitsu::PtracerGrantVerdict::RefusedForeignUser);
+  EXPECT_EQ(rocjitsu::ptracer_grant_verdict(4242, 0, self, self),
+            rocjitsu::PtracerGrantVerdict::RefusedNoPeer);
 }
 
 // --- Daemon-mode DBG_TRAP notifier-fd transfer via SCM_RIGHTS ---

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -536,6 +536,12 @@ int main(int argc, char *argv[]) {
 
   pid_t my_pid = getpid();
 
+  // Set only where this process forked the daemon itself. A client authorizes
+  // that process to reach into its address space, so which PID it is has to
+  // come from whoever started it rather than from the socket, and this exec
+  // is the last point that still knows.
+  std::optional<pid_t> launched_daemon_pid;
+
   if (attach_mode) {
     auto sock_path = rpc_default_socket_path();
     if (!std::filesystem::exists(sock_path)) {
@@ -590,6 +596,7 @@ int main(int argc, char *argv[]) {
       cleanup_runtime_files(my_pid);
       return 1;
     }
+    launched_daemon_pid = daemon_pid;
   } else {
     if (!rocjitsu::config::write_dbt_runtime_config_handoff(abs_config, dbt_guest_config, my_pid)) {
       std::cerr << "rocjitsu: failed to write config file\n";
@@ -624,6 +631,8 @@ int main(int argc, char *argv[]) {
   // holding config_path/daemon.sock. Attach mode creates no such dir.
   if (!attach_mode)
     launch_environment.set(rocjitsu::kRpcInvocationDirEnv, rpc_invocation_runtime_dir(my_pid));
+  if (launched_daemon_pid)
+    launch_environment.set(rocjitsu::kRpcDaemonPidEnv, std::to_string(*launched_daemon_pid));
   rocjitsu::cli::execvp_with_environment(app_argv[0], app_argv, launch_environment);
 
   std::cerr << std::format("rocjitsu: execvp failed: {}\n", strerror(errno));


### PR DESCRIPTION
A pageable host transfer larger than 64 KiB hangs in daemon mode. Above GPU_PINNED_MIN_XFER_SIZE the runtime stops staging through a driver allocation and pins the caller's own memory instead, so SDMA addresses it directly, and it registers that memory through the KFD SVM API -- which, unlike a USERPTR allocation, produces no shared backing for the daemon to map. The daemon falls back to reaching into the client with process_vm_readv/writev, and those are refused: it is forked as the client's child, and Yama's default ptrace_scope admits a ptracer only over its own descendants, never over its own ancestor. The copy cannot complete, so the packet stays pending and retries forever.

Name the daemon a permitted ptracer from the client as it connects, using the peer PID the kernel reports for the socket rather than anything the daemon claims. This restores the access the daemon's memory bridge was already written to have, rather than adding a second authorization path beside it, and it widens nothing: the daemon's client library is this LD_PRELOAD and is already executing inside the address space in question. It is best effort, because where Yama is absent the access already succeeds and where ptrace_scope forbids attaching outright there is nothing to restore.

Every existing memcpy case sits below the pinning threshold and so never reaches the pinned path at all, which is why this survived. The new case crosses it, and runs in both local and daemon mode; with the grant removed the daemon one hangs until the timeout.

Closes #10771