### PR TITLE
fix(rocprofiler-compute): skip roofline for sets without roofline metrics

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -32,6 +32,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
+* Fixed `--set` running the roofline microbenchmark, which is never part of a metric set.
+
 * Fixed false `0` values in the gfx115x Memory Chart; missing counter data now reports `N/A`.
 
 * Fixed `GL2-Fabric Write BW` understating write bandwidth on gfx115x in the System Speed-of-Light and Memory Chart panels.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -51,6 +51,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed `L2 Cache (per Channel)` labels to use a `Metric` column and numbered `Channel` row labels in CLI, TUI, and analysis database output.
 
+* Fixed `--set` running the roofline microbenchmark, which is never part of a metric set.
+
 * Fixed false `0` values in the gfx115x Memory Chart; missing counter data now reports `N/A`.
 
 * Fixed `GL2-Fabric Write BW` understating write bandwidth on gfx115x in the System Speed-of-Light and Memory Chart panels.

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -315,6 +315,9 @@ class RocProfCompute_Base:
             args.remaining = ""
 
         self._filter_blocks = self._soc.profiling_setup()
+        # --set and --roof-only resolve to block ids here, so store them back on
+        # the args every later stage reads.
+        self.__args.filter_blocks = self._filter_blocks
 
         # Write profiling configuration as yaml file
         with open(
@@ -323,8 +326,6 @@ class RocProfCompute_Base:
             encoding="utf-8",
         ) as f:
             args_dict = dict(vars(self.__args))
-            # Override filter_blocks when writing profiling config yaml
-            args_dict["filter_blocks"] = self._filter_blocks
             args_dict["config_dir"] = str(args_dict["config_dir"])
             args_dict["format_rocprof_output"] = PROFILE_OUTPUT_FORMAT
             yaml.dump(args_dict, f)

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_profile/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_profile/test_profiler_base.py
@@ -696,6 +696,7 @@ def test_pre_processing_persists_membw_analysis_config(
     )
     assert profiling_config["membw_analysis"] is True
     assert profiling_config["filter_blocks"] == effective_filter_blocks
+    assert profiling_args.filter_blocks == effective_filter_blocks
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_profile/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_profile/test_profiler_base.py
@@ -696,7 +696,6 @@ def test_pre_processing_persists_membw_analysis_config(
     )
     assert profiling_config["membw_analysis"] is True
     assert profiling_config["filter_blocks"] == effective_filter_blocks
-    assert profiling_args.filter_blocks == effective_filter_blocks
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -8,6 +8,7 @@ Tests LimitedSet, CounterFile, and the bin-packing helpers used by
 perfmon_coalesce — no GPU hardware required.
 """
 
+from contextlib import ExitStack
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -528,3 +529,56 @@ def test_membw_analysis_counter_selection(
 
     assert counters & FIXTURE_COUNTERS == expected_counters
     assert effective_filter_blocks == filter_blocks
+
+
+# =============================================================================
+# post_profiling: roofline gating
+# =============================================================================
+
+
+def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base:
+    """Build a benchmark-capable SoC with the given effective filter blocks."""
+    args = SimpleNamespace(
+        device=0,
+        filter_blocks=filter_blocks,
+        no_roof=False,
+        output_directory=str(tmp_path),
+    )
+    mspec = SimpleNamespace(cache_sizes={}, rocminfo_lines=None)
+    with patch("rocprof_compute_soc.soc_base.console_debug"):
+        soc = OmniSoC_Base(args, mspec)
+    soc.set_arch("gfx942")
+    return soc
+
+
+@pytest.mark.parametrize(
+    ("filter_blocks", "expect_benchmark"),
+    [
+        pytest.param([], True, id="no_filter_runs_benchmark"),
+        pytest.param(["4"], True, id="block_4_runs_benchmark"),
+        pytest.param(["roof"], True, id="roof_alias_runs_benchmark"),
+        pytest.param(["11.2.3", "11.2.4"], False, id="set_metrics_skip_benchmark"),
+        pytest.param(["2"], False, id="unrelated_block_skips_benchmark"),
+    ],
+)
+def test_post_profiling_roofline_gating(
+    tmp_path: Path, filter_blocks: list[str], expect_benchmark: bool
+) -> None:
+    """Roofline runs only when the effective filter blocks cover block 4."""
+    soc = _make_roofline_soc(tmp_path, filter_blocks)
+
+    with ExitStack() as patch_stack:
+        mock_benchmark = patch_stack.enter_context(
+            patch("rocprof_compute_soc.soc_base.run_roofline_benchmark")
+        )
+        patch_stack.enter_context(
+            patch(
+                "rocprof_compute_soc.soc_base.validate_roofline_csv",
+                return_value=(True, ""),
+            )
+        )
+        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_log"))
+        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_debug"))
+        soc.post_profiling()
+
+    assert mock_benchmark.called is expect_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -535,21 +535,6 @@ def test_membw_analysis_counter_selection(
 # =============================================================================
 
 
-def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base:
-    """Build a benchmark-capable SoC with the given effective filter blocks."""
-    args = SimpleNamespace(
-        device=0,
-        filter_blocks=filter_blocks,
-        no_roof=False,
-        output_directory=str(tmp_path),
-    )
-    mspec = SimpleNamespace(cache_sizes={}, rocminfo_lines=None)
-    with patch("rocprof_compute_soc.soc_base.console_debug"):
-        soc = OmniSoC_Base(args, mspec)
-    soc.set_arch("gfx942")
-    return soc
-
-
 @pytest.mark.parametrize(
     ("filter_blocks", "expect_benchmark"),
     [
@@ -561,10 +546,19 @@ def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base
     ],
 )
 def test_post_profiling_roofline_gating(
-    tmp_path: Path, monkeypatch, filter_blocks: list[str], expect_benchmark: bool
+    perfmon_config,
+    tmp_path: Path,
+    monkeypatch,
+    filter_blocks: list[str],
+    expect_benchmark: bool,
 ) -> None:
     """Roofline runs only when the effective filter blocks cover block 4."""
-    soc = _make_roofline_soc(tmp_path, filter_blocks)
+    soc = _make_soc(perfmon_config, arch="gfx942")
+    args = soc.get_args()
+    args.device = 0
+    args.filter_blocks = filter_blocks
+    args.no_roof = False
+    args.output_directory = str(tmp_path)
     mock_benchmark = MagicMock()
     monkeypatch.setattr(
         "rocprof_compute_soc.soc_base.run_roofline_benchmark", mock_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -136,7 +136,7 @@ def _make_soc(perfmon_config, arch="gfx908", num_xcd=1, l2_banks=4):
 
 
 # =============================================================================
-# A. LimitedSet
+# LimitedSet
 # =============================================================================
 
 
@@ -192,7 +192,7 @@ def test_limited_set_reserve_does_not_add_elements():
 
 
 # =============================================================================
-# B. CounterFile
+# CounterFile
 # =============================================================================
 
 
@@ -247,7 +247,7 @@ def test_counter_file_reserve_delegates_to_block(perfmon_config):
 
 
 # =============================================================================
-# C. flat_counters_in_perfmon_file
+# flat_counters_in_perfmon_file
 # =============================================================================
 
 
@@ -268,7 +268,7 @@ def test_flat_counters_in_perfmon_file(perfmon_config):
 
 
 # =============================================================================
-# D. _trial_counter_file_with_extra
+# _trial_counter_file_with_extra
 # =============================================================================
 
 
@@ -308,7 +308,7 @@ def test_trial_counter_file_with_extra_overflow(perfmon_config):
 
 
 # =============================================================================
-# E. _rebuild_tcc_channel_file_map
+# _rebuild_tcc_channel_file_map
 # =============================================================================
 
 
@@ -328,7 +328,7 @@ def test_rebuild_tcc_channel_file_map(perfmon_config):
 
 
 # =============================================================================
-# F. _allocate_perfmon_counter_files
+# _allocate_perfmon_counter_files
 # =============================================================================
 
 
@@ -407,7 +407,7 @@ def test_allocate_tcc_channel_coalescing(perfmon_config):
 
 
 # =============================================================================
-# G. _expand_tcc_template_counters
+# _expand_tcc_template_counters
 # =============================================================================
 
 
@@ -433,7 +433,7 @@ def test_expand_tcc_no_templates(perfmon_config):
 
 
 # =============================================================================
-# H. _append_analysis_yaml_for_filter_token alias handling
+# _append_analysis_yaml_for_filter_token alias handling
 # =============================================================================
 
 
@@ -468,7 +468,7 @@ def test_filter_token_known_alias_resolves_without_crash(monkeypatch):
 
 
 # =============================================================================
-# I. Memory Bandwidth Analysis counter selection
+# Memory Bandwidth Analysis counter selection
 # =============================================================================
 
 
@@ -531,7 +531,7 @@ def test_membw_analysis_counter_selection(
 
 
 # =============================================================================
-# post_profiling: roofline gating
+# post_profiling
 # =============================================================================
 
 

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -8,7 +8,6 @@ Tests LimitedSet, CounterFile, and the bin-packing helpers used by
 perfmon_coalesce — no GPU hardware required.
 """
 
-from contextlib import ExitStack
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -562,23 +561,19 @@ def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base
     ],
 )
 def test_post_profiling_roofline_gating(
-    tmp_path: Path, filter_blocks: list[str], expect_benchmark: bool
+    tmp_path: Path, monkeypatch, filter_blocks: list[str], expect_benchmark: bool
 ) -> None:
     """Roofline runs only when the effective filter blocks cover block 4."""
     soc = _make_roofline_soc(tmp_path, filter_blocks)
+    mock_benchmark = MagicMock()
+    monkeypatch.setattr(
+        "rocprof_compute_soc.soc_base.run_roofline_benchmark", mock_benchmark
+    )
+    monkeypatch.setattr(
+        "rocprof_compute_soc.soc_base.validate_roofline_csv",
+        lambda _workload_dir: (True, ""),
+    )
 
-    with ExitStack() as patch_stack:
-        mock_benchmark = patch_stack.enter_context(
-            patch("rocprof_compute_soc.soc_base.run_roofline_benchmark")
-        )
-        patch_stack.enter_context(
-            patch(
-                "rocprof_compute_soc.soc_base.validate_roofline_csv",
-                return_value=(True, ""),
-            )
-        )
-        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_log"))
-        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_debug"))
-        soc.post_profiling()
+    soc.post_profiling()
 
     assert mock_benchmark.called is expect_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -762,23 +762,19 @@ def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base
     ],
 )
 def test_post_profiling_roofline_gating(
-    tmp_path: Path, filter_blocks: list[str], expect_benchmark: bool
+    tmp_path: Path, monkeypatch, filter_blocks: list[str], expect_benchmark: bool
 ) -> None:
     """Roofline runs only when the effective filter blocks cover block 4."""
     soc = _make_roofline_soc(tmp_path, filter_blocks)
+    mock_benchmark = MagicMock()
+    monkeypatch.setattr(
+        "rocprof_compute_soc.soc_base.run_roofline_benchmark", mock_benchmark
+    )
+    monkeypatch.setattr(
+        "rocprof_compute_soc.soc_base.validate_roofline_csv",
+        lambda _workload_dir: (True, ""),
+    )
 
-    with ExitStack() as patch_stack:
-        mock_benchmark = patch_stack.enter_context(
-            patch("rocprof_compute_soc.soc_base.run_roofline_benchmark")
-        )
-        patch_stack.enter_context(
-            patch(
-                "rocprof_compute_soc.soc_base.validate_roofline_csv",
-                return_value=(True, ""),
-            )
-        )
-        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_log"))
-        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_debug"))
-        soc.post_profiling()
+    soc.post_profiling()
 
     assert mock_benchmark.called is expect_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -729,3 +729,56 @@ def test_membw_analysis_counter_selection(
 
     assert counters & FIXTURE_COUNTERS == expected_counters
     assert effective_filter_blocks == filter_blocks
+
+
+# =============================================================================
+# post_profiling: roofline gating
+# =============================================================================
+
+
+def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base:
+    """Build a benchmark-capable SoC with the given effective filter blocks."""
+    args = SimpleNamespace(
+        device=0,
+        filter_blocks=filter_blocks,
+        no_roof=False,
+        output_directory=str(tmp_path),
+    )
+    mspec = SimpleNamespace(cache_sizes={}, rocminfo_lines=None)
+    with patch("rocprof_compute_soc.soc_base.console_debug"):
+        soc = OmniSoC_Base(args, mspec)
+    soc.set_arch("gfx942")
+    return soc
+
+
+@pytest.mark.parametrize(
+    ("filter_blocks", "expect_benchmark"),
+    [
+        pytest.param([], True, id="no_filter_runs_benchmark"),
+        pytest.param(["4"], True, id="block_4_runs_benchmark"),
+        pytest.param(["roof"], True, id="roof_alias_runs_benchmark"),
+        pytest.param(["11.2.3", "11.2.4"], False, id="set_metrics_skip_benchmark"),
+        pytest.param(["2"], False, id="unrelated_block_skips_benchmark"),
+    ],
+)
+def test_post_profiling_roofline_gating(
+    tmp_path: Path, filter_blocks: list[str], expect_benchmark: bool
+) -> None:
+    """Roofline runs only when the effective filter blocks cover block 4."""
+    soc = _make_roofline_soc(tmp_path, filter_blocks)
+
+    with ExitStack() as patch_stack:
+        mock_benchmark = patch_stack.enter_context(
+            patch("rocprof_compute_soc.soc_base.run_roofline_benchmark")
+        )
+        patch_stack.enter_context(
+            patch(
+                "rocprof_compute_soc.soc_base.validate_roofline_csv",
+                return_value=(True, ""),
+            )
+        )
+        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_log"))
+        patch_stack.enter_context(patch("rocprof_compute_soc.soc_base.console_debug"))
+        soc.post_profiling()
+
+    assert mock_benchmark.called is expect_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -736,21 +736,6 @@ def test_membw_analysis_counter_selection(
 # =============================================================================
 
 
-def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base:
-    """Build a benchmark-capable SoC with the given effective filter blocks."""
-    args = SimpleNamespace(
-        device=0,
-        filter_blocks=filter_blocks,
-        no_roof=False,
-        output_directory=str(tmp_path),
-    )
-    mspec = SimpleNamespace(cache_sizes={}, rocminfo_lines=None)
-    with patch("rocprof_compute_soc.soc_base.console_debug"):
-        soc = OmniSoC_Base(args, mspec)
-    soc.set_arch("gfx942")
-    return soc
-
-
 @pytest.mark.parametrize(
     ("filter_blocks", "expect_benchmark"),
     [
@@ -762,10 +747,19 @@ def _make_roofline_soc(tmp_path: Path, filter_blocks: list[str]) -> OmniSoC_Base
     ],
 )
 def test_post_profiling_roofline_gating(
-    tmp_path: Path, monkeypatch, filter_blocks: list[str], expect_benchmark: bool
+    perfmon_config,
+    tmp_path: Path,
+    monkeypatch,
+    filter_blocks: list[str],
+    expect_benchmark: bool,
 ) -> None:
     """Roofline runs only when the effective filter blocks cover block 4."""
-    soc = _make_roofline_soc(tmp_path, filter_blocks)
+    soc = _make_soc(perfmon_config, arch="gfx942")
+    args = soc.get_args()
+    args.device = 0
+    args.filter_blocks = filter_blocks
+    args.no_roof = False
+    args.output_directory = str(tmp_path)
     mock_benchmark = MagicMock()
     monkeypatch.setattr(
         "rocprof_compute_soc.soc_base.run_roofline_benchmark", mock_benchmark

--- a/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/unit/rocprof_compute_soc/test_soc_base.py
@@ -207,7 +207,7 @@ def _resolve_metric_name(config_dir: Path, arch: str, metric_id: str) -> str | N
 
 
 # =============================================================================
-# A. LimitedSet
+# LimitedSet
 # =============================================================================
 
 
@@ -263,7 +263,7 @@ def test_limited_set_reserve_does_not_add_elements():
 
 
 # =============================================================================
-# B. CounterFile
+# CounterFile
 # =============================================================================
 
 
@@ -318,7 +318,7 @@ def test_counter_file_reserve_delegates_to_block(perfmon_config):
 
 
 # =============================================================================
-# C. flat_counters_in_perfmon_file
+# flat_counters_in_perfmon_file
 # =============================================================================
 
 
@@ -339,7 +339,7 @@ def test_flat_counters_in_perfmon_file(perfmon_config):
 
 
 # =============================================================================
-# D. _trial_counter_file_with_extra
+# _trial_counter_file_with_extra
 # =============================================================================
 
 
@@ -379,7 +379,7 @@ def test_trial_counter_file_with_extra_overflow(perfmon_config):
 
 
 # =============================================================================
-# E. _rebuild_tcc_channel_file_map
+# _rebuild_tcc_channel_file_map
 # =============================================================================
 
 
@@ -399,7 +399,7 @@ def test_rebuild_tcc_channel_file_map(perfmon_config):
 
 
 # =============================================================================
-# F. _allocate_perfmon_counter_files
+# _allocate_perfmon_counter_files
 # =============================================================================
 
 
@@ -478,7 +478,7 @@ def test_allocate_tcc_channel_coalescing(perfmon_config):
 
 
 # =============================================================================
-# F2. metric-aware coalesce: accum buckets and formula-only grouping
+# metric-aware coalesce: accum buckets and formula-only grouping
 # =============================================================================
 
 
@@ -608,7 +608,7 @@ def test_same_bucket_priority_empty_for_gfx950():
 
 
 # =============================================================================
-# G. _expand_tcc_template_counters
+# _expand_tcc_template_counters
 # =============================================================================
 
 
@@ -634,7 +634,7 @@ def test_expand_tcc_no_templates(perfmon_config):
 
 
 # =============================================================================
-# H. _append_analysis_yaml_for_filter_token alias handling
+# _append_analysis_yaml_for_filter_token alias handling
 # =============================================================================
 
 
@@ -669,7 +669,7 @@ def test_filter_token_known_alias_resolves_without_crash(monkeypatch):
 
 
 # =============================================================================
-# I. Memory Bandwidth Analysis counter selection
+# Memory Bandwidth Analysis counter selection
 # =============================================================================
 
 
@@ -732,7 +732,7 @@ def test_membw_analysis_counter_selection(
 
 
 # =============================================================================
-# post_profiling: roofline gating
+# post_profiling
 # =============================================================================
 
 


### PR DESCRIPTION
## Motivation
Bugfix: `--set` ran the roofline microbenchmark on top of the counter pass.

`--set` collects a group of metrics in a single pass. Roofline is a separate
microbenchmark run and is never part of a set, so it is now skipped for `--set`
and profiling costs only the single pass the set asks for.

## Technical Details
- `--set` and `--roof-only` are resolved into block ids by `detect_counters`, and the result is now stored back on the args in `pre_processing`.
- The post-profiling roofline gate reads `filter_blocks` from the args, so it now sees the resolved blocks instead of an empty list.
- Writing `profiling_config.yaml` no longer needs to override `filter_blocks`.
- Unit coverage for the roofline gate across resolved block inputs.

## Issue Tracking
JIRA ID: N/A

## Test Plan
`pytest tests/unit` locally on gfx942.

## Test Result
Full unit suite passes locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
