### PR TITLE
(fix): Add ownership management for memory handles in drivers to prevent double close under borrowing

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -241,6 +241,8 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
     handle->handle = reinterpret_cast<uint64_t>(mem);
     handle->vaddr = mem;
     handle->size = size;
+    handle->owner = this;
+    handle->owns_allocation = true;
   };
 
   kmt_alloc_flags.ui32.ExecuteAccess =
@@ -576,6 +578,9 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     }
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     handle->size = res.alloc_size;
+    handle->owner = this;
+    // hsaKmtHandleImport creates a distinct object per import, so this handle owns it.
+    handle->owns_allocation = true;
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE: {
@@ -600,6 +605,9 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     if (rocr::os::DmaBufClose(&res.dmabuf_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
     handle->size = res.alloc_size;
+    handle->owner = this;
+    // hsaKmtHandleImport creates a distinct object per import, so this handle owns it.
+    handle->owns_allocation = true;
     return HSA_STATUS_SUCCESS;
   }
   default:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -236,6 +236,8 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
     handle->handle = reinterpret_cast<uint64_t>(mem);
     handle->vaddr = mem;
     handle->size = size;
+    handle->owner = this;
+    handle->owns_allocation = true;
   };
 
   kmt_alloc_flags.ui32.ExecuteAccess =
@@ -530,6 +532,9 @@ hsa_status_t KfdVirtioDriver::ImportMemoryHandle(const core::Agent& agent, core:
 
     *handle = core::DriverMemoryHandle{reinterpret_cast<uint64_t>(res.buf_handle)};
     handle->size = res.alloc_size;
+    handle->owner = this;
+    // vamdgpu_bo_import creates a distinct bo per import, so this handle owns it.
+    handle->owns_allocation = true;
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -899,7 +899,8 @@ hsa_status_t XdnaDriver::ImportMemoryHandle(const core::Agent& agent, core::Driv
     // A drm_file holds at most one GEM handle per object, so importing an allocation this
     // driver already owns hands back the owner's own handle instead of creating one, and
     // releasing that in DestroyMemoryHandle would destroy the allocation.
-    handle->owns_allocation = source->owner != this;
+    handle->owns_allocation =
+        (source->owner != this) || (source->handle != static_cast<uint64_t>(import_params.handle));
 
     // Establish the size from the dma-buf.
     struct stat dmabuf_stat = {};

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -56,6 +56,7 @@
 #include <libdrm/drm.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "inc/hsa_ext_amd_aie.h"
@@ -756,6 +757,8 @@ hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
   handle->handle = bo_handle.handle;
   handle->vaddr = bo_handle.vaddr;
   handle->size = size;
+  handle->owner = this;
+  handle->owns_allocation = true;
 
   return HSA_STATUS_SUCCESS;
 }
@@ -878,7 +881,9 @@ hsa_status_t XdnaDriver::ImportMemoryHandle(const core::Agent& agent, core::Driv
 
   switch (type) {
   case core::ShareType::DMABUF_FD: {
-    const int dmabuf_fd = static_cast<const core::DriverMemoryHandle*>(import_handle)->dmabuf_fd;
+    const auto* source = static_cast<const core::DriverMemoryHandle*>(import_handle);
+
+    const int dmabuf_fd = source->dmabuf_fd;
 
     drm_prime_handle import_params = {};
     import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
@@ -889,7 +894,23 @@ hsa_status_t XdnaDriver::ImportMemoryHandle(const core::Agent& agent, core::Driv
     }
 
     *handle = core::DriverMemoryHandle{import_params.handle};
-    handle->size = lseek(dmabuf_fd, 0, SEEK_END);
+    handle->owner = this;
+
+    // A drm_file holds at most one GEM handle per object, so importing an allocation this
+    // driver already owns hands back the owner's own handle instead of creating one, and
+    // releasing that in DestroyMemoryHandle would destroy the allocation.
+    handle->owns_allocation = source->owner != this;
+
+    // Establish the size from the dma-buf.
+    struct stat dmabuf_stat = {};
+    if (fstat(dmabuf_fd, &dmabuf_stat) != 0) {
+      const hsa_status_t rollback_err = DestroyMemoryHandle(handle);
+      assert(rollback_err == HSA_STATUS_SUCCESS && "Failed to release the imported BO.");
+      (void)rollback_err;
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
+    handle->size = static_cast<size_t>(dmabuf_stat.st_size);
+
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE:
@@ -972,21 +993,30 @@ hsa_status_t XdnaDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
 }
 
 hsa_status_t XdnaDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
+  // Attempt every release even if an earlier one fails, and clear the handle either way: a
+  // handle left holding an fd that was already closed would close it a second time, by which
+  // point the descriptor may name something else entirely.
+  hsa_status_t err = HSA_STATUS_SUCCESS;
+
   // Close the dmabuf_fd.
-  if (handle->dmabuf_fd >= 0) {
-    close(handle->dmabuf_fd);
+  if (handle->dmabuf_fd >= 0 && close(handle->dmabuf_fd) != 0) {
+    err = HSA_STATUS_ERROR;
   }
 
-  // Close the BO handle.
-  drm_gem_close close_params = {};
-  close_params.handle = handle->handle;
-  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params);
-  if (err != HSA_STATUS_SUCCESS) {
-    return err;
+  // Close the BO handle, unless there is none or it is borrowed from the handle that owns it,
+  // which ImportMemoryHandle decided when it created this one.
+  if (handle->owns_allocation &&
+      static_cast<uint32_t>(handle->handle) != AMDXDNA_INVALID_BO_HANDLE) {
+    drm_gem_close close_params = {};
+    close_params.handle = handle->handle;
+    hsa_status_t ioctl_err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params);
+    if (ioctl_err != HSA_STATUS_SUCCESS) {
+      err = ioctl_err;
+    }
   }
   *handle = {};
 
-  return HSA_STATUS_SUCCESS;
+  return err;
 }
 
 hsa_status_t XdnaDriver::QueryDriverVersion() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -55,6 +55,7 @@
 namespace rocr {
 namespace core {
 
+class Driver;
 class Queue;
 
 enum class DriverQuery { GET_DRIVER_VERSION };
@@ -74,7 +75,7 @@ struct DriverMemoryHandle {
   /// - allocation address / thunk buffer handle for @ref KfdDriver
   /// - XDNA BO handle for @ref XdnaDriver
   uint64_t handle{};
-  /// Virtual address of this allocation, or nullptr if the driver exposes none.
+  /// @brief Virtual address of this allocation, or nullptr if the driver exposes none.
   /// Whether FreeMemory unmaps it is driver-defined: an allocation may borrow a
   /// mapping owned by something else, in which case FreeMemory leaves it intact.
   void* vaddr{};
@@ -82,9 +83,17 @@ struct DriverMemoryHandle {
   uint64_t mmap_offset{0};
   size_t size{0};
   hsa_fabric_handle_t fabric_handle{};
-
-  bool operator<(const DriverMemoryHandle& b) const { return handle < b.handle; }
-  bool operator==(const DriverMemoryHandle& b) const { return handle == b.handle; }
+  /// @brief Driver that created this handle.
+  ///
+  /// Native ids are only meaningful to their own driver and are not unique across drivers, so
+  /// this is what lets a driver recognize one of its own handles when one is passed back to it.
+  const Driver* owner{nullptr};
+  /// @brief False when the allocation is borrowed from the handle that owns it and so
+  /// must not be released when this handle is destroyed.
+  ///
+  /// Only @ref Driver::ImportMemoryHandle can produce a borrowed handle, and only when the
+  /// import resolves to an allocation the importing driver already owns.
+  bool owns_allocation{true};
 };
 
 /// @brief Format of a shareable memory handle for export and import.


### PR DESCRIPTION
## Motivation

Unmapping AIE memory using vmem APIs would destroy the BO which was leading to errors during remap. The problem was also affecting changing permissions on that memory.

## Technical Details

Granting an AIE agent access to AIE-owned memory imports a buffer into the drm_file that already holds a handle for it. On KFD the importing agent is a different DRM device, so the import genuinely creates a new handle.

This does not affect KFD as it does not use raw GEM handles. KfdDriver::ImportMemoryHandle goes through hsaKmtHandleImport() and returns an opaque HsaMemoryObjectHandle, released with hsaKmtMemHandleFree(). The DRM one-handle-per-drm_file invariant does not apply, and a same-GPU import returns a distinct object that is safe to release independently.

While this could have been handled at the `Runtime` object level, specifically https://github.com/ROCm/rocm-systems/blob/9b42a4ade5e4c6ed48e89ce64739e6de3796b80c/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp#L4312, it would also mean that we'd be adding this aliasing for KFD (which today gives unique handles); the impact of this is unclear to me so I opted for doing it internally.

## Issue Tracking

https://github.com/ROCm/rocm-systems/issues/10798

## Test Plan

rocrtst and tests in https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
