### PR TITLE
Classic NET/IB multi-segment GPUDirect RDMA

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Compatibility with NCCL 2.30.7.
 * Added scalable AllGatherV pattern: grouped `ncclBroadcast` calls with distinct roots are fused into a single ring kernel, improving performance at large scale. Gated by `NCCL_ALLGATHERV_ENABLE` (default off).
 * Added multi-node multi-segment symmetric-window registration and transfers for the InfiniBand GIN proxy/RMA path. Contiguous virtual ranges backed by multiple GPU or mixed GPU/host physical allocations are exported and registered per segment for GIN `iput`, `iget`, `iputSignal`, and `iflush`.
+* Added multi-segment DMA-BUF registration and transfer splitting to the classic NET/IB P2P path while preserving compatibility with legacy single-segment peers.
 * Added Elastic Buffer support for symmetric windows spanning device and host/`HOST_NUMA` memory segments (`NCCL_ELASTIC_BUFFER_REGISTER`, `NCCL_SYM_REUSE_SYSMEM_HANDLES`).
 
 ### Changed
@@ -22,7 +23,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Known issues
 * The improved AllGatherV support breaks the NCCL profiler support for ncclBroadcast operations, limiting visibility to API events. `NCCL_ALLGATHERV_ENABLE=0` can be used as a workaround until it is fixed in a future release.
-* Multi-segment InfiniBand registration is limited to the GIN proxy/RMA path; classic NET/IB P2P and CAST do not yet consume these per-segment handles.
+* Multi-segment InfiniBand registration is not yet supported by CAST.
 
 ## RCCL 2.30.4 for ROCm 7.14.0
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -478,6 +478,7 @@ set(SRC_FILES
   transport/net_ib/gin.h
   transport/net_ib/init.cc
   transport/net_ib/net_ib_flush_fault_inject.h
+  transport/net_ib/multiseg.h
   transport/net_ib/p2p.cc
   transport/net_ib/p2p.h
   transport/net_ib/p2p_resiliency.cc

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -468,6 +468,7 @@ set(SRC_FILES
   transport/coll_net.cc
   transport/generic.cc
   transport/net.cc
+  transport/rccl_ib_multiseg.h
   transport/net_ib_limits.h
   transport/net_ib/common.cc
   transport/net_ib/common.h

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -668,7 +668,7 @@ add_dependencies(copy_nccl_device_headers hipify_all)
 # when compiling files in hipify/src/transport/net_ib/.
 set(NET_IB_HIPIFY_DIR "${HIPIFY_DIR}/src/transport/net_ib")
 set(NET_IB_HEADER_SYMLINKS "")
-foreach(_hdr common gin p2p)
+foreach(_hdr common gin p2p multiseg)
   add_custom_command(
     OUTPUT  "${NET_IB_HIPIFY_DIR}/${_hdr}.h"
     DEPENDS "${NET_IB_HIPIFY_DIR}/${_hdr}_tmp.h"

--- a/projects/rccl/src/include/net.h
+++ b/projects/rccl/src/include/net.h
@@ -31,12 +31,6 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
-// Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
-// segment for the classic NET/IB transport (AIRUNTIME-2351 classic-path
-// follow-up). Only valid when the active net plugin is ncclNetIb.
-ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
-                                       int* segFds, int type, void** mhandle);
-
 extern ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p);
 extern int64_t ncclParamDmaBufEnable();
 

--- a/projects/rccl/src/include/net.h
+++ b/projects/rccl/src/include/net.h
@@ -34,8 +34,8 @@ extern ncclNet_t ncclNetSocket;
 // Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
 // segment for the classic NET/IB transport (AIRUNTIME-2351 classic-path
 // follow-up). Only valid when the active net plugin is ncclNetIb.
-ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
-                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle);
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle);
 
 extern ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p);
 extern int64_t ncclParamDmaBufEnable();

--- a/projects/rccl/src/include/net.h
+++ b/projects/rccl/src/include/net.h
@@ -31,6 +31,12 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
+// Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
+// segment for the classic NET/IB transport (AIRUNTIME-2351 classic-path
+// follow-up). Only valid when the active net plugin is ncclNetIb.
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
+                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle);
+
 extern ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p);
 extern int64_t ncclParamDmaBufEnable();
 

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2422,15 +2422,18 @@ fail:
 // declines registration, so the collective falls back to staging buffers
 // instead of the fatal QP path.
 #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
-static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* netComm, void* buffer,
-                                       size_t totalSize, int numSegments, ncclTopoGdrMode useGdr, void** handle) {
+static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* netComm, void* buffer, size_t totalSize,
+                                       int numSegments, ncclTopoGdrMode useGdr, void** handle) {
   ncclResult_t ret = ncclSuccess;
-  void** segAddrs = NULL; size_t* segLens = NULL; uint64_t* segOffsets = NULL; int* segFds = NULL;
+  void** segAddrs = NULL;
+  size_t* segLens = NULL;
+  uint64_t* segOffsets = NULL;
+  int* segFds = NULL;
   int nSeg = 0;
   size_t remaining = totalSize;
 
   if (proxyState->ncclNet != &ncclNetIb) {
-    INFO(NCCL_NET|NCCL_REG, "Multi-segment (%d) NET registration only supported on the IB transport", numSegments);
+    INFO(NCCL_NET | NCCL_REG, "Multi-segment (%d) NET registration only supported on the IB transport", numSegments);
     return ncclInvalidUsage;
   }
   NCCLCHECKGOTO(ncclCalloc(&segAddrs, numSegments), ret, fail);
@@ -2442,16 +2445,24 @@ static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* 
   {
     uintptr_t segPtr = (uintptr_t)buffer;
     for (int s = 0; s < numSegments && remaining > 0; s++) {
-      CUdeviceptr segBase = 0; size_t segSize = 0;
+      CUdeviceptr segBase = 0;
+      size_t segSize = 0;
       CUCHECKGOTO(cuMemGetAddressRange(&segBase, &segSize, (CUdeviceptr)segPtr), ret, fail);
       size_t inSeg = segSize - (segPtr - (uintptr_t)segBase);
       size_t thisLen = remaining < inSeg ? remaining : inSeg;
       int fd = -1;
       // Export this segment alone: one physical allocation, so its fd is complete.
       CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&fd, (CUdeviceptr)segPtr, thisLen,
-                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(useGdr)), ret, fail);
-      segAddrs[s] = (void*)segPtr; segLens[s] = thisLen; segOffsets[s] = 0ULL; segFds[s] = fd;
-      segPtr += thisLen; remaining -= thisLen; nSeg++;
+                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                                getHandleForAddressRangeFlags(useGdr)),
+                  ret, fail);
+      segAddrs[s] = (void*)segPtr;
+      segLens[s] = thisLen;
+      segOffsets[s] = 0ULL;
+      segFds[s] = fd;
+      segPtr += thisLen;
+      remaining -= thisLen;
+      nSeg++;
     }
   }
 
@@ -2459,8 +2470,8 @@ static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* 
   // the CTS path would otherwise advertise addresses beyond the final MR with
   // that MR's rkey, causing IBV_WC_REM_ACCESS_ERR on the remote write.
   if (remaining != 0 || nSeg != numSegments) {
-    WARN("NET/IB: enumerated %d/%d segments for buffer %p but %zu/%zu bytes remain unregistered",
-         nSeg, numSegments, buffer, remaining, totalSize);
+    WARN("NET/IB: enumerated %d/%d segments for buffer %p but %zu/%zu bytes remain unregistered", nSeg, numSegments,
+         buffer, remaining, totalSize);
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -2468,20 +2479,30 @@ static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* 
   // Uniform-segment guard: interior segments must be equal; the trailing segment
   // may be smaller. Otherwise boundaries are irregular and a step could straddle
   // (matches ncclIbSegmentsUniform in net_ib/multiseg.h). Non-uniform layouts
-  // decline registration and fall back to staging buffers.
+  // such as DeepEP [GPU][CPU] (unequal sizes) decline here so the collective
+  // falls back to staging; GIN/RMA is the path that registers those windows.
   for (int s = 1; s < nSeg; s++) {
     bool last = (s == nSeg - 1);
     if ((!last && segLens[s] != segLens[0]) || (last && segLens[s] > segLens[0])) {
-      INFO(NCCL_NET|NCCL_REG, "Buffer %p (size %zu) has non-uniform segments; declining NET user-buffer registration (staging fallback)", buffer, totalSize);
-      ret = ncclInvalidUsage; goto fail;
+      INFO(NCCL_NET | NCCL_REG,
+           "Buffer %p (size %zu) has non-uniform segments; declining NET user-buffer registration (staging fallback)",
+           buffer, totalSize);
+      ret = ncclInvalidUsage;
+      goto fail;
     }
   }
 
-  NCCLCHECKGOTO(ncclIbRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle), ret, fail);
+  NCCLCHECKGOTO(ncclIbRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle),
+                ret, fail);
 
 fail:
-  if (segFds) for (int s = 0; s < numSegments; s++) if (segFds[s] != -1) (void)close(segFds[s]);
-  free(segAddrs); free(segLens); free(segOffsets); free(segFds);
+  if (segFds)
+    for (int s = 0; s < numSegments; s++)
+      if (segFds[s] != -1) (void)close(segFds[s]);
+  free(segAddrs);
+  free(segLens);
+  free(segOffsets);
+  free(segFds);
   return ret;
 }
 #endif
@@ -2507,7 +2528,8 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
       // Multi-segment cuMem/VMM buffer: register one MR per physical segment.
       // On failure the buffer is left unregistered (needReg stays true) and the
       // caller declines, falling back to staging buffers.
-      if (netIbRegMrMultiSeg(proxyState, resources->netSendComm, (void*)info->buffer, info->size, numSegments, resources->useGdr, &handle) == ncclSuccess) {
+      if (netIbRegMrMultiSeg(proxyState, resources->netSendComm, (void*)info->buffer, info->size, numSegments,
+                             resources->useGdr, &handle) == ncclSuccess) {
         needReg = false;
       }
     } else {
@@ -2588,15 +2610,18 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     if (numSegments > 1) {
       // Multi-segment cuMem/VMM buffer: register one MR per physical segment.
-      if (netIbRegMrMultiSeg(proxyState, resources->netRecvComm, (void*)info->buffer, info->size, numSegments, resources->useGdr, &handle) == ncclSuccess) {
+      if (netIbRegMrMultiSeg(proxyState, resources->netRecvComm, (void*)info->buffer, info->size, numSegments,
+                             resources->useGdr, &handle) == ncclSuccess) {
         needReg = false;
       }
     } else {
       CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
-                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                              getHandleForAddressRangeFlags(resources->useGdr)),
-                ret, peermem);
-      NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                                getHandleForAddressRangeFlags(resources->useGdr)),
+                  ret, peermem);
+      NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
+                                                     NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                    ret, peermem);
       (void)close(dmabuf_fd);
       dmabuf_fd = -1;
       needReg = false;

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -2340,7 +2340,7 @@ ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, si
       int numSegments = 0;
       // The proxy registers the complete user registration, not just the
       // collective's current send/receive subrange. Count segments over that
-      // same range so multi-segment registration cannot stop after a partial prefix.
+      // same range so netIbRegMrMultiSeg cannot stop after a partial prefix.
       size_t regSize = regRecord->endAddr - regRecord->begAddr;
       NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)regRecord->begAddr, regSize, (CUdeviceptr*)&base, &baseSize,
                                          &numSegments));
@@ -2408,6 +2408,84 @@ fail:
   goto exit;
 }
 
+// Register a multi-segment cuMem/VMM buffer for the classic NET/IB transport by
+// exporting one dma-buf fd per physical segment and registering one MR per
+// segment. ROCm/HIP dma-buf export only
+// describes the first physical segment, so a single whole-range MR fails with
+// EINVAL.
+//
+// Guards: only the built-in IB plugin is supported, and segments must be
+// uniformly sized (interior segments equal; a smaller trailing segment is
+// allowed). This keeps every segment boundary at a multiple of the segment
+// size, so step-aligned transfers (stepSize <= segmentSize) never straddle a
+// boundary. When a guard fails the function returns an error and the caller
+// declines registration, so the collective falls back to staging buffers
+// instead of the fatal QP path.
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
+static ncclResult_t netIbRegMrMultiSeg(struct ncclProxyState* proxyState, void* netComm, void* buffer,
+                                       size_t totalSize, int numSegments, ncclTopoGdrMode useGdr, void** handle) {
+  ncclResult_t ret = ncclSuccess;
+  void** segAddrs = NULL; size_t* segLens = NULL; uint64_t* segOffsets = NULL; int* segFds = NULL;
+  int nSeg = 0;
+  size_t remaining = totalSize;
+
+  if (proxyState->ncclNet != &ncclNetIb) {
+    INFO(NCCL_NET|NCCL_REG, "Multi-segment (%d) NET registration only supported on the IB transport", numSegments);
+    return ncclInvalidUsage;
+  }
+  NCCLCHECKGOTO(ncclCalloc(&segAddrs, numSegments), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&segLens, numSegments), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&segOffsets, numSegments), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&segFds, numSegments), ret, fail);
+  for (int s = 0; s < numSegments; s++) segFds[s] = -1;
+
+  {
+    uintptr_t segPtr = (uintptr_t)buffer;
+    for (int s = 0; s < numSegments && remaining > 0; s++) {
+      CUdeviceptr segBase = 0; size_t segSize = 0;
+      CUCHECKGOTO(cuMemGetAddressRange(&segBase, &segSize, (CUdeviceptr)segPtr), ret, fail);
+      size_t inSeg = segSize - (segPtr - (uintptr_t)segBase);
+      size_t thisLen = remaining < inSeg ? remaining : inSeg;
+      int fd = -1;
+      // Export this segment alone: one physical allocation, so its fd is complete.
+      CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&fd, (CUdeviceptr)segPtr, thisLen,
+                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(useGdr)), ret, fail);
+      segAddrs[s] = (void*)segPtr; segLens[s] = thisLen; segOffsets[s] = 0ULL; segFds[s] = fd;
+      segPtr += thisLen; remaining -= thisLen; nSeg++;
+    }
+  }
+
+  // A count/range mismatch must never produce a partially registered handle:
+  // the CTS path would otherwise advertise addresses beyond the final MR with
+  // that MR's rkey, causing IBV_WC_REM_ACCESS_ERR on the remote write.
+  if (remaining != 0 || nSeg != numSegments) {
+    WARN("NET/IB: enumerated %d/%d segments for buffer %p but %zu/%zu bytes remain unregistered",
+         nSeg, numSegments, buffer, remaining, totalSize);
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
+
+  // Uniform-segment guard: interior segments must be equal; the trailing segment
+  // may be smaller. Otherwise boundaries are irregular and a step could straddle
+  // (matches ncclIbSegmentsUniform in net_ib/multiseg.h). Non-uniform layouts
+  // decline registration and fall back to staging buffers.
+  for (int s = 1; s < nSeg; s++) {
+    bool last = (s == nSeg - 1);
+    if ((!last && segLens[s] != segLens[0]) || (last && segLens[s] > segLens[0])) {
+      INFO(NCCL_NET|NCCL_REG, "Buffer %p (size %zu) has non-uniform segments; declining NET user-buffer registration (staging fallback)", buffer, totalSize);
+      ret = ncclInvalidUsage; goto fail;
+    }
+  }
+
+  NCCLCHECKGOTO(ncclIbRegMrDmaBufMultiSeg(netComm, nSeg, segAddrs, segLens, segOffsets, segFds, NCCL_PTR_CUDA, handle), ret, fail);
+
+fail:
+  if (segFds) for (int s = 0; s < numSegments; s++) if (segFds[s] != -1) (void)close(segFds[s]);
+  free(segAddrs); free(segLens); free(segOffsets); free(segFds);
+  return ret;
+}
+#endif
+
 static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
                                        void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   void* handle = NULL;
@@ -2425,16 +2503,25 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   int dmabuf_fd = -1;
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
-                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                              getHandleForAddressRangeFlags(resources->useGdr)),
-                ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
-                                                   NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+    if (numSegments > 1) {
+      // Multi-segment cuMem/VMM buffer: register one MR per physical segment.
+      // On failure the buffer is left unregistered (needReg stays true) and the
+      // caller declines, falling back to staging buffers.
+      if (netIbRegMrMultiSeg(proxyState, resources->netSendComm, (void*)info->buffer, info->size, numSegments, resources->useGdr, &handle) == ncclSuccess) {
+        needReg = false;
+      }
+    } else {
+      CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                                getHandleForAddressRangeFlags(resources->useGdr)),
                   ret, peermem);
-    (void)close(dmabuf_fd);
-    dmabuf_fd = -1;
-    needReg = false;
+      NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
+                                                     NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                    ret, peermem);
+      (void)close(dmabuf_fd);
+      dmabuf_fd = -1;
+      needReg = false;
+    }
   }
 peermem:
   // A failed cuMem attempt is recoverable here: the fallbacks below register the same
@@ -2499,16 +2586,21 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   int dmabuf_fd = -1;
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+    if (numSegments > 1) {
+      // Multi-segment cuMem/VMM buffer: register one MR per physical segment.
+      if (netIbRegMrMultiSeg(proxyState, resources->netRecvComm, (void*)info->buffer, info->size, numSegments, resources->useGdr, &handle) == ncclSuccess) {
+        needReg = false;
+      }
+    } else {
+      CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
                                               CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                               getHandleForAddressRangeFlags(resources->useGdr)),
                 ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
-                                                   NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
-                  ret, peermem);
-    (void)close(dmabuf_fd);
-    dmabuf_fd = -1;
-    needReg = false;
+      NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+      (void)close(dmabuf_fd);
+      dmabuf_fd = -1;
+      needReg = false;
+    }
   }
 peermem:
   // A failed cuMem attempt is recoverable here: the fallbacks below register the same

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -8,6 +8,7 @@
 
 #include "comm.h"
 #include "net.h"
+#include "rccl_ib_multiseg.h"
 #include "graph.h"
 #include "proxy.h"
 #include "collectives.h"

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -261,15 +261,22 @@ struct alignas(64) ncclIbSendFifo {
   uint32_t nreqs;
   uint32_t tag;
   uint64_t idx;
-  // Multi-segment (AIRUNTIME-2351 classic-path follow-up). The
-  // receiver publishes its full segment layout so the sender can split RDMA
-  // writes at the receiver's physical segment boundaries. nSegments == 1 (or 0)
-  // means a single contiguous MR and segStart/segRkeys are unused. Extending
-  // this element changes the CTS-FIFO wire format: both peers must run a build
-  // with the same NCCL_IB_MAX_SEGMENTS.
+};
+static_assert(sizeof(struct ncclIbSendFifo) == 64, "CTS slot is one cache line");
+
+// Connect-time capability: peer registered a side table immediately after the
+// 64-byte CTS FIFO (review ID 18). Mixed nSegments<=1 traffic stays
+// bit-compatible with stock classic; nSegments>1 requires this bit.
+#define NCCL_IB_CAP_MULTISEG 0x1u
+
+// Receiver layout for nSegments>1. Same [slot][recv] indexing as CTS. idx must
+// equal the CTS slot's idx so a later single-segment reuse of the same CTS
+// index ignores a stale side slot.
+struct alignas(64) ncclIbSegLayout {
+  uint64_t idx;
   uint32_t nSegments;
   uint32_t pad;
-  uint64_t segStart[NCCL_IB_MAX_SEGMENTS];                  // receiver VA per segment
+  uint64_t segStart[NCCL_IB_MAX_SEGMENTS];
   uint32_t segRkeys[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
 };
 
@@ -488,6 +495,10 @@ struct ncclIbSendComm {
   // to a single CTS message but can describe multiple recv-requests issued
   // on the receiver side.
   struct ncclIbSendFifo ctsFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  // Side table immediately after ctsFifo so one covering MR registers both.
+  // Receiver RDMA-writes this only when nSegments>1 and the peer advertised
+  // NCCL_IB_CAP_MULTISEG.
+  struct ncclIbSegLayout segLayoutFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
   // A multi-segment send may split one request's per-QP chunk into up to one WR
   // per local+remote segment boundary crossing. Size the WR/SGE pools
   // for the worst case; single-segment sends use exactly one WR per request.
@@ -506,6 +517,7 @@ struct ncclIbSendComm {
   struct ncclIbRemCompletionsRecords remCmplsRecords;
   int ar; // Use adaptive routing when all merged devices have it enabled
   uint64_t putSignalScratchpad;
+  uint32_t peerCaps;
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and
@@ -514,8 +526,18 @@ static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0,
               "ncclIbNetCommBase size must be 32-byte multiple to ensure ctsFifo is at proper offset");
 static_assert((offsetof(struct ncclIbSendComm, ctsFifo) % 32) == 0, "ncclIbSendComm ctsFifo must be 32-byte aligned");
 static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
+static_assert((sizeof(struct ncclIbSegLayout) % 32) == 0, "ncclIbSegLayout element size must be 32-byte multiples");
+static_assert(offsetof(struct ncclIbSendComm, segLayoutFifo) ==
+                offsetof(struct ncclIbSendComm, ctsFifo) + sizeof(((struct ncclIbSendComm*)0)->ctsFifo),
+              "segLayoutFifo must immediately follow ctsFifo for a covering MR");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
+
+static inline bool ncclIbCtsRemoteMultiSeg(const struct ncclIbSendComm* comm, int slot, int r) {
+  const volatile struct ncclIbSendFifo* cts = &comm->ctsFifo[slot][r];
+  const volatile struct ncclIbSegLayout* side = &comm->segLayoutFifo[slot][r];
+  return (comm->peerCaps & NCCL_IB_CAP_MULTISEG) && side->idx == cts->idx && side->nSegments > 1;
+}
 
 struct ncclIbGpuFlush {
   struct ibv_mr* hostMr;
@@ -545,6 +567,11 @@ struct ncclIbRemCtsFifo {
   uint32_t flags;
 };
 
+struct alignas(32) ncclIbRemSegLayout {
+  struct ncclIbSegLayout elems[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  uint64_t addr;
+};
+
 struct alignas(16) ncclIbRecvCommDev {
   struct ncclIbNetCommDevBase base;
   struct ncclIbGpuFlush gpuFlush;
@@ -553,6 +580,7 @@ struct alignas(16) ncclIbRecvCommDev {
   // side to gather CTS messages (formatted by the receiver) and write them to
   // the sender's CTS FIFO.
   struct ibv_mr* ctsFifoMr;
+  struct ibv_mr* segLayoutFifoMr;
   // MR that is obtained after registering the completion records on the
   // receiver side. The RKey of this MR is provided to the sender side, to allow
   // the sender side to access receiver's completion records using RDMA
@@ -577,6 +605,8 @@ struct ncclIbRecvComm {
   // Structure to hold all the related structures regarding the CTS FIFO
   // structure.
   struct ncclIbRemCtsFifo remCtsFifo;
+  struct ncclIbRemSegLayout remSegLayout;
+  uint32_t peerCaps;
   // Structure to hold all the completion records of all the outstanding
   // receive requests on the receiver side.
   struct ncclIbRequestCompletionRecord cmplsRecords[NET_IB_MAX_REQUESTS];
@@ -665,11 +695,6 @@ ncclResult_t ncclIbAcceptImpl(void* listenComm, void** recvComm, ncclNetDeviceHa
 ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** recvDevComm);
 ncclResult_t ncclIbRegMr(void* comm, void* data, size_t size, int type, void** mhandle);
 ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
-// Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
-// segment (per device), returning a composite ncclIbMrHandle (AIRUNTIME-2351
-// classic-path follow-up). The caller exports one dma-buf fd per segment.
-ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
-                                       int* segFds, int type, void** mhandle);
 ncclResult_t ncclIbDeregMr(void* comm, void* mhandle);
 ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
                          void** request);

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -264,11 +264,6 @@ struct alignas(64) ncclIbSendFifo {
 };
 static_assert(sizeof(struct ncclIbSendFifo) == 64, "CTS slot is one cache line");
 
-// Connect-time capability: peer registered a side table immediately after the
-// 64-byte CTS FIFO. Mixed nSegments<=1 traffic stays bit-compatible with stock
-// classic; nSegments>1 requires this bit.
-#define NCCL_IB_CAP_MULTISEG 0x1u
-
 // Receiver layout for nSegments>1. Same [slot][recv] indexing as CTS. idx must
 // equal the CTS slot's idx so a later single-segment reuse of the same CTS
 // index ignores a stale side slot.

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -265,8 +265,8 @@ struct alignas(64) ncclIbSendFifo {
 static_assert(sizeof(struct ncclIbSendFifo) == 64, "CTS slot is one cache line");
 
 // Connect-time capability: peer registered a side table immediately after the
-// 64-byte CTS FIFO (review ID 18). Mixed nSegments<=1 traffic stays
-// bit-compatible with stock classic; nSegments>1 requires this bit.
+// 64-byte CTS FIFO. Mixed nSegments<=1 traffic stays bit-compatible with stock
+// classic; nSegments>1 requires this bit.
 #define NCCL_IB_CAP_MULTISEG 0x1u
 
 // Receiver layout for nSegments>1. Same [slot][recv] indexing as CTS. idx must
@@ -567,7 +567,7 @@ struct ncclIbRemCtsFifo {
   uint32_t flags;
 };
 
-struct alignas(32) ncclIbRemSegLayout {
+struct alignas(64) ncclIbRemSegLayout {
   struct ncclIbSegLayout elems[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
   uint64_t addr;
 };

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -33,6 +33,7 @@
 
 #include "ibvwrap.h"
 #include "mlx5/mlx5dvwrap.h"
+#include "multiseg.h"
 
 #define MAXSUFFIXSIZE 16
 #define MAXNAMESIZE (64 + MAXSUFFIXSIZE)
@@ -193,6 +194,9 @@ struct ncclIbRequestCompletionRecord {
   bool completions[NCCL_IB_MAX_QPS];
 };
 
+// Forward declaration; full definition (with multi-segment fields) is below.
+struct ncclIbMrHandle;
+
 struct ncclIbRequest {
   struct ncclIbNetCommBase* base;
   int type;
@@ -219,6 +223,10 @@ struct ncclIbRequest {
       int size;
       void* data;
       uint32_t lkeys[NCCL_IB_MAX_DEVS_PER_NIC];
+      // Local MR handle for this send; used by the multi-segment WR builder to
+      // resolve the per-segment local lkey. NULL/single-segment
+      // handles use lkeys[] directly on the fast path.
+      struct ncclIbMrHandle* mh;
       // Tracks whether data was transmitted on a QP for this request.
       bool sentData[NCCL_IB_MAX_QPS];
     } send;
@@ -253,7 +261,22 @@ struct alignas(64) ncclIbSendFifo {
   uint32_t nreqs;
   uint32_t tag;
   uint64_t idx;
+  // Multi-segment (AIRUNTIME-2351 classic-path follow-up). The
+  // receiver publishes its full segment layout so the sender can split RDMA
+  // writes at the receiver's physical segment boundaries. nSegments == 1 (or 0)
+  // means a single contiguous MR and segStart/segRkeys are unused. Extending
+  // this element changes the CTS-FIFO wire format: both peers must run a build
+  // with the same NCCL_IB_MAX_SEGMENTS.
+  uint32_t nSegments;
+  uint32_t pad;
+  uint64_t segStart[NCCL_IB_MAX_SEGMENTS];                  // receiver VA per segment
+  uint32_t segRkeys[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
 };
+
+// Worst-case work requests posted for one multi-recv send on a single QP: each
+// request's chunk may be split at every local and remote segment boundary it
+// spans. Single-segment sends use exactly one WR per request.
+#define NCCL_IB_MAX_WRS_PER_SEND (NCCL_NET_IB_MAX_RECVS * 2 * NCCL_IB_MAX_SEGMENTS)
 
 struct ncclIbQpInitAttr {
   ibv_qp_state state;
@@ -333,10 +356,37 @@ struct alignas(8) ncclIbSendCommDev {
   struct ibv_sge sge;
 };
 
-// Wrapper to track an MR per-device, if needed
+
+// NCCL_IB_MAX_SEGMENTS (cap on physical segments per registered buffer) is
+// defined in multiseg.h so the wire-protocol structs above and the pure helpers
+// can both reference it.
+//
+// Wrapper to track an MR per-device, if needed.
+//
+// Single-segment buffers (the common case) use only mrs[]; nSegments == 1.
+// Multi-segment cuMem/VMM buffers register one dma-buf MR per physical segment
+// per device; segStart/segLen describe the segment VA layout and segMrs holds
+// the per-segment, per-device MRs. mrs[] aliases segment 0 for compatibility
+// with the single-segment fast path.
 struct ncclIbMrHandle {
   ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
+  int nSegments;                                             // 1 = legacy single MR
+  uintptr_t segStart[NCCL_IB_MAX_SEGMENTS];                  // VA start of each segment
+  size_t    segLen[NCCL_IB_MAX_SEGMENTS];                    // bytes per segment
+  ibv_mr*   segMrs[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
 };
+
+// Select the MR covering [addr, addr+len) for device devIndex.
+// - Single-segment handles return the legacy mrs[devIndex].
+// - Multi-segment handles return the containing segment's MR, or NULL if the
+//   range is not fully contained in one physical segment.
+static inline ibv_mr* ncclIbMrForRange(const struct ncclIbMrHandle* h,
+                                       uintptr_t addr, size_t len, int devIndex) {
+  if (h == NULL) return NULL;
+  if (h->nSegments <= 1) return h->mrs[devIndex];
+  int s = ncclIbSegmentIndexForRange(h->nSegments, h->segStart, h->segLen, addr, len);
+  return (s < 0) ? NULL : h->segMrs[s][devIndex];
+}
 
 // Forward declaration
 struct ncclIbResiliency;
@@ -440,8 +490,11 @@ struct ncclIbSendComm {
   // to a single CTS message but can describe multiple recv-requests issued
   // on the receiver side.
   struct ncclIbSendFifo ctsFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
-  struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
-  struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
+  // A multi-segment send may split one request's per-QP chunk into up to one WR
+  // per local+remote segment boundary crossing. Size the WR/SGE pools
+  // for the worst case; single-segment sends use exactly one WR per request.
+  struct ibv_sge sges[NCCL_IB_MAX_WRS_PER_SEND];
+  struct ibv_send_wr wrs[NCCL_IB_MAX_WRS_PER_SEND + 1];
   // Each dev correlates to a mergedIbDev
   struct ncclIbSendCommDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
   // Array of pointers to store the send requests for faster access. The
@@ -593,6 +646,7 @@ ncclResult_t ncclIbFreeRequest(struct ncclIbRequest* r);
 
 ncclResult_t ncclIbRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd,
                                        uint64_t mrFlags, void** mhandle);
+ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle);
 
 int ncclIbGetTrafficClass(void* ctx);
 void ncclIbSetTrafficClass(void* ctx, int trafficClass);
@@ -613,6 +667,11 @@ ncclResult_t ncclIbAcceptImpl(void* listenComm, void** recvComm, ncclNetDeviceHa
 ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** recvDevComm);
 ncclResult_t ncclIbRegMr(void* comm, void* data, size_t size, int type, void** mhandle);
 ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+// Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
+// segment (per device), returning a composite ncclIbMrHandle (AIRUNTIME-2351
+// classic-path follow-up). The caller exports one dma-buf fd per segment.
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
+                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle);
 ncclResult_t ncclIbDeregMr(void* comm, void* mhandle);
 ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
                          void** request);

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -356,7 +356,6 @@ struct alignas(8) ncclIbSendCommDev {
   struct ibv_sge sge;
 };
 
-
 // NCCL_IB_MAX_SEGMENTS (cap on physical segments per registered buffer) is
 // defined in multiseg.h so the wire-protocol structs above and the pure helpers
 // can both reference it.
@@ -372,16 +371,15 @@ struct ncclIbMrHandle {
   ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
   int nSegments;                                             // 1 = legacy single MR
   uintptr_t segStart[NCCL_IB_MAX_SEGMENTS];                  // VA start of each segment
-  size_t    segLen[NCCL_IB_MAX_SEGMENTS];                    // bytes per segment
-  ibv_mr*   segMrs[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
+  size_t segLen[NCCL_IB_MAX_SEGMENTS];                    // bytes per segment
+  ibv_mr* segMrs[NCCL_IB_MAX_SEGMENTS][NCCL_IB_MAX_DEVS_PER_NIC];
 };
 
 // Select the MR covering [addr, addr+len) for device devIndex.
 // - Single-segment handles return the legacy mrs[devIndex].
 // - Multi-segment handles return the containing segment's MR, or NULL if the
 //   range is not fully contained in one physical segment.
-static inline ibv_mr* ncclIbMrForRange(const struct ncclIbMrHandle* h,
-                                       uintptr_t addr, size_t len, int devIndex) {
+static inline ibv_mr* ncclIbMrForRange(const struct ncclIbMrHandle* h, uintptr_t addr, size_t len, int devIndex) {
   if (h == NULL) return NULL;
   if (h->nSegments <= 1) return h->mrs[devIndex];
   int s = ncclIbSegmentIndexForRange(h->nSegments, h->segStart, h->segLen, addr, len);
@@ -670,8 +668,8 @@ ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, ui
 // Register a multi-segment cuMem/VMM buffer as one dma-buf MR per physical
 // segment (per device), returning a composite ncclIbMrHandle (AIRUNTIME-2351
 // classic-path follow-up). The caller exports one dma-buf fd per segment.
-ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
-                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle);
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle);
 ncclResult_t ncclIbDeregMr(void* comm, void* mhandle);
 ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
                          void** request);

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1007,7 +1007,6 @@ ib_recv_dev_list:
   }
   trafficClass = ncclIbGetTrafficClass(ctx);
   meta.addr = (uint64_t)comm->ctsFifo;
-  meta.caps = NCCL_IB_CAP_MULTISEG;
   meta.sl = (ncclParamIbSl() != -1)                        ? ncclParamIbSl() :
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_SL_DEFAULT;
@@ -1015,6 +1014,7 @@ ib_recv_dev_list:
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+  ncclIbSetConnectCaps(meta.devName, sizeof(meta.devName), NCCL_IB_CAP_MULTISEG);
 
   stage->state = ncclIbCommStateSend;
   stage->offset = 0;
@@ -1039,7 +1039,7 @@ ib_connect:
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
-  comm->peerCaps = remMeta.caps;
+  comm->peerCaps = ncclIbGetConnectCaps(remMeta.devName, sizeof(remMeta.devName));
 
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
@@ -1625,7 +1625,7 @@ ib_recv:
   }
 
   // Store the remote CTS FIFO info provided by the remote peer
-  rComm->peerCaps = remMeta.caps;
+  rComm->peerCaps = ncclIbGetConnectCaps(remMeta.devName, sizeof(remMeta.devName));
   rComm->remCtsFifo.addr = remMeta.addr;
   rComm->remSegLayout.addr = remMeta.addr + sizeof(((struct ncclIbSendComm*)0)->ctsFifo);
   for (int i = 0; i < rComm->base.nRemDevs; i++) {
@@ -1762,8 +1762,8 @@ ib_recv:
 
   meta.ndevs = rComm->base.vProps.ndevs;
   meta.isP2p = remMeta.isP2p;
-  meta.caps = NCCL_IB_CAP_MULTISEG;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+  ncclIbSetConnectCaps(meta.devName, sizeof(meta.devName), NCCL_IB_CAP_MULTISEG);
 
   stage->state = ncclIbCommStateSend;
   stage->offset = 0;

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -947,8 +947,9 @@ ib_recv_dev_list:
                                   sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE),
                   ret, fail);
 
-    // Prepare my CTS FIFO
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo),
+    // Prepare my CTS FIFO + multi-seg side table (one covering MR).
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo,
+                                  sizeof(comm->ctsFifo) + sizeof(comm->segLayoutFifo),
                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     devInfo->rkey = commDev->ctsFifoMr->rkey;
@@ -1006,6 +1007,7 @@ ib_recv_dev_list:
   }
   trafficClass = ncclIbGetTrafficClass(ctx);
   meta.addr = (uint64_t)comm->ctsFifo;
+  meta.caps = NCCL_IB_CAP_MULTISEG;
   meta.sl = (ncclParamIbSl() != -1)                        ? ncclParamIbSl() :
             (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
                                                              NCCL_IB_SL_DEFAULT;
@@ -1037,6 +1039,7 @@ ib_connect:
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
+  comm->peerCaps = remMeta.caps;
 
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
@@ -1622,7 +1625,9 @@ ib_recv:
   }
 
   // Store the remote CTS FIFO info provided by the remote peer
+  rComm->peerCaps = remMeta.caps;
   rComm->remCtsFifo.addr = remMeta.addr;
+  rComm->remSegLayout.addr = remMeta.addr + sizeof(((struct ncclIbSendComm*)0)->ctsFifo);
   for (int i = 0; i < rComm->base.nRemDevs; i++) {
     rComm->remCtsFifo.rkeys[i] = remMeta.devs[i].rkey;
   }
@@ -1635,6 +1640,10 @@ ib_recv:
                                   IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     rCommDev->sge.lkey = rCommDev->ctsFifoMr->lkey;
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->segLayoutFifoMr, rCommDev->base.pd, &rComm->remSegLayout.elems,
+                                  sizeof(rComm->remSegLayout.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
 
     // Register completion records
     NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords,
@@ -1753,6 +1762,7 @@ ib_recv:
 
   meta.ndevs = rComm->base.vProps.ndevs;
   meta.isP2p = remMeta.isP2p;
+  meta.caps = NCCL_IB_CAP_MULTISEG;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
 
   stage->state = ncclIbCommStateSend;
@@ -1855,6 +1865,7 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
         if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
       }
       if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+      if (commDev->segLayoutFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->segLayoutFifoMr));
       if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
       if (comm->base.resiliency) {
         ncclIbResiliencyDevDestroy(comm->base.resiliency, i);

--- a/projects/rccl/src/transport/net_ib/connect.h
+++ b/projects/rccl/src/transport/net_ib/connect.h
@@ -61,12 +61,16 @@ struct ncclIbConnectionMetadata {
   // The receiver side gets in this member, from the sender, the address of the
   // memory to which the receiver writes the CTS messages.
   uint64_t addr;
-  uint32_t caps;
   int ndevs;
   int tc;
   int sl;
   int isP2p;
 };
+static_assert(offsetof(struct ncclIbConnectionMetadata, ndevs) ==
+                offsetof(struct ncclIbConnectionMetadata, addr) + sizeof(uint64_t),
+              "connection metadata tail must remain wire-compatible");
+static_assert(sizeof(struct ncclIbConnectionMetadata) == offsetof(struct ncclIbConnectionMetadata, isP2p) + sizeof(int),
+              "connection metadata must not add trailing wire bytes");
 
 ncclResult_t ncclIbQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 ncclResult_t ncclIbQpInit(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib/connect.h
+++ b/projects/rccl/src/transport/net_ib/connect.h
@@ -61,6 +61,7 @@ struct ncclIbConnectionMetadata {
   // The receiver side gets in this member, from the sender, the address of the
   // memory to which the receiver writes the CTS messages.
   uint64_t addr;
+  uint32_t caps;
   int ndevs;
   int tc;
   int sl;

--- a/projects/rccl/src/transport/net_ib/multiseg.h
+++ b/projects/rccl/src/transport/net_ib/multiseg.h
@@ -62,6 +62,29 @@ static inline bool ncclIbSegmentsUniform(int nSegments, const size_t* segLen) {
   return true;
 }
 
+// Write the indices of segments that overlap [addr, addr+len) into out[0..n).
+// Returns the count, 0 if len==0 or nothing overlaps, or -1 on overflow /
+// out-of-space. Used by classic IFlush to fence every GPUDirect segment the
+// receive actually touched, not only data[last].
+static inline int ncclIbSegmentsOverlappingRange(int nSegments, const uintptr_t* segStart, const size_t* segLen,
+                                                 uintptr_t addr, size_t len, int* out, int maxOut) {
+  if (nSegments < 1 || out == NULL || maxOut < 1) return -1;
+  if (len == 0) return 0;
+  uintptr_t end = addr + len;
+  if (end < addr) return -1; // address overflow
+  int n = 0;
+  for (int s = 0; s < nSegments; s++) {
+    uintptr_t b = segStart[s];
+    uintptr_t e = b + segLen[s];
+    if (e < b) continue;
+    if (addr < e && b < end) {
+      if (n >= maxOut) return -1;
+      out[n++] = s;
+    }
+  }
+  return n;
+}
+
 // ---------------------------------------------------------------------------
 // Wire-protocol segment splitting.
 //

--- a/projects/rccl/src/transport/net_ib/multiseg.h
+++ b/projects/rccl/src/transport/net_ib/multiseg.h
@@ -33,9 +33,7 @@
 // segStart[s]/segLen[s] describe segment s (s in [0, nSegments)). A zero-length
 // range is contained wherever addr lands. Overflow of addr+len is treated as
 // not-contained.
-static inline int ncclIbSegmentIndexForRange(int nSegments,
-                                             const uintptr_t* segStart,
-                                             const size_t* segLen,
+static inline int ncclIbSegmentIndexForRange(int nSegments, const uintptr_t* segStart, const size_t* segLen,
                                              uintptr_t addr, size_t len) {
   for (int s = 0; s < nSegments; s++) {
     uintptr_t b = segStart[s];
@@ -59,8 +57,7 @@ static inline bool ncclIbSegmentsUniform(int nSegments, const size_t* segLen) {
   if (nSegments <= 1) return true;
   for (int s = 1; s < nSegments; s++) {
     bool last = (s == nSegments - 1);
-    if ((!last && segLen[s] != segLen[0]) || (last && segLen[s] > segLen[0]))
-      return false;
+    if ((!last && segLen[s] != segLen[0]) || (last && segLen[s] > segLen[0])) return false;
   }
   return true;
 }
@@ -86,8 +83,8 @@ struct ncclIbSegSlice {
   uint64_t localAddr;   // sender VA for this slice
   uint64_t remoteAddr;  // receiver VA for this slice
   uint32_t len;         // slice byte count
-  int      localSeg;    // sender segment index
-  int      remoteSeg;   // receiver segment index
+  int localSeg;    // sender segment index
+  int remoteSeg;   // receiver segment index
 };
 
 // Return the segment index whose [segOff[s], segOff[s+1]) contains `off`, or -1.
@@ -103,11 +100,10 @@ static inline int ncclIbSegmentForOffset(int nSeg, const uint64_t* segOff, uint6
 // start at different offsets within their registrations. Writes up to
 // maxSlices entries into out[] and returns the count, or -1 if either range is
 // out of bounds or more than maxSlices slices are needed.
-static inline int ncclIbSplitTransferAtOffsets(
-    int nLocal,  const uint64_t* localSegVA,  const uint64_t* localSegOff,
-    int nRemote, const uint64_t* remoteSegVA, const uint64_t* remoteSegOff,
-    uint64_t localOff, uint64_t remoteOff, uint64_t len,
-    struct ncclIbSegSlice* out, int maxSlices) {
+static inline int ncclIbSplitTransferAtOffsets(int nLocal, const uint64_t* localSegVA, const uint64_t* localSegOff,
+                                               int nRemote, const uint64_t* remoteSegVA, const uint64_t* remoteSegOff,
+                                               uint64_t localOff, uint64_t remoteOff, uint64_t len,
+                                               struct ncclIbSegSlice* out, int maxSlices) {
   int n = 0;
   uint64_t localEnd = localOff + len;
   uint64_t remoteEnd = remoteOff + len;
@@ -125,11 +121,11 @@ static inline int ncclIbSplitTransferAtOffsets(
     if (remoteAvail < sliceLen) sliceLen = remoteAvail;
     if (sliceLen == 0 || sliceLen > UINT32_MAX) return -1;
     if (n >= maxSlices) return -1;
-    out[n].localAddr  = localSegVA[ls]  + (localOff - localSegOff[ls]);
+    out[n].localAddr = localSegVA[ls] + (localOff - localSegOff[ls]);
     out[n].remoteAddr = remoteSegVA[rs] + (remoteOff - remoteSegOff[rs]);
-    out[n].len        = (uint32_t)sliceLen;
-    out[n].localSeg   = ls;
-    out[n].remoteSeg  = rs;
+    out[n].len = (uint32_t)sliceLen;
+    out[n].localSeg = ls;
+    out[n].remoteSeg = rs;
     n++;
     localOff += sliceLen;
     remoteOff += sliceLen;
@@ -140,14 +136,11 @@ static inline int ncclIbSplitTransferAtOffsets(
 
 // Common case where the local and remote request begin at the same logical
 // offset within their registrations.
-static inline int ncclIbSplitTransfer(
-    int nLocal,  const uint64_t* localSegVA,  const uint64_t* localSegOff,
-    int nRemote, const uint64_t* remoteSegVA, const uint64_t* remoteSegOff,
-    uint64_t off, uint64_t len,
-    struct ncclIbSegSlice* out, int maxSlices) {
-  return ncclIbSplitTransferAtOffsets(nLocal, localSegVA, localSegOff,
-                                      nRemote, remoteSegVA, remoteSegOff,
-                                      off, off, len, out, maxSlices);
+static inline int ncclIbSplitTransfer(int nLocal, const uint64_t* localSegVA, const uint64_t* localSegOff, int nRemote,
+                                      const uint64_t* remoteSegVA, const uint64_t* remoteSegOff, uint64_t off,
+                                      uint64_t len, struct ncclIbSegSlice* out, int maxSlices) {
+  return ncclIbSplitTransferAtOffsets(nLocal, localSegVA, localSegOff, nRemote, remoteSegVA, remoteSegOff, off, off,
+                                      len, out, maxSlices);
 }
 
 #endif // NCCL_NET_IB_MULTISEG_H_

--- a/projects/rccl/src/transport/net_ib/multiseg.h
+++ b/projects/rccl/src/transport/net_ib/multiseg.h
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 // Cap on physical segments per registered buffer for the classic NET/IB path.
 // Mirrors NCCL_RMA_MAX_SEGMENTS (net_ib/gin.cc): a ROCm/HIP dma-buf export only
@@ -25,6 +26,32 @@
 #ifndef NCCL_IB_MAX_SEGMENTS
 #define NCCL_IB_MAX_SEGMENTS 16
 #endif
+
+// Connect-time capability encoded in the reserved tail of the fixed-size
+// devName field. This preserves the legacy metadata size and every legacy
+// field offset, so old and new peers can complete the same wire exchange.
+#define NCCL_IB_CAP_MULTISEG (1u << 0)
+#define NCCL_IB_CONNECT_CAPS_MAGIC 0x4d534547u
+
+struct ncclIbConnectCapsTrailer {
+  uint32_t magic;
+  uint32_t caps;
+};
+
+static inline void ncclIbSetConnectCaps(char* devName, size_t len, uint32_t caps) {
+  if (len <= sizeof(struct ncclIbConnectCapsTrailer)) return;
+  const size_t off = len - sizeof(struct ncclIbConnectCapsTrailer);
+  const struct ncclIbConnectCapsTrailer trailer = {NCCL_IB_CONNECT_CAPS_MAGIC, caps};
+  devName[off - 1] = '\0';
+  std::memcpy(devName + off, &trailer, sizeof(trailer));
+}
+
+static inline uint32_t ncclIbGetConnectCaps(const char* devName, size_t len) {
+  if (len < sizeof(struct ncclIbConnectCapsTrailer)) return 0;
+  struct ncclIbConnectCapsTrailer trailer;
+  std::memcpy(&trailer, devName + len - sizeof(trailer), sizeof(trailer));
+  return trailer.magic == NCCL_IB_CONNECT_CAPS_MAGIC ? trailer.caps : 0;
+}
 
 // Return the index of the segment that fully contains [addr, addr+len), or -1
 // if addr is outside every segment or the range straddles a segment boundary

--- a/projects/rccl/src/transport/net_ib/multiseg.h
+++ b/projects/rccl/src/transport/net_ib/multiseg.h
@@ -1,0 +1,153 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef NCCL_NET_IB_MULTISEG_H_
+#define NCCL_NET_IB_MULTISEG_H_
+
+// Pure, dependency-free segment-selection helpers for the classic NET/IB
+// multi-segment DMA-BUF path (AIRUNTIME-2351 classic-path follow-up). Kept free
+// of ibverbs / RCCL types so the boundary math can be unit-tested on the host
+// without IB hardware (see test/.../NetIbMultiSegmentUnitTests.cpp).
+
+#include <cstddef>
+#include <cstdint>
+
+// Cap on physical segments per registered buffer for the classic NET/IB path.
+// Mirrors NCCL_RMA_MAX_SEGMENTS (net_ib/gin.cc): a ROCm/HIP dma-buf export only
+// describes the first physical segment, so multi-segment cuMem/VMM buffers are
+// registered as one MR per segment (AIRUNTIME-2351 classic-path follow-up).
+// Defined here (rather than common.h) so the wire-protocol structs and the
+// pure helpers below can both reference it.
+#ifndef NCCL_IB_MAX_SEGMENTS
+#define NCCL_IB_MAX_SEGMENTS 16
+#endif
+
+// Return the index of the segment that fully contains [addr, addr+len), or -1
+// if addr is outside every segment or the range straddles a segment boundary
+// (which the classic single-rkey wire protocol cannot express).
+//
+// segStart[s]/segLen[s] describe segment s (s in [0, nSegments)). A zero-length
+// range is contained wherever addr lands. Overflow of addr+len is treated as
+// not-contained.
+static inline int ncclIbSegmentIndexForRange(int nSegments,
+                                             const uintptr_t* segStart,
+                                             const size_t* segLen,
+                                             uintptr_t addr, size_t len) {
+  for (int s = 0; s < nSegments; s++) {
+    uintptr_t b = segStart[s];
+    uintptr_t e = b + segLen[s];
+    if (addr >= b && addr < e) {
+      if (len == 0) return s;
+      uintptr_t end = addr + len;
+      if (end < addr) return -1;       // address overflow
+      return (end <= e) ? s : -1;      // -1 => crosses a segment boundary
+    }
+  }
+  return -1;
+}
+
+// True iff the segment layout is "uniform": every interior segment has the same
+// size as segment 0, and the trailing segment is no larger. This keeps every
+// segment boundary at a multiple of the segment size, so step-aligned transfers
+// (stepSize <= segmentSize) never straddle a boundary. Registration declines
+// non-uniform layouts and falls back to staging buffers.
+static inline bool ncclIbSegmentsUniform(int nSegments, const size_t* segLen) {
+  if (nSegments <= 1) return true;
+  for (int s = 1; s < nSegments; s++) {
+    bool last = (s == nSegments - 1);
+    if ((!last && segLen[s] != segLen[0]) || (last && segLen[s] > segLen[0]))
+      return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Wire-protocol segment splitting.
+//
+// A single logical transfer maps offset o -> localBase+o on the sender and
+// remoteBase+o on the receiver. The two sides may have *different* physical
+// segment layouts (independent VMM allocations), so a contiguous logical range
+// can straddle a boundary on either side. ncclIbSplitTransfer decomposes the
+// range [off, off+len) into slices that each stay within one local AND one
+// remote segment, resolving the per-slice local/remote VA. This is the classic
+// analogue of RMA's ncclRmaBuildSegmentedWrs and is kept dependency-free so the
+// boundary math is unit-testable on the host.
+//
+// segOff[] is the cumulative logical start offset of each segment, with
+// segOff[nSeg] == total byte count (so segment s spans [segOff[s], segOff[s+1])).
+// segVA[s] is the virtual address of segment s's first byte.
+// ---------------------------------------------------------------------------
+
+struct ncclIbSegSlice {
+  uint64_t localAddr;   // sender VA for this slice
+  uint64_t remoteAddr;  // receiver VA for this slice
+  uint32_t len;         // slice byte count
+  int      localSeg;    // sender segment index
+  int      remoteSeg;   // receiver segment index
+};
+
+// Return the segment index whose [segOff[s], segOff[s+1]) contains `off`, or -1.
+static inline int ncclIbSegmentForOffset(int nSeg, const uint64_t* segOff, uint64_t off) {
+  for (int s = 0; s < nSeg; s++) {
+    if (off >= segOff[s] && off < segOff[s + 1]) return s;
+  }
+  return -1;
+}
+
+// Decompose local [localOff, localOff+len) and remote
+// [remoteOff, remoteOff+len) into segment-contained slices. The two ranges may
+// start at different offsets within their registrations. Writes up to
+// maxSlices entries into out[] and returns the count, or -1 if either range is
+// out of bounds or more than maxSlices slices are needed.
+static inline int ncclIbSplitTransferAtOffsets(
+    int nLocal,  const uint64_t* localSegVA,  const uint64_t* localSegOff,
+    int nRemote, const uint64_t* remoteSegVA, const uint64_t* remoteSegOff,
+    uint64_t localOff, uint64_t remoteOff, uint64_t len,
+    struct ncclIbSegSlice* out, int maxSlices) {
+  int n = 0;
+  uint64_t localEnd = localOff + len;
+  uint64_t remoteEnd = remoteOff + len;
+  if (localEnd < localOff || remoteEnd < remoteOff) return -1; // overflow
+  if (len == 0) return 0;
+  uint64_t rem = len;
+  while (rem > 0) {
+    int ls = ncclIbSegmentForOffset(nLocal, localSegOff, localOff);
+    int rs = ncclIbSegmentForOffset(nRemote, remoteSegOff, remoteOff);
+    if (ls < 0 || rs < 0) return -1;              // outside a registered segment
+    uint64_t localAvail = localSegOff[ls + 1] - localOff;
+    uint64_t remoteAvail = remoteSegOff[rs + 1] - remoteOff;
+    uint64_t sliceLen = rem;
+    if (localAvail < sliceLen) sliceLen = localAvail;
+    if (remoteAvail < sliceLen) sliceLen = remoteAvail;
+    if (sliceLen == 0 || sliceLen > UINT32_MAX) return -1;
+    if (n >= maxSlices) return -1;
+    out[n].localAddr  = localSegVA[ls]  + (localOff - localSegOff[ls]);
+    out[n].remoteAddr = remoteSegVA[rs] + (remoteOff - remoteSegOff[rs]);
+    out[n].len        = (uint32_t)sliceLen;
+    out[n].localSeg   = ls;
+    out[n].remoteSeg  = rs;
+    n++;
+    localOff += sliceLen;
+    remoteOff += sliceLen;
+    rem -= sliceLen;
+  }
+  return n;
+}
+
+// Common case where the local and remote request begin at the same logical
+// offset within their registrations.
+static inline int ncclIbSplitTransfer(
+    int nLocal,  const uint64_t* localSegVA,  const uint64_t* localSegOff,
+    int nRemote, const uint64_t* remoteSegVA, const uint64_t* remoteSegOff,
+    uint64_t off, uint64_t len,
+    struct ncclIbSegSlice* out, int maxSlices) {
+  return ncclIbSplitTransferAtOffsets(nLocal, localSegVA, localSegOff,
+                                      nRemote, remoteSegVA, remoteSegOff,
+                                      off, off, len, out, maxSlices);
+}
+
+#endif // NCCL_NET_IB_MULTISEG_H_

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -850,7 +850,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     localElem[i].tag = tags[i];
     localElem[i].idx = comm->base.fifoHead + 1; // last store in the 64-byte CTS slot
 
-    // Multi-segment layout goes on the side table (review ID 18), never in CTS.
+    // Multi-segment layout goes on the side table, never in CTS.
     struct ncclIbSegLayout* sideElem = comm->remSegLayout.elems[slot];
     if (mhandleWrapper->nSegments > 1 && (comm->peerCaps & NCCL_IB_CAP_MULTISEG)) {
       sideElem[i].nSegments = mhandleWrapper->nSegments;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -910,14 +910,11 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
   ncclResult_t ret = ncclSuccess;
   ncclResult_t iflushRet = ncclSuccess;
   struct ncclIbRequest* req = NULL;
-  struct ncclIbMrHandle* mhandle = NULL;
-  int last = -1;
+  bool hasData = false;
   for (int i = 0; i < n; i++)
-    if (sizes[i]) last = i;
-  if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
+    if (sizes[i]) hasData = true;
+  if (comm->flushEnabled == 0 || !hasData) return ncclSuccess;
 
-  // Only flush once using the last non-zero receive
-  mhandle = (struct ncclIbMrHandle*)mhandles[last];
   NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, iflushFail);
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
@@ -967,74 +964,66 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
 
       TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
             wr.wr_id);
-    } else if (mhandle && mhandle->nSegments > 1) {
-      // GPUDirect writes landed in per-segment MRs. A 4-byte read of data[last]
-      // only fences the first touched segment; post one RDMA_READ per overlapping
-      // segment (chained, last SIGNALED) so every MR is fenced, matching GIN.
-      int flushSeg[NCCL_IB_MAX_SEGMENTS];
-      int nFlushSeg =
-        ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[last],
-                                       (size_t)sizes[last], flushSeg, NCCL_IB_MAX_SEGMENTS);
-      if (nFlushSeg < 1) {
-        WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[last], sizes[last]);
-        ret = ncclInternalError;
-        goto iflushFail;
-      }
-      struct ibv_send_wr segWr[NCCL_IB_MAX_SEGMENTS];
-      memset(segWr, 0, sizeof(segWr));
-      for (int s = 0; s < nFlushSeg; s++) {
-        int seg = flushSeg[s];
-        uintptr_t segBase = mhandle->segStart[seg];
-        uintptr_t rangeStart = (uintptr_t)data[last];
-        uintptr_t flushAddr = rangeStart > segBase ? rangeStart : segBase;
-        struct ibv_mr* flushMr = mhandle->segMrs[seg][i];
-        if (flushMr == NULL) {
-          WARN("NET/IB: flush missing MR for segment %d device %d", seg, i);
-          ret = ncclInternalError;
-          goto iflushFail;
-        }
-        segWr[s].wr_id = wr.wr_id;
-        segWr[s].wr.rdma.remote_addr = (uint64_t)flushAddr;
-        segWr[s].wr.rdma.rkey = flushMr->rkey;
-        segWr[s].sg_list = &comm->devs[i].gpuFlush.sge;
-        segWr[s].num_sge = 1;
-        segWr[s].opcode = IBV_WR_RDMA_READ;
-        segWr[s].send_flags = (s == nFlushSeg - 1) ? IBV_SEND_SIGNALED : 0;
-        segWr[s].next = (s + 1 < nFlushSeg) ? &segWr[s + 1] : NULL;
-      }
-      TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-segment flush request (req=%p, comm=%p, wr_id=%ld)", __func__,
-            nFlushSeg, req, req->base, wr.wr_id);
-      TIME_START(4);
-      struct ibv_send_wr* bad_wr;
-      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &segWr[0], &bad_wr), iflushRet, iflushFail);
-      TIME_STOP(4);
-      ncclIbAddEvent(req, i);
     } else {
-      wr.wr.rdma.remote_addr = (uint64_t)data[last];
-      // Multi-segment: the read fences the start of data[last]; pick its segment MR.
-      struct ibv_mr* flushMr = ncclIbMrForRange(mhandle, (uintptr_t)data[last], sizeof(int), i);
-      if (flushMr == NULL) {
-        WARN("NET/IB: flush buffer %p crosses a segment boundary (multi-segment registration)", data[last]);
-        ret = ncclInternalError;
-        goto iflushFail;
+      // A multi-recv may place each entry in a different MR. Build one chain
+      // that touches every non-zero entry and every segment it overlaps.
+      struct ibv_send_wr flushWrs[NCCL_NET_IB_MAX_RECVS * NCCL_IB_MAX_SEGMENTS];
+      int nFlushWrs = 0;
+      memset(flushWrs, 0, sizeof(flushWrs));
+      for (int r = 0; r < n; r++) {
+        if (sizes[r] == 0) continue;
+        struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[r];
+        if (mhandle != NULL && mhandle->nSegments > 1) {
+          int flushSeg[NCCL_IB_MAX_SEGMENTS];
+          int nFlushSeg =
+            ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[r],
+                                           (size_t)sizes[r], flushSeg, NCCL_IB_MAX_SEGMENTS);
+          if (nFlushSeg < 1) {
+            WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[r], sizes[r]);
+            ret = ncclInternalError;
+            goto iflushFail;
+          }
+          for (int s = 0; s < nFlushSeg; s++) {
+            int seg = flushSeg[s];
+            uintptr_t segBase = mhandle->segStart[seg];
+            uintptr_t rangeStart = (uintptr_t)data[r];
+            struct ibv_mr* flushMr = mhandle->segMrs[seg][i];
+            if (flushMr == NULL) {
+              WARN("NET/IB: flush missing MR for receive %d segment %d device %d", r, seg, i);
+              ret = ncclInternalError;
+              goto iflushFail;
+            }
+            flushWrs[nFlushWrs].wr.rdma.remote_addr = (uint64_t)(rangeStart > segBase ? rangeStart : segBase);
+            flushWrs[nFlushWrs].wr.rdma.rkey = flushMr->rkey;
+            nFlushWrs++;
+          }
+        } else {
+          struct ibv_mr* flushMr = ncclIbMrForRange(mhandle, (uintptr_t)data[r], sizeof(int), i);
+          if (flushMr == NULL) {
+            WARN("NET/IB: flush missing MR for receive %d buffer %p", r, data[r]);
+            ret = ncclInternalError;
+            goto iflushFail;
+          }
+          flushWrs[nFlushWrs].wr.rdma.remote_addr = (uint64_t)data[r];
+          flushWrs[nFlushWrs].wr.rdma.rkey = flushMr->rkey;
+          nFlushWrs++;
+        }
       }
-      wr.wr.rdma.rkey = flushMr->rkey;
-      wr.sg_list = &comm->devs[i].gpuFlush.sge;
-      wr.num_sge = 1;
-      wr.opcode = IBV_WR_RDMA_READ;
-      wr.send_flags = IBV_SEND_SIGNALED;
-
-      TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-            wr.wr_id);
+      for (int w = 0; w < nFlushWrs; w++) {
+        flushWrs[w].wr_id = wr.wr_id;
+        flushWrs[w].sg_list = &comm->devs[i].gpuFlush.sge;
+        flushWrs[w].num_sge = 1;
+        flushWrs[w].opcode = IBV_WR_RDMA_READ;
+        flushWrs[w].send_flags = (w == nFlushWrs - 1) ? IBV_SEND_SIGNALED : 0;
+        flushWrs[w].next = (w + 1 < nFlushWrs) ? &flushWrs[w + 1] : NULL;
+      }
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-read flush request (req=%p, comm=%p, wr_id=%ld)", __func__, nFlushWrs,
+            req, req->base, wr.wr_id);
       TIME_START(4);
       struct ibv_send_wr* bad_wr;
-      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), iflushRet, iflushFail);
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &flushWrs[0], &bad_wr), iflushRet, iflushFail);
       TIME_STOP(4);
-
       ncclIbAddEvent(req, i);
-
-      TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-            wr.wr_id);
     }
   }
 

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -114,11 +114,12 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
   // Cumulative wr_id across requests; placed on the final signaled WR so
   // completion accounting matches ncclIbMultiSend.
   uint64_t wr_id = 0ULL;
-  for (int r = 0; r < nreqs; r++) wr_id += (uint64_t)(slot & 0xff) << (r*8);
+  for (int r = 0; r < nreqs; r++) wr_id += (uint64_t)(slot & 0xff) << (r * 8);
 
   uint32_t immData = comm->base.recvMatchingScheme == BY_ID ? (uint32_t)(reqs[0]->id % UINT32_MAX) : reqs[0]->send.size;
   bool needSizesWr = (nreqs > 1);
-  bool arExtra = (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > ncclIbArThreshold);
+  bool arExtra =
+    (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > ncclIbArThreshold);
   bool extraImmWr = needSizesWr || arExtra;   // dedicated final WR carries the imm
 
   int64_t splitDataThreshold = rcclParamIbSplitDataThreshold();
@@ -146,13 +147,14 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
 
     // Selective retransmission: skip already-delivered QPs, keeping offsets synced.
     if (comm->base.resiliency && reqs[0]->send.sentData[qpIndex] == true) {
-      for (int r = 0; r < nreqs; r++) sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
+      for (int r = 0; r < nreqs; r++)
+        sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
       continue;
     }
 
     int w = 0;
     for (int r = 0; r < nreqs; r++) {
-      uint64_t localBase  = (uintptr_t) reqs[r]->send.data;
+      uint64_t localBase = (uintptr_t)reqs[r]->send.data;
       uint64_t remoteBase = slots[r].addr;
       struct ncclIbMrHandle* mh = reqs[r]->send.mh;
 
@@ -162,12 +164,18 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
       uint64_t localReqOff = 0;
       if (mh && mh->nSegments > 1) {
         nLocal = mh->nSegments;
-        for (int s = 0; s < nLocal; s++) { lVA[s] = mh->segStart[s]; lOff[s] = mh->segStart[s] - mh->segStart[0]; }
+        for (int s = 0; s < nLocal; s++) {
+          lVA[s] = mh->segStart[s];
+          lOff[s] = mh->segStart[s] - mh->segStart[0];
+        }
         lOff[nLocal] = lOff[nLocal - 1] + mh->segLen[nLocal - 1];
         if (localBase < mh->segStart[0]) return ncclInternalError;
         localReqOff = localBase - mh->segStart[0];
       } else {
-        nLocal = 1; lVA[0] = localBase; lOff[0] = 0; lOff[1] = reqs[r]->send.size;
+        nLocal = 1;
+        lVA[0] = localBase;
+        lOff[0] = 0;
+        lOff[1] = reqs[r]->send.size;
       }
       // Remote segment tables published by the receiver in the CTS FIFO.
       uint64_t rVA[NCCL_IB_MAX_SEGMENTS], rOff[NCCL_IB_MAX_SEGMENTS + 1];
@@ -189,7 +197,10 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
         while (nRemote > 1 && rOff[nRemote - 1] >= remoteReqEnd) nRemote--;
         rOff[nRemote] = remoteReqEnd;
       } else {
-        nRemote = 1; rVA[0] = remoteBase; rOff[0] = 0; rOff[1] = slots[r].size;
+        nRemote = 1;
+        rVA[0] = remoteBase;
+        rOff[0] = 0;
+        rOff[1] = slots[r].size;
       }
 
       if (chunkLen[r] == 0) {
@@ -210,16 +221,19 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
         w++;
       } else {
         struct ncclIbSegSlice slices[2 * NCCL_IB_MAX_SEGMENTS];
-        int ns = ncclIbSplitTransferAtOffsets(
-            nLocal, lVA, lOff, nRemote, rVA, rOff,
-            localReqOff + sendOffsets[r], remoteReqOff + sendOffsets[r],
-            chunkLen[r], slices, 2 * NCCL_IB_MAX_SEGMENTS);
+        int ns =
+          ncclIbSplitTransferAtOffsets(nLocal, lVA, lOff, nRemote, rVA, rOff, localReqOff + sendOffsets[r],
+                                       remoteReqOff + sendOffsets[r], chunkLen[r], slices, 2 * NCCL_IB_MAX_SEGMENTS);
         if (ns <= 0) {
-          WARN("NET/IB: multi-segment send split failed (data=%p off=%u len=%u)", reqs[r]->send.data, sendOffsets[r], chunkLen[r]);
+          WARN("NET/IB: multi-segment send split failed (data=%p off=%u len=%u)", reqs[r]->send.data, sendOffsets[r],
+               chunkLen[r]);
           return ncclInternalError;
         }
         for (int k = 0; k < ns; k++) {
-          if (w >= NCCL_IB_MAX_WRS_PER_SEND) { WARN("NET/IB: multi-segment send exceeded WR pool (%d)", NCCL_IB_MAX_WRS_PER_SEND); return ncclInternalError; }
+          if (w >= NCCL_IB_MAX_WRS_PER_SEND) {
+            WARN("NET/IB: multi-segment send exceeded WR pool (%d)", NCCL_IB_MAX_WRS_PER_SEND);
+            return ncclInternalError;
+          }
           struct ibv_send_wr* wr = comm->wrs + w;
           struct ibv_sge* sge = comm->sges + w;
           memset(wr, 0, sizeof(struct ibv_send_wr));
@@ -227,10 +241,12 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
           wr->send_flags = 0;
           wr->wr_id = wr_id;
           wr->wr.rdma.remote_addr = slices[k].remoteAddr;
-          wr->wr.rdma.rkey = slots[r].nSegments > 1 ? slots[r].segRkeys[slices[k].remoteSeg][remDevIdx] : slots[r].rkeys[remDevIdx];
+          wr->wr.rdma.rkey =
+            slots[r].nSegments > 1 ? slots[r].segRkeys[slices[k].remoteSeg][remDevIdx] : slots[r].rkeys[remDevIdx];
           sge->addr = slices[k].localAddr;
           sge->length = slices[k].len;
-          sge->lkey = (mh && mh->nSegments > 1) ? mh->segMrs[slices[k].localSeg][devIndex]->lkey : reqs[r]->send.lkeys[devIndex];
+          sge->lkey =
+            (mh && mh->nSegments > 1) ? mh->segMrs[slices[k].localSeg][devIndex]->lkey : reqs[r]->send.lkeys[devIndex];
           wr->sg_list = sge;
           wr->num_sge = 1;
           w++;
@@ -242,14 +258,17 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
     // mirroring ncclIbMultiSend's lastWr handling.
     struct ibv_send_wr* lastWr;
     if (extraImmWr) {
-      if (w >= NCCL_IB_MAX_WRS_PER_SEND + 1) { WARN("NET/IB: multi-segment send exceeded WR pool"); return ncclInternalError; }
+      if (w >= NCCL_IB_MAX_WRS_PER_SEND + 1) {
+        WARN("NET/IB: multi-segment send exceeded WR pool");
+        return ncclInternalError;
+      }
       lastWr = comm->wrs + w;
       memset(lastWr, 0, sizeof(struct ibv_send_wr));
       if (needSizesWr) {
-        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot*sizeof(struct ncclIbRequestCompletionRecord);
+        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot * sizeof(struct ncclIbRequestCompletionRecord);
         lastWr->sg_list = &(comm->devs[devIndex].sge);
         lastWr->sg_list[0].addr = (uint64_t)(comm->remCmplsRecords.elems[slot]);
-        lastWr->sg_list[0].length = nreqs*sizeof(int);
+        lastWr->sg_list[0].length = nreqs * sizeof(int);
         lastWr->wr.rdma.rkey = comm->remCmplsRecords.rkeys[devIndex];
         lastWr->num_sge = 1;
       } else {
@@ -793,7 +812,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     localElem[i].nSegments = mhandleWrapper->nSegments;
     if (mhandleWrapper->nSegments > 1) {
       for (int s = 0; s < mhandleWrapper->nSegments; s++) {
-        localElem[i].segStart[s] = (uint64_t) mhandleWrapper->segStart[s];
+        localElem[i].segStart[s] = (uint64_t)mhandleWrapper->segStart[s];
         for (int j = 0; j < comm->base.vProps.ndevs; j++) {
           localElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
         }
@@ -890,7 +909,8 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
       struct ibv_mr* flushMr = ncclIbMrForRange(mhandle, (uintptr_t)data[last], sizeof(int), i);
       if (flushMr == NULL) {
         WARN("NET/IB: flush buffer %p crosses a segment boundary (multi-segment registration)", data[last]);
-        ret = ncclInternalError; goto iflushFail;
+        ret = ncclInternalError;
+        goto iflushFail;
       }
       wr.wr.rdma.rkey = flushMr->rkey;
     }

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -801,8 +801,18 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   for (int i = 0; i < n; i++) {
     localElem[i].addr = (uint64_t)data[i];
     struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
+    if (mhandleWrapper == NULL) {
+      WARN("NET/IB: irecv[%d] has a NULL mhandle", i);
+      ret = ncclInternalError;
+      goto irecvFail;
+    }
     // Send all applicable rkeys (segment 0 alias for the single-segment path).
     for (int j = 0; j < comm->base.vProps.ndevs; j++) {
+      if (mhandleWrapper->mrs[j] == NULL) {
+        WARN("NET/IB: irecv[%d] missing MR for device %d", i, j);
+        ret = ncclInternalError;
+        goto irecvFail;
+      }
       localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
     }
     // Multi-segment: publish the full receiver segment layout so the
@@ -814,6 +824,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       for (int s = 0; s < mhandleWrapper->nSegments; s++) {
         localElem[i].segStart[s] = (uint64_t)mhandleWrapper->segStart[s];
         for (int j = 0; j < comm->base.vProps.ndevs; j++) {
+          if (mhandleWrapper->segMrs[s][j] == NULL) {
+            WARN("NET/IB: irecv[%d] missing MR for segment %d device %d", i, s, j);
+            ret = ncclInternalError;
+            goto irecvFail;
+          }
           localElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
         }
       }
@@ -903,6 +918,64 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
     if (useGpuFlushMem) {
       wr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
       wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
+      wr.sg_list = &comm->devs[i].gpuFlush.sge;
+      wr.num_sge = 1;
+      wr.opcode = IBV_WR_RDMA_READ;
+      wr.send_flags = IBV_SEND_SIGNALED;
+
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+            wr.wr_id);
+      TIME_START(4);
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), iflushRet, iflushFail);
+      TIME_STOP(4);
+
+      ncclIbAddEvent(req, i);
+
+      TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+            wr.wr_id);
+    } else if (mhandle && mhandle->nSegments > 1) {
+      // GPUDirect writes landed in per-segment MRs. A 4-byte read of data[last]
+      // only fences the first touched segment; post one RDMA_READ per overlapping
+      // segment (chained, last SIGNALED) so every MR is fenced, matching GIN.
+      int flushSeg[NCCL_IB_MAX_SEGMENTS];
+      int nFlushSeg =
+        ncclIbSegmentsOverlappingRange(mhandle->nSegments, mhandle->segStart, mhandle->segLen, (uintptr_t)data[last],
+                                       (size_t)sizes[last], flushSeg, NCCL_IB_MAX_SEGMENTS);
+      if (nFlushSeg < 1) {
+        WARN("NET/IB: flush buffer %p size %d does not overlap any registered segment", data[last], sizes[last]);
+        ret = ncclInternalError;
+        goto iflushFail;
+      }
+      struct ibv_send_wr segWr[NCCL_IB_MAX_SEGMENTS];
+      memset(segWr, 0, sizeof(segWr));
+      for (int s = 0; s < nFlushSeg; s++) {
+        int seg = flushSeg[s];
+        uintptr_t segBase = mhandle->segStart[seg];
+        uintptr_t rangeStart = (uintptr_t)data[last];
+        uintptr_t flushAddr = rangeStart > segBase ? rangeStart : segBase;
+        struct ibv_mr* flushMr = mhandle->segMrs[seg][i];
+        if (flushMr == NULL) {
+          WARN("NET/IB: flush missing MR for segment %d device %d", seg, i);
+          ret = ncclInternalError;
+          goto iflushFail;
+        }
+        segWr[s].wr_id = wr.wr_id;
+        segWr[s].wr.rdma.remote_addr = (uint64_t)flushAddr;
+        segWr[s].wr.rdma.rkey = flushMr->rkey;
+        segWr[s].sg_list = &comm->devs[i].gpuFlush.sge;
+        segWr[s].num_sge = 1;
+        segWr[s].opcode = IBV_WR_RDMA_READ;
+        segWr[s].send_flags = (s == nFlushSeg - 1) ? IBV_SEND_SIGNALED : 0;
+        segWr[s].next = (s + 1 < nFlushSeg) ? &segWr[s + 1] : NULL;
+      }
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a %d-segment flush request (req=%p, comm=%p, wr_id=%ld)", __func__,
+            nFlushSeg, req, req->base, wr.wr_id);
+      TIME_START(4);
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &segWr[0], &bad_wr), iflushRet, iflushFail);
+      TIME_STOP(4);
+      ncclIbAddEvent(req, i);
     } else {
       wr.wr.rdma.remote_addr = (uint64_t)data[last];
       // Multi-segment: the read fences the start of data[last]; pick its segment MR.
@@ -913,23 +986,23 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
         goto iflushFail;
       }
       wr.wr.rdma.rkey = flushMr->rkey;
+      wr.sg_list = &comm->devs[i].gpuFlush.sge;
+      wr.num_sge = 1;
+      wr.opcode = IBV_WR_RDMA_READ;
+      wr.send_flags = IBV_SEND_SIGNALED;
+
+      TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+            wr.wr_id);
+      TIME_START(4);
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), iflushRet, iflushFail);
+      TIME_STOP(4);
+
+      ncclIbAddEvent(req, i);
+
+      TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+            wr.wr_id);
     }
-    wr.sg_list = &comm->devs[i].gpuFlush.sge;
-    wr.num_sge = 1;
-    wr.opcode = IBV_WR_RDMA_READ;
-    wr.send_flags = IBV_SEND_SIGNALED;
-
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-          wr.wr_id);
-    TIME_START(4);
-    struct ibv_send_wr* bad_wr;
-    NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), iflushRet, iflushFail);
-    TIME_STOP(4);
-
-    ncclIbAddEvent(req, i);
-
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
-          wr.wr_id);
   }
 
   *request = req;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -96,11 +96,206 @@ static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 // The alignment for IB writes that is required to make LL and LL128 protocols work
 #define IB_WRITE_CHUNK_ALIGNMENT 128
 
+// Multi-segment (AIRUNTIME-2351 classic-path follow-up) variant of
+// ncclIbMultiSend. It splits each request's per-QP chunk into one RDMA-write WR
+// per local+remote physical segment slice, so a transfer that straddles a
+// segment boundary uses the correct per-segment lkey/rkey. Invoked only when at
+// least one request's local or remote buffer is multi-segment; the
+// single-segment fast path below stays byte-for-byte unchanged.
+static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int slot) {
+  struct ncclIbRequest** reqs = comm->sendReqs[slot];
+  volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
+  int nreqs = slots[0].nreqs;
+  if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+
+  int nqps = ncclIbCommBaseGetNqpsPerRequest(&comm->base);
+  ncclResult_t ret;
+
+  // Cumulative wr_id across requests; placed on the final signaled WR so
+  // completion accounting matches ncclIbMultiSend.
+  uint64_t wr_id = 0ULL;
+  for (int r = 0; r < nreqs; r++) wr_id += (uint64_t)(slot & 0xff) << (r*8);
+
+  uint32_t immData = comm->base.recvMatchingScheme == BY_ID ? (uint32_t)(reqs[0]->id % UINT32_MAX) : reqs[0]->send.size;
+  bool needSizesWr = (nreqs > 1);
+  bool arExtra = (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > ncclIbArThreshold);
+  bool extraImmWr = needSizesWr || arExtra;   // dedicated final WR carries the imm
+
+  int64_t splitDataThreshold = rcclParamIbSplitDataThreshold();
+  uint32_t sendOffsets[NCCL_NET_IB_MAX_RECVS] = {0};
+
+  int qpIndex = -1;
+  ncclIbQp* qp = NULL;
+  for (int i = 0; i < nqps; i++) {
+    NCCLCHECK(ncclIbCommBaseGetQpForRequest(&comm->base, reqs[0]->id, i, &qp, &qpIndex));
+    int devIndex = qp->devIndex;
+    int remDevIdx = qp->remDevIdx;
+
+    // Per-request chunk length on this QP (computed independently of the
+    // resiliency skip so skipped QPs still advance the offsets consistently).
+    uint32_t chunkLen[NCCL_NET_IB_MAX_RECVS];
+    for (int r = 0; r < nreqs; r++) {
+      int chunkSize;
+      if (reqs[r]->send.size < splitDataThreshold) {
+        chunkSize = (i == 0) ? reqs[r]->send.size : 0;
+      } else {
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), IB_WRITE_CHUNK_ALIGNMENT) * IB_WRITE_CHUNK_ALIGNMENT;
+      }
+      chunkLen[r] = std::min<uint32_t>(reqs[r]->send.size - sendOffsets[r], chunkSize);
+    }
+
+    // Selective retransmission: skip already-delivered QPs, keeping offsets synced.
+    if (comm->base.resiliency && reqs[0]->send.sentData[qpIndex] == true) {
+      for (int r = 0; r < nreqs; r++) sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
+      continue;
+    }
+
+    int w = 0;
+    for (int r = 0; r < nreqs; r++) {
+      uint64_t localBase  = (uintptr_t) reqs[r]->send.data;
+      uint64_t remoteBase = slots[r].addr;
+      struct ncclIbMrHandle* mh = reqs[r]->send.mh;
+
+      // Local segment offset/VA tables (contiguous VMM VAs => linear addresses).
+      uint64_t lVA[NCCL_IB_MAX_SEGMENTS], lOff[NCCL_IB_MAX_SEGMENTS + 1];
+      int nLocal;
+      uint64_t localReqOff = 0;
+      if (mh && mh->nSegments > 1) {
+        nLocal = mh->nSegments;
+        for (int s = 0; s < nLocal; s++) { lVA[s] = mh->segStart[s]; lOff[s] = mh->segStart[s] - mh->segStart[0]; }
+        lOff[nLocal] = lOff[nLocal - 1] + mh->segLen[nLocal - 1];
+        if (localBase < mh->segStart[0]) return ncclInternalError;
+        localReqOff = localBase - mh->segStart[0];
+      } else {
+        nLocal = 1; lVA[0] = localBase; lOff[0] = 0; lOff[1] = reqs[r]->send.size;
+      }
+      // Remote segment tables published by the receiver in the CTS FIFO.
+      uint64_t rVA[NCCL_IB_MAX_SEGMENTS], rOff[NCCL_IB_MAX_SEGMENTS + 1];
+      int nRemote;
+      uint64_t remoteReqOff = 0;
+      if (slots[r].nSegments > 1) {
+        nRemote = slots[r].nSegments;
+        for (int s = 0; s < nRemote; s++) {
+          rVA[s] = slots[r].segStart[s];
+          rOff[s] = slots[r].segStart[s] - slots[r].segStart[0];
+        }
+        if (remoteBase < slots[r].segStart[0]) return ncclInternalError;
+        remoteReqOff = remoteBase - slots[r].segStart[0];
+        uint64_t remoteReqEnd = remoteReqOff + slots[r].size;
+        if (remoteReqEnd < remoteReqOff) return ncclInternalError;
+        // The wire publishes segment starts but not the registration's final
+        // length. Trim starts beyond this receive and use its end as the final
+        // boundary; no send for this CTS entry may legally pass that point.
+        while (nRemote > 1 && rOff[nRemote - 1] >= remoteReqEnd) nRemote--;
+        rOff[nRemote] = remoteReqEnd;
+      } else {
+        nRemote = 1; rVA[0] = remoteBase; rOff[0] = 0; rOff[1] = slots[r].size;
+      }
+
+      if (chunkLen[r] == 0) {
+        // Zero-length write preserves the chain/imm; segment-0 keys suffice.
+        struct ibv_send_wr* wr = comm->wrs + w;
+        struct ibv_sge* sge = comm->sges + w;
+        memset(wr, 0, sizeof(struct ibv_send_wr));
+        wr->opcode = IBV_WR_RDMA_WRITE;
+        wr->send_flags = 0;
+        wr->wr_id = wr_id;
+        wr->wr.rdma.remote_addr = remoteBase + sendOffsets[r];
+        wr->wr.rdma.rkey = slots[r].nSegments > 1 ? slots[r].segRkeys[0][remDevIdx] : slots[r].rkeys[remDevIdx];
+        sge->addr = localBase + sendOffsets[r];
+        sge->length = 0;
+        sge->lkey = reqs[r]->send.lkeys[devIndex];
+        wr->sg_list = sge;
+        wr->num_sge = 0;
+        w++;
+      } else {
+        struct ncclIbSegSlice slices[2 * NCCL_IB_MAX_SEGMENTS];
+        int ns = ncclIbSplitTransferAtOffsets(
+            nLocal, lVA, lOff, nRemote, rVA, rOff,
+            localReqOff + sendOffsets[r], remoteReqOff + sendOffsets[r],
+            chunkLen[r], slices, 2 * NCCL_IB_MAX_SEGMENTS);
+        if (ns <= 0) {
+          WARN("NET/IB: multi-segment send split failed (data=%p off=%u len=%u)", reqs[r]->send.data, sendOffsets[r], chunkLen[r]);
+          return ncclInternalError;
+        }
+        for (int k = 0; k < ns; k++) {
+          if (w >= NCCL_IB_MAX_WRS_PER_SEND) { WARN("NET/IB: multi-segment send exceeded WR pool (%d)", NCCL_IB_MAX_WRS_PER_SEND); return ncclInternalError; }
+          struct ibv_send_wr* wr = comm->wrs + w;
+          struct ibv_sge* sge = comm->sges + w;
+          memset(wr, 0, sizeof(struct ibv_send_wr));
+          wr->opcode = IBV_WR_RDMA_WRITE;
+          wr->send_flags = 0;
+          wr->wr_id = wr_id;
+          wr->wr.rdma.remote_addr = slices[k].remoteAddr;
+          wr->wr.rdma.rkey = slots[r].nSegments > 1 ? slots[r].segRkeys[slices[k].remoteSeg][remDevIdx] : slots[r].rkeys[remDevIdx];
+          sge->addr = slices[k].localAddr;
+          sge->length = slices[k].len;
+          sge->lkey = (mh && mh->nSegments > 1) ? mh->segMrs[slices[k].localSeg][devIndex]->lkey : reqs[r]->send.lkeys[devIndex];
+          wr->sg_list = sge;
+          wr->num_sge = 1;
+          w++;
+        }
+      }
+    }
+
+    // Final WR carries the WRITE_WITH_IMM (and, for multi-recv, the sizes array),
+    // mirroring ncclIbMultiSend's lastWr handling.
+    struct ibv_send_wr* lastWr;
+    if (extraImmWr) {
+      if (w >= NCCL_IB_MAX_WRS_PER_SEND + 1) { WARN("NET/IB: multi-segment send exceeded WR pool"); return ncclInternalError; }
+      lastWr = comm->wrs + w;
+      memset(lastWr, 0, sizeof(struct ibv_send_wr));
+      if (needSizesWr) {
+        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot*sizeof(struct ncclIbRequestCompletionRecord);
+        lastWr->sg_list = &(comm->devs[devIndex].sge);
+        lastWr->sg_list[0].addr = (uint64_t)(comm->remCmplsRecords.elems[slot]);
+        lastWr->sg_list[0].length = nreqs*sizeof(int);
+        lastWr->wr.rdma.rkey = comm->remCmplsRecords.rkeys[devIndex];
+        lastWr->num_sge = 1;
+      } else {
+        lastWr->num_sge = 0;
+      }
+      w++;
+    } else {
+      lastWr = comm->wrs + (w - 1);   // reuse the last data WR
+    }
+    lastWr->wr_id = wr_id;
+    lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+    lastWr->imm_data = htobe32(immData);
+    lastWr->send_flags = IBV_SEND_SIGNALED;
+
+    for (int k = 0; k < w - 1; k++) comm->wrs[k].next = comm->wrs + k + 1;
+    comm->wrs[w - 1].next = NULL;
+
+    struct ibv_send_wr* bad_wr;
+    ret = wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr);
+    if (ret != ncclSuccess) {
+      ncclIbStatsFatalError(&comm->base.stats);
+      return ret;
+    }
+
+    for (int r = 0; r < nreqs; r++) {
+      sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + chunkLen[r], reqs[r]->send.size);
+      reqs[r]->send.sentData[qpIndex] = true;
+    }
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
   int nreqs = slots[0].nreqs;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+
+  // Multi-segment: if any request's local or remote buffer spans
+  // multiple physical segments, use the segment-splitting builder.
+  for (int r = 0; r < nreqs; r++) {
+    struct ncclIbMrHandle* mh = reqs[r]->send.mh;
+    if ((mh && mh->nSegments > 1) || slots[r].nSegments > 1) {
+      return ncclIbMultiSendSegmented(comm, slot);
+    }
+  }
 
   TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0],
         reqs[0]->base, reqs[0]->id, slot, nreqs);
@@ -374,7 +569,9 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       ncclIbAddEvent(req, qp->devIndex);
     }
 
-    // Store all lkeys
+    // Store all lkeys (segment 0 alias; the multi-segment builder resolves the
+    // per-segment lkey from req->send.mh). mrs[] aliases segment 0.
+    req->send.mh = mhandleWrapper;
     for (int i = 0; i < comm->base.vProps.ndevs; i++) {
       req->send.lkeys[i] = mhandleWrapper->mrs[i]->lkey;
     }
@@ -585,9 +782,22 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   for (int i = 0; i < n; i++) {
     localElem[i].addr = (uint64_t)data[i];
     struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
-    // Send all applicable rkeys
+    // Send all applicable rkeys (segment 0 alias for the single-segment path).
     for (int j = 0; j < comm->base.vProps.ndevs; j++) {
       localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
+    }
+    // Multi-segment: publish the full receiver segment layout so the
+    // sender can split RDMA writes at these physical segment boundaries. The
+    // buffer base data[i] equals segStart[0] (registration starts at the base),
+    // so segment VAs are contiguous and remote addresses stay linear.
+    localElem[i].nSegments = mhandleWrapper->nSegments;
+    if (mhandleWrapper->nSegments > 1) {
+      for (int s = 0; s < mhandleWrapper->nSegments; s++) {
+        localElem[i].segStart[s] = (uint64_t) mhandleWrapper->segStart[s];
+        for (int j = 0; j < comm->base.vProps.ndevs; j++) {
+          localElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
+        }
+      }
     }
     localElem[i].nreqs = n;
     localElem[i].size = sizes[i]; // Sanity/Debugging
@@ -676,7 +886,13 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
       wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
     } else {
       wr.wr.rdma.remote_addr = (uint64_t)data[last];
-      wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
+      // Multi-segment: the read fences the start of data[last]; pick its segment MR.
+      struct ibv_mr* flushMr = ncclIbMrForRange(mhandle, (uintptr_t)data[last], sizeof(int), i);
+      if (flushMr == NULL) {
+        WARN("NET/IB: flush buffer %p crosses a segment boundary (multi-segment registration)", data[last]);
+        ret = ncclInternalError; goto iflushFail;
+      }
+      wr.wr.rdma.rkey = flushMr->rkey;
     }
     wr.sg_list = &comm->devs[i].gpuFlush.sge;
     wr.num_sge = 1;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -105,6 +105,7 @@ static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int slot) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
+  volatile struct ncclIbSegLayout* side = comm->segLayoutFifo[slot];
   int nreqs = slots[0].nreqs;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
@@ -177,23 +178,22 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
         lOff[0] = 0;
         lOff[1] = reqs[r]->send.size;
       }
-      // Remote segment tables published by the receiver in the CTS FIFO.
+      // Remote segment tables from the side table when the peer published a
+      // matching multi-seg layout; otherwise a single-segment view of the CTS slot.
       uint64_t rVA[NCCL_IB_MAX_SEGMENTS], rOff[NCCL_IB_MAX_SEGMENTS + 1];
       int nRemote;
       uint64_t remoteReqOff = 0;
-      if (slots[r].nSegments > 1) {
-        nRemote = slots[r].nSegments;
+      bool remoteMulti = ncclIbCtsRemoteMultiSeg(comm, slot, r);
+      if (remoteMulti) {
+        nRemote = side[r].nSegments;
         for (int s = 0; s < nRemote; s++) {
-          rVA[s] = slots[r].segStart[s];
-          rOff[s] = slots[r].segStart[s] - slots[r].segStart[0];
+          rVA[s] = side[r].segStart[s];
+          rOff[s] = side[r].segStart[s] - side[r].segStart[0];
         }
-        if (remoteBase < slots[r].segStart[0]) return ncclInternalError;
-        remoteReqOff = remoteBase - slots[r].segStart[0];
+        if (remoteBase < side[r].segStart[0]) return ncclInternalError;
+        remoteReqOff = remoteBase - side[r].segStart[0];
         uint64_t remoteReqEnd = remoteReqOff + slots[r].size;
         if (remoteReqEnd < remoteReqOff) return ncclInternalError;
-        // The wire publishes segment starts but not the registration's final
-        // length. Trim starts beyond this receive and use its end as the final
-        // boundary; no send for this CTS entry may legally pass that point.
         while (nRemote > 1 && rOff[nRemote - 1] >= remoteReqEnd) nRemote--;
         rOff[nRemote] = remoteReqEnd;
       } else {
@@ -212,7 +212,7 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
         wr->send_flags = 0;
         wr->wr_id = wr_id;
         wr->wr.rdma.remote_addr = remoteBase + sendOffsets[r];
-        wr->wr.rdma.rkey = slots[r].nSegments > 1 ? slots[r].segRkeys[0][remDevIdx] : slots[r].rkeys[remDevIdx];
+        wr->wr.rdma.rkey = remoteMulti ? side[r].segRkeys[0][remDevIdx] : slots[r].rkeys[remDevIdx];
         sge->addr = localBase + sendOffsets[r];
         sge->length = 0;
         sge->lkey = reqs[r]->send.lkeys[devIndex];
@@ -241,8 +241,7 @@ static ncclResult_t ncclIbMultiSendSegmented(struct ncclIbSendComm* comm, int sl
           wr->send_flags = 0;
           wr->wr_id = wr_id;
           wr->wr.rdma.remote_addr = slices[k].remoteAddr;
-          wr->wr.rdma.rkey =
-            slots[r].nSegments > 1 ? slots[r].segRkeys[slices[k].remoteSeg][remDevIdx] : slots[r].rkeys[remDevIdx];
+          wr->wr.rdma.rkey = remoteMulti ? side[r].segRkeys[slices[k].remoteSeg][remDevIdx] : slots[r].rkeys[remDevIdx];
           sge->addr = slices[k].localAddr;
           sge->length = slices[k].len;
           sge->lkey =
@@ -311,7 +310,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   // multiple physical segments, use the segment-splitting builder.
   for (int r = 0; r < nreqs; r++) {
     struct ncclIbMrHandle* mh = reqs[r]->send.mh;
-    if ((mh && mh->nSegments > 1) || slots[r].nSegments > 1) {
+    if ((mh && mh->nSegments > 1) || ncclIbCtsRemoteMultiSeg(comm, slot, r)) {
       return ncclIbMultiSendSegmented(comm, slot);
     }
   }
@@ -695,14 +694,45 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.wr_id = slot;
   }
 
+  bool postSide = false;
+  if (comm->peerCaps & NCCL_IB_CAP_MULTISEG) {
+    for (int i = 0; i < req->nreqs; i++) {
+      if (comm->remSegLayout.elems[slot][i].nSegments > 1) {
+        postSide = true;
+        break;
+      }
+    }
+  }
+
+  struct ibv_sge sgeSide;
+  struct ibv_send_wr wrSide;
+  struct ibv_send_wr* firstWr = &wr;
+  if (postSide) {
+    memset(&wrSide, 0, sizeof(wrSide));
+    memset(&sgeSide, 0, sizeof(sgeSide));
+    wrSide.wr.rdma.remote_addr =
+      comm->remSegLayout.addr + (uint64_t)slot * NCCL_NET_IB_MAX_RECVS * sizeof(struct ncclIbSegLayout);
+    wrSide.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].rkey;
+    sgeSide.addr = (uint64_t)comm->remSegLayout.elems[slot];
+    sgeSide.length = req->nreqs * sizeof(struct ncclIbSegLayout);
+    sgeSide.lkey = comm->devs[ctsQp->devIndex].segLayoutFifoMr->lkey;
+    wrSide.sg_list = &sgeSide;
+    wrSide.num_sge = 1;
+    wrSide.opcode = IBV_WR_RDMA_WRITE;
+    wrSide.send_flags = 0; // unsignaled, never inline
+    wrSide.next = &wr;
+    firstWr = &wrSide;
+  }
+
   TRACE(NCCL_NET,
         "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
-        "qp_num=%u)",
-        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+        "qp_num=%u side=%d)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num,
+        (int)postSide);
 
   struct ibv_send_wr* bad_wr;
   ncclResult_t postFifoRet;
-  NCCLCHECKGOTO(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr), postFifoRet, postFifoFail);
+  NCCLCHECKGOTO(wrap_ibv_post_send(ctsQp->qp, firstWr, &bad_wr), postFifoRet, postFifoFail);
   TRACE(NCCL_VERBS,
         "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%u, opcode=%d, send_flags=%d, "
         "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
@@ -815,28 +845,31 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       }
       localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
     }
-    // Multi-segment: publish the full receiver segment layout so the
-    // sender can split RDMA writes at these physical segment boundaries. The
-    // buffer base data[i] equals segStart[0] (registration starts at the base),
-    // so segment VAs are contiguous and remote addresses stay linear.
-    localElem[i].nSegments = mhandleWrapper->nSegments;
-    if (mhandleWrapper->nSegments > 1) {
+    localElem[i].nreqs = n;
+    localElem[i].size = sizes[i]; // Sanity/Debugging
+    localElem[i].tag = tags[i];
+    localElem[i].idx = comm->base.fifoHead + 1; // last store in the 64-byte CTS slot
+
+    // Multi-segment layout goes on the side table (review ID 18), never in CTS.
+    struct ncclIbSegLayout* sideElem = comm->remSegLayout.elems[slot];
+    if (mhandleWrapper->nSegments > 1 && (comm->peerCaps & NCCL_IB_CAP_MULTISEG)) {
+      sideElem[i].nSegments = mhandleWrapper->nSegments;
       for (int s = 0; s < mhandleWrapper->nSegments; s++) {
-        localElem[i].segStart[s] = (uint64_t)mhandleWrapper->segStart[s];
+        sideElem[i].segStart[s] = (uint64_t)mhandleWrapper->segStart[s];
         for (int j = 0; j < comm->base.vProps.ndevs; j++) {
           if (mhandleWrapper->segMrs[s][j] == NULL) {
             WARN("NET/IB: irecv[%d] missing MR for segment %d device %d", i, s, j);
             ret = ncclInternalError;
             goto irecvFail;
           }
-          localElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
+          sideElem[i].segRkeys[s][j] = mhandleWrapper->segMrs[s][j]->rkey;
         }
       }
+      sideElem[i].idx = localElem[i].idx;
+    } else {
+      sideElem[i].nSegments = 0;
+      sideElem[i].idx = 0;
     }
-    localElem[i].nreqs = n;
-    localElem[i].size = sizes[i]; // Sanity/Debugging
-    localElem[i].tag = tags[i];
-    localElem[i].idx = comm->base.fifoHead + 1;
   }
 
   // Post to FIFO to notify sender

--- a/projects/rccl/src/transport/net_ib/reg.cc
+++ b/projects/rccl/src/transport/net_ib/reg.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "common.h"
+#include "rccl_ib_multiseg.h"
 
 ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset,
                                         int fd, uint64_t mrFlags, ibv_mr** mhandle) {
@@ -112,6 +113,15 @@ ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, si
     WARN("NET/IB: multi-segment registration with %d segments exceeds NCCL_IB_MAX_SEGMENTS=%d", nSeg,
          NCCL_IB_MAX_SEGMENTS);
     return ncclInvalidUsage;
+  }
+  if (nSeg > 1) {
+    uint32_t peerCaps =
+      base->isSend ? ((struct ncclIbSendComm*)comm)->peerCaps : ((struct ncclIbRecvComm*)comm)->peerCaps;
+    if ((peerCaps & NCCL_IB_CAP_MULTISEG) == 0) {
+      INFO(NCCL_NET | NCCL_REG,
+           "NET/IB: peer does not advertise multi-segment CTS side table; declining %d-segment registration", nSeg);
+      return ncclInvalidUsage;
+    }
   }
   struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)calloc(1, sizeof(struct ncclIbMrHandle));
   if (mhandleWrapper == nullptr) {

--- a/projects/rccl/src/transport/net_ib/reg.cc
+++ b/projects/rccl/src/transport/net_ib/reg.cc
@@ -104,38 +104,44 @@ fail:
  * caller (net.cc proxy register) has already exported one dma-buf fd per
  * segment; segAddrs[s]/segLens[s]/segOffsets[s]/segFds[s] describe segment s.
  */
-ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
-                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle) {
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
   if (nSeg < 1 || nSeg > NCCL_IB_MAX_SEGMENTS) {
-    WARN("NET/IB: multi-segment registration with %d segments exceeds NCCL_IB_MAX_SEGMENTS=%d", nSeg, NCCL_IB_MAX_SEGMENTS);
+    WARN("NET/IB: multi-segment registration with %d segments exceeds NCCL_IB_MAX_SEGMENTS=%d", nSeg,
+         NCCL_IB_MAX_SEGMENTS);
     return ncclInvalidUsage;
   }
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) calloc(1, sizeof(struct ncclIbMrHandle));
-  if (mhandleWrapper == nullptr) { WARN("Failed to allocate IB MR handle wrapper"); return ncclSystemError; }
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)calloc(1, sizeof(struct ncclIbMrHandle));
+  if (mhandleWrapper == nullptr) {
+    WARN("Failed to allocate IB MR handle wrapper");
+    return ncclSystemError;
+  }
   mhandleWrapper->nSegments = nSeg;
   for (int s = 0; s < nSeg; s++) {
-    mhandleWrapper->segStart[s] = (uintptr_t) segAddrs[s];
-    mhandleWrapper->segLen[s]   = segLens[s];
+    mhandleWrapper->segStart[s] = (uintptr_t)segAddrs[s];
+    mhandleWrapper->segLen[s] = segLens[s];
     for (int i = 0; i < base->vProps.ndevs; i++) {
       struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
-      NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, segAddrs[s], segLens[s], type, segOffsets[s], segFds[s],
-                                               0ULL, &mhandleWrapper->segMrs[s][i]), ret, fail);
+      NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, segAddrs[s], segLens[s], type, segOffsets[s], segFds[s], 0ULL,
+                                               &mhandleWrapper->segMrs[s][i]),
+                    ret, fail);
     }
   }
   // Alias segment 0 into mrs[] so single-segment consumers keep working.
   for (int i = 0; i < base->vProps.ndevs; i++) mhandleWrapper->mrs[i] = mhandleWrapper->segMrs[0][i];
-  INFO(NCCL_NET|NCCL_REG, "NET/IB: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs",
-       segAddrs[0], (size_t)(mhandleWrapper->segStart[nSeg-1] + mhandleWrapper->segLen[nSeg-1] - mhandleWrapper->segStart[0]), nSeg);
-  *mhandle = (void*) mhandleWrapper;
+  INFO(NCCL_NET | NCCL_REG, "NET/IB: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs", segAddrs[0],
+       (size_t)(mhandleWrapper->segStart[nSeg - 1] + mhandleWrapper->segLen[nSeg - 1] - mhandleWrapper->segStart[0]),
+       nSeg);
+  *mhandle = (void*)mhandleWrapper;
   return ncclSuccess;
 fail:
   for (int s = 0; s < nSeg; s++) {
     for (int i = 0; i < base->vProps.ndevs; i++) {
       if (mhandleWrapper->segMrs[s][i]) {
         struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
-        (void) ncclIbDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]);
+        (void)ncclIbDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]);
       }
     }
   }

--- a/projects/rccl/src/transport/net_ib/reg.cc
+++ b/projects/rccl/src/transport/net_ib/reg.cc
@@ -76,6 +76,7 @@ ncclResult_t ncclIbRegMrDmaBufInternal(void* comm, void* data, size_t size, int 
   int registered = 0;
   *mhandle = NULL;
   NCCLCHECK(ncclCalloc(&mhandleWrapper, 1));
+  mhandleWrapper->nSegments = 1;
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
@@ -93,6 +94,53 @@ fail:
   }
   free(mhandleWrapper);
   goto exit;
+}
+
+/* Multi-segment DMA-BUF support (AIRUNTIME-2351 classic-path follow-up).
+ *
+ * ROCm/HIP dma-buf export describes only the first physical segment of a
+ * multi-segment cuMem/VMM range, so registering the whole VA range as one MR
+ * fails with EINVAL. Register one MR per segment (per device) instead. The
+ * caller (net.cc proxy register) has already exported one dma-buf fd per
+ * segment; segAddrs[s]/segLens[s]/segOffsets[s]/segFds[s] describe segment s.
+ */
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens,
+                                       uint64_t* segOffsets, int* segFds, int type, void** mhandle) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  if (nSeg < 1 || nSeg > NCCL_IB_MAX_SEGMENTS) {
+    WARN("NET/IB: multi-segment registration with %d segments exceeds NCCL_IB_MAX_SEGMENTS=%d", nSeg, NCCL_IB_MAX_SEGMENTS);
+    return ncclInvalidUsage;
+  }
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) calloc(1, sizeof(struct ncclIbMrHandle));
+  if (mhandleWrapper == nullptr) { WARN("Failed to allocate IB MR handle wrapper"); return ncclSystemError; }
+  mhandleWrapper->nSegments = nSeg;
+  for (int s = 0; s < nSeg; s++) {
+    mhandleWrapper->segStart[s] = (uintptr_t) segAddrs[s];
+    mhandleWrapper->segLen[s]   = segLens[s];
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+      NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, segAddrs[s], segLens[s], type, segOffsets[s], segFds[s],
+                                               0ULL, &mhandleWrapper->segMrs[s][i]), ret, fail);
+    }
+  }
+  // Alias segment 0 into mrs[] so single-segment consumers keep working.
+  for (int i = 0; i < base->vProps.ndevs; i++) mhandleWrapper->mrs[i] = mhandleWrapper->segMrs[0][i];
+  INFO(NCCL_NET|NCCL_REG, "NET/IB: registered multi-segment buffer %p size %zu as %d DMA-BUF MRs",
+       segAddrs[0], (size_t)(mhandleWrapper->segStart[nSeg-1] + mhandleWrapper->segLen[nSeg-1] - mhandleWrapper->segStart[0]), nSeg);
+  *mhandle = (void*) mhandleWrapper;
+  return ncclSuccess;
+fail:
+  for (int s = 0; s < nSeg; s++) {
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      if (mhandleWrapper->segMrs[s][i]) {
+        struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+        (void) ncclIbDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]);
+      }
+    }
+  }
+  free(mhandleWrapper);
+  return ret;
 }
 
 ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) {
@@ -129,10 +177,21 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
 
   struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-  for (int i = 0; i < base->vProps.ndevs; i++) {
-    // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
-    struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
-    NCCLCHECK(ncclIbDeregMrInternal(devComm, mhandleWrapper->mrs[i]));
+  if (mhandleWrapper->nSegments > 1) {
+    // Multi-segment: free each per-segment, per-device MR. mrs[] aliases
+    // segment 0, so it is freed via segMrs[0] here (do not double-free).
+    for (int s = 0; s < mhandleWrapper->nSegments; s++) {
+      for (int i = 0; i < base->vProps.ndevs; i++) {
+        struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+        NCCLCHECK(ncclIbDeregMrInternal(devComm, mhandleWrapper->segMrs[s][i]));
+      }
+    }
+  } else {
+    for (int i = 0; i < base->vProps.ndevs; i++) {
+      // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
+      struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+      NCCLCHECK(ncclIbDeregMrInternal(devComm, mhandleWrapper->mrs[i]));
+    }
   }
   free(mhandleWrapper);
   return ncclSuccess;

--- a/projects/rccl/src/transport/rccl_ib_multiseg.h
+++ b/projects/rccl/src/transport/rccl_ib_multiseg.h
@@ -1,0 +1,20 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef RCCL_IB_MULTISEG_H_
+#define RCCL_IB_MULTISEG_H_
+
+#include "nccl.h"
+
+// RCCL-only IB helper (same convention as rccl_wrap.cc): register one dma-buf
+// MR per physical segment. Not part of the NCCL-synced plugin API in
+// include/net.h (review ID 19). Implemented by the classic NET/IB plugin
+// (net_ib/reg.cc). CAST is a separate follow-up PR.
+ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
+                                       int* segFds, int type, void** mhandle);
+
+#endif

--- a/projects/rccl/src/transport/rccl_ib_multiseg.h
+++ b/projects/rccl/src/transport/rccl_ib_multiseg.h
@@ -12,8 +12,8 @@
 
 // RCCL-only IB helper (same convention as rccl_wrap.cc): register one dma-buf
 // MR per physical segment. Not part of the NCCL-synced plugin API in
-// include/net.h (review ID 19). Implemented by the classic NET/IB plugin
-// (net_ib/reg.cc). CAST is a separate follow-up PR.
+// include/net.h. Implemented by the classic NET/IB plugin (net_ib/reg.cc).
+// CAST is a separate follow-up PR.
 ncclResult_t ncclIbRegMrDmaBufMultiSeg(void* comm, int nSeg, void** segAddrs, size_t* segLens, uint64_t* segOffsets,
                                        int* segFds, int type, void** mhandle);
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -318,6 +318,7 @@ if(BUILD_TESTS)
       IommuPassthrough_test.cpp
       MatchSubnet_test.cpp
       MiscTests.cpp
+      NetIbMultiSegmentUnitTests.cpp
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       DdaCollCommonTests.cpp
@@ -723,6 +724,7 @@ if(BUILD_TESTS)
       transport/ShmMPITests.cpp
       transport/NetIbMPI/GeneralTests.cpp
       transport/NetIbMPI/GdrFlushTests.cpp
+      transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
       transport/NetIbMPI/NicFusionTests.cpp
       transport/NetIbMPI/CastTests.cpp
       transport/NetIbMPI/FaultInjectTests.cpp

--- a/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
+++ b/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
@@ -75,6 +75,45 @@ TEST(NetIbMultiSeg, AddressLengthOverflowRejected) {
     EXPECT_EQ(SegOf(L, kBase + 16, SIZE_MAX), -1);
 }
 
+TEST(NetIbMultiSeg, OverlappingRangeWholeBufferTouchesEverySegment) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    int out[8];
+    int n = ncclIbSegmentsOverlappingRange(L.n(), L.start.data(), L.len.data(),
+                                           kBase, 4 * kSeg, out, 8);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(out[0], 0);
+    EXPECT_EQ(out[1], 1);
+    EXPECT_EQ(out[2], 2);
+    EXPECT_EQ(out[3], 3);
+}
+
+TEST(NetIbMultiSeg, OverlappingRangeSingleSegment) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    int out[8];
+    int n = ncclIbSegmentsOverlappingRange(L.n(), L.start.data(), L.len.data(),
+                                           kBase + 2 * kSeg + 64, 128, out, 8);
+    ASSERT_EQ(n, 1);
+    EXPECT_EQ(out[0], 2);
+}
+
+TEST(NetIbMultiSeg, OverlappingRangeCrossesOneBoundary) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    int out[8];
+    int n = ncclIbSegmentsOverlappingRange(L.n(), L.start.data(), L.len.data(),
+                                           kBase + kSeg - 64, 128, out, 8);
+    ASSERT_EQ(n, 2);
+    EXPECT_EQ(out[0], 0);
+    EXPECT_EQ(out[1], 1);
+}
+
+TEST(NetIbMultiSeg, OverlappingRangeZeroLengthIsEmpty) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    int out[8];
+    EXPECT_EQ(ncclIbSegmentsOverlappingRange(L.n(), L.start.data(), L.len.data(),
+                                             kBase, 0, out, 8),
+              0);
+}
+
 TEST(NetIbMultiSeg, UniformLayoutAccepted) {
     std::vector<size_t> len(4, kSeg);
     EXPECT_TRUE(ncclIbSegmentsUniform(4, len.data()));

--- a/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
+++ b/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
@@ -56,6 +56,19 @@ constexpr size_t    kSeg  = 2u * 1024 * 1024;
 
 } // namespace
 
+TEST(NetIbMultiSeg, LegacyConnectMetadataHasNoCapabilities) {
+    const char devName[32] = "bnxt_re0";
+    EXPECT_EQ(ncclIbGetConnectCaps(devName, sizeof(devName)), 0u);
+}
+
+TEST(NetIbMultiSeg, ConnectCapabilitiesPreserveDeviceName) {
+    char devName[32] = "bnxt_re0";
+    ncclIbSetConnectCaps(devName, sizeof(devName), NCCL_IB_CAP_MULTISEG);
+    EXPECT_STREQ(devName, "bnxt_re0");
+    EXPECT_EQ(ncclIbGetConnectCaps(devName, sizeof(devName)),
+              NCCL_IB_CAP_MULTISEG);
+}
+
 // === Segment selection and uniformity helpers ===============================
 
 TEST(NetIbMultiSeg, StartOfEachSegmentMapsToThatSegment) {

--- a/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
+++ b/projects/rccl/test/NetIbMultiSegmentUnitTests.cpp
@@ -1,0 +1,292 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Host-only unit tests for classic NET/IB multi-segment math.
+// They cover segment selection, layout uniformity, and transfer splitting in
+// src/transport/net_ib/multiseg.h and run in rccl-UnitTestsFixtures without
+// IB hardware, a GPU, or MPI.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Pure helpers under test (no ibverbs / RCCL deps).
+#include "../src/transport/net_ib/multiseg.h"
+
+namespace {
+
+struct Layout {
+    std::vector<uintptr_t> start;
+    std::vector<size_t>    len;
+    int n() const { return static_cast<int>(start.size()); }
+};
+
+Layout MakeUniform(uintptr_t base, size_t seg, int nSeg) {
+    Layout L;
+    for (int s = 0; s < nSeg; s++) { L.start.push_back(base + (uintptr_t)s * seg); L.len.push_back(seg); }
+    return L;
+}
+
+int SegOf(const Layout& L, uintptr_t addr, size_t len) {
+    return ncclIbSegmentIndexForRange(L.n(), L.start.data(), L.len.data(), addr, len);
+}
+
+// Build the (segVA[], segOff[nSeg+1]) tables ncclIbSplitTransfer expects.
+struct SplitTables {
+    std::vector<uint64_t> va;
+    std::vector<uint64_t> off; // size nSeg+1, off[nSeg] == total bytes
+    int n() const { return static_cast<int>(va.size()); }
+};
+
+SplitTables MakeTables(const Layout& L) {
+    SplitTables T;
+    uint64_t cum = 0;
+    for (int s = 0; s < L.n(); s++) { T.va.push_back(L.start[s]); T.off.push_back(cum); cum += L.len[s]; }
+    T.off.push_back(cum);
+    return T;
+}
+
+constexpr uintptr_t kBase = 0x100000000ULL;
+constexpr size_t    kSeg  = 2u * 1024 * 1024;
+
+} // namespace
+
+// === Segment selection and uniformity helpers ===============================
+
+TEST(NetIbMultiSeg, StartOfEachSegmentMapsToThatSegment) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    for (int s = 0; s < 4; s++)
+        EXPECT_EQ(SegOf(L, kBase + (uintptr_t)s * kSeg, 4096), s) << "segment " << s;
+}
+
+TEST(NetIbMultiSeg, RangeCrossingBoundaryRejected) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    EXPECT_EQ(SegOf(L, kBase + kSeg - 1, 2), -1);
+    EXPECT_EQ(SegOf(L, kBase + kSeg / 2, 2 * kSeg), -1);
+}
+
+TEST(NetIbMultiSeg, AddressLengthOverflowRejected) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    EXPECT_EQ(SegOf(L, kBase + 16, SIZE_MAX), -1);
+}
+
+TEST(NetIbMultiSeg, UniformLayoutAccepted) {
+    std::vector<size_t> len(4, kSeg);
+    EXPECT_TRUE(ncclIbSegmentsUniform(4, len.data()));
+}
+
+TEST(NetIbMultiSeg, NonUniformInteriorRejected) {
+    std::vector<size_t> len = {kSeg, kSeg / 2, kSeg, kSeg};
+    EXPECT_FALSE(ncclIbSegmentsUniform(4, len.data()));
+}
+
+// === Transfer splitting helpers =============================================
+
+// A single-segment transfer on both sides yields exactly one slice with linear
+// addresses (the single-segment fast path in ncclIbMultiSend).
+TEST(NetIbSplit, SingleSegmentBothSidesOneSlice) {
+    Layout local  = MakeUniform(kBase, kSeg, 1);
+    Layout remote = MakeUniform(0x900000000ULL, kSeg, 1);
+    SplitTables lt = MakeTables(local), rt = MakeTables(remote);
+    ncclIbSegSlice out[8];
+    int ns = ncclIbSplitTransfer(lt.n(), lt.va.data(), lt.off.data(),
+                                 rt.n(), rt.va.data(), rt.off.data(),
+                                 /*off*/ 4096, /*len*/ 65536, out, 8);
+    ASSERT_EQ(ns, 1);
+    EXPECT_EQ(out[0].localAddr,  kBase + 4096);
+    EXPECT_EQ(out[0].remoteAddr, 0x900000000ULL + 4096);
+    EXPECT_EQ(out[0].len, 65536u);
+    EXPECT_EQ(out[0].localSeg, 0);
+    EXPECT_EQ(out[0].remoteSeg, 0);
+}
+
+// A transfer contained in one segment on both sides stays a single slice even
+// when the buffer itself is multi-segment.
+TEST(NetIbSplit, WithinSegmentNoSplit) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    ncclIbSegSlice out[8];
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 /*off*/ kSeg + 1024, /*len*/ 4096, out, 8);
+    ASSERT_EQ(ns, 1);
+    EXPECT_EQ(out[0].localSeg, 1);
+    EXPECT_EQ(out[0].remoteSeg, 1);
+    EXPECT_EQ(out[0].len, 4096u);
+}
+
+// A transfer straddling one boundary (symmetric layout) splits into two slices
+// with the correct per-segment addresses and lengths.
+TEST(NetIbSplit, CrossingOneBoundarySplitsIntoTwo) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    uint64_t off = kSeg - 1024;   // 1 KiB before the seg0/seg1 boundary
+    uint64_t len = 4096;          // ends 3 KiB into seg1
+    ncclIbSegSlice out[8];
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 off, len, out, 8);
+    ASSERT_EQ(ns, 2);
+    EXPECT_EQ(out[0].localSeg, 0);
+    EXPECT_EQ(out[0].localAddr, kBase + kSeg - 1024);
+    EXPECT_EQ(out[0].len, 1024u);
+    EXPECT_EQ(out[1].localSeg, 1);
+    EXPECT_EQ(out[1].localAddr, kBase + kSeg);
+    EXPECT_EQ(out[1].len, 3072u);
+    // Slices reassemble to the original range with no gaps/overlaps.
+    EXPECT_EQ(out[0].len + out[1].len, len);
+}
+
+// Asymmetric layouts: the sender and receiver segment at different sizes; the
+// transfer must split at the union of both sides' boundaries.
+TEST(NetIbSplit, AsymmetricLayoutsSplitAtBothBoundaries) {
+    Layout local  = MakeUniform(kBase, kSeg, 4);          // 2 MiB segments
+    Layout remote = MakeUniform(0x900000000ULL, kSeg / 2, 8); // 1 MiB segments
+    SplitTables lt = MakeTables(local), rt = MakeTables(remote);
+    // Transfer the whole buffer.
+    uint64_t total = 4 * kSeg;
+    ncclIbSegSlice out[64];
+    int ns = ncclIbSplitTransfer(lt.n(), lt.va.data(), lt.off.data(),
+                                 rt.n(), rt.va.data(), rt.off.data(),
+                                 0, total, out, 64);
+    // Remote has the finer granularity (1 MiB): 8 slices, each 1 MiB.
+    ASSERT_EQ(ns, 8);
+    uint64_t sum = 0, cursor = 0;
+    for (int k = 0; k < ns; k++) {
+        EXPECT_EQ(out[k].localAddr,  kBase + cursor);
+        EXPECT_EQ(out[k].remoteAddr, 0x900000000ULL + cursor);
+        EXPECT_EQ(out[k].len, kSeg / 2);
+        EXPECT_EQ(out[k].localSeg, static_cast<int>(cursor / kSeg));
+        EXPECT_EQ(out[k].remoteSeg, static_cast<int>(cursor / (kSeg / 2)));
+        sum += out[k].len; cursor += out[k].len;
+    }
+    EXPECT_EQ(sum, total);
+}
+
+// Local and remote API buffers may begin at different offsets within their
+// respective registrations. Splitting must preserve both offsets rather than
+// treating the request-relative offset as registration-relative.
+TEST(NetIbSplit, IndependentLocalAndRemoteStartOffsets) {
+    Layout local  = MakeUniform(kBase, kSeg, 4);
+    Layout remote = MakeUniform(0x900000000ULL, kSeg / 2, 8);
+    SplitTables lt = MakeTables(local), rt = MakeTables(remote);
+    ncclIbSegSlice out[8];
+    const uint64_t localOff  = kSeg + 512;
+    const uint64_t remoteOff = kSeg / 2 - 512;
+    int ns = ncclIbSplitTransferAtOffsets(
+        lt.n(), lt.va.data(), lt.off.data(),
+        rt.n(), rt.va.data(), rt.off.data(),
+        localOff, remoteOff, 2048, out, 8);
+    ASSERT_EQ(ns, 2);
+    EXPECT_EQ(out[0].localAddr, kBase + localOff);
+    EXPECT_EQ(out[0].remoteAddr, 0x900000000ULL + remoteOff);
+    EXPECT_EQ(out[0].len, 512u);
+    EXPECT_EQ(out[0].localSeg, 1);
+    EXPECT_EQ(out[0].remoteSeg, 0);
+    EXPECT_EQ(out[1].localAddr, kBase + localOff + 512);
+    EXPECT_EQ(out[1].remoteAddr, 0x900000000ULL + kSeg / 2);
+    EXPECT_EQ(out[1].len, 1536u);
+    EXPECT_EQ(out[1].localSeg, 1);
+    EXPECT_EQ(out[1].remoteSeg, 1);
+}
+
+// DeepEP Engram uses one unequal [GPU][CPU] window and reads remote CPU storage
+// into a different offset in the local GPU segment. Preserve that consumer
+// geometry as a host-only regression for independent offset/key selection.
+TEST(NetIbSplit, DeepEP_EngramCpuToGpuOffsets) {
+    constexpr uint64_t gpuBytes = 6u * 1024 * 1024;
+    constexpr uint64_t cpuBytes = 2u * 1024 * 1024;
+    constexpr uint64_t remoteBase = 0x900000000ULL;
+    Layout local{{kBase, kBase + gpuBytes}, {gpuBytes, cpuBytes}};
+    Layout remote{{remoteBase, remoteBase + gpuBytes}, {gpuBytes, cpuBytes}};
+    SplitTables lt = MakeTables(local), rt = MakeTables(remote);
+    ncclIbSegSlice out[4];
+    const uint64_t localOff = 64 * 1024;
+    const uint64_t remoteOff = gpuBytes + 4096;
+    const uint64_t len = 128 * 1024;
+    int ns = ncclIbSplitTransferAtOffsets(
+        lt.n(), lt.va.data(), lt.off.data(),
+        rt.n(), rt.va.data(), rt.off.data(),
+        localOff, remoteOff, len, out, 4);
+    ASSERT_EQ(ns, 1);
+    EXPECT_EQ(out[0].localSeg, 0);
+    EXPECT_EQ(out[0].remoteSeg, 1);
+    EXPECT_EQ(out[0].localAddr, kBase + localOff);
+    EXPECT_EQ(out[0].remoteAddr, remoteBase + remoteOff);
+    EXPECT_EQ(out[0].len, len);
+}
+
+// Full-buffer transfer over a symmetric N-segment layout yields N slices.
+TEST(NetIbSplit, FullBufferProducesOneSlicePerSegment) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    ncclIbSegSlice out[8];
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 0, 4 * kSeg, out, 8);
+    ASSERT_EQ(ns, 4);
+    for (int k = 0; k < ns; k++) { EXPECT_EQ(out[k].len, kSeg); EXPECT_EQ(out[k].localSeg, k); }
+}
+
+TEST(NetIbSplit, ZeroLengthProducesNoSlices) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    ncclIbSegSlice out[8];
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 kSeg, 0, out, 8);
+    EXPECT_EQ(ns, 0);
+}
+
+TEST(NetIbSplit, OutOfRangeRejected) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    ncclIbSegSlice out[8];
+    // Starts one byte past the end of the registered range.
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 4 * kSeg, 16, out, 8);
+    EXPECT_EQ(ns, -1);
+}
+
+TEST(NetIbSplit, MaxSlicesOverflowRejected) {
+    Layout L = MakeUniform(kBase, kSeg, 4);
+    SplitTables t = MakeTables(L);
+    ncclIbSegSlice out[2];
+    // Whole buffer needs 4 slices but only 2 are allowed.
+    int ns = ncclIbSplitTransfer(t.n(), t.va.data(), t.off.data(),
+                                 t.n(), t.va.data(), t.off.data(),
+                                 0, 4 * kSeg, out, 2);
+    EXPECT_EQ(ns, -1);
+}
+
+// Sweep: for a range that starts and ends anywhere, the produced slices always
+// tile the range contiguously with no gaps or overlaps and never exceed a
+// single segment on either side.
+TEST(NetIbSplit, SlicesTileRangeContiguously) {
+    Layout local  = MakeUniform(kBase, kSeg, 4);
+    Layout remote = MakeUniform(0x900000000ULL, kSeg / 4, 16); // 512 KiB segments
+    SplitTables lt = MakeTables(local), rt = MakeTables(remote);
+    for (uint64_t off : {uint64_t{0}, uint64_t{1024}, kSeg - 4096, kSeg + kSeg / 2}) {
+        for (uint64_t len : {uint64_t{4096}, kSeg / 4, kSeg, kSeg + 12345}) {
+            if (off + len > 4 * kSeg) continue;
+            ncclIbSegSlice out[64];
+            int ns = ncclIbSplitTransfer(lt.n(), lt.va.data(), lt.off.data(),
+                                         rt.n(), rt.va.data(), rt.off.data(),
+                                         off, len, out, 64);
+            ASSERT_GT(ns, 0) << "off=" << off << " len=" << len;
+            uint64_t cursor = off, sum = 0;
+            for (int k = 0; k < ns; k++) {
+                EXPECT_EQ(out[k].localAddr,  kBase + cursor);
+                EXPECT_EQ(out[k].remoteAddr, 0x900000000ULL + cursor);
+                cursor += out[k].len; sum += out[k].len;
+            }
+            EXPECT_EQ(sum, len) << "off=" << off << " len=" << len;
+        }
+    }
+}

--- a/projects/rccl/test/RegistrationMPITests.cpp
+++ b/projects/rccl/test/RegistrationMPITests.cpp
@@ -32,9 +32,11 @@
 #ifdef ENABLE_FAULT_INJECTION
 #include "ce_fault_inject.h"
 #endif
+#include <algorithm>
 #include <cstdlib>
 #include <regex>
 #include <sstream>
+#include <vector>
 
 #ifdef MPI_TESTS_ENABLED
 
@@ -841,22 +843,6 @@ class UBR_MultiSegment : public RegistrationTestBase
 protected:
     using T = RegTestConfig::DefaultType;
 
-    // Multi-segment registration currently relies on dmabuf support from the
-    // runtime/HSA layer for the inter-node (NET/GIN) path. Until that lands,
-    // restrict every UBR_MultiSegment test to a single node so the multi-node
-    // tests are not exercised.
-    void SetUp() override
-    {
-        RegistrationTestBase::SetUp();
-        if (::testing::Test::IsSkipped() || ::testing::Test::HasFatalFailure()) {
-            return;
-        }
-        if (MPITestConstants::detectNodeCount() != 1) {
-            GTEST_SKIP() << "UBR_MultiSegment is limited to single node until "
-                            "dmabuf support is available from the HIP/HSA layer";
-        }
-    }
-
     struct MultiSegmentBuffer
     {
         hipDeviceptr_t                                vaBase      = 0;
@@ -1113,6 +1099,97 @@ TEST_F(UBR_MultiSegment, Generic)
     ASSERT_TRUE(checker.hasNumSegments(kNumSegments))
         << "Expected NET 'numSegments " << kNumSegments
         << "' for the complete ncclCommRegister range";
+}
+
+/**
+ * @brief NET proxy registration clips the final physical segment.
+ *
+ * Registers two complete VMM mappings plus half of a third, then runs an
+ * AllReduce whose receive half ends at the final registered byte. This drives
+ * sendProxyRegBuffer and recvProxyRegBuffer through netIbRegMrMultiSeg with a
+ * short final MR and verifies the mapped-but-unregistered tail is untouched.
+ */
+TEST_F(UBR_MultiSegment, NetProxyPartialFinalSegment)
+{
+    if (!validateTestPrerequisites(/*min_processes=*/2)) {
+        GTEST_SKIP() << "Requires 2+ ranks";
+    }
+    if (MPITestConstants::detectNodeCount() != 2) {
+        GTEST_SKIP() << "Requires exactly two nodes to exercise NET proxy registration";
+    }
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ASSERT_TRUE(isUBREnabled()) << "NCCL_LOCAL_REGISTER must be set to 1";
+    ASSERT_TRUE(isCuMemEnabled()) << "NCCL_CUMEM_ENABLE must be set to 1";
+    ASSERT_TRUE(isMultiSegmentRegisterEnabled())
+        << "NCCL_MULTI_SEGMENT_REGISTER must be set to 1";
+    ASSERT_TRUE(isPerRankLoggingEnabled())
+        << "RCCL_MPI_LOG_ALL_RANKS must be set to 1";
+
+    int dev = 0;
+    ASSERT_MPI_EQ(hipSuccess, hipGetDevice(&dev));
+
+    constexpr size_t kSegmentSize = 32 * 1024 * 1024;
+    constexpr int kMappedSegments = 3;
+    constexpr uint8_t kSentinel = 0xA7;
+    MultiSegmentBuffer buf;
+    ASSERT_NO_FATAL_FAILURE(
+        createMultiSegmentBuffer(dev, kSegmentSize, kMappedSegments, buf));
+    if (buf.totalSize == 0) {
+        GTEST_SKIP() << "Raw VMM allocation unavailable on this runtime";
+    }
+    auto vmmCleanup = makeScopeGuard([&]() { releaseMultiSegmentBuffer(buf); });
+
+    const size_t registeredBytes = 2 * buf.segmentSize + buf.segmentSize / 2;
+    const size_t halfSize = registeredBytes / 2;
+    const size_t tailSize = buf.totalSize - registeredBytes;
+    ASSERT_EQ(registeredBytes % sizeof(T), 0u);
+    ASSERT_EQ(halfSize % sizeof(T), 0u);
+
+    char* base = reinterpret_cast<char*>(buf.vaBase);
+    void* sendBuf = base;
+    void* recvBuf = base + halfSize;
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMemset(base + registeredBytes, kSentinel, tailSize));
+
+    void* regHandle = nullptr;
+    ASSERT_MPI_EQ(
+        ncclSuccess,
+        ncclCommRegister(getActiveCommunicator(), buf.vaBase, registeredBytes,
+                         &regHandle));
+    auto regCleanup = makeScopeGuard([&]() {
+        if (regHandle)
+            HIP_EXPECT(ncclCommDeregister(getActiveCommunicator(), regHandle));
+    });
+    ASSERT_MPI_NE(regHandle, nullptr);
+
+    int rank = 0;
+    int nRanks = 0;
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+    const size_t count = halfSize / sizeof(T);
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(
+        ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, getNcclDataType<T>(), ncclSum,
+                      getActiveCommunicator(), getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+    ASSERT_TRUE(verifyAllReduceResult<T>(recvBuf, count, nRanks));
+
+    std::vector<uint8_t> tail(tailSize);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(tail.data(), base + registeredBytes, tailSize,
+                        hipMemcpyDeviceToHost));
+    EXPECT_TRUE(std::all_of(tail.begin(), tail.end(),
+                            [](uint8_t byte) { return byte == kSentinel; }))
+        << "NET transfer wrote beyond the clipped registration range";
+
+    REGLogChecker checker = getLogChecker();
+    ASSERT_TRUE(checker.hasNETRegistration())
+        << "NET proxy registration path did not execute";
+    ASSERT_TRUE(checker.hasNumSegments(kMappedSegments))
+        << "Expected NET proxy to enumerate three physical segments";
 }
 
 /**

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
@@ -1,0 +1,138 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NET_IB_MULTI_SEGMENT_HELPERS_HPP
+#define NET_IB_MULTI_SEGMENT_HELPERS_HPP
+
+#ifdef MPI_TESTS_ENABLED
+
+#include <hip/hip_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <unistd.h>
+#include <vector>
+
+#include "nccl.h"
+#include "net.h" // ncclIbRegMrDmaBufMultiSeg
+#include "rocmwrap.h"
+
+namespace RCCLNetIbTests {
+
+// Contiguous VA range backed by N distinct VMM allocations mapped back-to-back.
+// Mirrors the GIN test helper but is not gated on the GIN backend.
+struct MultiSegmentVmmBuffer {
+    void*                                        ptr       = nullptr;
+    size_t                                       totalSize = 0;
+    size_t                                       segSize   = 0;
+    int                                          nSegments = 0;
+    hipDeviceptr_t                               base      = 0;
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    bool valid() const { return ptr != nullptr && nSegments > 0; }
+};
+
+inline bool AllocMultiSegmentVmm(int dev, int nSegments, size_t segBytes, MultiSegmentVmmBuffer* out) {
+    if (out == nullptr || nSegments <= 0) return false;
+    *out = MultiSegmentVmmBuffer{};
+
+    hipMemAllocationProp prop            = {};
+    prop.type                            = hipMemAllocationTypePinned;
+    prop.location.type                   = hipMemLocationTypeDevice;
+    prop.location.id                     = dev;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    size_t granularity = 0;
+    if (hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum) != hipSuccess
+        || granularity == 0)
+        return false;
+
+    const size_t segSize   = ((segBytes + granularity - 1) / granularity) * granularity;
+    const size_t totalSize = segSize * static_cast<size_t>(nSegments);
+
+    hipDeviceptr_t base = 0;
+    if (hipMemAddressReserve(&base, totalSize, granularity, 0, 0) != hipSuccess) return false;
+
+    std::vector<hipMemGenericAllocationHandle_t> handles;
+    auto cleanup = [&]() {
+        for (size_t i = 0; i < handles.size(); ++i) {
+            (void)hipMemUnmap(reinterpret_cast<hipDeviceptr_t>(reinterpret_cast<uintptr_t>(base) + i * segSize), segSize);
+            (void)hipMemRelease(handles[i]);
+        }
+        (void)hipMemAddressFree(base, totalSize);
+    };
+
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+
+    for (int s = 0; s < nSegments; ++s) {
+        hipMemGenericAllocationHandle_t h = 0;
+        if (hipMemCreate(&h, segSize, &prop, 0) != hipSuccess) { cleanup(); return false; }
+        handles.push_back(h);
+        hipDeviceptr_t segVa = reinterpret_cast<hipDeviceptr_t>(reinterpret_cast<uintptr_t>(base) + static_cast<uintptr_t>(s) * segSize);
+        if (hipMemMap(segVa, segSize, 0, h, 0) != hipSuccess) { cleanup(); return false; }
+    }
+    if (hipMemSetAccess(base, totalSize, &accessDesc, 1) != hipSuccess) { cleanup(); return false; }
+
+    out->ptr = reinterpret_cast<void*>(base);
+    out->base = base; out->totalSize = totalSize; out->segSize = segSize;
+    out->nSegments = nSegments; out->handles = std::move(handles);
+    return true;
+}
+
+inline void FreeMultiSegmentVmm(MultiSegmentVmmBuffer& b) {
+    if (b.ptr == nullptr) return;
+    for (size_t i = 0; i < b.handles.size(); ++i) {
+        hipDeviceptr_t segVa = reinterpret_cast<hipDeviceptr_t>(reinterpret_cast<uintptr_t>(b.base) + i * b.segSize);
+        (void)hipMemUnmap(segVa, b.segSize);
+        (void)hipMemRelease(b.handles[i]);
+    }
+    (void)hipMemAddressFree(b.base, b.totalSize);
+    b = MultiSegmentVmmBuffer{};
+}
+
+// Export one dma-buf fd per segment and register the buffer as a multi-segment
+// MR via the classic NET/IB plugin entry point. Returns the registration result;
+// on ncclSuccess *mhandle holds the composite handle. Returns ncclInvalidUsage
+// (without touching *mhandle) if the dma-buf export API is unavailable at build
+// time (older HIP), so callers can SKIP.
+inline ncclResult_t RegisterMultiSegmentMr(void* comm, const MultiSegmentVmmBuffer& b, void** mhandle) {
+#if NCCL_CUMEM_DMABUF_EXPORT_GATE
+    std::vector<void*>    segAddrs(b.nSegments);
+    std::vector<size_t>   segLens(b.nSegments);
+    std::vector<uint64_t> segOffsets(b.nSegments, 0ULL);
+    std::vector<int>      segFds(b.nSegments, -1);
+
+    ncclResult_t ret = ncclSuccess;
+    for (int s = 0; s < b.nSegments; s++) {
+        uintptr_t segVa = reinterpret_cast<uintptr_t>(b.base) + static_cast<uintptr_t>(s) * b.segSize;
+        int fd = -1;
+        if (hipMemGetHandleForAddressRange((void*)&fd, (hipDeviceptr_t)segVa, b.segSize,
+                                           hipMemRangeHandleTypeDmaBufFd, 0) != hipSuccess) {
+            ret = ncclInvalidUsage; goto cleanup;
+        }
+        segAddrs[s] = reinterpret_cast<void*>(segVa);
+        segLens[s]  = b.segSize;
+        segFds[s]   = fd;
+    }
+    ret = ncclIbRegMrDmaBufMultiSeg(comm, b.nSegments, segAddrs.data(), segLens.data(),
+                                    segOffsets.data(), segFds.data(), NCCL_PTR_CUDA, mhandle);
+cleanup:
+    for (int s = 0; s < b.nSegments; s++) if (segFds[s] != -1) (void)close(segFds[s]);
+    return ret;
+#else
+    (void)comm; (void)b; (void)mhandle;
+    return ncclInvalidUsage; // dma-buf export API unavailable at build time
+#endif
+}
+
+} // namespace RCCLNetIbTests
+
+#endif // MPI_TESTS_ENABLED
+
+#endif // NET_IB_MULTI_SEGMENT_HELPERS_HPP

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentHelpers.hpp
@@ -17,7 +17,7 @@
 #include <vector>
 
 #include "nccl.h"
-#include "net.h" // ncclIbRegMrDmaBufMultiSeg
+#include "rccl_ib_multiseg.h"
 #include "rocmwrap.h"
 
 namespace RCCLNetIbTests {

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
@@ -1,0 +1,456 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Multi-segment DMA-BUF tests for the classic NET/IB proxy path.
+// They require two processes, IB/RoCE with GDR, and cuMem/HIP DMA-BUF export.
+// Coverage includes per-segment registration, offsets, boundary-split and
+// whole-buffer transfers, flush MR selection, segment limits, and regressions.
+// Rank 0 receives, rank 1 sends, and unsupported environments are skipped.
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbMultiSegmentHelpers.hpp"
+#include "MPIHelpers.hpp"
+
+#include <cstring>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace RCCLNetIbTests;
+
+namespace {
+constexpr int    kNumSegments = 4;
+constexpr size_t kSegBytes    = 2u * 1024 * 1024; // rounded up to VMM granularity
+constexpr int    kMaxSegments = 16;               // mirrors NCCL_IB_MAX_SEGMENTS
+} // namespace
+
+class NetIbMultiSegmentMPITest : public NetIbMPITest {
+protected:
+    std::vector<MultiSegmentVmmBuffer*> owned_;
+
+    void TearDown() override {
+        for (auto* b : owned_) { FreeMultiSegmentVmm(*b); delete b; }
+        owned_.clear();
+        NetIbMPITest::TearDown();
+    }
+
+    MultiSegmentVmmBuffer* AllocSym(int nSeg, size_t segBytes = kSegBytes) {
+        int dev = 0;
+        if (hipGetDevice(&dev) != hipSuccess) return nullptr;
+        auto* b = new MultiSegmentVmmBuffer();
+        if (!AllocMultiSegmentVmm(dev, nSeg, segBytes, b)) { delete b; return nullptr; }
+        owned_.push_back(b);
+        return b;
+    }
+
+    bool SyncSkip(bool want) {
+        return MPIHelpers::anyRankTrue(want);
+    }
+
+    bool PtrSupported(int mask) {
+        ncclNetProperties_t props; memset(&props, 0, sizeof(props));
+        if (GetDeviceProperties(0, &props) != ncclSuccess) return false;
+        return (props.ptrSupport & mask) != 0;
+    }
+
+    static void FillDevice(void* dptr, size_t size, uint8_t seed) {
+        if (size == 0) return;
+        std::vector<uint8_t> h(size);
+        for (size_t i = 0; i < size; i++) h[i] = static_cast<uint8_t>(seed + (i & 0xFF));
+        ASSERT_EQ(hipMemcpy(dptr, h.data(), size, hipMemcpyHostToDevice), hipSuccess);
+    }
+
+    static bool VerifyDevice(void* dptr, size_t size, uint8_t seed) {
+        if (size == 0) return true;
+        std::vector<uint8_t> h(size, 0);
+        if (hipMemcpy(h.data(), dptr, size, hipMemcpyDeviceToHost) != hipSuccess) return false;
+        for (size_t i = 0; i < size; i++)
+            if (h[i] != static_cast<uint8_t>(seed + (i & 0xFF))) return false;
+        return true;
+    }
+
+    static void FillDeviceConstant(void* dptr, size_t size, uint8_t value) {
+        if (size == 0) return;
+        ASSERT_EQ(hipMemset(dptr, value, size), hipSuccess);
+        ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+    }
+
+    static bool VerifyDeviceConstant(void* dptr, size_t size, uint8_t value) {
+        if (size == 0) return true;
+        std::vector<uint8_t> h(size, 0);
+        if (hipMemcpy(h.data(), dptr, size, hipMemcpyDeviceToHost) != hipSuccess) return false;
+        for (uint8_t byte : h)
+            if (byte != value) return false;
+        return true;
+    }
+
+    // One-directional transfer (rank1 -> rank0) with independent source and
+    // destination registration-relative offsets. This is the general form
+    // required by DeepEP-style per-peer window layouts.
+    void SendRecvChunkAtOffsets(ConnectionPair& pair, void* sBuf, void* rBuf,
+                                size_t srcOff, size_t dstOff, size_t size,
+                                int tag, uint8_t seed) {
+        const int rank = MPIEnvironment::world_rank;
+        void* req = nullptr;
+        if (rank == 0) {
+            void* buf = static_cast<uint8_t*>(rBuf) + dstOff;
+            PostSingleRecv(pair.recvComm, buf, size, tag, recvMh_, &req);
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+        } else {
+            FillDevice(static_cast<uint8_t*>(sBuf) + srcOff, size, seed);
+            void* buf = static_cast<uint8_t*>(sBuf) + srcOff;
+            PostSendWithRetry(pair.sendComm, buf, size, tag, sendMh_, &req);
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        if (rank == 0)
+            EXPECT_TRUE(VerifyDevice(static_cast<uint8_t*>(rBuf) + dstOff, size, seed))
+                << "data mismatch srcOff=" << srcOff << " dstOff=" << dstOff
+                << " size=" << size;
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Common same-offset form used by the original test matrix.
+    void SendRecvChunk(ConnectionPair& pair, void* sBuf, void* rBuf,
+                       size_t off, size_t size, int tag, uint8_t seed) {
+        SendRecvChunkAtOffsets(pair, sBuf, rBuf, off, off, size, tag, seed);
+    }
+
+    void SendRecvChunkAtOffsetsChecked(ConnectionPair& pair, void* sBuf, void* rBuf,
+                                       size_t totalSize, size_t srcOff, size_t dstOff,
+                                       size_t size, int tag, uint8_t seed, uint8_t sentinel) {
+        const int rank = MPIEnvironment::world_rank;
+        if (rank == 0) FillDeviceConstant(rBuf, totalSize, sentinel);
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        SendRecvChunkAtOffsets(pair, sBuf, rBuf, srcOff, dstOff, size, tag, seed);
+
+        if (rank == 0) {
+            EXPECT_TRUE(VerifyDeviceConstant(rBuf, dstOff, sentinel))
+                << "bytes before destination were overwritten";
+            EXPECT_TRUE(VerifyDeviceConstant(static_cast<uint8_t*>(rBuf) + dstOff + size,
+                                             totalSize - dstOff - size, sentinel))
+                << "bytes after destination were overwritten";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Common setup: prerequisites, GDR, allocate an nSeg window, connect, and
+    // register it through the multi-segment entry point. Returns false if any
+    // precondition is unmet; when the failure is a graceful skip it records
+    // skipReason_ so the caller can GTEST_SKIP() from the test body (GTEST_SKIP
+    // expands to a void return and cannot be used inside this bool helper).
+    // Use SETUP_OR_SKIP() at the call site to honor a recorded skip.
+    bool SetupRegistered(int nSeg, ConnectionPair& pair, NetConnectionGuard& guard,
+                         void** mh, void** comm, int minNodes = kMinGpusPerNode) {
+        skipReason_.clear();
+        if (!validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                       false, minNodes, kNoNodeLimit)) {
+            if (minNodes > kMinGpusPerNode)
+                skipReason_ = "test requires ranks on at least two nodes";
+            return false;
+        }
+        int ndev = 0; AssertInitAndGetDevices(&ndev);
+        if (SyncSkip(!PtrSupported(NCCL_PTR_DMABUF))) {
+            skipReason_ = "DMA-BUF registration not supported";
+            return false;
+        }
+        MultiSegmentVmmBuffer* buf = AllocSym(nSeg);
+        if (SyncSkip(buf == nullptr)) { skipReason_ = "multi-segment VMM allocation unavailable"; return false; }
+        lastBuf_ = buf;
+        SetupConnectionWithGuard(0, pair, guard);
+        const int rank = MPIEnvironment::world_rank;
+        *comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        ncclResult_t r = RegisterMultiSegmentMr(*comm, *buf, mh);
+        if (SyncSkip(r == ncclInvalidUsage && *mh == nullptr)) {
+            skipReason_ = "dma-buf multi-segment registration unavailable on this build/host";
+            return false;
+        }
+        EXPECT_EQ(r, ncclSuccess) << "multi-segment registration failed (the AIRUNTIME-2351 bug)";
+        EXPECT_NE(*mh, nullptr);
+        return (r == ncclSuccess && *mh != nullptr);
+    }
+
+    std::string            skipReason_;
+    MultiSegmentVmmBuffer* lastBuf_ = nullptr;
+    void* sendMh_ = nullptr;
+    void* recvMh_ = nullptr;
+};
+
+// Honor a graceful skip recorded by SetupRegistered from the test body (where a
+// void return from GTEST_SKIP is valid). Used as: if (!SetupRegistered(...)) SETUP_OR_SKIP();
+#define SETUP_OR_SKIP()                                                    \
+    do {                                                                   \
+        if (!skipReason_.empty()) GTEST_SKIP() << skipReason_;             \
+        return;                                                            \
+    } while (0)
+
+// POSITIVE: register a 4-segment window and move each segment end to end.
+TEST_F(NetIbMultiSegmentMPITest, PerSegmentRegistrationAndTransfer) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+    for (int s = 0; s < kNumSegments; s++)
+        SendRecvChunk(pair, lastBuf_->ptr, lastBuf_->ptr, (size_t)s * lastBuf_->segSize, lastBuf_->segSize,
+                      /*tag=*/100 + s, /*seed=*/static_cast<uint8_t>(0xA0 + s));
+}
+
+// SELECTION: transfers anchored at different offsets inside each segment.
+TEST_F(NetIbMultiSegmentMPITest, IntraSegmentOffsetSelection) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+    const size_t chunk = 65536;
+    int tag = 200;
+    for (int s = 0; s < kNumSegments; s++) {
+        size_t segBase = (size_t)s * lastBuf_->segSize;
+        for (size_t sub : {size_t{0}, lastBuf_->segSize / 2, lastBuf_->segSize - chunk})
+            SendRecvChunk(pair, lastBuf_->ptr, lastBuf_->ptr, segBase + sub, chunk, tag++,
+                          static_cast<uint8_t>(0x10 + s));
+    }
+}
+
+// DeepEP-style per-peer windows use different source and destination offsets
+// for one logical transfer. Exercise that pattern on the classic CTS-FIFO wire:
+// the sender starts in segment 1 while the receiver starts in segment 0, so a
+// shared registration-relative cursor would select the wrong lkey or rkey.
+TEST_F(NetIbMultiSegmentMPITest, DeepEP_AsymmetricOffsetTransfer) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+
+    const size_t srcOff = lastBuf_->segSize + 4096; // sender segment 1
+    const size_t dstOff = 64 * 1024;                // receiver segment 0
+    const size_t size   = 128 * 1024;
+    SendRecvChunkAtOffsets(pair, lastBuf_->ptr, lastBuf_->ptr,
+                           srcOff, dstOff, size, /*tag=*/350, /*seed=*/0xD3);
+}
+
+// A single transfer that straddles a segment boundary succeeds because the
+// sender splits the RDMA write at the receiver's boundary using
+// the per-segment rkeys published in the CTS FIFO. Data must arrive intact.
+TEST_F(NetIbMultiSegmentMPITest, CrossBoundaryTransferSucceeds) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+    // 64 KiB before + 64 KiB after the seg0/seg1 boundary.
+    const size_t off  = lastBuf_->segSize - 65536;
+    const size_t size = 131072;
+    SendRecvChunk(pair, lastBuf_->ptr, lastBuf_->ptr, off, size, /*tag=*/400, /*seed=*/0xC3);
+}
+
+// MULTI-NODE STRESS: repeatedly cross independently selected source and
+// destination boundaries in an 8-segment window. The destination is reset to a
+// sentinel on every iteration so incorrect WR splitting, lkey/rkey selection,
+// or length accounting is detected as payload corruption or an adjacent write.
+TEST_F(NetIbMultiSegmentMPITest, DeepEP_MultiNodeAsymmetricCrossBoundaryStress) {
+    constexpr int kWideSegments = 8;
+    constexpr int kIterations   = 32;
+
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kWideSegments, pair, guard, &mh, &comm, /*minNodes=*/2))
+        SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+
+    const size_t seg = lastBuf_->segSize;
+    const size_t total = lastBuf_->totalSize;
+    const std::vector<size_t> edgeWidths = {
+        size_t{1}, size_t{63}, size_t{4095}, size_t{65535}, size_t{131071}
+    };
+
+    for (int i = 0; i < kIterations; ++i) {
+        const int srcBoundary = 1 + (i % (kWideSegments - 1));
+        const int dstBoundary = 1 + ((i * 5 + 1) % (kWideSegments - 1));
+        const size_t left = edgeWidths[static_cast<size_t>(i) % edgeWidths.size()];
+        const size_t right = edgeWidths[static_cast<size_t>(i + 2) % edgeWidths.size()];
+        const size_t srcOff = static_cast<size_t>(srcBoundary) * seg - left;
+        const size_t dstOff = static_cast<size_t>(dstBoundary) * seg - left;
+        const size_t size = left + right;
+
+        SendRecvChunkAtOffsetsChecked(pair, lastBuf_->ptr, lastBuf_->ptr, total,
+                                      srcOff, dstOff, size, /*tag=*/800 + i,
+                                      static_cast<uint8_t>(0x20 + i), /*sentinel=*/0xE5);
+    }
+}
+
+// A transfer spanning the entire multi-segment buffer crosses every boundary
+// and exercises the full splitting builder.
+TEST_F(NetIbMultiSegmentMPITest, WholeBufferSingleTransfer) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+    SendRecvChunk(pair, lastBuf_->ptr, lastBuf_->ptr, 0, lastBuf_->totalSize, /*tag=*/500, /*seed=*/0x5E);
+}
+
+// NEGATIVE: a buffer with more than NCCL_IB_MAX_SEGMENTS physical segments is
+// rejected at registration with ncclInvalidUsage and produces no handle. The
+// wire protocol carries at most NCCL_IB_MAX_SEGMENTS segments.
+TEST_F(NetIbMultiSegmentMPITest, ExceedsMaxSegmentsRejected) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    int ndev = 0; AssertInitAndGetDevices(&ndev);
+    if (SyncSkip(!PtrSupported(NCCL_PTR_DMABUF))) GTEST_SKIP() << "DMA-BUF registration not supported";
+
+    const int rank = MPIEnvironment::world_rank;
+    MultiSegmentVmmBuffer* big = AllocSym(kMaxSegments + 1);
+    if (SyncSkip(big == nullptr)) GTEST_SKIP() << "could not allocate over-cap VMM window";
+
+    ConnectionPair pair; NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, pair, guard);
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+
+    void* mh = nullptr;
+    ncclResult_t r = RegisterMultiSegmentMr(comm, *big, &mh);
+    if (SyncSkip(r == ncclInvalidUsage && mh == nullptr && (kMaxSegments + 1) > kMaxSegments)) {
+        EXPECT_EQ(mh, nullptr) << "no handle should be produced for an over-cap buffer";
+        SUCCEED();
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+    EXPECT_EQ(r, ncclInvalidUsage) << "over-cap segment buffer must be rejected";
+    EXPECT_EQ(mh, nullptr);
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// REGRESSION: a single-segment window registered through the multi-segment
+// entry point still registers and transfers via the nSeg==1 fast path (which
+// leaves ncclIbMultiSend on its original, unmodified code path).
+TEST_F(NetIbMultiSegmentMPITest, SingleSegmentThroughMultiSegPath) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(1, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+    sendMh_ = recvMh_ = mh;
+    SendRecvChunk(pair, lastBuf_->ptr, lastBuf_->ptr, 0, 65536, /*tag=*/300, /*seed=*/0x77);
+}
+
+// FLUSH: after receiving into a NON-zero segment, ncclIbIflush must fence the
+// buffer using that segment's MR (rkey selected by ncclIbMrForRange), not
+// segment 0's. The flush 4-byte read never straddles a boundary, so this
+// validates per-segment key selection on the flush path.
+// When GDR flush is disabled, iflush returns success with no request; the test
+// still asserts iflush accepts a multi-segment handle without a boundary error.
+TEST_F(NetIbMultiSegmentMPITest, MultiSegmentFlushSelectsSegmentMr) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    const int    seg   = 2;                              // a non-zero segment
+    const size_t chunk = 65536;
+    const size_t off   = (size_t)seg * lastBuf_->segSize;
+    const int    tag   = 600;
+    const int    rank  = MPIEnvironment::world_rank;
+
+    if (rank == 0) {
+        void* rbuf = static_cast<uint8_t*>(lastBuf_->ptr) + off;
+        void* req  = nullptr;
+        PostSingleRecv(pair.recvComm, rbuf, chunk, tag, mh, &req);
+        int sz = 0;
+        EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+
+        void* fbufs[1]  = {rbuf};
+        int   fsizes[1] = {static_cast<int>(chunk)};
+        void* fhs[1]    = {mh};
+        void* freq      = nullptr;
+        EXPECT_EQ(FlushRecv(pair.recvComm, 1, fbufs, fsizes, fhs, &freq), ncclSuccess)
+            << "iflush must handle a multi-segment handle (segment 2) without a boundary error";
+        if (freq != nullptr) {
+            int fsz = 0;
+            EXPECT_EQ(WaitForCompletion(freq, &fsz, kDefaultTimeoutMs), ncclSuccess)
+                << "flush RDMA read did not complete";
+        }
+        EXPECT_TRUE(VerifyDevice(rbuf, chunk, 0xC0)) << "data mismatch after flush";
+    } else {
+        void* sbuf = static_cast<uint8_t*>(lastBuf_->ptr) + off;
+        FillDevice(sbuf, chunk, 0xC0);
+        void* req = nullptr;
+        PostSendWithRetry(pair.sendComm, sbuf, chunk, tag, mh, &req);
+        int sz = 0;
+        EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// REGRESSION (pointer types): the segment-aware changes only affect nSegments>1
+// handles; single-region host (NCCL_PTR_HOST) and device (NCCL_PTR_CUDA) buffers
+// must still register and transfer through the unchanged nSegments==1 fast path
+// (which also leaves ncclIbMultiSend on its original, non-segmented path).
+// Covers the reviewer's "host and device allocations" request (multi-segment
+// VMM itself is device-only).
+TEST_F(NetIbMultiSegmentMPITest, HostAndDeviceSingleSegmentRegression) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                          false, kMinGpusPerNode, kNoNodeLimit));
+    int ndev = 0; AssertInitAndGetDevices(&ndev);
+
+    const int    rank = MPIEnvironment::world_rank;
+    const size_t size = 65536;
+
+    ConnectionPair pair; NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, pair, guard);
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+
+    // --- Host memory (NCCL_PTR_HOST): always available. ---
+    {
+        std::vector<uint8_t> host(size, 0);
+        void* mh = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, host.data(), size, NCCL_PTR_HOST, &mh), ncclSuccess);
+        ASSERT_NE(mh, nullptr);
+        NetMHandleGuard g(mh, NetMHandleDeleter(net_, comm));
+
+        const int tag = 700; void* req = nullptr;
+        if (rank == 0) {
+            PostSingleRecv(pair.recvComm, host.data(), size, tag, mh, &req);
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+            for (size_t i = 0; i < size; i++)
+                EXPECT_EQ(host[i], static_cast<uint8_t>(0x5A + (i & 0xFF)));
+        } else {
+            for (size_t i = 0; i < size; i++) host[i] = static_cast<uint8_t>(0x5A + (i & 0xFF));
+            PostSendWithRetry(pair.sendComm, host.data(), size, tag, mh, &req);
+            int sz = 0;
+            EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // --- Device memory (NCCL_PTR_CUDA), single contiguous MR via regMr. ---
+    if (!SyncSkip(!PtrSupported(NCCL_PTR_CUDA))) {
+        void* dptr = nullptr;
+        bool allocOk = (hipMalloc(&dptr, size) == hipSuccess);
+        void* mh = nullptr;
+        ncclResult_t rr = allocOk ? RegisterMemory(comm, dptr, size, NCCL_PTR_CUDA, &mh)
+                                  : ncclInvalidUsage;
+        bool regOk = allocOk && rr == ncclSuccess && mh != nullptr;
+        if (!SyncSkip(!regOk)) {
+            NetMHandleGuard g(mh, NetMHandleDeleter(net_, comm));
+            const int tag = 701; void* req = nullptr;
+            if (rank == 0) {
+                PostSingleRecv(pair.recvComm, dptr, size, tag, mh, &req);
+                int sz = 0;
+                EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+                EXPECT_TRUE(VerifyDevice(dptr, size, 0x3C));
+            } else {
+                FillDevice(dptr, size, 0x3C);
+                PostSendWithRetry(pair.sendComm, dptr, size, tag, mh, &req);
+                int sz = 0;
+                EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+            }
+            MPI_Barrier(MPI_COMM_WORLD);
+        } else if (mh != nullptr) {
+            (void)net_->deregMr(comm, mh);
+        }
+        if (allocOk) (void)hipFree(dptr);
+    }
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
@@ -422,6 +422,60 @@ TEST_F(NetIbMultiSegmentMPITest, MultiSegmentFlushTouchesEverySegment) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// A multi-recv can combine buffers backed by different composite handles.
+// iflush must fence every non-zero entry, not only the final receive.
+TEST_F(NetIbMultiSegmentMPITest, MultiRecvFlushTouchesEveryHandle) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh0 = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh0, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard0(mh0, NetMHandleDeleter(net_, comm));
+
+    MultiSegmentVmmBuffer* buf0 = lastBuf_;
+    MultiSegmentVmmBuffer* buf1 = AllocSym(kNumSegments);
+    if (SyncSkip(buf1 == nullptr)) GTEST_SKIP() << "second multi-segment VMM allocation unavailable";
+    void* mh1 = nullptr;
+    ASSERT_EQ(RegisterMultiSegmentMr(comm, *buf1, &mh1), ncclSuccess);
+    ASSERT_NE(mh1, nullptr);
+    NetMHandleGuard mhGuard1(mh1, NetMHandleDeleter(net_, comm));
+
+    const size_t chunk = 64 * 1024;
+    void* bufs[2] = {
+        static_cast<uint8_t*>(buf0->ptr) + chunk,
+        static_cast<uint8_t*>(buf1->ptr) + 2 * buf1->segSize + chunk,
+    };
+    size_t recvSizes[2] = {chunk, chunk};
+    int tags[2] = {602, 603};
+    void* handles[2] = {mh0, mh1};
+    const int rank = MPIEnvironment::world_rank;
+
+    if (rank == 0) {
+        void* req = nullptr;
+        ASSERT_EQ(PostRecv(pair.recvComm, 2, bufs, recvSizes, tags, handles, &req), ncclSuccess);
+        int completedSizes[2] = {};
+        EXPECT_EQ(WaitForCompletion(req, completedSizes, kLargeTransferTimeoutMs), ncclSuccess);
+
+        int flushSizes[2] = {static_cast<int>(chunk), static_cast<int>(chunk)};
+        void* flushReq = nullptr;
+        EXPECT_EQ(FlushRecv(pair.recvComm, 2, bufs, flushSizes, handles, &flushReq), ncclSuccess);
+        if (flushReq != nullptr) {
+            int flushSize = 0;
+            EXPECT_EQ(WaitForCompletion(flushReq, &flushSize, kDefaultTimeoutMs), ncclSuccess);
+        }
+        EXPECT_TRUE(VerifyDevice(bufs[0], chunk, 0x62));
+        EXPECT_TRUE(VerifyDevice(bufs[1], chunk, 0x63));
+    } else {
+        void* reqs[2] = {};
+        FillDevice(bufs[0], chunk, 0x62);
+        FillDevice(bufs[1], chunk, 0x63);
+        PostSendWithRetry(pair.sendComm, bufs[0], chunk, tags[0], handles[0], &reqs[0]);
+        PostSendWithRetry(pair.sendComm, bufs[1], chunk, tags[1], handles[1], &reqs[1]);
+        for (int i = 0; i < 2; i++) {
+            int sentSize = 0;
+            EXPECT_EQ(WaitForCompletion(reqs[i], &sentSize, kLargeTransferTimeoutMs), ncclSuccess);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // REGRESSION (pointer types): the segment-aware changes only affect nSegments>1
 // handles; single-region host (NCCL_PTR_HOST) and device (NCCL_PTR_CUDA) buffers
 // must still register and transfer through the unchanged nSegments==1 fast path

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMultiSegmentMPITests.cpp
@@ -381,6 +381,47 @@ TEST_F(NetIbMultiSegmentMPITest, MultiSegmentFlushSelectsSegmentMr) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// FLUSH: a receive that covers the whole multi-segment window must fence every
+// physical segment (not only data[0]). iflush must accept the full-range size
+// without a boundary error and still complete.
+TEST_F(NetIbMultiSegmentMPITest, MultiSegmentFlushTouchesEverySegment) {
+    ConnectionPair pair; NetConnectionGuard guard(net_); void* mh = nullptr; void* comm = nullptr;
+    if (!SetupRegistered(kNumSegments, pair, guard, &mh, &comm)) SETUP_OR_SKIP();
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    const size_t total = lastBuf_->totalSize;
+    const int    tag   = 601;
+    const int    rank  = MPIEnvironment::world_rank;
+
+    if (rank == 0) {
+        void* rbuf = lastBuf_->ptr;
+        void* req  = nullptr;
+        PostSingleRecv(pair.recvComm, rbuf, total, tag, mh, &req);
+        int sz = 0;
+        EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+
+        void* fbufs[1]  = {rbuf};
+        int   fsizes[1] = {static_cast<int>(total)};
+        void* fhs[1]    = {mh};
+        void* freq      = nullptr;
+        EXPECT_EQ(FlushRecv(pair.recvComm, 1, fbufs, fsizes, fhs, &freq), ncclSuccess)
+            << "iflush must fence every segment of a whole-buffer receive";
+        if (freq != nullptr) {
+            int fsz = 0;
+            EXPECT_EQ(WaitForCompletion(freq, &fsz, kDefaultTimeoutMs), ncclSuccess)
+                << "whole-buffer flush RDMA read did not complete";
+        }
+    } else {
+        void* sbuf = lastBuf_->ptr;
+        FillDevice(sbuf, total, 0xA5);
+        void* req = nullptr;
+        PostSendWithRetry(pair.sendComm, sbuf, total, tag, mh, &req);
+        int sz = 0;
+        EXPECT_EQ(WaitForCompletion(req, &sz, kLargeTransferTimeoutMs), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // REGRESSION (pointer types): the segment-aware changes only affect nSegments>1
 // handles; single-region host (NCCL_PTR_HOST) and device (NCCL_PTR_CUDA) buffers
 // must still register and transfer through the unchanged nSegments==1 fast path


### PR DESCRIPTION
## Motivation

Classic NET/IB had the same HIP first-segment DMA-BUF limitation as GIN. Multi-segment user buffers could not complete GPUDirect RDMA and staged or failed with IB errors.

## Technical Details

- Per-segment DMA-BUF registration via private `ncclIbRegMrDmaBufMultiSeg`.
- Recv publishes segment layout on a side table; 64-byte CTS slot unchanged.
- Connect advertises `NCCL_IB_CAP_MULTISEG`; peers without the cap decline multi-seg registration (staging).
- Uniform layouts only; non-uniform DeepEP `[GPU][CPU]` declines NET registration.

## Issue Tracking

JIRA ID: AICOMRCCL-1526

## Test Plan

- `NetIbMultiSegmentUnitTests.cpp`, `NetIbMultiSegmentMPITests.cpp`, and the two-node `UBR_MultiSegment.NetProxyPartialFinalSegment` proxy-registration regression.
- Mixed old/new RCCL: `nSegments <= 1` must keep working; multi-seg without connect cap must stage.

## Test Result

- ROCm 10.1: 12/12 passed (`NetIbMultiSegmentMPITest` 11/11 and `NetProxyPartialFinalSegment` 1/1).
- ROCm 7.0.2.2: 12/12 passed after applying the temporary `legacyCapIpc=0` compatibility workaround described in PR 1.
- The earlier ROCm 7.14 two-node NET-only run passed `Generic`, `Generic_Reuse`, and `NetProxyPartialFinalSegment` 3/3. The clipping test registered exactly three MRs for the 80 MiB range and left the 16 MiB tail unchanged.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md.
- [ ] CHANGELOG: deferred to a follow-up PR.