### PR TITLE
fix(rocr): fix cpu memset access failing on imported VMM allocations

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -212,6 +212,12 @@ virtualMemoryManagement:
     # Multiprocess export/import over a unix socket.
     # ROCr refuses a CPU mapping of VMM memory under WSL DXG.
     disabled: [amd_windows, amd_wsl]
+  Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess_ExporterNotDeviceZero:
+    <<: *level_2
+    # Multiprocess export/import over a unix socket.
+    # ROCr refuses a CPU mapping of VMM memory under WSL DXG.
+    disabled: [amd_windows, amd_wsl]
+    tags: [multigpu]
   Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostThenDeviceAccess:
     <<: *level_2
     # Multiprocess export/import over a unix socket.

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -207,6 +207,16 @@ virtualMemoryManagement:
   Unit_hipMemSetAccessHost_devicealloc:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
+  Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess:
+    <<: *level_2
+    # Multiprocess export/import over a unix socket.
+    # ROCr refuses a CPU mapping of VMM memory under WSL DXG.
+    disabled: [amd_windows, amd_wsl]
+  Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostThenDeviceAccess:
+    <<: *level_2
+    # Multiprocess export/import over a unix socket.
+    # ROCr refuses a CPU mapping of VMM memory under WSL DXG.
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemGetAllocationPropertiesFromHandle_functional:
     <<: *level_2
     # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/CMakeLists.txt
@@ -22,7 +22,8 @@ if(UNIX)
   set(TEST_SRC
       ${TEST_SRC}
       hipMemExportToShareableHandle.cc
-      hipMemImportFromShareableHandle.cc)
+      hipMemImportFromShareableHandle.cc
+      hipMemSetAccessImportedHandle.cc)
 endif()
 
 if(HIP_PLATFORM MATCHES "amd")

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
@@ -23,6 +23,11 @@
 #include <hip_test_common.hh>
 #include "hip_vmm_common.hh"
 
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>  // strsignal
+#include <unistd.h>
+
 #define DATA_SIZE (1 << 13)
 
 // Device access on the imported mapping is exercised with hipMemsetD32 rather than a
@@ -30,94 +35,149 @@
 // object there is unreliable.
 #define MEMSET_PATTERN 0xdeadbeef
 
-/**
- * Test Description
- * ------------------------
- *    - Multiprocess functionality test. The Parent Process creates a device backed Vmm
- * allocation, seeds it and exports it to the Child Process over a socket. The Child
- * Process imports the handle, maps it into its own reserved address range and grants
- * *CPU* access to the imported mapping. The Child then reads the Parent's data and writes
- * back through the CPU mapping, and the Parent verifies the result.
- * ------------------------
- *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
- * Test requirements
- * ------------------------
- *    - Host specific (LINUX)
- *    - HIP_VERSION >= 6.2
- */
-HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
+namespace {
+
+/* Short transfers are legal, and a >= 0 check also accepts read() returning 0 (peer gone), which
+ * leaves the child running on an uninitialised size. */
+bool WriteExact(int fd, const void* buf, size_t len) {
+  const char* p = static_cast<const char*>(buf);
+  while (len) {
+    ssize_t n = write(fd, p, len);
+    if (n < 0 && errno == EINTR) continue;
+    if (n <= 0) return false;
+    p += n;
+    len -= static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool ReadExact(int fd, void* buf, size_t len) {
+  char* p = static_cast<char*>(buf);
+  while (len) {
+    ssize_t n = read(fd, p, len);
+    if (n < 0 && errno == EINTR) continue;
+    if (n <= 0) return false;
+    p += n;
+    len -= static_cast<size_t>(n);
+  }
+  return true;
+}
+
+constexpr int kChildAssertFailed = 42;
+
+/* Catch2 assertions and HIP_CHECK throw. In a forked child that unwinds past exit() and re-runs
+ * the runner's teardown, turning a plain failure into a stray signal. Confine it to an exit code. */
+template <typename F> void RunChildBody(F&& body) {
+  int rc = 0;
+  try {
+    body();
+  } catch (...) {
+    rc = kChildAssertFailed;
+  }
+  fflush(nullptr);
+  _exit(rc);
+}
+
+/* A raw "status == 0" check reports a child killed by SIGBUS as "135 == 0", indistinguishable
+ * from a failed assertion. Say which one happened. */
+void RequireChildExitedCleanly(int status) {
+  if (WIFSIGNALED(status)) {
+    INFO("Child process terminated by signal " << WTERMSIG(status) << " ("
+                                               << strsignal(WTERMSIG(status)) << ")");
+    REQUIRE(!WIFSIGNALED(status));
+  }
+  REQUIRE(WIFEXITED(status));
+  INFO("Child process exited with code " << WEXITSTATUS(status));
+  REQUIRE(WEXITSTATUS(status) == 0);
+}
+
+/* Parent allocates and seeds device memory on @p device and exports it; the child imports it,
+ * grants CPU access, reads it back and writes through the CPU mapping for the parent to verify. */
+void ImportedDeviceMemHostAccessTest(int device) {
   constexpr int N = DATA_SIZE;
-  size_t buffer_size = N * sizeof(int);
+  const size_t buffer_size = N * sizeof(int);
+
+  HIP_CHECK(hipSetDevice(device));
+  hipDevice_t hipDev;
+  HIP_CHECK(hipDeviceGet(&hipDev, device));
+  checkVMMSupported(hipDev);
+
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
+
+  /* Drain stdio first: under ctest it is fully buffered, so a child that flushes would re-emit
+   * whatever the parent had queued. */
+  fflush(nullptr);
 
   auto pid = fork();
   REQUIRE(pid >= 0);
 
   if (pid == 0) {  // child
-    REQUIRE(close(fd[1]) == 0);
-    REQUIRE(close(fdSig[0]) == 0);
-    CTX_CREATE();
-    // Wait for parent process to create the socket.
-    size_t size_mem = 0;
-    REQUIRE(read(fd[0], &size_mem, sizeof(size_t)) >= 0);
-    // Open Socket as client
-    ipcSocketCom sockObj(false);
-    hipShareableHdl shHandle;
-    // Signal Parent process that Child is ready to receive msg
-    int sig = 0;
-    REQUIRE(write(fdSig[1], &sig, sizeof(int)) >= 0);
-    // receive message from parent process
-    checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
-    hipMemGenericAllocationHandle_t imported_handle;
-    // import the shareable handle
-    HIP_CHECK(hipMemImportFromShareableHandle(&imported_handle,
-              reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
-              hipMemHandleTypePosixFileDescriptor));
-    // Allocate virtual address range and map the imported allocation into it
-    void* ptrA;
-    HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
-    HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
+    RunChildBody([&]() {
+      REQUIRE(close(fd[1]) == 0);
+      REQUIRE(close(fdSig[0]) == 0);
+      CTX_CREATE();
+      HIP_CHECK(hipSetDevice(device));
 
-    // Grant CPU access to the imported mapping. This is the case under test: the imported
-    // allocation has no CPU mapping of its own, so one has to be established here.
-    hipMemAccessDesc accHost = {};
-    accHost.location.type = hipMemLocationTypeHost;
-    accHost.location.id = 0;
-    accHost.flags = hipMemAccessFlagsProtReadWrite;
+      // Wait for parent process to create the socket.
+      size_t size_mem = 0;
+      REQUIRE(ReadExact(fd[0], &size_mem, sizeof(size_mem)));
+      REQUIRE(size_mem >= buffer_size);
+      // Open Socket as client
+      ipcSocketCom sockObj(false);
+      hipShareableHdl shHandle;
+      // Signal Parent process that Child is ready to receive msg
+      int sig = 0;
+      REQUIRE(WriteExact(fdSig[1], &sig, sizeof(sig)));
+      // receive message from parent process
+      checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
+      hipMemGenericAllocationHandle_t imported_handle;
+      // import the shareable handle
+      HIP_CHECK(hipMemImportFromShareableHandle(
+          &imported_handle, reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
+          hipMemHandleTypePosixFileDescriptor));
+      // Allocate virtual address range and map the imported allocation into it
+      void* ptrA;
+      HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
+      HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
+
+      // Grant CPU access to the imported mapping. This is the case under test: the imported
+      // allocation has no CPU mapping of its own, so one has to be established here.
+      hipMemAccessDesc accHost = {};
+      accHost.location.type = hipMemLocationTypeHost;
+      accHost.location.id = 0;
+      accHost.flags = hipMemAccessFlagsProtReadWrite;
 #if HT_AMD
-    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
+      HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
 
-    // The CPU can now read what the parent seeded and write back through the mapping.
-    int* hostPtr = reinterpret_cast<int*>(ptrA);
-    std::vector<int> expected(N);
-    for (size_t idx = 0; idx < N; idx++) expected[idx] = idx;
-    REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
+      // Read what the parent seeded and write back. A mapping made through the wrong GPU's DRM
+      // context faults here rather than failing above.
+      int* hostPtr = reinterpret_cast<int*>(ptrA);
+      std::vector<int> expected(N);
+      for (size_t idx = 0; idx < N; idx++) expected[idx] = idx;
+      REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
 
-    for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx) * 2;
+      for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx) * 2;
 #else
-    // CUDA does not allow host access to a device located allocation.
-    HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
+      // CUDA does not allow host access to a device located allocation.
+      HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
 #endif
 
-    // free resources
-    HIP_CHECK(hipMemUnmap(ptrA, size_mem));
-    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
-    HIP_CHECK(hipMemRelease(imported_handle));
-    CTX_DESTROY();
-    checkSysCallErrors(sockObj.closeThisSock());
-    REQUIRE(close(fd[0]) == 0);
-    REQUIRE(close(fdSig[1]) == 0);
-    exit(0);
+      // free resources
+      HIP_CHECK(hipMemUnmap(ptrA, size_mem));
+      HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+      HIP_CHECK(hipMemRelease(imported_handle));
+      CTX_DESTROY();
+      checkSysCallErrors(sockObj.closeThisSock());
+      REQUIRE(close(fd[0]) == 0);
+      REQUIRE(close(fdSig[1]) == 0);
+    });
   } else {  // parent
     REQUIRE(close(fd[0]) == 0);
     REQUIRE(close(fdSig[1]) == 0);
     CTX_CREATE();
 
-    hipDevice_t device;
-    HIP_CHECK(hipDeviceGet(&device, 0));
-    checkVMMSupported(device);
     // Set property
     hipMemAllocationProp prop = {};
     prop.type = hipMemAllocationTypePinned;
@@ -153,15 +213,15 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
     // Create the socket for communication as Server
     ipcSocketCom sockObj(true);
     // Signal child process that socket is ready
-    REQUIRE(write(fd[1], &size_mem, sizeof(size_t)) >= 0);
+    REQUIRE(WriteExact(fd[1], &size_mem, sizeof(size_mem)));
     // Wait for the child process to receive msg
     int sig = 0;
-    REQUIRE(read(fdSig[0], &sig, sizeof(int)) >= 0);
+    REQUIRE(ReadExact(fdSig[0], &sig, sizeof(sig)));
     checkSysCallErrors(sockObj.sendShareableHdl(shareable_handle, pid));
     // Wait for child process to exit.
     int status;
     REQUIRE(wait(&status) >= 0);
-    REQUIRE(status == 0);
+    RequireChildExitedCleanly(status);
 
 #if HT_AMD
     // Check what the child wrote through its CPU mapping of the imported allocation.
@@ -180,6 +240,53 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
     REQUIRE(close(fd[1]) == 0);
     REQUIRE(close(fdSig[0]) == 0);
   }
+
+  // Parent only; RunChildBody() never returns. Do not leak a non-zero device into the next test.
+  HIP_CHECK(hipSetDevice(0));
+}
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Multiprocess functionality test. The Parent Process creates a device backed Vmm
+ * allocation, seeds it and exports it to the Child Process over a socket. The Child
+ * Process imports the handle, maps it into its own reserved address range and grants
+ * *CPU* access to the imported mapping. The Child then reads the Parent's data and writes
+ * back through the CPU mapping, and the Parent verifies the result.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 6.2
+ */
+HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
+  ImportedDeviceMemHostAccessTest(0);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Same as Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess, but exporting from the
+ * last device, so a wrong pick of the exporting GPU is not masked by everything agreeing.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - Multiple devices
+ *    - HIP_VERSION >= 6.2
+ */
+HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess_ExporterNotDeviceZero) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+  if (deviceCount < 2) {
+    HIP_SKIP_TEST("Test needs at least 2 devices. Skipping Test..");
+    return;
+  }
+  ImportedDeviceMemHostAccessTest(deviceCount - 1);
 }
 
 /**
@@ -200,89 +307,98 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
 HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostThenDeviceAccess) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+  checkVMMSupported(device);
+
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
+
+  /* Drain stdio first: under ctest it is fully buffered, so a child that flushes would re-emit
+   * whatever the parent had queued. */
+  fflush(nullptr);
 
   auto pid = fork();
   REQUIRE(pid >= 0);
 
   if (pid == 0) {  // child
-    REQUIRE(close(fd[1]) == 0);
-    REQUIRE(close(fdSig[0]) == 0);
-    CTX_CREATE();
-    // Wait for parent process to create the socket.
-    size_t size_mem = 0;
-    REQUIRE(read(fd[0], &size_mem, sizeof(size_t)) >= 0);
-    // Open Socket as client
-    ipcSocketCom sockObj(false);
-    hipShareableHdl shHandle;
-    // Signal Parent process that Child is ready to receive msg
-    int sig = 0;
-    REQUIRE(write(fdSig[1], &sig, sizeof(int)) >= 0);
-    // receive message from parent process
-    checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
-    hipMemGenericAllocationHandle_t imported_handle;
-    // import the shareable handle
-    HIP_CHECK(hipMemImportFromShareableHandle(&imported_handle,
-              reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
-              hipMemHandleTypePosixFileDescriptor));
-    // Allocate virtual address range and map the imported allocation into it
-    void* ptrA;
-    HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
-    HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
+    RunChildBody([&]() {
+      REQUIRE(close(fd[1]) == 0);
+      REQUIRE(close(fdSig[0]) == 0);
+      CTX_CREATE();
+      // Wait for parent process to create the socket.
+      size_t size_mem = 0;
+      REQUIRE(ReadExact(fd[0], &size_mem, sizeof(size_mem)));
+      REQUIRE(size_mem >= buffer_size);
+      // Open Socket as client
+      ipcSocketCom sockObj(false);
+      hipShareableHdl shHandle;
+      // Signal Parent process that Child is ready to receive msg
+      int sig = 0;
+      REQUIRE(WriteExact(fdSig[1], &sig, sizeof(sig)));
+      // receive message from parent process
+      checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
+      hipMemGenericAllocationHandle_t imported_handle;
+      // import the shareable handle
+      HIP_CHECK(hipMemImportFromShareableHandle(
+          &imported_handle, reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
+          hipMemHandleTypePosixFileDescriptor));
+      // Allocate virtual address range and map the imported allocation into it
+      void* ptrA;
+      HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
+      HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
 
-    // Grant CPU access first, then GPU access, on the same imported mapping.
-    hipMemAccessDesc accHost = {};
-    accHost.location.type = hipMemLocationTypeHost;
-    accHost.location.id = 0;
-    accHost.flags = hipMemAccessFlagsProtReadWrite;
+      // Grant CPU access first, then GPU access, on the same imported mapping.
+      hipMemAccessDesc accHost = {};
+      accHost.location.type = hipMemLocationTypeHost;
+      accHost.location.id = 0;
+      accHost.flags = hipMemAccessFlagsProtReadWrite;
 #if HT_AMD
-    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
+      HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
 
-    hipMemAccessDesc accDev = {};
-    accDev.location.type = hipMemLocationTypeDevice;
-    accDev.location.id = 0;
-    accDev.flags = hipMemAccessFlagsProtReadWrite;
-    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accDev, 1));
+      hipMemAccessDesc accDev = {};
+      accDev.location.type = hipMemLocationTypeDevice;
+      accDev.location.id = 0;
+      accDev.flags = hipMemAccessFlagsProtReadWrite;
+      HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accDev, 1));
 
-    // Seed through the CPU mapping, overwrite from the GPU, then read back through the CPU
-    // mapping. Both mappings of the imported allocation have to be live for this to hold.
-    int* hostPtr = reinterpret_cast<int*>(ptrA);
-    for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx);
+      // Seed through the CPU mapping, overwrite from the GPU, then read back through the CPU
+      // mapping. Both mappings of the imported allocation have to be live for this to hold.
+      int* hostPtr = reinterpret_cast<int*>(ptrA);
+      for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx);
 
-    HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(ptrA), MEMSET_PATTERN, N));
-    HIP_CHECK(hipDeviceSynchronize());
+      HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(ptrA), MEMSET_PATTERN, N));
+      HIP_CHECK(hipDeviceSynchronize());
 
-    std::vector<int> expected(N, static_cast<int>(MEMSET_PATTERN));
-    REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
+      std::vector<int> expected(N, static_cast<int>(MEMSET_PATTERN));
+      REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
 
-    // And the device side observes the same memory through hipMemcpyDtoH.
-    std::vector<int> readback(N, 0);
-    HIP_CHECK(hipMemcpyDtoH(readback.data(), reinterpret_cast<hipDeviceptr_t>(ptrA), buffer_size));
-    REQUIRE(true == std::equal(readback.begin(), readback.end(), expected.data()));
+      // And the device side observes the same memory through hipMemcpyDtoH.
+      std::vector<int> readback(N, 0);
+      HIP_CHECK(
+          hipMemcpyDtoH(readback.data(), reinterpret_cast<hipDeviceptr_t>(ptrA), buffer_size));
+      REQUIRE(true == std::equal(readback.begin(), readback.end(), expected.data()));
 #else
-    // CUDA does not allow host access to a device located allocation.
-    HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
+      // CUDA does not allow host access to a device located allocation.
+      HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
 #endif
 
-    // free resources
-    HIP_CHECK(hipMemUnmap(ptrA, size_mem));
-    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
-    HIP_CHECK(hipMemRelease(imported_handle));
-    CTX_DESTROY();
-    checkSysCallErrors(sockObj.closeThisSock());
-    REQUIRE(close(fd[0]) == 0);
-    REQUIRE(close(fdSig[1]) == 0);
-    exit(0);
+      // free resources
+      HIP_CHECK(hipMemUnmap(ptrA, size_mem));
+      HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+      HIP_CHECK(hipMemRelease(imported_handle));
+      CTX_DESTROY();
+      checkSysCallErrors(sockObj.closeThisSock());
+      REQUIRE(close(fd[0]) == 0);
+      REQUIRE(close(fdSig[1]) == 0);
+    });
   } else {  // parent
     REQUIRE(close(fd[0]) == 0);
     REQUIRE(close(fdSig[1]) == 0);
     CTX_CREATE();
 
-    hipDevice_t device;
-    HIP_CHECK(hipDeviceGet(&device, 0));
-    checkVMMSupported(device);
     // Set property
     hipMemAllocationProp prop = {};
     prop.type = hipMemAllocationTypePinned;
@@ -304,15 +420,15 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostThenDeviceAcces
     // Create the socket for communication as Server
     ipcSocketCom sockObj(true);
     // Signal child process that socket is ready
-    REQUIRE(write(fd[1], &size_mem, sizeof(size_t)) >= 0);
+    REQUIRE(WriteExact(fd[1], &size_mem, sizeof(size_mem)));
     // Wait for the child process to receive msg
     int sig = 0;
-    REQUIRE(read(fdSig[0], &sig, sizeof(int)) >= 0);
+    REQUIRE(ReadExact(fdSig[0], &sig, sizeof(sig)));
     checkSysCallErrors(sockObj.sendShareableHdl(shareable_handle, pid));
     // Wait for child process to exit.
     int status;
     REQUIRE(wait(&status) >= 0);
-    REQUIRE(status == 0);
+    RequireChildExitedCleanly(status);
 
     // Free all resources
     HIP_CHECK(hipMemRelease(handle));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
@@ -186,9 +186,10 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
  * Test Description
  * ------------------------
  *    - Multiprocess functionality test. Same import as above, but the Child Process grants
- * CPU access to the imported mapping *before* granting GPU access, then launches a kernel
- * on it. This checks that the host and device mappings of an imported allocation coexist
- * and that granting host access first does not disturb the subsequent device mapping.
+ * CPU access to the imported mapping *before* granting GPU access, seeds it through the CPU
+ * mapping and then overwrites it from the device with hipMemsetD32. This checks that the host
+ * and device mappings of an imported allocation coexist and that granting host access first
+ * does not disturb the subsequent device mapping.
  * ------------------------
  *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
  * Test requirements

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipMemSetAccess hipMemSetAccess
+ * @{
+ * @ingroup VirtualMemoryManagementTest
+ * `hipError_t hipMemSetAccess(void* ptr, size_t size, const hipMemAccessDesc* desc,
+ *                             size_t count)` -
+ * 	Sets the access flags for each location specified in desc for the given virtual
+ * address range.
+ *
+ * These tests cover granting *CPU* access (hipMemLocationTypeHost) to a mapping backed by
+ * an allocation that was created in another process and brought in with
+ * hipMemImportFromShareableHandle. An imported allocation carries no CPU mapping of its
+ * own, so this exercises a different path than the same call on a locally created handle
+ * (covered by Unit_hipMemSetAccessHost_devicealloc).
+ */
+
+#include <hip_test_common.hh>
+#include "hip_vmm_common.hh"
+
+#define DATA_SIZE (1 << 13)
+
+// Device access on the imported mapping is exercised with hipMemsetD32 rather than a
+// kernel launch: these tests run their HIP work in a fork()ed child, and loading a code
+// object there is unreliable.
+#define MEMSET_PATTERN 0xdeadbeef
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Multiprocess functionality test. The Parent Process creates a device backed Vmm
+ * allocation, seeds it and exports it to the Child Process over a socket. The Child
+ * Process imports the handle, maps it into its own reserved address range and grants
+ * *CPU* access to the imported mapping. The Child then reads the Parent's data and writes
+ * back through the CPU mapping, and the Parent verifies the result.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 6.2
+ */
+HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostAccess) {
+  constexpr int N = DATA_SIZE;
+  size_t buffer_size = N * sizeof(int);
+  int fd[2], fdSig[2];
+  REQUIRE(pipe(fd) == 0);
+  REQUIRE(pipe(fdSig) == 0);
+
+  auto pid = fork();
+  REQUIRE(pid >= 0);
+
+  if (pid == 0) {  // child
+    REQUIRE(close(fd[1]) == 0);
+    REQUIRE(close(fdSig[0]) == 0);
+    CTX_CREATE();
+    // Wait for parent process to create the socket.
+    size_t size_mem = 0;
+    REQUIRE(read(fd[0], &size_mem, sizeof(size_t)) >= 0);
+    // Open Socket as client
+    ipcSocketCom sockObj(false);
+    hipShareableHdl shHandle;
+    // Signal Parent process that Child is ready to receive msg
+    int sig = 0;
+    REQUIRE(write(fdSig[1], &sig, sizeof(int)) >= 0);
+    // receive message from parent process
+    checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
+    hipMemGenericAllocationHandle_t imported_handle;
+    // import the shareable handle
+    HIP_CHECK(hipMemImportFromShareableHandle(&imported_handle,
+              reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
+              hipMemHandleTypePosixFileDescriptor));
+    // Allocate virtual address range and map the imported allocation into it
+    void* ptrA;
+    HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
+    HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
+
+    // Grant CPU access to the imported mapping. This is the case under test: the imported
+    // allocation has no CPU mapping of its own, so one has to be established here.
+    hipMemAccessDesc accHost = {};
+    accHost.location.type = hipMemLocationTypeHost;
+    accHost.location.id = 0;
+    accHost.flags = hipMemAccessFlagsProtReadWrite;
+#if HT_AMD
+    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
+
+    // The CPU can now read what the parent seeded and write back through the mapping.
+    int* hostPtr = reinterpret_cast<int*>(ptrA);
+    std::vector<int> expected(N);
+    for (size_t idx = 0; idx < N; idx++) expected[idx] = idx;
+    REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
+
+    for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx) * 2;
+#else
+    // CUDA does not allow host access to a device located allocation.
+    HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
+#endif
+
+    // free resources
+    HIP_CHECK(hipMemUnmap(ptrA, size_mem));
+    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+    HIP_CHECK(hipMemRelease(imported_handle));
+    CTX_DESTROY();
+    checkSysCallErrors(sockObj.closeThisSock());
+    REQUIRE(close(fd[0]) == 0);
+    REQUIRE(close(fdSig[1]) == 0);
+    exit(0);
+  } else {  // parent
+    REQUIRE(close(fd[0]) == 0);
+    REQUIRE(close(fdSig[1]) == 0);
+    CTX_CREATE();
+
+    hipDevice_t device;
+    HIP_CHECK(hipDeviceGet(&device, 0));
+    checkVMMSupported(device);
+    // Set property
+    hipMemAllocationProp prop = {};
+    prop.type = hipMemAllocationTypePinned;
+    prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
+    prop.location.type = hipMemLocationTypeDevice;
+    prop.location.id = device;
+    // Set Granularity of the VMM memory
+    size_t granularity;
+    HIP_CHECK(
+        hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum));
+    REQUIRE(granularity > 0);
+    size_t size_mem = ((granularity + buffer_size - 1) / granularity) * granularity;
+    hipMemGenericAllocationHandle_t handle;
+    HIP_CHECK(hipMemCreate(&handle, size_mem, &prop, 0));
+
+    // Map it locally and seed it so the child has something to read back.
+    void* ptrA;
+    HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
+    HIP_CHECK(hipMemMap(ptrA, size_mem, 0, handle, 0));
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type = hipMemLocationTypeDevice;
+    accessDesc.location.id = device;
+    accessDesc.flags = hipMemAccessFlagsProtReadWrite;
+    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accessDesc, 1));
+
+    std::vector<int> A_h(N), B_h(N);
+    for (size_t idx = 0; idx < N; idx++) A_h[idx] = idx;
+    HIP_CHECK(hipMemcpyHtoD(reinterpret_cast<hipDeviceptr_t>(ptrA), A_h.data(), buffer_size));
+
+    hipShareableHdl shareable_handle;
+    HIP_CHECK(hipMemExportToShareableHandle(&shareable_handle, handle,
+                                            hipMemHandleTypePosixFileDescriptor, 0));
+    // Create the socket for communication as Server
+    ipcSocketCom sockObj(true);
+    // Signal child process that socket is ready
+    REQUIRE(write(fd[1], &size_mem, sizeof(size_t)) >= 0);
+    // Wait for the child process to receive msg
+    int sig = 0;
+    REQUIRE(read(fdSig[0], &sig, sizeof(int)) >= 0);
+    checkSysCallErrors(sockObj.sendShareableHdl(shareable_handle, pid));
+    // Wait for child process to exit.
+    int status;
+    REQUIRE(wait(&status) >= 0);
+    REQUIRE(status == 0);
+
+#if HT_AMD
+    // Check what the child wrote through its CPU mapping of the imported allocation.
+    HIP_CHECK(hipMemcpyDtoH(B_h.data(), reinterpret_cast<hipDeviceptr_t>(ptrA), buffer_size));
+    std::vector<int> expected(N);
+    for (size_t idx = 0; idx < N; idx++) expected[idx] = static_cast<int>(idx) * 2;
+    REQUIRE(true == std::equal(B_h.begin(), B_h.end(), expected.data()));
+#endif
+
+    // Free all resources
+    HIP_CHECK(hipMemUnmap(ptrA, size_mem));
+    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+    HIP_CHECK(hipMemRelease(handle));
+    checkSysCallErrors(sockObj.closeThisSock());
+    CTX_DESTROY();
+    REQUIRE(close(fd[1]) == 0);
+    REQUIRE(close(fdSig[0]) == 0);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Multiprocess functionality test. Same import as above, but the Child Process grants
+ * CPU access to the imported mapping *before* granting GPU access, then launches a kernel
+ * on it. This checks that the host and device mappings of an imported allocation coexist
+ * and that granting host access first does not disturb the subsequent device mapping.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemSetAccessImportedHandle.cc
+ * Test requirements
+ * ------------------------
+ *    - Host specific (LINUX)
+ *    - HIP_VERSION >= 6.2
+ */
+HIP_TEST_CASE(Unit_hipMemSetAccess_MulProc_ImportedDeviceMem_HostThenDeviceAccess) {
+  constexpr int N = DATA_SIZE;
+  size_t buffer_size = N * sizeof(int);
+  int fd[2], fdSig[2];
+  REQUIRE(pipe(fd) == 0);
+  REQUIRE(pipe(fdSig) == 0);
+
+  auto pid = fork();
+  REQUIRE(pid >= 0);
+
+  if (pid == 0) {  // child
+    REQUIRE(close(fd[1]) == 0);
+    REQUIRE(close(fdSig[0]) == 0);
+    CTX_CREATE();
+    // Wait for parent process to create the socket.
+    size_t size_mem = 0;
+    REQUIRE(read(fd[0], &size_mem, sizeof(size_t)) >= 0);
+    // Open Socket as client
+    ipcSocketCom sockObj(false);
+    hipShareableHdl shHandle;
+    // Signal Parent process that Child is ready to receive msg
+    int sig = 0;
+    REQUIRE(write(fdSig[1], &sig, sizeof(int)) >= 0);
+    // receive message from parent process
+    checkSysCallErrors(sockObj.recvShareableHdl(&shHandle));
+    hipMemGenericAllocationHandle_t imported_handle;
+    // import the shareable handle
+    HIP_CHECK(hipMemImportFromShareableHandle(&imported_handle,
+              reinterpret_cast<void*>(static_cast<uintptr_t>(shHandle)),
+              hipMemHandleTypePosixFileDescriptor));
+    // Allocate virtual address range and map the imported allocation into it
+    void* ptrA;
+    HIP_CHECK(hipMemAddressReserve(&ptrA, size_mem, 0, 0, 0));
+    HIP_CHECK(hipMemMap(ptrA, size_mem, 0, imported_handle, 0));
+
+    // Grant CPU access first, then GPU access, on the same imported mapping.
+    hipMemAccessDesc accHost = {};
+    accHost.location.type = hipMemLocationTypeHost;
+    accHost.location.id = 0;
+    accHost.flags = hipMemAccessFlagsProtReadWrite;
+#if HT_AMD
+    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accHost, 1));
+
+    hipMemAccessDesc accDev = {};
+    accDev.location.type = hipMemLocationTypeDevice;
+    accDev.location.id = 0;
+    accDev.flags = hipMemAccessFlagsProtReadWrite;
+    HIP_CHECK(hipMemSetAccess(ptrA, size_mem, &accDev, 1));
+
+    // Seed through the CPU mapping, overwrite from the GPU, then read back through the CPU
+    // mapping. Both mappings of the imported allocation have to be live for this to hold.
+    int* hostPtr = reinterpret_cast<int*>(ptrA);
+    for (size_t idx = 0; idx < N; idx++) hostPtr[idx] = static_cast<int>(idx);
+
+    HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(ptrA), MEMSET_PATTERN, N));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    std::vector<int> expected(N, static_cast<int>(MEMSET_PATTERN));
+    REQUIRE(true == std::equal(expected.begin(), expected.end(), hostPtr));
+
+    // And the device side observes the same memory through hipMemcpyDtoH.
+    std::vector<int> readback(N, 0);
+    HIP_CHECK(hipMemcpyDtoH(readback.data(), reinterpret_cast<hipDeviceptr_t>(ptrA), buffer_size));
+    REQUIRE(true == std::equal(readback.begin(), readback.end(), expected.data()));
+#else
+    // CUDA does not allow host access to a device located allocation.
+    HIP_CHECK_ERROR(hipMemSetAccess(ptrA, size_mem, &accHost, 1), hipErrorNotSupported);
+#endif
+
+    // free resources
+    HIP_CHECK(hipMemUnmap(ptrA, size_mem));
+    HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
+    HIP_CHECK(hipMemRelease(imported_handle));
+    CTX_DESTROY();
+    checkSysCallErrors(sockObj.closeThisSock());
+    REQUIRE(close(fd[0]) == 0);
+    REQUIRE(close(fdSig[1]) == 0);
+    exit(0);
+  } else {  // parent
+    REQUIRE(close(fd[0]) == 0);
+    REQUIRE(close(fdSig[1]) == 0);
+    CTX_CREATE();
+
+    hipDevice_t device;
+    HIP_CHECK(hipDeviceGet(&device, 0));
+    checkVMMSupported(device);
+    // Set property
+    hipMemAllocationProp prop = {};
+    prop.type = hipMemAllocationTypePinned;
+    prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
+    prop.location.type = hipMemLocationTypeDevice;
+    prop.location.id = device;
+    // Set Granularity of the VMM memory
+    size_t granularity;
+    HIP_CHECK(
+        hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum));
+    REQUIRE(granularity > 0);
+    size_t size_mem = ((granularity + buffer_size - 1) / granularity) * granularity;
+    hipMemGenericAllocationHandle_t handle;
+    HIP_CHECK(hipMemCreate(&handle, size_mem, &prop, 0));
+
+    hipShareableHdl shareable_handle;
+    HIP_CHECK(hipMemExportToShareableHandle(&shareable_handle, handle,
+                                            hipMemHandleTypePosixFileDescriptor, 0));
+    // Create the socket for communication as Server
+    ipcSocketCom sockObj(true);
+    // Signal child process that socket is ready
+    REQUIRE(write(fd[1], &size_mem, sizeof(size_t)) >= 0);
+    // Wait for the child process to receive msg
+    int sig = 0;
+    REQUIRE(read(fdSig[0], &sig, sizeof(int)) >= 0);
+    checkSysCallErrors(sockObj.sendShareableHdl(shareable_handle, pid));
+    // Wait for child process to exit.
+    int status;
+    REQUIRE(wait(&status) >= 0);
+    REQUIRE(status == 0);
+
+    // Free all resources
+    HIP_CHECK(hipMemRelease(handle));
+    checkSysCallErrors(sockObj.closeThisSock());
+    CTX_DESTROY();
+    REQUIRE(close(fd[1]) == 0);
+    REQUIRE(close(fdSig[0]) == 0);
+  }
+}
+
+/**
+ * End doxygen group VirtualMemoryManagementTest.
+ * @}
+ */

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -576,6 +576,13 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     }
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     handle->size = res.alloc_size;
+    // Record the DRM mmap offset of the imported BO so the CPU mapping can be established
+    // later in Runtime::MappedHandleAllowedAgent::EnableAccess. set mmap_offset to 0 and
+    // let the CPU-access path report the error if its requested.
+    if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
+                                           &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
+      handle->mmap_offset = 0;
+    }
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE: {
@@ -600,6 +607,11 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     if (rocr::os::DmaBufClose(&res.dmabuf_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
     handle->size = res.alloc_size;
+    //Refer the DMABUF_FD case, best-effort mmap offset for the CPU-access path.
+    if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
+                                           &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
+      handle->mmap_offset = 0;
+    }
     return HSA_STATUS_SUCCESS;
   }
   default:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -577,12 +577,13 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     handle->size = res.alloc_size;
     // Record the DRM mmap offset of the imported BO so the CPU mapping can be established
-    // later in Runtime::MappedHandleAllowedAgent::EnableAccess. set mmap_offset to 0 and
-    // let the CPU-access path report the error if its requested.
-    if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
-                                           &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
-      handle->mmap_offset = 0;
-    }
+    // later in Runtime::MappedHandleAllowedAgent::EnableAccess. This is best effort: a BO that
+    // is not CPU mappable must still import successfully for GPU access, so leave the offset
+    // marked invalid and let the CPU-access path reject it if a CPU mapping is requested.
+    handle->mmap_offset_valid =
+        HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
+                                           &handle->mmap_offset)) == HSAKMT_STATUS_SUCCESS;
+    if (!handle->mmap_offset_valid) handle->mmap_offset = 0;
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE: {
@@ -607,11 +608,11 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
     if (rocr::os::DmaBufClose(&res.dmabuf_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
     handle->size = res.alloc_size;
-    //Refer the DMABUF_FD case, best-effort mmap offset for the CPU-access path.
-    if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
-                                           &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
-      handle->mmap_offset = 0;
-    }
+    // See the DMABUF_FD case above: best-effort mmap offset for the CPU-access path.
+    handle->mmap_offset_valid =
+        HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(gpu_agent.libThunkDev(), res.buf_handle,
+                                           &handle->mmap_offset)) == HSAKMT_STATUS_SUCCESS;
+    if (!handle->mmap_offset_valid) handle->mmap_offset = 0;
     return HSA_STATUS_SUCCESS;
   }
   default:
@@ -689,6 +690,9 @@ hsa_status_t KfdDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
     DestroyMemoryHandle(&targetHandle);
     return HSA_STATUS_ERROR;
   }
+  // Unlike the import path this is not best effort: a locally created shareable handle always
+  // carries a usable CPU mmap offset, or CreateShareableHandle fails above.
+  handle->mmap_offset_valid = true;
 
   // handle->handle is replaced by the imported BO; handle->size carries over from allocation.
   handle->handle = targetHandle.handle;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -965,6 +965,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
   // handle->handle and handle->size carry over from allocation
   handle->dmabuf_fd = params.fd;
   handle->mmap_offset = get_bo_info_args.map_offset;
+  handle->mmap_offset_valid = true;
 
   *offset = 0;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -79,7 +79,12 @@ struct DriverMemoryHandle {
   /// mapping owned by something else, in which case FreeMemory leaves it intact.
   void* vaddr{};
   int dmabuf_fd{-1};
+  /// DRM "fake" mmap offset for this BO, usable only on the DRM fd of the context that
+  /// produced it, and only when @ref mmap_offset_valid is set.
   uint64_t mmap_offset{0};
+  /// Whether a driver filled @ref mmap_offset. 0 is a legal DRM offset, so it cannot double as
+  /// a "not set" sentinel; mmap()ing offset 0 on a real DRM fd can map an unrelated BO.
+  bool mmap_offset_valid{false};
   size_t size{0};
   hsa_fabric_handle_t fabric_handle{};
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -1103,6 +1103,11 @@ class Runtime {
     MemoryRegion::AllocateFlags alloc_flag;
     core::Agent* drm_owner;  // Gpu agent used for import of host memory, NULL for device
                              // memory/imported handles
+
+    // Imported handles: the GPU that exported the dmabuf, the only DRM context that can CPU map
+    // it. Filled lazily by ImportedHandleCpuMmapAgent(); the flag marks "already looked up".
+    core::Agent* cpu_mmap_agent = nullptr;
+    bool cpu_mmap_agent_resolved = false;
   };
   // hsa_amd_vmem_alloc_handle_t (MemoryHandle*) to MemoryHandle mapping. Owns MemoryHandle
   // lifetime. Uniqueness is guaranteed by the runtime, independent of any driver-supplied
@@ -1111,6 +1116,10 @@ class Runtime {
 
   MemoryHandle* FindMemoryHandle(MemoryHandle* handle);
   void ReleaseMemoryHandle(MemoryHandle* handle);
+
+  /// @brief GPU that exported @p memHandle's BO, to use as the DRM context of its CPU mapping.
+  /// Call with memory_lock_ held. Returns nullptr if unknown, i.e. no CPU mapping is possible.
+  Agent* ImportedHandleCpuMmapAgent(MemoryHandle* memHandle);
 
   struct MappedHandle;
   struct MappedHandleAllowedAgent {
@@ -1129,10 +1138,11 @@ class Runtime {
     DriverMemoryHandle driver_handle;
     // False when driver_handle is borrowed from MemoryHandle::driver_handle (drm_owner reuse path)
     bool owns_driver_handle = true;
-    // For CPU targetAgent over an imported MemoryHandle: the GPU agent whose DRM context
-    // holds the BO that driver_handle refers to, and whose device fd the CPU mmap uses.
-    // set to nullptr for all other cases.
+    // CPU targetAgent over an imported handle: MemoryHandle::cpu_mmap_agent, whose DRM context
+    // holds driver_handle's BO and whose fd the mmap uses. nullptr in every other case.
     Agent* cpu_mmap_drm_agent = nullptr;
+    // Whether EnableAccess established the CPU mmap the destructor has to undo.
+    bool cpu_mapped = false;
   };
 
   struct MappedHandle {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -1129,6 +1129,10 @@ class Runtime {
     DriverMemoryHandle driver_handle;
     // False when driver_handle is borrowed from MemoryHandle::driver_handle (drm_owner reuse path)
     bool owns_driver_handle = true;
+    // For CPU targetAgent over an imported MemoryHandle: the GPU agent whose DRM context
+    // holds the BO that driver_handle refers to, and whose device fd the CPU mmap uses.
+    // set to nullptr for all other cases.
+    Agent* cpu_mmap_drm_agent = nullptr;
   };
 
   struct MappedHandle {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4317,6 +4317,60 @@ hsa_status_t Runtime::VMemoryHandleUnmap(void* va, size_t size) {
   return HSA_STATUS_SUCCESS;
 }
 
+/* Any GPU can import a dmabuf for peer access, but only its exporter can CPU map it: elsewhere it
+ * is a ttm_bo_type_sg BO whose mmap succeeds and then takes SIGBUS on the first fault. */
+Agent* Runtime::ImportedHandleCpuMmapAgent(MemoryHandle* memHandle) {
+  assert(memHandle->imported && "Exporter lookup only applies to imported handles");
+
+  if (memHandle->cpu_mmap_agent_resolved) return memHandle->cpu_mmap_agent;
+  memHandle->cpu_mmap_agent_resolved = true;
+
+  /* hsaKmtHandleImport mints a fabric handle's dmabuf on whichever device it is handed, so that
+   * device is the exporter by construction and any GPU agent serves. */
+  if (memHandle->is_fabric_handle) {
+    memHandle->cpu_mmap_agent = KfdGttAnchorGpu();
+    return memHandle->cpu_mmap_agent;
+  }
+
+  const int dmabuf_fd = memHandle->driver_handle.dmabuf_fd;
+
+  if (dmabuf_fd >= 0) {
+    HsaGraphicsResourceInfo info = {};
+    HSA_REGISTER_MEM_FLAGS regFlags{0};
+    /* No VA and no node list: the "import without VA assigned" form, cheapest way to get NodeId. */
+    regFlags.ui32.requiresVAddr = 0;
+
+    if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt(static_cast<HSAuint64>(dmabuf_fd),
+                                                           &info, 0, nullptr, regFlags)) ==
+        HSAKMT_STATUS_SUCCESS) {
+      const uint32_t exporter_node = info.NodeId;
+      HSAKMT_CALL(hsaKmtDeregisterMemory(info.MemoryAddress));
+
+      /* A definitive answer: take the exporting agent if it is visible, give up if it is not.
+       * Substituting another GPU is what produces the SIGBUS above. */
+      auto it = agents_by_node_.find(exporter_node);
+      if (it != agents_by_node_.end()) {
+        for (Agent* agent : it->second) {
+          if (agent->device_type() == core::Agent::DeviceType::kAmdGpuDevice) {
+            memHandle->cpu_mmap_agent = agent;
+            return memHandle->cpu_mmap_agent;
+          }
+        }
+      }
+      debug_print("CPU mapping of imported handle: exporting node %u is not a visible GPU agent\n",
+                  exporter_node);
+      return memHandle->cpu_mmap_agent;
+    }
+    debug_print("CPU mapping of imported handle: could not query the exporting node\n");
+  }
+
+  /* No answer at all. With one visible GPU there is no other device the BO could have come from,
+   * so it is the exporter; with more than one, refuse rather than guess. */
+  if (gpu_agents_.size() == 1) memHandle->cpu_mmap_agent = gpu_agents_[0];
+
+  return memHandle->cpu_mmap_agent;
+}
+
 Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(MappedHandle* _mappedHandle,
                                                             Agent* targetAgent, void* va,
                                                             size_t size,
@@ -4329,18 +4383,14 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(MappedHandle* _mappe
   MemoryHandle* memHandle = mappedHandle->mem_handle;
 
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
-    /* A locally-created handle already has a CPU mapping: CreateShareableHandle recorded that
-     * BO's mmap offset. An imported handle owns only the fd, so import the dmabuf here to get an
-     * offset EnableAccess can mmap. The GPU must be the KFD GTT anchor VMemoryHandleCreate uses;
-     * on CPX+NPS2 it is not the lowest DRM minor and the wrong context faults on first CPU
-     * store. */
+    /* A locally-created handle already has a CPU mapping from CreateShareableHandle. An imported
+     * one owns only the fd, so import the dmabuf here for an offset EnableAccess can mmap. It has
+     * to land in the exporting GPU's DRM context; see ImportedHandleCpuMmapAgent. */
     if (!memHandle->imported) return;
 
-    core::Agent* drm_agent = core::Runtime::runtime_singleton_->KfdGttAnchorGpu();
-    if (drm_agent == nullptr) {
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
-                               "No GPU agent available to map imported memory on the CPU");
-    }
+    core::Agent* drm_agent =
+        core::Runtime::runtime_singleton_->ImportedHandleCpuMmapAgent(memHandle);
+    if (drm_agent == nullptr) return;
 
     hsa_status_t status = drm_agent->driver().ImportMemoryHandle(
         *drm_agent, &driver_handle,
@@ -4378,10 +4428,13 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
     if (core::Runtime::runtime_singleton_->thunkLoader()->IsWslDxg()) assert(!"Unimplemented");
 
-    /* Remap the CPU mapping back to anonymous, freeing the DRM FD while retaining VA reservation */
-    bool result = rocr::os::UncommitMemory(va, size);
-    assert(result && "Failed to remap VA to anonymous");
-    (void)result;
+    /* Remap the CPU mapping back to anonymous, freeing the DRM FD while retaining VA reservation.
+     * Only if one was made: on the EnableAccess failure path this would drop a live reservation. */
+    if (cpu_mapped) {
+      bool result = rocr::os::UncommitMemory(va, size);
+      assert(result && "Failed to remap VA to anonymous");
+      (void)result;
+    }
 
     /* Release the BO imported by the constructor for the imported-handle CPU mapping. */
     if (cpu_mmap_drm_agent != nullptr) {
@@ -4411,7 +4464,11 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
      * for a locally-created one. */
     if (mappedHandle->mem_handle->imported) {
       agent = cpu_mmap_drm_agent;
-      if (agent == nullptr) return HSA_STATUS_ERROR;
+      if (agent == nullptr) {
+        debug_print(
+            "EnableAccess: cannot CPU map an imported handle whose exporting GPU is unknown\n");
+        return HSA_STATUS_ERROR;
+      }
       agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
       cpu_mmap_handle = &driver_handle;
     } else if (mappedHandle->mem_handle->region) {
@@ -4437,6 +4494,7 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
                              cpu_mmap_handle->mmap_offset)) {
       return HSA_STATUS_ERROR;
     }
+    cpu_mapped = true;
   } else {
     hsa_status_t status = targetAgent->driver().Map(driver_handle, va, mappedHandle->offset, size,
                                                     perms, targetAgent->node_id());

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4326,12 +4326,35 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(MappedHandle* _mappe
       targetAgent(targetAgent),
       permissions(perms),
       mappedHandle(_mappedHandle) {
-  // CPU agents have access as the memory is already mapped to the host.
+  MemoryHandle* memHandle = mappedHandle->mem_handle;
+
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
+    /* A locally-created handle already has a CPU mapping. CreateShareableHandle imported the
+     * allocation into a GPU DRM context and recorded that BO's mmap offset in
+     * memHandle->driver_handle. An imported handle has no such BO. MemoryHandle(int dmabuf_fd)
+     * only owns the fd. so import the dmabuf into a GPU DRM context here to obtain an offset
+     * that EnableAccess can mmap.
+     * The GPU is not arbitrary: it must be the KFD GTT anchor (libhsakmt first_gpu_mem), the
+     * same one VMemoryHandleCreate uses. On CPX+NPS2 the anchor is not the lowest DRM render
+     * minor, and importing into the wrong DRM context faults on first CPU store. */
+    if (!memHandle->imported) return;
+
+    core::Agent* drm_agent = core::Runtime::runtime_singleton_->KfdGttAnchorGpu();
+    if (drm_agent == nullptr) {
+      throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
+                               "No GPU agent available to map imported memory on the CPU");
+    }
+
+    hsa_status_t status = drm_agent->driver().ImportMemoryHandle(
+        *drm_agent, &driver_handle,
+        memHandle->is_fabric_handle ? ShareType::FABRIC_HANDLE : ShareType::DMABUF_FD,
+        &memHandle->driver_handle);
+    if (status != HSA_STATUS_SUCCESS) {
+      throw AMD::hsa_exception(status, "Failed to import memory for CPU access");
+    }
+    cpu_mmap_drm_agent = drm_agent;
     return;
   }
-
-  MemoryHandle* memHandle = mappedHandle->mem_handle;
 
   /* Avoid creating multiple amdgpu bos in the same gpu agent that was used
   for drm import of host memory during the creation of a shareable_handle */
@@ -4362,6 +4385,13 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
     bool result = rocr::os::UncommitMemory(va, size);
     assert(result && "Failed to remap VA to anonymous");
     (void)result;
+
+    /* Release the BO imported by the constructor for the imported-handle CPU mapping. */
+    if (cpu_mmap_drm_agent != nullptr) {
+      hsa_status_t status = cpu_mmap_drm_agent->driver().DestroyMemoryHandle(&driver_handle);
+      assert(status == HSA_STATUS_SUCCESS);
+      (void)status;
+    }
   } else {
     if (owns_driver_handle) {
       hsa_status_t status = targetAgent->driver().DestroyMemoryHandle(&driver_handle);
@@ -4377,24 +4407,28 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
 
     core::Agent* agent = nullptr;
     int mmap_fd = -1;
+    uint64_t mmap_offset = 0;
 
-    /* For imported handles, we don't have a region/owner, but we can use any GPU agent for mmap.
-     * The driver_handle created during import should have the correct mmap_offset. */
+    /* The mmap offset is only valid on the DRM fd whose context holds the BO, so the fd and the
+     * offset must come from the same import. For an imported handle that is the BO the
+     * constructor imported into cpu_mmap_drm_agent; for a locally-created handle it is the one
+     * CreateShareableHandle imported into drmAgent(). */
     if (mappedHandle->mem_handle->imported) {
-      core::Agent* drm_agent = core::Runtime::runtime_singleton_->KfdGttAnchorGpu();
-      if (drm_agent != nullptr) {
-        agent = drm_agent;
-        agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
-      }
+      /* The constructor already resolved the anchor GPU and imported the BO into its DRM
+       * context; reuse that agent so the fd and the offset come from the same import. */
+      agent = cpu_mmap_drm_agent;
+      if (agent == nullptr) return HSA_STATUS_ERROR;
+      agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
+      mmap_offset = driver_handle.mmap_offset;
     } else if (mappedHandle->mem_handle->region) {
       agent = mappedHandle->mem_handle->drmAgent();
       /* Do not check the return value of GetDeviceFd. We do not need mmap_fd in some cases, so it
        * is valid for mmap_fd to be -1*/
       agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
+      mmap_offset = mappedHandle->mem_handle->driver_handle.mmap_offset;
     }
 
-    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd,
-                             mappedHandle->mem_handle->driver_handle.mmap_offset)) {
+    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd, mmap_offset)) {
       return HSA_STATUS_ERROR;
     }
   } else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4329,14 +4329,11 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(MappedHandle* _mappe
   MemoryHandle* memHandle = mappedHandle->mem_handle;
 
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
-    /* A locally-created handle already has a CPU mapping. CreateShareableHandle imported the
-     * allocation into a GPU DRM context and recorded that BO's mmap offset in
-     * memHandle->driver_handle. An imported handle has no such BO. MemoryHandle(int dmabuf_fd)
-     * only owns the fd. so import the dmabuf into a GPU DRM context here to obtain an offset
-     * that EnableAccess can mmap.
-     * The GPU is not arbitrary: it must be the KFD GTT anchor (libhsakmt first_gpu_mem), the
-     * same one VMemoryHandleCreate uses. On CPX+NPS2 the anchor is not the lowest DRM render
-     * minor, and importing into the wrong DRM context faults on first CPU store. */
+    /* A locally-created handle already has a CPU mapping: CreateShareableHandle recorded that
+     * BO's mmap offset. An imported handle owns only the fd, so import the dmabuf here to get an
+     * offset EnableAccess can mmap. The GPU must be the KFD GTT anchor VMemoryHandleCreate uses;
+     * on CPX+NPS2 it is not the lowest DRM minor and the wrong context faults on first CPU
+     * store. */
     if (!memHandle->imported) return;
 
     core::Agent* drm_agent = core::Runtime::runtime_singleton_->KfdGttAnchorGpu();
@@ -4407,28 +4404,37 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
 
     core::Agent* agent = nullptr;
     int mmap_fd = -1;
-    uint64_t mmap_offset = 0;
+    const DriverMemoryHandle* cpu_mmap_handle = nullptr;
 
-    /* The mmap offset is only valid on the DRM fd whose context holds the BO, so the fd and the
-     * offset must come from the same import. For an imported handle that is the BO the
-     * constructor imported into cpu_mmap_drm_agent; for a locally-created handle it is the one
-     * CreateShareableHandle imported into drmAgent(). */
+    /* An mmap offset is only valid on the DRM fd whose context holds the BO, so both must come
+     * from the same import: the constructor's for an imported handle, CreateShareableHandle's
+     * for a locally-created one. */
     if (mappedHandle->mem_handle->imported) {
-      /* The constructor already resolved the anchor GPU and imported the BO into its DRM
-       * context; reuse that agent so the fd and the offset come from the same import. */
       agent = cpu_mmap_drm_agent;
       if (agent == nullptr) return HSA_STATUS_ERROR;
       agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
-      mmap_offset = driver_handle.mmap_offset;
+      cpu_mmap_handle = &driver_handle;
     } else if (mappedHandle->mem_handle->region) {
       agent = mappedHandle->mem_handle->drmAgent();
       /* Do not check the return value of GetDeviceFd. We do not need mmap_fd in some cases, so it
        * is valid for mmap_fd to be -1*/
       agent->driver().GetDeviceFd(agent->node_id(), &mmap_fd);
-      mmap_offset = mappedHandle->mem_handle->driver_handle.mmap_offset;
+      cpu_mmap_handle = &mappedHandle->mem_handle->driver_handle;
     }
 
-    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd, mmap_offset)) {
+    /* Check both mmap inputs first: a driver that never populates mmap_offset (KfdVirtioDriver)
+     * would otherwise map offset 0 on a real DRM fd and silently get an unrelated BO. */
+    if (cpu_mmap_handle == nullptr || !cpu_mmap_handle->mmap_offset_valid) {
+      debug_print("EnableAccess: no valid DRM mmap offset for a CPU mapping of this handle\n");
+      return HSA_STATUS_ERROR;
+    }
+    if (mmap_fd < 0) {
+      debug_print("EnableAccess: no DRM device fd for the agent holding the CPU mapping BO\n");
+      return HSA_STATUS_ERROR;
+    }
+
+    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd,
+                             cpu_mmap_handle->mmap_offset)) {
       return HSA_STATUS_ERROR;
     }
   } else {


### PR DESCRIPTION
## Motivation

hipMemsetAccess fails setting cpu access to a device allocation imported using VMM shareable handle

## Technical Details

 Import VMM dmabuf into a DRM context so CPU access can mmap it with the right offset.

## Issue Tracking

JIRA ID: ROCM-29812

## Test Plan

Added couple of HIP catch tests verifying the behavior

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
