### PR TITLE
fix(amdsmi) Fix backwards includes in rocm_smi.h

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -5,12 +5,11 @@
 #define ROCM_SMI_ROCM_SMI_H_
 
 #ifdef __cplusplus
-extern "C" {
-#include <stddef.h>
-#include <stdint.h>
-#else
 #include <cstddef>
 #include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
 #endif  // __cplusplus
 
 #include <stdbool.h>

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -16,6 +16,10 @@
 
 #include "rocm_smi/kfd_ioctl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /** \file rocm_smi.h
  *  Main header file for the ROCm SMI library.
  *  All required function, structure, enum, etc. definitions should be defined


### PR DESCRIPTION
The includes for cplusplus and C were backwards, and extern C is redundant in this case, I believe.

## Motivation

Fixes compilation errors or warnings for rocm_smi

## Technical Details


## Issue Tracking


## Test Plan


## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
