### PR TITLE
fix(rccl): [ROCM-29722] cherry-pick #10718 to BKC 10.1

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1325,6 +1325,20 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     {
       bool userOptedHigher = false;
       int upper = ncclP2pChannelsUpperBound(comm, &userOptedHigher);
+      // When the user set MAX_P2P_NCHANNELS, it is also a downward cap. pow2Up(p2pnChannelsPerPeer)
+      // (single-node doubling on gfx942/950/1250) would otherwise raise the pool above a small
+      // request such as NCCL_MAX_P2P_NCHANNELS=1. pow2Up of the user max keeps the existing
+      // non-pow2 rounding (48 -> 64).
+      if (ncclParamMaxP2pNChannels() != -2) {
+        int userMax = pow2Up(std::max(1, ncclMaxP2pNchannels()));
+        int minP2p = (int)ncclParamMinP2pNChannels();
+        if (minP2p > userMax) {
+          INFO(NCCL_GRAPH | NCCL_ENV,
+               "NCCL_MAX_P2P_NCHANNELS=%d overrides NCCL_MIN_P2P_NCHANNELS=%d; using %d P2P channels",
+               (int)ncclParamMaxP2pNChannels(), minP2p, userMax);
+        }
+        upper = std::min(upper, userMax);
+      }
       comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), upper);
       if (!userOptedHigher) {
         // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS

--- a/projects/rccl/test/ChannelDefaultsTests.cpp
+++ b/projects/rccl/test/ChannelDefaultsTests.cpp
@@ -217,6 +217,23 @@ TEST(ChannelDefaults, Gfx950_RequestedBelow64IsHonored)
         {{"NCCL_MAX_P2P_NCHANNELS", "32"}});
 }
 
+// Single-node doubling raises p2pnChannelsPerPeer; a user max of 1 must still win.
+TEST(ChannelDefaults, Gfx1250_Requested1CapsDoubling)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "ChannelDefaults_Gfx1250_Requested1",
+        []()
+        {
+            const ResolvedChannels r =
+              ResolveP2pChannels("gfx1250", /*nRanks=*/4, kDefaultCollChannels, /*nNodes=*/1,
+                                 /*allRanksLocal=*/true);
+            EXPECT_EQ(r.p2pnChannels, 1);
+            EXPECT_EQ(r.p2pnChannelsPerPeer, 1);
+            ExpectPoolInvariant(r);
+        },
+        {{"NCCL_MAX_P2P_NCHANNELS", "1"}});
+}
+
 TEST(ChannelDefaults, Gfx1250_RequestedOverridesArchDefault)
 {
     RUN_ISOLATED_TEST_WITH_ENV(

--- a/projects/rccl/test/SendRecvTests.cpp
+++ b/projects/rccl/test/SendRecvTests.cpp
@@ -83,6 +83,85 @@ namespace RcclUnitTesting
     globfree(&g);
   }
 
+  // Force a lightweight NET loopback for P2P+SHM-disabled tests. IB-CAST on this path treats
+  // each GPU as its own node and ibv_create_qp fails (EAGAIN); GIN still opens IB QPs even when
+  // NCCL_NET=Socket. Socket + GIN off still goes through net.cc staging-buffer allocation.
+  struct NetLoopbackEnvBackup {
+    bool        hadNet           = false;
+    bool        hadGinEnable     = false;
+    bool        hadMinNchannels  = false;
+    bool        hadMaxNchannels  = false;
+    std::string net;
+    std::string ginEnable;
+    std::string minNchannels;
+    std::string maxNchannels;
+  };
+
+  static NetLoopbackEnvBackup netLoopbackEnvBackup;
+
+  static void PinNetLoopbackTransport()
+  {
+    if (const char* v = ::getenv("NCCL_NET")) {
+      netLoopbackEnvBackup.hadNet = true;
+      netLoopbackEnvBackup.net    = v;
+    } else {
+      netLoopbackEnvBackup.hadNet = false;
+      netLoopbackEnvBackup.net.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_GIN_ENABLE")) {
+      netLoopbackEnvBackup.hadGinEnable = true;
+      netLoopbackEnvBackup.ginEnable    = v;
+    } else {
+      netLoopbackEnvBackup.hadGinEnable = false;
+      netLoopbackEnvBackup.ginEnable.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_MIN_NCHANNELS")) {
+      netLoopbackEnvBackup.hadMinNchannels = true;
+      netLoopbackEnvBackup.minNchannels    = v;
+    } else {
+      netLoopbackEnvBackup.hadMinNchannels = false;
+      netLoopbackEnvBackup.minNchannels.clear();
+    }
+
+    if (const char* v = ::getenv("NCCL_MAX_NCHANNELS")) {
+      netLoopbackEnvBackup.hadMaxNchannels = true;
+      netLoopbackEnvBackup.maxNchannels    = v;
+    } else {
+      netLoopbackEnvBackup.hadMaxNchannels = false;
+      netLoopbackEnvBackup.maxNchannels.clear();
+    }
+
+    ::setenv("NCCL_NET", "Socket", 1);
+    ::setenv("NCCL_GIN_ENABLE", "0", 1);
+    ::setenv("NCCL_MIN_NCHANNELS", "1", 1);
+    ::setenv("NCCL_MAX_NCHANNELS", "2", 1);
+  }
+
+  static void UnpinNetLoopbackTransport()
+  {
+    if (netLoopbackEnvBackup.hadMaxNchannels)
+      ::setenv("NCCL_MAX_NCHANNELS", netLoopbackEnvBackup.maxNchannels.c_str(), 1);
+    else
+      ::unsetenv("NCCL_MAX_NCHANNELS");
+
+    if (netLoopbackEnvBackup.hadMinNchannels)
+      ::setenv("NCCL_MIN_NCHANNELS", netLoopbackEnvBackup.minNchannels.c_str(), 1);
+    else
+      ::unsetenv("NCCL_MIN_NCHANNELS");
+
+    if (netLoopbackEnvBackup.hadGinEnable)
+      ::setenv("NCCL_GIN_ENABLE", netLoopbackEnvBackup.ginEnable.c_str(), 1);
+    else
+      ::unsetenv("NCCL_GIN_ENABLE");
+
+    if (netLoopbackEnvBackup.hadNet)
+      ::setenv("NCCL_NET", netLoopbackEnvBackup.net.c_str(), 1);
+    else
+      ::unsetenv("NCCL_NET");
+  }
+
   TEST(SendRecv, SinglePairs)
   {
     TestBed testBed;
@@ -271,6 +350,7 @@ namespace RcclUnitTesting
                         {1,2}, //two group, second group sendrecv to self, has 2 coll
                         testBed.GetNumStreamsPerGroup(1,2),
                         2);
+      if (::testing::Test::HasFatalFailure()) return;
 
       for (int dataIdx = 0; dataIdx < dataTypes.size() && isCorrect; ++dataIdx)
       for (int numIdx = 0; numIdx < numElements.size() && isCorrect; ++numIdx)
@@ -446,6 +526,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "0", 1); // disabled case
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
     setenv("NCCL_P2P_LL_THRESHOLD", "16384", 1);     // legacy-LL threshold governs when the LL128 path is off
@@ -466,6 +547,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_P2P_LL_THRESHOLD");
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }
@@ -480,6 +562,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("RCCL_LL128_FORCE_ENABLE", "1", 1);       // ll128Enabled=true (required by the P2P LL128 gate)
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "1", 1); // enabled case
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
@@ -509,6 +592,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
     unsetenv("RCCL_LL128_FORCE_ENABLE");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }
@@ -596,6 +680,7 @@ namespace RcclUnitTesting
   {
     setenv("NCCL_P2P_DISABLE", "1", 1);              // disable P2P/IPC so send/recv does not use it
     setenv("NCCL_SHM_DISABLE", "1", 1);              // disable SHM so send/recv falls through to NET
+    PinNetLoopbackTransport();
     setenv("RCCL_LL128_FORCE_ENABLE", "1", 1);       // ll128Enabled=true (required by the P2P LL128 gate)
     setenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS", "1", 1); // enable the LL128 staging buffer
     setenv("NCCL_MAX_P2P_NCHANNELS", "1", 1);        // single channel -> deterministic per-channel threshold
@@ -623,6 +708,7 @@ namespace RcclUnitTesting
     unsetenv("NCCL_MAX_P2P_NCHANNELS");
     unsetenv("NCCL_ALLOC_P2P_NET_LL_BUFFERS");
     unsetenv("RCCL_LL128_FORCE_ENABLE");
+    UnpinNetLoopbackTransport();
     unsetenv("NCCL_SHM_DISABLE");
     unsetenv("NCCL_P2P_DISABLE");
   }

--- a/projects/rccl/test/common/TestBedChild.cpp
+++ b/projects/rccl/test/common/TestBedChild.cpp
@@ -404,8 +404,17 @@ namespace RcclUnitTesting
       {
         CollectiveArgs& collArg = this->collArgs[groupId][localRank][collIdx];
         CHECK_CALL(collArg.AllocateMem(inPlace, useManagedMem, userRegistered));
-        if (collArg.userRegistered && (collArg.funcType == ncclCollSend || collArg.funcType == ncclCollRecv))
-          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr, collArg.numInputBytesAllocated, &(collArg.commRegHandle)),"ncclCommRegister");
+        if (collArg.userRegistered && collArg.funcType == ncclCollSend) {
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr,
+                                           collArg.numInputBytesAllocated, &(collArg.commRegHandle)),
+                          "ncclCommRegister");
+        } else if (collArg.userRegistered && collArg.funcType == ncclCollRecv) {
+          // ncclRecv writes outputGpu; registering inputGpu leaves the recv buffer
+          // unregistered and SIMPLE/IPC can write into the wrong mapping (zeros + fault).
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.outputGpu.ptr,
+                                           collArg.numOutputBytesAllocated, &(collArg.commRegHandle)),
+                          "ncclCommRegister");
+        }
         if (this->verbose) TEST_INFO("Rank %d on child %d allocates memory for collective %d in group %d on device %d (%s,%s,%s) Input: %p Output %p",
                                 globalRank, this->childId, collIdx, groupId, this->deviceIds[localRank],
                                 inPlace ? "in-place" : "out-of-place",


### PR DESCRIPTION
## Motivation

Cherry-pick ROCm/rocm-systems#10718 into `release/bkc/therock-10.1-20260825`. The source change is merged on `develop` but absent from this release branch. It fixes RCCL send/receive unit-test failures associated with ROCM-29722 by honoring a user-specified P2P channel maximum, making P2P+SHM-disabled NET tests use a bounded Socket-loopback path, and registering the actual receive output buffer for user-buffer registration.

## Technical Details

- Cap `p2pnChannels` and `p2pnChannelsPerPeer` when `NCCL_MAX_P2P_NCHANNELS` is explicitly set, including the gfx942/gfx950/gfx1250 single-node doubling path.
- Add `ChannelDefaults.Gfx1250_Requested1CapsDoubling` to lock the one-channel behavior.
- Pin the three P2P+SHM-disabled SendRecv protocol tests to Socket loopback with GIN disabled, while restoring the caller's environment afterward.
- Register `outputGpu` for `ncclRecv` user-buffer tests; receive operations write to that allocation, not `inputGpu`.

Source: https://github.com/ROCm/rocm-systems/pull/10718

Source commit: `67075a6509dec178cec864cca7dee66fc6b02870`

Target: `ROCm/rocm-systems@release/bkc/therock-10.1-20260825`

Applied with `git cherry-pick -x` as `d6b8cbc9a7f4345bc3d11e41523d0e169edca324`. The source and release commits have the same stable patch ID, `6dfb452e1acfc425edcac35de26139fb3813d7b1`.

The source #10718 merge is an ancestor of source PR #10640. Existing release PR #10866 carries #10161 and every non-merge commit from #10640, but not #10718. Merge this PR before #10866 (or rebase #10866 after this lands) to preserve the upstream order.

## Issue Tracking

JIRA ID : ROCM-29722

Related PRs:

- Source: https://github.com/ROCm/rocm-systems/pull/10718
- Downstream release PR: https://github.com/ROCm/rocm-systems/pull/10866

## Risk Assessment

Risk level 4/5. This is a clean, patch-identical cherry-pick with focused regression coverage, but it changes shipping RCCL channel selection and receive-buffer registration. The source PR did not record an executed pass result, and the required gfx1250 DPX/NPS2 target-branch run is still pending.

## Device / Architecture Coverage

The reported failure is on gfx1250 in DPX/NPS2 with two ranks. That configuration requires a before/after targeted run. The channel-cap path is also used by gfx942 and gfx950 single-node doubling, and the receive registration fix is not architecture-specific; run the adjacent RCCL CI lanes before leaving draft.

## Test Plan

From `projects/rccl`:

```bash
./install.sh --debug --tests_build --amdgpu_targets gfx1250
./build/debug/test/rccl-UnitTests --gtest_filter="ChannelDefaults.Gfx1250_Requested1CapsDoubling:SendRecv.LL128NetBuffersDisabled:SendRecv.LL128NetBuffersEnabled:SendRecv.SeparateThresholdLL128UsesLL128Knob:SendRecv.UserBufferRegister"
```

Then run the full `ChannelDefaults.*` and `SendRecv.*` groups on gfx1250 DPX/NPS2, plus the repository-required RCCL CI.

## Test Result

- [x] Deterministic containment check against target `f0851d77dc5d873c00cb90c1aa8586379f3ce28d` - Status: source not contained; cherry-pick required.
- [x] Clean `git cherry-pick -x`, `git diff --check`, changed-file scope, and stable patch-ID comparison - Status: Passed.
- [ ] Before/after targeted RCCL unit tests on gfx1250 DPX/NPS2 - Status: Pending; no compatible local hardware runner was available.
- [ ] Adjacent gfx942/gfx950 RCCL coverage - Status: Pending.
- [ ] PR CI - GitHub PR checks - Status: Pending.

The source PR's Test Result says only "Test should pass"; this draft does not treat that as executed validation.

## Flags / Guardrails

No new feature flag. The behavior change applies only when the existing `NCCL_MAX_P2P_NCHANNELS` setting is explicitly supplied; the transport settings are scoped to the affected unit tests and restored afterward.

## Adjacent Tests Considered

`ChannelDefaults.*` covers other architecture/default combinations. `SendRecv.*` covers legacy LL, LL128, SIMPLE, P2P/SHM, NET-loopback, and user-buffer registration paths. Those broader groups remain pending on the target branch.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [x] Included source provenance and a `git cherry-pick -x` trailer.
- [x] Included regression-test source changes required by the repository policy bot.
- [ ] Completed target hardware validation and required CI before marking ready for review.
