### PR TITLE
[rocjitsu] Stabilize the public GPU target enum ABI.

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -137,7 +137,19 @@ RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 RJ_API_EXPORT void rj_code_inst_destroy(rj_code_inst_t *inst);
 
 /// @brief GPU target identifiers.
+///
+/// @details Named target values and ROCJITSU_CODE_TARGET_INVALID are stable C
+/// API values. New targets must use the next unallocated value without
+/// renumbering an existing target. ROCJITSU_CODE_TARGET_NUM_TARGETS is the
+/// one-past-the-last upper bound for named targets and grows when a target is
+/// added; it is not itself a target identifier. The ABI representation of
+/// rj_code_target_id_t is one 32-bit integer. C++ fixes the underlying type to
+/// int32_t; C clients must use a compiler ABI with a 32-bit enum representation.
+#ifdef __cplusplus
+typedef enum rj_code_target_id_t : int32_t {
+#else
 typedef enum rj_code_target_id_t {
+#endif
   /// @brief gfx90a target ID (CDNA2).
   ROCJITSU_CODE_TARGET_GFX90A = 0,
   /// @brief gfx942 target ID (CDNA3).
@@ -152,8 +164,10 @@ typedef enum rj_code_target_id_t {
   ROCJITSU_CODE_TARGET_GFX1250 = 5,
   // \NPI new GPU: add its public target identifier here and bind its
   // code-object name and ELF machine value in the corresponding ISA provider.
-  /// @brief Sentinel value representing an invalid target.
-  ROCJITSU_CODE_TARGET_INVALID = 6
+  /// @brief Number of named GPU targets and their exclusive upper bound.
+  ROCJITSU_CODE_TARGET_NUM_TARGETS = 6,
+  /// @brief Stable sentinel value representing an invalid target.
+  ROCJITSU_CODE_TARGET_INVALID = INT32_MAX
 } rj_code_target_id_t;
 
 /// @brief Instruction property flags.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/target_registry.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/target_registry.cpp
@@ -30,7 +30,7 @@ constexpr bool is_public_architecture_key(rj_code_arch_t key) {
 constexpr bool is_public_gpu_target_key(rj_code_target_id_t key) {
   const std::underlying_type_t<rj_code_target_id_t> value = enum_value(key);
   return value >= enum_value(ROCJITSU_CODE_TARGET_GFX90A) &&
-         value < enum_value(ROCJITSU_CODE_TARGET_INVALID);
+         value < enum_value(ROCJITSU_CODE_TARGET_NUM_TARGETS);
 }
 
 bool contains_id(const IsaTargetDescriptor &descriptor, std::string_view id) {

--- a/emulation/rocjitsu/tests/isa_target_registry_test.cpp
+++ b/emulation/rocjitsu/tests/isa_target_registry_test.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <span>
 #include <string>
@@ -94,8 +95,16 @@ static_assert(cdna2::kTargetDescriptor.gpu_targets.front().public_id ==
 static_assert(rdna4::kTargetDescriptor.aliases.size() == 2);
 static_assert(rdna4::kTargetDescriptor.aliases[0] == "gfx1200");
 static_assert(rdna4::kTargetDescriptor.aliases[1] == "gfx1201");
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX90A) == 0);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX942) == 1);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX950) == 2);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX1200) == 3);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX1201) == 4);
 static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_GFX1250) == 5);
-static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_INVALID) == 6);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_NUM_TARGETS) == 6);
+static_assert(static_cast<int>(ROCJITSU_CODE_TARGET_INVALID) == INT32_MAX);
+static_assert(sizeof(rj_code_target_id_t) == sizeof(int32_t));
+static_assert(std::is_same_v<std::underlying_type_t<rj_code_target_id_t>, int32_t>);
 
 TEST(IsaTargetRegistryTest, PreservesStaticDescriptorOrder) {
   static constexpr std::array targets = {
@@ -196,6 +205,15 @@ TEST(IsaTargetRegistryTest, RejectsInvalidTargetDescriptors) {
       fixture_target("invalid-gpu-target", {}, ROCJITSU_CODE_ARCH_CDNA1, invalid_gpu_value),
   };
   expect_registry_error(invalid_gpu_target, "unallocated GPU target");
+
+  static constexpr std::array past_last_gpu_value = {
+      fixture_gpu_target(ROCJITSU_CODE_TARGET_NUM_TARGETS, "past-last-gpu-target",
+                         EF_AMDGPU_MACH_AMDGCN_GFX90A),
+  };
+  static constexpr std::array past_last_gpu_target = {
+      fixture_target("past-last-gpu-target", {}, ROCJITSU_CODE_ARCH_CDNA1, past_last_gpu_value),
+  };
+  expect_registry_error(past_last_gpu_target, "unallocated GPU target");
 
   static constexpr std::array<std::string_view, 1> duplicate_enum_alias{"duplicate-enums-alias"};
   static constexpr std::array duplicate_enum_values = {


### PR DESCRIPTION
Appending GPU targets previously shifted INVALID because it also served as the target count. That silently changed values passed through exported C APIs and could alias a value from one release with a real target in another.

Separate the growing count from the stable invalid representation. Keep named targets append-only, add NUM_TARGETS as the exclusive registry bound, and pin INVALID to INT32_MAX. Fix the C++ underlying type to int32_t while retaining a C17-compatible declaration and documenting the required 32-bit enum ABI.

Pin every existing ordinal, the enum size and underlying type, and rejection of both NUM_TARGETS and INVALID in the registry tests.