### PR TITLE
fix(amdsmi): repair the SPDX header check, which fails on develop

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
@@ -1,24 +1,5 @@
-/*
- * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 // Null out-pointer contract for the error-string helpers: a NULL status_string
 // must return AMDSMI_STATUS_INVAL instead of being dereferenced. No GPU required.

--- a/projects/amdsmi/tests/check_license_headers.py
+++ b/projects/amdsmi/tests/check_license_headers.py
@@ -55,7 +55,12 @@ EXCLUDE_PREFIX = (
     "include/libdrm/",  # vendored DRM headers, other owners
     "src/nic/brcm-nic/",  # Broadcom-owned NIC implementation
     "include/ras-decode/",  # vendored RAS decode headers, not maintained here
-    "include/ualoe_lib/",  # vendored UALoE library headers, not maintained here
+    # Vendored UALoE library, not maintained here -- both halves are replaced
+    # wholesale by the periodic "sync UALoE lib" drops, so a header rewritten
+    # here is reverted by the next sync. Matches the `ualoe_lib/` entry that
+    # keeps the rest of the pre-commit suite off this code.
+    "include/ualoe_lib/",
+    "src/ualoe_lib/",
 )
 EXCLUDE_EXACT = frozenset(
     {

--- a/projects/amdsmi/tests/python/unit/gpu/test_cli_vram_type_lpddr5.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_cli_vram_type_lpddr5.py
@@ -1,23 +1,6 @@
 #!/usr/bin/env python3
-#
-# Copyright (C) Advanced Micro Devices. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-# the Software, and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 
 """Mock-based unit test for ``amd-smi static --vram`` memory-type labelling.
 

--- a/projects/amdsmi/tests/python/unit/system/test_expect_status.py
+++ b/projects/amdsmi/tests/python/unit/system/test_expect_status.py
@@ -1,23 +1,7 @@
 #!/usr/bin/env python3
-#
-# Copyright (C) Advanced Micro Devices. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-# the Software, and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 """Unit tests for the expect_status/status_sweep assertion harness.
 
 The two are tested together because expect_status changes behaviour depending on


### PR DESCRIPTION
## Why

#10402 converted every amd-smi source to the two-line SPDX MIT header and added the `amdsmi-license-headers` pre-commit hook to hold the line. **The hook currently fails on `develop` itself**, so every open amd-smi PR is red — including ones that touch none of the offending files.

```
$ git checkout origin/develop
$ python3 projects/amdsmi/tests/check_license_headers.py
Missing or malformed AMD SPDX license header:
  src/ualoe_lib/ualoe_nl.c
  src/ualoe_lib/ualoe_telem.c
  tests/amd_smi_test/unit/system/status_string_test.cc
  tests/python/unit/gpu/test_cli_vram_type_lpddr5.py
  tests/python/unit/system/test_expect_status.py
```

The blast radius is wide because the hook is `pass_filenames: false` and rescans the whole tracked tree. It fires for any PR touching a single amd-smi `.py`/`.cc`/`.txt` and then reports files that PR never went near. #10083 trips it by editing one line of `src/CMakeLists.txt`.

## What

The five files fall into two groups with different causes.

**Three are amd-smi's own**, and simply landed while #10402 was in review, so its branch never saw them and they arrived with the old twenty-line MIT block. Converted here:

| File | Landed via |
|---|---|
| `tests/amd_smi_test/unit/system/status_string_test.cc` | #10177 |
| `tests/python/unit/gpu/test_cli_vram_type_lpddr5.py` | #10775 |
| `tests/python/unit/system/test_expect_status.py` | `88dbbe3b93c` |

**The other two are not ours to edit.** `src/ualoe_lib/` is the vendored UALoE library, replaced wholesale by the periodic *"sync UALoE lib"* drops — which is exactly why #9688 added `ualoe_lib/` to the pre-commit `exclude:` block, keeping clang-format and the rest off that code. #10402 carried only the `include/ualoe_lib/` half of that exclusion into the checker and left `src/` behind, so the checker now polices code the next sync will overwrite. Rewriting those headers would be reverted by the next drop and the hook would break again, so the missing prefix is added to `EXCLUDE_PREFIX` instead.

The three files #10402 did rewrite under `src/ualoe_lib/` are left alone; they now fall outside the check and will drift back on their own at the next sync.

Header text and check scope only — no functional change.

## Verification

```
$ python3 projects/amdsmi/tests/check_license_headers.py           # exit 0
$ python3 projects/amdsmi/tests/run_amdsmi_license_header_test.py  # 6/6 cases
$ pre-commit run --config projects/amdsmi/.pre-commit-config.yaml --files <changed>
  codespell / trailing-whitespace / end-of-file-fixer / merge-conflicts /
  large-files / mixed-line-ending / clang-format / ruff format /
  amd-smi C++ test conventions / amd-smi SPDX license headers ....... all Passed
```

Confirmed the two vendored files are byte-identical to `develop` (`git diff origin/develop -- projects/amdsmi/src/ualoe_lib/` is empty), and that the checker skips them when named explicitly.

Fixes the `amdsmi-license-headers` hook regression introduced by #10402.

