### PR TITLE
Multi-segment GIN/RMA registration and segmented IGet/IPut

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -7,8 +7,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Added
 * Compatibility with NCCL 2.30.7.
 * Added scalable AllGatherV pattern: grouped `ncclBroadcast` calls with distinct roots are fused into a single ring kernel, improving performance at large scale. Gated by `NCCL_ALLGATHERV_ENABLE` (default off).
-* Added GPU-only multi-segment registration for symmetric memory windows, enabling contiguous VA ranges backed by multiple physical segments (single-node validated).
-* Added Elastic Buffer support for symmetric windows spanning device and host/`HOST_NUMA` memory segments (`NCCL_ELASTIC_BUFFER_REGISTER`, `NCCL_SYM_REUSE_SYSMEM_HANDLES`). Single-node path validated; multi-node registration remains limited pending HIP/HSA multi-segment DMA-BUF export support.
+* Added multi-node multi-segment symmetric-window registration and transfers for the InfiniBand GIN proxy/RMA path. Contiguous virtual ranges backed by multiple GPU or mixed GPU/host physical allocations are exported and registered per segment for GIN `iput`, `iget`, `iputSignal`, and `iflush`.
+* Added Elastic Buffer support for symmetric windows spanning device and host/`HOST_NUMA` memory segments (`NCCL_ELASTIC_BUFFER_REGISTER`, `NCCL_SYM_REUSE_SYSMEM_HANDLES`).
 
 ### Changed
 * Raised the default channel count on single-node gfx1250 (MI450) to 256 for both collectives and P2P. The count is still clamped by the GPU CU count and by `NCCL_MAX_NCHANNELS` / `NCCL_MAX_CTAS` / `NCCL_MAX_P2P_NCHANNELS`. Multi-node gfx1250 keeps the 64-channel cap on the NET path. `RCCL_SATURATE_P2P_NCHANNELS` now defaults to on for gfx1250 so the per-peer channel count tiles the larger pool; set it to `0` to restore the previous behavior.
@@ -22,7 +22,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Known issues
 * The improved AllGatherV support breaks the NCCL profiler support for ncclBroadcast operations, limiting visibility to API events. `NCCL_ALLGATHERV_ENABLE=0` can be used as a workaround until it is fixed in a future release.
-* Multi-node multi-segment and Elastic Buffer symmetric-window registration is not yet enabled; NET and LSA+GIN multi-segment paths depend on runtime support for exporting contiguous DMA-BUF handles across all physical segments.
+* Multi-segment InfiniBand registration is limited to the GIN proxy/RMA path; classic NET/IB P2P and CAST do not yet consume these per-segment handles.
 
 ## RCCL 2.30.4 for ROCm 7.14.0
 

--- a/projects/rccl/cmake/ROCSHMEM.cmake
+++ b/projects/rccl/cmake/ROCSHMEM.cmake
@@ -143,8 +143,13 @@ function(add_rocshmem_targets)
 
             CONFIGURE_COMMAND   ""
             BUILD_COMMAND
-                ${CMAKE_COMMAND} -E make_directory build
-                && ${CMAKE_COMMAND} -E chdir build bash -lc "INSTALL_PREFIX=${ROCSHMEM_INSTALL_DIR} ../scripts/build_configs/gda -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DUSE_EXTERNAL_MPI=OFF -DGDA_MLX5=ON -DGDA_BNXT=ON -DGDA_IONIC=ON -DBUILD_EXAMPLES=OFF -DBUILD_FUNCTIONAL_TESTS=OFF -DBUILD_UNIT_TESTS=OFF -DBUILD_CTESTS=OFF -DBUILD_TOOLS=OFF -DGPU_TARGETS=${_rocshmem_gpu_targets} ${_rocshmem_sdma_opt} ${_rocshmem_cmake_opts} "
+                ${CMAKE_COMMAND} -E make_directory "${ROCSHMEM_INSTALL_DIR}/build"
+                && ${CMAKE_COMMAND} -E chdir "${ROCSHMEM_INSTALL_DIR}/build" ${CMAKE_COMMAND} -E env
+                   "PATH=${ROCM_PATH}/bin:$ENV{PATH}"
+                   "ROCM_PATH=${ROCM_PATH}"
+                   "HIP_PATH=${ROCM_PATH}"
+                   bash -lc "INSTALL_PREFIX=${ROCSHMEM_INSTALL_DIR} ${ROCSHMEM_SOURCE_DIR}/scripts/build_configs/gda -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_C_COMPILER=${ROCM_PATH}/bin/amdclang -DCMAKE_CXX_COMPILER=${ROCM_PATH}/bin/amdclang++ -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DROCM_PATH=${ROCM_PATH} -DUSE_EXTERNAL_MPI=OFF -DGDA_MLX5=ON -DGDA_BNXT=ON -DGDA_IONIC=ON -DBUILD_EXAMPLES=OFF -DBUILD_FUNCTIONAL_TESTS=OFF -DBUILD_UNIT_TESTS=OFF -DBUILD_CTESTS=OFF -DBUILD_TOOLS=OFF -DGPU_TARGETS=${_rocshmem_gpu_targets} ${_rocshmem_sdma_opt} ${_rocshmem_cmake_opts} "
+            BUILD_BYPRODUCTS    "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a"
             INSTALL_COMMAND ""
         )
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -933,6 +933,12 @@ endif()
 #   Does not enable alltoall_wg offload.
 if (ENABLE_ROCSHMEM OR ENABLE_ROCSHMEM_GIN)
   add_rocshmem_targets()
+  # add_rocshmem_targets runs in this directory. Export its resolved paths to
+  # the top-level scope so sibling test targets can compile and link the GIN
+  # backend against the same rocSHMEM build.
+  set(ROCSHMEM_SOURCE_DIR "${ROCSHMEM_SOURCE_DIR}" PARENT_SCOPE)
+  set(ROCSHMEM_INSTALL_DIR "${ROCSHMEM_INSTALL_DIR}" PARENT_SCOPE)
+  set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INCLUDE_DIR}" PARENT_SCOPE)
   # Ensure rocSHMEM is fully built/installed before compiling rccl
   if (TARGET rocshmem_ext)
     add_dependencies(rccl rocshmem_ext)

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -7,6 +7,7 @@
 
 #include "connect.h"
 #include "common.h"
+#include "gin.h"
 #include "p2p_resiliency.h"
 
 NCCL_PARAM(IbGidIndex, "IB_GID_INDEX", -1);
@@ -660,8 +661,9 @@ static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
-  // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
-  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  // GIN data requests can keep a full segmented payload plus a trailing signal
+  // outstanding. Classic NET/IB uses fewer entries but shares this QP path.
+  qpCreateAttrs.maxSendWorkRequest = std::max(2 * NET_IB_MAX_REQUESTS, NCCL_RMA_MAX_SIGNAL_WRS);
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1294,7 +1296,8 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.cq = rCommDev->base.cq;
       qpCreateAttrs.pd = rCommDev->base.pd;
       qpCreateAttrs.maxRecvWorkRequest = 0;
-      qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+      // One logical GIN flush can post one read per registered segment.
+      qpCreateAttrs.maxSendWorkRequest = std::max(NET_IB_MAX_REQUESTS, NCCL_RMA_MAX_FLUSH_WRS);
       qpCreateAttrs.qpContext = &rComm->base.stats;
       NCCLCHECK(ncclIbQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       INFO(NCCL_NET,

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -346,11 +346,101 @@ ncclGin_t ncclGinIbGdaki = {"GIN_IB_GDAKI",
                             ncclGinIbFinalize};
 #endif // !defined(__HIP_PLATFORM_AMD__)
 
+
+// Cap on physical segments per symmetric buffer
+#define NCCL_RMA_MAX_SEGMENTS 16
+
 struct ncclRmaIbProxyMrHandle {
-  struct ncclIbMrHandle* mrHandle;
-  uintptr_t* base_vas;
-  uint32_t* rkeys;
+  int nSegments;
+  // segOff[0]==0, segOff[nSegments]==size; per-segment local MRs; remote view
+  // base_vas/rkeys indexed [rank*nSegments + seg]. See walkthrough doc.
+  size_t segOff[NCCL_RMA_MAX_SEGMENTS + 1];
+  struct ncclIbMrHandle *mrHandle[NCCL_RMA_MAX_SEGMENTS];
+  uintptr_t *base_vas;
+  uint32_t  *rkeys;
 };
+
+// Return the segment index that contains byte offset off within the buffer.
+static inline int ncclRmaSegOf(const struct ncclRmaIbProxyMrHandle* h, uint64_t off) {
+  for (int s = 0; s < h->nSegments; s++)
+    if (off < h->segOff[s + 1]) return s;
+  return h->nSegments - 1;
+}
+
+// Total registered bytes (segOff[nSegments] is the cumulative end offset).
+static inline uint64_t ncclRmaMrBytes(const struct ncclRmaIbProxyMrHandle* h) {
+  return h->segOff[h->nSegments];
+}
+
+// True iff [off, off+size) fits in the window (overflow-safe).
+static inline bool ncclRmaRangeOk(const struct ncclRmaIbProxyMrHandle* h, uint64_t off, size_t size) {
+  uint64_t bytes = ncclRmaMrBytes(h);
+  return off <= bytes && (uint64_t)size <= bytes - off;
+}
+
+// Build a chained RDMA WR list, splitting at segment boundaries so every WR
+// stays within a single physical segment's MR.
+//
+// Paired mode (flushSge == NULL): move `size` bytes between a local and a
+// remote symmetric buffer, splitting on both sides; each WR carries one local
+// lkey and one remote rkey.
+//
+// Flush mode (flushSge != NULL): the local handle is ignored; emit one tiny
+// RDMA_READ per remote segment touched by [remoteOff, remoteOff+size), each
+// landing a single byte in the caller's flush scratch. Passing the whole
+// window thus fences GPUDirect writes across every physical segment (the
+// caller reads its own buffer via base_vas[self]/rkeys[self] on a loopback QP).
+static ncclResult_t ncclRmaBuildSegmentedWrs(
+    struct ibv_send_wr* wr, struct ibv_sge* sge, int maxWr, int* nWr, enum ibv_wr_opcode opcode, uint64_t wrId,
+    struct ncclRmaIbProxyMrHandle* localH,  int localRank,  uint64_t localOff,
+    struct ncclRmaIbProxyMrHandle* remoteH, int remoteRank, uint64_t remoteOff,
+    size_t size, const struct ibv_sge* flushSge) {
+  int n = 0;
+  uint64_t lOff = localOff, rOff = remoteOff;
+  size_t rem = size;
+  while (rem > 0) {
+    if (n >= maxWr) {
+      WARN("NET/IB/RMA: transfer of %zu bytes spans more than %d segment slices", size, maxWr);
+      return ncclInternalError;
+    }
+    int rs = ncclRmaSegOf(remoteH, rOff);
+    size_t chunk = rem;
+    if (remoteH->segOff[rs + 1] - rOff < chunk) chunk = remoteH->segOff[rs + 1] - rOff;
+
+    int ls = 0;
+    if (flushSge == NULL) {
+      ls = ncclRmaSegOf(localH, lOff);
+      if (localH->segOff[ls + 1] - lOff < chunk) chunk = localH->segOff[ls + 1] - lOff;
+    }
+
+    uintptr_t rAddr = remoteH->base_vas[(size_t)remoteRank * remoteH->nSegments + rs] + (rOff - remoteH->segOff[rs]);
+
+    memset(&wr[n], 0, sizeof(wr[n]));
+    memset(&sge[n], 0, sizeof(sge[n]));
+    wr[n].opcode = opcode;
+    wr[n].wr_id = wrId;
+    wr[n].next = NULL;
+    wr[n].wr.rdma.remote_addr = (uint64_t)rAddr;
+    wr[n].wr.rdma.rkey = remoteH->rkeys[(size_t)remoteRank * remoteH->nSegments + rs];
+    wr[n].sg_list = &sge[n];
+    wr[n].num_sge = 1;
+    if (flushSge != NULL) {
+      // Touch one byte of this segment; the data lands in the fixed scratch.
+      sge[n] = *flushSge;
+      sge[n].length = 1;
+    } else {
+      uintptr_t lAddr = localH->base_vas[(size_t)localRank * localH->nSegments + ls] + (lOff - localH->segOff[ls]);
+      sge[n].addr = (uintptr_t)lAddr;
+      sge[n].length = chunk;
+      sge[n].lkey = localH->mrHandle[ls]->mrs[0]->lkey;
+    }
+    if (n > 0) wr[n - 1].next = &wr[n];
+
+    lOff += chunk; rOff += chunk; rem -= chunk; n++;
+  }
+  *nWr = n;
+  return ncclSuccess;
+}
 
 ncclResult_t ncclRmaIbProxyInit(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction) {
   return ncclGinIbInitType(ctx, commId, logFunction, ncclParamGinType());
@@ -465,29 +555,112 @@ ncclResult_t ncclRmaIbProxyDestroyContext(void* rmaCtx) {
 }
 
 ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
-                                          uint64_t mr_flags, void** mhandle) {
+                                         uint64_t mr_flags, void** mhandle) {
+  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
+  struct ncclRmaIbProxyMrHandle *rmaMrHandle = NULL;
+  uintptr_t localVas[NCCL_RMA_MAX_SEGMENTS];
+  uint32_t  localRkeys[NCCL_RMA_MAX_SEGMENTS];
   ncclResult_t ret = ncclSuccess;
-  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
-  struct ncclRmaIbProxyMrHandle* rmaMrHandle = NULL;
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle, 1), ret, fail);
+  int nSeg = 1;
+  int registered = 0;
 
-  NCCLCHECKGOTONOWARN(ncclIbRegMrDmaBufInternal(cComm->recvComm, data, size, type, offset, fd, mr_flags,
-                                                (void**)&rmaMrHandle->mrHandle),
-                      ret, fail, NCCL_NET);
+  NCCLCHECK(ncclCalloc(&rmaMrHandle, 1));
 
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->base_vas, cComm->nranks), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->rkeys, cComm->nranks), ret, fail);
+  // Count physical segments; ROCm/HIP describes only the first per export,
+  // so multi-segment ranges register one MR per segment below.
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
+  if (type == NCCL_PTR_CUDA && ncclCuMemEnable()) {
+    CUdeviceptr base = 0;
+    size_t baseSize = 0;
+    NCCLCHECKGOTO(ncclCuMemGetAddressRange((CUdeviceptr)data, size, &base, &baseSize, &nSeg), ret, fail);
+  }
+#endif
+  if (nSeg < 1) nSeg = 1;
+  if (nSeg > NCCL_RMA_MAX_SEGMENTS) {
+    WARN("NET/IB/RMA: buffer %p (size %zu) spans %d segments, exceeds NCCL_RMA_MAX_SEGMENTS=%d",
+         data, size, nSeg, NCCL_RMA_MAX_SEGMENTS);
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
+  rmaMrHandle->nSegments = nSeg;
+  rmaMrHandle->segOff[0] = 0;
 
-  NCCLCHECKGOTO(cComm->allGather(cComm, &data, rmaMrHandle->base_vas, sizeof(uintptr_t)), ret, fail);
-  NCCLCHECKGOTO(cComm->allGather(cComm, &rmaMrHandle->mrHandle->mrs[0]->rkey, rmaMrHandle->rkeys, sizeof(uint32_t)),
-                ret, fail);
+  if (nSeg == 1) {
+    // Single segment: reuse the caller's fd (fd==-1 falls back to ibv_reg_mr).
+    NCCLCHECKGOTO(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd,
+                                    (void**)&rmaMrHandle->mrHandle[0]), ret, fail);
+    registered = 1;
+    rmaMrHandle->segOff[1] = size;
+    localVas[0] = (uintptr_t)data;
+    localRkeys[0] = rmaMrHandle->mrHandle[0]->mrs[0]->rkey;
+  } else {
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
+    uintptr_t segPtr = (uintptr_t)data;
+    size_t remaining = size;
+    size_t cum = 0;
+    for (int s = 0; s < nSeg; s++) {
+      CUdeviceptr segBase = 0;
+      size_t segSize = 0;
+      CUCHECKGOTO(cuMemGetAddressRange(&segBase, &segSize, (CUdeviceptr)segPtr), ret, fail);
+      size_t inSeg = segSize - (segPtr - (uintptr_t)segBase);
+      size_t thisLen = remaining < inSeg ? remaining : inSeg;
+      int segFd = -1;
+      // Export this segment alone: one physical allocation, so its fd is complete.
+      CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&segFd, (CUdeviceptr)segPtr, thisLen,
+                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0), ret, fail);
+      ret = ncclIbRegMrDmaBuf(cComm->recvComm, (void*)segPtr, thisLen, type, 0ULL, segFd,
+                              (void**)&rmaMrHandle->mrHandle[s]);
+      (void)close(segFd);
+      if (ret != ncclSuccess) goto fail;
+      registered = s + 1;
+      localVas[s] = segPtr;
+      localRkeys[s] = rmaMrHandle->mrHandle[s]->mrs[0]->rkey;
+      cum += thisLen;
+      rmaMrHandle->segOff[s + 1] = cum;
+      segPtr += thisLen;
+      remaining -= thisLen;
+    }
+    INFO(NCCL_NET|NCCL_REG, "NET/IB/RMA: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs",
+         data, size, nSeg);
+#else
+    WARN("NET/IB/RMA: multi-segment (%d) registration requires HIP >= 7.12.60540", nSeg);
+    ret = ncclInvalidUsage;
+    goto fail;
+#endif
+  }
+
+  // Cross-rank symmetry guard: every rank must register the same segment count,
+  // else the fixed-stride all-gather/indexing below would corrupt memory.
+  {
+    int* allNSeg = NULL;
+    NCCLCHECKGOTO(ncclCalloc(&allNSeg, cComm->nranks), ret, fail);
+    ret = cComm->allGather(cComm, &nSeg, allNSeg, sizeof(int));
+    for (int r = 0; ret == ncclSuccess && r < cComm->nranks; r++) {
+      if (allNSeg[r] != nSeg) {
+        WARN("NET/IB/RMA: buffer %p segment-count mismatch (rank %d has %d, local %d); "
+             "symmetric registration required", data, r, allNSeg[r], nSeg);
+        ret = ncclInternalError;
+      }
+    }
+    free(allNSeg);
+    if (ret != ncclSuccess) goto fail;
+  }
+
+  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->base_vas, (size_t)cComm->nranks * nSeg), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->rkeys, (size_t)cComm->nranks * nSeg), ret, fail);
+
+  // Gather per-segment base VAs/rkeys; symmetry verified above keeps nSeg/sizes aligned.
+  NCCLCHECKGOTO(cComm->allGather(cComm, localVas, rmaMrHandle->base_vas, sizeof(uintptr_t) * nSeg), ret, fail);
+  NCCLCHECKGOTO(cComm->allGather(cComm, localRkeys, rmaMrHandle->rkeys, sizeof(uint32_t) * nSeg), ret, fail);
 
   *mhandle = rmaMrHandle;
-
   return ncclSuccess;
+
 fail:
   if (rmaMrHandle) {
-    if (rmaMrHandle->mrHandle) ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle);
+    for (int s = 0; s < registered; s++) {
+      if (rmaMrHandle->mrHandle[s]) (void)ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle[s]);
+    }
     free(rmaMrHandle->base_vas);
     free(rmaMrHandle->rkeys);
     free(rmaMrHandle);
@@ -504,7 +677,9 @@ ncclResult_t ncclRmaIbProxyDeregMrSym(void* collComm, void* mhandle) {
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   struct ncclRmaIbProxyMrHandle* rmaMrHandle = (struct ncclRmaIbProxyMrHandle*)mhandle;
 
-  NCCLCHECK(ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle));
+  for (int s = 0; s < rmaMrHandle->nSegments; s++) {
+    if (rmaMrHandle->mrHandle[s]) NCCLCHECK(ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle[s]));
+  }
   free(rmaMrHandle->base_vas);
   free(rmaMrHandle->rkeys);
   free(rmaMrHandle);
@@ -542,10 +717,11 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
   struct ncclRmaIbProxyMrHandle* srcMrHandle = (struct ncclRmaIbProxyMrHandle*)srcMhandle;
   struct ncclRmaIbProxyMrHandle* dstMrHandle = (struct ncclRmaIbProxyMrHandle*)dstMhandle;
 
-  void* srcPtr = (void*)(srcMrHandle->base_vas[rmaProxyCtx->rank] + srcOff);
-  void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
-  uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
-  uint32_t rkey = dstMrHandle->rkeys[rank];
+  // Reject out-of-range transfers before any WR is posted.
+  if (!ncclRmaRangeOk(srcMrHandle, srcOff, size) || !ncclRmaRangeOk(dstMrHandle, dstOff, size)) {
+    WARN("NET/IB/RMA: iput out of range (srcOff=%lu dstOff=%lu size=%zu)", srcOff, dstOff, size);
+    return ncclInvalidArgument;
+  }
 
   struct ncclIbSendComm* comm;
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
@@ -561,27 +737,26 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  struct ibv_send_wr wr;
-  memset(&wr, 0, sizeof(wr));
-  struct ibv_sge sge;
-  memset(&sge, 0, sizeof(sge));
+  // Split the transfer at segment boundaries on both the local (src) and remote
+  // (dst) buffers; each slice maps to one local lkey and one remote rkey.
+  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
+  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_WRITE,
+                                     req - comm->base.reqs,
+                                     srcMrHandle, rmaProxyCtx->rank, srcOff,
+                                     dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+  for (int i = 0; i < nWr; i++) {
+    wr[i].send_flags = IBV_SEND_SIGNALED;
+    ncclIbAddEvent(req, qp->devIndex);
+  }
 
-  wr.opcode = IBV_WR_RDMA_WRITE;
-  wr.send_flags = IBV_SEND_SIGNALED;
-  wr.wr_id = req - comm->base.reqs;
-  wr.next = NULL;
-  wr.wr.rdma.remote_addr = (uint64_t)dstPtr;
-  wr.wr.rdma.rkey = rkey;
-  wr.sg_list = &sge;
-  wr.num_sge = 1;
-
-  sge.addr = (uintptr_t)srcPtr;  // Local buffer address
-  sge.length = size;  // Size of the transfer
-  sge.lkey = lkey;  // Local key
-
-  struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr, &bad_wr));
-  ncclIbAddEvent(req, qp->devIndex);
+  // size==0 yields nWr==0: nothing to post; the request completes in test()
+  // (events[0]==0). Posting wr[0] here would submit an uninitialized WR.
+  if (nWr > 0) {
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr[0], &bad_wr));
+  }
 
   *request = req;
   return ncclSuccess;
@@ -593,6 +768,12 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
 
   struct ncclRmaIbProxyMrHandle* remoteMrHandle = (struct ncclRmaIbProxyMrHandle*)remoteMhandle;
   struct ncclRmaIbProxyMrHandle* localMrHandle = (struct ncclRmaIbProxyMrHandle*)localMhandle;
+
+  // Reject out-of-range transfers before any WR is posted.
+  if (!ncclRmaRangeOk(remoteMrHandle, remoteOffset, size) || !ncclRmaRangeOk(localMrHandle, localOffset, size)) {
+    WARN("NET/IB/RMA: iget out of range (remoteOff=%lu localOff=%lu size=%zu)", remoteOffset, localOffset, size);
+    return ncclInvalidArgument;
+  }
 
   struct ncclIbSendComm* comm;
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
@@ -608,32 +789,25 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  void* remotePtr = (void*)(remoteMrHandle->base_vas[rank] + remoteOffset);
-  void* localPtr = (void*)(localMrHandle->base_vas[rmaProxyCtx->rank] + localOffset);
-  uint32_t rkey = remoteMrHandle->rkeys[rank];
-  uint32_t lkey = localMrHandle->mrHandle->mrs[0]->lkey;
+  // RDMA READ: local buffer is the destination (lkey), remote buffer the source
+  // (rkey). Split at segment boundaries on both sides.
+  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
+  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ,
+                                     req - comm->base.reqs,
+                                     localMrHandle, rmaProxyCtx->rank, localOffset,
+                                     remoteMrHandle, rank, remoteOffset, size, /*flushSge=*/NULL));
+  for (int i = 0; i < nWr; i++) {
+    wr[i].send_flags = IBV_SEND_SIGNALED;
+    ncclIbAddEvent(req, qp->devIndex);
+  }
 
-  struct ibv_send_wr wr;
-  memset(&wr, 0, sizeof(wr));
-  struct ibv_sge sge;
-  memset(&sge, 0, sizeof(sge));
-
-  wr.opcode = IBV_WR_RDMA_READ;
-  wr.send_flags = IBV_SEND_SIGNALED; // TODO: Potentially optimize this?
-  wr.wr_id = req - comm->base.reqs;
-  wr.next = NULL;
-  wr.wr.rdma.remote_addr = (uint64_t)remotePtr;
-  wr.wr.rdma.rkey = rkey;
-  wr.sg_list = &sge;
-  wr.num_sge = 1;
-
-  sge.addr = (uintptr_t)localPtr;
-  sge.length = size;
-  sge.lkey = lkey;
-
-  struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr, &bad_wr));
-  ncclIbAddEvent(req, qp->devIndex);
+  // size==0 yields nWr==0: nothing to post; the request completes in test().
+  if (nWr > 0) {
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr[0], &bad_wr));
+  }
 
   *request = req;
   return ncclSuccess;
@@ -655,6 +829,16 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
   struct ncclRmaIbProxyMrHandle* dstMrHandle = (struct ncclRmaIbProxyMrHandle*)dstMhandle;
   struct ncclRmaIbProxyMrHandle* signalMrHandle = (struct ncclRmaIbProxyMrHandle*)signalMhandle;
 
+  // Reject out-of-range payload/signal before any WR is posted (signal is an 8-byte atomic).
+  if ((size > 0 && (!srcMrHandle || !dstMrHandle ||
+                    !ncclRmaRangeOk(srcMrHandle, srcOff, size) ||
+                    !ncclRmaRangeOk(dstMrHandle, dstOff, size))) ||
+      !signalMrHandle || !ncclRmaRangeOk(signalMrHandle, signalOff, sizeof(uint64_t))) {
+    WARN("NET/IB/RMA: iputSignal out of range (srcOff=%lu dstOff=%lu size=%zu signalOff=%lu)",
+         srcOff, dstOff, size, signalOff);
+    return ncclInvalidArgument;
+  }
+
   struct ncclIbSendComm* comm;
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
   struct ncclIbQp* qp = &comm->base.qps[0];
@@ -670,54 +854,53 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  struct ibv_send_wr wr[2];
+  // Up to 2*NCCL_RMA_MAX_SEGMENTS slices for the segmented PUT plus one signal WR.
+  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS + 1];
+  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS + 1];
   memset(&wr, 0, sizeof(wr));
-  struct ibv_sge sge[2];
   memset(&sge, 0, sizeof(sge));
+  int nPut = 0;
 
   // If size is 0, we only need to send the signal. srcMrHandle must be non-NULL
   if (size > 0 && dstMrHandle) {
-    void* srcPtr = (void*)(srcMrHandle->base_vas[rmaProxyCtx->rank] + srcOff);
-    void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
-    uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
-    uint32_t rkey = dstMrHandle->rkeys[rank];
-
-    // PUT
-    wr[0].opcode = IBV_WR_RDMA_WRITE;
-    wr[0].send_flags = 0; // We only need the CQE from the signal
-    wr[0].wr_id = req - comm->base.reqs;
-    wr[0].next = &wr[1];
-    wr[0].wr.rdma.remote_addr = (uint64_t)dstPtr;
-    wr[0].wr.rdma.rkey = rkey;
-    wr[0].sg_list = &sge[0];
-    wr[0].num_sge = 1;
-
-    sge[0].addr = (uintptr_t)srcPtr;  // Local buffer address
-    sge[0].length = size;  // Size of the transfer
-    sge[0].lkey = lkey;  // Local key
+    // PUT slices carry no CQE; only the trailing signal is signaled. Same-QP RC
+    // ordering guarantees all writes land before the signal.
+    NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nPut, IBV_WR_RDMA_WRITE,
+                                       req - comm->base.reqs,
+                                       srcMrHandle, rmaProxyCtx->rank, srcOff,
+                                       dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+    for (int i = 0; i < nPut; i++) wr[i].send_flags = 0;
   }
 
-  void* signalPtr = (void*)(signalMrHandle->base_vas[rank] + signalOff);
-  uint32_t signalRkey = signalMrHandle->rkeys[rank];
+  // SIGNAL (route to the segment that contains signalOff)
+  int sig = ncclRmaSegOf(signalMrHandle, signalOff);
+  void *signalPtr = (void *)(signalMrHandle->base_vas[(size_t)rank * signalMrHandle->nSegments + sig]
+                             + (signalOff - signalMrHandle->segOff[sig]));
+  uint32_t signalRkey = signalMrHandle->rkeys[(size_t)rank * signalMrHandle->nSegments + sig];
 
-  // SIGNAL
-  wr[1].opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
-  wr[1].send_flags = IBV_SEND_SIGNALED;
-  wr[1].wr_id = req - comm->base.reqs;  // used for matching completions with request
-  wr[1].next = NULL;
-  wr[1].wr.atomic.remote_addr = (uint64_t)signalPtr;
-  wr[1].wr.atomic.compare_add = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
-  wr[1].wr.atomic.rkey = signalRkey;
-  wr[1].sg_list = &sge[1];
-  wr[1].num_sge = 1;
+  struct ibv_send_wr* sigWr = &wr[nPut];
+  struct ibv_sge* sigSge = &sge[nPut];
+  memset(sigWr, 0, sizeof(*sigWr));
+  memset(sigSge, 0, sizeof(*sigSge));
+  sigWr->opcode                  = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  sigWr->send_flags              = IBV_SEND_SIGNALED;
+  sigWr->wr_id                   = req - comm->base.reqs;  // used for matching completions with request
+  sigWr->next                    = NULL;
+  sigWr->wr.atomic.remote_addr   = (uint64_t)signalPtr;
+  sigWr->wr.atomic.compare_add   = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
+  sigWr->wr.atomic.rkey          = signalRkey;
+  sigWr->sg_list = sigSge;
+  sigWr->num_sge = 1;
 
-  sge[1].addr = (uintptr_t)&comm->putSignalScratchpad;
-  sge[1].length = sizeof(comm->putSignalScratchpad);
-  sge[1].lkey = comm->devs[devIndex].putSignalScratchpadMr->lkey;
+  sigSge->addr = (uintptr_t)&comm->putSignalScratchpad;
+  sigSge->length = sizeof(comm->putSignalScratchpad);
+  sigSge->lkey = comm->devs[devIndex].putSignalScratchpadMr->lkey;
+
+  if (nPut > 0) wr[nPut - 1].next = sigWr;
 
   // Send the put and the signal in one go
   struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(qp->qp, size > 0 ? &wr[0] : &wr[1], &bad_wr));
+  NCCLCHECK(wrap_ibv_post_send(qp->qp, nPut > 0 ? &wr[0] : sigWr, &bad_wr));
   ncclIbAddEvent(req, qp->devIndex);
   *request = req;
   return ncclSuccess;
@@ -796,28 +979,31 @@ ncclResult_t ncclRmaIbProxyIFlush(void* rmaCtx, int context, void* mhandle, uint
   req->iput.rank = rank;
   req->rmaProxyCtx = rmaProxyCtx;
 
-  struct ibv_send_wr wr;
-  memset(&wr, 0, sizeof(wr));
-  wr.wr_id = req - comm->base.reqs;
+  // Fence GPUDirect writes across EVERY physical segment, not just segment 0.
+  // The builder (flush mode) emits one loopback RDMA_READ per segment of the
+  // local recv buffer -- read via base_vas[self]/rkeys[self], the same own-MR
+  // addr/rkey ncclIbIflush uses -- each landing one byte in the flush scratch.
+  struct ibv_send_wr wr[NCCL_RMA_MAX_SEGMENTS];
+  struct ibv_sge sge[NCCL_RMA_MAX_SEGMENTS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ,
+                                     req - comm->base.reqs,
+                                     /*localH=*/NULL, /*localRank=*/0, /*localOff=*/0,
+                                     /*remoteH=*/rmaMrHandle, /*remoteRank=*/rmaProxyCtx->rank, /*remoteOff=*/0,
+                                     /*size=*/ncclRmaMrBytes(rmaMrHandle),
+                                     /*flushSge=*/&comm->devs[qp->devIndex].gpuFlush.sge));
+  for (int i = 0; i < nWr; i++) {
+    wr[i].send_flags = IBV_SEND_SIGNALED;
+    ncclIbAddEvent(req, qp->devIndex);
+  }
 
-  void* flushPtr = (void*)(rmaMrHandle->base_vas[rank]);
-  wr.wr.rdma.remote_addr = (uint64_t)flushPtr;
-  wr.wr.rdma.rkey = rmaMrHandle->rkeys[rank];
-  wr.sg_list = &comm->devs[qp->devIndex].gpuFlush.sge;
-  wr.num_sge = 1;
-  wr.opcode = IBV_WR_RDMA_READ;
-  wr.send_flags = IBV_SEND_SIGNALED;
-
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-        wr.wr_id);
+  TRACE(NCCL_NET, "NET/IB: %s: Posting %d-segment flush request (req=%p, comm=%p)", __func__, nWr, req, req->base);
   TIME_START(4);
-  struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr, &bad_wr));
+  if (nWr > 0) {
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr[0], &bad_wr));
+  }
   TIME_STOP(4);
-
-  ncclIbAddEvent(req, qp->devIndex);
-
-  TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
 
   *request = req;
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -347,9 +347,6 @@ ncclGin_t ncclGinIbGdaki = {"GIN_IB_GDAKI",
 #endif // !defined(__HIP_PLATFORM_AMD__)
 
 
-// Cap on physical segments per symmetric buffer
-#define NCCL_RMA_MAX_SEGMENTS 16
-
 struct ncclRmaIbProxyMrHandle {
   int nSegments;
   // segOff[0]==0, segOff[nSegments]==size; per-segment local MRs; remote view

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -359,6 +359,12 @@ struct ncclRmaIbProxyMrHandle {
   uint32_t* rkeys;
 };
 
+struct ncclRmaIbProxyRegistration {
+  ncclResult_t status;
+  int nSegments;
+  size_t segOff[NCCL_RMA_MAX_SEGMENTS + 1];
+};
+
 static inline size_t ncclRmaRkeyIndex(int nSegments, int rank, int seg, int remDevIdx) {
   return ((size_t)rank * nSegments + (size_t)seg) * NCCL_IB_MAX_DEVS_PER_NIC + (size_t)remDevIdx;
 }
@@ -412,14 +418,19 @@ static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_
       return ncclInternalError;
     }
     int rs = ncclRmaSegOf(remoteH, rOff);
-    size_t chunk = rem;
-    if (remoteH->segOff[rs + 1] - rOff < chunk) chunk = remoteH->segOff[rs + 1] - rOff;
+    size_t remoteRemaining = remoteH->segOff[rs + 1] - rOff;
 
     int ls = 0;
+    size_t localRemaining = SIZE_MAX;
     if (flushSge == NULL) {
       ls = ncclRmaSegOf(localH, lOff);
-      if (localH->segOff[ls + 1] - lOff < chunk) chunk = localH->segOff[ls + 1] - lOff;
+      localRemaining = localH->segOff[ls + 1] - lOff;
     }
+    // Paired transfers are limited by ibv_sge::length. Flush WRs read one byte
+    // but advance to the next physical segment in one step, regardless of the
+    // segment's size.
+    size_t chunk = flushSge == NULL ? ncclRmaSegmentSliceBytes(rem, localRemaining, remoteRemaining) :
+                                      (rem < remoteRemaining ? rem : remoteRemaining);
 
     uintptr_t rAddr = remoteH->base_vas[(size_t)remoteRank * remoteH->nSegments + rs] + (rOff - remoteH->segOff[rs]);
 
@@ -444,7 +455,7 @@ static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_
         return ncclInternalError;
       }
       sge[n].addr = (uintptr_t)lAddr;
-      sge[n].length = chunk;
+      sge[n].length = (uint32_t)chunk;
       sge[n].lkey = lmr->lkey;
     }
     if (n > 0) wr[n - 1].next = &wr[n];
@@ -574,13 +585,17 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
                                           uint64_t mr_flags, void** mhandle) {
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   struct ncclRmaIbProxyMrHandle* rmaMrHandle = NULL;
-  uintptr_t localVas[NCCL_RMA_MAX_SEGMENTS];
-  uint32_t localRkeys[NCCL_RMA_MAX_SEGMENTS * NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ncclRmaIbProxyRegistration localRegistration = {};
+  struct ncclRmaIbProxyRegistration* registrations = NULL;
+  uintptr_t localVas[NCCL_RMA_MAX_SEGMENTS] = {};
+  uint32_t localRkeys[NCCL_RMA_MAX_SEGMENTS * NCCL_IB_MAX_DEVS_PER_NIC] = {};
   ncclResult_t ret = ncclSuccess;
   int nSeg = 1;
   int registered = 0;
 
+  *mhandle = NULL;
   NCCLCHECK(ncclCalloc(&rmaMrHandle, 1));
+  NCCLCHECKGOTO(ncclCalloc(&registrations, cComm->nranks), ret, fail);
   // calloc zeroes nSegments; fail paths below only dereg `registered` complete
   // handles, so a half-built ncclIbMrHandle is never passed to deregMr.
 
@@ -590,7 +605,7 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
   if (type == NCCL_PTR_CUDA && ncclCuMemEnable()) {
     CUdeviceptr base = 0;
     size_t baseSize = 0;
-    NCCLCHECKGOTO(ncclCuMemGetAddressRange((CUdeviceptr)data, size, &base, &baseSize, &nSeg), ret, fail);
+    NCCLCHECKGOTO(ncclCuMemGetAddressRange((CUdeviceptr)data, size, &base, &baseSize, &nSeg), ret, reconcile);
   }
 #endif
   if (nSeg < 1) nSeg = 1;
@@ -598,7 +613,7 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     WARN("NET/IB/RMA: buffer %p (size %zu) spans %d segments, exceeds NCCL_RMA_MAX_SEGMENTS=%d", data, size, nSeg,
          NCCL_RMA_MAX_SEGMENTS);
     ret = ncclInvalidUsage;
-    goto fail;
+    goto reconcile;
   }
   rmaMrHandle->nSegments = nSeg;
   rmaMrHandle->segOff[0] = 0;
@@ -607,7 +622,7 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     // Single segment: reuse the caller's fd (fd==-1 falls back to ibv_reg_mr).
     NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal(cComm->recvComm, data, size, type, offset, fd, mr_flags,
                                             (void**)&rmaMrHandle->mrHandle[0]),
-                  ret, fail);
+                  ret, reconcile);
     registered = 1;
     rmaMrHandle->segOff[1] = size;
     localVas[0] = (uintptr_t)data;
@@ -619,18 +634,18 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     for (int s = 0; s < nSeg; s++) {
       CUdeviceptr segBase = 0;
       size_t segSize = 0;
-      CUCHECKGOTO(cuMemGetAddressRange(&segBase, &segSize, (CUdeviceptr)segPtr), ret, fail);
+      CUCHECKGOTO(cuMemGetAddressRange(&segBase, &segSize, (CUdeviceptr)segPtr), ret, reconcile);
       size_t inSeg = segSize - (segPtr - (uintptr_t)segBase);
       size_t thisLen = remaining < inSeg ? remaining : inSeg;
       int segFd = -1;
       // Export this segment alone: one physical allocation, so its fd is complete.
       CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&segFd, (CUdeviceptr)segPtr, thisLen,
                                                 CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0),
-                  ret, fail);
+                  ret, reconcile);
       ret = ncclIbRegMrDmaBufInternal(cComm->recvComm, (void*)segPtr, thisLen, type, 0ULL, segFd, mr_flags,
                                       (void**)&rmaMrHandle->mrHandle[s]);
       (void)close(segFd);
-      if (ret != ncclSuccess) goto fail;
+      if (ret != ncclSuccess) goto reconcile;
       registered = s + 1;
       localVas[s] = segPtr;
       cum += thisLen;
@@ -643,7 +658,7 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
 #else
     WARN("NET/IB/RMA: multi-segment (%d) registration requires HIP >= 7.12.60540", nSeg);
     ret = ncclInvalidUsage;
-    goto fail;
+    goto reconcile;
 #endif
   }
 
@@ -654,7 +669,7 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     if (ndevs < 1 || ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
       WARN("NET/IB/RMA: invalid ndevs %d for buffer %p", ndevs, data);
       ret = ncclInternalError;
-      goto fail;
+      goto reconcile;
     }
     for (int s = 0; s < nSeg; s++) {
       for (int d = 0; d < ndevs; d++) {
@@ -662,40 +677,65 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
         if (mr == NULL) {
           WARN("NET/IB/RMA: missing MR for segment %d device %d", s, d);
           ret = ncclInternalError;
-          goto fail;
+          goto reconcile;
         }
         localRkeys[(size_t)s * NCCL_IB_MAX_DEVS_PER_NIC + d] = mr->rkey;
       }
     }
   }
 
-  // Cross-rank symmetry guard: every rank must register the same segment count,
-  // else the fixed-stride all-gather/indexing below would corrupt memory.
-  {
-    int* allNSeg = NULL;
-    NCCLCHECKGOTO(ncclCalloc(&allNSeg, cComm->nranks), ret, fail);
-    ret = cComm->allGather(cComm, &nSeg, allNSeg, sizeof(int));
-    for (int r = 0; ret == ncclSuccess && r < cComm->nranks; r++) {
-      if (allNSeg[r] != nSeg) {
-        WARN("NET/IB/RMA: buffer %p segment-count mismatch (rank %d has %d, local %d); "
-             "symmetric registration required",
-             data, r, allNSeg[r], nSeg);
-        ret = ncclInternalError;
-      }
+reconcile:
+  // No rank-local enumeration/export/registration/device-validation failure may
+  // return before peers reach this first registration collective. Exchange the
+  // complete status and layout in one fixed-size record.
+  localRegistration.status = ret;
+  localRegistration.nSegments = nSeg;
+  if (nSeg <= NCCL_RMA_MAX_SEGMENTS) memcpy(localRegistration.segOff, rmaMrHandle->segOff, sizeof(size_t) * (nSeg + 1));
+  NCCLCHECKGOTO(cComm->allGather(cComm, &localRegistration, registrations, sizeof(struct ncclRmaIbProxyRegistration)),
+                ret, fail);
+
+  for (int r = 0; r < cComm->nranks; r++) {
+    if (registrations[r].status != ncclSuccess) {
+      WARN("NET/IB/RMA: symmetric registration rejected because rank %d failed with error %d", r,
+           registrations[r].status);
+      ret = registrations[r].status;
+      goto fail;
     }
-    free(allNSeg);
-    if (ret != ncclSuccess) goto fail;
   }
 
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->base_vas, (size_t)cComm->nranks * nSeg), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->rkeys, (size_t)cComm->nranks * nSeg * NCCL_IB_MAX_DEVS_PER_NIC), ret, fail);
+  // Equal counts are insufficient: segOff is used to translate offsets into
+  // remote MRs, so every boundary including the terminal size must match.
+  for (int r = 0; r < cComm->nranks; r++) {
+    if (registrations[r].nSegments != nSeg ||
+        memcmp(registrations[r].segOff, rmaMrHandle->segOff, sizeof(size_t) * (nSeg + 1)) != 0) {
+      WARN("NET/IB/RMA: buffer %p segment layout differs on rank %d; symmetric registration required", data, r);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+  }
 
-  // Gather per-segment VAs and per-device rkeys; symmetry verified above keeps nSeg aligned.
+  // Reconcile allocation failures too, before entering the VA/rkey gathers.
+  ret = ncclCalloc(&rmaMrHandle->base_vas, (size_t)cComm->nranks * nSeg);
+  if (ret == ncclSuccess)
+    ret = ncclCalloc(&rmaMrHandle->rkeys, (size_t)cComm->nranks * nSeg * NCCL_IB_MAX_DEVS_PER_NIC);
+  localRegistration.status = ret;
+  NCCLCHECKGOTO(cComm->allGather(cComm, &localRegistration, registrations, sizeof(struct ncclRmaIbProxyRegistration)),
+                ret, fail);
+  for (int r = 0; r < cComm->nranks; r++) {
+    if (registrations[r].status != ncclSuccess) {
+      ret = registrations[r].status;
+      goto fail;
+    }
+  }
+
+  // Gather per-segment VAs and per-device rkeys; full layout symmetry keeps all
+  // remote segment indexing and registration-relative offsets aligned.
   NCCLCHECKGOTO(cComm->allGather(cComm, localVas, rmaMrHandle->base_vas, sizeof(uintptr_t) * nSeg), ret, fail);
   NCCLCHECKGOTO(cComm->allGather(cComm, localRkeys, rmaMrHandle->rkeys,
                                  sizeof(uint32_t) * nSeg * NCCL_IB_MAX_DEVS_PER_NIC),
                 ret, fail);
 
+  free(registrations);
   *mhandle = rmaMrHandle;
   return ncclSuccess;
 
@@ -710,6 +750,7 @@ fail:
     free(rmaMrHandle->rkeys);
     free(rmaMrHandle);
   }
+  free(registrations);
   return ret;
 }
 
@@ -721,14 +762,18 @@ ncclResult_t ncclRmaIbProxyRegMrSym(void* collComm, void* data, size_t size, int
 ncclResult_t ncclRmaIbProxyDeregMrSym(void* collComm, void* mhandle) {
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   struct ncclRmaIbProxyMrHandle* rmaMrHandle = (struct ncclRmaIbProxyMrHandle*)mhandle;
+  ncclResult_t ret = ncclSuccess;
 
   for (int s = 0; s < rmaMrHandle->nSegments; s++) {
-    if (rmaMrHandle->mrHandle[s]) NCCLCHECK(ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle[s]));
+    if (rmaMrHandle->mrHandle[s]) {
+      ncclResult_t r = ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle[s]);
+      if (ret == ncclSuccess && r != ncclSuccess) ret = r;
+    }
   }
   free(rmaMrHandle->base_vas);
   free(rmaMrHandle->rkeys);
   free(rmaMrHandle);
-  return ncclSuccess;
+  return ret;
 }
 
 ncclResult_t ncclRmaIbProxyCloseColl(void* collComm) {
@@ -772,6 +817,14 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
   struct ncclIbQp* qp = &comm->base.qps[0];
 
+  // Split the transfer at segment boundaries on both the local (src) and remote
+  // (dst) buffers; each slice maps to one local lkey and one remote rkey.
+  struct ibv_send_wr wr[NCCL_RMA_MAX_DATA_WRS];
+  struct ibv_sge sge[NCCL_RMA_MAX_DATA_WRS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_DATA_WRS, &nWr, IBV_WR_RDMA_WRITE, 0, qp, srcMrHandle,
+                                     rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
   req->rmaProxyCtx = rmaProxyCtx;
@@ -781,19 +834,11 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     req->devBases[i] = &comm->devs[i].base;
   }
-
-  // Split the transfer at segment boundaries on both the local (src) and remote
-  // (dst) buffers; each slice maps to one local lkey and one remote rkey.
-  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
-  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
-  int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_WRITE, req - comm->base.reqs,
-                                     qp, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size,
-                                     /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
-    wr[i].send_flags = IBV_SEND_SIGNALED;
-    ncclIbAddEvent(req, qp->devIndex);
+    wr[i].wr_id = req - comm->base.reqs;
+    wr[i].send_flags = ncclRmaWrIsSignaled(i, nWr) ? IBV_SEND_SIGNALED : 0;
   }
+  if (nWr > 0) ncclIbAddEvent(req, qp->devIndex);
 
   // size==0 yields nWr==0: nothing to post; the request completes in test()
   // (events[0]==0). Posting wr[0] here would submit an uninitialized WR.
@@ -823,6 +868,15 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
   struct ncclIbQp* qp = &comm->base.qps[0];
 
+  // RDMA READ: local buffer is the destination (lkey), remote buffer the source
+  // (rkey). Split at segment boundaries on both sides.
+  struct ibv_send_wr wr[NCCL_RMA_MAX_DATA_WRS];
+  struct ibv_sge sge[NCCL_RMA_MAX_DATA_WRS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_DATA_WRS, &nWr, IBV_WR_RDMA_READ, 0, qp, localMrHandle,
+                                     rmaProxyCtx->rank, localOffset, remoteMrHandle, rank, remoteOffset, size,
+                                     /*flushSge=*/NULL));
+
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
   req->rmaProxyCtx = rmaProxyCtx;
@@ -832,19 +886,11 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     req->devBases[i] = &comm->devs[i].base;
   }
-
-  // RDMA READ: local buffer is the destination (lkey), remote buffer the source
-  // (rkey). Split at segment boundaries on both sides.
-  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
-  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
-  int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs,
-                                     qp, localMrHandle, rmaProxyCtx->rank, localOffset, remoteMrHandle, rank,
-                                     remoteOffset, size, /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
-    wr[i].send_flags = IBV_SEND_SIGNALED;
-    ncclIbAddEvent(req, qp->devIndex);
+    wr[i].wr_id = req - comm->base.reqs;
+    wr[i].send_flags = ncclRmaWrIsSignaled(i, nWr) ? IBV_SEND_SIGNALED : 0;
   }
+  if (nWr > 0) ncclIbAddEvent(req, qp->devIndex);
 
   // size==0 yields nWr==0: nothing to post; the request completes in test().
   if (nWr > 0) {
@@ -880,11 +926,33 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
          signalOff);
     return ncclInvalidArgument;
   }
+  int sig = ncclRmaSegOf(signalMrHandle, signalOff);
+  if (!ncclRmaSignalOffsetValid(signalOff, signalMrHandle->segOff[sig + 1])) {
+    WARN("NET/IB/RMA: iputSignal atomic must be 8-byte aligned and contained in one segment (signalOff=%lu)",
+         signalOff);
+    return ncclInvalidArgument;
+  }
 
   struct ncclIbSendComm* comm;
   NCCLCHECK(ncclRmaIbProxyGetSendComm(rmaProxyCtx, rank, &comm));
   struct ncclIbQp* qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
+
+  // Up to 2*NCCL_RMA_MAX_SEGMENTS slices for the segmented PUT plus one signal WR.
+  struct ibv_send_wr wr[NCCL_RMA_MAX_SIGNAL_WRS];
+  struct ibv_sge sge[NCCL_RMA_MAX_SIGNAL_WRS];
+  memset(&wr, 0, sizeof(wr));
+  memset(&sge, 0, sizeof(sge));
+  int nPut = 0;
+
+  // If size is 0, we only need to send the signal. srcMrHandle must be non-NULL
+  if (size > 0 && dstMrHandle) {
+    // PUT slices carry no CQE; only the trailing signal is signaled. Same-QP RC
+    // ordering guarantees all writes land before the signal.
+    NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_DATA_WRS, &nPut, IBV_WR_RDMA_WRITE, 0, qp, srcMrHandle,
+                                       rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+    for (int i = 0; i < nPut; i++) wr[i].send_flags = 0;
+  }
 
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
@@ -895,26 +963,9 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     req->devBases[i] = &comm->devs[i].base;
   }
-
-  // Up to 2*NCCL_RMA_MAX_SEGMENTS slices for the segmented PUT plus one signal WR.
-  struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS + 1];
-  struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS + 1];
-  memset(&wr, 0, sizeof(wr));
-  memset(&sge, 0, sizeof(sge));
-  int nPut = 0;
-
-  // If size is 0, we only need to send the signal. srcMrHandle must be non-NULL
-  if (size > 0 && dstMrHandle) {
-    // PUT slices carry no CQE; only the trailing signal is signaled. Same-QP RC
-    // ordering guarantees all writes land before the signal.
-    NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nPut, IBV_WR_RDMA_WRITE,
-                                       req - comm->base.reqs, qp, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle,
-                                       rank, dstOff, size, /*flushSge=*/NULL));
-    for (int i = 0; i < nPut; i++) wr[i].send_flags = 0;
-  }
+  for (int i = 0; i < nPut; i++) wr[i].wr_id = req - comm->base.reqs;
 
   // SIGNAL (route to the segment that contains signalOff)
-  int sig = ncclRmaSegOf(signalMrHandle, signalOff);
   void* signalPtr = (void*)(signalMrHandle->base_vas[(size_t)rank * signalMrHandle->nSegments + sig] +
                             (signalOff - signalMrHandle->segOff[sig]));
   uint32_t signalRkey = ncclRmaRemoteRkey(signalMrHandle, rank, sig, qp->remDevIdx);
@@ -1013,29 +1064,30 @@ ncclResult_t ncclRmaIbProxyIFlush(void* rmaCtx, int context, void* mhandle, uint
   NCCLCHECK(ncclRmaIbProxyGetRecvComm(rmaProxyCtx, rank, &comm));
   struct ncclIbQp* qp = &comm->devs[0].gpuFlush.qp;
 
+  // Fence GPUDirect writes across EVERY physical segment, not just segment 0.
+  // The builder (flush mode) emits one loopback RDMA_READ per segment of the
+  // local recv buffer -- read via base_vas[self] and rkeys[self][qp->remDevIdx]
+  // -- each landing one byte in the flush scratch.
+  struct ibv_send_wr wr[NCCL_RMA_MAX_FLUSH_WRS];
+  struct ibv_sge sge[NCCL_RMA_MAX_FLUSH_WRS];
+  int nWr = 0;
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_FLUSH_WRS, &nWr, IBV_WR_RDMA_READ, 0, qp,
+                                     /*localH=*/NULL, /*localRank=*/0, /*localOff=*/0,
+                                     /*remoteH=*/rmaMrHandle, /*remoteRank=*/rmaProxyCtx->rank, /*remoteOff=*/0,
+                                     /*size=*/ncclRmaMrBytes(rmaMrHandle),
+                                     /*flushSge=*/&comm->devs[qp->devIndex].gpuFlush.sge));
+
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
   req->iput.rank = rank;
   req->rmaProxyCtx = rmaProxyCtx;
-
-  // Fence GPUDirect writes across EVERY physical segment, not just segment 0.
-  // The builder (flush mode) emits one loopback RDMA_READ per segment of the
-  // local recv buffer -- read via base_vas[self] and rkeys[self][qp->remDevIdx]
-  // -- each landing one byte in the flush scratch.
-  struct ibv_send_wr wr[NCCL_RMA_MAX_SEGMENTS];
-  struct ibv_sge sge[NCCL_RMA_MAX_SEGMENTS];
-  int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs, qp,
-                                     /*localH=*/NULL, /*localRank=*/0, /*localOff=*/0,
-                                     /*remoteH=*/rmaMrHandle, /*remoteRank=*/rmaProxyCtx->rank, /*remoteOff=*/0,
-                                     /*size=*/ncclRmaMrBytes(rmaMrHandle),
-                                     /*flushSge=*/&comm->devs[qp->devIndex].gpuFlush.sge));
   for (int i = 0; i < nWr; i++) {
-    wr[i].send_flags = IBV_SEND_SIGNALED;
-    ncclIbAddEvent(req, qp->devIndex);
+    wr[i].wr_id = req - comm->base.reqs;
+    wr[i].send_flags = ncclRmaWrIsSignaled(i, nWr) ? IBV_SEND_SIGNALED : 0;
   }
+  if (nWr > 0) ncclIbAddEvent(req, qp->devIndex);
 
   TRACE(NCCL_NET, "NET/IB: %s: Posting %d-segment flush request (req=%p, comm=%p)", __func__, nWr, req, req->base);
   TIME_START(4);

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -348,13 +348,24 @@ ncclGin_t ncclGinIbGdaki = {"GIN_IB_GDAKI",
 
 struct ncclRmaIbProxyMrHandle {
   int nSegments;
-  // segOff[0]==0, segOff[nSegments]==size; per-segment local MRs; remote view
-  // base_vas/rkeys indexed [rank*nSegments + seg]. See walkthrough doc.
+  // segOff[0]==0, segOff[nSegments]==size; per-segment local MRs.
+  // base_vas indexed [rank*nSegments + seg].
+  // rkeys indexed [rank][seg][dev]:
+  //   (rank * nSegments + seg) * NCCL_IB_MAX_DEVS_PER_NIC + remDevIdx
+  // so posting can pick the remote device that owns the QP, same as classic IB.
   size_t segOff[NCCL_RMA_MAX_SEGMENTS + 1];
   struct ncclIbMrHandle* mrHandle[NCCL_RMA_MAX_SEGMENTS];
   uintptr_t* base_vas;
   uint32_t* rkeys;
 };
+
+static inline size_t ncclRmaRkeyIndex(int nSegments, int rank, int seg, int remDevIdx) {
+  return ((size_t)rank * nSegments + (size_t)seg) * NCCL_IB_MAX_DEVS_PER_NIC + (size_t)remDevIdx;
+}
+
+static inline uint32_t ncclRmaRemoteRkey(const struct ncclRmaIbProxyMrHandle* h, int rank, int seg, int remDevIdx) {
+  return h->rkeys[ncclRmaRkeyIndex(h->nSegments, rank, seg, remDevIdx)];
+}
 
 // Return the segment index that contains byte offset off within the buffer.
 static inline int ncclRmaSegOf(const struct ncclRmaIbProxyMrHandle* h, uint64_t off) {
@@ -385,9 +396,10 @@ static inline bool ncclRmaRangeOk(const struct ncclRmaIbProxyMrHandle* h, uint64
 // RDMA_READ per remote segment touched by [remoteOff, remoteOff+size), each
 // landing a single byte in the caller's flush scratch. Passing the whole
 // window thus fences GPUDirect writes across every physical segment (the
-// caller reads its own buffer via base_vas[self]/rkeys[self] on a loopback QP).
+// caller reads its own buffer via base_vas[self]/rkeys[self][qp->remDevIdx]
+// on a loopback QP).
 static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_sge* sge, int maxWr, int* nWr,
-                                             enum ibv_wr_opcode opcode, uint64_t wrId,
+                                             enum ibv_wr_opcode opcode, uint64_t wrId, const struct ncclIbQp* qp,
                                              struct ncclRmaIbProxyMrHandle* localH, int localRank, uint64_t localOff,
                                              struct ncclRmaIbProxyMrHandle* remoteH, int remoteRank, uint64_t remoteOff,
                                              size_t size, const struct ibv_sge* flushSge) {
@@ -417,7 +429,7 @@ static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_
     wr[n].wr_id = wrId;
     wr[n].next = NULL;
     wr[n].wr.rdma.remote_addr = (uint64_t)rAddr;
-    wr[n].wr.rdma.rkey = remoteH->rkeys[(size_t)remoteRank * remoteH->nSegments + rs];
+    wr[n].wr.rdma.rkey = ncclRmaRemoteRkey(remoteH, remoteRank, rs, qp->remDevIdx);
     wr[n].sg_list = &sge[n];
     wr[n].num_sge = 1;
     if (flushSge != NULL) {
@@ -426,9 +438,14 @@ static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_
       sge[n].length = 1;
     } else {
       uintptr_t lAddr = localH->base_vas[(size_t)localRank * localH->nSegments + ls] + (lOff - localH->segOff[ls]);
+      struct ibv_mr* lmr = localH->mrHandle[ls]->mrs[qp->devIndex];
+      if (lmr == NULL) {
+        WARN("NET/IB/RMA: no local MR for segment %d device %d", ls, qp->devIndex);
+        return ncclInternalError;
+      }
       sge[n].addr = (uintptr_t)lAddr;
       sge[n].length = chunk;
-      sge[n].lkey = localH->mrHandle[ls]->mrs[0]->lkey;
+      sge[n].lkey = lmr->lkey;
     }
     if (n > 0) wr[n - 1].next = &wr[n];
 
@@ -558,12 +575,14 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   struct ncclRmaIbProxyMrHandle* rmaMrHandle = NULL;
   uintptr_t localVas[NCCL_RMA_MAX_SEGMENTS];
-  uint32_t localRkeys[NCCL_RMA_MAX_SEGMENTS];
+  uint32_t localRkeys[NCCL_RMA_MAX_SEGMENTS * NCCL_IB_MAX_DEVS_PER_NIC];
   ncclResult_t ret = ncclSuccess;
   int nSeg = 1;
   int registered = 0;
 
   NCCLCHECK(ncclCalloc(&rmaMrHandle, 1));
+  // calloc zeroes nSegments; fail paths below only dereg `registered` complete
+  // handles, so a half-built ncclIbMrHandle is never passed to deregMr.
 
   // Count physical segments; ROCm/HIP describes only the first per export,
   // so multi-segment ranges register one MR per segment below.
@@ -586,12 +605,12 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
 
   if (nSeg == 1) {
     // Single segment: reuse the caller's fd (fd==-1 falls back to ibv_reg_mr).
-    NCCLCHECKGOTO(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd, (void**)&rmaMrHandle->mrHandle[0]),
+    NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal(cComm->recvComm, data, size, type, offset, fd, mr_flags,
+                                            (void**)&rmaMrHandle->mrHandle[0]),
                   ret, fail);
     registered = 1;
     rmaMrHandle->segOff[1] = size;
     localVas[0] = (uintptr_t)data;
-    localRkeys[0] = rmaMrHandle->mrHandle[0]->mrs[0]->rkey;
   } else {
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
     uintptr_t segPtr = (uintptr_t)data;
@@ -608,13 +627,12 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
       CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&segFd, (CUdeviceptr)segPtr, thisLen,
                                                 CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0),
                   ret, fail);
-      ret = ncclIbRegMrDmaBuf(cComm->recvComm, (void*)segPtr, thisLen, type, 0ULL, segFd,
-                              (void**)&rmaMrHandle->mrHandle[s]);
+      ret = ncclIbRegMrDmaBufInternal(cComm->recvComm, (void*)segPtr, thisLen, type, 0ULL, segFd, mr_flags,
+                                      (void**)&rmaMrHandle->mrHandle[s]);
       (void)close(segFd);
       if (ret != ncclSuccess) goto fail;
       registered = s + 1;
       localVas[s] = segPtr;
-      localRkeys[s] = rmaMrHandle->mrHandle[s]->mrs[0]->rkey;
       cum += thisLen;
       rmaMrHandle->segOff[s + 1] = cum;
       segPtr += thisLen;
@@ -627,6 +645,28 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     ret = ncclInvalidUsage;
     goto fail;
 #endif
+  }
+
+  {
+    struct ncclIbNetCommBase* recvBase = (struct ncclIbNetCommBase*)cComm->recvComm;
+    int ndevs = recvBase->vProps.ndevs;
+    memset(localRkeys, 0, sizeof(localRkeys));
+    if (ndevs < 1 || ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+      WARN("NET/IB/RMA: invalid ndevs %d for buffer %p", ndevs, data);
+      ret = ncclInternalError;
+      goto fail;
+    }
+    for (int s = 0; s < nSeg; s++) {
+      for (int d = 0; d < ndevs; d++) {
+        struct ibv_mr* mr = rmaMrHandle->mrHandle[s]->mrs[d];
+        if (mr == NULL) {
+          WARN("NET/IB/RMA: missing MR for segment %d device %d", s, d);
+          ret = ncclInternalError;
+          goto fail;
+        }
+        localRkeys[(size_t)s * NCCL_IB_MAX_DEVS_PER_NIC + d] = mr->rkey;
+      }
+    }
   }
 
   // Cross-rank symmetry guard: every rank must register the same segment count,
@@ -648,16 +688,20 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
   }
 
   NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->base_vas, (size_t)cComm->nranks * nSeg), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->rkeys, (size_t)cComm->nranks * nSeg), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&rmaMrHandle->rkeys, (size_t)cComm->nranks * nSeg * NCCL_IB_MAX_DEVS_PER_NIC), ret, fail);
 
-  // Gather per-segment base VAs/rkeys; symmetry verified above keeps nSeg/sizes aligned.
+  // Gather per-segment VAs and per-device rkeys; symmetry verified above keeps nSeg aligned.
   NCCLCHECKGOTO(cComm->allGather(cComm, localVas, rmaMrHandle->base_vas, sizeof(uintptr_t) * nSeg), ret, fail);
-  NCCLCHECKGOTO(cComm->allGather(cComm, localRkeys, rmaMrHandle->rkeys, sizeof(uint32_t) * nSeg), ret, fail);
+  NCCLCHECKGOTO(cComm->allGather(cComm, localRkeys, rmaMrHandle->rkeys,
+                                 sizeof(uint32_t) * nSeg * NCCL_IB_MAX_DEVS_PER_NIC),
+                ret, fail);
 
   *mhandle = rmaMrHandle;
   return ncclSuccess;
 
 fail:
+  // `registered` counts complete ncclIbMrHandle objects. ncclIbRegMrDmaBufInternal
+  // does not write *mhandle on failure, so a half-built wrapper is never dereg'd.
   if (rmaMrHandle) {
     for (int s = 0; s < registered; s++) {
       if (rmaMrHandle->mrHandle[s]) (void)ncclNetIb.deregMr(cComm->recvComm, rmaMrHandle->mrHandle[s]);
@@ -744,7 +788,7 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
   struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
   NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_WRITE, req - comm->base.reqs,
-                                     srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size,
+                                     qp, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size,
                                      /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
     wr[i].send_flags = IBV_SEND_SIGNALED;
@@ -795,8 +839,8 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
   struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
   NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs,
-                                     localMrHandle, rmaProxyCtx->rank, localOffset, remoteMrHandle, rank, remoteOffset,
-                                     size, /*flushSge=*/NULL));
+                                     qp, localMrHandle, rmaProxyCtx->rank, localOffset, remoteMrHandle, rank,
+                                     remoteOffset, size, /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
     wr[i].send_flags = IBV_SEND_SIGNALED;
     ncclIbAddEvent(req, qp->devIndex);
@@ -864,8 +908,8 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
     // PUT slices carry no CQE; only the trailing signal is signaled. Same-QP RC
     // ordering guarantees all writes land before the signal.
     NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nPut, IBV_WR_RDMA_WRITE,
-                                       req - comm->base.reqs, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank,
-                                       dstOff, size, /*flushSge=*/NULL));
+                                       req - comm->base.reqs, qp, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle,
+                                       rank, dstOff, size, /*flushSge=*/NULL));
     for (int i = 0; i < nPut; i++) wr[i].send_flags = 0;
   }
 
@@ -873,7 +917,7 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
   int sig = ncclRmaSegOf(signalMrHandle, signalOff);
   void* signalPtr = (void*)(signalMrHandle->base_vas[(size_t)rank * signalMrHandle->nSegments + sig] +
                             (signalOff - signalMrHandle->segOff[sig]));
-  uint32_t signalRkey = signalMrHandle->rkeys[(size_t)rank * signalMrHandle->nSegments + sig];
+  uint32_t signalRkey = ncclRmaRemoteRkey(signalMrHandle, rank, sig, qp->remDevIdx);
 
   struct ibv_send_wr* sigWr = &wr[nPut];
   struct ibv_sge* sigSge = &sge[nPut];
@@ -978,12 +1022,12 @@ ncclResult_t ncclRmaIbProxyIFlush(void* rmaCtx, int context, void* mhandle, uint
 
   // Fence GPUDirect writes across EVERY physical segment, not just segment 0.
   // The builder (flush mode) emits one loopback RDMA_READ per segment of the
-  // local recv buffer -- read via base_vas[self]/rkeys[self], the same own-MR
-  // addr/rkey ncclIbIflush uses -- each landing one byte in the flush scratch.
+  // local recv buffer -- read via base_vas[self] and rkeys[self][qp->remDevIdx]
+  // -- each landing one byte in the flush scratch.
   struct ibv_send_wr wr[NCCL_RMA_MAX_SEGMENTS];
   struct ibv_sge sge[NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs,
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs, qp,
                                      /*localH=*/NULL, /*localRank=*/0, /*localOff=*/0,
                                      /*remoteH=*/rmaMrHandle, /*remoteRank=*/rmaProxyCtx->rank, /*remoteOff=*/0,
                                      /*size=*/ncclRmaMrBytes(rmaMrHandle),

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -346,15 +346,14 @@ ncclGin_t ncclGinIbGdaki = {"GIN_IB_GDAKI",
                             ncclGinIbFinalize};
 #endif // !defined(__HIP_PLATFORM_AMD__)
 
-
 struct ncclRmaIbProxyMrHandle {
   int nSegments;
   // segOff[0]==0, segOff[nSegments]==size; per-segment local MRs; remote view
   // base_vas/rkeys indexed [rank*nSegments + seg]. See walkthrough doc.
   size_t segOff[NCCL_RMA_MAX_SEGMENTS + 1];
-  struct ncclIbMrHandle *mrHandle[NCCL_RMA_MAX_SEGMENTS];
-  uintptr_t *base_vas;
-  uint32_t  *rkeys;
+  struct ncclIbMrHandle* mrHandle[NCCL_RMA_MAX_SEGMENTS];
+  uintptr_t* base_vas;
+  uint32_t* rkeys;
 };
 
 // Return the segment index that contains byte offset off within the buffer.
@@ -387,11 +386,11 @@ static inline bool ncclRmaRangeOk(const struct ncclRmaIbProxyMrHandle* h, uint64
 // landing a single byte in the caller's flush scratch. Passing the whole
 // window thus fences GPUDirect writes across every physical segment (the
 // caller reads its own buffer via base_vas[self]/rkeys[self] on a loopback QP).
-static ncclResult_t ncclRmaBuildSegmentedWrs(
-    struct ibv_send_wr* wr, struct ibv_sge* sge, int maxWr, int* nWr, enum ibv_wr_opcode opcode, uint64_t wrId,
-    struct ncclRmaIbProxyMrHandle* localH,  int localRank,  uint64_t localOff,
-    struct ncclRmaIbProxyMrHandle* remoteH, int remoteRank, uint64_t remoteOff,
-    size_t size, const struct ibv_sge* flushSge) {
+static ncclResult_t ncclRmaBuildSegmentedWrs(struct ibv_send_wr* wr, struct ibv_sge* sge, int maxWr, int* nWr,
+                                             enum ibv_wr_opcode opcode, uint64_t wrId,
+                                             struct ncclRmaIbProxyMrHandle* localH, int localRank, uint64_t localOff,
+                                             struct ncclRmaIbProxyMrHandle* remoteH, int remoteRank, uint64_t remoteOff,
+                                             size_t size, const struct ibv_sge* flushSge) {
   int n = 0;
   uint64_t lOff = localOff, rOff = remoteOff;
   size_t rem = size;
@@ -433,7 +432,10 @@ static ncclResult_t ncclRmaBuildSegmentedWrs(
     }
     if (n > 0) wr[n - 1].next = &wr[n];
 
-    lOff += chunk; rOff += chunk; rem -= chunk; n++;
+    lOff += chunk;
+    rOff += chunk;
+    rem -= chunk;
+    n++;
   }
   *nWr = n;
   return ncclSuccess;
@@ -552,11 +554,11 @@ ncclResult_t ncclRmaIbProxyDestroyContext(void* rmaCtx) {
 }
 
 ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
-                                         uint64_t mr_flags, void** mhandle) {
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
-  struct ncclRmaIbProxyMrHandle *rmaMrHandle = NULL;
+                                          uint64_t mr_flags, void** mhandle) {
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
+  struct ncclRmaIbProxyMrHandle* rmaMrHandle = NULL;
   uintptr_t localVas[NCCL_RMA_MAX_SEGMENTS];
-  uint32_t  localRkeys[NCCL_RMA_MAX_SEGMENTS];
+  uint32_t localRkeys[NCCL_RMA_MAX_SEGMENTS];
   ncclResult_t ret = ncclSuccess;
   int nSeg = 1;
   int registered = 0;
@@ -574,8 +576,8 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
 #endif
   if (nSeg < 1) nSeg = 1;
   if (nSeg > NCCL_RMA_MAX_SEGMENTS) {
-    WARN("NET/IB/RMA: buffer %p (size %zu) spans %d segments, exceeds NCCL_RMA_MAX_SEGMENTS=%d",
-         data, size, nSeg, NCCL_RMA_MAX_SEGMENTS);
+    WARN("NET/IB/RMA: buffer %p (size %zu) spans %d segments, exceeds NCCL_RMA_MAX_SEGMENTS=%d", data, size, nSeg,
+         NCCL_RMA_MAX_SEGMENTS);
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -584,8 +586,8 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
 
   if (nSeg == 1) {
     // Single segment: reuse the caller's fd (fd==-1 falls back to ibv_reg_mr).
-    NCCLCHECKGOTO(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd,
-                                    (void**)&rmaMrHandle->mrHandle[0]), ret, fail);
+    NCCLCHECKGOTO(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd, (void**)&rmaMrHandle->mrHandle[0]),
+                  ret, fail);
     registered = 1;
     rmaMrHandle->segOff[1] = size;
     localVas[0] = (uintptr_t)data;
@@ -604,7 +606,8 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
       int segFd = -1;
       // Export this segment alone: one physical allocation, so its fd is complete.
       CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&segFd, (CUdeviceptr)segPtr, thisLen,
-                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0), ret, fail);
+                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0),
+                  ret, fail);
       ret = ncclIbRegMrDmaBuf(cComm->recvComm, (void*)segPtr, thisLen, type, 0ULL, segFd,
                               (void**)&rmaMrHandle->mrHandle[s]);
       (void)close(segFd);
@@ -617,8 +620,8 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
       segPtr += thisLen;
       remaining -= thisLen;
     }
-    INFO(NCCL_NET|NCCL_REG, "NET/IB/RMA: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs",
-         data, size, nSeg);
+    INFO(NCCL_NET | NCCL_REG, "NET/IB/RMA: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs", data, size,
+         nSeg);
 #else
     WARN("NET/IB/RMA: multi-segment (%d) registration requires HIP >= 7.12.60540", nSeg);
     ret = ncclInvalidUsage;
@@ -635,7 +638,8 @@ ncclResult_t ncclRmaIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
     for (int r = 0; ret == ncclSuccess && r < cComm->nranks; r++) {
       if (allNSeg[r] != nSeg) {
         WARN("NET/IB/RMA: buffer %p segment-count mismatch (rank %d has %d, local %d); "
-             "symmetric registration required", data, r, allNSeg[r], nSeg);
+             "symmetric registration required",
+             data, r, allNSeg[r], nSeg);
         ret = ncclInternalError;
       }
     }
@@ -739,10 +743,9 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
   struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
   struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_WRITE,
-                                     req - comm->base.reqs,
-                                     srcMrHandle, rmaProxyCtx->rank, srcOff,
-                                     dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_WRITE, req - comm->base.reqs,
+                                     srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank, dstOff, size,
+                                     /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
     wr[i].send_flags = IBV_SEND_SIGNALED;
     ncclIbAddEvent(req, qp->devIndex);
@@ -791,10 +794,9 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
   struct ibv_send_wr wr[2 * NCCL_RMA_MAX_SEGMENTS];
   struct ibv_sge sge[2 * NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ,
-                                     req - comm->base.reqs,
-                                     localMrHandle, rmaProxyCtx->rank, localOffset,
-                                     remoteMrHandle, rank, remoteOffset, size, /*flushSge=*/NULL));
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs,
+                                     localMrHandle, rmaProxyCtx->rank, localOffset, remoteMrHandle, rank, remoteOffset,
+                                     size, /*flushSge=*/NULL));
   for (int i = 0; i < nWr; i++) {
     wr[i].send_flags = IBV_SEND_SIGNALED;
     ncclIbAddEvent(req, qp->devIndex);
@@ -827,12 +829,11 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
   struct ncclRmaIbProxyMrHandle* signalMrHandle = (struct ncclRmaIbProxyMrHandle*)signalMhandle;
 
   // Reject out-of-range payload/signal before any WR is posted (signal is an 8-byte atomic).
-  if ((size > 0 && (!srcMrHandle || !dstMrHandle ||
-                    !ncclRmaRangeOk(srcMrHandle, srcOff, size) ||
+  if ((size > 0 && (!srcMrHandle || !dstMrHandle || !ncclRmaRangeOk(srcMrHandle, srcOff, size) ||
                     !ncclRmaRangeOk(dstMrHandle, dstOff, size))) ||
       !signalMrHandle || !ncclRmaRangeOk(signalMrHandle, signalOff, sizeof(uint64_t))) {
-    WARN("NET/IB/RMA: iputSignal out of range (srcOff=%lu dstOff=%lu size=%zu signalOff=%lu)",
-         srcOff, dstOff, size, signalOff);
+    WARN("NET/IB/RMA: iputSignal out of range (srcOff=%lu dstOff=%lu size=%zu signalOff=%lu)", srcOff, dstOff, size,
+         signalOff);
     return ncclInvalidArgument;
   }
 
@@ -863,29 +864,28 @@ ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff
     // PUT slices carry no CQE; only the trailing signal is signaled. Same-QP RC
     // ordering guarantees all writes land before the signal.
     NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, 2 * NCCL_RMA_MAX_SEGMENTS, &nPut, IBV_WR_RDMA_WRITE,
-                                       req - comm->base.reqs,
-                                       srcMrHandle, rmaProxyCtx->rank, srcOff,
-                                       dstMrHandle, rank, dstOff, size, /*flushSge=*/NULL));
+                                       req - comm->base.reqs, srcMrHandle, rmaProxyCtx->rank, srcOff, dstMrHandle, rank,
+                                       dstOff, size, /*flushSge=*/NULL));
     for (int i = 0; i < nPut; i++) wr[i].send_flags = 0;
   }
 
   // SIGNAL (route to the segment that contains signalOff)
   int sig = ncclRmaSegOf(signalMrHandle, signalOff);
-  void *signalPtr = (void *)(signalMrHandle->base_vas[(size_t)rank * signalMrHandle->nSegments + sig]
-                             + (signalOff - signalMrHandle->segOff[sig]));
+  void* signalPtr = (void*)(signalMrHandle->base_vas[(size_t)rank * signalMrHandle->nSegments + sig] +
+                            (signalOff - signalMrHandle->segOff[sig]));
   uint32_t signalRkey = signalMrHandle->rkeys[(size_t)rank * signalMrHandle->nSegments + sig];
 
   struct ibv_send_wr* sigWr = &wr[nPut];
   struct ibv_sge* sigSge = &sge[nPut];
   memset(sigWr, 0, sizeof(*sigWr));
   memset(sigSge, 0, sizeof(*sigSge));
-  sigWr->opcode                  = IBV_WR_ATOMIC_FETCH_AND_ADD;
-  sigWr->send_flags              = IBV_SEND_SIGNALED;
-  sigWr->wr_id                   = req - comm->base.reqs;  // used for matching completions with request
-  sigWr->next                    = NULL;
-  sigWr->wr.atomic.remote_addr   = (uint64_t)signalPtr;
-  sigWr->wr.atomic.compare_add   = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
-  sigWr->wr.atomic.rkey          = signalRkey;
+  sigWr->opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  sigWr->send_flags = IBV_SEND_SIGNALED;
+  sigWr->wr_id = req - comm->base.reqs;  // used for matching completions with request
+  sigWr->next = NULL;
+  sigWr->wr.atomic.remote_addr = (uint64_t)signalPtr;
+  sigWr->wr.atomic.compare_add = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
+  sigWr->wr.atomic.rkey = signalRkey;
   sigWr->sg_list = sigSge;
   sigWr->num_sge = 1;
 
@@ -983,8 +983,7 @@ ncclResult_t ncclRmaIbProxyIFlush(void* rmaCtx, int context, void* mhandle, uint
   struct ibv_send_wr wr[NCCL_RMA_MAX_SEGMENTS];
   struct ibv_sge sge[NCCL_RMA_MAX_SEGMENTS];
   int nWr = 0;
-  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ,
-                                     req - comm->base.reqs,
+  NCCLCHECK(ncclRmaBuildSegmentedWrs(wr, sge, NCCL_RMA_MAX_SEGMENTS, &nWr, IBV_WR_RDMA_READ, req - comm->base.reqs,
                                      /*localH=*/NULL, /*localRank=*/0, /*localOff=*/0,
                                      /*remoteH=*/rmaMrHandle, /*remoteRank=*/rmaProxyCtx->rank, /*remoteOff=*/0,
                                      /*size=*/ncclRmaMrBytes(rmaMrHandle),

--- a/projects/rccl/src/transport/net_ib/gin.h
+++ b/projects/rccl/src/transport/net_ib/gin.h
@@ -12,6 +12,13 @@
 #include <stdint.h>
 #include "nccl.h"
 
+// Cap on physical segments per GIN/RMA symmetric buffer. HIP dma-buf export
+// describes only the first physical segment, so registration allocates one MR
+// per segment up to this limit.
+#ifndef NCCL_RMA_MAX_SEGMENTS
+#define NCCL_RMA_MAX_SEGMENTS 16
+#endif
+
 struct ncclGinIbCollComm {
   void* ctx;
   int rank;

--- a/projects/rccl/src/transport/net_ib/gin.h
+++ b/projects/rccl/src/transport/net_ib/gin.h
@@ -10,6 +10,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <limits.h>
 #include "nccl.h"
 
 // Cap on physical segments per GIN/RMA symmetric buffer. HIP dma-buf export
@@ -18,6 +19,30 @@
 #ifndef NCCL_RMA_MAX_SEGMENTS
 #define NCCL_RMA_MAX_SEGMENTS 16
 #endif
+
+// A paired data transfer can split at every local and remote boundary. A
+// segment slice may split once more at the verbs 32-bit SGE length limit; the
+// fixed budget deliberately rejects larger chains before posting.
+#define NCCL_RMA_MAX_DATA_WRS (2 * NCCL_RMA_MAX_SEGMENTS)
+#define NCCL_RMA_MAX_SIGNAL_WRS (NCCL_RMA_MAX_DATA_WRS + 1)
+#define NCCL_RMA_MAX_FLUSH_WRS NCCL_RMA_MAX_SEGMENTS
+
+static inline size_t ncclRmaSegmentSliceBytes(size_t remaining, size_t localRemaining, size_t remoteRemaining) {
+  size_t chunk = remaining;
+  if (localRemaining < chunk) chunk = localRemaining;
+  if (remoteRemaining < chunk) chunk = remoteRemaining;
+  if ((size_t)UINT32_MAX < chunk) chunk = (size_t)UINT32_MAX;
+  return chunk;
+}
+
+static inline int ncclRmaWrIsSignaled(int wrIndex, int nWrs) {
+  return nWrs > 0 && wrIndex == nWrs - 1;
+}
+
+static inline int ncclRmaSignalOffsetValid(size_t signalOff, size_t segmentEnd) {
+  return (signalOff & (sizeof(uint64_t) - 1)) == 0 && signalOff <= segmentEnd &&
+         sizeof(uint64_t) <= segmentEnd - signalOff;
+}
 
 struct ncclGinIbCollComm {
   void* ctx;

--- a/projects/rccl/src/transport/net_ib/reg.cc
+++ b/projects/rccl/src/transport/net_ib/reg.cc
@@ -64,23 +64,33 @@ ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, 
   return ncclSuccess;
 }
 
+ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle);
+
 /* DMA-BUF support */
 ncclResult_t ncclIbRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd,
                                        uint64_t mrFlags, void** mhandle) {
   ncclResult_t ret = ncclSuccess;
   assert(size > 0);
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)malloc(sizeof(struct ncclIbMrHandle));
+  struct ncclIbMrHandle* mhandleWrapper = NULL;
+  int registered = 0;
+  *mhandle = NULL;
+  NCCLCHECK(ncclCalloc(&mhandleWrapper, 1));
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
     NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, data, size, type, offset, fd, mrFlags, mhandleWrapper->mrs + i),
                   ret, fail);
+    registered++;
   }
   *mhandle = (void*)mhandleWrapper;
 exit:
   return ret;
 fail:
+  for (int i = 0; i < registered; i++) {
+    struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+    (void)ncclIbDeregMrInternal(devComm, mhandleWrapper->mrs[i]);
+  }
   free(mhandleWrapper);
   goto exit;
 }

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -727,6 +727,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/FaultInjectTests.cpp
       transport/NetIbMPI/OpsFaultUnitTests.cpp
       transport/RmaMPI/RmaMPITests.cpp
+      transport/RmaMPI/RmaMultiSegmentMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
       transport/GinDeviceMPITests.cpp
       WarpSpeedMPITests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -850,6 +850,13 @@ if(BUILD_TESTS)
     # Link the GIN device backend library and device-link its rdc code (-fgpu-rdc
     # --hip-link --offload-arch=... -rdynamic) so GIN device tests can run.
     if(ENABLE_ROCSHMEM_GIN AND ROCSHMEM_INSTALL_DIR AND "${test_executable}" STREQUAL "rccl-UnitTestsMPI")
+      if(TARGET rocshmem_ext)
+        add_dependencies(${test_executable} rocshmem_ext)
+      endif()
+      target_include_directories(${test_executable} PRIVATE
+        ${ROCSHMEM_INCLUDE_DIR}
+        ${ROCSHMEM_SOURCE_DIR}/include
+        ${ROCSHMEM_SOURCE_DIR}/src)
       set(_ROCSHMEM_OFFLOAD_FLAGS "")
       foreach(_g IN LISTS GPU_TARGETS)
         if(_g)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -233,6 +233,7 @@ if(BUILD_TESTS)
     ReduceScatterTests.cpp
     ReduceTests.cpp
     RegisterTests.cpp
+    RmaSegmentMathTests.cpp
     ScatterTests.cpp
     P2pChannelScalingTests.cpp
     VersionGateTests.cpp

--- a/projects/rccl/test/HybridVmmHelpers.hpp
+++ b/projects/rccl/test/HybridVmmHelpers.hpp
@@ -1,0 +1,460 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef HYBRID_VMM_HELPERS_HPP
+#define HYBRID_VMM_HELPERS_HPP
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "MPIHelpers.hpp"
+#include "ipcsocket.h"
+
+#include <hip/hip_runtime.h>
+#include <mpi.h>
+
+#include <unistd.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace RCCLHybridVmmTests
+{
+
+constexpr size_t kHybridVmmAlignment = 2u * 1024 * 1024;
+
+// Hybrid device/host VMM shape:
+// [GPU][CPU local-rank 0]...[CPU local-rank N-1].
+// Every process on a node imports the same CPU allocation handles in local-rank
+// order before registering the complete VA as one symmetric window.
+struct HybridVmmBuffer
+{
+    void*                                        ptr       = nullptr;
+    hipDeviceptr_t                               base      = 0;
+    size_t                                       totalSize = 0;
+    size_t                                       gpuBytes  = 0;
+    int                                          localRank = -1;
+    int                                          localSize = 0;
+    int                                          exportFd  = -1;
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    std::vector<size_t>                          segSizes;
+
+    bool valid() const
+    {
+        return ptr != nullptr && handles.size() == static_cast<size_t>(localSize + 1);
+    }
+};
+
+struct HybridVmmRuntimeSupport
+{
+    bool importedHostCpuAccess = false;
+    bool importedPosixReexport = false;
+};
+
+inline HybridVmmRuntimeSupport ProbeHybridVmmRuntimeSupport(int dev)
+{
+    HybridVmmRuntimeSupport support;
+    hipMemGenericAllocationHandle_t original = 0;
+    hipMemGenericAllocationHandle_t imported = 0;
+    hipDeviceptr_t va = 0;
+    size_t bytes = 0;
+    int fd = -1;
+    int reexportFd = -1;
+    bool mapped = false;
+    hipMemAccessDesc access = {};
+
+    hipMemAllocationProp prop = {};
+    prop.type = hipMemAllocationTypePinned;
+    prop.location.type = hipMemLocationTypeHost;
+    prop.location.id = 0;
+    prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+
+    size_t granularity = 0;
+    if (hipMemGetAllocationGranularity(
+            &granularity, &prop, hipMemAllocationGranularityMinimum) != hipSuccess ||
+        granularity == 0)
+        goto cleanup;
+    bytes = ((kHybridVmmAlignment + granularity - 1) / granularity) * granularity;
+
+    if (hipMemCreate(&original, bytes, &prop, 0) != hipSuccess ||
+        hipMemExportToShareableHandle(
+            &fd, original, hipMemHandleTypePosixFileDescriptor, 0) != hipSuccess ||
+        hipMemImportFromShareableHandle(
+            &imported, reinterpret_cast<void*>(static_cast<intptr_t>(fd)),
+            hipMemHandleTypePosixFileDescriptor) != hipSuccess)
+        goto cleanup;
+
+    support.importedPosixReexport =
+        hipMemExportToShareableHandle(
+            &reexportFd, imported, hipMemHandleTypePosixFileDescriptor, 0) == hipSuccess;
+
+    if (hipMemAddressReserve(&va, bytes, 0, 0, 0) != hipSuccess ||
+        hipMemMap(va, bytes, 0, imported, 0) != hipSuccess)
+        goto cleanup;
+    mapped = true;
+
+    access.location.type = hipMemLocationTypeDevice;
+    access.location.id = dev;
+    access.flags = hipMemAccessFlagsProtReadWrite;
+    if (hipMemSetAccess(va, bytes, &access, 1) != hipSuccess)
+        goto cleanup;
+
+    access.location.type = hipMemLocationTypeHost;
+    access.location.id = 0;
+    support.importedHostCpuAccess =
+        hipMemSetAccess(va, bytes, &access, 1) == hipSuccess;
+
+cleanup:
+    if (mapped) (void)hipMemUnmap(va, bytes);
+    if (va != 0) (void)hipMemAddressFree(va, bytes);
+    if (reexportFd >= 0) (void)close(reexportFd);
+    if (imported != 0) (void)hipMemRelease(imported);
+    if (fd >= 0) (void)close(fd);
+    if (original != 0) (void)hipMemRelease(original);
+    return support;
+}
+
+inline bool CheckHybridVmmRuntimeSupport(int dev, bool requireReexport,
+                                         std::string* reason = nullptr)
+{
+    HybridVmmRuntimeSupport local = ProbeHybridVmmRuntimeSupport(dev);
+    bool cpuAccessSupported = MPIHelpers::allRanksTrue(local.importedHostCpuAccess);
+    bool reexportSupported = MPIHelpers::allRanksTrue(local.importedPosixReexport);
+
+    // TODO(ROCM-29812): Remove this skip gate when imported host VMM CPU access is fixed.
+    if (!cpuAccessSupported)
+    {
+        if (reason) *reason = "ROCM-29812: imported host VMM CPU access is unsupported";
+        return false;
+    }
+    // TODO(ROCM-29815): Remove this skip gate when imported POSIX VMM re-export is fixed.
+    if (requireReexport && !reexportSupported)
+    {
+        if (reason) *reason = "ROCM-29815: imported POSIX VMM re-export is unsupported";
+        return false;
+    }
+    return true;
+}
+
+inline void FreeHybridVmm(HybridVmmBuffer& b)
+{
+    size_t offset = 0;
+    for (size_t i = 0; i < b.handles.size(); ++i)
+    {
+        if (b.base != 0 && i < b.segSizes.size())
+        {
+            hipDeviceptr_t va = reinterpret_cast<hipDeviceptr_t>(
+                reinterpret_cast<uintptr_t>(b.base) + offset);
+            (void)hipMemUnmap(va, b.segSizes[i]);
+            offset += b.segSizes[i];
+        }
+        if (b.handles[i] != 0)
+            (void)hipMemRelease(b.handles[i]);
+    }
+    if (b.exportFd >= 0)
+        (void)close(b.exportFd);
+    if (b.base != 0 && b.totalSize != 0)
+        (void)hipMemAddressFree(b.base, b.totalSize);
+    b = HybridVmmBuffer{};
+}
+
+// Create a workload-independent hybrid VMM allocation. Each local rank creates
+// and exports one host allocation, all local descriptors are exchanged, then
+// each rank imports all host handles into the same ordered VA layout. Returns
+// false collectively within the node on unsupported kernels or host VMM
+// runtimes. File descriptors are transferred with RCCL's existing SCM_RIGHTS
+// IPC socket API rather than passing process-local descriptor integers.
+inline bool AllocHybridVmm(int dev, size_t gpuBytes, size_t localCpuBytes,
+                           HybridVmmBuffer* out, std::string* reason = nullptr)
+{
+    if (out == nullptr || gpuBytes == 0 || localCpuBytes == 0 ||
+        gpuBytes % kHybridVmmAlignment != 0 || localCpuBytes % kHybridVmmAlignment != 0)
+    {
+        if (reason) *reason = "hybrid sizes must be non-zero and 2 MiB aligned";
+        return false;
+    }
+    *out = HybridVmmBuffer{};
+
+    MPI_Comm localComm = MPI_COMM_NULL;
+    if (MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &localComm) != MPI_SUCCESS)
+    {
+        if (reason) *reason = "MPI_Comm_split_type(MPI_COMM_TYPE_SHARED) failed";
+        return false;
+    }
+
+    int localRank = 0;
+    int localSize = 0;
+    MPI_Comm_rank(localComm, &localRank);
+    MPI_Comm_size(localComm, &localSize);
+
+    hipMemAllocationProp gpuProp            = {};
+    gpuProp.type                            = hipMemAllocationTypePinned;
+    gpuProp.location.type                   = hipMemLocationTypeDevice;
+    gpuProp.location.id                     = dev;
+    gpuProp.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
+    gpuProp.allocFlags.gpuDirectRDMACapable = 1;
+
+    hipMemAllocationProp cpuProp = {};
+    cpuProp.type                = hipMemAllocationTypePinned;
+    cpuProp.location.type       = hipMemLocationTypeHost;
+    cpuProp.location.id         = 0;
+    cpuProp.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+
+    size_t gpuGran = 0;
+    size_t cpuGran = 0;
+    bool localOk =
+        hipMemGetAllocationGranularity(&gpuGran, &gpuProp, hipMemAllocationGranularityMinimum) == hipSuccess &&
+        hipMemGetAllocationGranularity(&cpuGran, &cpuProp, hipMemAllocationGranularityMinimum) == hipSuccess &&
+        gpuGran != 0 && cpuGran != 0 &&
+        kHybridVmmAlignment % gpuGran == 0 && kHybridVmmAlignment % cpuGran == 0;
+    if (!MPIHelpers::allRanksTrue(localOk, localComm))
+    {
+        if (reason) *reason = "GPU/host VMM allocation is unavailable or incompatible with 2 MiB alignment";
+        MPI_Comm_free(&localComm);
+        return false;
+    }
+
+    hipMemGenericAllocationHandle_t localCpuHandle = 0;
+    int exportFd = -1;
+    localOk = hipMemCreate(&localCpuHandle, localCpuBytes, &cpuProp, 0) == hipSuccess;
+    if (localOk)
+    {
+        localOk = hipMemExportToShareableHandle(&exportFd, localCpuHandle,
+                                                hipMemHandleTypePosixFileDescriptor, 0) == hipSuccess;
+    }
+    if (!MPIHelpers::allRanksTrue(localOk, localComm))
+    {
+        if (exportFd >= 0) (void)close(exportFd);
+        if (localCpuHandle != 0) (void)hipMemRelease(localCpuHandle);
+        if (reason) *reason = "host VMM allocation/export is unavailable";
+        MPI_Comm_free(&localComm);
+        return false;
+    }
+
+    uint64_t localBytes = static_cast<uint64_t>(localCpuBytes);
+    std::vector<uint64_t> cpuBytes(static_cast<size_t>(localSize), 0);
+    MPI_Allgather(&localBytes, 1, MPI_UINT64_T,
+                  cpuBytes.data(), 1, MPI_UINT64_T, localComm);
+
+    // Use RCCL's production IPC socket transport to duplicate descriptors with
+    // SCM_RIGHTS. The hash only needs to be unique while these node-local
+    // sockets are alive; the local leader's PID provides that scope.
+    uint64_t socketHash = localRank == 0
+        ? (static_cast<uint64_t>(getpid()) << 32) ^ UINT64_C(0x48594252)
+        : 0;
+    MPI_Bcast(&socketHash, 1, MPI_UINT64_T, 0, localComm);
+
+    volatile uint32_t abortFlag = 0;
+    ncclIpcSocket ipcSocket = {};
+    localOk = ncclIpcSocketInit(
+        &ipcSocket, localRank, socketHash, &abortFlag) == ncclSuccess;
+    if (!MPIHelpers::allRanksTrue(localOk, localComm))
+    {
+        if (localOk) (void)ncclIpcSocketClose(&ipcSocket);
+        (void)close(exportFd);
+        (void)hipMemRelease(localCpuHandle);
+        if (reason) *reason = "RCCL IPC socket initialization failed";
+        MPI_Comm_free(&localComm);
+        return false;
+    }
+
+    MPI_Barrier(localComm); // all destination sockets must be bound before send
+    for (int peer = 0; localOk && peer < localSize; ++peer)
+    {
+        if (peer == localRank) continue;
+        int sender = localRank;
+        localOk = ncclIpcSocketSendMsg(
+            &ipcSocket, &sender, sizeof(sender), exportFd,
+            peer, socketHash) == ncclSuccess;
+    }
+    if (!MPIHelpers::allRanksTrue(localOk, localComm))
+    {
+        abortFlag = 1;
+        (void)ncclIpcSocketClose(&ipcSocket);
+        (void)close(exportFd);
+        (void)hipMemRelease(localCpuHandle);
+        if (reason) *reason = "RCCL IPC socket FD send failed";
+        MPI_Comm_free(&localComm);
+        return false;
+    }
+
+    std::vector<MPIHelpers::FileDescriptor> peerFds(
+        static_cast<size_t>(localSize));
+    for (int received = 0; localOk && received < localSize - 1; ++received)
+    {
+        int sender = -1;
+        int receivedFd = -1;
+        localOk = ncclIpcSocketRecvMsg(
+            &ipcSocket, &sender, sizeof(sender), &receivedFd) == ncclSuccess &&
+            sender >= 0 && sender < localSize && sender != localRank &&
+            !peerFds[static_cast<size_t>(sender)].is_valid();
+        if (localOk)
+            peerFds[static_cast<size_t>(sender)] =
+                MPIHelpers::FileDescriptor(receivedFd);
+        else if (receivedFd >= 0)
+            (void)close(receivedFd);
+    }
+    (void)ncclIpcSocketClose(&ipcSocket);
+    if (!MPIHelpers::allRanksTrue(localOk, localComm))
+    {
+        (void)close(exportFd);
+        (void)hipMemRelease(localCpuHandle);
+        if (reason) *reason = "RCCL IPC socket FD receive failed";
+        MPI_Comm_free(&localComm);
+        return false;
+    }
+
+    size_t totalSize = gpuBytes;
+    for (uint64_t bytes : cpuBytes)
+        totalSize += static_cast<size_t>(bytes);
+
+    HybridVmmBuffer tmp;
+    tmp.gpuBytes  = gpuBytes;
+    tmp.totalSize = totalSize;
+    tmp.localRank = localRank;
+    tmp.localSize = localSize;
+    tmp.exportFd  = exportFd;
+
+    localOk = hipMemAddressReserve(&tmp.base, totalSize, kHybridVmmAlignment, 0, 0) == hipSuccess;
+    if (localOk)
+    {
+        hipMemGenericAllocationHandle_t gpuHandle = 0;
+        localOk = hipMemCreate(&gpuHandle, gpuBytes, &gpuProp, 0) == hipSuccess;
+        if (localOk && hipMemMap(tmp.base, gpuBytes, 0, gpuHandle, 0) == hipSuccess)
+        {
+            tmp.handles.push_back(gpuHandle);
+            tmp.segSizes.push_back(gpuBytes);
+        }
+        else
+        {
+            if (gpuHandle != 0) (void)hipMemRelease(gpuHandle);
+            localOk = false;
+        }
+    }
+
+    size_t offset = gpuBytes;
+    for (int i = 0; localOk && i < localSize; ++i)
+    {
+        bool isLocal = i == localRank;
+        int localFd = isLocal ? exportFd : peerFds[static_cast<size_t>(i)].get();
+        if (localFd < 0 || (isLocal && localCpuHandle == 0))
+        {
+            localOk = false;
+            break;
+        }
+
+        hipMemGenericAllocationHandle_t segmentHandle = localCpuHandle;
+        hipError_t importResult = hipSuccess;
+        if (!isLocal)
+        {
+            segmentHandle = 0;
+            importResult = hipMemImportFromShareableHandle(
+                &segmentHandle, reinterpret_cast<void*>(static_cast<intptr_t>(localFd)),
+                hipMemHandleTypePosixFileDescriptor);
+        }
+        size_t bytes = static_cast<size_t>(cpuBytes[static_cast<size_t>(i)]);
+        hipDeviceptr_t va = reinterpret_cast<hipDeviceptr_t>(
+            reinterpret_cast<uintptr_t>(tmp.base) + offset);
+        hipError_t mapResult = importResult == hipSuccess
+            ? hipMemMap(va, bytes, 0, segmentHandle, 0)
+            : hipErrorInvalidValue;
+        if (importResult != hipSuccess || mapResult != hipSuccess)
+        {
+            if (reason)
+                *reason = importResult != hipSuccess
+                    ? std::string("hipMemImportFromShareableHandle: ") +
+                          hipGetErrorString(importResult)
+                    : std::string("hipMemMap(imported host segment): ") +
+                          hipGetErrorString(mapResult);
+            if (!isLocal && segmentHandle != 0) (void)hipMemRelease(segmentHandle);
+            localOk = false;
+            break;
+        }
+        tmp.handles.push_back(segmentHandle);
+        if (isLocal) localCpuHandle = 0; // ownership transferred to tmp.handles
+        tmp.segSizes.push_back(bytes);
+        offset += bytes;
+    }
+    if (localCpuHandle != 0) (void)hipMemRelease(localCpuHandle);
+
+    if (localOk)
+    {
+        hipMemAccessDesc access = {};
+        access.location.type = hipMemLocationTypeDevice;
+        access.location.id   = dev;
+        access.flags         = hipMemAccessFlagsProtReadWrite;
+        size_t accessOffset = 0;
+        for (size_t segment = 0; segment < tmp.segSizes.size(); ++segment)
+        {
+            size_t bytes = tmp.segSizes[segment];
+            hipDeviceptr_t segmentVa = reinterpret_cast<hipDeviceptr_t>(
+                reinterpret_cast<uintptr_t>(tmp.base) + accessOffset);
+            hipError_t accessResult =
+                hipMemSetAccess(segmentVa, bytes, &access, 1);
+            if (accessResult != hipSuccess)
+            {
+                if (reason)
+                    *reason = std::string("hipMemSetAccess(hybrid segment ") +
+                        std::to_string(segment) +
+                        (segment == 0 ? " GPU): " : " imported host): ") +
+                        hipGetErrorString(accessResult);
+                localOk = false;
+                break;
+            }
+            accessOffset += bytes;
+        }
+    }
+
+    if (localOk)
+    {
+        hipMemAccessDesc access = {};
+        access.location.type = hipMemLocationTypeHost;
+        access.location.id   = 0;
+        access.flags         = hipMemAccessFlagsProtReadWrite;
+        size_t accessOffset = gpuBytes;
+        for (size_t segment = 1; segment < tmp.segSizes.size(); ++segment)
+        {
+            size_t bytes = tmp.segSizes[segment];
+            hipDeviceptr_t segmentVa = reinterpret_cast<hipDeviceptr_t>(
+                reinterpret_cast<uintptr_t>(tmp.base) + accessOffset);
+            hipError_t accessResult =
+                hipMemSetAccess(segmentVa, bytes, &access, 1);
+            if (accessResult != hipSuccess)
+            {
+                if (reason)
+                    *reason = std::string("hipMemSetAccess(hybrid host segment ") +
+                        std::to_string(segment) + "): " +
+                        hipGetErrorString(accessResult);
+                localOk = false;
+                break;
+            }
+            accessOffset += bytes;
+        }
+    }
+
+    bool allOk = MPIHelpers::allRanksTrue(localOk, localComm);
+    MPI_Barrier(localComm); // every peer has imported before SCM_RIGHTS FDs close
+    MPI_Comm_free(&localComm);
+
+    if (!allOk)
+    {
+        FreeHybridVmm(tmp);
+        if (reason && reason->empty())
+            *reason = "hybrid host-handle import/map failed on another rank";
+        return false;
+    }
+
+    tmp.ptr = reinterpret_cast<void*>(tmp.base);
+    *out = std::move(tmp);
+    return true;
+}
+
+} // namespace RCCLHybridVmmTests
+
+#endif // MPI_TESTS_ENABLED
+
+#endif // HYBRID_VMM_HELPERS_HPP

--- a/projects/rccl/test/RmaSegmentMathTests.cpp
+++ b/projects/rccl/test/RmaSegmentMathTests.cpp
@@ -1,0 +1,66 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "../src/transport/net_ib/gin.h"
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+
+TEST(RmaSegmentMathTest, SplitsAtVerbsLengthLimitWithoutLargeAllocation)
+{
+    ASSERT_GT(SIZE_MAX, static_cast<size_t>(UINT32_MAX));
+    size_t remaining = static_cast<size_t>(UINT32_MAX) + 1;
+
+    const size_t first =
+        ncclRmaSegmentSliceBytes(remaining, remaining, remaining);
+    EXPECT_EQ(first, static_cast<size_t>(UINT32_MAX));
+    remaining -= first;
+    EXPECT_EQ(ncclRmaSegmentSliceBytes(remaining, remaining, remaining),
+              size_t{1});
+}
+
+TEST(RmaSegmentMathTest, FixedDataWrBudgetRejectsUnrepresentableChain)
+{
+    ASSERT_GT(SIZE_MAX, static_cast<size_t>(UINT32_MAX));
+    size_t remaining =
+        static_cast<size_t>(UINT32_MAX) * (NCCL_RMA_MAX_DATA_WRS + 1ULL);
+    int slices = 0;
+    while (remaining != 0 && slices < NCCL_RMA_MAX_DATA_WRS)
+    {
+        const size_t chunk =
+            ncclRmaSegmentSliceBytes(remaining, remaining, remaining);
+        remaining -= chunk;
+        ++slices;
+    }
+
+    EXPECT_EQ(slices, NCCL_RMA_MAX_DATA_WRS);
+    EXPECT_NE(remaining, size_t{0});
+}
+
+TEST(RmaSegmentMathTest, OnlyFinalWrIsSignaled)
+{
+    constexpr int kWrs = 7;
+    for (int i = 0; i < kWrs; ++i)
+        EXPECT_EQ(ncclRmaWrIsSignaled(i, kWrs), i == kWrs - 1);
+    EXPECT_FALSE(ncclRmaWrIsSignaled(0, 0));
+}
+
+TEST(RmaSegmentMathTest, SignalAtomicMustBeAlignedWithinSegment)
+{
+    EXPECT_TRUE(ncclRmaSignalOffsetValid(/*signalOff=*/8, /*segmentEnd=*/16));
+    EXPECT_FALSE(ncclRmaSignalOffsetValid(/*signalOff=*/4, /*segmentEnd=*/16));
+    EXPECT_FALSE(ncclRmaSignalOffsetValid(/*signalOff=*/8, /*segmentEnd=*/12));
+}
+
+TEST(RmaSegmentMathTest, WorkRequestDepthsCoverMaximumChains)
+{
+    EXPECT_EQ(NCCL_RMA_MAX_DATA_WRS, 2 * NCCL_RMA_MAX_SEGMENTS);
+    EXPECT_EQ(NCCL_RMA_MAX_SIGNAL_WRS, NCCL_RMA_MAX_DATA_WRS + 1);
+    EXPECT_EQ(NCCL_RMA_MAX_FLUSH_WRS, NCCL_RMA_MAX_SEGMENTS);
+}

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -22,13 +22,16 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
+#include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <mpi.h>
 #include <memory>
 #include <optional>
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <vector>
 
 /**
  * @namespace MPIHelpers
@@ -36,6 +39,62 @@
  */
 namespace MPIHelpers
 {
+
+// Collective predicates used by capability-gated MPI tests. Keeping these in
+// the common infrastructure prevents tests from open-coding MPI_Allreduce with
+// inconsistent MIN/MAX conventions.
+inline bool allRanksTrue(bool localValue, MPI_Comm comm = MPI_COMM_WORLD)
+{
+    int value = localValue ? 1 : 0;
+    MPI_Allreduce(MPI_IN_PLACE, &value, 1, MPI_INT, MPI_MIN, comm);
+    return value != 0;
+}
+
+inline bool anyRankTrue(bool localValue, MPI_Comm comm = MPI_COMM_WORLD)
+{
+    int value = localValue ? 1 : 0;
+    MPI_Allreduce(MPI_IN_PLACE, &value, 1, MPI_INT, MPI_MAX, comm);
+    return value != 0;
+}
+
+// Find a rank on another node with the requested shared-memory local rank.
+// Returns -1 when the topology has no such peer.
+inline int findRemotePeerForLocalRank(int wantedLocalRank,
+                                      MPI_Comm worldComm = MPI_COMM_WORLD)
+{
+    int worldSize = 0;
+    MPI_Comm_size(worldComm, &worldSize);
+
+    char localName[MPI_MAX_PROCESSOR_NAME] = {};
+    int nameLength = 0;
+    MPI_Get_processor_name(localName, &nameLength);
+
+    MPI_Comm localComm = MPI_COMM_NULL;
+    if (MPI_Comm_split_type(worldComm, MPI_COMM_TYPE_SHARED, 0,
+                            MPI_INFO_NULL, &localComm) != MPI_SUCCESS)
+        return -1;
+    int localRank = -1;
+    MPI_Comm_rank(localComm, &localRank);
+    MPI_Comm_free(&localComm);
+
+    std::vector<char> allNames(
+        static_cast<size_t>(worldSize) * MPI_MAX_PROCESSOR_NAME, 0);
+    std::vector<int> allLocalRanks(static_cast<size_t>(worldSize), -1);
+    MPI_Allgather(localName, MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
+                  allNames.data(), MPI_MAX_PROCESSOR_NAME, MPI_CHAR, worldComm);
+    MPI_Allgather(&localRank, 1, MPI_INT, allLocalRanks.data(), 1, MPI_INT,
+                  worldComm);
+
+    for (int rank = 0; rank < worldSize; ++rank)
+    {
+        const char* rankName =
+            allNames.data() + static_cast<size_t>(rank) * MPI_MAX_PROCESSOR_NAME;
+        if (std::strcmp(rankName, localName) != 0 &&
+            allLocalRanks[static_cast<size_t>(rank)] == wantedLocalRank)
+            return rank;
+    }
+    return -1;
+}
 
 // Returns the MPI world rank as a string for diagnostic messages.
 // Probes OpenMPI, MPICH/PMIx, and SLURM env vars in order; returns "?" if none set.

--- a/projects/rccl/test/common/ResourceGuards.hpp
+++ b/projects/rccl/test/common/ResourceGuards.hpp
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#pragma once
+#ifndef RESOURCE_GUARDS_HPP
+#define RESOURCE_GUARDS_HPP
 
 #include "nccl.h"
 #include "net.h"
@@ -492,4 +493,6 @@ inline NcclCommAutoGuard makeCommAutoGuard(ncclComm_t comm)
 }
 
 } // namespace RCCLTestGuards
+
+#endif // RESOURCE_GUARDS_HPP
 

--- a/projects/rccl/test/host/CMakeLists.txt
+++ b/projects/rccl/test/host/CMakeLists.txt
@@ -430,6 +430,7 @@ add_executable(rccl-HostUnitTests
   ${RCCL_TEST_DIR}/RomeTopoConsensusTests.cpp
   RomeTopoConsensusLogTests.cpp
   ${RCCL_TEST_DIR}/MiscTests.cpp
+  ${RCCL_TEST_DIR}/RmaSegmentMathTests.cpp
   ${RCCL_TEST_DIR}/VersionGateTests.cpp
   ${RCCL_TEST_DIR}/TimeoutTests.cpp
   ${RCCL_TEST_DIR}/EnqueueCountTests.cpp

--- a/projects/rccl/test/transport/RmaMPI/RmaMPITestBase.hpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMPITestBase.hpp
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#pragma once
+#ifndef RMA_MPI_TEST_BASE_HPP
+#define RMA_MPI_TEST_BASE_HPP
 
 #ifdef MPI_TESTS_ENABLED
 #ifdef RCCL_HAS_RMA_IB_PROXY
@@ -163,7 +164,8 @@ protected:
 
     bool SetUpFixture(int minProcesses = kMinProcessesForMPI,
                       int maxProcesses = kNoProcessLimit,
-                      int minNodes = 1)
+                      int minNodes = 1,
+                      int maxNodes = kNoNodeLimit)
     {
         // SetUp() already recorded the skip + warning when NCCL_NET wasn't
         // ib / ib-cast. Short-circuit so the per-test body doesn't proceed to
@@ -172,7 +174,7 @@ protected:
 
         if(!validateTestPrerequisites(minProcesses, maxProcesses,
                                       kNoPowerOfTwoRequired,
-                                      minNodes, kNoNodeLimit))
+                                      minNodes, maxNodes))
         {
             return false;
         }
@@ -515,3 +517,5 @@ protected:
 
 #endif // RCCL_HAS_RMA_IB_PROXY
 #endif // MPI_TESTS_ENABLED
+
+#endif // RMA_MPI_TEST_BASE_HPP

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentHelpers.hpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentHelpers.hpp
@@ -1,0 +1,255 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RMA_MULTI_SEGMENT_HELPERS_HPP
+#define RMA_MULTI_SEGMENT_HELPERS_HPP
+
+#ifdef MPI_TESTS_ENABLED
+#ifdef RCCL_HAS_RMA_IB_PROXY
+
+#include <hip/hip_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace RCCLRmaTests
+{
+
+// Contiguous VA range backed by N distinct VMM allocations mapped back-to-back.
+struct MultiSegmentVmmBuffer
+{
+    void*                                        ptr        = nullptr;
+    size_t                                       totalSize  = 0;
+    size_t                                       segSize    = 0;
+    int                                          nSegments  = 0;
+    hipDeviceptr_t                               base       = 0;
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    std::vector<size_t>                          segSizes;
+
+    bool valid() const { return ptr != nullptr && nSegments > 0; }
+};
+
+// Map `nSegments` granularity-rounded segments contiguously on `dev`. Returns
+// false (cleaned up) on any HIP failure so the caller can GTEST_SKIP.
+inline bool AllocMultiSegmentVmm(int dev, int nSegments, size_t segBytes,
+                                 MultiSegmentVmmBuffer* out)
+{
+    if (out == nullptr || nSegments <= 0) return false;
+    *out = MultiSegmentVmmBuffer{};
+
+    hipMemAllocationProp prop            = {};
+    prop.type                            = hipMemAllocationTypePinned;
+    prop.location.type                   = hipMemLocationTypeDevice;
+    prop.location.id                     = dev;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    size_t granularity = 0;
+    if (hipMemGetAllocationGranularity(&granularity, &prop,
+                                       hipMemAllocationGranularityMinimum) != hipSuccess
+        || granularity == 0)
+    {
+        return false;
+    }
+
+    const size_t segSize   = ((segBytes + granularity - 1) / granularity) * granularity;
+    const size_t totalSize = segSize * static_cast<size_t>(nSegments);
+
+    hipDeviceptr_t base = 0;
+    if (hipMemAddressReserve(&base, totalSize, granularity, 0, 0) != hipSuccess)
+    {
+        return false;
+    }
+
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    handles.reserve(nSegments);
+
+    auto cleanup = [&]() {
+        for (size_t i = 0; i < handles.size(); ++i)
+        {
+            (void)hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(
+                                  reinterpret_cast<uintptr_t>(base) + i * segSize),
+                              segSize);
+            (void)hipMemRelease(handles[i]);
+        }
+        (void)hipMemAddressFree(base, totalSize);
+    };
+
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+
+    for (int s = 0; s < nSegments; ++s)
+    {
+        hipMemGenericAllocationHandle_t h = 0;
+        if (hipMemCreate(&h, segSize, &prop, 0) != hipSuccess)
+        {
+            cleanup();
+            return false;
+        }
+        handles.push_back(h);
+
+        hipDeviceptr_t segVa = reinterpret_cast<hipDeviceptr_t>(
+            reinterpret_cast<uintptr_t>(base) + static_cast<uintptr_t>(s) * segSize);
+        if (hipMemMap(segVa, segSize, 0, h, 0) != hipSuccess)
+        {
+            cleanup();
+            return false;
+        }
+    }
+
+    // One access grant over the whole contiguous range.
+    if (hipMemSetAccess(base, totalSize, &accessDesc, 1) != hipSuccess)
+    {
+        cleanup();
+        return false;
+    }
+
+    out->ptr       = reinterpret_cast<void*>(base);
+    out->base      = base;
+    out->totalSize = totalSize;
+    out->segSize   = segSize;
+    out->nSegments = nSegments;
+    out->handles   = std::move(handles);
+    out->segSizes.assign(nSegments, segSize);
+    return true;
+}
+
+// Reproduce DeepEP's non-hybrid ElasticSymmetricMemory layout:
+// one 2 MiB-aligned GPU segment followed by one independently-sized CPU segment
+// in a single reserved VA range. DeepEP registers the whole range as one NCCL
+// symmetric window and uses RMA IGet from the CPU segment into the GPU segment.
+inline bool AllocDeepEpElasticVmm(int dev, size_t gpuBytes, size_t cpuBytes,
+                                  MultiSegmentVmmBuffer* out)
+{
+    constexpr size_t kDeepEpAlignment = 2u * 1024 * 1024;
+    if (out == nullptr || gpuBytes == 0 || cpuBytes == 0 ||
+        gpuBytes % kDeepEpAlignment != 0 || cpuBytes % kDeepEpAlignment != 0)
+        return false;
+    *out = MultiSegmentVmmBuffer{};
+
+    hipMemAllocationProp gpuProp            = {};
+    gpuProp.type                            = hipMemAllocationTypePinned;
+    gpuProp.location.type                   = hipMemLocationTypeDevice;
+    gpuProp.location.id                     = dev;
+    gpuProp.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
+    gpuProp.allocFlags.gpuDirectRDMACapable = 1;
+
+    hipMemAllocationProp cpuProp = {};
+    cpuProp.type                    = hipMemAllocationTypePinned;
+    cpuProp.location.type           = hipMemLocationTypeHost;
+    cpuProp.location.id             = 0;
+    cpuProp.requestedHandleType     = hipMemHandleTypePosixFileDescriptor;
+
+    size_t gpuGran = 0, cpuGran = 0;
+    if (hipMemGetAllocationGranularity(&gpuGran, &gpuProp, hipMemAllocationGranularityMinimum) != hipSuccess ||
+        hipMemGetAllocationGranularity(&cpuGran, &cpuProp, hipMemAllocationGranularityMinimum) != hipSuccess ||
+        gpuGran == 0 || cpuGran == 0 ||
+        kDeepEpAlignment % gpuGran != 0 || kDeepEpAlignment % cpuGran != 0)
+        return false;
+
+    const size_t totalSize = gpuBytes + cpuBytes;
+    hipDeviceptr_t base = 0;
+    if (hipMemAddressReserve(&base, totalSize, kDeepEpAlignment, 0, 0) != hipSuccess)
+        return false;
+
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    std::vector<size_t> segSizes = {gpuBytes, cpuBytes};
+    auto cleanup = [&]() {
+        size_t off = 0;
+        for (size_t i = 0; i < handles.size(); ++i) {
+            (void)hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(
+                                  reinterpret_cast<uintptr_t>(base) + off),
+                              segSizes[i]);
+            (void)hipMemRelease(handles[i]);
+            off += segSizes[i];
+        }
+        (void)hipMemAddressFree(base, totalSize);
+    };
+
+    for (int s = 0; s < 2; ++s) {
+        hipMemGenericAllocationHandle_t h = 0;
+        hipMemAllocationProp* prop = s == 0 ? &gpuProp : &cpuProp;
+        if (hipMemCreate(&h, segSizes[s], prop, 0) != hipSuccess) {
+            cleanup();
+            return false;
+        }
+        handles.push_back(h);
+        const size_t off = s == 0 ? 0 : gpuBytes;
+        hipDeviceptr_t segVa = reinterpret_cast<hipDeviceptr_t>(
+            reinterpret_cast<uintptr_t>(base) + off);
+        if (hipMemMap(segVa, segSizes[s], 0, h, 0) != hipSuccess) {
+            cleanup();
+            return false;
+        }
+    }
+
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+    if (hipMemSetAccess(base, gpuBytes, &accessDesc, 1) != hipSuccess ||
+        hipMemSetAccess(reinterpret_cast<hipDeviceptr_t>(
+                            reinterpret_cast<uintptr_t>(base) + gpuBytes),
+                        cpuBytes, &accessDesc, 1) != hipSuccess) {
+        cleanup();
+        return false;
+    }
+
+    out->ptr       = reinterpret_cast<void*>(base);
+    out->base      = base;
+    out->totalSize = totalSize;
+    out->segSize   = 0; // non-uniform by design
+    out->nSegments = 2;
+    out->handles   = std::move(handles);
+    out->segSizes  = std::move(segSizes);
+    return true;
+}
+
+// Release in HIP-required order: unmap each segment, release each handle, free VA.
+inline void FreeMultiSegmentVmm(MultiSegmentVmmBuffer& b)
+{
+    if (b.ptr == nullptr) return;
+    size_t off = 0;
+    for (size_t i = 0; i < b.handles.size(); ++i)
+    {
+        const size_t len = b.segSizes.empty() ? b.segSize : b.segSizes[i];
+        hipDeviceptr_t segVa = reinterpret_cast<hipDeviceptr_t>(
+            reinterpret_cast<uintptr_t>(b.base) + off);
+        (void)hipMemUnmap(segVa, len);
+        (void)hipMemRelease(b.handles[i]);
+        off += len;
+    }
+    (void)hipMemAddressFree(b.base, b.totalSize);
+    b = MultiSegmentVmmBuffer{};
+}
+
+// RAII wrapper so a test body can early-return / ASSERT without leaking VMM.
+class MultiSegmentVmmGuard
+{
+public:
+    MultiSegmentVmmGuard() = default;
+    explicit MultiSegmentVmmGuard(MultiSegmentVmmBuffer buf) : buf_(std::move(buf)) {}
+    ~MultiSegmentVmmGuard() { FreeMultiSegmentVmm(buf_); }
+
+    MultiSegmentVmmGuard(const MultiSegmentVmmGuard&)            = delete;
+    MultiSegmentVmmGuard& operator=(const MultiSegmentVmmGuard&) = delete;
+
+    MultiSegmentVmmBuffer&       get()       { return buf_; }
+    const MultiSegmentVmmBuffer& get() const { return buf_; }
+
+private:
+    MultiSegmentVmmBuffer buf_;
+};
+
+} // namespace RCCLRmaTests
+
+#endif // RCCL_HAS_RMA_IB_PROXY
+#endif // MPI_TESTS_ENABLED
+
+#endif // RMA_MULTI_SEGMENT_HELPERS_HPP

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
@@ -14,6 +14,7 @@
 #include "RmaMultiSegmentHelpers.hpp"
 #include "../../HybridVmmHelpers.hpp"
 #include "MPIHelpers.hpp"
+#include "../../../src/transport/net_ib/gin.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -26,10 +27,6 @@ namespace RCCLRmaTests
 
 namespace
 {
-
-// Mirrors NCCL_RMA_MAX_SEGMENTS in src/transport/net_ib/gin.cc (not exposed to
-// the test target); update if the backend cap changes.
-constexpr int    kRmaMaxSegments = 16;
 
 constexpr size_t kSegRequestBytes = 2u * 1024 * 1024;
 constexpr int    kNumSegments     = 4;
@@ -945,7 +942,7 @@ TEST_F(RmaMultiSegmentMPITest, RegisterExceedsMaxSegmentsRejected)
             GTEST_SKIP() << "multi-segment path not exercised on this host";
     }
 
-    const int kOverCap = kRmaMaxSegments + 1;
+    const int kOverCap = NCCL_RMA_MAX_SEGMENTS + 1;
     MultiSegmentVmmBuffer* big = AllocSym(kOverCap, kSegRequestBytes);
     if (SyncSkip(big == nullptr))
         GTEST_SKIP() << "Could not allocate " << kOverCap << " VMM segments";
@@ -954,7 +951,7 @@ TEST_F(RmaMultiSegmentMPITest, RegisterExceedsMaxSegmentsRejected)
     ncclResult_t r = RegMr(big->ptr, big->totalSize, &mh, &gh);
     EXPECT_EQ(r, ncclInvalidUsage)
         << "registration of a " << kOverCap << "-segment buffer should be rejected "
-        << "with ncclInvalidUsage (cap=" << kRmaMaxSegments << "), got " << r;
+        << "with ncclInvalidUsage (cap=" << NCCL_RMA_MAX_SEGMENTS << "), got " << r;
     EXPECT_EQ(mh, nullptr) << "no MR handle should be produced on rejection";
 }
 

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
@@ -1063,10 +1063,61 @@ TEST_F(RmaMultiSegmentMPITest, RegisterAsymmetricSegmentCountRejected)
     if (SyncSkip(r == ncclSuccess))
         GTEST_SKIP() << "ranks enumerated identical segment counts; no asymmetry";
 
-    EXPECT_EQ(r, ncclInternalError)
+    EXPECT_EQ(r, ncclInvalidUsage)
         << "asymmetric per-rank segment count must be rejected (rank " << worldRank_
         << " requested " << myNSeg << " segments)";
     EXPECT_EQ(mh, nullptr) << "no MR handle should be produced on rejection";
+}
+
+// NEGATIVE: equal segment counts are not sufficient symmetry. Rank 0 maps
+// [4 MiB GPU][2 MiB CPU], while rank 1 maps [2 MiB GPU][4 MiB CPU]. The total
+// size and count match, but using either rank's local boundary for the other's
+// MR would address the wrong registration.
+TEST_F(RmaMultiSegmentMPITest, RegisterEqualCountDifferentBoundariesRejected)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer* bb =
+        worldRank_ == 0 ? AllocDeepEpElastic(4 * kMiB, 2 * kMiB)
+                        : AllocDeepEpElastic(2 * kMiB, 4 * kMiB);
+    if (SyncSkip(bb == nullptr))
+        GTEST_SKIP() << "mixed GPU/CPU VMM allocation unavailable on this host";
+
+    void *mh = nullptr, *gh = nullptr;
+    const ncclResult_t r = RegMr(bb->ptr, bb->totalSize, &mh, &gh);
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    EXPECT_EQ(r, ncclInvalidUsage);
+    EXPECT_EQ(mh, nullptr);
+}
+
+// NEGATIVE: only rank 0 exceeds the segment cap. Rank 1 successfully registers
+// locally, then both ranks must meet in the status collective, reject, and
+// clean up. If rank 0 returns early this test hangs in registration.
+TEST_F(RmaMultiSegmentMPITest, RankLocalRegistrationFailureRejectedCollectively)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer* probe = AllocSym(2, kSegRequestBytes);
+    if (SyncSkip(probe == nullptr))
+        GTEST_SKIP() << "multi-segment VMM allocation unavailable on this host";
+    void *probeMh = nullptr, *probeGh = nullptr;
+    ASSERT_EQ(ncclSuccess,
+              RegMr(probe->ptr, probe->totalSize, &probeMh, &probeGh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    const int myNSeg =
+        worldRank_ == 0 ? NCCL_RMA_MAX_SEGMENTS + 1 : 2;
+    MultiSegmentVmmBuffer* bb = AllocSym(myNSeg, kSegRequestBytes);
+    if (SyncSkip(bb == nullptr))
+        GTEST_SKIP() << "asymmetric failure layout allocation unavailable";
+
+    void *mh = nullptr, *gh = nullptr;
+    const ncclResult_t r = RegMr(bb->ptr, bb->totalSize, &mh, &gh);
+    EXPECT_EQ(r, ncclInvalidUsage);
+    EXPECT_EQ(mh, nullptr);
 }
 
 // NEGATIVE (range guard): out-of-range IPut offsets/sizes must be rejected with
@@ -1186,6 +1237,11 @@ TEST_F(RmaMultiSegmentMPITest, IPutSignalOutOfRangeRejectedNoCorruption)
                                    /*signalOff=*/kSignalSize - 4, sigMh, 0,
                                    NCCL_NET_SIGNAL_OP_INC, /*isStrongSignal=*/false, &req))
             << "out-of-range signal offset must be rejected";
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iputSignal(rmaCtx_, 0, 0, sendMh, total, 0, recvMh, 1,
+                                   /*signalOff=*/4, sigMh, 0,
+                                   NCCL_NET_SIGNAL_OP_INC, /*isStrongSignal=*/false, &req))
+            << "unaligned signal atomic must be rejected";
         EXPECT_EQ(req, nullptr) << "rejected iputSignal must not produce a request";
     }
     Barrier();

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
@@ -1,0 +1,1309 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Multi-segment DMA-BUF registration tests for ncclRmaIbProxy (AIRUNTIME-2351).
+// Run with NCCL_NET=IB NCCL_CUMEM_ENABLE=1.
+
+#ifdef MPI_TESTS_ENABLED
+#ifdef RCCL_HAS_RMA_IB_PROXY
+
+#include "RmaMPITestBase.hpp"
+#include "RmaMultiSegmentHelpers.hpp"
+#include "../../HybridVmmHelpers.hpp"
+#include "MPIHelpers.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace RCCLRmaTests
+{
+
+namespace
+{
+
+// Mirrors NCCL_RMA_MAX_SEGMENTS in src/transport/net_ib/gin.cc (not exposed to
+// the test target); update if the backend cap changes.
+constexpr int    kRmaMaxSegments = 16;
+
+constexpr size_t kSegRequestBytes = 2u * 1024 * 1024;
+constexpr int    kNumSegments     = 4;
+constexpr size_t kSignalSize      = 64;
+constexpr size_t kMiB             = 1024u * 1024;
+
+// INFO marker emitted by the backend when the per-segment path fires.
+constexpr const char* kMultiSegMarker = "multi-segment buffer";
+
+// Edge-case payload sizes from 0 up to `maxBytes`, anchored around byte/word,
+// page (4K), 64K, and the per-segment boundary `seg`. Deduplicated + sorted.
+inline std::vector<size_t> EdgeCaseSizes(size_t seg, size_t maxBytes)
+{
+    std::vector<size_t> v;
+    auto add = [&](size_t s) { if (s <= maxBytes) v.push_back(s); };
+    for (size_t s : {size_t{0}, size_t{1}, size_t{2}, size_t{3}, size_t{7},
+                     size_t{63}, size_t{64}, size_t{65}, size_t{255}, size_t{256},
+                     size_t{4095}, size_t{4096}, size_t{4097},
+                     size_t{65535}, size_t{65536}, size_t{65537}})
+        add(s);
+    // Per-segment boundary neighbourhood (the split points under test).
+    if (seg >= 1)     { add(seg - 1); add(seg); add(seg + 1); add(seg + 4096); }
+    if (2 * seg >= 1) { add(2 * seg - 1); add(2 * seg); add(2 * seg + 1); }
+    add(3 * seg);
+    add(maxBytes ? maxBytes - 1 : 0);
+    add(maxBytes);
+    std::sort(v.begin(), v.end());
+    v.erase(std::unique(v.begin(), v.end()), v.end());
+    return v;
+}
+
+} // namespace
+
+// RMA proxy fixture + NCCL INFO log capture to confirm the per-segment path
+// fired (vs single-MR fallback when cuMem enumeration is unavailable).
+class RmaMultiSegmentMPITest : public RmaMPITestBase
+{
+protected:
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             cuMemGuard_;
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugGuard_;
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugSubsysGuard_;
+    std::unique_ptr<MPIHelpers::TestLogAssertionContext> logCtx_;
+
+    int GetNumContexts() const override { return 1; }
+
+    void SetUp() override
+    {
+        // Per-segment enumeration needs the cuMem path; the marker gate below
+        // covers cases where the param was already cached process-wide.
+        cuMemGuard_       = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_CUMEM_ENABLE",  "1");
+        debugGuard_       = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG",         "INFO");
+        debugSubsysGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG_SUBSYS",  "ALL");
+
+        RmaMPITestBase::SetUp();
+
+        logCtx_ = std::make_unique<MPIHelpers::TestLogAssertionContext>(
+            MPIHelpers::makeCombinedAssertionLogOptions(getTestMpiRank()));
+    }
+
+    void TearDown() override
+    {
+        // Deregister IB MRs (base TearDown) BEFORE releasing their backing VMM;
+        // freeing VMM under a live DMA-BUF MR aborts/stalls cleanup (AIRUNTIME-2351).
+        RmaMPITestBase::TearDown();
+        for (auto& b : vmmBuffers_)
+            FreeMultiSegmentVmm(*b);
+        vmmBuffers_.clear();
+        for (auto& b : hybridBuffers_)
+            RCCLHybridVmmTests::FreeHybridVmm(*b);
+        hybridBuffers_.clear();
+        logCtx_.reset();
+        debugSubsysGuard_.reset();
+        debugGuard_.reset();
+        cuMemGuard_.reset();
+    }
+
+    std::string readAllLogs() const
+    {
+        if (!logCtx_) return {};
+        return logCtx_->readNcclDebugLog() + logCtx_->readPerRankStderrLog();
+    }
+
+    // Collective skip: if ANY rank wants to skip, all ranks return true so they
+    // GTEST_SKIP together (a unilateral skip would hang peers).
+    bool SyncSkip(bool wantSkip)
+    {
+        return MPIHelpers::anyRankTrue(wantSkip);
+    }
+
+    // True only if EVERY rank observed the per-segment registration marker.
+    bool AllTookMultiSegPath()
+    {
+        return MPIHelpers::allRanksTrue(
+            readAllLogs().find(kMultiSegMarker) != std::string::npos);
+    }
+
+    // Allocate a fixture-owned N-segment VMM window (freed in TearDown after MR
+    // dereg). Returns nullptr on failure so the caller can SyncSkip. Uses the
+    // rank's CURRENT GPU (round-robin assigned by the harness), not the IB-device
+    // index defaultDevice_, or rank>0 would fault touching dev-0 memory.
+    MultiSegmentVmmBuffer* AllocSym(int nSegments, size_t segBytes)
+    {
+        int dev = 0;
+        if (hipGetDevice(&dev) != hipSuccess)
+            return nullptr;
+        auto buf = std::make_unique<MultiSegmentVmmBuffer>();
+        if (!AllocMultiSegmentVmm(dev, nSegments, segBytes, buf.get()))
+            return nullptr;
+        vmmBuffers_.push_back(std::move(buf));
+        return vmmBuffers_.back().get();
+    }
+
+    MultiSegmentVmmBuffer* AllocDeepEpElastic(size_t gpuBytes, size_t cpuBytes)
+    {
+        int dev = 0;
+        if (hipGetDevice(&dev) != hipSuccess)
+            return nullptr;
+        auto buf = std::make_unique<MultiSegmentVmmBuffer>();
+        if (!AllocDeepEpElasticVmm(dev, gpuBytes, cpuBytes, buf.get()))
+            return nullptr;
+        vmmBuffers_.push_back(std::move(buf));
+        return vmmBuffers_.back().get();
+    }
+
+    RCCLHybridVmmTests::HybridVmmBuffer* AllocHybrid(
+        size_t gpuBytes, size_t localCpuBytes, std::string* reason)
+    {
+        int dev = 0;
+        if (hipGetDevice(&dev) != hipSuccess)
+            return nullptr;
+        if (!RCCLHybridVmmTests::CheckHybridVmmRuntimeSupport(
+                dev, /*requireReexport=*/true, reason))
+            return nullptr;
+        auto buf = std::make_unique<RCCLHybridVmmTests::HybridVmmBuffer>();
+        if (!RCCLHybridVmmTests::AllocHybridVmm(
+                dev, gpuBytes, localCpuBytes, buf.get(), reason))
+            return nullptr;
+        hybridBuffers_.push_back(std::move(buf));
+        return hybridBuffers_.back().get();
+    }
+
+    bool AllocHybridForLocalRanks(
+        size_t gpuBytes, size_t localCpuBytes, int expectedLocalRanks,
+        RCCLHybridVmmTests::HybridVmmBuffer** out, std::string* reason)
+    {
+        *out = AllocHybrid(gpuBytes, localCpuBytes, reason);
+        if (SyncSkip(*out == nullptr)) {
+            if (reason && reason->empty())
+                *reason = "hybrid VMM allocation failed on another rank";
+            return false;
+        }
+        if (SyncSkip((*out)->localSize != expectedLocalRanks)) {
+            if (reason)
+                *reason = "unexpected number of shared-memory local ranks";
+            return false;
+        }
+        return true;
+    }
+
+    bool AllocSymPair(MultiSegmentVmmBuffer** src, MultiSegmentVmmBuffer** dst,
+                      int nSegments = kNumSegments,
+                      size_t segBytes = kSegRequestBytes)
+    {
+        *src = AllocSym(nSegments, segBytes);
+        *dst = AllocSym(nSegments, segBytes);
+        return !SyncSkip(*src == nullptr || *dst == nullptr);
+    }
+
+    bool MultiSegmentPathAvailable()
+    {
+        return !SyncSkip(!AllTookMultiSegPath());
+    }
+
+    void ExpectPayloadIsolated(const void* window, size_t totalSize,
+                               size_t offset, size_t size, int seed,
+                               uint8_t sentinel, const std::string& context)
+    {
+        SCOPED_TRACE(context);
+        const auto* bytes = static_cast<const uint8_t*>(window);
+        EXPECT_TRUE(VerifyBuf(bytes + offset, size, seed));
+        EXPECT_TRUE(AllSentinel(window, offset, sentinel));
+        EXPECT_TRUE(AllSentinel(bytes + offset + size,
+                                totalSize - offset - size, sentinel));
+    }
+
+    void RunIPutSizeSweep(MultiSegmentVmmBuffer* src,
+                          MultiSegmentVmmBuffer* dst,
+                          void* srcMh, void* dstMh, size_t offset,
+                          uint8_t seedBase, uint8_t sentinel)
+    {
+        const size_t total = src->totalSize;
+        const size_t seg = src->segSize;
+        const std::vector<size_t> sizes = EdgeCaseSizes(seg, total - offset);
+        for (size_t idx = 0; idx < sizes.size(); ++idx)
+        {
+            const size_t size = sizes[idx];
+            const uint8_t seed =
+                static_cast<uint8_t>(seedBase + (idx & 0x3F));
+            const std::string context =
+                "size=" + std::to_string(size) +
+                " offset=" + std::to_string(offset);
+            SCOPED_TRACE(context);
+
+            if (worldRank_ == 0 && size > 0)
+                FillBuf(static_cast<uint8_t*>(src->ptr) + offset, size, seed);
+            if (worldRank_ == 1)
+                FillSentinel(dst->ptr, total, sentinel);
+
+            Barrier();
+            if (worldRank_ == 0)
+            {
+                void* req = nullptr;
+                ASSERT_EQ(ncclSuccess,
+                          rma_->iput(rmaCtx_, 0, offset, srcMh, size,
+                                     offset, dstMh, 1, &req));
+                ASSERT_TRUE(PollUntilDone(req));
+            }
+            Barrier();
+
+            if (worldRank_ == 1)
+                ExpectPayloadIsolated(dst->ptr, total, offset, size,
+                                      seed, sentinel, context);
+            Barrier();
+        }
+    }
+
+    std::vector<std::unique_ptr<MultiSegmentVmmBuffer>> vmmBuffers_;
+    std::vector<std::unique_ptr<RCCLHybridVmmTests::HybridVmmBuffer>> hybridBuffers_;
+};
+
+// Reproducer (AIRUNTIME-2351): a multi-segment window must register per-segment
+// and move data correctly end to end. Flagship positive case.
+TEST_F(RmaMultiSegmentMPITest, Reproducer_MultiSegmentRegistrationAndTransfer)
+{
+    if (!SetUpFixture(/*minProcs=*/2, /*maxProcs=*/2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t kSize = sb->totalSize;
+
+    if (worldRank_ == 0)
+        FillBuf(sb->ptr, kSize, /*seed=*/0xA0);
+
+    void *sendMh = nullptr, *sendGh = nullptr, *recvMh = nullptr, *recvGh = nullptr;
+    EXPECT_EQ(ncclSuccess, RegMr(sb->ptr, kSize, &sendMh, &sendGh))
+        << "multi-segment send buffer registration failed (the AIRUNTIME-2351 bug)";
+    EXPECT_EQ(ncclSuccess, RegMr(rb->ptr, kSize, &recvMh, &recvGh))
+        << "multi-segment recv buffer registration failed (the AIRUNTIME-2351 bug)";
+
+    // Confirm the per-segment path fired; otherwise the feature isn't exercised.
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "Buffer registered as a single MR (cuMem disabled or "
+                        "range not segmented) - multi-segment path not exercised";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, /*context=*/0,
+                             /*srcOff=*/0, sendMh, kSize,
+                             /*dstOff=*/0, recvMh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+        EXPECT_TRUE(VerifyBuf(rb->ptr, kSize, /*seed=*/0xA0))
+            << "data corrupted across segment boundaries";
+}
+
+// IPut starting/ending mid-segment so the WR builder splits on a non-zero
+// per-segment offset on both sides (most prone to addr/lkey/rkey errors).
+TEST_F(RmaMultiSegmentMPITest, IPutCrossSegmentBoundaryAtOffset)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      segSize   = sb->segSize;
+    const size_t      off       = segSize / 2;              // start mid-first-segment
+    const size_t      kSize     = sb->totalSize - segSize;  // end mid-last-segment
+    constexpr uint8_t kSentinel = 0xCC;
+
+    if (worldRank_ == 0)
+        FillBuf(static_cast<uint8_t*>(sb->ptr) + off, kSize, /*seed=*/0x5A);
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, rb->totalSize, kSentinel);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, sb->totalSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, rb->totalSize, &recvMh, &recvGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, /*srcOff=*/off, sendMh, kSize,
+                             /*dstOff=*/off, recvMh, 1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        ExpectPayloadIsolated(rb->ptr, rb->totalSize, off, kSize,
+                              /*seed=*/0x5A, kSentinel,
+                              "IPut at offset " + std::to_string(off));
+    }
+}
+
+// IGet of a whole multi-segment remote buffer — read opcode through the split.
+TEST_F(RmaMultiSegmentMPITest, IGetMultiSegment)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer* bb = AllocSym(kNumSegments, kSegRequestBytes);
+
+    if (SyncSkip(bb == nullptr))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t kSize = bb->totalSize;
+    if (worldRank_ == 1)
+        FillBuf(bb->ptr, kSize, /*seed=*/0xC3);
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(bb->ptr, kSize, &mh, &gh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iget(rmaCtx_, 0, /*remoteOff=*/0, mh, kSize,
+                             /*localOff=*/0, mh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+        EXPECT_TRUE(VerifyBuf(bb->ptr, kSize, /*seed=*/0xC3))
+            << "iget data corrupted across segment boundaries";
+    }
+    Barrier();
+}
+
+// IGet starting/ending mid-segment so the read WR builder splits on a non-zero
+// per-segment offset on both the remote (source) and local (dest) sides. Mirrors
+// IPutCrossSegmentBoundaryAtOffset for the read opcode (only whole-buffer IGet
+// was covered before).
+TEST_F(RmaMultiSegmentMPITest, IGetCrossSegmentBoundaryAtOffset)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      segSize   = sb->segSize;
+    const size_t      off       = segSize / 2;              // start mid-first-segment
+    const size_t      kSize     = sb->totalSize - segSize;  // end mid-last-segment
+    constexpr uint8_t kSentinel = 0xD4;
+
+    if (worldRank_ == 1)
+        FillBuf(static_cast<uint8_t*>(sb->ptr) + off, kSize, /*seed=*/0x6E);
+    if (worldRank_ == 0)
+        FillSentinel(rb->ptr, rb->totalSize, kSentinel);
+
+    void *srcMh, *srcGh, *dstMh, *dstGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, sb->totalSize, &srcMh, &srcGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, rb->totalSize, &dstMh, &dstGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iget(rmaCtx_, 0, /*remoteOff=*/off, srcMh, kSize,
+                             /*localOff=*/off, dstMh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+
+        ExpectPayloadIsolated(rb->ptr, rb->totalSize, off, kSize,
+                              /*seed=*/0x6E, kSentinel,
+                              "IGet at offset " + std::to_string(off));
+    }
+    Barrier();
+}
+
+// DeepEP Engram pattern (DeepEP/csrc/kernels/backend/symmetric.hpp and
+// DeepEP/csrc/kernels/elastic/engram.hpp): one symmetric VMM window contains a
+// large GPU receive segment followed by an independently-sized CPU storage
+// segment. An IGet reads from a non-zero offset in the remote CPU segment into a
+// different non-zero offset in the local GPU segment. This specifically guards
+// independent local and remote registration-relative offset tracking.
+TEST_F(RmaMultiSegmentMPITest, DeepEP_EngramMixedWindowIGet)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    constexpr size_t kGpuBytes   = 4 * kMiB;
+    constexpr size_t kCpuBytes   = 2 * kMiB;
+    constexpr size_t kRemoteOff  = kGpuBytes + 4096;
+    constexpr size_t kLocalOff   = 64 * 1024;
+    constexpr size_t kPayload    = 128 * 1024;
+    constexpr uint8_t kSentinel  = 0xD7;
+
+    MultiSegmentVmmBuffer* window = AllocDeepEpElastic(kGpuBytes, kCpuBytes);
+    if (SyncSkip(window == nullptr))
+        GTEST_SKIP() << "DeepEP-style GPU+CPU VMM allocation unavailable on this runtime";
+
+    if (worldRank_ == 1)
+        FillBuf(static_cast<uint8_t*>(window->ptr) + kRemoteOff, kPayload, /*seed=*/0x4D);
+    if (worldRank_ == 0)
+        FillSentinel(window->ptr, kGpuBytes, kSentinel);
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(window->ptr, window->totalSize, &mh, &gh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "DeepEP window did not take the multi-segment RMA registration path";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iget(rmaCtx_, 0,
+                             /*remoteOff=*/kRemoteOff, mh, kPayload,
+                             /*localOff=*/kLocalOff, mh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+        ExpectPayloadIsolated(window->ptr, kGpuBytes, kLocalOff, kPayload,
+                              /*seed=*/0x4D, kSentinel,
+                              "DeepEP CPU-to-GPU IGet");
+    }
+    Barrier();
+}
+
+// Multi-node stress form of the DeepEP Engram fetch pattern. The registered
+// window is [GPU receive area][CPU Engram storage] at DeepEP's 2 MiB alignment.
+// Each IGet reads a changing non-zero remote CPU offset into an unrelated local
+// GPU offset, while sentinels ensure the GPU receive area is not over-written.
+TEST_F(RmaMultiSegmentMPITest, DeepEP_MultiNodeEngramMixedWindowIGetStress)
+{
+    if (!SetUpFixture(2, 2)) return;
+    if (MPIEnvironment::cached_multi_node_result != 1)
+        GTEST_SKIP() << "requires exactly one rank on each of two nodes";
+
+    constexpr size_t kGpuBytes  = 8 * kMiB;
+    constexpr size_t kCpuBytes  = 4 * kMiB;
+    constexpr int    kIterations = 32;
+    constexpr uint8_t kSentinel = 0xD9;
+    const std::vector<size_t> payloadSizes = {
+        size_t{1}, size_t{63}, size_t{4095}, size_t{4096},
+        size_t{65535}, size_t{65536}, size_t{131072}, size_t{262144}
+    };
+
+    MultiSegmentVmmBuffer* window = AllocDeepEpElastic(kGpuBytes, kCpuBytes);
+    if (SyncSkip(window == nullptr))
+        GTEST_SKIP() << "DeepEP-style GPU+CPU VMM allocation unavailable on this runtime";
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(window->ptr, window->totalSize, &mh, &gh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "DeepEP window did not take the multi-segment RMA registration path";
+
+    for (int i = 0; i < kIterations; ++i)
+    {
+        const size_t len = payloadSizes[static_cast<size_t>(i) % payloadSizes.size()];
+        const size_t remoteSpan = kCpuBytes - len - 4096;
+        const size_t localSpan = kGpuBytes - len - 65536;
+        const size_t remoteOff = kGpuBytes + 4096 +
+                                 (static_cast<size_t>(i) * 131071) % remoteSpan;
+        const size_t localOff = 65536 +
+                                (static_cast<size_t>(i) * 65537) % localSpan;
+        const uint8_t seed = static_cast<uint8_t>(0x40 + i);
+
+        if (worldRank_ == 1)
+            FillBuf(static_cast<uint8_t*>(window->ptr) + remoteOff, len, seed);
+        if (worldRank_ == 0)
+            FillSentinel(window->ptr, kGpuBytes, kSentinel);
+
+        Barrier();
+        if (worldRank_ == 0)
+        {
+            void* req = nullptr;
+            ASSERT_EQ(ncclSuccess,
+                      rma_->iget(rmaCtx_, 0, remoteOff, mh, len,
+                                 localOff, mh, /*peerRank=*/1, &req))
+                << "DeepEP Engram IGet post failed at iteration " << i;
+            ASSERT_TRUE(PollUntilDone(req))
+                << "DeepEP Engram IGet stalled at iteration " << i;
+            ExpectPayloadIsolated(window->ptr, kGpuBytes, localOff, len,
+                                  seed, kSentinel,
+                                  "DeepEP Engram iteration " + std::to_string(i));
+        }
+        Barrier();
+    }
+}
+
+// DeepEP HybridElasticSymmetricMemory:
+// [GPU][CPU local-rank 0][CPU local-rank 1]. Each process imports the same
+// local CPU handles before registration. Fetch from the matching CPU segment
+// on the other node into a non-zero local GPU offset.
+TEST_F(RmaMultiSegmentMPITest, DeepEP_HybridImportedCpuSegmentIGet)
+{
+    if (!SetUpFixture(/*minProcesses=*/4, /*maxProcesses=*/4,
+                      /*minNodes=*/2, /*maxNodes=*/2))
+        GTEST_SKIP() << "requires exactly 4 ranks across 2 nodes";
+
+    constexpr size_t kGpuBytes = 8 * kMiB;
+    constexpr size_t kCpuBytes = 2 * kMiB;
+    constexpr size_t kPayload = 128 * 1024;
+    constexpr size_t kLocalOff = 64 * 1024;
+    constexpr uint8_t kSentinel = 0xB7;
+
+    std::string reason;
+    RCCLHybridVmmTests::HybridVmmBuffer* window = nullptr;
+    if (!AllocHybridForLocalRanks(
+            kGpuBytes, kCpuBytes, /*expectedLocalRanks=*/2, &window, &reason))
+        GTEST_SKIP() << "DeepEP hybrid allocation unavailable: " << reason;
+
+    const size_t remoteOff = kGpuBytes + static_cast<size_t>(window->localRank) * kCpuBytes + 4096;
+    const int peer = MPIHelpers::findRemotePeerForLocalRank(window->localRank);
+    ASSERT_GE(peer, 0);
+
+    FillBuf(static_cast<uint8_t*>(window->ptr) + remoteOff, kPayload,
+            static_cast<uint8_t>(0x30 + worldRank_));
+    FillSentinel(window->ptr, kGpuBytes, kSentinel);
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(window->ptr, window->totalSize, &mh, &gh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "hybrid window did not take the multi-segment RMA path";
+
+    Barrier();
+    void* req = nullptr;
+    ASSERT_EQ(ncclSuccess,
+              rma_->iget(rmaCtx_, 0, remoteOff, mh, kPayload,
+                         kLocalOff, mh, peer, &req));
+    ASSERT_TRUE(PollUntilDone(req));
+    ExpectPayloadIsolated(window->ptr, kGpuBytes, kLocalOff, kPayload,
+                          static_cast<uint8_t>(0x30 + peer), kSentinel,
+                          "DeepEP hybrid imported CPU IGet");
+    Barrier();
+}
+
+// Multi-node hybrid stress: alternate the remote node's imported CPU-owner
+// segment while varying source/destination offsets and transfer sizes. This
+// exercises segment-window selection, shared-handle lifetime, and independent
+// local/remote cursors with sentinel protection.
+TEST_F(RmaMultiSegmentMPITest, DeepEP_HybridMultiNodeIGetStress)
+{
+    if (!SetUpFixture(/*minProcesses=*/4, /*maxProcesses=*/4,
+                      /*minNodes=*/2, /*maxNodes=*/2))
+        GTEST_SKIP() << "requires exactly 4 ranks across 2 nodes";
+
+    constexpr size_t kGpuBytes = 8 * kMiB;
+    constexpr size_t kCpuBytes = 2 * kMiB;
+    constexpr int kIterations = 32;
+    constexpr uint8_t kSentinel = 0xBC;
+    const std::vector<size_t> sizes = {
+        size_t{1}, size_t{63}, size_t{4095}, size_t{4096},
+        size_t{65535}, size_t{65536}, size_t{131072}, size_t{262144}
+    };
+
+    std::string reason;
+    RCCLHybridVmmTests::HybridVmmBuffer* window = nullptr;
+    if (!AllocHybridForLocalRanks(
+            kGpuBytes, kCpuBytes, /*expectedLocalRanks=*/2, &window, &reason))
+        GTEST_SKIP() << "DeepEP hybrid allocation unavailable: " << reason;
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(window->ptr, window->totalSize, &mh, &gh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "hybrid window did not take the multi-segment RMA path";
+
+    for (int i = 0; i < kIterations; ++i)
+    {
+        const size_t len = sizes[static_cast<size_t>(i) % sizes.size()];
+        const size_t sourceInnerOff = 4096 +
+            (static_cast<size_t>(i) * 131071) % (kCpuBytes - len - 4096);
+        const size_t ownCpuOff = kGpuBytes +
+            static_cast<size_t>(window->localRank) * kCpuBytes + sourceInnerOff;
+        const size_t localOff = 65536 +
+            (static_cast<size_t>(i) * 65537) % (kGpuBytes - len - 65536);
+        const uint8_t seed = static_cast<uint8_t>(0x40 + worldRank_ + i);
+
+        FillBuf(static_cast<uint8_t*>(window->ptr) + ownCpuOff, len, seed);
+        FillSentinel(window->ptr, kGpuBytes, kSentinel);
+        Barrier();
+
+        const int sourceLocalRank = (i + window->localRank) % window->localSize;
+        const int peer = MPIHelpers::findRemotePeerForLocalRank(sourceLocalRank);
+        ASSERT_GE(peer, 0);
+        const size_t remoteOff = kGpuBytes +
+            static_cast<size_t>(sourceLocalRank) * kCpuBytes + sourceInnerOff;
+
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iget(rmaCtx_, 0, remoteOff, mh, len,
+                             localOff, mh, peer, &req))
+            << "hybrid IGet post failed at iteration " << i;
+        ASSERT_TRUE(PollUntilDone(req))
+            << "hybrid IGet stalled at iteration " << i;
+        ExpectPayloadIsolated(window->ptr, kGpuBytes, localOff, len,
+                              static_cast<uint8_t>(0x40 + peer + i),
+                              kSentinel,
+                              "hybrid IGet iteration " + std::to_string(i));
+        Barrier();
+    }
+}
+
+// Negative hybrid range guard: an IGet that overruns the final imported CPU
+// segment must be rejected before posting and leave the GPU destination intact.
+TEST_F(RmaMultiSegmentMPITest, DeepEP_HybridOutOfRangeIGetRejected)
+{
+    if (!SetUpFixture(/*minProcesses=*/4, /*maxProcesses=*/4,
+                      /*minNodes=*/2, /*maxNodes=*/2))
+        GTEST_SKIP() << "requires exactly 4 ranks across 2 nodes";
+
+    constexpr size_t kGpuBytes = 8 * kMiB;
+    constexpr size_t kCpuBytes = 2 * kMiB;
+    constexpr uint8_t kSentinel = 0xC7;
+
+    std::string reason;
+    RCCLHybridVmmTests::HybridVmmBuffer* window = nullptr;
+    if (!AllocHybridForLocalRanks(
+            kGpuBytes, kCpuBytes, /*expectedLocalRanks=*/2, &window, &reason))
+        GTEST_SKIP() << "DeepEP hybrid allocation unavailable: " << reason;
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(window->ptr, window->totalSize, &mh, &gh));
+    FillSentinel(window->ptr, kGpuBytes, kSentinel);
+    Barrier();
+
+    const int peer = MPIHelpers::findRemotePeerForLocalRank(window->localRank);
+    ASSERT_GE(peer, 0);
+    void* req = nullptr;
+    EXPECT_EQ(ncclInvalidArgument,
+              rma_->iget(rmaCtx_, 0, window->totalSize - 32, mh, 64,
+                         /*localOff=*/0, mh, peer, &req));
+    EXPECT_EQ(req, nullptr);
+    EXPECT_TRUE(AllSentinel(window->ptr, kGpuBytes, kSentinel));
+    Barrier();
+}
+
+// Receiver-side flush over a multi-segment buffer: after a plain iput, rank 1
+// must fence EVERY physical segment via iflush (one loopback read per segment)
+// before reading. Exercises the multi-segment flush path; a segment-0-only
+// flush faults here on a multi-segment handle.
+TEST_F(RmaMultiSegmentMPITest, IFlushMultiSegment)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t kSize = sb->totalSize;
+    if (worldRank_ == 0)
+        FillBuf(sb->ptr, kSize, /*seed=*/0x3C);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, kSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, kSize, &recvMh, &recvGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, kSize, 0, recvMh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        void* freq = nullptr;
+        EXPECT_EQ(ncclSuccess, rma_->iflush(rmaCtx_, 0, recvMh, /*peerRank=*/0, &freq))
+            << "multi-segment iflush post failed";
+        EXPECT_TRUE(PollUntilDone(freq)) << "multi-segment flush did not complete";
+        EXPECT_TRUE(VerifyBuf(rb->ptr, kSize, /*seed=*/0x3C))
+            << "data corrupted across segment boundaries after flush";
+    }
+    Barrier();
+}
+
+// Flush after a PARTIAL, offset multi-segment iput: only a sub-range straddling
+// an interior boundary is written, then rank 1 flushes the whole handle. Since
+// iflush fences EVERY physical segment (no offset/size args), it must fence the
+// touched segments and leave the untouched sentinel bytes intact. Complements
+// IFlushMultiSegment (which flushes after a full-window iput).
+TEST_F(RmaMultiSegmentMPITest, IFlushAfterPartialMultiSegmentPut)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      segSize   = sb->segSize;
+    const size_t      off       = segSize / 2;              // start mid-first-segment
+    const size_t      kSize     = sb->totalSize - segSize;  // end mid-last-segment
+    constexpr uint8_t kSentinel = 0x71;
+
+    if (worldRank_ == 0)
+        FillBuf(static_cast<uint8_t*>(sb->ptr) + off, kSize, /*seed=*/0x4F);
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, rb->totalSize, kSentinel);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, sb->totalSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, rb->totalSize, &recvMh, &recvGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, /*srcOff=*/off, sendMh, kSize,
+                             /*dstOff=*/off, recvMh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        void* freq = nullptr;
+        EXPECT_EQ(ncclSuccess, rma_->iflush(rmaCtx_, 0, recvMh, /*peerRank=*/0, &freq))
+            << "multi-segment iflush post failed after partial put";
+        EXPECT_TRUE(PollUntilDone(freq)) << "multi-segment flush did not complete";
+
+        ExpectPayloadIsolated(rb->ptr, rb->totalSize, off, kSize,
+                              /*seed=*/0x4F, kSentinel,
+                              "partial IPut followed by flush");
+    }
+    Barrier();
+}
+
+// REGRESSION (flush fast path): iflush on an ordinary single-allocation buffer
+// must still fence and verify. IFlushMultiSegment only covers the multi-segment
+// handle and SingleSegmentRegression never flushes, so the nSeg==1 flush path --
+// which the multi-segment change must not regress -- is otherwise untested. No
+// AllTookMultiSegPath gate: a single-segment buffer intentionally does NOT take
+// the per-segment path.
+TEST_F(RmaMultiSegmentMPITest, IFlushSingleSegmentRegression)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    const size_t kSize = 1u << 20; // 1 MiB, plain hipMalloc => single segment
+    void* sendBuf = AllocBuf(kSize);
+    void* recvBuf = AllocBuf(kSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+
+    if (worldRank_ == 0)
+        FillBuf(sendBuf, kSize, /*seed=*/0x2D);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kSize, &recvMh, &recvGh));
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, kSize, 0, recvMh, /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        void* freq = nullptr;
+        EXPECT_EQ(ncclSuccess, rma_->iflush(rmaCtx_, 0, recvMh, /*peerRank=*/0, &freq))
+            << "single-segment iflush post failed";
+        EXPECT_TRUE(PollUntilDone(freq)) << "single-segment flush did not complete";
+        EXPECT_TRUE(VerifyBuf(recvBuf, kSize, /*seed=*/0x2D))
+            << "data corrupted after single-segment flush";
+    }
+    Barrier();
+}
+
+// IPutSignal over a multi-segment payload: data WRs split per segment, then a
+// chained signal WR. Verifies both payload and the atomic.
+TEST_F(RmaMultiSegmentMPITest, IPutSignalMultiSegment)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t kSize = sb->totalSize;
+
+    void* sigBuf = AllocBuf(kSignalSize);
+    ASSERT_NE(sigBuf, nullptr);
+
+    if (worldRank_ == 0)
+        FillBuf(sb->ptr, kSize, /*seed=*/0x55);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, kSize,       &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, kSize,       &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iputSignal(rmaCtx_, 0,
+                                   /*srcOff=*/0, sendMh, kSize,
+                                   /*dstOff=*/0, recvMh, /*peerRank=*/1,
+                                   /*signalOff=*/0, sigMh, /*signalValue=*/0,
+                                   NCCL_NET_SIGNAL_OP_INC, /*isStrongSignal=*/false, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        EXPECT_TRUE(VerifyBuf(rb->ptr, kSize, /*seed=*/0x55))
+            << "multi-segment iputSignal payload mismatch";
+        EXPECT_EQ(ReadSignal(sigBuf), 1u)
+            << "signal not delivered after multi-segment payload";
+    }
+}
+
+// Sweep IPut payloads from 0 to the full window across edge sizes (byte, word,
+// page, 64K, and segment boundaries). Verifies the payload landed and that no
+// byte past `size` was touched (catches over-write / boundary-split errors).
+TEST_F(RmaMultiSegmentMPITest, IPutSizeSweepFromZero)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    constexpr uint8_t kSentinel = 0xBD;
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, sb->totalSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, rb->totalSize, &recvMh, &recvGh));
+
+    if (!MultiSegmentPathAvailable())
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    RunIPutSizeSweep(sb, rb, sendMh, recvMh, /*offset=*/0,
+                     /*seedBase=*/0x40, kSentinel);
+}
+
+// Same sweep but starting at an offset that sits just inside the first segment,
+// so every transfer begins mid-segment and most cross >=1 boundary. Stresses
+// the non-zero per-segment offset arithmetic on both local and remote sides.
+TEST_F(RmaMultiSegmentMPITest, IPutSizeSweepAtBoundaryOffset)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t off = (sb->segSize >= 64) ? sb->segSize - 64 : 0;
+    constexpr uint8_t kSentinel = 0x9C;
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, sb->totalSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, rb->totalSize, &recvMh, &recvGh));
+
+    if (!MultiSegmentPathAvailable())
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    RunIPutSizeSweep(sb, rb, sendMh, recvMh, off,
+                     /*seedBase=*/0x80, kSentinel);
+}
+
+// NEGATIVE: a buffer spanning more than NCCL_RMA_MAX_SEGMENTS must be rejected
+// with ncclInvalidUsage (no truncation, no crash). Gated on the path being live.
+TEST_F(RmaMultiSegmentMPITest, RegisterExceedsMaxSegmentsRejected)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    // Confirm the per-segment path is live first, else the assertion is moot.
+    {
+        MultiSegmentVmmBuffer* probe = AllocSym(2, kSegRequestBytes);
+        if (SyncSkip(probe == nullptr))
+            GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+        void *pmh = nullptr, *pgh = nullptr;
+        EXPECT_EQ(ncclSuccess, RegMr(probe->ptr, probe->totalSize, &pmh, &pgh));
+        if (SyncSkip(!AllTookMultiSegPath()))
+            GTEST_SKIP() << "multi-segment path not exercised on this host";
+    }
+
+    const int kOverCap = kRmaMaxSegments + 1;
+    MultiSegmentVmmBuffer* big = AllocSym(kOverCap, kSegRequestBytes);
+    if (SyncSkip(big == nullptr))
+        GTEST_SKIP() << "Could not allocate " << kOverCap << " VMM segments";
+
+    void *mh = nullptr, *gh = nullptr;
+    ncclResult_t r = RegMr(big->ptr, big->totalSize, &mh, &gh);
+    EXPECT_EQ(r, ncclInvalidUsage)
+        << "registration of a " << kOverCap << "-segment buffer should be rejected "
+        << "with ncclInvalidUsage (cap=" << kRmaMaxSegments << "), got " << r;
+    EXPECT_EQ(mh, nullptr) << "no MR handle should be produced on rejection";
+}
+
+// REGRESSION: an ordinary single-allocation buffer must still register and
+// transfer via the nSeg==1 fast path.
+TEST_F(RmaMultiSegmentMPITest, SingleSegmentRegression)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    const size_t kSize = 1u << 20; // 1 MiB, plain hipMalloc => single segment
+
+    void* sendBuf = AllocBuf(kSize);
+    void* recvBuf = AllocBuf(kSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+
+    if (worldRank_ == 0)
+        FillBuf(sendBuf, kSize, /*seed=*/0x77);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kSize, &recvMh, &recvGh));
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, kSize, 0, recvMh, 1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+        EXPECT_TRUE(VerifyBuf(recvBuf, kSize, /*seed=*/0x77));
+}
+
+// NEGATIVE (cross-rank symmetry guard): ranks register windows with different
+// physical segment counts; the backend must reject collectively with
+// ncclInternalError instead of running the mismatched-stride all-gather.
+TEST_F(RmaMultiSegmentMPITest, RegisterAsymmetricSegmentCountRejected)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    // Distinct counts per rank (2 vs 8) so enumeration is very unlikely to agree.
+    const int myNSeg = (worldRank_ == 0) ? 2 : 8;
+    MultiSegmentVmmBuffer* bb = AllocSym(myNSeg, kSegRequestBytes);
+    if (SyncSkip(bb == nullptr))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    void *mh = nullptr, *gh = nullptr;
+    ncclResult_t r = RegMr(bb->ptr, bb->totalSize, &mh, &gh);
+
+    // Both ranks must have taken the per-segment path, else there is nothing to test.
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    // If enumeration happened to return identical counts there is no asymmetry
+    // to reject (registration succeeds on both ranks); skip rather than misfire.
+    if (SyncSkip(r == ncclSuccess))
+        GTEST_SKIP() << "ranks enumerated identical segment counts; no asymmetry";
+
+    EXPECT_EQ(r, ncclInternalError)
+        << "asymmetric per-rank segment count must be rejected (rank " << worldRank_
+        << " requested " << myNSeg << " segments)";
+    EXPECT_EQ(mh, nullptr) << "no MR handle should be produced on rejection";
+}
+
+// NEGATIVE (range guard): out-of-range IPut offsets/sizes must be rejected with
+// ncclInvalidArgument and must NOT post anything (recv stays untouched).
+TEST_F(RmaMultiSegmentMPITest, IPutOutOfRangeRejectedNoCorruption)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      total     = sb->totalSize;
+    constexpr uint8_t kSentinel = 0xE7;
+
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, total, kSentinel);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, total, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, total, &recvMh, &recvGh));
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        // size exactly one byte past the window.
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, total + 1, 0, recvMh, 1, &req))
+            << "oversized transfer must be rejected";
+        // valid size but srcOff pushes the source past the end.
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iput(rmaCtx_, 0, /*srcOff=*/1, sendMh, total, 0, recvMh, 1, &req))
+            << "src offset overrun must be rejected";
+        // valid size but dstOff pushes the destination past the end.
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, total, /*dstOff=*/1, recvMh, 1, &req))
+            << "dst offset overrun must be rejected";
+        EXPECT_EQ(req, nullptr) << "rejected iput must not produce a request";
+    }
+    Barrier();
+
+    // Nothing was posted, so the receiver's window must be byte-for-byte intact.
+    if (worldRank_ == 1)
+        EXPECT_TRUE(AllSentinel(rb->ptr, total, kSentinel))
+            << "rejected iput corrupted the destination window";
+}
+
+// NEGATIVE (range guard): out-of-range IGet offsets/sizes must be rejected.
+TEST_F(RmaMultiSegmentMPITest, IGetOutOfRangeRejected)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer* bb = AllocSym(kNumSegments, kSegRequestBytes);
+    if (SyncSkip(bb == nullptr))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t total = bb->totalSize;
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(bb->ptr, total, &mh, &gh));
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iget(rmaCtx_, 0, /*remoteOff=*/0, mh, total + 1, 0, mh, 1, &req))
+            << "oversized iget must be rejected";
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iget(rmaCtx_, 0, /*remoteOff=*/1, mh, total, 0, mh, 1, &req))
+            << "remote offset overrun must be rejected";
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iget(rmaCtx_, 0, 0, mh, total, /*localOff=*/1, mh, 1, &req))
+            << "local offset overrun must be rejected";
+        EXPECT_EQ(req, nullptr) << "rejected iget must not produce a request";
+    }
+    Barrier();
+}
+
+// NEGATIVE (range guard): IPutSignal must reject both an out-of-range payload
+// and an out-of-range signal offset (the 8-byte atomic) without posting.
+TEST_F(RmaMultiSegmentMPITest, IPutSignalOutOfRangeRejectedNoCorruption)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      total     = sb->totalSize;
+    constexpr uint8_t kSentinel = 0x3B;
+
+    void* sigBuf = AllocBuf(kSignalSize);
+    ASSERT_NE(sigBuf, nullptr);
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, total, kSentinel);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, total,        &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, total,        &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize,  &sigMh,  &sigGh));
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        // Payload past the window (valid signal offset).
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iputSignal(rmaCtx_, 0, 0, sendMh, total + 1, 0, recvMh, 1,
+                                   /*signalOff=*/0, sigMh, 0, NCCL_NET_SIGNAL_OP_INC,
+                                   /*isStrongSignal=*/false, &req))
+            << "oversized iputSignal payload must be rejected";
+        // Signal atomic straddles the end of the signal window (signalOff+8 > size).
+        EXPECT_EQ(ncclInvalidArgument,
+                  rma_->iputSignal(rmaCtx_, 0, 0, sendMh, total, 0, recvMh, 1,
+                                   /*signalOff=*/kSignalSize - 4, sigMh, 0,
+                                   NCCL_NET_SIGNAL_OP_INC, /*isStrongSignal=*/false, &req))
+            << "out-of-range signal offset must be rejected";
+        EXPECT_EQ(req, nullptr) << "rejected iputSignal must not produce a request";
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+    {
+        EXPECT_TRUE(AllSentinel(rb->ptr, total, kSentinel))
+            << "rejected iputSignal corrupted the destination window";
+        EXPECT_EQ(ReadSignal(sigBuf), 0u)
+            << "rejected iputSignal must not deliver the signal";
+    }
+}
+
+// SCALE/CORRUPTION variation: exercise EVERY internal segment boundary of a
+// wide (many-segment) window. For each boundary, transfer a chunk that straddles
+// it and verify the payload landed exactly and no neighbouring byte was touched.
+TEST_F(RmaMultiSegmentMPITest, BoundaryStressNoCorruption)
+{
+    if (!SetUpFixture(2, 2)) return;
+
+    constexpr int     kWideSegments = 8; // more boundaries == closer to "at scale"
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb, kWideSegments))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t      total     = sb->totalSize;
+    const size_t      seg       = sb->segSize;
+    const int         nSeg      = sb->nSegments;
+    constexpr uint8_t kSentinel = 0x6F;
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, total, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, total, &recvMh, &recvGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    // Straddle each interior boundary k*seg with a chunk that lands in both the
+    // preceding and following segment, so a WR split happens at every boundary.
+    const size_t kHalf = (seg >= 256) ? 128 : seg / 2;
+    for (int k = 1; k < nSeg; ++k)
+    {
+        const size_t off  = k * seg - kHalf;
+        const size_t len  = 2 * kHalf;
+        const uint8_t seed = static_cast<uint8_t>(0x10 + k);
+
+        if (worldRank_ == 0)
+            FillBuf(static_cast<uint8_t*>(sb->ptr) + off, len, seed);
+        if (worldRank_ == 1)
+            FillSentinel(rb->ptr, total, kSentinel);
+
+        Barrier();
+        if (worldRank_ == 0)
+        {
+            void* req = nullptr;
+            ASSERT_EQ(ncclSuccess,
+                      rma_->iput(rmaCtx_, 0, off, sendMh, len, off, recvMh, 1, &req))
+                << "iput failed straddling boundary " << k;
+            ASSERT_TRUE(PollUntilDone(req)) << "iput stalled at boundary " << k;
+        }
+        Barrier();
+
+        if (worldRank_ == 1)
+        {
+            ExpectPayloadIsolated(rb->ptr, total, off, len, seed, kSentinel,
+                                  "boundary " + std::to_string(k));
+        }
+        Barrier();
+    }
+
+    // Full-window transfer across all boundaries at once.
+    if (worldRank_ == 0)
+        FillBuf(sb->ptr, total, /*seed=*/0xAB);
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, total, kSentinel);
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, 0, sendMh, total, 0, recvMh, 1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+        EXPECT_TRUE(VerifyBuf(rb->ptr, total, /*seed=*/0xAB))
+            << "full multi-segment window transfer corrupted data";
+}
+
+// MULTI-NODE IGET STRESS: DeepEP-style operations use independent remote and
+// local offsets. Repeatedly cross a different physical boundary on each side,
+// exercising remote rkey and local lkey selection while sentinels detect writes
+// outside the requested destination range.
+TEST_F(RmaMultiSegmentMPITest, MultiNodeAsymmetricIGetBoundaryStress)
+{
+    if (!SetUpFixture(2, 2)) return;
+    if (MPIEnvironment::cached_multi_node_result != 1)
+        GTEST_SKIP() << "requires exactly one rank on each of two nodes";
+
+    constexpr int kWideSegments = 8;
+    constexpr int kIterations   = 32;
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb, kWideSegments))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t total = sb->totalSize;
+    const size_t seg = sb->segSize;
+    constexpr uint8_t kSentinel = 0xA7;
+    const std::vector<size_t> edgeWidths = {
+        size_t{1}, size_t{63}, size_t{4095}, size_t{65535}, size_t{131071}
+    };
+
+    void *srcMh, *srcGh, *dstMh, *dstGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sb->ptr, total, &srcMh, &srcGh));
+    ASSERT_EQ(ncclSuccess, RegMr(rb->ptr, total, &dstMh, &dstGh));
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    for (int i = 0; i < kIterations; ++i)
+    {
+        const int remoteBoundary = 1 + (i % (kWideSegments - 1));
+        const int localBoundary = 1 + ((i * 3 + 2) % (kWideSegments - 1));
+        const size_t left = edgeWidths[static_cast<size_t>(i) % edgeWidths.size()];
+        const size_t right = edgeWidths[static_cast<size_t>(i + 3) % edgeWidths.size()];
+        const size_t remoteOff = static_cast<size_t>(remoteBoundary) * seg - left;
+        const size_t localOff = static_cast<size_t>(localBoundary) * seg - left;
+        const size_t len = left + right;
+        const uint8_t seed = static_cast<uint8_t>(0x30 + i);
+
+        if (worldRank_ == 1)
+            FillBuf(static_cast<uint8_t*>(sb->ptr) + remoteOff, len, seed);
+        if (worldRank_ == 0)
+            FillSentinel(rb->ptr, total, kSentinel);
+
+        Barrier();
+        if (worldRank_ == 0)
+        {
+            void* req = nullptr;
+            ASSERT_EQ(ncclSuccess,
+                      rma_->iget(rmaCtx_, 0, remoteOff, srcMh, len,
+                                 localOff, dstMh, /*peerRank=*/1, &req))
+                << "iget post failed at iteration " << i;
+            ASSERT_TRUE(PollUntilDone(req)) << "iget stalled at iteration " << i;
+            ExpectPayloadIsolated(rb->ptr, total, localOff, len, seed,
+                                  kSentinel,
+                                  "asymmetric IGet iteration " + std::to_string(i));
+        }
+        Barrier();
+    }
+}
+
+} // namespace RCCLRmaTests
+
+#else // !RCCL_HAS_RMA_IB_PROXY
+
+#include <gtest/gtest.h>
+
+TEST(RmaMultiSegmentMPITest, BuildSkipped)
+{
+    GTEST_SKIP() << "IB RMA proxy backend not built into this binary. Skipping multi-segment RMA tests...";
+}
+
+#endif // RCCL_HAS_RMA_IB_PROXY
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/RmaMPI/RmaMultiSegmentMPITests.cpp
@@ -300,6 +300,55 @@ TEST_F(RmaMultiSegmentMPITest, Reproducer_MultiSegmentRegistrationAndTransfer)
             << "data corrupted across segment boundaries";
 }
 
+// Register two complete physical mappings plus half of a third. The final MR
+// must be clipped to the requested range, while a transfer ending at the last
+// registered byte succeeds without touching the mapped-but-unregistered tail.
+TEST_F(RmaMultiSegmentMPITest, PartialFinalSegmentRegistrationAndTransfer)
+{
+    if (!SetUpFixture(/*minProcs=*/2, /*maxProcs=*/2)) return;
+
+    MultiSegmentVmmBuffer *sb = nullptr, *rb = nullptr;
+    if (!AllocSymPair(&sb, &rb, /*nSegments=*/3))
+        GTEST_SKIP() << "Multi-segment VMM allocation unavailable on this host";
+
+    const size_t registeredBytes = 2 * sb->segSize + sb->segSize / 2;
+    const size_t transferOffset  = 2 * sb->segSize - 4096;
+    const size_t transferBytes   = registeredBytes - transferOffset;
+    constexpr uint8_t kSentinel  = 0xB7;
+
+    if (worldRank_ == 0)
+        FillBuf(static_cast<uint8_t*>(sb->ptr) + transferOffset,
+                transferBytes, /*seed=*/0x71);
+    if (worldRank_ == 1)
+        FillSentinel(rb->ptr, rb->totalSize, kSentinel);
+
+    void *sendMh = nullptr, *sendGh = nullptr;
+    void *recvMh = nullptr, *recvGh = nullptr;
+    ASSERT_EQ(ncclSuccess,
+              RegMr(sb->ptr, registeredBytes, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess,
+              RegMr(rb->ptr, registeredBytes, &recvMh, &recvGh));
+
+    if (SyncSkip(!AllTookMultiSegPath()))
+        GTEST_SKIP() << "multi-segment path not exercised on this host";
+
+    Barrier();
+    if (worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  rma_->iput(rmaCtx_, 0, transferOffset, sendMh, transferBytes,
+                             transferOffset, recvMh, 1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if (worldRank_ == 1)
+        ExpectPayloadIsolated(rb->ptr, rb->totalSize, transferOffset,
+                              transferBytes, /*seed=*/0x71, kSentinel,
+                              "partial final physical segment");
+}
+
 // IPut starting/ending mid-segment so the WR builder splits on a non-zero
 // per-segment offset on both sides (most prone to addr/lkey/rkey errors).
 TEST_F(RmaMultiSegmentMPITest, IPutCrossSegmentBoundaryAtOffset)


### PR DESCRIPTION
## Motivation

HIP DMA-BUF export describes only the first physical segment of a multi-segment VMM range. GIN/RMA registered that range as one MR, so IGet/IPut crossing a segment boundary failed and could leave the QP fatal.

## Technical Details

- One DMA-BUF MR per physical segment (cap 16); fail path deregisters partial registrations.
- Hybrid elastic windows require `NCCL_ELASTIC_BUFFER_REGISTER=1` and `NCCL_SYM_REUSE_SYSMEM_HANDLES=1`.
- Segmented WR builder splits IGet/IPut/IPutSignal at segment bounds; IFlush walks every segment.
- Cross-rank guard: all ranks must register the same segment count.
- GIN-enabled test targets inherit the resolved rocSHMEM source/install paths, depend on the external rocSHMEM build, and declare its static-library byproduct so both Make and Ninja builds order compilation correctly.
- The rocSHMEM ExternalProject receives RCCL's selected `ROCM_PATH` and builds outside the source checkout to prevent stale compiler caches from mixing incompatible ROCm/LLVM toolchains.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- `RmaMultiSegmentMPITests.cpp` (boundary, flush, exceed-cap reject, asymmetric count reject, DeepEP mixed window, clipped final physical segment).
- Single- and multi-node, gfx942/gfx950 as available.

## Test Result

- The selected two-node RMA tests passed 3/3 on ROCm 7.14, including the partial-final-segment case and verification that the unregistered tail was unchanged.
- With `ENABLE_ROCSHMEM_GIN=ON` and host-proxy GIN (`GIN_TYPE=2`) on ROCm 7.0.2.2, all 24 focused RMA tests passed: 21 with two ranks and the three hybrid cases with four ranks. No RMA/runtime compatibility backport is required for ROCm 7.0.2.2 beyond the build-integration fixes in this PR.
- On ROCm 10.1, the 21 two-rank tests passed. The three four-rank hybrid tests skipped collectively because imported host VMM CPU access is unsupported (ROCM-29812). This validation used `ENABLE_ROCSHMEM_GIN=ON` with the optional GDA/SDMA device templates compile-gated off; LLVM 23 otherwise fails to resolve their hidden device symbols from `librocshmem.a`. Host-proxy `GIN_TYPE=2`, the backend under test, remained enabled.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.