### PR TITLE
Count full registered VA range for NET DMA-BUF segmentation

### DIFF
--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2301,8 +2301,8 @@ static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size
             regRecord->netHandleHead = netHandle;
             outHandle[p] = handle;
             *outRegBufFlag = 1;
-            INFO(NCCL_REG, "rank %d - NET register userbuff %p (handle %p), buffSize %ld", comm->rank, userbuff, handle,
-                 buffSize);
+            INFO(NCCL_REG, "rank %d - NET register userbuff %p (handle %p), buffSize %ld numSegments %d", comm->rank,
+                 userbuff, handle, buffSize, numSegments);
           } else {
             goto fail;
           }

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2338,7 +2338,11 @@ ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, si
     NCCLCHECKGOTO(ncclRegLocalIsValid(regRecord, &isValid), ret, fail);
     if (isValid) {
       int numSegments = 0;
-      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)userbuff, buffSize, (CUdeviceptr*)&base, &baseSize,
+      // The proxy registers the complete user registration, not just the
+      // collective's current send/receive subrange. Count segments over that
+      // same range so multi-segment registration cannot stop after a partial prefix.
+      size_t regSize = regRecord->endAddr - regRecord->begAddr;
+      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)regRecord->begAddr, regSize, (CUdeviceptr*)&base, &baseSize,
                                          &numSegments));
       if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
       NCCLCHECKGOTO(netRegisterBuffer(comm, userbuff, buffSize, peerConns, nPeers, regRecord, outRegBufFlag, outHandle,

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -1043,17 +1043,19 @@ protected:
  *
  * The collective operates on four segments per half, while ncclCommRegister
  * covers the complete eight-segment allocation. NET registration must count
- * that full range (numSegments 8). Intra-node IPC may still log the four-segment
- * operation half.
+ * that full range (numSegments 8). This regression requires multiple nodes so
+ * an IPC-only registration cannot satisfy the assertion.
  *
  * Confirmation in the logs (NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=REG):
  *   NET: "... numSegments 8"
- *   IPC: "... numSegments 4"
  */
 TEST_F(UBR_MultiSegment, Generic)
 {
-    if (!validateTestPrerequisites(/*min_processes=*/2)) {
-        GTEST_SKIP() << "Requires 2+ ranks";
+    if (!validateTestPrerequisites(
+            /*min_processes=*/2, /*max_processes=*/kNoProcessLimit,
+            /*require_power_of_two=*/kNoPowerOfTwoRequired,
+            /*min_nodes=*/2, /*max_nodes=*/kNoNodeLimit)) {
+        GTEST_SKIP() << "Requires 2+ ranks across at least 2 nodes";
     }
     ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
 
@@ -1108,11 +1110,9 @@ TEST_F(UBR_MultiSegment, Generic)
     REGLogChecker checker = getLogChecker();
     TEST_INFO("SpansMultipleSegments: %s (log size: %zu bytes)",
               checker.getSummary().c_str(), checker.getContentLength());
-    ASSERT_TRUE(checker.hasNumSegments(kNumSegments) ||
-                checker.hasNumSegments(kNumSegments / 2))
+    ASSERT_TRUE(checker.hasNumSegments(kNumSegments))
         << "Expected NET 'numSegments " << kNumSegments
-        << "' for the complete ncclCommRegister range, or IPC 'numSegments "
-        << (kNumSegments / 2) << "' for the operation half";
+        << "' for the complete ncclCommRegister range";
 }
 
 /**

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -1041,8 +1041,14 @@ protected:
  *   sendbuff = [0,                  N * kSegmentSize)  covers first N segments
  *   recvbuff = [N * kSegmentSize,  2N * kSegmentSize)  covers last  N segments
  *
- * Confirmation in the logs (NCCL_DEBUG=TRACE NCCL_DEBUG_SUBSYS=REG):
- *   "... numSegments 4"
+ * The collective operates on four segments per half, while ncclCommRegister
+ * covers the complete eight-segment allocation. NET registration must count
+ * that full range (numSegments 8). Intra-node IPC may still log the four-segment
+ * operation half.
+ *
+ * Confirmation in the logs (NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=REG):
+ *   NET: "... numSegments 8"
+ *   IPC: "... numSegments 4"
  */
 TEST_F(UBR_MultiSegment, Generic)
 {
@@ -1102,9 +1108,11 @@ TEST_F(UBR_MultiSegment, Generic)
     REGLogChecker checker = getLogChecker();
     TEST_INFO("SpansMultipleSegments: %s (log size: %zu bytes)",
               checker.getSummary().c_str(), checker.getContentLength());
-    ASSERT_TRUE(checker.hasNumSegments(kNumSegments / 2))
-        << "Expected 'numSegments " << (kNumSegments / 2)
-        << "' in log - the multi-segment registration branch did not fire";
+    ASSERT_TRUE(checker.hasNumSegments(kNumSegments) ||
+                checker.hasNumSegments(kNumSegments / 2))
+        << "Expected NET 'numSegments " << kNumSegments
+        << "' for the complete ncclCommRegister range, or IPC 'numSegments "
+        << (kNumSegments / 2) << "' for the operation half";
 }
 
 /**


### PR DESCRIPTION
## Motivation

NET registration counted physical DMA-BUF segments over the collective's subrange, not the range passed to `ncclCommRegister`. Multi-segment windows could register as a single MR; transfers crossing a segment boundary failed.

## Technical Details

`net.cc` now calls `ncclCuMemGetAddressRange` over the full registered VA range so NET allocates one MR per physical segment.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- `UBR_MultiSegment.Generic` log-check that DMA-BUF MR count matches the full registered range.

## Test Result

- ROCm 10.1: `UBR_MultiSegment.Generic` passed 1/1 and confirmed that a 256 MiB registered range produced eight DMA-BUF MRs.
- The 256 MiB size is the test geometry, not a product limit: the allocation contains eight 32 MiB physical segments, while the collective operates on one 128 MiB half spanning four segments.
- The check verifies that NET registers all eight segments in the complete range passed to `ncclCommRegister`, rather than only the collective subrange.
- ROCm 7.0.2.2: the same test passed after applying the temporary `legacyCapIpc=0` compatibility workaround described in PR 1. This workaround is required until HIP support for `HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE` is backported to ROCm 7.0.2.2 under [ROCM-2593](https://amd-hub.atlassian.net/browse/AIRUNTIME-2593). No implementation failure remains.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.

[ROCM-2593]: https://amd-hub-sandbox-20240925.atlassian.net/browse/ROCM-2593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ