### PR TITLE
fix(rocjitsu): Sign-extend the gfx1250 GLOBAL saddr VGPR offset

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -148,8 +148,20 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
       continue;
     uint64_t vaddr;
     if (saddr_present) {
-      vaddr = vaddr_region.lane(0, lane);
-      vaddr *= scale;
+      // The VGPR half of a GLOBAL saddr address is a SIGNED 32-bit offset on
+      // gfx1250, and its scaled form scales that value signed as well. LLVM
+      // gates both on hasSignedGVSOffset, matching a sign extension over a zero
+      // extension and selecting the signed multiply-add, so it emits a negative
+      // value here whenever an access walks backwards from its base -- a
+      // reversed iteration order is enough. Zero-extending one does not reach
+      // below the base, it reaches 4 GiB above the allocation, where the access
+      // silently reads or drops rather than faulting. The steps are named
+      // rather than nested so both signed conversions stay visible: the offset
+      // is reinterpreted as signed before it is widened, and it is widened
+      // before it is scaled, which is what keeps the multiply signed.
+      const int32_t voffset = static_cast<int32_t>(vaddr_region.lane(0, lane));
+      const int64_t scaled_voffset = static_cast<int64_t>(voffset) * scale;
+      vaddr = static_cast<uint64_t>(scaled_voffset);
     } else {
       vaddr = vaddr_region.lane64(0, lane);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna5/addr_calc.cpp
@@ -153,8 +153,20 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
       continue;
     uint64_t vaddr;
     if (saddr_present) {
-      vaddr = vaddr_region.lane(0, lane);
-      vaddr *= scale;
+      // The VGPR half of a GLOBAL saddr address is a SIGNED 32-bit offset on
+      // gfx1250, and its scaled form scales that value signed as well. LLVM
+      // gates both on hasSignedGVSOffset, matching a sign extension over a zero
+      // extension and selecting the signed multiply-add, so it emits a negative
+      // value here whenever an access walks backwards from its base -- a
+      // reversed iteration order is enough. Zero-extending one does not reach
+      // below the base, it reaches 4 GiB above the allocation, where the access
+      // silently reads or drops rather than faulting. The steps are named
+      // rather than nested so both signed conversions stay visible: the offset
+      // is reinterpreted as signed before it is widened, and it is widened
+      // before it is scaled, which is what keeps the multiply signed.
+      const int32_t voffset = static_cast<int32_t>(vaddr_region.lane(0, lane));
+      const int64_t scaled_voffset = static_cast<int64_t>(voffset) * scale;
+      vaddr = static_cast<uint64_t>(scaled_voffset);
     } else {
       vaddr = vaddr_region.lane64(0, lane);
     }

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -440,6 +440,88 @@ TEST(Gfx1250SimulationTest, GlobalStoreWritesVisibleMemory) {
     EXPECT_EQ(sim.memory->read32(output_addr + lane * sizeof(uint32_t)), 1u) << "lane " << lane;
 }
 
+/// @brief A GLOBAL saddr access sign-extends its VGPR offset on gfx1250.
+/// @details LLVM gates this on hasSignedGVSOffset and hands a negative offset to
+/// the saddr form whenever an access walks backwards from its base, so the case
+/// arises from ordinary reversed iteration. Zero-extending -4 puts the access
+/// 4 GiB above the allocation rather than one dword below it, which lands on
+/// nothing and is dropped, making the symptom silently missing data rather than
+/// a fault.
+TEST(Gfx1250SimulationTest, GlobalStoreSignExtendsNegativeSaddrVgprOffset) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t base_addr = 0x2000;
+  constexpr uint32_t marker = 0xA5A5A5A5u;
+
+  const uint32_t code[] = {
+      0xBE8400FFu,    static_cast<uint32_t>(base_addr), // s_mov_b32 s4, base_addr
+      0xBE850080u,                                      // s_mov_b32 s5, 0
+      0x7E0002FFu,    0xFFFFFFFCu,                      // v_mov_b32_e32 v0, -4
+      0x7E0202FFu,    marker,                           // v_mov_b32_e32 v1, marker
+      0xEE068004u,    0x00800000u,
+      0x00000000u, // global_store_b32 v0, v1, s[4:5]
+      0xBFC10000u, // s_wait_storecnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code));
+  sim.memory->write32(base_addr - sizeof(uint32_t), 0);
+  sim.memory->write32(base_addr, 0);
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 32, 32);
+  sim.engine->run();
+  sim.soc->flush_all();
+
+  EXPECT_EQ(sim.memory->read32(base_addr - sizeof(uint32_t)), marker);
+  EXPECT_EQ(sim.memory->read32(base_addr), 0u);
+}
+
+/// @brief The scaled form of a GLOBAL saddr offset scales it as a signed value.
+/// @details `scale_offset` multiplies the VGPR offset by the access size, and
+/// that multiply is a separate path from the unscaled one above. A -1 offset
+/// scaled by the four bytes of a b32 access reaches one dword below the base;
+/// scaling it unsigned reaches four bytes short of 16 GiB above it instead. The
+/// distinction is invisible to the unscaled test, which never multiplies, and to
+/// the existing scaled tests, whose offsets are all non-negative.
+TEST(Gfx1250SimulationTest, GlobalStoreScalesANegativeSaddrVgprOffsetSigned) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t base_addr = 0x2000;
+  constexpr uint32_t marker = 0x5A5A5A5Au;
+
+  const uint32_t code[] = {
+      0xBE8400FFu,
+      static_cast<uint32_t>(base_addr), // s_mov_b32 s4, base_addr
+      0xBE850080u,                      // s_mov_b32 s5, 0
+      0x7E0002FFu,
+      0xFFFFFFFFu, // v_mov_b32_e32 v0, -1
+      0x7E0202FFu,
+      marker, // v_mov_b32_e32 v1, marker
+      // global_store_b32 v0, v1, s[4:5] scale_offset -- bit 48 of the VGLOBAL
+      // encoding, which is bit 16 of the second dword, on top of the vsrc=1
+      // already there.
+      0xEE068004u,
+      0x00810000u,
+      0x00000000u,
+      0xBFC10000u, // s_wait_storecnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code));
+  sim.memory->write32(base_addr - sizeof(uint32_t), 0);
+  sim.memory->write32(base_addr, 0);
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 32, 32);
+  sim.engine->run();
+  sim.soc->flush_all();
+
+  EXPECT_EQ(sim.memory->read32(base_addr - sizeof(uint32_t)), marker)
+      << "a -1 offset scaled by the b32 access size must land one dword below the base";
+  EXPECT_EQ(sim.memory->read32(base_addr), 0u);
+}
+
 TEST(Gfx1250SimulationTest, BufferStoreUsesM0Soffset) {
   constexpr uint64_t kernel_addr = 0x10000;
   constexpr uint64_t output_addr = 0x2000;

--- a/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_dispatch_memory_test.cpp
@@ -440,6 +440,43 @@ TEST(Gfx1250SimulationTest, GlobalStoreWritesVisibleMemory) {
     EXPECT_EQ(sim.memory->read32(output_addr + lane * sizeof(uint32_t)), 1u) << "lane " << lane;
 }
 
+/// @brief A GLOBAL saddr access sign-extends its VGPR offset on gfx1250.
+/// @details LLVM gates this on hasSignedGVSOffset and hands a negative offset to
+/// the saddr form whenever an access walks backwards from its base, so the case
+/// arises from ordinary reversed iteration. Zero-extending -4 puts the access
+/// 4 GiB above the allocation rather than one dword below it, which lands on
+/// nothing and is dropped, making the symptom silently missing data rather than
+/// a fault.
+TEST(Gfx1250SimulationTest, GlobalStoreSignExtendsNegativeSaddrVgprOffset) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t base_addr = 0x2000;
+  constexpr uint32_t marker = 0xA5A5A5A5u;
+
+  const uint32_t code[] = {
+      0xBE8400FFu,    static_cast<uint32_t>(base_addr), // s_mov_b32 s4, base_addr
+      0xBE850080u,                                      // s_mov_b32 s5, 0
+      0x7E0002FFu,    0xFFFFFFFCu,                      // v_mov_b32_e32 v0, -4
+      0x7E0202FFu,    marker,                           // v_mov_b32_e32 v1, marker
+      0xEE068004u,    0x00800000u,
+      0x00000000u, // global_store_b32 v0, v1, s[4:5]
+      0xBFC10000u, // s_wait_storecnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code));
+  sim.memory->write32(base_addr - sizeof(uint32_t), 0);
+  sim.memory->write32(base_addr, 0);
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 32, 32);
+  sim.engine->run();
+  sim.soc->flush_all();
+
+  EXPECT_EQ(sim.memory->read32(base_addr - sizeof(uint32_t)), marker);
+  EXPECT_EQ(sim.memory->read32(base_addr), 0u);
+}
+
 TEST(Gfx1250SimulationTest, BufferStoreUsesM0Soffset) {
   constexpr uint64_t kernel_addr = 0x10000;
   constexpr uint64_t output_addr = 0x2000;


### PR DESCRIPTION
The VGPR half of a GLOBAL saddr address is a signed 32-bit offset on gfx1250, where every earlier target zero-extends it. LLVM gates the difference on hasSignedGVSOffset, matching a sign extension rather than a zero extension and selecting the signed multiply-add for the scaled form, so it will place a negative value there whenever an access walks backwards from its base. The address calculation zero-extended it, which does not move an offset of -4 one dword below the base but 4 GiB above it. Nothing is mapped that far out, so in daemon mode the access fell through to the client-memory bridge, failed there, and the store was discarded -- the symptom is quietly missing data rather than a fault.

Widen the offset through int32_t, and apply the scale to the widened value so the multiply is signed too. A two-element torch.flip reproduces the original: the lane carrying the -4 stride lost its store and the destination kept the zero it was allocated with, while the lane at offset zero wrote correctly. A single element passes either way because its only offset is zero, which is why this survived until a reversed iteration order reached the simulator. The regression test stores a marker through a negative offset and checks that it lands below the base and that the base itself is untouched.

Closes #10757