### PR TITLE
fix(rocjitsu): honor guest MODE.FP_ROUND in host arithmetic

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -45,6 +45,28 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
+# The guest's MODE.FP_ROUND is executed by setting the host's rounding mode --
+# fp_mode.h wraps each architectural operation in a ScopedFenv and lets the
+# hardware round. A compiler may assume the default rounding mode unless told
+# otherwise, and every compiler tried moves the arithmetic across the fesetround
+# call without this: v_fmac_f64 of 1.0 * 2^-53 + 1.0 under MODE.FP_ROUND=+inf
+# returned 1.0 where the guest should see 1.0 + 1ulp, and every directed mode
+# silently gave the round-to-nearest answer. Measured wrong without the flag and
+# right with it on GCC 13.4, clang 14, clang 15 and AMD clang 22 -- this is not
+# one compiler's quirk, and it is not avoided by building with amdclang.
+#
+# The standard spelling is `#pragma STDC FENV_ACCESS ON`; GCC does not implement
+# it, so the flag is what is portable between the two. It only forbids
+# optimisations that assume a rounding mode, so it cannot make arithmetic less
+# correct. It has to be global because fp_mode.h is header-only and inlines into
+# every ISA translation unit.
+if(
+    CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+)
+    add_compile_options(-frounding-math)
+endif()
+
 find_package(Threads REQUIRED)
 
 # GCC 14+ emits false-positive -Wuninitialized on reinterpret_cast<uint32_t*>

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -58,13 +58,33 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 # The standard spelling is `#pragma STDC FENV_ACCESS ON`; GCC does not implement
 # it, so the flag is what is portable between the two. It only forbids
 # optimisations that assume a rounding mode, so it cannot make arithmetic less
-# correct. It has to be global because fp_mode.h is header-only and inlines into
-# every ISA translation unit.
+# correct.
+#
+# It is carried as a variable rather than applied here, because the contract it
+# imposes is only needed where fp_mode.h's ScopedFenv actually inlines. Applying
+# it at this scope would reach googletest, flatbuffers, simdojo, util, the VM,
+# the DBT and every tool as well, constraining code that never touches the host
+# rounding mode. Two places consume it, and they are the closure of the header:
+#
+#   - rocjitsu_isa_<arch>_exec (isa/CMakeLists.txt), the object libraries that
+#     own the generated *_exec*.cpp sources. Those are the only translation
+#     units that include fp_mode.h or simd_glue.h; the sibling _model libraries
+#     and the RISC-V ISA do not.
+#   - tests/ (directory scope). fp_mode.h's helpers are `inline`, so a test that
+#     includes it emits its own copy and the linker keeps one of the two. A test
+#     compiled without the flag could therefore supply the copy the library
+#     calls, which is the miscompile this flag exists to prevent.
+#
+# Moving fma_f64/finish_f64/scale_u53_f64_rtz out of line into a single strict
+# translation unit would narrow this to one file and drop the ODR concern, but
+# simd_glue.h holds a ScopedFenv inside a template that cannot follow them.
 if(
     CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
 )
-    add_compile_options(-frounding-math)
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS -frounding-math)
+else()
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS "")
 endif()
 
 find_package(Threads REQUIRED)

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -75,16 +75,40 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 #     compiled without the flag could therefore supply the copy the library
 #     calls, which is the miscompile this flag exists to prevent.
 #
-# Moving fma_f64/finish_f64/scale_u53_f64_rtz out of line into a single strict
-# translation unit would narrow this to one file and drop the ODR concern, but
-# simd_glue.h holds a ScopedFenv inside a template that cannot follow them.
+# ROCJITSU_STRICT_FP_ROUNDING travels with the flag, so the header boundary and
+# the option boundary cannot drift apart. fp_mode.h refuses to compile without
+# it; the helpers that never touch the host FP environment -- effective_omod and
+# the rest of the OMOD plumbing -- live in fp_mode_no_fenv.h and carry no such
+# requirement. That is what lets vm/amdgpu/compute_unit.cpp reach the OMOD
+# helpers through alu_exceptions.h from outside this option set: it can no
+# longer emit an unflagged inline definition of fma_f64 or finish_f64 by
+# accident, because it can no longer see one.
 if(
     CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
 )
-    set(RJ_STRICT_FP_ROUNDING_OPTIONS -frounding-math)
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS
+        -frounding-math
+        -DROCJITSU_STRICT_FP_ROUNDING=1
+    )
+elseif(MSVC)
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS
+        /fp:strict
+        -DROCJITSU_STRICT_FP_ROUNDING=1
+    )
 else()
-    set(RJ_STRICT_FP_ROUNDING_OPTIONS "")
+    # Unknown compiler: nothing to spell "the rounding mode is dynamic" with, so
+    # the miscompile above may well be present. Define the guard anyway rather
+    # than failing the build -- that is the behaviour such a toolchain already
+    # had -- but say so, because otherwise the only report is the f64
+    # directed-rounding tests failing.
+    message(
+        WARNING
+        "No strict floating-point rounding option known for "
+        "${CMAKE_CXX_COMPILER_ID}; the guest's MODE.FP_ROUND may not reach f64 "
+        "arithmetic. See fp_mode.h."
+    )
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS -DROCJITSU_STRICT_FP_ROUNDING=1)
 endif()
 
 find_package(Threads REQUIRED)

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -83,7 +83,12 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 # helpers through alu_exceptions.h from outside this option set: it can no
 # longer emit an unflagged inline definition of fma_f64 or finish_f64 by
 # accident, because it can no longer see one.
-if(
+if(MSVC)
+    set(RJ_STRICT_FP_ROUNDING_OPTIONS
+        /fp:strict
+        -DROCJITSU_STRICT_FP_ROUNDING=1
+    )
+elseif(
     CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
 )
@@ -91,21 +96,16 @@ if(
         -frounding-math
         -DROCJITSU_STRICT_FP_ROUNDING=1
     )
-elseif(MSVC)
-    set(RJ_STRICT_FP_ROUNDING_OPTIONS
-        /fp:strict
-        -DROCJITSU_STRICT_FP_ROUNDING=1
-    )
 else()
     # Unknown compiler: nothing to spell "the rounding mode is dynamic" with, so
     # the miscompile above may well be present. Define the guard anyway rather
     # than failing the build -- that is the behaviour such a toolchain already
-    # had -- but say so, because otherwise the only report is the f64
+    # had -- but say so, because otherwise the only report is the
     # directed-rounding tests failing.
     message(
         WARNING
         "No strict floating-point rounding option known for "
-        "${CMAKE_CXX_COMPILER_ID}; the guest's MODE.FP_ROUND may not reach f64 "
+        "${CMAKE_CXX_COMPILER_ID}; the guest's MODE.FP_ROUND may not reach host "
         "arithmetic. See fp_mode.h."
     )
     set(RJ_STRICT_FP_ROUNDING_OPTIONS -DROCJITSU_STRICT_FP_ROUNDING=1)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -38,6 +38,12 @@ from amdisa.codegen.execute.vector_cmp import (
 from amdisa.codegen.execute.simd_codegen import simd_probe_line
 from amdisa.cross_isa import CrossIsaAnalyzer
 from amdisa.gpuisa import Instruction, Operand
+
+# The generated *_exec.cpp sources reach fp_mode.h, which refuses to compile
+# without the strict rounding-mode build options. CMake attaches these to
+# rocjitsu_isa_<arch>_exec via RJ_STRICT_FP_ROUNDING_OPTIONS; a preprocess-only
+# check has to supply the define the same way. See emulation/rocjitsu/CMakeLists.txt.
+STRICT_FP_ROUNDING_DEFINE = '-DROCJITSU_STRICT_FP_ROUNDING=1'
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
@@ -3521,6 +3527,7 @@ def test_single_isa_cdna1_sources_preprocess_with_source_includes(
         [
             compiler,
             '-E',
+            STRICT_FP_ROUNDING_DEFINE,
             *(flag for root in include_roots for flag in ('-I', str(root))),
             str(generated_root / 'cdna1' / 'vop3p_exec.cpp'),
             '-o',
@@ -3572,6 +3579,7 @@ def test_custom_identity_preprocesses_with_profile_handwritten_includes(
             [
                 compiler,
                 '-E',
+                STRICT_FP_ROUNDING_DEFINE,
                 *(flag for root in include_roots for flag in ('-I', str(root))),
                 str(source_path),
                 '-o',

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -38,6 +38,12 @@ from amdisa.codegen.execute.vector_cmp import (
 from amdisa.codegen.execute.simd_codegen import simd_probe_line
 from amdisa.cross_isa import CrossIsaAnalyzer
 from amdisa.gpuisa import Instruction, Operand
+
+# The generated *_exec.cpp sources reach fp_mode.h, which refuses to compile
+# without the strict rounding-mode build options. CMake attaches these to
+# rocjitsu_isa_<arch>_exec via RJ_STRICT_FP_ROUNDING_OPTIONS; a preprocess-only
+# check has to supply the define the same way. See emulation/rocjitsu/CMakeLists.txt.
+STRICT_FP_ROUNDING_DEFINE = '-DROCJITSU_STRICT_FP_ROUNDING=1'
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
@@ -3589,6 +3595,7 @@ def test_single_isa_cdna1_sources_preprocess_with_source_includes(
         [
             compiler,
             '-E',
+            STRICT_FP_ROUNDING_DEFINE,
             *(flag for root in include_roots for flag in ('-I', str(root))),
             str(generated_root / 'cdna1' / 'vop3p_exec.cpp'),
             '-o',
@@ -3640,6 +3647,7 @@ def test_custom_identity_preprocesses_with_profile_handwritten_includes(
             [
                 compiler,
                 '-E',
+                STRICT_FP_ROUNDING_DEFINE,
                 *(flag for root in include_roots for flag in ('-I', str(root))),
                 str(source_path),
                 '-o',

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -38,12 +38,6 @@ from amdisa.codegen.execute.vector_cmp import (
 from amdisa.codegen.execute.simd_codegen import simd_probe_line
 from amdisa.cross_isa import CrossIsaAnalyzer
 from amdisa.gpuisa import Instruction, Operand
-
-# The generated *_exec.cpp sources reach fp_mode.h, which refuses to compile
-# without the strict rounding-mode build options. CMake attaches these to
-# rocjitsu_isa_<arch>_exec via RJ_STRICT_FP_ROUNDING_OPTIONS; a preprocess-only
-# check has to supply the define the same way. See emulation/rocjitsu/CMakeLists.txt.
-STRICT_FP_ROUNDING_DEFINE = '-DROCJITSU_STRICT_FP_ROUNDING=1'
 from amdisa.isa_profile import (
     Cdna1Profile,
     Cdna2Profile,
@@ -65,6 +59,12 @@ from amdisa.semantics import (
     derive_all_semantics,
     derive_semantics,
 )
+
+# The generated *_exec.cpp sources reach fp_mode.h, which refuses to compile
+# without the strict rounding-mode build options. CMake attaches these to
+# rocjitsu_isa_<arch>_exec via RJ_STRICT_FP_ROUNDING_OPTIONS; a preprocess-only
+# check has to supply the define the same way. See emulation/rocjitsu/CMakeLists.txt.
+STRICT_FP_ROUNDING_DEFINE = '-DROCJITSU_STRICT_FP_ROUNDING=1'
 
 
 def _repo_root() -> Path:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
@@ -54,7 +54,10 @@ function(rj_add_split_amdgpu_isa_library arch)
     # so they are the ones that need the compiler to stop assuming a rounding
     # mode across the ScopedFenv. See RJ_STRICT_FP_ROUNDING_OPTIONS in the
     # top-level CMakeLists.txt. The _model sources never see either header.
-    target_compile_options(${_target}_exec PRIVATE ${RJ_STRICT_FP_ROUNDING_OPTIONS})
+    target_compile_options(
+        ${_target}_exec
+        PRIVATE ${RJ_STRICT_FP_ROUNDING_OPTIONS}
+    )
 
     add_library(${_target} INTERFACE)
     target_sources(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
@@ -50,6 +50,12 @@ function(rj_add_split_amdgpu_isa_library arch)
     rj_add_object_library(${_target}_model ${_model_sources})
     rj_add_object_library(${_target}_exec ${_execution_sources})
 
+    # The execution sources are the ones that include fp_mode.h and simd_glue.h,
+    # so they are the ones that need the compiler to stop assuming a rounding
+    # mode across the ScopedFenv. See RJ_STRICT_FP_ROUNDING_OPTIONS in the
+    # top-level CMakeLists.txt. The _model sources never see either header.
+    target_compile_options(${_target}_exec PRIVATE ${RJ_STRICT_FP_ROUNDING_OPTIONS})
+
     add_library(${_target} INTERFACE)
     target_sources(
         ${_target}

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/alu_exceptions.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/alu_exceptions.h
@@ -4,7 +4,7 @@
 #ifndef ROCJITSU_ISA_AMDGPU_SHARED_ALU_EXCEPTIONS_H_
 #define ROCJITSU_ISA_AMDGPU_SHARED_ALU_EXCEPTIONS_H_
 
-#include "rocjitsu/isa/arch/amdgpu/shared/fp_mode.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/fp_mode_no_fenv.h"
 #include "rocjitsu/vm/amdgpu/register_access.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include <bit>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
@@ -4,9 +4,33 @@
 #pragma once
 
 /// @file fp_mode.h
-/// @brief Shared MODE-aware floating-point execution helpers.
+/// @brief Shared MODE-aware floating-point execution helpers that run the
+/// arithmetic under the guest's MODE.FP_ROUND.
+///
+/// @details Everything here delegates rounding to the host FPU: an operation is
+/// wrapped in a detail::ScopedFenv, which calls fesetround() and restores the
+/// previous environment on the way out. That is only correct if the compiler
+/// has been told the rounding mode is dynamic; otherwise it is entitled to
+/// assume round-to-nearest and move the arithmetic across the fesetround call,
+/// which silently returns the round-to-nearest answer under every directed
+/// mode. See RJ_STRICT_FP_ROUNDING_OPTIONS in emulation/rocjitsu/CMakeLists.txt.
+///
+/// Helpers that do not touch the host FP environment live in fp_mode_no_fenv.h,
+/// which this header pulls in, and carry no such requirement.
 
-#include "rocjitsu/code/rj_code.h"
+// The definition travels with the flag in RJ_STRICT_FP_ROUNDING_OPTIONS, so a
+// target that has not opted in fails here. Because these helpers are `inline`,
+// the alternative to failing is worse than an unflagged call site: the linker
+// picks one of the emitted copies, so a single unflagged translation unit can
+// supply the definition the whole image uses and reintroduce the miscompile
+// everywhere. Include fp_mode_no_fenv.h instead if the fenv-free helpers are
+// all that is needed.
+#ifndef ROCJITSU_STRICT_FP_ROUNDING
+#error                                                                                             \
+    "fp_mode.h requires the strict rounding-mode build options (RJ_STRICT_FP_ROUNDING_OPTIONS); include fp_mode_no_fenv.h for the helpers that do not use the host FP environment"
+#endif
+
+#include "rocjitsu/isa/arch/amdgpu/shared/fp_mode_no_fenv.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/pseudo_scalar.h"
 #include "util/data_types.h"
 
@@ -18,26 +42,6 @@
 namespace rocjitsu::amdgpu::fp_mode {
 
 namespace detail {
-
-inline uint16_t modify_f16(uint16_t value, bool absolute, bool negate) {
-  if (absolute)
-    value &= 0x7fffu;
-  if (negate)
-    value ^= 0x8000u;
-  return value;
-}
-
-inline uint16_t flush_input_f16(uint16_t value, uint32_t denorm_mode) {
-  if ((denorm_mode & 1u) == 0 && (value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
-    return value & 0x8000u;
-  return value;
-}
-
-inline uint64_t flush_f64(uint64_t value) {
-  if ((value & 0x7ff0000000000000ULL) == 0 && (value & 0x000fffffffffffffULL) != 0)
-    return value & 0x8000000000000000ULL;
-  return value;
-}
 
 inline int host_round_mode(uint32_t round_mode) {
   switch (round_mode & 3u) {
@@ -74,72 +78,11 @@ private:
 
 } // namespace detail
 
-/// @brief Return the OMOD value supported by an ordinary floating-point result.
-inline uint32_t effective_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
-                               uint32_t omod) {
-  if (omod == 0)
-    return 0;
-  if (arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5)
-    return omod;
-  return (denorm_mode & 2u) == 0 && !ieee_mode ? omod : 0;
-}
-
-/// @brief Return the OMOD value that applies to an F16 result on the selected ISA.
-/// @details GFX11+ packed-F16 results explicitly ignore OMOD. Older profiles expose
-/// OMOD on the promoted VOP3 form of V_PK_FMAC_F16, subject to their ordinary
-/// output-denormal and MODE.IEEE restrictions. GFX12 and gfx1250 allow OMOD on
-/// non-packed F16 results regardless of output-denormal mode.
-inline uint32_t effective_f16_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
-                                   bool packed_result, uint32_t omod) {
-  if (omod == 0)
-    return 0;
-  if (packed_result && (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-                        arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5))
-    return 0;
-  return effective_omod(arch, denorm_mode, ieee_mode, omod);
-}
-
-/// @brief Apply the result-format rules required by an active OMOD.
-/// @details OMOD always flushes an output subnormal and maps either signed zero
-/// to positive zero. These helpers operate after the result has been rounded to
-/// its architectural destination format.
-inline uint16_t finalize_omod_f16(uint16_t value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  if ((value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
-    value &= 0x8000u;
-  return (value & 0x7fffu) == 0 ? 0 : value;
-}
-
-inline uint16_t finalize_omod_bf16(uint16_t value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  if ((value & 0x7f80u) == 0 && (value & 0x007fu) != 0)
-    value &= 0x8000u;
-  return (value & 0x7fffu) == 0 ? 0 : value;
-}
-
-inline float finalize_omod_f32(float value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  uint32_t bits = std::bit_cast<uint32_t>(value);
-  if ((bits & 0x7f800000u) == 0 && (bits & 0x007fffffu) != 0)
-    bits &= 0x80000000u;
-  if ((bits & 0x7fffffffu) == 0)
-    bits = 0;
-  return std::bit_cast<float>(bits);
-}
-
-inline double finalize_omod_f64(double value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  uint64_t bits = detail::flush_f64(std::bit_cast<uint64_t>(value));
-  if ((bits & 0x7fffffffffffffffULL) == 0)
-    bits = 0;
-  return std::bit_cast<double>(bits);
-}
-
 /// @brief Execute an F16 fused multiply-add and return its raw F16 encoding.
+/// @details The intermediate is computed in double and rounded to F16 in
+/// software by pseudo_scalar, but the double fma is still subject to whatever
+/// rounding mode is in effect when this runs, so it belongs on this side of the
+/// split.
 inline uint16_t fma_f16(uint16_t src0, uint16_t src1, uint16_t src2, bool abs0, bool abs1,
                         bool abs2, bool neg0, bool neg1, bool neg2, uint32_t round_mode,
                         uint32_t denorm_mode, uint32_t omod, bool clamp, bool fp16_ovfl,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
@@ -4,9 +4,33 @@
 #pragma once
 
 /// @file fp_mode.h
-/// @brief Shared MODE-aware floating-point execution helpers.
+/// @brief Shared MODE-aware floating-point execution helpers that run the
+/// arithmetic under the guest's MODE.FP_ROUND.
+///
+/// @details Everything here delegates rounding to the host FPU: an operation is
+/// wrapped in a detail::ScopedFenv, which calls fesetround() and restores the
+/// previous environment on the way out. That is only correct if the compiler
+/// has been told the rounding mode is dynamic; otherwise it is entitled to
+/// assume round-to-nearest and move the arithmetic across the fesetround call,
+/// which silently returns the round-to-nearest answer under every directed
+/// mode. See RJ_STRICT_FP_ROUNDING_OPTIONS in emulation/rocjitsu/CMakeLists.txt.
+///
+/// Helpers that do not touch the host FP environment live in fp_mode_no_fenv.h,
+/// which this header pulls in, and carry no such requirement.
 
-#include "rocjitsu/code/rj_code.h"
+// The definition travels with the flag in RJ_STRICT_FP_ROUNDING_OPTIONS, so a
+// target that has not opted in fails here. Because these helpers are `inline`,
+// the alternative to failing is worse than an unflagged call site: the linker
+// picks one of the emitted copies, so a single unflagged translation unit can
+// supply the definition the whole image uses and reintroduce the miscompile
+// everywhere. Include fp_mode_no_fenv.h instead if the fenv-free helpers are
+// all that is needed.
+#ifndef ROCJITSU_STRICT_FP_ROUNDING
+#error                                                                                             \
+    "fp_mode.h requires the strict rounding-mode build options (RJ_STRICT_FP_ROUNDING_OPTIONS); include fp_mode_no_fenv.h for the helpers that do not use the host FP environment"
+#endif
+
+#include "rocjitsu/isa/arch/amdgpu/shared/fp_mode_no_fenv.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/pseudo_scalar.h"
 #include "util/data_types.h"
 
@@ -22,26 +46,6 @@
 namespace rocjitsu::amdgpu::fp_mode {
 
 namespace detail {
-
-inline uint16_t modify_f16(uint16_t value, bool absolute, bool negate) {
-  if (absolute)
-    value &= 0x7fffu;
-  if (negate)
-    value ^= 0x8000u;
-  return value;
-}
-
-inline uint16_t flush_input_f16(uint16_t value, uint32_t denorm_mode) {
-  if ((denorm_mode & 1u) == 0 && (value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
-    return value & 0x8000u;
-  return value;
-}
-
-inline uint64_t flush_f64(uint64_t value) {
-  if ((value & 0x7ff0000000000000ULL) == 0 && (value & 0x000fffffffffffffULL) != 0)
-    return value & 0x8000000000000000ULL;
-  return value;
-}
 
 inline int host_round_mode(uint32_t round_mode) {
   switch (round_mode & 3u) {
@@ -223,51 +227,6 @@ inline uint16_t round_exact_to_bf16(ExactF64Sum sum, uint32_t round_mode) {
 
 } // namespace detail
 
-/// @brief Return the OMOD value supported by an ordinary floating-point result.
-inline uint32_t effective_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
-                               uint32_t omod) {
-  if (omod == 0)
-    return 0;
-  if (arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5)
-    return omod;
-  return (denorm_mode & 2u) == 0 && !ieee_mode ? omod : 0;
-}
-
-/// @brief Return the OMOD value that applies to an F16 result on the selected ISA.
-/// @details GFX11+ packed-F16 results explicitly ignore OMOD. Older profiles expose
-/// OMOD on the promoted VOP3 form of V_PK_FMAC_F16, subject to their ordinary
-/// output-denormal and MODE.IEEE restrictions. GFX12 and gfx1250 allow OMOD on
-/// non-packed F16 results regardless of output-denormal mode.
-inline uint32_t effective_f16_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
-                                   bool packed_result, uint32_t omod) {
-  if (omod == 0)
-    return 0;
-  if (packed_result && (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-                        arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5))
-    return 0;
-  return effective_omod(arch, denorm_mode, ieee_mode, omod);
-}
-
-/// @brief Apply the result-format rules required by an active OMOD.
-/// @details OMOD always flushes an output subnormal and maps either signed zero
-/// to positive zero. These helpers operate after the result has been rounded to
-/// its architectural destination format.
-inline uint16_t finalize_omod_f16(uint16_t value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  if ((value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
-    value &= 0x8000u;
-  return (value & 0x7fffu) == 0 ? 0 : value;
-}
-
-inline uint16_t finalize_omod_bf16(uint16_t value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  if ((value & 0x7f80u) == 0 && (value & 0x007fu) != 0)
-    value &= 0x8000u;
-  return (value & 0x7fffu) == 0 ? 0 : value;
-}
-
 namespace detail {
 
 /// @brief Execute F32-source fused multiply-add in an established clean nearest environment.
@@ -335,27 +294,11 @@ inline uint16_t packed_mul_bf16(float a, float b, bool fp16_ovfl) {
   return packed_fma_bf16(a, b, zero, fp16_ovfl);
 }
 
-inline float finalize_omod_f32(float value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  uint32_t bits = std::bit_cast<uint32_t>(value);
-  if ((bits & 0x7f800000u) == 0 && (bits & 0x007fffffu) != 0)
-    bits &= 0x80000000u;
-  if ((bits & 0x7fffffffu) == 0)
-    bits = 0;
-  return std::bit_cast<float>(bits);
-}
-
-inline double finalize_omod_f64(double value, uint32_t omod) {
-  if (omod == 0)
-    return value;
-  uint64_t bits = detail::flush_f64(std::bit_cast<uint64_t>(value));
-  if ((bits & 0x7fffffffffffffffULL) == 0)
-    bits = 0;
-  return std::bit_cast<double>(bits);
-}
-
 /// @brief Execute an F16 fused multiply-add and return its raw F16 encoding.
+/// @details The intermediate is computed in double and rounded to F16 in
+/// software by pseudo_scalar, but the double fma is still subject to whatever
+/// rounding mode is in effect when this runs, so it belongs on this side of the
+/// split.
 inline uint16_t fma_f16(uint16_t src0, uint16_t src1, uint16_t src2, bool abs0, bool abs1,
                         bool abs2, bool neg0, bool neg1, bool neg2, uint32_t round_mode,
                         uint32_t denorm_mode, uint32_t omod, bool clamp, bool fp16_ovfl,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode.h
@@ -295,10 +295,9 @@ inline uint16_t packed_mul_bf16(float a, float b, bool fp16_ovfl) {
 }
 
 /// @brief Execute an F16 fused multiply-add and return its raw F16 encoding.
-/// @details The intermediate is computed in double and rounded to F16 in
-/// software by pseudo_scalar, but the double fma is still subject to whatever
-/// rounding mode is in effect when this runs, so it belongs on this side of the
-/// split.
+/// @details The double intermediate is computed under the guest rounding mode,
+/// then rounded to F16 in software by pseudo_scalar. The host environment is
+/// restored before the software result policy runs.
 inline uint16_t fma_f16(uint16_t src0, uint16_t src1, uint16_t src2, bool abs0, bool abs1,
                         bool abs2, bool neg0, bool neg1, bool neg2, uint32_t round_mode,
                         uint32_t denorm_mode, uint32_t omod, bool clamp, bool fp16_ovfl,
@@ -310,9 +309,13 @@ inline uint16_t fma_f16(uint16_t src0, uint16_t src1, uint16_t src2, bool abs0, 
   const double multiplicand = static_cast<double>(util::f16_to_f32(src0));
   const double multiplier = static_cast<double>(util::f16_to_f32(src1));
   const double addend = static_cast<double>(util::f16_to_f32(src2));
-  uint16_t result =
-      pseudo_scalar::round_f16_result(std::fma(multiplicand, multiplier, addend), round_mode, omod,
-                                      clamp, fp16_ovfl, clamp_nan_to_zero);
+  double intermediate;
+  {
+    detail::ScopedFenv environment(round_mode);
+    intermediate = std::fma(multiplicand, multiplier, addend);
+  }
+  uint16_t result = pseudo_scalar::round_f16_result(intermediate, round_mode, omod, clamp,
+                                                    fp16_ovfl, clamp_nan_to_zero);
   if ((denorm_mode & 2u) == 0 && (result & 0x7c00u) == 0 && (result & 0x03ffu) != 0)
     result &= 0x8000u;
   return finalize_omod_f16(result, omod);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode_no_fenv.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/fp_mode_no_fenv.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/// @file fp_mode_no_fenv.h
+/// @brief The MODE-aware helpers that do not touch the host FP environment.
+///
+/// @details These are split out of fp_mode.h so that a translation unit which
+/// only needs, say, effective_omod does not have to opt in to the strict
+/// rounding-mode contract fp_mode.h requires. Everything here is integer or
+/// bit-pattern work: it neither reads nor writes the host rounding mode, so it
+/// is correct under any compiler floating-point settings. Anything that reaches
+/// for detail::ScopedFenv belongs in fp_mode.h instead.
+
+#include "rocjitsu/code/rj_code.h"
+
+#include <bit>
+#include <cstdint>
+
+namespace rocjitsu::amdgpu::fp_mode {
+
+namespace detail {
+
+inline uint16_t modify_f16(uint16_t value, bool absolute, bool negate) {
+  if (absolute)
+    value &= 0x7fffu;
+  if (negate)
+    value ^= 0x8000u;
+  return value;
+}
+
+inline uint16_t flush_input_f16(uint16_t value, uint32_t denorm_mode) {
+  if ((denorm_mode & 1u) == 0 && (value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
+    return value & 0x8000u;
+  return value;
+}
+
+inline uint64_t flush_f64(uint64_t value) {
+  if ((value & 0x7ff0000000000000ULL) == 0 && (value & 0x000fffffffffffffULL) != 0)
+    return value & 0x8000000000000000ULL;
+  return value;
+}
+
+} // namespace detail
+
+/// @brief Return the OMOD value supported by an ordinary floating-point result.
+inline uint32_t effective_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
+                               uint32_t omod) {
+  if (omod == 0)
+    return 0;
+  if (arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5)
+    return omod;
+  return (denorm_mode & 2u) == 0 && !ieee_mode ? omod : 0;
+}
+
+/// @brief Return the OMOD value that applies to an F16 result on the selected ISA.
+/// @details GFX11+ packed-F16 results explicitly ignore OMOD. Older profiles expose
+/// OMOD on the promoted VOP3 form of V_PK_FMAC_F16, subject to their ordinary
+/// output-denormal and MODE.IEEE restrictions. GFX12 and gfx1250 allow OMOD on
+/// non-packed F16 results regardless of output-denormal mode.
+inline uint32_t effective_f16_omod(rj_code_arch_t arch, uint32_t denorm_mode, bool ieee_mode,
+                                   bool packed_result, uint32_t omod) {
+  if (omod == 0)
+    return 0;
+  if (packed_result && (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+                        arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_CDNA5))
+    return 0;
+  return effective_omod(arch, denorm_mode, ieee_mode, omod);
+}
+
+/// @brief Apply the result-format rules required by an active OMOD.
+/// @details OMOD always flushes an output subnormal and maps either signed zero
+/// to positive zero. These helpers operate after the result has been rounded to
+/// its architectural destination format.
+inline uint16_t finalize_omod_f16(uint16_t value, uint32_t omod) {
+  if (omod == 0)
+    return value;
+  if ((value & 0x7c00u) == 0 && (value & 0x03ffu) != 0)
+    value &= 0x8000u;
+  return (value & 0x7fffu) == 0 ? 0 : value;
+}
+
+inline uint16_t finalize_omod_bf16(uint16_t value, uint32_t omod) {
+  if (omod == 0)
+    return value;
+  if ((value & 0x7f80u) == 0 && (value & 0x007fu) != 0)
+    value &= 0x8000u;
+  return (value & 0x7fffu) == 0 ? 0 : value;
+}
+
+inline float finalize_omod_f32(float value, uint32_t omod) {
+  if (omod == 0)
+    return value;
+  uint32_t bits = std::bit_cast<uint32_t>(value);
+  if ((bits & 0x7f800000u) == 0 && (bits & 0x007fffffu) != 0)
+    bits &= 0x80000000u;
+  if ((bits & 0x7fffffffu) == 0)
+    bits = 0;
+  return std::bit_cast<float>(bits);
+}
+
+inline double finalize_omod_f64(double value, uint32_t omod) {
+  if (omod == 0)
+    return value;
+  uint64_t bits = detail::flush_f64(std::bit_cast<uint64_t>(value));
+  if ((bits & 0x7fffffffffffffffULL) == 0)
+    bits = 0;
+  return std::bit_cast<double>(bits);
+}
+
+} // namespace rocjitsu::amdgpu::fp_mode

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -658,8 +658,9 @@ inline util::native<uint32_t> finalize_omod_f16_bits_simd(util::native<uint32_t>
 /// @brief Execute a native-width batch of architectural F16 fused multiply-adds.
 /// @details The raw F16 operands remain in 32-bit SIMD lanes. Each native-width
 /// batch is split into double-width chunks so the multiply-add itself is fused
-/// in SIMD without the erroneous F16-to-F32-to-F16 double rounding. The final
-/// F16 rounding and output policy reuse the scalar architectural primitive.
+/// in SIMD under the guest rounding mode without the erroneous
+/// F16-to-F32-to-F16 double rounding. The final F16 rounding and output policy
+/// reuse the scalar architectural primitive.
 inline util::native<uint32_t>
 fma_f16_mode_simd(util::native<uint32_t> src0, util::native<uint32_t> src1,
                   util::native<uint32_t> src2, bool abs0, bool abs1, bool abs2, bool neg0,
@@ -692,7 +693,11 @@ fma_f16_mode_simd(util::native<uint32_t> src0, util::native<uint32_t> src1,
     const util::native<double> a(a_lanes, util::stdx::vector_aligned);
     const util::native<double> b(b_lanes, util::stdx::vector_aligned);
     const util::native<double> c(c_lanes, util::stdx::vector_aligned);
-    const util::native<double> result = util::stdx::fma(a, b, c);
+    util::native<double> result;
+    {
+      fp_mode::detail::ScopedFenv environment(round_mode);
+      result = util::stdx::fma(a, b, c);
+    }
     alignas(util::native<double>) double result_lanes[W64];
     result.copy_to(result_lanes, util::stdx::vector_aligned);
     for (std::size_t i = 0; i < W64; ++i) {

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -47,6 +47,15 @@ inline constexpr bool has_stdx_simd =
     false;
 #endif
 
+/// Compile-time switch for the 64-bit-lane SIMD paths specifically. The
+/// `ROCJITSU_TRY_SIMD_*_F64` probes in simd_glue.h expand to nothing when
+/// `UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS` is set, so execution falls through to
+/// the scalar implementation even though `has_stdx_simd` is true. A test that
+/// gates only on `has_stdx_simd` would then run the scalar path twice and
+/// report the second run as SIMD coverage; gate on this instead.
+inline constexpr bool has_stdx_simd_64bit_lanes =
+    has_stdx_simd && UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS == 0;
+
 namespace detail {
 
 inline bool init_force_scalar() {

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -47,12 +47,13 @@ inline constexpr bool has_stdx_simd =
     false;
 #endif
 
-/// Compile-time switch for the 64-bit-lane SIMD paths specifically. The
-/// `ROCJITSU_TRY_SIMD_*_F64` probes in simd_glue.h expand to nothing when
-/// `UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS` is set, so execution falls through to
-/// the scalar implementation even though `has_stdx_simd` is true. A test that
-/// gates only on `has_stdx_simd` would then run the scalar path twice and
-/// report the second run as SIMD coverage; gate on this instead.
+/// Compile-time switch for the SIMD paths that need 64-bit lanes, and the
+/// 64-bit masks that go with them. `has_stdx_simd` only reports that the header
+/// is available; where `UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS` is set those paths
+/// are compiled out and execution falls through to the scalar implementation
+/// even though `has_stdx_simd` is true. Selecting or asserting on a 64-bit
+/// vector path therefore has to gate on this and not on `has_stdx_simd`, which
+/// would silently exercise the scalar implementation instead.
 inline constexpr bool has_stdx_simd_64bit_lanes =
     has_stdx_simd && UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS == 0;
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -7,6 +7,14 @@ include(rj_find_amdcxx)
 # Device kernels (compiled from HIP sources for simulator testing).
 add_subdirectory(kernels)
 
+# fp_mode.h's helpers are `inline`, so a test that includes it -- directly or
+# through simd_glue.h -- emits its own copy of them and the linker keeps one of
+# the two. Without this the copy compiled here could be the one the library ends
+# up calling, reintroducing the miscompile the flag exists to prevent. Applied
+# after the HIP kernels above so it reaches only host test code. See
+# RJ_STRICT_FP_ROUNDING_OPTIONS in the top-level CMakeLists.txt.
+add_compile_options(${RJ_STRICT_FP_ROUNDING_OPTIONS})
+
 # Common object libraries linked by all test/tool executables.
 set(RJ_OBJECT_LIBS
     rocjitsu_analysis

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -1047,7 +1047,7 @@ TEST(Gfx1250LiteralOperandTest, NegativeI64CompareCoversScalarAndAvailableSimdPa
   };
 
   run_case(true);
-  if constexpr (util::has_stdx_simd && !UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS)
+  if constexpr (util::has_stdx_simd_64bit_lanes)
     run_case(false);
 }
 

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/fp_mode.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/gfx12_cache_flags.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/isa/target_provider.h"
 #include "rocjitsu/vm/plugins/execution_plugin_group.h"
 
@@ -717,6 +718,42 @@ TEST(FpModePolicyTest, F64HelpersRestoreAmbientHostEnvironment) {
     EXPECT_EQ(std::fegetround(), FE_DOWNWARD);
     (void)amdgpu::fp_mode::finish_f64(input, 1, 1, false, true);
     EXPECT_EQ(std::fegetround(), FE_DOWNWARD);
+  }
+}
+
+TEST(FpModePolicyTest, F16FmaUsesGuestRoundingAndRestoresAmbientHostEnvironment) {
+  HostFenvGuard environment_guard;
+  struct TestCase {
+    int ambient_rounding;
+    uint32_t guest_rounding;
+    uint16_t src0;
+    uint16_t src1;
+    uint16_t src2;
+    uint16_t expected;
+  };
+  constexpr std::array kCases{
+      TestCase{FE_TONEAREST, 1, 0x0001u, 0x0001u, 0x7800u, 0x7801u},
+      TestCase{FE_UPWARD, 0, 0x0001u, 0x0001u, 0x7800u, 0x7800u},
+      TestCase{FE_TONEAREST, 2, 0x8001u, 0x0001u, 0xf800u, 0xf801u},
+  };
+
+  for (const TestCase &test : kCases) {
+    ASSERT_EQ(std::fesetround(test.ambient_rounding), 0);
+    EXPECT_EQ(amdgpu::fp_mode::fma_f16(test.src0, test.src1, test.src2, false, false, false, false,
+                                       false, false, test.guest_rounding, 3, 0, false, false,
+                                       false),
+              test.expected);
+    EXPECT_EQ(std::fegetround(), test.ambient_rounding);
+
+    if constexpr (util::has_stdx_simd) {
+      const auto result = amdgpu::fma_f16_mode_simd(
+          util::broadcast<uint32_t>(test.src0), util::broadcast<uint32_t>(test.src1),
+          util::broadcast<uint32_t>(test.src2), false, false, false, false, false, false,
+          test.guest_rounding, 3, 0, false, false, false);
+      for (std::size_t lane = 0; lane < util::native_width_v<uint32_t>; ++lane)
+        EXPECT_EQ(result[lane], test.expected) << "lane " << lane;
+      EXPECT_EQ(std::fegetround(), test.ambient_rounding);
+    }
   }
 }
 

--- a/emulation/rocjitsu/tests/cdna5_execution_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_execution_test.cpp
@@ -1644,7 +1644,7 @@ TEST(Gfx1250LiteralOperandTest, NegativeI64CompareCoversScalarAndAvailableSimdPa
   };
 
   run_case(true);
-  if constexpr (util::has_stdx_simd && !UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS)
+  if constexpr (util::has_stdx_simd_64bit_lanes)
     run_case(false);
 }
 

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -125,33 +125,38 @@ RunResult run_fmac(bool force_scalar, uint64_t exec, uint32_t mode, bool literal
 }
 
 TEST(Vop2FmaF64SimdCorrectness, InlineLiteralUsesEncodedHighWord) {
-  if constexpr (!util::has_stdx_simd)
-    GTEST_SKIP() << "<experimental/simd> unavailable";
   ForceScalarGuard guard;
   const RunResult scalar = run_fmac(true, ~uint64_t{0}, /*mode=*/3u << 6, true);
-  const RunResult simd = run_fmac(false, ~uint64_t{0}, /*mode=*/3u << 6, true);
-  EXPECT_EQ(simd.output, scalar.output);
-  EXPECT_EQ(simd.output[0], 0x3e10000000000000ULL);
+  EXPECT_EQ(scalar.output[0], 0x3e10000000000000ULL);
+  if constexpr (util::has_stdx_simd_64bit_lanes) {
+    const RunResult simd = run_fmac(false, ~uint64_t{0}, /*mode=*/3u << 6, true);
+    EXPECT_EQ(simd.output, scalar.output);
+  }
 }
 
 TEST(Vop2FmaF64SimdCorrectness, PartialExecPreservesBothInactiveVgprWords) {
-  if constexpr (!util::has_stdx_simd)
-    GTEST_SKIP() << "<experimental/simd> unavailable";
   ForceScalarGuard guard;
   constexpr uint64_t kExec = 0xa5a5f0f012348001ULL;
   const RunResult scalar = run_fmac(true, kExec, /*mode=*/3u << 6);
-  const RunResult simd = run_fmac(false, kExec, /*mode=*/3u << 6);
-  EXPECT_EQ(simd.output, scalar.output);
   for (uint32_t lane = 0; lane < kWaveSize; ++lane) {
     if ((kExec & (uint64_t{1} << lane)) == 0) {
-      EXPECT_EQ(simd.output[lane], simd.accumulator[lane]) << "inactive lane " << lane;
+      EXPECT_EQ(scalar.output[lane], scalar.accumulator[lane]) << "scalar, inactive lane " << lane;
+    }
+  }
+  if constexpr (util::has_stdx_simd_64bit_lanes) {
+    const RunResult simd = run_fmac(false, kExec, /*mode=*/3u << 6);
+    EXPECT_EQ(simd.output, scalar.output);
+    for (uint32_t lane = 0; lane < kWaveSize; ++lane) {
+      if ((kExec & (uint64_t{1} << lane)) == 0) {
+        EXPECT_EQ(simd.output[lane], simd.accumulator[lane]) << "simd, inactive lane " << lane;
+      }
     }
   }
 }
 
 TEST(Vop2FmaF64SimdCorrectness, AllRoundAndDenormModesMatchScalar) {
-  if constexpr (!util::has_stdx_simd)
-    GTEST_SKIP() << "<experimental/simd> unavailable";
+  if constexpr (!util::has_stdx_simd_64bit_lanes)
+    GTEST_SKIP() << "64-bit-lane SIMD path unavailable; both runs would be the scalar one";
   ForceScalarGuard guard;
   for (uint32_t round = 0; round < 4; ++round) {
     for (uint32_t denorm = 0; denorm < 4; ++denorm) {
@@ -164,8 +169,8 @@ TEST(Vop2FmaF64SimdCorrectness, AllRoundAndDenormModesMatchScalar) {
 }
 
 TEST(Vop2FmaF64SimdCorrectness, SpecialValuesAndDenormBoundariesMatchScalarExactly) {
-  if constexpr (!util::has_stdx_simd)
-    GTEST_SKIP() << "<experimental/simd> unavailable";
+  if constexpr (!util::has_stdx_simd_64bit_lanes)
+    GTEST_SKIP() << "64-bit-lane SIMD path unavailable; both runs would be the scalar one";
   ForceScalarGuard guard;
 
   constexpr uint64_t kPositiveZero = 0x0000'0000'0000'0000ULL;

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -229,9 +229,14 @@ TEST(Vop2FmaF64SimdCorrectness, SpecialValuesAndDenormBoundariesMatchScalarExact
 ///      keep 1.0.
 ///   b) 1.125 * 2^-53 + 1.25 lands 0.5625 ulp above 1.25. Nearest is past the
 ///      halfway point and steps up, as does +inf; -inf and zero truncate.
+///
+/// Because the reference is the ISA and not the other path, the scalar half
+/// stands on its own and runs everywhere -- it is the half that caught this bug.
+/// The SIMD half is gated on `has_stdx_simd_64bit_lanes`, not `has_stdx_simd`:
+/// where the 64-bit-lane probes are compiled out, `run_fmac(false, ...)` falls
+/// through to the scalar implementation, and asserting on it would report the
+/// scalar path a second time as SIMD coverage.
 TEST(Vop2FmaF64SimdCorrectness, DirectedRoundingMatchesTheIsaNotTheOtherPath) {
-  if constexpr (!util::has_stdx_simd)
-    GTEST_SKIP() << "<experimental/simd> unavailable";
   ForceScalarGuard guard;
 
   constexpr uint64_t kOne = 0x3FF0000000000000ULL;
@@ -267,12 +272,15 @@ TEST(Vop2FmaF64SimdCorrectness, DirectedRoundingMatchesTheIsaNotTheOtherPath) {
       const uint32_t mode = (round << 2) | (3u << 6);
       const uint64_t want = test_case.expected[round];
       const RunResult scalar = run_fmac(true, ~uint64_t{0}, mode, false, &inputs);
-      const RunResult simd = run_fmac(false, ~uint64_t{0}, mode, false, &inputs);
-      for (uint32_t lane = 0; lane < kWaveSize; ++lane) {
+      for (uint32_t lane = 0; lane < kWaveSize; ++lane)
         EXPECT_EQ(scalar.output[lane], want)
             << "scalar, " << test_case.what << ", round=" << round << ", lane=" << lane;
-        EXPECT_EQ(simd.output[lane], want)
-            << "simd, " << test_case.what << ", round=" << round << ", lane=" << lane;
+
+      if constexpr (util::has_stdx_simd_64bit_lanes) {
+        const RunResult simd = run_fmac(false, ~uint64_t{0}, mode, false, &inputs);
+        for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+          EXPECT_EQ(simd.output[lane], want)
+              << "simd, " << test_case.what << ", round=" << round << ", lane=" << lane;
       }
     }
   }

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -211,4 +211,71 @@ TEST(Vop2FmaF64SimdCorrectness, SpecialValuesAndDenormBoundariesMatchScalarExact
   }
 }
 
+/// @brief Both paths against the architecturally correct result, not against
+///        each other.
+///
+/// @details The tests above compare the scalar and SIMD paths. That catches a
+/// divergence but not a shared mistake, and it names whichever path it is given
+/// as the reference: when MODE.FP_ROUND stopped reaching the arithmetic, the
+/// scalar path returned the round-to-nearest answer under every mode and the
+/// failure read as "the two disagree" rather than "one is wrong".
+///
+/// These expectations are computed from the ISA definition rather than from the
+/// model. Both operands are chosen so the result lands on a rounding boundary,
+/// where the mode is the only thing that decides the answer:
+///
+///   a) 1.0 * 2^-53 + 1.0 is an exact tie, half an ulp above 1.0. Nearest
+///      rounds to even and keeps 1.0; +inf must step up one ulp; -inf and zero
+///      keep 1.0.
+///   b) 1.125 * 2^-53 + 1.25 lands 0.5625 ulp above 1.25. Nearest is past the
+///      halfway point and steps up, as does +inf; -inf and zero truncate.
+TEST(Vop2FmaF64SimdCorrectness, DirectedRoundingMatchesTheIsaNotTheOtherPath) {
+  if constexpr (!util::has_stdx_simd)
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+  ForceScalarGuard guard;
+
+  constexpr uint64_t kOne = 0x3FF0000000000000ULL;
+  constexpr uint64_t kOneAndAnEighth = 0x3FF2000000000000ULL;
+  constexpr uint64_t kOneAndAQuarter = 0x3FF4000000000000ULL;
+  constexpr uint64_t kTwoPowMinus53 = 0x3CA0000000000000ULL;
+
+  struct Case {
+    const char *what;
+    uint64_t src0;
+    uint64_t src1;
+    uint64_t accumulator;
+    // Indexed by MODE.FP_ROUND: 0 nearest-even, 1 +inf, 2 -inf, 3 zero.
+    std::array<uint64_t, 4> expected;
+  };
+
+  const Case cases[] = {
+      {"exact tie half an ulp above 1.0", kOne, kTwoPowMinus53, kOne, {kOne, kOne + 1, kOne, kOne}},
+      {"0.5625 ulp above 1.25",
+       kOneAndAnEighth,
+       kTwoPowMinus53,
+       kOneAndAQuarter,
+       {kOneAndAQuarter + 1, kOneAndAQuarter + 1, kOneAndAQuarter, kOneAndAQuarter}},
+  };
+
+  for (const Case &test_case : cases) {
+    RawInputs inputs{};
+    for (uint32_t lane = 0; lane < kWaveSize; ++lane)
+      inputs[lane] = {test_case.src0, test_case.src1, test_case.accumulator};
+
+    for (uint32_t round = 0; round < 4; ++round) {
+      // Denorm mode is irrelevant here; nothing in these cases is subnormal.
+      const uint32_t mode = (round << 2) | (3u << 6);
+      const uint64_t want = test_case.expected[round];
+      const RunResult scalar = run_fmac(true, ~uint64_t{0}, mode, false, &inputs);
+      const RunResult simd = run_fmac(false, ~uint64_t{0}, mode, false, &inputs);
+      for (uint32_t lane = 0; lane < kWaveSize; ++lane) {
+        EXPECT_EQ(scalar.output[lane], want)
+            << "scalar, " << test_case.what << ", round=" << round << ", lane=" << lane;
+        EXPECT_EQ(simd.output[lane], want)
+            << "simd, " << test_case.what << ", round=" << round << ", lane=" << lane;
+      }
+    }
+  }
+}
+
 } // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -234,6 +234,14 @@ TEST(Vop2FmaF64SimdCorrectness, SpecialValuesAndDenormBoundariesMatchScalarExact
 ///      keep 1.0.
 ///   b) 1.125 * 2^-53 + 1.25 lands 0.5625 ulp above 1.25. Nearest is past the
 ///      halfway point and steps up, as does +inf; -inf and zero truncate.
+///   c) the negative mirror of (b), 0.5625 ulp below -1.25. Nearest and -inf
+///      take the more-negative neighbor; +inf and zero truncate toward -1.25.
+///
+/// (c) is what separates the four modes from each other. Both positive rows
+/// give -inf and toward-zero the same answer, so on their own they would still
+/// pass with FE_DOWNWARD and FE_TOWARDZERO transposed. Adding a negative row
+/// splits that pair -- and splits nearest from +inf -- so each of the four
+/// MODE.FP_ROUND values is pinned to exactly one host mode.
 ///
 /// Because the reference is the ISA and not the other path, the scalar half
 /// stands on its own and runs everywhere -- it is the half that caught this bug.
@@ -248,6 +256,8 @@ TEST(Vop2FmaF64SimdCorrectness, DirectedRoundingMatchesTheIsaNotTheOtherPath) {
   constexpr uint64_t kOneAndAnEighth = 0x3FF2000000000000ULL;
   constexpr uint64_t kOneAndAQuarter = 0x3FF4000000000000ULL;
   constexpr uint64_t kTwoPowMinus53 = 0x3CA0000000000000ULL;
+  constexpr uint64_t kNegativeOneAndAnEighth = 0xBFF2000000000000ULL;
+  constexpr uint64_t kNegativeOneAndAQuarter = 0xBFF4000000000000ULL;
 
   struct Case {
     const char *what;
@@ -265,6 +275,13 @@ TEST(Vop2FmaF64SimdCorrectness, DirectedRoundingMatchesTheIsaNotTheOtherPath) {
        kTwoPowMinus53,
        kOneAndAQuarter,
        {kOneAndAQuarter + 1, kOneAndAQuarter + 1, kOneAndAQuarter, kOneAndAQuarter}},
+      // Bits are sign-magnitude, so +1 here is the neighbor further from zero.
+      {"0.5625 ulp below -1.25",
+       kNegativeOneAndAnEighth,
+       kTwoPowMinus53,
+       kNegativeOneAndAQuarter,
+       {kNegativeOneAndAQuarter + 1, kNegativeOneAndAQuarter, kNegativeOneAndAQuarter + 1,
+        kNegativeOneAndAQuarter}},
   };
 
   for (const Case &test_case : cases) {


### PR DESCRIPTION
Closes #10855

## The bug

`MODE.FP_ROUND` is a guest architectural register: an AMDGPU wave can select
round-to-nearest-even, +inf, -inf, or toward-zero, and its FP results must honor
that choice.

RocJITsu implements the operations that need more precision than their guest
type by borrowing the host FPU. `fp_mode.h` wraps this arithmetic in a
`ScopedFenv`, which sets the requested host rounding mode and restores the
caller's environment afterward. Without a strict floating-point compiler
option, however, the compiler may assume the host rounding mode never changes
and move or fold the arithmetic as round-to-nearest.

For F64, `v_fmac_f64` of `1.0 * 2^-53 + 1.0` demonstrates the wrong answer:

| | round-to-nearest | +inf | -inf | toward-zero |
|---|---|---|---|---|
| hardware / ISA | `1.0` | `1.0 + 1ulp` | `1.0` | `1.0` |
| RocJITsu, before | `1.0` | **`1.0`** | `1.0` | `1.0` |
| RocJITsu, after | `1.0` | `1.0 + 1ulp` | `1.0` | `1.0` |

Review also identified the same class of bug in F16 FMA. F16 operands are
represented exactly as doubles, but their exact product-plus-addend can require
more than the 53 bits available in a double. For example,
`0x0001 * 0x0001 + 0x7800` under guest round-toward-+inf must produce `0x7801`.
If the double FMA first runs under host round-to-nearest, the tiny product is
lost before the software F16 rounding step and the result is incorrectly
`0x7800`. Both the scalar and SIMD helpers had this issue.

## The fix

- Apply the strict rounding option only to targets that can inline the
  host-environment helpers: `-frounding-math` for GNU-style GCC/Clang and
  `/fp:strict` for MSVC, including clang-cl. The MSVC check comes first because
  clang-cl satisfies both `MSVC` and the Clang compiler-ID test.
- Split helpers that never touch the host environment into
  `fp_mode_no_fenv.h`, so unrelated translation units do not inherit the strict
  option.
- Compute scalar and SIMD F16 FMA double intermediates inside `ScopedFenv`, then
  restore the caller's environment before applying the software F16 result
  policy.
- Guard the fenv-sensitive header with the corresponding build definition so a
  new include site cannot silently compile without strict rounding semantics.

## Tests

- F64 scalar and SIMD directed-rounding cases are pinned to ISA-derived bit
  patterns rather than only compared with each other.
- `FpModePolicyTest.F16FmaUsesGuestRoundingAndRestoresAmbientHostEnvironment`
  exercises scalar and SIMD F16 counterexamples for +inf and -inf, a mismatched
  ambient/guest round-to-nearest case, and restoration of the caller's host
  rounding mode.
- Release GCC 13 default build completes successfully.
- Focused CTest: 14/14 passed.
- Full amdisa Python suite: 2,074 passed, 46 skipped.
- PR-range pre-commit hooks and Ruff pass.

The clang-cl branch is selected correctly by CMake; runtime validation here is
on Linux/GCC because this host does not provide a Windows clang-cl environment.
